### PR TITLE
feat(caching): subagents get their own prompt-cache TTL tier (Claude Code v2.1.243 port)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -998,6 +998,18 @@ def init_agent(
 
         _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
         _ttl = _pc_cfg.get("cache_ttl", "5m")
+        # Delegation subagents can carry their own tier (inspired by Claude
+        # Code v2.1.243's promptCacheTtl/subagentPromptCacheTtl split): a 1h
+        # cache amortizes across a long main conversation, but a subagent
+        # lives minutes — paying the 2x 1h write premium on every short-lived
+        # child is pure waste. prompt_caching.subagent_cache_ttl overrides
+        # the tier for platform == "subagent" agents; the default "inherit"
+        # (or any unknown value) keeps the main cache_ttl. A disable synonym
+        # ("off"/false/...) disables caching for subagents only.
+        if getattr(agent, "platform", None) == "subagent":
+            _sub_ttl = _pc_cfg.get("subagent_cache_ttl", "inherit")
+            if _sub_ttl in {"5m", "1h"} or cache_ttl_means_disabled(_sub_ttl):
+                _ttl = _sub_ttl
         if _ttl in {"5m", "1h"}:
             agent._cache_ttl = _ttl
         elif cache_ttl_means_disabled(_ttl):

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -728,6 +728,9 @@ compression:
 #
 prompt_caching:
   cache_ttl: "5m" # use "1h" for long sessions with pauses between turns
+  # subagent_cache_ttl: "inherit"  # "5m"/"1h" pin a tier for delegation
+  #   subagents only (e.g. keep a 1h main-session cache while short-lived
+  #   subagents stay at 5m and skip the 2x 1h write premium)
 
 # =============================================================================
 # Auxiliary Models (Advanced — Experimental)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1021,8 +1021,14 @@ DEFAULT_CONFIG = {
     # cache_ttl: "5m" or "1h" (Anthropic-supported tiers). Other non-falsy
     # values are silently ignored. Falsy values (false, null, "off",
     # "disabled", "no", "none") disable prompt caching entirely.
+    # subagent_cache_ttl: TTL override for delegation subagents. "inherit"
+    #   (default) keeps cache_ttl; "5m"/"1h" pin a tier for subagents only;
+    #   a disable synonym turns caching off for subagents only. Lets a 1h
+    #   main-session cache coexist with 5m subagent caches, so short-lived
+    #   children don't pay the 2x 1h cache-write premium.
     "prompt_caching": {
         "cache_ttl": "5m",
+        "subagent_cache_ttl": "inherit",
     },
 
     # OpenRouter-specific settings.

--- a/tests/agent/test_subagent_cache_ttl.py
+++ b/tests/agent/test_subagent_cache_ttl.py
@@ -1,0 +1,119 @@
+"""prompt_caching.subagent_cache_ttl — per-subagent prompt-cache TTL override.
+
+Inspired by Claude Code v2.1.243's ``promptCacheTtl`` / ``subagentPromptCacheTtl``
+split: the 1h Anthropic cache tier costs 2x on writes and only amortizes across
+a long-lived conversation. Delegation subagents live minutes, so operators can
+keep a 1h main-session cache while pinning subagents to 5m (or disabling
+subagent caching entirely) without touching the main conversation's tier.
+
+Contract pinned here (agent/agent_init.py):
+- default ``"inherit"`` (or any unknown value) → subagents keep ``cache_ttl``
+- ``"5m"`` / ``"1h"`` → subagents get that tier regardless of ``cache_ttl``
+- disable synonym (``"off"``, ``false``, …) → caching disabled for subagents
+  only; the main agent's tier is untouched
+- non-subagent platforms never read the key
+"""
+
+import contextlib
+import io
+
+import pytest
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _config(cache_ttl="1h", subagent_cache_ttl=None):
+    pc = {"cache_ttl": cache_ttl}
+    if subagent_cache_ttl is not None:
+        pc["subagent_cache_ttl"] = subagent_cache_ttl
+    return {
+        "prompt_caching": pc,
+        "sessions": {},
+        "bedrock": {},
+    }
+
+
+def _make_agent(monkeypatch, tmp_path, *, platform, cache_ttl="1h",
+                subagent_cache_ttl=None):
+    from hermes_cli import config as config_mod
+
+    cfg = _config(cache_ttl=cache_ttl, subagent_cache_ttl=subagent_cache_ttl)
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda: cfg)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        with contextlib.redirect_stdout(io.StringIO()):
+            agent = AIAgent(
+                base_url="https://openrouter.ai/api/v1",
+                api_key="test-key",
+                provider="openrouter",
+                model="anthropic/claude-opus-4.8",
+                enabled_toolsets=[],
+                disabled_toolsets=[],
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                session_db=db,
+                platform=platform,
+            )
+        return agent
+    finally:
+        db.close()
+
+
+class TestSubagentCacheTtlOverride:
+    def test_default_inherit_keeps_main_ttl(self, monkeypatch, tmp_path):
+        agent = _make_agent(monkeypatch, tmp_path, platform="subagent",
+                            cache_ttl="1h")
+        assert agent._cache_ttl == "1h"
+        assert agent._cache_disabled is False
+
+    def test_explicit_inherit_keeps_main_ttl(self, monkeypatch, tmp_path):
+        agent = _make_agent(monkeypatch, tmp_path, platform="subagent",
+                            cache_ttl="1h", subagent_cache_ttl="inherit")
+        assert agent._cache_ttl == "1h"
+
+    def test_5m_override_downgrades_subagent_only(self, monkeypatch, tmp_path):
+        agent = _make_agent(monkeypatch, tmp_path, platform="subagent",
+                            cache_ttl="1h", subagent_cache_ttl="5m")
+        assert agent._cache_ttl == "5m"
+        assert agent._cache_disabled is False
+
+    def test_1h_override_upgrades_subagent(self, monkeypatch, tmp_path):
+        agent = _make_agent(monkeypatch, tmp_path, platform="subagent",
+                            cache_ttl="5m", subagent_cache_ttl="1h")
+        assert agent._cache_ttl == "1h"
+
+    def test_disable_synonym_disables_subagent_caching(self, monkeypatch, tmp_path):
+        agent = _make_agent(monkeypatch, tmp_path, platform="subagent",
+                            cache_ttl="1h", subagent_cache_ttl="off")
+        assert agent._cache_ttl is None
+        assert agent._cache_disabled is True
+        assert agent._use_prompt_caching is False
+        assert agent._use_native_cache_layout is False
+
+    def test_unknown_value_falls_back_to_main_ttl(self, monkeypatch, tmp_path):
+        # Unknown tiers are neither valid nor a disable synonym — keep the
+        # main cache_ttl, matching cache_ttl's own unknown-value behavior.
+        agent = _make_agent(monkeypatch, tmp_path, platform="subagent",
+                            cache_ttl="1h", subagent_cache_ttl="2h")
+        assert agent._cache_ttl == "1h"
+        assert agent._cache_disabled is False
+
+
+class TestNonSubagentPlatformsIgnoreOverride:
+    @pytest.mark.parametrize("platform", ["cli", "telegram", None])
+    def test_main_agent_ignores_subagent_key(self, monkeypatch, tmp_path, platform):
+        agent = _make_agent(monkeypatch, tmp_path, platform=platform,
+                            cache_ttl="1h", subagent_cache_ttl="off")
+        assert agent._cache_ttl == "1h"
+        assert agent._cache_disabled is False
+
+    def test_main_agent_disable_still_works(self, monkeypatch, tmp_path):
+        # Sibling guard: the main cache_ttl disable path is untouched.
+        agent = _make_agent(monkeypatch, tmp_path, platform="cli",
+                            cache_ttl="off")
+        assert agent._cache_ttl is None
+        assert agent._cache_disabled is True

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -518,6 +518,7 @@ Prompt caching is automatically enabled when:
 # config.yaml — TTL is configurable (must be "5m" or "1h")
 prompt_caching:
   cache_ttl: "5m"
+  subagent_cache_ttl: "inherit"  # per-subagent tier override ("5m"/"1h"/disable); "inherit" keeps cache_ttl
 ```
 
 The CLI shows caching status at startup:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1202,10 +1202,13 @@ The one explicit knob is the cache TTL tier Hermes requests on Anthropic-style b
 
 ```yaml
 prompt_caching:
-  cache_ttl: "5m"   # "5m" or "1h" (Anthropic-supported tiers); other values are ignored
+  cache_ttl: "5m"           # "5m" or "1h" (Anthropic-supported tiers); other values are ignored
+  subagent_cache_ttl: "inherit"  # optional per-subagent override: "inherit" (default), "5m", "1h", or a disable value
 ```
 
 `cache_ttl` selects the breakpoint TTL Hermes attaches for Claude via the native Anthropic API, OpenRouter, and Nous Portal. Only the two Anthropic-supported tiers (`"5m"`, `"1h"`) are honored — any other value is ignored. Providers with their own caps (e.g. Qwen Cloud, which maxes at 5 minutes) still clamp to what the upstream allows.
+
+`subagent_cache_ttl` gives delegation subagents (`delegate_task` children, including orchestrator batches) their own tier. The 1h tier costs 2x on cache writes and only pays off across a long-lived conversation — a subagent typically lives minutes, so pinning subagents to `"5m"` while the main session runs `"1h"` avoids paying the 1h write premium on every short-lived child. `"inherit"` (the default) keeps the main `cache_ttl`; a disable value (`"off"`, `false`, …) turns prompt caching off for subagents only.
 
 ## Auxiliary Models
 


### PR DESCRIPTION
## Summary

Delegation subagents can now run their own prompt-cache TTL tier: `prompt_caching.subagent_cache_ttl` lets a 1h main-session cache coexist with 5m subagent caches, so short-lived `delegate_task` children stop paying Anthropic's 2x 1h cache-write premium.

Inspired by Claude Code v2.1.243 (`promptCacheTtl` / `subagentPromptCacheTtl` settings, Aug 25 2026) and v2.1.248 (per-agent `experimental.cacheTtl` frontmatter): https://code.claude.com/docs/en/changelog#2-1-243

## Why

The 1h tier costs 2x on cache writes (vs 1.25x for 5m) and only amortizes across a long-lived conversation with pauses. A subagent typically lives minutes and never pauses — with a global `cache_ttl: "1h"`, every child in a fan-out paid the 1h write premium for a cache that dies with the task. Until now the only knob was global (#14971's `prompt_caching.cache_ttl`).

## How our implementation differs from Claude Code

| | Claude Code | Hermes |
|---|---|---|
| Main setting | `promptCacheTtl` | existing `prompt_caching.cache_ttl` (unchanged) |
| Subagent setting | `subagentPromptCacheTtl` + per-agent `experimental.cacheTtl` frontmatter | `prompt_caching.subagent_cache_ttl` (config.yaml only — no per-agent frontmatter; delegation has no persona files to hang it on) |
| Default | independent values | `"inherit"` — follows `cache_ttl` unless set |
| Disable | n/a | disable synonyms (`"off"`, `false`, …) turn caching off for subagents only |

The override is snapshotted once in `agent_init` for `platform == "subagent"` agents — the tier is fixed for the child's lifetime, so no mid-conversation cache invalidation is possible. Existing clamps (Qwen 1h→5m) still apply downstream via `effective_cache_ttl`.

## Changes

- `agent/agent_init.py`: subagent-platform TTL override in the existing `_cache_ttl` snapshot block (valid tier or disable synonym wins; unknown values inherit)
- `hermes_cli/config_defaults.py`: `prompt_caching.subagent_cache_ttl: "inherit"` default (+ comment)
- `cli-config.yaml.example`: documented alongside `cache_ttl`
- `website/docs/user-guide/configuration.md`, `website/docs/developer-guide/context-compression-and-caching.md`: docs
- `tests/agent/test_subagent_cache_ttl.py`: 10 tests with real `AIAgent` construction (override tiers, disable, inherit, unknown-value fallback, non-subagent platforms ignore the key, main disable path unchanged)

## Validation

| Check | Result |
|---|---|
| `tests/agent/test_subagent_cache_ttl.py` | 10 passed |
| Sabotage run (agent_init change reverted) | 3 override tests fail as designed |
| Sibling caching suites (`test_prompt_cache_ttl_propagation`, `test_cache_disabled_on_stubs`, `test_prompt_caching`, `test_codex_gpt55_autoraise_notice`) | 69 passed |
| Config suites (`test_config`, `test_config_validation`) | 121 passed, 4 skipped |

## Infographic

![Subagent cache TTL — arcade attract screen](https://v3b.fal.media/files/b/0aa836ff/jz0N4eF1nwA8GARTeNVc5_JhEyzCwy.png)
