### PR TITLE
fix(desktop): keep user-placed enforce panes across boots

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Enforced dock invariants: a pane whose dock hint carries `enforce: true`
-// (Bot Mode's Bots pane) re-homes onto its center anchor at EVERY boot's
-// first adoption pass — persisted layouts otherwise pin the stale stacked
-// arrangement forever, because adoption only ever places panes MISSING from
-// the tree. Unlike the retired one-time heal, nothing exempts the pane: not
-// a previously burned heal token, not $userPlacedPanes. The invariant is
-// boot-scoped, so an intra-session drag sticks until the next launch.
+// (Bot Mode's Bots pane, Cronjobs) is guaranteed present and sanely docked
+// at boot. A stale stacked arrangement WITHOUT a user-placed record still
+// re-homes — persisted layouts otherwise pin that broken shape forever,
+// because adoption only ever places panes MISSING from the tree. A pane the
+// user explicitly dragged (`$userPlacedPanes`) whose persisted group still
+// resolves keeps that spot across boots. An unusable persisted spot (the
+// pane's group no longer resolves) re-homes even when the drag record
+// exists. Unlike the retired one-time heal, a burned heal token does not
+// exempt the pane. The invariant is boot-scoped, so an intra-session drag
+// sticks until the next launch.
 
 const TREE_KEY = 'hermes.desktop.layoutTree.v2'
 const USER_PLACED_KEY = 'hermes.desktop.userPlacedPanes.v1'
@@ -109,7 +113,7 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
     expect(JSON.stringify(persisted)).toContain('"panes":["sessions","hermes-bots:pane"]')
   })
 
-  it('re-homes even a USER-PLACED pane — the owner invariant beats the drag record', async () => {
+  it('keeps a USER-PLACED pane whose persisted group still resolves', async () => {
     window.localStorage.setItem(USER_PLACED_KEY, JSON.stringify(['hermes-bots:pane']))
 
     const { model, tree } = await setup()
@@ -118,7 +122,10 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
 
     const group = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:pane')!
 
-    expect(group.panes).toEqual(['sessions', 'hermes-bots:pane'])
+    // The user dragged Bots out of the sessions strip into its own zone.
+    // That group still resolves, so boot must not stomp it.
+    expect(group.panes).toEqual(['hermes-bots:pane'])
+    expect(group.id).toBe('g-bots')
   })
 
   it('re-homes even when the retired heal token was already burned, and clears the stale ledger', async () => {
@@ -243,6 +250,88 @@ describe('enforced dock (stacked Bots pane → sessions-zone tab, every boot)', 
     expect(botsGroup.active).toBe('hermes-bots:pane')
     expect(routinesGroup.panes).toEqual(['hermes-bots:routines'])
     expect(routinesGroup.id).not.toBe(botsGroup.id)
+  })
+
+  it('keeps a USER-PLACED edge-enforced pane at a resolvable stacked spot', async () => {
+    // Field report: Cronjobs (`pos: 'right'` of workspace, `enforce: true`)
+    // was dragged into its own zone under the chat. That placement is
+    // recorded and still resolves — boot must not yank it back to a
+    // workspace-right split.
+    const userStackedRoutinesTree = {
+      type: 'split',
+      id: 'root',
+      orientation: 'row',
+      weights: [1, 3],
+      children: [
+        {
+          type: 'group',
+          id: 'g-sessions',
+          panes: ['sessions', 'hermes-bots:pane'],
+          active: 'hermes-bots:pane'
+        },
+        {
+          type: 'split',
+          id: 'main-col',
+          orientation: 'column',
+          weights: [3, 1],
+          children: [
+            { type: 'group', id: 'g-main', panes: ['workspace'], active: 'workspace' },
+            {
+              type: 'group',
+              id: 'g-routines',
+              panes: ['hermes-bots:routines'],
+              active: 'hermes-bots:routines'
+            }
+          ]
+        }
+      ]
+    }
+
+    window.localStorage.setItem(USER_PLACED_KEY, JSON.stringify(['hermes-bots:routines']))
+
+    const { model, tree } = await setupTree(userStackedRoutinesTree, { routines: true })
+
+    tree.watchContributedPanes()
+
+    const routinesGroup = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:routines')!
+
+    expect(routinesGroup.panes).toEqual(['hermes-bots:routines'])
+    expect(routinesGroup.id).toBe('g-routines')
+    expect(tree.$layoutTree.get()).toEqual(userStackedRoutinesTree)
+  })
+
+  it('re-homes a USER-PLACED pane whose persisted group no longer resolves', async () => {
+    // Anchor destroyed: Cronjobs was user-placed, but its group is gone from
+    // the persisted tree (the pane is missing). Enforce + adoption must still
+    // guarantee it is present and docked on workspace's right edge.
+    const missingRoutinesTree = {
+      type: 'split',
+      id: 'root',
+      orientation: 'row',
+      weights: [1, 3],
+      children: [
+        {
+          type: 'group',
+          id: 'g-sessions',
+          panes: ['sessions', 'hermes-bots:pane'],
+          active: 'hermes-bots:pane'
+        },
+        { type: 'group', id: 'g-main', panes: ['workspace'], active: 'workspace' }
+      ]
+    }
+
+    window.localStorage.setItem(USER_PLACED_KEY, JSON.stringify(['hermes-bots:routines']))
+
+    const { model, tree } = await setupTree(missingRoutinesTree, { routines: true })
+
+    tree.watchContributedPanes()
+
+    const routinesGroup = model.findGroupOfPane(tree.$layoutTree.get()!, 'hermes-bots:routines')!
+    const workspaceGroup = model.findGroupOfPane(tree.$layoutTree.get()!, 'workspace')!
+
+    expect(routinesGroup.panes).toEqual(['hermes-bots:routines'])
+    expect(routinesGroup.id).not.toBe(workspaceGroup.id)
+    expect(routinesGroup.id).not.toBe('g-sessions')
   })
 
   it('leaves an edge-enforced pane alone when it already occupies the declared split', async () => {

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1221,11 +1221,12 @@ interface PaneDockHint {
   pos: DropPosition
   /** Center docks: stack BEFORE this pane id (the strip divider's slot). */
   before?: null | string
-  /** Enforced dock invariant: the pane is re-homed onto this hint's anchor
-   *  on EVERY boot when it isn't already in the declared relationship —
-   *  no one-time token, and user placement does not exempt it. Once per
-   *  adoption lifetime (per boot), so an intra-session drag sticks until the
-   *  next boot. See `enforceDockedPanes`. */
+  /** Enforced dock invariant: at boot the pane is guaranteed present and
+   *  sanely docked. Re-homes when it is missing, has no user-placed record,
+   *  or its persisted group no longer resolves. A user-dragged pane whose
+   *  spot still resolves is left alone. Once per adoption lifetime (per
+   *  boot), so an intra-session drag sticks until the next boot. See
+   *  `enforceDockedPanes`. */
   enforce?: boolean
 }
 
@@ -1241,14 +1242,15 @@ writeKey('hermes.desktop.paneDockHeals.v1', null)
 const enforcedDocksThisBoot = new Set<string>()
 
 /**
- * A `panes` contribution whose dock hint carries `enforce: true` is re-homed
- * onto the hint's anchor at every boot's first adoption pass when it isn't
- * already docked there. Unlike the retired one-time heal, nothing
- * exempts the pane — not a burned token, not $userPlacedPanes — because the
- * hint is the owner's standing invariant about where the pane lives
- * (Bot Mode's Bots pane IS the SESSIONS | BOTS tab strip), not a one-shot
- * migration. Center hints consolidate panes into their anchor's tab strip;
- * edge hints restore the declared split beside their anchor.
+ * A `panes` contribution whose dock hint carries `enforce: true` is
+ * guaranteed present and sanely docked at every boot's first adoption pass.
+ * Unlike the retired one-time heal, a burned token does not exempt it —
+ * that ledger skipped the users who had fought a stacked layout and then
+ * pinned the broken shape forever. `$userPlacedPanes` DOES exempt a pane
+ * whose persisted group still resolves: enforce means "here if missing or
+ * unusable", not "override the user on every launch". Center hints
+ * consolidate panes into their anchor's tab strip; edge hints restore the
+ * declared split beside their anchor.
  *
  * Silent like adoption — the anchor zone keeps its active tab. The center
  * insert pins the zone's header shown, which is the point: the strip is how
@@ -1277,6 +1279,13 @@ function enforceDockedPanes(
     const anchor = findGroupOfPane(next, dock.pane)
 
     if (!from || !anchor) {
+      continue
+    }
+
+    // User dragged this pane and the persisted group still resolves — keep
+    // that spot. Missing panes never reach this loop; adoption places them
+    // on the hint, which is how a destroyed group still re-homes.
+    if ($userPlacedPanes.get().has(pane.id)) {
       continue
     }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
@@ -4,10 +4,10 @@
  *
  *  - the Bots pane center-stacks into the sessions zone (a SESSIONS | BOTS tab
  *    strip), never splits below it, and carries the ENFORCED dock invariant so
- *    every boot re-homes a stacked install. No heal token, no user-placed
- *    exemption — the retired one-shot heal burned its token even when its
- *    guards skipped the move, so exactly the users who had dragged their panes
- *    stayed stacked forever;
+ *    a stacked install with no user-placed record re-homes at boot. No heal
+ *    token — the retired one-shot heal burned its token even when its guards
+ *    skipped the move, pinning the broken stacked shape forever. User-placed
+ *    exemption lives in the tree store (`enforceDockedPanes`), not on the hint;
  *  - the Scheduled jobs (internally `routines`) pane only exists while a BOT
  *    CHAT owns the main workspace and the Bots pane is on screen. It is
  *    registered and unregistered through the contribution disposer, driven by

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -368,15 +368,14 @@ export default {
       // never vanish behind a stripless Bots tab — the lone-pane auto-hide
       // trap this dock used to work around with a 'bottom' split.
       // enforce: standing invariant, not a one-shot migration — the pane
-      // re-homes into the sessions strip at EVERY boot it isn't already
-      // there, whatever tokens or user placement an older install persisted.
-      // The one-time heal ('sessions-tab-v1') burned its token even when its
-      // guards skipped the move, so exactly the users who had fought the old
-      // stacked layout (dragged panes → $userPlacedPanes) stayed stacked
-      // forever. Owner's order: SESSIONS | BOTS is always a tab strip.
-      // An intra-session drag still sticks until the next launch (the
-      // invariant runs at adoption time only — see enforceDockedPanes in the
-      // tree store).
+      // is guaranteed present and sanely docked at boot. A stale stacked
+      // layout with no user-placed record still re-homes into the sessions
+      // strip (the retired one-time heal burned its token even when its
+      // guards skipped the move, pinning that broken shape forever). A pane
+      // the user dragged (`$userPlacedPanes`) whose persisted group still
+      // resolves keeps that spot. An intra-session drag still sticks until
+      // the next launch (the invariant runs at adoption time only — see
+      // enforceDockedPanes in the tree store).
       // collapsible: the pane lives in the sessions zone, so it must LEAVE
       // the grid with that zone below the sidebar-collapse breakpoint. The
       // sessions pane collapses alone without this flag. The zone then keeps


### PR DESCRIPTION
## What does this PR do?

Makes the enforced dock invariant respect deliberate user placement. Bot Mode's Cronjobs pane (`hermes-bots:routines`, dock `{ pane: 'workspace', pos: 'right', enforce: true }`) — and any other `enforce: true` pane — currently re-homes at **every boot's** first adoption pass, so a user who drags it elsewhere loses that placement on every launch, forever.

This is a follow-up to #88872, which (deliberately) made enforce unconditional because the retired one-time heal burned its token even when its guards skipped the move, pinning broken stacked layouts forever. This PR keeps that guarantee while narrowing it: **enforce now means "guaranteed present and sanely docked", not "override the user on every launch".**

- Re-home still happens when the pane is missing from the tree, has no user-placed record, or its persisted spot no longer resolves (missing pane → adoption places it on the hint).
- The move is skipped when `$userPlacedPanes` (`hermes.desktop.userPlacedPanes.v1`, already written by `moveTreePane` / `moveTreePanes` / `mergeTreeZones`) contains the pane and `findGroupOfPane` still resolves it.
- A burned heal token still does not exempt anything; intra-session drags still stick until next launch (`enforcedDocksThisBoot`).

The original #88872 regressions (stacked Bots pane, stranded Cronjobs, no drag record) re-home exactly as today — covered by the kept tests.

Reproduced on real macOS installs (Hermes Desktop v0.20.5); fix developed and verified against current `main`. Related: #94726 (Bot Mode umbrella sweep).

## Related Issue

Related: #88872 (introduced the unconditional invariant), #94726 (Bot Mode tracking umbrella). No standalone issue exists for this; the repro below is complete.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/store.ts` — `enforceDockedPanes` skips a pane recorded in `$userPlacedPanes` whose group still resolves; doc comments updated to the narrowed invariant.
- `apps/desktop/src/components/pane-shell/tree/dock-enforce.test.ts` — existing regression shapes kept; the "user placement is overridden" case now asserts survival (paired with the kept no-record variant); new cases: user-placed pane survives boot, user-placed pane whose group vanished is re-adopted onto the hint.
- `apps/desktop/src/plugins/hermes-bots/plugin.tsx` / `plugin-panes.test.tsx` — comment/test-description updates only (they documented the old invariant verbatim).

## How to Test

1. Repro on `main`: enable Bot Mode, drag the Cronjobs pane off workspace-right (e.g. stack it elsewhere), quit, relaunch → it's back on workspace-right. On this branch: it stays where you put it.
2. `cd apps/desktop && npx vitest run src/components/pane-shell/tree/dock-enforce.test.ts` → 10 passed (the two new survival tests fail on unfixed `main`).
3. `cd apps/desktop && npm run test:ui` → 679 files / 6707 tests passed.
4. `cd apps/desktop && npm run check:lint` → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suites relevant to this change — desktop-only: `npm run test:ui` (6707 passed) and `npm run check:lint`; the Python agent is untouched
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple silicon), repro confirmed on Hermes Desktop v0.20.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the invariant doc comments in `store.ts` / `plugin.tsx`
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — layout-store logic only, no platform APIs
- [x] Tool descriptions/schemas — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
