### PR TITLE
fix(desktop): keep Bot Chat tab identity across backend restarts

### DIFF
--- a/apps/desktop/src/app/chat/canonical-tab-title.test.ts
+++ b/apps/desktop/src/app/chat/canonical-tab-title.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { CANONICAL_BOT_CHAT_TITLE, canonicalSessionTabCaption, isCanonicalBotChatTitle } from './canonical-tab-title'
+
+describe('isCanonicalBotChatTitle', () => {
+  it('treats root_title Bot Chat as canonical even when the listing title drifted', () => {
+    expect(isCanonicalBotChatTitle('hey there', 'Bot Chat')).toBe(true)
+  })
+
+  it('treats stored title Bot Chat as canonical when root_title is absent', () => {
+    expect(isCanonicalBotChatTitle('Bot Chat', undefined)).toBe(true)
+    expect(isCanonicalBotChatTitle('Bot Chat', '')).toBe(true)
+  })
+
+  it('does not treat a preview-shaped title as canonical', () => {
+    expect(isCanonicalBotChatTitle('hey there', undefined)).toBe(false)
+    expect(isCanonicalBotChatTitle('', 'Daily notes')).toBe(false)
+  })
+})
+
+describe('canonicalSessionTabCaption', () => {
+  it('keeps Bot Chat on canonical re-bind instead of a preview-derived caption', () => {
+    expect(
+      canonicalSessionTabCaption({
+        preview: 'what is the weather in oslo',
+        rootTitle: 'Bot Chat',
+        title: '',
+        untitledFallback: 'New session'
+      })
+    ).toBe(CANONICAL_BOT_CHAT_TITLE)
+
+    expect(
+      canonicalSessionTabCaption({
+        preview: 'what is the weather in oslo',
+        title: 'Bot Chat'
+      })
+    ).toBe(CANONICAL_BOT_CHAT_TITLE)
+
+    expect(
+      canonicalSessionTabCaption({
+        preview: 'what is the weather in oslo',
+        title: '',
+        workspaceTabTitle: 'Bot Chat'
+      })
+    ).toBe(CANONICAL_BOT_CHAT_TITLE)
+  })
+
+  it('keeps preview captions for non-canonical sessions', () => {
+    expect(
+      canonicalSessionTabCaption({
+        preview: 'what is the weather in oslo',
+        title: '',
+        untitledFallback: 'New session'
+      })
+    ).toBe('what is the weather in oslo')
+
+    expect(
+      canonicalSessionTabCaption({
+        preview: 'ignored because a real title exists',
+        title: 'Daily notes'
+      })
+    ).toBe('Daily notes')
+  })
+})

--- a/apps/desktop/src/app/chat/canonical-tab-title.ts
+++ b/apps/desktop/src/app/chat/canonical-tab-title.ts
@@ -1,0 +1,55 @@
+/**
+ * Canonical Bot Chat tab identity — the session titled exactly "Bot Chat"
+ * must keep that caption on re-bind/restore, never a message-derived preview.
+ *
+ * Identity is the NAME (see repo AGENTS.md Bot Mode). `root_title` is the
+ * durable lineage-root title exact-lookup gateways report; `title` covers
+ * windowed listings and the stored row.
+ */
+
+export const CANONICAL_BOT_CHAT_TITLE = 'Bot Chat'
+
+export function isCanonicalBotChatTitle(title?: null | string, rootTitle?: null | string): boolean {
+  const root = String(rootTitle || '').trim()
+  const stored = String(title || '').trim()
+
+  return root === CANONICAL_BOT_CHAT_TITLE || stored === CANONICAL_BOT_CHAT_TITLE
+}
+
+/** Caption for a session tab / tile. Canonical Bot Chat always wins over a
+ *  preview-derived listing title. Non-canonical sessions keep title → preview
+ *  → fallback, matching `sessionTitle`. */
+export function canonicalSessionTabCaption(input: {
+  preview?: null | string
+  rootTitle?: null | string
+  title?: null | string
+  untitledFallback?: string
+  workspaceTabTitle?: null | string
+}): string {
+  if (
+    isCanonicalBotChatTitle(input.title, input.rootTitle) ||
+    String(input.workspaceTabTitle || '').trim() === CANONICAL_BOT_CHAT_TITLE
+  ) {
+    return CANONICAL_BOT_CHAT_TITLE
+  }
+
+  const title = String(input.title || '').trim()
+
+  if (title) {
+    return title
+  }
+
+  const explicit = String(input.workspaceTabTitle || '').trim()
+
+  if (explicit) {
+    return explicit
+  }
+
+  const preview = String(input.preview || '').trim()
+
+  if (preview) {
+    return preview
+  }
+
+  return input.untitledFallback ?? 'Untitled session'
+}

--- a/apps/desktop/src/app/chat/session-tile.test.ts
+++ b/apps/desktop/src/app/chat/session-tile.test.ts
@@ -1,6 +1,29 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
-import { sessionTileResumeFailure } from './session-tile'
+import { setSessions } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
+
+import { sessionTileResumeFailure, tileTitle } from './session-tile'
+
+function listed(over: Partial<SessionInfo>): SessionInfo {
+  return {
+    ended_at: null,
+    id: 'bot-chat',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1,
+    message_count: 2,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: 'desktop',
+    started_at: 1,
+    title: null,
+    tool_call_count: 0,
+    ...over
+  }
+}
 
 describe('sessionTileResumeFailure', () => {
   it('keeps a confirmed durable session retryable instead of repeating a stale 404', () => {
@@ -15,5 +38,33 @@ describe('sessionTileResumeFailure', () => {
 
   it('does not overwrite a tile that rebound while the lookup was pending', () => {
     expect(sessionTileResumeFailure('session not found', true, false)).toBeUndefined()
+  })
+})
+
+describe('tileTitle canonical Bot Chat identity', () => {
+  afterEach(() => {
+    setSessions([])
+    $sessionTiles.set([])
+  })
+
+  it('keeps Bot Chat on re-bind instead of a preview-derived listing caption', () => {
+    setSessions([listed({ id: 'bot-chat', preview: 'what is the weather in oslo', root_title: 'Bot Chat', title: '' })])
+    $sessionTiles.set([{ storedSessionId: 'bot-chat', workspaceMode: 'bots' }])
+
+    expect(tileTitle('bot-chat')).toBe('Bot Chat')
+  })
+
+  it('keeps Bot Chat when the tile already carries the canonical tab title', () => {
+    setSessions([listed({ id: 'bot-chat', preview: 'what is the weather in oslo', title: '' })])
+    $sessionTiles.set([{ storedSessionId: 'bot-chat', workspaceMode: 'bots', workspaceTabTitle: 'Bot Chat' }])
+
+    expect(tileTitle('bot-chat')).toBe('Bot Chat')
+  })
+
+  it('keeps preview captions for non-canonical sessions', () => {
+    setSessions([listed({ id: 'notes', preview: 'what is the weather in oslo', title: '' })])
+    $sessionTiles.set([{ storedSessionId: 'notes' }])
+
+    expect(tileTitle('notes')).toBe('what is the weather in oslo')
   })
 })

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -33,7 +33,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
-import { NEW_SESSION_TITLE, sessionTitle } from '@/lib/chat-runtime'
+import { NEW_SESSION_TITLE } from '@/lib/chat-runtime'
 import { transcribeAudioClientDirect } from '@/lib/voice-client-direct'
 import { createComposerAttachmentScope, draftTitleFor } from '@/store/composer'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
@@ -60,6 +60,7 @@ import {
 } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
+import { canonicalSessionTabCaption } from './canonical-tab-title'
 import type { SessionDragPayload } from './composer/inline-refs'
 import { type ComposerScope, ComposerScopeProvider } from './composer/scope'
 import { useComposerActions } from './hooks/use-composer-actions'
@@ -448,11 +449,17 @@ export function tileStoredRow(storedSessionId: string): SessionInfo | undefined 
  *  per keystroke would re-render the strip, and holding the draft's text here
  *  would let the registered name already match the row that lands on send —
  *  skipping the re-register that hands the tab back to this string. */
-function tileTitle(storedSessionId: string): string {
+export function tileTitle(storedSessionId: string): string {
   const stored = tileStoredRow(storedSessionId)
   const explicit = $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.workspaceTabTitle
 
-  return stored ? sessionTitle(stored) : explicit || NEW_SESSION_TITLE
+  return canonicalSessionTabCaption({
+    preview: stored?.preview,
+    rootTitle: stored?.root_title,
+    title: stored?.title,
+    untitledFallback: stored ? 'Untitled session' : NEW_SESSION_TITLE,
+    workspaceTabTitle: explicit
+  })
 }
 
 /** The `@session` link payload for a tile tab drag — id + owning profile + title.
@@ -460,7 +467,14 @@ function tileTitle(storedSessionId: string): string {
 function tileDragPayload(storedSessionId: string): SessionDragPayload {
   const stored = tileStoredRow(storedSessionId)
   const explicit = $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.workspaceTabTitle
-  const title = stored ? sessionTitle(stored) : explicit || draftTitleFor(storedSessionId) || NEW_SESSION_TITLE
+
+  const title = canonicalSessionTabCaption({
+    preview: stored?.preview,
+    rootTitle: stored?.root_title,
+    title: stored?.title,
+    untitledFallback: draftTitleFor(storedSessionId) || NEW_SESSION_TITLE,
+    workspaceTabTitle: explicit
+  })
 
   return { id: storedSessionId, profile: stored?.profile ?? '', title }
 }

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { atom, computed } from 'nanostores'
 import type { CSSProperties, ReactElement, PointerEvent as ReactPointerEvent } from 'react'
 
+import { CANONICAL_BOT_CHAT_TITLE, canonicalSessionTabCaption } from '@/app/chat/canonical-tab-title'
 import { SessionDraftTitle } from '@/app/chat/session-draft-title'
 import { SessionStatusDot } from '@/app/chat/session-status-dot'
 import { PALETTE_AREA, type PaletteContribution, paletteToggle } from '@/app/command-palette/contrib'
@@ -70,6 +71,7 @@ import {
 } from '@/store/review'
 import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionMatchesStoredId } from '@/store/session'
 import { watchSessionPins } from '@/store/session-pin-sync'
+import { $sessionTiles, isCanonicalBotChatSession } from '@/store/session-states'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
 import { isBrowserWindow, isHudWindow } from '@/store/windows'
@@ -484,12 +486,27 @@ const syncWorkspaceTitle = () => {
   const selected = $selectedStoredSessionId.get()
   const stored = selected ? $sessions.get().find(s => sessionMatchesStoredId(s, selected)) : null
 
+  const explicit = selected
+    ? $sessionTiles.get().find(tile => tile.storedSessionId === selected)?.workspaceTabTitle
+    : undefined
+
+  const title =
+    selected && isCanonicalBotChatSession(selected)
+      ? CANONICAL_BOT_CHAT_TITLE
+      : canonicalSessionTabCaption({
+          preview: stored?.preview,
+          rootTitle: stored?.root_title,
+          title: stored?.title,
+          untitledFallback: stored ? 'Untitled session' : NEW_SESSION_TITLE,
+          workspaceTabTitle: explicit
+        })
+
   registry.register({
     id: 'workspace',
     area: 'panes',
     // The placeholder, not the draft's live name — `tabTitle` below renders
     // that. Keeping it here would re-register the pane on every keystroke.
-    title: stored ? storedSessionTitle(stored) : NEW_SESSION_TITLE,
+    title,
     data: {
       // The tab's status dot — the SAME primitive the sidebar row and session
       // tiles render, so the main tab never disagrees with its sidebar row. A

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1996,6 +1996,39 @@ describe('resumeSession drops a redundant tile when the session loads into main'
     // Only the resumed session's tile closes; the sibling tile stays put.
     expect($sessionTiles.get().map(t => t.storedSessionId)).toEqual(['stored-2'])
   })
+
+  it('does not close a canonical Bot Chat tile when the session loads into main', async () => {
+    $sessionTiles.set([
+      {
+        storedSessionId: 'bot-chat',
+        workspaceMode: 'bots',
+        workspaceTabTitle: 'Bot Chat',
+        workspaceOwnerKey: 'bot:local::ops'
+      }
+    ])
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        return { session_id: 'runtime-bot', resumed: params?.session_id, messages: [], info: {} } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [] } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(<ResumeHarness onReady={r => (resume = r)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    await resume!('bot-chat', true)
+
+    expect($sessionTiles.get().some(t => t.storedSessionId === 'bot-chat')).toBe(true)
+    expect($sessionTiles.get()[0]).toMatchObject({
+      storedSessionId: 'bot-chat',
+      workspaceTabTitle: 'Bot Chat'
+    })
+  })
 })
 
 // ── Warm-cache mapping integrity (the "open chat A, chat B loads" bug) ─────────

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -108,6 +108,7 @@ import {
   closeSessionTile,
   dropSessionState,
   holdSessionOwnerUntilForeground,
+  isCanonicalBotChatSession,
   openSessionTile,
   patchSessionTile,
   publishSessionState,
@@ -840,7 +841,13 @@ export function useSessionActions({
       // now-redundant tile so main owns it. Runs before the async awaits below (and
       // before the selection listener homes focus) so the tile is gone the same tick
       // the route takes over; the warm cache/runtime binding survives for main to reuse.
-      if ($sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
+      // Canonical Bot Chat tiles are the exception: a backend restart can 404 the
+      // main resume while the DB row is intact, and closing the tile dumps Bot Mode
+      // to the home screen. Those tabs re-bind in place.
+      if (
+        $sessionTiles.get().some(t => t.storedSessionId === storedSessionId) &&
+        !isCanonicalBotChatSession(storedSessionId)
+      ) {
         closeSessionTile(storedSessionId)
       }
 
@@ -1867,7 +1874,7 @@ export function useSessionActions({
 
           const verdict = goneSessionVerdict({
             createdThisRun: createdThisRun.has(storedSessionId),
-            stillListed,
+            stillListed: stillListed || isCanonicalBotChatSession(storedSessionId),
             switchInFlight:
               $gatewaySwitching.get() ||
               Boolean($gatewaySwapTarget.get()) ||

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -16,6 +16,7 @@ import type { SessionProfileRoute } from '@/store/session-request-router'
 import type { SessionTile } from '@/store/session-states'
 import type * as SessionStatesModule from '@/store/session-states'
 import {
+  $canonicalBotChatSessionIds,
   $focusedStoredSessionId,
   $sessionStates,
   $sessionTiles,
@@ -26,6 +27,7 @@ import {
   focusOpenSession,
   focusWorkspaceOwnerSessionTile,
   foregroundSessionScopes,
+  isCanonicalBotChatSession,
   isSessionRemote,
   knownOwnerForSession,
   markSelectionRestore,
@@ -106,6 +108,8 @@ describe('foregroundSessionScopes', () => {
 describe('resetTileRuntimeBindings', () => {
   afterEach(() => {
     $sessionTiles.set([])
+    $canonicalBotChatSessionIds.set(new Set())
+    setSessions([])
   })
 
   it('invalidates the delegate wiring cache AND drops tile runtime ids (sleep/wake reconnect)', () => {
@@ -233,6 +237,82 @@ describe('resetTileRuntimeBindings', () => {
     expect(workBot).toMatchObject({ runtimeId: 'runtime-work-live', storedSessionId: 'stored-work-bot' })
     expect(ordinarySession).not.toHaveProperty('runtimeId')
     expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set(['stored-work-bot']))
+  })
+
+  it('re-applies the Bot Chat tab title when a canonical tile rebinds after disconnect', () => {
+    setSessions([
+      {
+        ended_at: null,
+        id: 'bot-chat',
+        input_tokens: 0,
+        is_active: false,
+        last_active: 1,
+        message_count: 2,
+        model: null,
+        output_tokens: 0,
+        preview: 'what is the weather in oslo',
+        source: 'desktop',
+        started_at: 1,
+        title: 'Bot Chat',
+        tool_call_count: 0
+      }
+    ])
+    $sessionTiles.set([
+      {
+        runtimeId: 'runtime-dead',
+        storedSessionId: 'bot-chat',
+        workspaceMode: 'bots',
+        workspaceOwnerKey: 'bot:local::ops'
+      }
+    ])
+
+    resetTileRuntimeBindings()
+
+    const rebound = $sessionTiles.get()[0]
+
+    expect(rebound.storedSessionId).toBe('bot-chat')
+    expect(rebound.runtimeId).toBeUndefined()
+    expect(rebound.workspaceTabTitle).toBe('Bot Chat')
+    expect(rebound.workspaceMode).toBe('bots')
+    expect($sessionTiles.get()).toHaveLength(1)
+  })
+
+  it('does not remove a canonical Bot Chat tile on backend reconnect', () => {
+    $sessionTiles.set([
+      {
+        runtimeId: 'runtime-dead',
+        storedSessionId: 'bot-chat',
+        workspaceMode: 'bots',
+        workspaceTabTitle: 'Bot Chat',
+        workspaceOwnerKey: 'bot:local::ops'
+      }
+    ])
+
+    resetTileRuntimeBindings()
+
+    expect($sessionTiles.get()).toEqual([
+      expect.objectContaining({
+        storedSessionId: 'bot-chat',
+        workspaceMode: 'bots',
+        workspaceTabTitle: 'Bot Chat'
+      })
+    ])
+    expect($sessionTiles.get()[0]).not.toHaveProperty('runtimeId')
+  })
+})
+
+describe('isCanonicalBotChatSession', () => {
+  afterEach(() => {
+    $sessionTiles.set([])
+    $canonicalBotChatSessionIds.set(new Set())
+    setSessions([])
+  })
+
+  it('recognizes a tile that already carries the canonical tab title', () => {
+    $sessionTiles.set([{ storedSessionId: 'bot-chat', workspaceTabTitle: 'Bot Chat' }])
+
+    expect(isCanonicalBotChatSession('bot-chat')).toBe(true)
+    expect(isCanonicalBotChatSession('other')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -19,6 +19,7 @@
 import { LOCAL_CONNECTION_ID, registryBackendScopeKey } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
+import { CANONICAL_BOT_CHAT_TITLE, isCanonicalBotChatTitle } from '@/app/chat/canonical-tab-title'
 import type { ClientSessionState } from '@/app/types'
 import { findGroup, findGroupOfPane, type LayoutNode } from '@/components/pane-shell/tree/model'
 import {
@@ -1087,23 +1088,74 @@ export const $botChatSessionIds = atom<ReadonlySet<string>>(
   new Set((readJson<unknown>(BOT_CHAT_SCOPE_KEY) as unknown[] | null)?.filter(id => typeof id === 'string') ?? [])
 )
 
-function rememberBotChatScope(storedSessionId: string, isBotChat: boolean): void {
-  const current = $botChatSessionIds.get()
+const CANONICAL_BOT_CHAT_IDS_KEY = 'hermes.desktop.canonicalBotChatSessions.v1'
 
-  if (current.has(storedSessionId) === isBotChat) {
+/** Stored ids last opened as the profile's canonical "Bot Chat". Survives a
+ *  renderer relaunch the way `$botChatSessionIds` does, so a hidden forever-
+ *  chat (absent from `$sessions`) still re-applies its tab title on re-bind. */
+export const $canonicalBotChatSessionIds = atom<ReadonlySet<string>>(
+  new Set(
+    (readJson<unknown>(CANONICAL_BOT_CHAT_IDS_KEY) as unknown[] | null)?.filter(id => typeof id === 'string') ?? []
+  )
+)
+
+function persistIdSet(store: typeof $botChatSessionIds, key: string, storedSessionId: string, present: boolean): void {
+  const current = store.get()
+
+  if (current.has(storedSessionId) === present) {
     return
   }
 
   const next = new Set(current)
 
-  if (isBotChat) {
+  if (present) {
     next.add(storedSessionId)
   } else {
     next.delete(storedSessionId)
   }
 
-  $botChatSessionIds.set(next)
-  writeJson(BOT_CHAT_SCOPE_KEY, next.size ? [...next] : null)
+  store.set(next)
+  writeJson(key, next.size ? [...next] : null)
+}
+
+function rememberBotChatScope(storedSessionId: string, isBotChat: boolean): void {
+  persistIdSet($botChatSessionIds, BOT_CHAT_SCOPE_KEY, storedSessionId, isBotChat)
+}
+
+function rememberCanonicalBotChat(storedSessionId: string, isCanonical: boolean): void {
+  persistIdSet($canonicalBotChatSessionIds, CANONICAL_BOT_CHAT_IDS_KEY, storedSessionId, isCanonical)
+}
+
+/** True when this stored session is the profile's forever-chat titled
+ *  "Bot Chat" — tile tabTitle, persisted canonical set, or listing row. */
+export function isCanonicalBotChatSession(storedSessionId: string): boolean {
+  const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
+
+  if (String(tile?.workspaceTabTitle || '').trim() === CANONICAL_BOT_CHAT_TITLE) {
+    return true
+  }
+
+  if ($canonicalBotChatSessionIds.get().has(storedSessionId)) {
+    return true
+  }
+
+  const stored = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+
+  return isCanonicalBotChatTitle(stored?.title, stored?.root_title)
+}
+
+function reapplyCanonicalTabTitle<T extends SessionTile>(tile: T): T {
+  if (!isCanonicalBotChatSession(tile.storedSessionId)) {
+    return tile
+  }
+
+  rememberCanonicalBotChat(tile.storedSessionId, true)
+
+  if (tile.workspaceTabTitle === CANONICAL_BOT_CHAT_TITLE) {
+    return tile
+  }
+
+  return { ...tile, workspaceTabTitle: CANONICAL_BOT_CHAT_TITLE }
 }
 
 /** True while this live session is a bot's chat rather than a working session.
@@ -1119,6 +1171,12 @@ export function setSessionTileWorkspaceScope(storedSessionId: string, scope: Ses
   // Before the tile lookup: openSession routes every open through here, and a
   // bot chat usually has no tile to record the scope on.
   rememberBotChatScope(storedSessionId, scope.workspaceMode === 'bots')
+
+  if (scope.workspaceMode === 'bots' && String(scope.workspaceTabTitle || '').trim() === CANONICAL_BOT_CHAT_TITLE) {
+    rememberCanonicalBotChat(storedSessionId, true)
+  } else if (scope.workspaceMode !== 'bots') {
+    rememberCanonicalBotChat(storedSessionId, false)
+  }
 
   const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
   const workspaceOwnerKey = scope.workspaceMode === 'bots' ? scope.workspaceOwnerKey : undefined
@@ -1217,7 +1275,15 @@ export function resetTileRuntimeBindings(
   sessionTileDelegate()?.invalidateRuntimeBindings?.(preservedStoredIds)
 
   if (tiles.some(tile => tile.runtimeId && !preservedStoredIds.has(tile.storedSessionId))) {
-    $sessionTiles.set(tiles.map(tile => (preservedStoredIds.has(tile.storedSessionId) ? tile : toStored(tile))))
+    $sessionTiles.set(
+      tiles.map(tile => reapplyCanonicalTabTitle(preservedStoredIds.has(tile.storedSessionId) ? tile : toStored(tile)))
+    )
+  } else {
+    const next = tiles.map(reapplyCanonicalTabTitle)
+
+    if (next.some((tile, i) => tile !== tiles[i])) {
+      $sessionTiles.set(next)
+    }
   }
 }
 
@@ -1753,8 +1819,10 @@ export function reopenLastClosedTile(): void {
 
     if (!$sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
       openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before, {
+        ownerRoute: tile.ownerRoute,
         workspaceMode: tile.workspaceMode ?? 'sessions',
-        workspaceOwnerKey: tile.workspaceOwnerKey
+        workspaceOwnerKey: tile.workspaceOwnerKey,
+        workspaceTabTitle: tile.workspaceTabTitle
       })
       focusOpenSession(storedSessionId)
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -520,6 +520,10 @@ export interface SessionInfo {
    *  Undefined against a backend predating the flag; treat as read. */
   unread?: boolean
   preview: null | string
+  /** Durable lineage-root title when this row is a compression-chain tip.
+   *  Exact-lookup gateways report it so a compacted Bot Chat is still
+   *  recognized by name. Absent on older listings. */
+  root_title?: null | string
   source: null | string
   started_at: number
   title: null | string


### PR DESCRIPTION
## What does this PR do?

Keeps a bot's canonical **Bot Chat** tab identity intact when its per-profile backend restarts. Today, when the `hermes --profile <name> serve` process behind an open Bot Chat dies or restarts (crash, kill, machine load), the renderer can:

- re-bind the tab as a plain session tab whose caption becomes a message-derived preview (the user's last message), and/or
- close the tile entirely and bounce the workspace to the Bots home screen.

The session is fine the whole time — its DB title stays `Bot Chat` (`title_source: user`), and clicking the bot re-runs `createCanonicalChat` and restores everything. This is a renderer identity/re-bind bug, not data loss. Reproduced repeatedly on real macOS installs (v0.20.5); fixed and verified against current `main`.

Root cause is three cooperating paths:

1. **Caption:** `tileTitle` (and the main workspace title sync) prefer `sessionTitle(stored)` = `title || preview` whenever a listing row exists; after reconnect a hidden Bot Chat can surface with a drifted/empty title and a preview — overwriting `workspaceTabTitle: 'Bot Chat'`.
2. **Tile close:** `resumeSession` always closed a matching tile when loading the session into main; a reconnect route-resume that then 404'd had no tile left.
3. **Draft bounce:** the gone path treated resume+REST 404 + `resolveStoredSession` miss as `'draft'` → `startFreshSessionDraft`. Hidden canonical chats are often absent from `$sessions`, so a transient backend-down 404 looked like "session deleted"; empty focus released `$openBotChat` and Bot Mode re-asserted the roster home.

Fix: a canonical caption helper (`root_title` / stored `title` / `workspaceTabTitle` === `Bot Chat` → caption `Bot Chat`), a persisted set of ids opened as canonical (`hermes.desktop.canonicalBotChatSessions.v1`) so hidden forever-chats still identify after reconnect, re-applying the caption on `resetTileRuntimeBindings`, never closing a canonical tile in `resumeSession`, treating a canonical 404 as still-listed → `'retry'`, and `reopenLastClosedTile` restoring `workspaceTabTitle` / `ownerRoute`. Non-canonical sessions are byte-for-byte unchanged (redundant tiles still close; calm 404s still draft).

## Related Issue

Addresses the disappearing / re-labeled Bot Chat symptoms reported in #93618; part of the Bot Mode issue sweep tracked in #94726. Distinct from #94212 (placeholder titles on *unrestored background* tabs — different path, no overlap).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/canonical-tab-title.ts` (new) — pure caption helper + `Bot Chat` identity predicate.
- `apps/desktop/src/app/chat/session-tile.tsx` — `tileTitle` and the tile drag payload use the helper.
- `apps/desktop/src/app/contrib/controller.tsx` — main workspace tab title sync uses the helper.
- `apps/desktop/src/store/session-states.ts` — persisted `$canonicalBotChatSessionIds`; `resetTileRuntimeBindings` re-applies the caption and keeps the tile; `reopenLastClosedTile` restores `workspaceTabTitle` / `ownerRoute`.
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts` — `resumeSession` keeps canonical tiles; canonical 404 → `'retry'`, not `'draft'`.
- `apps/desktop/src/types/hermes.ts` — `root_title` on the session row type.
- Tests: `canonical-tab-title.test.ts` (new), `session-tile.test.ts`, `session-states.test.ts`, `use-session-actions.test.tsx` — canonical re-bind keeps the caption, non-canonical keeps preview, reconnect keeps the tile, resume keeps canonical tiles, backend-drop 404 retries instead of drafting.

## How to Test

1. Repro on `main`: open a bot's Bot Chat, kill that profile's serve process (`pkill -f "hermes --profile <name> serve"`), watch the tab caption turn into a message preview or the tile vanish to the Bots home. On this branch: caption stays `Bot Chat`, tile stays, reconnect retries.
2. `cd apps/desktop && npx vitest run src/app/chat/canonical-tab-title.test.ts src/app/chat/session-tile.test.ts src/store/session-states.test.ts src/app/session/hooks/use-session-actions.test.tsx` → all pass (9 of these fail on unfixed `main`).
3. `cd apps/desktop && npm run test:ui` → 680 files / 6717 tests passed.
4. `cd apps/desktop && npm run check:lint` → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suites relevant to this change — desktop-only: `npm run test:ui` (6717 passed) and `npm run check:lint`; the Python agent is untouched
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple silicon), repro confirmed on Hermes Desktop v0.20.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation — doc comments on the new helper and touched stores
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — renderer store/caption logic only, no platform APIs
- [x] Tool descriptions/schemas — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
