### PR TITLE
fix(gateway/telegram): degrade unsupported and internal session links to plain text (#97497)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -577,6 +577,58 @@ def _rich_normalize_linebreaks(text: str) -> str:
     return ''.join(out)
 
 
+_SUPPORTED_TELEGRAM_LINK_SCHEMES = ("http://", "https://", "tg://", "mailto:", "tel:")
+
+
+def _is_supported_telegram_url(url: str) -> bool:
+    """Return True if url is a valid external URL or deep link supported by Telegram."""
+    if not url:
+        return False
+    url = url.strip()
+    return any(url.lower().startswith(scheme) for scheme in _SUPPORTED_TELEGRAM_LINK_SCHEMES)
+
+
+def _sanitize_unsupported_markdown_links(text: str) -> str:
+    """Degrade unsupported/internal/schemeless markdown links to their display text.
+
+    E.g. ``[Session Title](@session:profile/id)`` or ``[Title](Title)``
+    becomes ``Session Title`` or ``Title``. Valid links (``https://...``,
+    ``tg://...``) are preserved unchanged.
+    """
+    if not text:
+        return text
+
+    placeholders: dict = {}
+    counter = [0]
+
+    def _ph(val: str) -> str:
+        key = f"\x00PH_LINK_{counter[0]}\x00"
+        counter[0] += 1
+        placeholders[key] = val
+        return key
+
+    # 1. Protect fenced code blocks
+    text = re.sub(r'(```(?:[^\n]*\n)?[\s\S]*?```)', lambda m: _ph(m.group(0)), text)
+    # 2. Protect inline code
+    text = re.sub(r'(`[^`]+`)', lambda m: _ph(m.group(0)), text)
+
+    # 3. Degrade unsupported markdown links
+    def _replace_link(m):
+        display = m.group(1)
+        target = m.group(2).strip()
+        if _is_supported_telegram_url(target):
+            return m.group(0)
+        return display
+
+    text = re.sub(r'\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)', _replace_link, text)
+
+    # 4. Restore placeholders
+    for k, v in placeholders.items():
+        text = text.replace(k, v)
+
+    return text
+
+
 # Watchdog bound for `await updater.stop()`. When the underlying TCP socket is
 # in CLOSE-WAIT the PTB polling task is blocked on epoll on the dead socket and
 # never wakes, so an unguarded stop() hangs indefinitely and wedges the whole
@@ -2108,8 +2160,11 @@ class TelegramAdapter(BasePlatformAdapter):
         Single newlines are normalized to Markdown hard breaks so that
         multi-line content (slash-command lists, etc.) renders correctly
         in the rich-message path.  See ``_rich_normalize_linebreaks``.
+        Unsupported/schemeless/internal links (e.g. desktop-only ``@session:``)
+        are sanitized to their plain display text.
         """
-        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
+        cleaned = _sanitize_unsupported_markdown_links(content)
+        payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(cleaned)}
         if skip_entity_detection:
             payload["skip_entity_detection"] = True
         return payload
@@ -8355,10 +8410,16 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # 3) Convert markdown links – escape the display text; inside the URL
         #    only ')' and '\' need escaping per the MarkdownV2 spec.
+        #    Degrade unsupported, internal, or schemeless destinations (e.g.
+        #    @session:... or [Title](Title)) to plain escaped display text.
         def _convert_link(m):
-            display = _escape_mdv2(m.group(1))
-            url = m.group(2).replace('\\', '\\\\').replace(')', '\\)')
-            return _ph(f'[{display}]({url})')
+            display = m.group(1)
+            raw_url = m.group(2).strip()
+            if not _is_supported_telegram_url(raw_url):
+                return _ph(_escape_mdv2(display))
+            escaped_display = _escape_mdv2(display)
+            escaped_url = raw_url.replace('\\', '\\\\').replace(')', '\\)')
+            return _ph(f'[{escaped_display}]({escaped_url})')
 
         text = re.sub(r'\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)', _convert_link, text)
 

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -225,6 +225,25 @@ class TestFormatMessageLinks:
         # The ) in URL should be escaped
         assert "\\)" in result
 
+    def test_unsupported_link_destination_degrades_to_plain_text(self, adapter):
+        result = adapter.format_message("Already underway in [Long-Term Fix Research](Long-Term Fix Research).")
+        assert "Already underway in Long\\-Term Fix Research\\." in result
+        assert "(" not in result
+        assert "[" not in result
+
+    def test_desktop_session_reference_degrades_to_display_text(self, adapter):
+        result = adapter.format_message("Refer to [Previous Task](@session:default/20260722_204335_d62c16) for context.")
+        assert "Refer to Previous Task for context\\." in result
+        assert "@session" not in result
+
+    def test_valid_web_and_deep_links_preserved(self, adapter):
+        result = adapter.format_message(
+            "Visit [Docs](https://example.com) or [Telegram](tg://resolve?domain=bot) or [Email](mailto:a@b.com)."
+        )
+        assert "[Docs](https://example.com)" in result
+        assert "[Telegram](tg://resolve?domain=bot)" in result
+        assert "[Email](mailto:a@b.com)" in result
+
 
 # =========================================================================
 # format_message - BUG: italic regex spans newlines

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -84,6 +84,23 @@ def _rich_api_kwargs(adapter):
     return call.kwargs["api_kwargs"]
 
 
+def test_rich_message_payload_sanitizes_unsupported_links():
+    adapter = _make_adapter()
+    raw = (
+        "## Overview\n\n"
+        "| Section | Status |\n|---|---|\n| Main | Done |\n\n"
+        "Already underway in [Long-Term Fix Research](Long-Term Fix Research).\n"
+        "See [Session Alpha](@session:default/12345) and [Docs](https://docs.hermes.ai).\n"
+        "Code: `[Keep](Keep)`."
+    )
+    payload = adapter._rich_message_payload(raw)
+    markdown = payload["markdown"]
+    assert "Already underway in Long-Term Fix Research." in markdown
+    assert "See Session Alpha and [Docs](https://docs.hermes.ai)." in markdown
+    assert "`[Keep](Keep)`" in markdown
+    assert "@session" not in markdown
+
+
 @pytest.mark.asyncio
 async def test_details_without_math_still_uses_rich_send():
     adapter = _make_adapter()


### PR DESCRIPTION
## Summary

Fixes #97497 by validating outbound Markdown link targets in the Telegram adapter and degrading unsupported, schemeless, or desktop-only internal destinations to readable plain display text across both MarkdownV2 and Rich Message delivery paths.

### Root Cause
When an agent referred to a `session_search` result in Telegram, internal desktop links (e.g. `@session:<profile>/<id>`) or schemeless targets (e.g. `[Long-Term Fix Research](Long-Term Fix Research)`) were passed as Markdown links. Because Telegram only supports URLs with valid external schemes (`http://`, `https://`, `tg://`, `mailto:`, `tel:`), Telegram either exposed raw malformed Markdown syntax (`[Title](Title)`) or failed entity parsing.

### Changes
1. **Telegram Adapter Link Validation**:
   - Added `_is_supported_telegram_url()` verifying supported scheme prefixes (`http://`, `https://`, `tg://`, `mailto:`, `tel:`).
   - Added `_sanitize_unsupported_markdown_links()` ensuring code spans/blocks are protected while unsupported destinations (like `@session:...` or duplicate title targets) degrade cleanly to display text.
   - Updated `format_message` to degrade invalid/schemeless links into escaped plain text rather than broken MarkdownV2 link syntax.
   - Integrated sanitization into `_rich_message_payload` to sanitize raw markdown before building `InputRichMessage` payloads.
2. **Session Search Tool Contract Clarification**:
   - Updated `tools/session_search_tool.py` docstrings to clarify that `@session:` titled links are a Hermes Desktop feature, while messaging platforms without internal session resolution should refer to the session by its title in plain text.
3. **Regression Tests**:
   - Added test coverage in `tests/gateway/test_telegram_format.py` asserting that `[Long-Term Fix Research](Long-Term Fix Research)` and `[Title](@session:...)` degrade to plain text while valid `https://`, `tg://`, and `mailto:` links remain preserved.
   - Added test in `tests/gateway/test_telegram_rich_messages.py` verifying link sanitization in rich message payloads with code-block protection.
