### PR TITLE
fix(tools): read pooled Nous credentials in status probes

### DIFF
--- a/tests/tools/test_managed_tool_gateway.py
+++ b/tests/tools/test_managed_tool_gateway.py
@@ -103,6 +103,20 @@ def test_read_nous_access_token_refreshes_expiring_cached_token(tmp_path, monkey
     assert managed_tool_gateway.read_nous_access_token() == "fresh-token"
 
 
+def test_peek_nous_access_token_reads_profile_credential_pool(tmp_path, monkeypatch):
+    """Availability probes must see device-code credentials in a profile."""
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "auth.json").write_text(json.dumps({
+        "providers": {},
+        "credential_pool": {
+            "nous": [{"access_token": "pooled-token"}],
+        },
+    }))
+
+    assert managed_tool_gateway.peek_nous_access_token() == "pooled-token"
+
+
 def test_managed_vendor_endpoints_pin_the_deployed_gateway_url():
     """The exact URL an agent may connect to is a code fact, not a lookup.
 

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -113,6 +113,22 @@ def peek_nous_access_token() -> Optional[str]:
     access_token = nous_provider.get("access_token")
     if isinstance(access_token, str) and access_token.strip():
         return access_token.strip()
+
+    # Device-code login stores the active Nous credential in the pooled
+    # credential store.  Use the same profile-aware/global-fallback reader as
+    # the rest of the auth stack, but keep this path read-only and
+    # refresh-free so availability probes remain cheap.
+    try:
+        from hermes_cli.auth import read_credential_pool
+
+        for entry in read_credential_pool("nous"):
+            if not isinstance(entry, dict):
+                continue
+            pooled_token = entry.get("access_token")
+            if isinstance(pooled_token, str) and pooled_token.strip():
+                return pooled_token.strip()
+    except Exception:
+        logger.debug("unable to inspect pooled Nous credentials", exc_info=True)
     return None
 
 
@@ -449,4 +465,3 @@ def build_managed_media_uploader(
         return f"nous-upload:{token}"
 
     return upload
-


### PR DESCRIPTION
Closes #97490\n\nMake the no-network Nous availability probe inspect profile-scoped and global-fallback credential pools, keeping provider-state precedence and refresh-free behavior. Adds a regression test for pooled credentials.