### PR TITLE
fix(desktop): route approvals through runtime event owners

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -12,7 +12,7 @@ import {
 import { $gateway } from '@/store/gateway'
 import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
-import { receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
+import { approvalOwnerRouteFromEvent, receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import { requestScrollToBottom } from '@/store/thread-scroll'
 
 import type { GatewayEventContext } from './types'
@@ -244,6 +244,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         : undefined,
       command,
       description,
+      ownerRoute: approvalOwnerRouteFromEvent(event),
       requestId: typeof payload?.request_id === 'string' ? payload.request_id : undefined,
       sessionId: sessionId ?? null,
       smartDenied: payload?.smart_denied === true

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -9,6 +9,22 @@ import { $activeSessionId } from '@/store/session'
 import { PendingApprovalFallback, PendingToolApproval } from './approval'
 import type { ToolPart } from './fallback-model'
 
+const routingMocks = vi.hoisted(() => ({
+  requestForSessionProfile: vi.fn(
+    async (
+      owner: unknown,
+      ambient: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
+      method: string,
+      params?: Record<string, unknown>
+    ) => (owner ? { resolved: true } : ambient(method, params))
+  )
+}))
+
+vi.mock('@/store/session-request-router', async () => ({
+  ...(await vi.importActual<Record<string, unknown>>('@/store/session-request-router')),
+  requestForSessionProfile: routingMocks.requestForSessionProfile
+}))
+
 // Radix's DropdownMenu touches pointer-capture + scrollIntoView, which jsdom
 // doesn't implement; stub them so the menu can open in tests.
 beforeAll(() => {
@@ -33,7 +49,12 @@ function part(toolName: string): ToolPart {
 function setRequest(
   command = 'rm -rf /tmp/x',
   allowPermanent?: boolean,
-  extra: { choices?: string[]; smartDenied?: boolean } = {}
+  extra: {
+    choices?: string[]
+    ownerRoute?: { connectionId: string; profile: string }
+    requestId?: string
+    smartDenied?: boolean
+  } = {}
 ) {
   $activeSessionId.set('sess-1')
   setApprovalRequest({ allowPermanent, command, description: 'dangerous command', sessionId: 'sess-1', ...extra })
@@ -49,6 +70,7 @@ function mockGateway() {
 afterEach(() => {
   cleanup()
   clearAllPrompts()
+  vi.clearAllMocks()
   $activeSessionId.set(null)
   $gateway.set(null)
 })
@@ -94,6 +116,52 @@ describe('PendingToolApproval', () => {
       expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
     })
     expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('answers through the exact owner attached to the inbound approval', async () => {
+    const ambient = mockGateway()
+    const ownerRoute = { connectionId: 'local', profile: 'default' }
+    setRequest('chmod 600 /tmp/x', undefined, { ownerRoute, requestId: 'approval-1' })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() => {
+      expect(routingMocks.requestForSessionProfile).toHaveBeenCalledWith(
+        ownerRoute,
+        expect.any(Function),
+        'approval.respond',
+        { choice: 'once', request_id: 'approval-1', session_id: 'sess-1' }
+      )
+      expect(routingMocks.requestForSessionProfile).toHaveBeenCalledWith(
+        ownerRoute,
+        expect.any(Function),
+        'approval.pending',
+        { session_id: 'sess-1' }
+      )
+    })
+    expect(ambient).not.toHaveBeenCalled()
+    expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('keeps the approval parked when its exact owner does not resolve it', async () => {
+    mockGateway()
+    routingMocks.requestForSessionProfile.mockResolvedValueOnce({ resolved: false })
+    const ownerRoute = { connectionId: 'local', profile: 'default' }
+    setRequest('chmod 600 /tmp/x', undefined, { ownerRoute, requestId: 'approval-stale' })
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() => {
+      expect(routingMocks.requestForSessionProfile).toHaveBeenCalledWith(
+        ownerRoute,
+        expect.any(Function),
+        'approval.respond',
+        { choice: 'once', request_id: 'approval-stale', session_id: 'sess-1' }
+      )
+    })
+    expect($approvalRequest.get()?.requestId).toBe('approval-stale')
   })
 
   it('reveals the full command inline when the Command toggle is clicked', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -25,10 +25,10 @@ import {
   clearApprovalRequest,
   registerApprovalInlineAnchor,
   replayPendingApproval,
+  respondToApproval,
   sessionApprovalInlineVisible,
   sessionApprovalRequest
 } from '@/store/prompts'
-import { requestForOwnedSession } from '@/store/session-states'
 
 import type { ToolPart } from './fallback-model'
 
@@ -148,27 +148,16 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
         // ambient only when no owner is known. The ambient socket follows
         // foreground focus, and for a cross-profile session it points at a
         // backend that never held this approval (#91684 client half).
-        await requestForOwnedSession<{ resolved?: boolean }>(
-          request.sessionId,
-          // Bound (not wrapped) so the ambient fallback keeps the exact
-          // 2-arg call shape gateway.request callers assert on.
-          gateway.request.bind(gateway) as typeof gateway.request,
-          'approval.respond',
-          {
-            choice,
-            request_id: request.requestId,
-            session_id: request.sessionId ?? undefined
-          }
-        )
+        await respondToApproval(gateway, request, choice)
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
         clearApprovalRequest(request.sessionId, request.requestId)
-        void replayPendingApproval(gateway, request.sessionId).catch(() => undefined)
+        void replayPendingApproval(gateway, request.sessionId, request.ownerRoute).catch(() => undefined)
       } catch (error) {
         notifyError(error, copy.sendFailed)
         setSubmitting(null)
       }
     },
-    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.requestId, request.sessionId]
+    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request]
   )
 
   // ⌘/Ctrl+Enter → Run, Esc → Reject.

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -5,7 +5,7 @@ import { persistString, storedString } from '@/lib/storage'
 
 import { $gateway } from './gateway'
 import { withinNativeNotifyBaseline } from './notify-baseline'
-import { clearApprovalRequest } from './prompts'
+import { clearApprovalRequest, respondToApproval, sessionApprovalRequest } from './prompts'
 import { $activeSessionId } from './session'
 import { requestForOwnedSession } from './session-states'
 
@@ -364,14 +364,21 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
     // ambient socket follows foreground focus and, for a background approval
     // raised by a cross-profile session, points at a backend that never held
     // the approval (#91684 client half). Ambient only when no owner is known.
-    await requestForOwnedSession(
-      sessionId,
-      // Bound (not wrapped) so the ambient fallback keeps the exact 2-arg
-      // call shape gateway.request callers assert on.
-      gateway.request.bind(gateway) as typeof gateway.request,
-      'approval.respond',
-      { choice, session_id: sessionId ?? undefined }
-    )
+    const pending = sessionApprovalRequest(sessionId).get()
+
+    if (pending) {
+      await respondToApproval(gateway, pending, choice)
+    } else {
+      await requestForOwnedSession(
+        sessionId,
+        // Bound (not wrapped) so the ambient fallback keeps the exact 2-arg
+        // call shape gateway.request callers assert on.
+        gateway.request.bind(gateway) as typeof gateway.request,
+        'approval.respond',
+        { choice, session_id: sessionId ?? undefined }
+      )
+    }
+
     clearApprovalRequest(sessionId)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -6,6 +6,7 @@ import {
   $approvalRequest,
   $secretRequest,
   $sudoRequest,
+  approvalOwnerRouteFromEvent,
   clearAllPrompts,
   clearApprovalRequest,
   clearSecretRequest,
@@ -31,6 +32,14 @@ afterEach(() => {
 })
 
 describe('approval prompt store', () => {
+  it('captures an exact owner only from a connection-tagged approval event', () => {
+    expect(approvalOwnerRouteFromEvent({ connectionId: 'local', profile: 'default' })).toEqual({
+      connectionId: 'local',
+      profile: 'default'
+    })
+    expect(approvalOwnerRouteFromEvent({ profile: 'default' })).toBeUndefined()
+  })
+
   it('holds the active session-keyed approval request', () => {
     setApprovalRequest({ command: 'rm -rf /tmp/x', description: 'recursive delete', sessionId: 's1' })
 

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -2,6 +2,8 @@ import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { $clarifyRequest, $clarifyRequests } from './clarify'
 import { $activeSessionId } from './session'
+import { requestForSessionProfile, type SessionOwnerRoute } from './session-request-router'
+import { requestForOwnedSession } from './session-states'
 
 // Blocking interactive prompts the gateway raises mid-turn. Each maps to a
 // `*.request` event the Python side emits while it blocks the agent thread
@@ -76,12 +78,19 @@ export interface ApprovalRequest extends KeyedPrompt {
   choices?: string[]
   command: string
   description: string
+  /** Exact registry route that delivered this approval request. */
+  ownerRoute?: SessionOwnerRoute
   requestId?: string
   smartDenied?: boolean
 }
 
 interface ApprovalGateway {
-  request: (method: string, params: Record<string, unknown>) => Promise<unknown>
+  request: (
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ) => Promise<unknown>
 }
 
 interface PendingApprovalPayload {
@@ -115,6 +124,66 @@ export const $approvalRequest = approval.$active
 export const setApprovalRequest = approval.set
 export const clearApprovalRequest = approval.clear
 
+export function approvalOwnerRouteFromEvent(event: {
+  connectionId?: string
+  profile?: string
+}): SessionOwnerRoute | undefined {
+  const connectionId = event.connectionId?.trim()
+
+  return connectionId
+    ? { connectionId, profile: event.profile?.trim() || 'default' }
+    : undefined
+}
+
+function requestThroughApprovalOwner<T>(
+  gateway: ApprovalGateway,
+  ownerRoute: SessionOwnerRoute | undefined,
+  method: string,
+  params: Record<string, unknown>
+): Promise<T> {
+  const ambient = <R>(
+    ambientMethod: string,
+    ambientParams?: Record<string, unknown>,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ): Promise<R> => {
+    const params = ambientParams ?? {}
+
+    return (timeoutMs === undefined && signal === undefined
+      ? gateway.request(ambientMethod, params)
+      : gateway.request(ambientMethod, params, timeoutMs, signal)) as Promise<R>
+  }
+
+  return ownerRoute
+    ? requestForSessionProfile(ownerRoute, ambient, method, params)
+    : requestForOwnedSession(params.session_id as string | undefined, ambient, method, params)
+}
+
+export async function respondToApproval(
+  gateway: ApprovalGateway,
+  request: ApprovalRequest,
+  choice: 'always' | 'deny' | 'once' | 'session'
+): Promise<unknown> {
+  const params = {
+    choice,
+    ...(request.requestId ? { request_id: request.requestId } : {}),
+    session_id: request.sessionId ?? undefined
+  }
+
+  const result = await requestThroughApprovalOwner<{ resolved?: boolean }>(
+    gateway,
+    request.ownerRoute,
+    'approval.respond',
+    params
+  )
+
+  if (result?.resolved === false) {
+    throw new Error('The approval is no longer pending on its owning backend.')
+  }
+
+  return result
+}
+
 export async function receiveApprovalRequest(gateway: ApprovalGateway | null, request: ApprovalRequest): Promise<void> {
   setApprovalRequest(request)
 
@@ -126,14 +195,21 @@ export async function receiveApprovalRequest(gateway: ApprovalGateway | null, re
   }
 }
 
-export async function replayPendingApproval(gateway: ApprovalGateway | null, sessionId: string | null): Promise<void> {
+export async function replayPendingApproval(
+  gateway: ApprovalGateway | null,
+  sessionId: string | null,
+  ownerRoute?: SessionOwnerRoute
+): Promise<void> {
   if (!gateway || !sessionId) {
     return
   }
 
-  const rawResult = await gateway.request('approval.pending', {
-    session_id: sessionId
-  })
+  const rawResult = await requestThroughApprovalOwner<{ approvals?: PendingApprovalPayload[] }>(
+    gateway,
+    ownerRoute,
+    'approval.pending',
+    { session_id: sessionId }
+  )
 
   const result =
     rawResult && typeof rawResult === 'object' ? (rawResult as { approvals?: PendingApprovalPayload[] }) : {}
@@ -149,6 +225,7 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
     choices: Array.isArray(pending.choices) ? pending.choices.filter(choice => typeof choice === 'string') : undefined,
     command: typeof pending.command === 'string' ? pending.command : '',
     description: typeof pending.description === 'string' ? pending.description : 'dangerous command',
+    ownerRoute,
     requestId: pending.request_id,
     sessionId,
     smartDenied: pending.smart_denied === true


### PR DESCRIPTION
Refs NousResearch/hermes-agent#97511

## Summary

- retain the exact gateway event owner on each pending command approval
- route inline and native approval responses back through that owner
- keep untagged events on the existing fail-closed owner-resolution path
- keep prompts parked when the owning backend reports the request is no longer pending
- replay queued approvals through the same owner route

## Why

Desktop can render an approval emitted by a secondary/profile-specific gateway, then fail to answer it because the later response no longer knows which gateway socket delivered the prompt. Guessing the ambient gateway would risk cross-profile misrouting.

This change scopes the captured route to the approval request itself. It does not weaken the generic session-owner resolver or add an ambient fallback.

## Verification

- approval-focused Vitest: 59 passed
- Desktop typecheck passed
- production build passed
- changed-file ESLint passed
- full UI run: 6,703 passed; four unrelated files timed out under the parallel run and all four passed in isolation (18 passed)
- independent security/correctness review passed; its replay and fail-closed follow-ups are included
