### PR TITLE
fix(memory): extract single-word entities

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -83,7 +83,7 @@ _TRUST_MIN       =  0.0
 _TRUST_MAX       =  1.0
 
 # Entity extraction patterns
-_RE_CAPITALIZED  = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b')
+_RE_CAPITALIZED  = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b')
 _RE_DOUBLE_QUOTE = re.compile(r'"([^"]+)"')
 _RE_SINGLE_QUOTE = re.compile(r"'([^']+)'")
 _RE_AKA          = re.compile(
@@ -449,7 +449,7 @@ class MemoryStore:
         """Extract entity candidates from text using simple regex rules.
 
         Rules applied (in order):
-        1. Capitalized multi-word phrases  e.g. "John Doe"
+        1. Capitalized words and multi-word phrases e.g. "Michael" / "John Doe"
         2. Double-quoted terms             e.g. "Python"
         3. Single-quoted terms             e.g. 'pytest'
         4. AKA patterns                    e.g. "Guido aka BDFL" -> two entities

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -108,6 +108,18 @@ class TestSharedConnection:
             b.close()
 
 
+def test_extract_entities_includes_single_word_proper_nouns(db_path):
+    """Ordinary single-token names must participate in entity retrieval."""
+    store = MemoryStore(db_path)
+    try:
+        assert store._extract_entities("Michael prefers dark roast coffee.") == ["Michael"]
+        assert store._extract_entities("Michael Jones prefers dark roast coffee.") == [
+            "Michael Jones"
+        ]
+    finally:
+        store.close()
+
+
 class TestCloseSemantics:
     def test_closing_one_instance_keeps_sibling_alive(self, db_path):
         a = MemoryStore(db_path)
@@ -224,4 +236,3 @@ class TestProviderShutdown:
 
         assert provider._store is None
         assert MemoryStore._shared == {}
-


### PR DESCRIPTION
Closes #97493\n\nAllow holographic memory to extract single-token proper nouns while preserving multi-word phrase matching. Adds regression coverage.