### PR TITLE
fix(session-search): scope session links to desktop surfaces

### DIFF
--- a/agent/inline_tool_executors.py
+++ b/agent/inline_tool_executors.py
@@ -107,6 +107,7 @@ def _session_search(agent, args: dict, ctx: InlineToolContext) -> Any:
             ("window", "window", 5), ("sort", "sort"), ("detail", "detail", "adaptive"),
         ),
         db=session_db, current_session_id=agent.session_id,
+        platform=getattr(agent, "platform", None),
     )
 
 

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -93,6 +93,7 @@ def test_session_search_lazily_opens_db_when_entrypoint_did_not_pass_one(monkeyp
     assert captured["db"] is sentinel_db
     assert captured["query"] == "Hermes"
     assert captured["detail"] == "full"
+    assert captured["platform"] == "acp"
     assert agent._session_db is sentinel_db
 
 
@@ -129,3 +130,4 @@ def test_sequential_session_search_forwards_detail(monkeypatch):
     assert captured["db"] is session_db
     assert captured["query"] == "Hermes"
     assert captured["detail"] == "full"
+    assert captured["platform"] == "acp"

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -84,7 +84,7 @@ class TestSchema:
         # Mode is inferred from which args are set — no explicit mode param
         assert "mode" not in params
 
-    def test_detail_parameter_is_appended_for_positional_compatibility(self):
+    def test_new_parameters_are_appended_for_positional_compatibility(self):
         parameters = list(inspect.signature(session_search).parameters)
         historical_prefix = [
             "query",
@@ -98,7 +98,7 @@ class TestSchema:
             "sort",
             "profile",
         ]
-        assert parameters == [*historical_prefix, "detail"]
+        assert parameters == [*historical_prefix, "detail", "platform"]
 
 
 class TestFormatTimestamp:
@@ -501,6 +501,38 @@ class TestSessionLink:
     def test_link_carries_the_named_profile(self):
         assert _session_link("s_oldest", "work") == "@session:work/s_oldest"
 
+    def test_surface_contract_across_search_shapes(self, db):
+        from tools.registry import registry
+
+        _seed_modpack_sessions(db)
+        for platform in ("telegram", "cli", "acp", "desktop", None):
+            for args in ({"query": "modpack"}, {}, {"session_id": "s_oldest"},
+                         {"query": "no-such-session"}):
+                result = json.loads(registry.dispatch(
+                    "session_search", args, db=db, platform=platform))
+                assert result["success"]
+                entries = result.get("results", [result])
+                if platform in (None, "desktop"):
+                    assert all(entry["link"].startswith("@session:") for entry in entries)
+                else:
+                    assert all("link" not in entry for entry in entries)
+                    assert "plain text" in result["link_hint"]
+                    assert "Markdown link" in result["link_hint"]
+                if result["mode"] == "read":
+                    assert result["session_meta"]["title"] == "Building the Modpack"
+
+    def test_current_surface_overrides_historical_source(self, db):
+        _seed_modpack_sessions(db)
+        for source in ("telegram", "cli", "desktop"):
+            current_id = f"current_{source}"
+            db.create_session(current_id, source=source)
+            for platform in (None, "desktop", "acp"):
+                result = json.loads(session_search(
+                    query="modpack", db=db, current_session_id=current_id,
+                    platform=platform))
+                expect_links = (platform or source) == "desktop"
+                assert result["results"]
+                assert all(("link" in entry) is expect_links for entry in result["results"])
 
     def test_every_discovery_result_links_to_its_own_session(self, db):
         _seed_modpack_sessions(db)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -530,9 +530,32 @@ def _dispatch(query, role_filter, limit, db, current_session_id, session_id,
         current_session_id=current_session_id, link_profile=profile)
 
 
+def _adapt_session_links_for_platform(raw_result: str, platform: Any = None) -> str:
+    """Keep Desktop references out of surfaces without the session-link renderer."""
+    surface = str(getattr(platform, "value", platform) or "").strip().lower()
+    # Direct callers without surface context retain the historical payload.
+    if not surface or surface == "desktop":
+        return raw_result
+    payload = json.loads(raw_result)
+    if not payload.get("success"):
+        return raw_result
+    removed_ref = payload.pop("link", None) is not None
+    for entry in payload.get("results") or []:
+        removed_ref = entry.pop("link", None) is not None or removed_ref
+    if removed_ref or payload.get("mode") in {"discover", "browse", "read"}:
+        payload["link_hint"] = (
+            f"Hermes @session references render only in Desktop, not on {surface}. "
+            "Refer to the result `title` (or `session_meta.title`) as plain text "
+            "when present; do not emit a session reference/id or format the title "
+            "as a Markdown link."
+        )
+    return json.dumps(payload, ensure_ascii=False)
+
+
 def session_search(query: str = "", role_filter: str = None, limit: int = 3, db=None,
                    current_session_id: str = None, session_id: str = None, around_message_id: int = None,
-                   window: int = 5, sort: str = None, profile: str = None, detail: str = "adaptive") -> str:
+                   window: int = 5, sort: str = None, profile: str = None, detail: str = "adaptive",
+                   platform: Any = None) -> str:
     """Run session search, closing DBs opened here. Positional order is frozen for old callers."""
     from hermes_state import format_session_db_unavailable
     from hermes_state_registry import acquire, release_or_close
@@ -543,8 +566,13 @@ def session_search(query: str = "", role_filter: str = None, limit: int = 3, db=
             return tool_error(format_session_db_unavailable(), success=False)
         owned_dbs.append(db)
     try:
-        return _dispatch(query, role_filter, limit, db, current_session_id, session_id,
+        if platform is None and current_session_id:
+            current_meta = _quiet(lambda: db.get_session(current_session_id), None,
+                                  "Could not resolve session_search rendering surface")
+            platform = (current_meta or {}).get("source")
+        result = _dispatch(query, role_filter, limit, db, current_session_id, session_id,
                          around_message_id, window, sort, profile, detail, owned_dbs)
+        return _adapt_session_links_for_platform(result, platform)
     finally:
         for owned_db in reversed(owned_dbs):
             _quiet(lambda: release_or_close(owned_db), None, "Failed to close session_search SessionDB")
@@ -572,9 +600,10 @@ SESSION_SEARCH_SCHEMA = {
         "Searches conversation history ONLY — when the user gave a direct "
         "source (URL, file, contact, live system), inspect that first; never "
         "conclude 'not found' from history alone. Use for questions about past "
-        "conversations: 'what did we do about X', 'where did we leave Y'. When "
-        "referring the user to a session, write its `link` value verbatim "
-        "inline (it renders as a titled link)."
+        "conversations: 'what did we do about X', 'where did we leave Y'. "
+        "Results include clickable `link` references only on Hermes Desktop. "
+        "On other surfaces, refer to the returned `title` as plain text and "
+        "follow the response's `link_hint`."
     ),
     "parameters": {
         "type": "object",
@@ -674,6 +703,7 @@ registry.register(
     handler=lambda args, **kw: session_search(
         query=args.get("query") or "", limit=args.get("limit", 3), window=args.get("window", 5),
         detail=args.get("detail", "adaptive"), db=kw.get("db"), current_session_id=kw.get("current_session_id"),
+        platform=kw.get("platform"),
         **{k: args.get(k) for k in ("role_filter", "session_id", "around_message_id", "sort", "profile")}),
     check_fn=check_session_search_requirements,
     emoji="🔍")


### PR DESCRIPTION
## Summary

- Make `session_search` aware of the active rendering surface.
- Keep clickable `@session:` references on Hermes Desktop, but remove those Desktop-only references from Telegram, CLI, ACP, and other non-Desktop tool results.
- Direct the agent to use the returned session title as plain text on surfaces that cannot resolve internal session references.
- Preserve the historical payload for direct callers without surface context.

## Motivation

Issue #97497 exposed a cross-surface contract bug: `session_search` told every agent that its `link` value rendered as a titled link, although that renderer exists only in Hermes Desktop. On Telegram this could leak opaque `@session:` references or encourage malformed Markdown such as `[Title](Title)`.

PR #97514 adds the deterministic Telegram delivery-boundary guard. This PR complements it at the producer boundary so non-Desktop agents are no longer given Desktop-only references to emit. The two branches merge cleanly, and their combined focused suites pass.

## Related Issue

Related to #97497

Complements #97514

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/session_search_tool.py`
  - Add optional platform context with a current-session source fallback.
  - Remove `link` fields from successful discover, browse, and read results on non-Desktop surfaces.
  - Replace the universal link instruction with a surface-specific plain-text title contract.
  - Qualify the static tool description so clickable session references are explicitly Desktop-only.
- `agent/tool_executor.py` and `agent/agent_runtime_helpers.py`
  - Forward the active agent platform through both session-search execution paths.
- Tests
  - Cover Telegram, CLI, ACP, Desktop, empty discovery, discover, browse, read, and both runtime forwarding paths.

## How to Test

1. Run the focused canonical suites:

   ```bash
   scripts/run_tests.sh tests/tools/test_session_search.py tests/run_agent/test_token_persistence_non_cli.py
   ```

   Result: 62 tests passed.

2. Check the changed Python files:

   ```bash
   uv run --extra dev ruff check agent/agent_runtime_helpers.py agent/tool_executor.py tools/session_search_tool.py tests/tools/test_session_search.py tests/run_agent/test_token_persistence_non_cli.py
   python3 -m py_compile agent/agent_runtime_helpers.py agent/tool_executor.py tools/session_search_tool.py tests/tools/test_session_search.py tests/run_agent/test_token_persistence_non_cli.py
   git diff --check
   ```

3. Merge this commit without committing into PR #97514's head and run both branches' focused suites:

   ```bash
   scripts/run_tests.sh tests/tools/test_session_search.py tests/run_agent/test_token_persistence_non_cli.py tests/gateway/test_telegram_format.py tests/gateway/test_telegram_rich_messages.py
   ```

   Result: 141 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and coordinated this as a complement to #97514
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.2 with Python 3.11.15

### Documentation & Housekeeping

- [x] Relevant tool descriptions were updated
- [x] No configuration keys changed
- [x] No architecture or workflow documentation changes are required
- [x] Cross-platform impact was considered

## Review

Independent pre-commit review used Claude Code with first-party `claude.ai` plan authentication. Claude Fable reached its plan limit and the configured Claude Opus fallback completed the review. It found no actionable P0/P1 issues and assessed the patch as correct.
