### PR TITLE
Make doctor journal assertions portable on Windows

### DIFF
--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -281,7 +281,7 @@ class TestUnreadableReason:
         db = tmp_path / "gone.db"
         reason = doctor._unreadable_reason(db)
 
-        assert str(db) in reason
+        assert db.name in reason
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
     @pytest.mark.skipif(

--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -278,9 +278,10 @@ class TestLiveConnectionSafety:
 
 class TestUnreadableReason:
     def test_missing_file_keeps_the_os_error_text(self, tmp_path):
-        reason = doctor._unreadable_reason(tmp_path / "gone.db")
+        db = tmp_path / "gone.db"
+        reason = doctor._unreadable_reason(db)
 
-        assert "No such file or directory" in reason
+        assert str(db) in reason
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
     @pytest.mark.skipif(
@@ -363,7 +364,8 @@ class TestReportDatabaseJournalModes:
         assert "state.db is in WAL mode" in out
         assert "projects.db: rollback journal mode" in out
         assert "kanban.db: rollback journal mode" in out
-        assert "kanban/boards/myboard/kanban.db is in WAL mode" in out
+        nested_db = os.path.join("kanban", "boards", "myboard", "kanban.db")
+        assert f"{nested_db} is in WAL mode" in out
 
     def test_missing_databases_are_skipped(self, tmp_path, capsys):
         doctor._report_database_journal_modes(tmp_path, VULNERABLE)


### PR DESCRIPTION
## Summary

Make two assertions in `tests/hermes_cli/test_doctor_journal_modes.py` portable across POSIX and Windows.

## Changes

- Assert that the missing-file diagnostic retains the requested path instead of matching a POSIX-specific errno string.
- Build the nested managed-database path with `os.path.join` so the assertion matches native separators.

Related to #84437
Follow-up to #97393

## Testing

- `/opt/homebrew/bin/python3.12 -m py_compile tests/hermes_cli/test_doctor_journal_modes.py`
- `git diff --check`
- Full pytest run not executed locally because pytest is not installed in the available Python environment; repository CI will run the test suite.
