### PR TITLE
fix(kanban): ready status requires assignee unless kanban.default_assignee set

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3166,6 +3166,26 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _kanban_default_assignee() -> Optional[str]:
+    """Read ``kanban.default_assignee`` from the active config (may be unset).
+
+    When set, the dispatcher auto-assigns unassigned ``ready`` tasks to this
+    profile on its next tick (#27145).  This means an unassigned card in
+    ``ready`` is *expected* and will be routed — there is no need to force
+    it to ``triage``.  When unset, an unassigned ``ready`` card would be
+    invisible to the dispatcher, so callers should force it to ``triage``
+    for the auto-decomposer to route instead.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        _cfg = load_config_readonly()
+        _kanban_cfg = _cfg.get("kanban", {}) if isinstance(_cfg, dict) else {}
+        return (_kanban_cfg.get("default_assignee") or "").strip() or None
+    except Exception:
+        return None
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3474,6 +3494,21 @@ def create_task(
                         ).fetchall()
                         if any(r["status"] != "done" for r in rows):
                             task_status = "todo"
+                    # A card that would land in 'ready' with no assignee is
+                    # invisible to the dispatcher and sits idle forever
+                    # — but only when ``kanban.default_assignee`` is NOT
+                    # configured.  When it is set, the dispatcher's #27145
+                    # path auto-assigns unassigned ready tasks on its next
+                    # tick, so forcing triage here would bypass that feature
+                    # (#27145 regression).  When unset, force triage so the
+                    # auto-decomposer can route the card to the right profile
+                    # instead of letting it sit invisible.
+                    if (
+                        task_status == "ready"
+                        and not assignee
+                        and not _kanban_default_assignee()
+                    ):
+                        task_status = "triage"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
                 if triage and parents:
@@ -4552,10 +4587,16 @@ def recompute_ready(
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
+    # Read ``kanban.default_assignee`` once (#27145).  When set, unassigned
+    # ready cards are expected — the dispatcher auto-assigns them on its
+    # next tick — so we must NOT force triage here.  When unset, force
+    # unassigned ready cards to triage so they're not invisible to the
+    # dispatcher (matches the same guard in ``create_task``).
+    _has_default_assignee = bool(_kanban_default_assignee())
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
+            "SELECT id, status, assignee, consecutive_failures, max_retries "
             "FROM tasks WHERE status IN ('todo', 'blocked')"
         ).fetchall()
         for row in todo_rows:
@@ -4592,6 +4633,22 @@ def recompute_ready(
                     )
                     if failures >= effective_limit:
                         continue
+                # Unassigned card without a default_assignee: lock to
+                # triage so the auto-decomposer can route it instead of
+                # landing it in ready where it would be invisible (#27145
+                # compatibility — see ``create_task`` for the same guard).
+                # When ``kanban.default_assignee`` IS set, the dispatcher
+                # auto-assigns on its next tick, so let it go to ready.
+                row_assignee = row["assignee"]
+                if (not row_assignee) and not _has_default_assignee:
+                    conn.execute(
+                        "UPDATE tasks SET status = 'triage' "
+                        "WHERE id = ? AND status IN ('todo', 'blocked')",
+                        (task_id,),
+                    )
+                    _append_event(conn, task_id, "forced_triage", None)
+                    continue
+                if cur_status == "blocked":
                     conn.execute(
                         "UPDATE tasks SET status = ? "
                         "WHERE id = ? AND status = 'blocked'",
@@ -6799,7 +6856,7 @@ def promote_task(
     promotion would succeed without mutating state.
     """
     row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        "SELECT status, assignee FROM tasks WHERE id = ?", (task_id,)
     ).fetchone()
     if row is None:
         return False, f"task {task_id} not found"
@@ -6809,6 +6866,19 @@ def promote_task(
         return False, (
             f"task {task_id} is {cur_status!r}; promote only applies to "
             f"'todo' or 'blocked'"
+        )
+
+    # Guard: don't promote an unassigned card to ready when there's no
+    # ``kanban.default_assignee`` — it would be invisible to the dispatcher.
+    # Match the create_task/recompute_ready guard so all three promotion
+    # paths are consistent.  ``--force`` overrides this (deliberate operator
+    # action, same audit trail).  When ``kanban.default_assignee`` IS set,
+    # the dispatcher picks it up on its next tick (#27145).
+    if not row["assignee"] and not _kanban_default_assignee() and not force:
+        return False, (
+            f"task {task_id} has no assignee and kanban.default_assignee "
+            f"is unset — it would be invisible in 'ready'. "
+            f"Assign it first, set kanban.default_assignee, or use --force."
         )
 
     if not force:
@@ -6930,6 +7000,18 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             if landing_status == "ready" and resume_status == "review"
             else landing_status
         )
+        # Unassigned card with no ``kanban.default_assignee`` and no open
+        # parents: don't land it in 'ready' where it would be invisible to
+        # the dispatcher — force triage instead.  This closes the same gap
+        # guarded in create_task / recompute_ready / promote_task.  When
+        # ``kanban.default_assignee`` IS set, the dispatcher auto-assigns
+        # on its next tick (#27145), so 'ready' is the right destination.
+        if new_status == "ready":
+            task_assignee = conn.execute(
+                "SELECT assignee FROM tasks WHERE id = ?", (task_id,)
+            ).fetchone()
+            if task_assignee and not task_assignee["assignee"] and not _kanban_default_assignee():
+                new_status = "triage"
         # NOTE: deliberately does NOT touch ``block_recurrences`` or
         # ``block_kind``. Resetting the recurrence counter on unblock is exactly
         # the amnesia that let a cron unblock → worker re-block loop run
@@ -7309,7 +7391,7 @@ def decompose_triage_task(
         {
             "title": "...",
             "body": "...",                     # optional
-            "assignee": "profile-name",        # optional, None -> default fallback
+            "assignee": "profile-name",        # required — null/blank raises ValueError
             "parents": [0, 2],                 # indices into this same children list
         }
 
@@ -7336,6 +7418,18 @@ def decompose_triage_task(
         title = child.get("title")
         if not isinstance(title, str) or not title.strip():
             raise ValueError(f"child[{idx}].title is required")
+        # Defensive: a child task must NEVER reach the DB with a null
+        # assignee — the decomposer normalizes upstream, but we guard
+        # here too so a direct caller bypassing decompose_task() can't
+        # create an unassigned ready card.
+        assignee_val = child.get("assignee")
+        if not assignee_val or (
+            isinstance(assignee_val, str) and not assignee_val.strip()
+        ):
+            raise ValueError(
+                f"child[{idx}].assignee is required — pass a valid profile "
+                "name or the default_assignee; null is not accepted"
+            )
         parents_idx = child.get("parents") or []
         if not isinstance(parents_idx, list):
             raise ValueError(f"child[{idx}].parents must be a list")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -564,6 +564,31 @@ def _hermetic_environment(tmp_path, monkeypatch):
     monkeypatch.delenv("GMI_BASE_URL", raising=False)
 
 
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB.
+
+    Creates a per-test tempdir, sets HERMES_HOME + Path.home() to point
+    under it, and initializes a fresh kanban DB. The autouse
+    ``_hermetic_environment`` fixture already clears all
+    ``HERMES_KANBAN_*`` env vars (including ``HERMES_KANBAN_DB`` which
+    the dispatcher injects into worker env, and which ``kanban_db_path()``
+    checks *before* HERMES_HOME), so ``connect()`` resolves to the
+    tempdir's ``kanban.db``. ``init_db()`` creates the schema.
+
+    Tests that need custom settings (e.g. ``HERMES_KANBAN_CRASH_GRACE_SECONDS``)
+    override this fixture locally, calling the shared one and adding
+    their extras on top.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli import kanban_db as kb
+    kb.init_db()
+    return home
+
+
 # Backward-compat alias — old tests reference this fixture name. Keep it
 # as a no-op wrapper so imports don't break.
 @pytest.fixture(autouse=True)

--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -59,7 +59,7 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
     Before #28712's fix, ``recompute_ready`` would silently flip it
     back to ``ready`` on the very next tick."""
     with kb.connect() as conn:
-        tid = kb.create_task(conn, title="needs human review")
+        tid = kb.create_task(conn, title="needs human review", assignee="worker")
         kb.claim_task(conn, tid)
         assert kb.block_task(
             conn, tid,
@@ -116,7 +116,7 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
     leaves the task blocked.
     """
     with kb.connect() as conn:
-        tid = kb.create_task(conn, title="loop reproducer")
+        tid = kb.create_task(conn, title="loop reproducer", assignee="worker")
         kb.claim_task(conn, tid)
         kb.block_task(
             conn, tid,

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -579,7 +579,7 @@ def test_worktree_workspace_explicit_target_materializes_linked_worktree(kanban_
 def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
     """Completion artifacts from scratch workspaces survive workspace cleanup."""
     with kb.connect() as conn:
-        t = kb.create_task(conn, title="render chart")
+        t = kb.create_task(conn, title="render chart", assignee="worker")
         task = kb.get_task(conn, t)
         ws = kb.resolve_workspace(task)
         kb.set_workspace_path(conn, t, ws)
@@ -631,10 +631,10 @@ def test_dir_child_completion_unblocks_deferred_scratch_parent(kanban_home, tmp_
     child_dir = tmp_path / "persistent-child"
     child_dir.mkdir()
     with kb.connect() as conn:
-        parent = kb.create_task(conn, title="scratch parent")
+        parent = kb.create_task(conn, title="scratch parent", assignee="worker")
         child = kb.create_task(
             conn, title="dir child", workspace_kind="dir",
-            workspace_path=str(child_dir),
+            workspace_path=str(child_dir), assignee="worker",
         )
         kb.link_tasks(conn, parent, child)
         p_task = kb.get_task(conn, parent)
@@ -1052,15 +1052,15 @@ def test_unlink_tasks_triggers_recompute_ready(kanban_home):
     """
     with kb.connect() as conn:
         # A is done.
-        a = kb.create_task(conn, title="parent-done")
+        a = kb.create_task(conn, title="parent-done", assignee="worker")
         kb.complete_task(conn, a)
 
         # C is running (not done) — blocks child B.
-        c = kb.create_task(conn, title="parent-running")
+        c = kb.create_task(conn, title="parent-running", assignee="worker")
         kb.claim_task(conn, c, claimer="worker:1")
 
         # B depends on both A (done) and C (running) → stays todo.
-        b = kb.create_task(conn, title="child", parents=[a, c])
+        b = kb.create_task(conn, title="child", parents=[a, c], assignee="worker")
         assert kb.get_task(conn, b).status == "todo"
 
         # Remove the blocking dependency C → B.

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -17,16 +17,6 @@ from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_decompose as decomp
 
 
-@pytest.fixture
-def kanban_home(tmp_path, monkeypatch):
-    home = tmp_path / ".hermes"
-    home.mkdir()
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    kb.init_db()
-    return home
-
-
 def _fake_aux_response(content: str):
     resp = MagicMock()
     resp.choices = [MagicMock()]
@@ -147,7 +137,7 @@ def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
 
 def test_decompose_returns_false_when_task_not_triage(kanban_home):
     with kb.connect() as conn:
-        tid = kb.create_task(conn, title="x")  # ready, not triage
+        tid = kb.create_task(conn, title="x", assignee="worker")  # ready, not triage
 
     patches = _patch_list_profiles(["orchestrator"])
     for p in patches:
@@ -159,5 +149,182 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
             p.stop()
     assert outcome.ok is False
     assert "not in triage" in outcome.reason
+
+
+def test_decompose_null_assignee_children_routed_to_default(kanban_home):
+    """Regression: every child task in decomposer output must have an assignee.
+
+    Feeds a minimal/unmatched task body and null assignees in the LLM
+    response. The decomposer must route every child to the default_assignee
+    — no child should end up with absent/null assignee.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="do stuff", triage=True)
+
+    # LLM returns null assignees for all children — should route to default.
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "test unmatched routing",
+        "tasks": [
+            {"title": "task A", "body": "minimal", "assignee": None, "parents": []},
+            {"title": "task B", "body": "unmatched", "assignee": None, "parents": [0]},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "default", "fallback"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"default_assignee": "fallback"}},
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.fanout is True
+    assert outcome.child_ids and len(outcome.child_ids) == 2
+
+    with kb.connect() as conn:
+        c0 = kb.get_task(conn, outcome.child_ids[0])
+        c1 = kb.get_task(conn, outcome.child_ids[1])
+
+    # Every child must have a non-null assignee — routed to the default.
+    assert c0.assignee is not None, "child[0] was left with null assignee"
+    assert c1.assignee is not None, "child[1] was left with null assignee"
+    assert c0.assignee == "fallback"
+    assert c1.assignee == "fallback"
+
+
+def test_decompose_rejects_null_assignee_in_decompose_triage_task(kanban_home):
+    """Direct call to decompose_triage_task with null assignee must raise.
+
+    The decomposer module normalizes upstream, but decompose_triage_task
+    itself must defensively reject children with null/empty assignees so
+    a direct caller can't bypass the router and create unassigned ready
+    cards.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="root", triage=True)
+
+    children = [
+        {"title": "child A", "body": "work", "assignee": None, "parents": []},
+    ]
+    with pytest.raises(ValueError, match="assignee is required"):
+        kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=children,
+            author="tester",
+        )
+
+
+def test_create_task_without_assignee_lands_in_triage(kanban_home):
+    """Regression: create_task() must not leave a card in 'ready' with no assignee.
+
+    A task created without --triage and without --assignee previously landed
+    in 'ready' and was invisible to the dispatcher. It must now be forced to
+    'triage' so the auto-decomposer can route it.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="orphan task")
+        task = kb.get_task(conn, tid)
+
+    assert task.status == "triage", (
+        f"unassigned task should land in triage, got {task.status!r}"
+    )
+    assert task.assignee is None
+
+    # An assigned task without triage should still go to ready.
+    with kb.connect() as conn:
+        tid2 = kb.create_task(conn, title="assigned task", assignee="worker")
+        task2 = kb.get_task(conn, tid2)
+
+    assert task2.status == "ready", (
+        f"assigned task should be ready, got {task2.status!r}"
+    )
+    assert task2.assignee == "worker"
+
+
+def test_recompute_ready_forces_unassigned_to_triage(kanban_home):
+    """Regression: recompute_ready() must not promote an unassigned card
+    to 'ready' when kanban.default_assignee is unset.
+
+    A child task with no assignee and a done parent would previously be
+    promoted by recompute_ready to 'ready' and sit invisible to the
+    dispatcher.  It must be forced to 'triage' instead.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        kb.complete_task(conn, parent)
+        child = kb.create_task(conn, title="child", parents=[parent])
+        # create_task already forces triage; simulate the bypass by
+        # moving the child back to 'todo' directly (as an external
+        # writer could).
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = ? WHERE id = ?",
+                ("todo", child),
+            )
+        kb.recompute_ready(conn)
+        task = kb.get_task(conn, child)
+
+    assert task.status == "triage", (
+        f"recompute_ready should force unassigned to triage, got {task.status!r}"
+    )
+
+
+def test_promote_task_rejects_unassigned_without_default(kanban_home):
+    """Regression: promote_task() must refuse to promote an unassigned
+    card to 'ready' when kanban.default_assignee is unset.
+
+    The operator can override with --force (deliberate action).
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="unassigned", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = ?, assignee = ? WHERE id = ?",
+                ("todo", None, tid),
+            )
+        ok, reason = kb.promote_task(conn, tid, actor="test")
+
+    assert not ok, "promote_task should reject unassigned card"
+    assert "no assignee" in reason
+
+    # --force overrides (deliberate operator action)
+    with kb.connect() as conn:
+        ok2, reason2 = kb.promote_task(conn, tid, actor="test", force=True)
+        task = kb.get_task(conn, tid)
+
+    assert ok2, "promote_task with --force should succeed"
+    assert task.status == "ready"
+
+
+def test_unblock_task_forces_unassigned_to_triage(kanban_home):
+    """Regression: unblock_task() must not land an unassigned card in
+    'ready' when kanban.default_assignee is unset.
+
+    A blocked unassigned task with no open parents would previously be
+    flipped to 'ready' and sit invisible.  It must be forced to 'triage'.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="blocked orphan", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = ?, assignee = ? WHERE id = ?",
+                ("blocked", None, tid),
+            )
+        result = kb.unblock_task(conn, tid)
+        task = kb.get_task(conn, tid)
+
+    assert result is True
+    assert task.status == "triage", (
+        f"unblock_task should force unassigned to triage, got {task.status!r}"
+    )
 
 

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -11,16 +11,6 @@ import pytest
 from hermes_cli import kanban_db as kb
 
 
-@pytest.fixture
-def kanban_home(tmp_path, monkeypatch):
-    home = tmp_path / ".hermes"
-    home.mkdir()
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    kb.init_db()
-    return home
-
-
 def _create_triage(conn, title="rough idea", body=None, assignee=None, tenant=None):
     return kb.create_task(
         conn,
@@ -86,7 +76,5 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
 
     assert any("Decomposed into" in (c.body or "") for c in comments)
     assert any(ev.kind == "decomposed" for ev in events)
-
-
 
 

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -19,6 +19,16 @@ def isolated_kanban_home(monkeypatch):
     """Spin up a fresh HERMES_HOME with a clean kanban DB."""
     test_home = tempfile.mkdtemp(prefix="kanban_default_assignee_test_")
     monkeypatch.setenv("HERMES_HOME", test_home)
+    # Write a config.yaml with kanban.default_assignee set so that
+    # ``create_task`` allows unassigned cards to land in 'ready' (the
+    # dispatcher auto-assigns on its next tick — #27145).  Without this,
+    # the create-time guard would force unassigned cards to triage and
+    # the dispatcher would never see them.
+    import pathlib
+
+    (pathlib.Path(test_home) / "config.yaml").write_text(
+        "kanban:\n  default_assignee: default\n"
+    )
     # Force-reimport so the fresh HERMES_HOME is picked up.
     for mod in list(sys.modules.keys()):
         if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
@@ -28,6 +38,9 @@ def isolated_kanban_home(monkeypatch):
     # Cleanup is best-effort; tempfile dir survives but pytest isolation
     # gives each test its own monkeypatched HERMES_HOME so no cross-test
     # contamination.
+    import shutil
+
+    shutil.rmtree(test_home, ignore_errors=True)
 
 
 def _fake_spawn(*args, **kwargs):

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -89,9 +89,9 @@ def _promote_ns(task_id, *, ids=None, reason=None, force=False,
 
 def test_cli_promote_bulk_ids_promotes_all(kanban_home, capsys):
     with kb.connect() as conn:
-        parent = kb.create_task(conn, title="parent")
+        parent = kb.create_task(conn, title="parent", assignee="worker")
         children = [
-            kb.create_task(conn, title=f"c{i}", parents=[parent])
+            kb.create_task(conn, title=f"c{i}", parents=[parent], assignee="worker")
             for i in range(3)
         ]
         conn.execute("UPDATE tasks SET status='done' WHERE id=?", (parent,))

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -70,7 +70,7 @@ def _patch_aux_client(content: str, *, model: str = "test-model"):
 
 def test_specify_task_happy_path(kanban_home):
     with kb.connect() as conn:
-        tid = kb.create_task(conn, title="rough", triage=True)
+        tid = kb.create_task(conn, title="rough", triage=True, assignee="worker")
 
     content = jsonlib.dumps({
         "title": "Refined rough",
@@ -113,9 +113,9 @@ def _run_cli(*argv: str) -> int:
 
 def test_cli_specify_tenant_filter(kanban_home, capsys):
     with kb.connect() as conn:
-        outside = kb.create_task(conn, title="outside", triage=True)
+        outside = kb.create_task(conn, title="outside", triage=True, assignee="worker")
         inside = kb.create_task(
-            conn, title="inside", triage=True, tenant="proj-a",
+            conn, title="inside", triage=True, tenant="proj-a", assignee="worker",
         )
 
     content = jsonlib.dumps({"title": "spec", "body": "body"})

--- a/tests/hermes_cli/test_kanban_specify_db.py
+++ b/tests/hermes_cli/test_kanban_specify_db.py
@@ -33,7 +33,7 @@ def _create_triage(conn, title="rough idea", body=None, assignee=None):
 
 def test_specify_promotes_triage_to_todo(kanban_home):
     with kb.connect() as conn:
-        tid = _create_triage(conn, title="rough idea")
+        tid = _create_triage(conn, title="rough idea", assignee="worker")
         assert kb.get_task(conn, tid).status == "triage"
     with kb.connect() as conn:
         ok = kb.specify_triage_task(


### PR DESCRIPTION
## Summary

A card that lands in `ready` with a null/blank `assignee` is invisible to the dispatcher: it is never spawned and sits idle forever. This closes that gap by forcing such cards to `triage` at every promotion path — **unless** `kanban.default_assignee` is configured, in which case the dispatcher's #27145 auto-assign path picks the card up on its next tick (forced triage would regress that feature).

## Changes

- **create_task**: a card that would land in `ready` with no assignee and no `kanban.default_assignee` is forced to `triage` so the auto-decomposer routes it.
- **recompute_ready**: same guard when flipping `todo`/`blocked` → `ready`.
- **promote_task**: refuses to promote an unassigned card to `ready` unless `--force` or a default assignee exists (operator override preserved, same audit trail).
- **unblock_task**: unassigned card with no open parents lands in `triage` instead of `ready`.
- **decompose_triage_task**: defensively raises `ValueError` on null/blank child assignee so a direct caller can't bypass the router and create an unassigned ready card.
- New helper `_kanban_default_assignee()` reads `kanban.default_assignee` from the active config.
- Stale docstring fixed: `decompose_triage_task` no longer says assignee is optional.
- Regression tests updated/aligned (`test_kanban_default_assignee.py`, `test_kanban_decompose.py` + assignee= on stale-expectation fixtures).

## Verification

Targeted kanban suite against this base: **53 passed, 1 skipped** (exit 0). Edge-case probes (empty/whitespace assignee, status-case variants, transaction rollback, dispatch default_assignee dead-ends) all pass.

Closes the null-assignee-in-ready bug that left cards invisible to the dispatcher.