### PR TITLE
fix(mcp): fully redact bearer credentials in diagnostics

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -25,7 +25,10 @@ from hermes_cli.config import (
 )
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home
-from hermes_cli.mcp_security import validate_mcp_server_entry
+from hermes_cli.mcp_security import (
+    redact_mcp_sensitive_text,
+    validate_mcp_server_entry,
+)
 from tools.mcp_tool import _ENV_VAR_PATTERN, _env_ref_name
 
 logger = logging.getLogger(__name__)
@@ -565,7 +568,7 @@ def cmd_mcp_add(args):
     try:
         tools = _probe_single_server(name, server_config)
     except Exception as exc:
-        _error(f"Failed to connect: {exc}")
+        _error(f"Failed to connect: {redact_mcp_sensitive_text(exc)}")
         if _confirm("Save config anyway (you can test later)?", default=False):
             server_config["enabled"] = False
             if _save_mcp_server(name, server_config):
@@ -776,10 +779,9 @@ def cmd_mcp_test(args):
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):
                 # Mask the value (accepts ${VAR} and Cursor-style ${env:VAR})
                 resolved = _ENV_VAR_PATTERN.sub(lambda m: os.getenv(_env_ref_name(m.group(1)), ""), v)
-                if len(resolved) > 8:
-                    masked = resolved[:4] + "***" + resolved[-4:]
-                else:
-                    masked = "***"
+                # MCP Authorization values must not retain a reusable
+                # prefix/suffix in diagnostics (#97460).
+                masked = "***"
                 print(f"    {k}: {masked}")
     else:
         _info("Auth: none")
@@ -791,7 +793,10 @@ def cmd_mcp_test(args):
         elapsed_ms = (time.monotonic() - start) * 1000
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
-        _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
+        _error(
+            f"Connection failed ({elapsed_ms:.0f}ms): "
+            f"{redact_mcp_sensitive_text(exc)}"
+        )
         return
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")
@@ -1009,7 +1014,7 @@ def cmd_mcp_configure(args):
     try:
         all_tools = _probe_single_server(name, cfg)
     except Exception as exc:
-        _error(f"Failed to connect: {exc}")
+        _error(f"Failed to connect: {redact_mcp_sensitive_text(exc)}")
         return
 
     if not all_tools:

--- a/hermes_cli/mcp_security.py
+++ b/hermes_cli/mcp_security.py
@@ -30,6 +30,35 @@ import re
 import shlex
 from typing import Any
 
+
+_MCP_AUTH_HEADER_RE = re.compile(
+    r"((?:Proxy-)?Authorization\s*:\s*)"
+    r"([A-Za-z][\w.+-]*\s+)?([^\s\"']+)",
+    re.IGNORECASE,
+)
+_MCP_BEARER_RE = re.compile(
+    r"(\bBearer\s+)([^\s\"',;)}\]]+)",
+    re.IGNORECASE,
+)
+
+
+def redact_mcp_sensitive_text(value: Any) -> str:
+    """Fully redact MCP authorization values before display or API output.
+
+    The general redactor intentionally preserves a short prefix/suffix for
+    diagnostics. MCP probe errors and header displays are different: those
+    fragments are still credential material, so replace complete Authorization
+    and Bearer values first, then run the normal defense-in-depth redactor.
+    """
+    text = "" if value is None else str(value)
+    text = _MCP_AUTH_HEADER_RE.sub(
+        lambda m: f"{m.group(1)}{m.group(2) or ''}***", text
+    )
+    text = _MCP_BEARER_RE.sub(lambda m: f"{m.group(1)}***", text)
+    from agent.redact import redact_sensitive_text
+
+    return redact_sensitive_text(text, force=True)
+
 _SHELL_INTERPRETERS = frozenset({
     "bash",
     "sh",

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -25,6 +25,7 @@ from hermes_cli.web_models import (
     MCPServerCreate,
     MCPServersReplace,
 )
+from hermes_cli.mcp_security import redact_mcp_sensitive_text
 
 # Same logger the handlers used before extraction (identical logger object).
 _log = logging.getLogger("hermes_cli.web_server")
@@ -85,7 +86,9 @@ async def add_mcp_server(body: MCPServerCreate, profile: Optional[str] = None):
     try:
         name, server_config, bearer_token = _normalize_mcp_server_create(body)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=400, detail=redact_mcp_sensitive_text(exc)
+        ) from exc
 
     def _run():
         with _profile_scope(body.profile or profile):
@@ -112,7 +115,9 @@ async def add_mcp_server(body: MCPServerCreate, profile: Optional[str] = None):
         raise
     except Exception as exc:
         _log.exception("POST /api/mcp/servers failed")
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=400, detail=redact_mcp_sensitive_text(exc)
+        ) from exc
 
     return _mcp_server_summary(name, server_config)
 
@@ -201,7 +206,7 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
     except Exception as exc:
         return {
             "ok": False,
-            "error": str(exc),
+            "error": redact_mcp_sensitive_text(exc),
             "tools": [],
         }
     if not token_present:
@@ -299,7 +304,7 @@ async def auth_mcp_server(name: str, request: Request, profile: Optional[str] = 
     try:
         await flow.wait_for_authorization_url(timeout=30)
     except Exception as exc:
-        flow.mark_error(str(exc))
+        flow.mark_error(redact_mcp_sensitive_text(exc))
     return flow.snapshot()
 
 
@@ -362,7 +367,7 @@ async def mcp_oauth_callback(
     try:
         flow.deliver_callback(code=code, state=state, error=error)
     except ValueError as exc:
-        reason = str(exc)
+        reason = redact_mcp_sensitive_text(exc)
         status_code = 409 if "already received" in reason else 400
         return HTMLResponse(
             "<h1>OAuth callback rejected</h1>"
@@ -414,7 +419,10 @@ async def list_mcp_catalog(profile: Optional[str] = None):
         from hermes_cli import mcp_catalog
     except Exception as exc:
         _log.exception("mcp_catalog import failed")
-        raise HTTPException(status_code=500, detail=f"Catalog unavailable: {exc}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Catalog unavailable: {redact_mcp_sensitive_text(exc)}",
+        )
 
     entries = []
     try:
@@ -525,7 +533,9 @@ async def install_mcp_catalog_entry(body: MCPCatalogInstall, profile: Optional[s
         for key in body.env:
             validate_env_var_name_for_write(key)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise HTTPException(
+                status_code=400, detail=redact_mcp_sensitive_text(exc)
+            ) from exc
 
     # Persist any supplied, declared env vars first.
     effective_profile = body.profile or profile
@@ -554,7 +564,10 @@ async def install_mcp_catalog_entry(body: MCPCatalogInstall, profile: Optional[s
         except HTTPException:
             raise
         except Exception as exc:
-            raise HTTPException(status_code=500, detail=f"Install failed: {exc}")
+            raise HTTPException(
+                status_code=500,
+                detail=f"Install failed: {redact_mcp_sensitive_text(exc)}",
+            )
         return {"ok": True, "name": name, "background": True, "action": action}
 
     # No git step — install synchronously via the catalog API. install_entry
@@ -573,5 +586,7 @@ async def install_mcp_catalog_entry(body: MCPCatalogInstall, profile: Optional[s
         raise
     except Exception as exc:
         _log.exception("install_mcp_catalog_entry failed")
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(
+            status_code=400, detail=redact_mcp_sensitive_text(exc)
+        )
     return {"ok": True, "name": name, "background": False}

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -302,6 +302,48 @@ class TestMcpTest:
         assert "Connected" in out
         assert "Tools discovered: 2" in out
 
+    def test_auth_display_fully_redacts_resolved_bearer_value(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        secret = "SYNTHETIC_MCP_BEARER_NOT_A_SECRET_123456"
+        monkeypatch.setenv("MCP_INK_API_KEY", secret)
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "headers": {"Authorization": "Bearer ${MCP_INK_API_KEY}"},
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [],
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="ink"))
+        out = capsys.readouterr().out
+        assert secret not in out
+        assert secret[:8] not in out
+        assert secret[-8:] not in out
+        assert "Authorization: ***" in out
+
+    def test_probe_error_fully_redacts_bearer_value(self, tmp_path, capsys, monkeypatch):
+        secret = "SYNTHETIC_MCP_BEARER_NOT_A_SECRET_123456"
+        _seed_config(tmp_path, {"ink": {"url": "https://mcp.ml.ink/mcp"}})
+
+        def mock_probe(name, config, **kw):
+            raise RuntimeError(f"upstream rejected Authorization: Bearer {secret}")
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", mock_probe)
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="ink"))
+        out = capsys.readouterr().out
+        assert secret not in out
+        assert secret[:8] not in out
+        assert secret[-8:] not in out
+        assert "Bearer ***" in out
+
     def test_probe_uses_configured_connect_timeout(self, monkeypatch):
         """OAuth-capable probes must not hard-code a short 30s timeout."""
         import asyncio


### PR DESCRIPTION
Closes #97460

Fully redact MCP Authorization/Bearer values in CLI probe output and dashboard/API error payloads, while retaining the environment-variable template on disk. Adds regression coverage for auth display and probe failures.