### PR TITLE
fix(gateway): bind clarify callbacks to active origin and session

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4389,6 +4389,65 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
+    async def dispatch_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        *,
+        binding: Optional[Any] = None,
+        require_binding: bool = False,
+    ) -> SendResult:
+        """Dispatch clarify without breaking pre-binding adapter overrides.
+
+        ``send_clarify`` is an established adapter hook. Third-party adapters
+        may still implement its pre-binding signature, so the compatibility
+        lane deliberately omits the new keyword. A surface that renders bound
+        callbacks (currently Telegram) opts into ``require_binding``; that lane
+        verifies both the immutable value and the handler capability before
+        invoking the adapter, and otherwise fails closed without posting an
+        unbound prompt.
+
+        Signature inspection happens before dispatch. We never catch and retry
+        ``TypeError`` from the adapter itself, because doing so would hide real
+        implementation bugs and could duplicate a prompt after a partial send.
+        """
+        kwargs: Dict[str, Any] = {
+            "chat_id": chat_id,
+            "question": question,
+            "choices": choices,
+            "clarify_id": clarify_id,
+            "session_key": session_key,
+            "metadata": metadata,
+        }
+        if require_binding:
+            from tools.clarify_gateway import ClarifyBinding
+
+            if not isinstance(binding, ClarifyBinding):
+                return SendResult(
+                    success=False,
+                    error="Missing immutable clarify binding",
+                )
+            try:
+                parameters = inspect.signature(self.send_clarify).parameters.values()
+            except (TypeError, ValueError):
+                parameters = ()
+            accepts_binding = any(
+                parameter.name == "binding"
+                or parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters
+            )
+            if not accepts_binding:
+                return SendResult(
+                    success=False,
+                    error="Adapter does not support immutable clarify binding",
+                )
+            kwargs["binding"] = binding
+        return await self.send_clarify(**kwargs)
+
     async def send_clarify(
         self,
         chat_id: str,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4397,6 +4397,7 @@ class BasePlatformAdapter(ABC):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        binding: Optional[Any] = None,
     ) -> SendResult:
         """Send a clarify prompt to the user.
 
@@ -4428,16 +4429,10 @@ class BasePlatformAdapter(ABC):
         override this for a richer UX.
         """
         if choices:
-            # Multi-select clarifies register their flag on the pending entry;
-            # look it up by id so the signature stays adapter-compatible.
-            _is_multi = False
-            try:
-                from tools import clarify_gateway as _cg
-                with _cg._lock:
-                    _entry = _cg._entries.get(clarify_id)
-                _is_multi = bool(_entry and getattr(_entry, "multi_select", False))
-            except Exception:
-                _is_multi = False
+            # Query through the primitive API; adapters must not inspect its
+            # lock or storage directly.
+            from tools.clarify_gateway import is_multi_select
+            _is_multi = is_multi_select(clarify_id)
             lines = [f"❓ {question}", ""]
             for i, choice in enumerate(choices, start=1):
                 lines.append(f"  {i}. {choice}")

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -764,6 +764,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        binding: Optional[Any] = None,
     ) -> SendResult:
         """Render a clarify prompt as native WhatsApp interactive buttons.
 

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -2911,6 +2911,7 @@ class RelayAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        binding: Optional[Any] = None,
     ) -> SendResult:
         """Native-button clarify over the relay (Phase 3).
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6772,20 +6772,25 @@ class TurnRunner:
                 "Session split detected: %s → %s (compression)",
                 ctx.session_id, agent_session_id,
             )
-            entry = self._runner.session_store._entries.get(ctx.session_key)
             _session_split_entry_persisted = False
-            if entry:
-                entry_session_id = getattr(entry, "session_id", None)
-                if not ctx._run_still_current():
-                    logger.info(
-                        "Skipping session split sync for stale run %s — "
-                        "generation %s is no longer current",
-                        ctx.session_key or "?",
-                        ctx.run_generation,
+            entry = None
+            if not ctx._run_still_current():
+                logger.info(
+                    "Skipping session split sync for stale run %s — "
+                    "generation %s is no longer current",
+                    ctx.session_key or "?",
+                    ctx.run_generation,
+                )
+            else:
+                entry = self._runner.session_store.advance_compression_session(
+                    ctx.session_key,
+                    ctx.session_id,
+                    agent_session_id,
+                )
+                if entry is None:
+                    entry_session_id = self._runner.session_store.peek_session_id(
+                        ctx.session_key,
                     )
-                elif entry_session_id == agent_session_id:
-                    _session_split_entry_persisted = True
-                elif entry_session_id != ctx.session_id:
                     logger.info(
                         "Skipping session split sync for %s because the "
                         "session binding moved from %s to %s before "
@@ -6795,8 +6800,6 @@ class TurnRunner:
                         entry_session_id,
                     )
                 else:
-                    entry.session_id = agent_session_id
-                    self._runner.session_store._save()
                     self._runner.session_store._record_gateway_session_peer(
                         agent_session_id,
                         ctx.session_key,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1018,6 +1018,24 @@ def _clear_pending_clarify_session(
         return 0
 
 
+def _fence_and_clear_pending_clarify(
+    agent: Any,
+    session_key: str,
+    *,
+    run_generation: Optional[int] = None,
+) -> int:
+    """Close clarify admission before waking this interrupted turn's waiter."""
+    if agent is not None:
+        try:
+            agent._gateway_clarify_admission_closed = True
+        except Exception:
+            logger.debug("Failed to fence clarify admission", exc_info=True)
+    return _clear_pending_clarify_session(
+        session_key,
+        run_generation=run_generation,
+    )
+
+
 def _clear_all_pending_clarifies() -> int:
     """Invalidate process-local clarify state before gateway teardown."""
     try:
@@ -3528,7 +3546,8 @@ def _abandon_timed_out_gateway_turn(
     agent = agent_holder[0] if agent_holder else None
     if agent is not None:
         try:
-            _clear_pending_clarify_session(
+            _fence_and_clear_pending_clarify(
+                agent,
                 session_key or "",
                 run_generation=run_generation,
             )
@@ -6156,6 +6175,8 @@ class TurnRunner:
                 except Exception:
                     return "[clarify unavailable because this turn is no longer active]"
                 _agent = ctx.agent_holder[0] if ctx.agent_holder else None
+                if getattr(_agent, "_gateway_clarify_admission_closed", False) is True:
+                    return "[clarify unavailable because this turn was interrupted]"
                 if getattr(_agent, "is_interrupted", False) is True:
                     return "[clarify unavailable because this turn was interrupted]"
                 return None
@@ -6303,6 +6324,7 @@ class TurnRunner:
                     )
             return _clarify_response
 
+        agent._gateway_clarify_admission_closed = False
         agent.clarify_callback = _clarify_callback_sync
 
         # Show assistant thinking between tool calls — independent of
@@ -10809,7 +10831,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 elif not _interrupt_text and _media_urls:
                     _interrupt_text = _build_media_placeholder(event)
-                _clear_pending_clarify_session(
+                _fence_and_clear_pending_clarify(
+                    running_agent,
                     session_key,
                     run_generation=_busy_run_generation,
                 )
@@ -11055,7 +11078,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
-                _clear_pending_clarify_session(session_key)
+                _fence_and_clear_pending_clarify(agent, session_key)
                 request_hard_interrupt(agent, reason)
                 logger.debug("Interrupted running agent for session %s during shutdown", session_key)
             except Exception as e:
@@ -18306,7 +18329,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             elif not _interrupt_text and _media_urls:
                 _interrupt_text = _build_media_placeholder(event)
-            _clear_pending_clarify_session(
+            _fence_and_clear_pending_clarify(
+                running_agent,
                 _quick_key,
                 run_generation=_running_generation,
             )
@@ -27817,9 +27841,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # A clarify wait blocks inside the agent worker.  Wake it before
         # requesting interruption so /stop, /new, and equivalent control
         # paths never leave an orphan waiter behind the interrupted turn.
-        _clear_pending_clarify_session(session_key)
         _iac_state = self._peek_session_state(session_key)
         running_agent = _iac_state.turn.agent if _iac_state else None
+        _fence_and_clear_pending_clarify(running_agent, session_key)
         _process_task_id = ""
         _process_baseline = None
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
@@ -29952,7 +29976,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 elif not pending_text and _media_urls:
                                     pending_text = _build_media_placeholder(_peek_event)
                             logger.debug("Interrupt detected from adapter, signaling agent...")
-                            _clear_pending_clarify_session(
+                            _fence_and_clear_pending_clarify(
+                                agent,
                                 session_key,
                                 run_generation=run_generation,
                             )
@@ -30245,7 +30270,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 session_key,
                                 "done" if interrupt_monitor.done() else "running",
                             )
-                            _clear_pending_clarify_session(
+                            _fence_and_clear_pending_clarify(
+                                _backup_agent,
                                 session_key,
                                 run_generation=run_generation,
                             )
@@ -30353,7 +30379,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 session_key,
                                 "done" if interrupt_monitor.done() else "running",
                             )
-                            _clear_pending_clarify_session(
+                            _fence_and_clear_pending_clarify(
+                                _backup_agent,
                                 session_key,
                                 run_generation=run_generation,
                             )
@@ -30391,7 +30418,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Interrupt the agent if it's still running so the thread
                 # pool worker is freed.
                 if _timed_out_agent:
-                    _clear_pending_clarify_session(
+                    _fence_and_clear_pending_clarify(
+                        _timed_out_agent,
                         session_key,
                         run_generation=run_generation,
                     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -990,6 +990,32 @@ def _clarify_send_then_wait(fut, *, clarify_id: str, session_key: str, clarify_m
     return response
 
 
+def _clear_pending_clarify_session(session_key: str) -> int:
+    """Invalidate one session's clarify callbacks and wake unresolved waiters."""
+    if not session_key:
+        return 0
+    try:
+        from tools.clarify_gateway import clear_session
+
+        return int(clear_session(session_key))
+    except Exception:
+        logger.debug(
+            "Failed to clear clarify state for %s", session_key, exc_info=True
+        )
+        return 0
+
+
+def _clear_all_pending_clarifies() -> int:
+    """Invalidate process-local clarify state before gateway teardown."""
+    try:
+        from tools.clarify_gateway import clear_all
+
+        return int(clear_all())
+    except Exception:
+        logger.debug("Failed to clear all clarify state", exc_info=True)
+        return 0
+
+
 def _resolve_progress_thread_id(
     platform: Any,
     source_thread_id: Any,
@@ -3472,6 +3498,7 @@ def _abandon_timed_out_gateway_turn(
     timeout_fired: threading.Event,
     cleanup_lock: threading.Lock,
     is_still_current: Optional[Callable[[], bool]] = None,
+    session_key: Optional[str] = None,
 ) -> bool:
     """Interrupt one timed-out turn and reap only processes it created."""
     with cleanup_lock:
@@ -3487,6 +3514,7 @@ def _abandon_timed_out_gateway_turn(
     agent = agent_holder[0] if agent_holder else None
     if agent is not None:
         try:
+            _clear_pending_clarify_session(session_key or "")
             request_hard_interrupt(agent, _INTERRUPT_REASON_TIMEOUT)
         except Exception:
             logger.debug("Timed-out agent interrupt failed", exc_info=True)
@@ -3518,6 +3546,7 @@ def _watch_gateway_turn_inactivity(
     cleanup_lock: threading.Lock,
     poll_interval: float = 5.0,
     is_still_current: Optional[Callable[[], bool]] = None,
+    session_key: Optional[str] = None,
 ) -> None:
     """Thread watchdog that remains runnable when gateway asyncio is starved."""
     while not worker_done.wait(max(0.01, poll_interval)):
@@ -3540,6 +3569,7 @@ def _watch_gateway_turn_inactivity(
             timeout_fired=timeout_fired,
             cleanup_lock=cleanup_lock,
             is_still_current=is_still_current,
+            session_key=session_key,
         )
         return
 
@@ -6094,15 +6124,45 @@ class TurnRunner:
 
             if not ctx._status_adapter:
                 return ""
+            if (
+                getattr(self._runner, "_running", True) is False
+                or getattr(self._runner, "_draining", False) is True
+            ):
+                return "[clarify unavailable while gateway is shutting down]"
 
             clarify_id = _uuid.uuid4().hex[:10]
-            _clarify_mod.register(
+            _clarify_binding_kwargs = {}
+            if ctx.source.platform == Platform.TELEGRAM:
+                _clarify_binding_kwargs = {
+                    "origin": _clarify_mod.ClarifyOrigin(
+                        getattr(ctx.source, "user_id", None) or "",
+                        getattr(ctx.source, "chat_id", None) or "",
+                        getattr(ctx.source, "thread_id", None),
+                    ),
+                    "session_id": ctx.session_id or "",
+                    "active_session_transaction": lambda action: self._runner.session_store.run_if_session_current(
+                        ctx.session_key or "",
+                        ctx.session_id or "",
+                        action,
+                    ),
+                }
+            _clarify_entry = _clarify_mod.register(
                 clarify_id=clarify_id,
                 session_key=ctx.session_key or "",
                 question=question,
                 choices=list(choices) if choices else None,
                 multi_select=bool(multi_select),
+                **_clarify_binding_kwargs,
             )
+            # Bracket registration with the liveness check. If shutdown raced
+            # the first check and its global clear ran before this register,
+            # the second check owns cancellation so no new waiter survives.
+            if (
+                getattr(self._runner, "_running", True) is False
+                or getattr(self._runner, "_draining", False) is True
+            ):
+                _clarify_mod.clear_session(ctx.session_key or "")
+                return "[clarify unavailable while gateway is shutting down]"
 
             # For WeCom native streaming: finalize the current stream before
             # showing the clarify prompt so the post-answer output opens a
@@ -6155,6 +6215,7 @@ class TurnRunner:
                     clarify_id=clarify_id,
                     session_key=ctx.session_key or "",
                     metadata=ctx._status_thread_metadata,
+                    binding=_clarify_entry.binding,
                 ),
                 ctx._loop_for_step,
                 logger=logger,
@@ -7110,6 +7171,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(
                 key, max_active_age=_bg_max_age_seconds,
             ),
+            session_boundary_cleanup_fn=_clear_pending_clarify_session,
         )
         # One enforced loop-side boundary for the synchronous SessionStore.
         # Sync helpers keep using ``session_store`` directly; async gateway
@@ -10698,6 +10760,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 elif not _interrupt_text and _media_urls:
                     _interrupt_text = _build_media_placeholder(event)
+                _clear_pending_clarify_session(session_key)
                 running_agent.interrupt(_interrupt_text)
             except Exception:
                 pass  # don't let interrupt failure block the ack
@@ -10940,6 +11003,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
+                _clear_pending_clarify_session(session_key)
                 request_hard_interrupt(agent, reason)
                 logger.debug("Interrupted running agent for session %s during shutdown", session_key)
             except Exception as e:
@@ -14455,6 +14519,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 for key, entry in _expired_entries:
                     try:
+                        # Expiry is a conversation boundary. Wake a blocked
+                        # clarify before finalize hooks or agent.close() can
+                        # release/recreate resources for this route.
+                        _clear_pending_clarify_session(key)
                         try:
                             _parts = key.split(":")
                             _platform = _parts[2] if len(_parts) > 2 else ""
@@ -15466,6 +15534,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return time.monotonic() - _stop_started_at
 
             self._running = False
+            # Wake clarify-blocked agent threads before the drain begins.
+            # Registration brackets its write with the same liveness state,
+            # so a prompt racing this clear cancels itself.
+            _clear_all_pending_clarifies()
             self._clear_plugin_message_injector()
             self._draining = True
 
@@ -17801,7 +17873,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # with an empty response.
             if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
                 _text_outcome = _clarify_mod.attempt_text_response_for_session(
-                    _quick_key, _raw_clarify_reply,
+                    _quick_key,
+                    _raw_clarify_reply,
+                    observed_origin=_clarify_mod.ClarifyOrigin(
+                        source.user_id or "",
+                        source.chat_id or "",
+                        source.thread_id,
+                    ),
                 )
                 if _text_outcome == _clarify_mod.TEXT_RESOLVED:
                     logger.info(
@@ -17844,10 +17922,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # routing. Release this clarify first: redirect()
                     # degrades to steer() while tools are executing, and
                     # that steer cannot drain until the clarify tool returns.
-                    _clarify_mod.resolve_gateway_clarify(
-                        _pending_clarify.clarify_id,
-                        "",
-                    )
+                    if _pending_clarify.binding is not None:
+                        _clarify_mod.cancel_bound_clarify(
+                            _pending_clarify.clarify_id,
+                            binding=_pending_clarify.binding,
+                            observed_origin=_clarify_mod.ClarifyOrigin(
+                                source.user_id or "",
+                                source.chat_id or "",
+                                source.thread_id,
+                            ),
+                        )
+                    else:
+                        _clarify_mod.resolve_gateway_clarify(
+                            _pending_clarify.clarify_id,
+                            "",
+                        )
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are
@@ -18160,6 +18249,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             elif not _interrupt_text and _media_urls:
                 _interrupt_text = _build_media_placeholder(event)
+            _clear_pending_clarify_session(_quick_key)
             running_agent.interrupt(_interrupt_text)
             # NOTE: self._pending_messages was write-only (never consumed).
             # The actual interrupt message is delivered via adapter._pending_messages
@@ -27374,6 +27464,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not session_key:
             return False
+        # Wake any clarify waiter before releasing or replacing the running
+        # turn.  This is deliberately before the generation guard: a stale
+        # unwind must not clobber a newer turn's slot, but its old session-
+        # scoped prompt still cannot survive completion/close/rotation.
+        _clear_pending_clarify_session(session_key)
         if run_generation is not None and not self._is_session_run_current(
             session_key, run_generation
         ):
@@ -27492,6 +27587,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not session_key:
             return
+        # Clarify waiters are conversation-scoped even though their registry
+        # lives outside SessionState.  Clear them at the boundary funnel before
+        # any other scoped state or cached agent can be released/recreated.
+        _clear_pending_clarify_session(session_key)
         # Structural clear: every conversation-scoped field resets in one
         # call — no per-attribute pop-list to drift.
         state = self._peek_session_state(session_key)
@@ -27618,6 +27717,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Interrupt the current run and clear queued session state consistently."""
         if not session_key:
             return
+        # A clarify wait blocks inside the agent worker.  Wake it before
+        # requesting interruption so /stop, /new, and equivalent control
+        # paths never leave an orphan waiter behind the interrupted turn.
+        _clear_pending_clarify_session(session_key)
         _iac_state = self._peek_session_state(session_key)
         running_agent = _iac_state.turn.agent if _iac_state else None
         _process_task_id = ""
@@ -29752,6 +29855,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 elif not pending_text and _media_urls:
                                     pending_text = _build_media_placeholder(_peek_event)
                             logger.debug("Interrupt detected from adapter, signaling agent...")
+                            _clear_pending_clarify_session(session_key)
                             agent.interrupt(pending_text)
                             _interrupt_detected.set()
                             # Abort streaming TTS on barge-in (#60671).
@@ -29988,6 +30092,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "cleanup_lock": _turn_cleanup_lock,
                         "poll_interval": 5.0,
                         "is_still_current": _turn_is_current,
+                        "session_key": session_key,
                     },
                     name=f"gateway-turn-watchdog-{_turn_task_id[:12]}",
                     daemon=True,
@@ -30039,6 +30144,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 session_key,
                                 "done" if interrupt_monitor.done() else "running",
                             )
+                            _clear_pending_clarify_session(session_key)
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
                             # Abort streaming TTS on barge-in (#60671).
@@ -30108,6 +30214,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "timeout_fired": _turn_timeout_fired,
                                 "cleanup_lock": _turn_cleanup_lock,
                                 "is_still_current": _turn_is_current,
+                                "session_key": session_key,
                             },
                             name=f"gateway-turn-reaper-{_turn_task_id[:12]}",
                             daemon=True,
@@ -30141,6 +30248,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 session_key,
                                 "done" if interrupt_monitor.done() else "running",
                             )
+                            _clear_pending_clarify_session(session_key)
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
                             # Abort streaming TTS on barge-in (#60671).
@@ -30175,6 +30283,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Interrupt the agent if it's still running so the thread
                 # pool worker is freed.
                 if _timed_out_agent:
+                    _clear_pending_clarify_session(session_key)
                     request_hard_interrupt(_timed_out_agent, _INTERRUPT_REASON_TIMEOUT)
 
                 _timeout_mins = int(_agent_timeout // 60) or 1

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6208,7 +6208,7 @@ class TurnRunner:
                 )
 
             fut = safe_schedule_threadsafe(
-                ctx._status_adapter.send_clarify(
+                ctx._status_adapter.dispatch_clarify(
                     chat_id=ctx._status_chat_id,
                     question=question,
                     choices=list(choices) if choices else None,
@@ -6216,6 +6216,7 @@ class TurnRunner:
                     session_key=ctx.session_key or "",
                     metadata=ctx._status_thread_metadata,
                     binding=_clarify_entry.binding,
+                    require_binding=ctx.source.platform == Platform.TELEGRAM,
                 ),
                 ctx._loop_for_step,
                 logger=logger,
@@ -20826,20 +20827,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             _hyg_rotated = False
                                             _hyg_in_place = False
                                         else:
-                                            session_entry.session_id = _hyg_new_sid
-                                            # The held turn lease follows the
-                                            # rotation so an alias key resolving
-                                            # the fresh child still serializes
-                                            # against this turn (#64934).
-                                            self._rebind_turn_lease(
-                                                _quick_key, run_generation, _hyg_new_sid
+                                            _hyg_prior_sid = session_entry.session_id
+                                            _hyg_advanced_entry = (
+                                                await self.async_session_store.advance_compression_session(
+                                                    session_entry.session_key,
+                                                    _hyg_prior_sid,
+                                                    _hyg_new_sid,
+                                                )
                                             )
-                                            await self.async_session_store._save()
-                                            await asyncio.to_thread(
-                                                self._sync_telegram_topic_binding,
-                                                source, session_entry,
-                                                reason="hygiene-compression",
-                                            )
+                                            if _hyg_advanced_entry is None:
+                                                logger.info(
+                                                    "Session hygiene: route %s moved "
+                                                    "away from %s before compression "
+                                                    "finished; leaving the newer route "
+                                                    "unchanged",
+                                                    session_entry.session_key,
+                                                    _hyg_prior_sid,
+                                                )
+                                                _hyg_rotated = False
+                                                _hyg_in_place = False
+                                            else:
+                                                session_entry = _hyg_advanced_entry
+                                                # The held turn lease follows the
+                                                # rotation so an alias key resolving
+                                                # the fresh child still serializes
+                                                # against this turn (#64934).
+                                                self._rebind_turn_lease(
+                                                    _quick_key,
+                                                    run_generation,
+                                                    _hyg_new_sid,
+                                                )
+                                                await asyncio.to_thread(
+                                                    self._sync_telegram_topic_binding,
+                                                    source, session_entry,
+                                                    reason="hygiene-compression",
+                                                )
 
                                     if _hyg_rotated:
                                         # Reset stored token count — transcript rewritten
@@ -21339,12 +21361,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 response = _sanitize_gateway_final_response(source.platform, response)
 
             # Ordering contract: the agent thread already updated the contextvar
-            # in conversation_compression.py; propagate to SessionEntry + _save().
-            # If the agent's session_id changed during compression, update
-            # session_entry so transcript writes below go to the right session.
+            # in conversation_compression.py. CAS-advance the SessionStore route;
+            # its locked funnel persists the mapping and invalidates callbacks
+            # before transcript writes below target the rotated session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-                if session_entry.session_id == _run_start_session_id:
-                    session_entry.session_id = agent_result["session_id"]
+                advanced_entry = (
+                    await self.async_session_store.advance_compression_session(
+                        session_key,
+                        _run_start_session_id,
+                        agent_result["session_id"],
+                    )
+                )
+                if advanced_entry is not None:
+                    session_entry = advanced_entry
                     # The held turn lease follows the rotation: the transcript
                     # persistence below writes to the NEW id, so the
                     # serialization boundary must move with it or an alias
@@ -21352,7 +21381,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._rebind_turn_lease(
                         _quick_key, run_generation, session_entry.session_id
                     )
-                    await self.async_session_store._save()
                     await self.async_session_store._record_gateway_session_peer(
                         session_entry.session_id,
                         session_key,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -990,14 +990,18 @@ def _clarify_send_then_wait(fut, *, clarify_id: str, session_key: str, clarify_m
     return response
 
 
-def _clear_pending_clarify_session(session_key: str) -> int:
-    """Invalidate one session's clarify callbacks and wake unresolved waiters."""
+def _clear_pending_clarify_session(
+    session_key: str,
+    *,
+    run_generation: Optional[int] = None,
+) -> int:
+    """Invalidate matching clarify callbacks and wake unresolved waiters."""
     if not session_key:
         return 0
     try:
         from tools.clarify_gateway import clear_session
 
-        return int(clear_session(session_key))
+        return int(clear_session(session_key, run_generation=run_generation))
     except Exception:
         logger.debug(
             "Failed to clear clarify state for %s", session_key, exc_info=True
@@ -6152,6 +6156,7 @@ class TurnRunner:
                 question=question,
                 choices=list(choices) if choices else None,
                 multi_select=bool(multi_select),
+                run_generation=ctx.run_generation,
                 **_clarify_binding_kwargs,
             )
             # Bracket registration with the liveness check. If shutdown raced
@@ -6674,7 +6679,10 @@ class TurnRunner:
             # completion, gateway shutdown).  Idempotent.
             try:
                 from tools.clarify_gateway import clear_session as _clear_clarify_session
-                _clear_clarify_session(_approval_session_key)
+                _clear_clarify_session(
+                    _approval_session_key,
+                    run_generation=ctx.run_generation,
+                )
             except Exception:
                 pass
             reset_current_session_key(_approval_session_token)
@@ -19084,7 +19092,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
             # inside _run_agent returns False, and the old sentinel-only check here
             # missed the leftover real agent — locking the session out forever (#28686).
-            self._release_running_agent_state(_quick_key)
+            self._release_running_agent_state(
+                _quick_key,
+                clarify_run_generation=_run_generation,
+            )
             # Turn lease (#64934): release THIS turn's lease token — keyed by
             # (routing key, run generation) so this unwind can only ever free
             # the lease its own turn acquired, never a newer turn's.
@@ -27469,6 +27480,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str,
         *,
         run_generation: Optional[int] = None,
+        clarify_run_generation: Any = _UNSET,
     ) -> bool:
         """Pop ALL per-running-agent state entries for ``session_key``.
 
@@ -27495,11 +27507,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not session_key:
             return False
-        # Wake any clarify waiter before releasing or replacing the running
-        # turn.  This is deliberately before the generation guard: a stale
-        # unwind must not clobber a newer turn's slot, but its old session-
-        # scoped prompt still cannot survive completion/close/rotation.
-        _clear_pending_clarify_session(session_key)
+        # Wake this turn's clarify waiter before releasing its slot.  A stale
+        # unwind still owns cleanup of its own prompt, but must not cancel a
+        # newer generation's prompt on the same routing key.  Callers that
+        # omit both generation arguments are true session boundaries and keep
+        # the legacy clear-all behavior.
+        if clarify_run_generation is _UNSET:
+            clarify_run_generation = run_generation
+        _clear_pending_clarify_session(
+            session_key,
+            run_generation=clarify_run_generation,
+        )
         if run_generation is not None and not self._is_session_run_current(
             session_key, run_generation
         ):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6143,11 +6143,26 @@ class TurnRunner:
 
             if not ctx._status_adapter:
                 return ""
-            if (
-                getattr(self._runner, "_running", True) is False
-                or getattr(self._runner, "_draining", False) is True
-            ):
-                return "[clarify unavailable while gateway is shutting down]"
+
+            def _clarify_admission_failure() -> "str | None":
+                if (
+                    getattr(self._runner, "_running", True) is False
+                    or getattr(self._runner, "_draining", False) is True
+                ):
+                    return "[clarify unavailable while gateway is shutting down]"
+                try:
+                    if not ctx._run_still_current():
+                        return "[clarify unavailable because this turn is no longer active]"
+                except Exception:
+                    return "[clarify unavailable because this turn is no longer active]"
+                _agent = ctx.agent_holder[0] if ctx.agent_holder else None
+                if getattr(_agent, "is_interrupted", False) is True:
+                    return "[clarify unavailable because this turn was interrupted]"
+                return None
+
+            _admission_failure = _clarify_admission_failure()
+            if _admission_failure is not None:
+                return _admission_failure
 
             clarify_id = _uuid.uuid4().hex[:10]
             _clarify_binding_kwargs = {}
@@ -6174,18 +6189,17 @@ class TurnRunner:
                 run_generation=ctx.run_generation,
                 **_clarify_binding_kwargs,
             )
-            # Bracket registration with the liveness check. If shutdown raced
-            # the first check and its global clear ran before this register,
-            # the second check owns cancellation so no new waiter survives.
-            if (
-                getattr(self._runner, "_running", True) is False
-                or getattr(self._runner, "_draining", False) is True
-            ):
+            # Bracket registration with turn liveness. If /stop, teardown, or
+            # shutdown cleared before this register won the race, the second
+            # check owns this exact registration so no stale waiter survives
+            # and no prompt is delivered for an abandoned generation.
+            _admission_failure = _clarify_admission_failure()
+            if _admission_failure is not None:
                 _clarify_mod.clear_session(
                     ctx.session_key or "",
                     clarify_id=clarify_id,
                 )
-                return "[clarify unavailable while gateway is shutting down]"
+                return _admission_failure
 
             # For WeCom native streaming: finalize the current stream before
             # showing the clarify prompt so the post-answer output opens a

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -938,7 +938,13 @@ def _approval_send_outcome(future, timeout: float) -> str:
     return "failed"
 
 
-def _clarify_send_disposition(fut, *, session_key: str, clarify_mod) -> "str | None":
+def _clarify_send_disposition(
+    fut,
+    *,
+    clarify_id: str,
+    session_key: str,
+    clarify_mod,
+) -> "str | None":
     """Decide whether a clarify prompt send aborts the wait, per the boundary rule.
 
     Same physics as the exec-approval card: the scheduling future can hit its
@@ -958,7 +964,7 @@ def _clarify_send_disposition(fut, *, session_key: str, clarify_mod) -> "str | N
         # Couldn't deliver the prompt — clean up and return the sentinel so
         # the agent can fall back to a sensible default rather than hanging.
         logger.warning("Clarify send failed definitively; clearing registration")
-        clarify_mod.clear_session(session_key)
+        clarify_mod.clear_session(session_key, clarify_id=clarify_id)
         return "[clarify prompt could not be delivered]"
     if outcome == "ambiguous":
         logger.warning(
@@ -978,7 +984,10 @@ def _clarify_send_then_wait(fut, *, clarify_id: str, session_key: str, clarify_m
     the (probably rendered) card still resolves.
     """
     abort = _clarify_send_disposition(
-        fut, session_key=session_key, clarify_mod=clarify_mod
+        fut,
+        clarify_id=clarify_id,
+        session_key=session_key,
+        clarify_mod=clarify_mod,
     )
     if abort is not None:
         return abort
@@ -3503,6 +3512,7 @@ def _abandon_timed_out_gateway_turn(
     cleanup_lock: threading.Lock,
     is_still_current: Optional[Callable[[], bool]] = None,
     session_key: Optional[str] = None,
+    run_generation: Optional[int] = None,
 ) -> bool:
     """Interrupt one timed-out turn and reap only processes it created."""
     with cleanup_lock:
@@ -3518,7 +3528,10 @@ def _abandon_timed_out_gateway_turn(
     agent = agent_holder[0] if agent_holder else None
     if agent is not None:
         try:
-            _clear_pending_clarify_session(session_key or "")
+            _clear_pending_clarify_session(
+                session_key or "",
+                run_generation=run_generation,
+            )
             request_hard_interrupt(agent, _INTERRUPT_REASON_TIMEOUT)
         except Exception:
             logger.debug("Timed-out agent interrupt failed", exc_info=True)
@@ -3551,6 +3564,7 @@ def _watch_gateway_turn_inactivity(
     poll_interval: float = 5.0,
     is_still_current: Optional[Callable[[], bool]] = None,
     session_key: Optional[str] = None,
+    run_generation: Optional[int] = None,
 ) -> None:
     """Thread watchdog that remains runnable when gateway asyncio is starved."""
     while not worker_done.wait(max(0.01, poll_interval)):
@@ -3574,6 +3588,7 @@ def _watch_gateway_turn_inactivity(
             cleanup_lock=cleanup_lock,
             is_still_current=is_still_current,
             session_key=session_key,
+            run_generation=run_generation,
         )
         return
 
@@ -6166,7 +6181,10 @@ class TurnRunner:
                 getattr(self._runner, "_running", True) is False
                 or getattr(self._runner, "_draining", False) is True
             ):
-                _clarify_mod.clear_session(ctx.session_key or "")
+                _clarify_mod.clear_session(
+                    ctx.session_key or "",
+                    clarify_id=clarify_id,
+                )
                 return "[clarify unavailable while gateway is shutting down]"
 
             # For WeCom native streaming: finalize the current stream before
@@ -10634,6 +10652,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         _busy_state = self._peek_session_state(session_key)
         running_agent = _busy_state.turn.agent if _busy_state else None
+        _busy_run_generation = getattr(
+            getattr(_busy_state, "persistent", None),
+            "run_generation",
+            None,
+        )
 
         busy_text_mode = self._effective_busy_text_mode(event.source)
         if (
@@ -10772,7 +10795,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 elif not _interrupt_text and _media_urls:
                     _interrupt_text = _build_media_placeholder(event)
-                _clear_pending_clarify_session(session_key)
+                _clear_pending_clarify_session(
+                    session_key,
+                    run_generation=_busy_run_generation,
+                )
                 running_agent.interrupt(_interrupt_text)
             except Exception:
                 pass  # don't let interrupt failure block the ack
@@ -18138,6 +18164,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             _ra_state = self._peek_session_state(_quick_key)
             running_agent = _ra_state.turn.agent if _ra_state else None
+            _running_generation = getattr(
+                getattr(_ra_state, "persistent", None),
+                "run_generation",
+                None,
+            )
             if running_agent is _AGENT_PENDING_SENTINEL:
                 # Agent is being set up but not ready yet.
                 if event.get_command() == "stop":
@@ -18261,7 +18292,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             elif not _interrupt_text and _media_urls:
                 _interrupt_text = _build_media_placeholder(event)
-            _clear_pending_clarify_session(_quick_key)
+            _clear_pending_clarify_session(
+                _quick_key,
+                run_generation=_running_generation,
+            )
             running_agent.interrupt(_interrupt_text)
             # NOTE: self._pending_messages was write-only (never consumed).
             # The actual interrupt message is delivered via adapter._pending_messages
@@ -29904,7 +29938,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 elif not pending_text and _media_urls:
                                     pending_text = _build_media_placeholder(_peek_event)
                             logger.debug("Interrupt detected from adapter, signaling agent...")
-                            _clear_pending_clarify_session(session_key)
+                            _clear_pending_clarify_session(
+                                session_key,
+                                run_generation=run_generation,
+                            )
                             agent.interrupt(pending_text)
                             _interrupt_detected.set()
                             # Abort streaming TTS on barge-in (#60671).
@@ -30142,6 +30179,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "poll_interval": 5.0,
                         "is_still_current": _turn_is_current,
                         "session_key": session_key,
+                        "run_generation": _turn_run_generation,
                     },
                     name=f"gateway-turn-watchdog-{_turn_task_id[:12]}",
                     daemon=True,
@@ -30193,7 +30231,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 session_key,
                                 "done" if interrupt_monitor.done() else "running",
                             )
-                            _clear_pending_clarify_session(session_key)
+                            _clear_pending_clarify_session(
+                                session_key,
+                                run_generation=run_generation,
+                            )
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
                             # Abort streaming TTS on barge-in (#60671).
@@ -30264,6 +30305,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "cleanup_lock": _turn_cleanup_lock,
                                 "is_still_current": _turn_is_current,
                                 "session_key": session_key,
+                                "run_generation": _turn_run_generation,
                             },
                             name=f"gateway-turn-reaper-{_turn_task_id[:12]}",
                             daemon=True,
@@ -30297,7 +30339,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 session_key,
                                 "done" if interrupt_monitor.done() else "running",
                             )
-                            _clear_pending_clarify_session(session_key)
+                            _clear_pending_clarify_session(
+                                session_key,
+                                run_generation=run_generation,
+                            )
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
                             # Abort streaming TTS on barge-in (#60671).
@@ -30332,7 +30377,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Interrupt the agent if it's still running so the thread
                 # pool worker is freed.
                 if _timed_out_agent:
-                    _clear_pending_clarify_session(session_key)
+                    _clear_pending_clarify_session(
+                        session_key,
+                        run_generation=run_generation,
+                    )
                     request_hard_interrupt(_timed_out_agent, _INTERRUPT_REASON_TIMEOUT)
 
                 _timeout_mins = int(_agent_timeout // 60) or 1

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -18,7 +18,7 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
-from typing import Dict, List, Optional, Any
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -1251,7 +1251,7 @@ class SessionStore:
     """
     
     def __init__(self, sessions_dir: Path, config: GatewayConfig,
-                 has_active_processes_fn=None):
+                 has_active_processes_fn=None, session_boundary_cleanup_fn=None):
         self.sessions_dir = sessions_dir
         self.config = config
         self._entries: Dict[str, SessionEntry] = {}
@@ -1289,6 +1289,7 @@ class SessionStore:
         self._transcript_append_failures: Dict[str, int] = {}
         self._fts_rebuild_attempted = False
         self._has_active_processes_fn = has_active_processes_fn
+        self._session_boundary_cleanup_fn = session_boundary_cleanup_fn
         # Whether to keep writing the legacy sessions.json mirror alongside
         # the primary gateway_routing table in state.db. Default True for
         # backward compatibility; disable via gateway.write_sessions_json.
@@ -1326,6 +1327,48 @@ class SessionStore:
             lock=self._db_handles_lock,
         )
         self._open_session_db_for_active_scope()
+
+    def _clear_session_boundary_locked(self, session_key: str) -> None:
+        """Invalidate turn-bound state before releasing or rotating a route.
+
+        ``self._lock`` must be held. The production callback clears the
+        clarify primitive under its own lock, establishing the total order
+        ``SessionStore._lock -> clarify_gateway._lock``. Bound callbacks use
+        :meth:`run_if_session_current` and never acquire these locks inversely.
+        """
+        cleanup = getattr(self, "_session_boundary_cleanup_fn", None)
+        if not session_key or not callable(cleanup):
+            return
+        try:
+            cleanup(session_key)
+        except Exception:
+            logger.debug(
+                "Session-boundary cleanup failed for %s",
+                session_key,
+                exc_info=True,
+            )
+
+    def run_if_session_current(
+        self,
+        session_key: str,
+        expected_session_id: str,
+        action: Callable[[], bool],
+    ) -> bool:
+        """Run ``action`` iff the route still points at the expected session.
+
+        Validation and ``action`` execute under ``self._lock``. Telegram's
+        bound-clarify action acquires only ``clarify_gateway._lock`` inside
+        this transaction, making consumption/event wakeup atomic with route
+        rotation while preserving the documented total lock order.
+        """
+        if not session_key or not expected_session_id or not callable(action):
+            return False
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or str(entry.session_id) != str(expected_session_id):
+                return False
+            return bool(action())
 
     def _open_session_db_for_active_scope(self):
         """Return the SessionDB for the profile scope active on this task.
@@ -1614,6 +1657,7 @@ class SessionStore:
                             row["end_reason"],
                             recovered_entry.session_id,
                         )
+                        self._clear_session_boundary_locked(key)
                         self._entries[key] = recovered_entry
                         recovered_keys += 1
                         continue
@@ -1650,6 +1694,7 @@ class SessionStore:
             return
 
         for key in stale_keys:
+            self._clear_session_boundary_locked(key)
             del self._entries[key]
 
         if stale_keys or recovered_keys:
@@ -1710,6 +1755,12 @@ class SessionStore:
                 continue
             elif current[key] == baseline[key]:
                 # Unchanged fallback data yields to the authoritative DB copy.
+                existing = self._entries.get(key)
+                if (
+                    existing is not None
+                    and existing.session_id != durable_entry.session_id
+                ):
+                    self._clear_session_boundary_locked(key)
                 self._entries[key] = durable_entry
 
         self._routing_db_loaded = True
@@ -2370,6 +2421,7 @@ class SessionStore:
         behavior (flag only, no override drop).
         """
         with self._lock:
+            self._clear_session_boundary_locked(entry.session_key)
             entry.expiry_finalized = True
             if clear_model_override:
                 # Session finalization is a conversation boundary — drop the
@@ -2583,6 +2635,7 @@ class SessionStore:
             or canonical_session_id == original_session_id
         ):
             return False
+        self._clear_session_boundary_locked(entry.session_key)
         logger.info(
             "SessionStore healed compressed session mapping: %s -> %s",
             entry.session_id,
@@ -2714,6 +2767,7 @@ class SessionStore:
                     else:
                         adopt = source.chat_type == "dm"
                     if adopt and self._claim_legacy_slack_key(legacy_key):
+                        self._clear_session_boundary_locked(legacy_key)
                         migrated_legacy_entry = self._entries.pop(legacy_key)
                         migrated_legacy_entry.session_key = session_key
                         migrated_legacy_entry.origin = source
@@ -2832,6 +2886,7 @@ class SessionStore:
                         "(#54878)",
                         session_key, entry.session_id,
                     )
+                    self._clear_session_boundary_locked(session_key)
                     self._entries.pop(session_key, None)
                     # If an expiry watcher (daily/idle reset) already finalized
                     # this session, honour the reset decision instead of silently
@@ -2860,6 +2915,7 @@ class SessionStore:
                         reset_had_activity = entry.last_prompt_tokens > 0
                         db_end_session_id = entry.session_id
                         prev_session_id = entry.session_id
+                        self._clear_session_boundary_locked(session_key)
                         self._entries.pop(session_key, None)
                         entry = None
                         _needs_recover = True
@@ -2930,6 +2986,8 @@ class SessionStore:
                     force_new and current is force_new_observed_entry
                 )
                 if may_publish:
+                    if current is not None and current.session_id != candidate.session_id:
+                        self._clear_session_boundary_locked(session_key)
                     self._entries[session_key] = candidate
                     published = candidate
                 else:
@@ -3369,6 +3427,7 @@ class SessionStore:
                 if entry.updated_at < cutoff:
                     removed_keys.append(key)
             for key in removed_keys:
+                self._clear_session_boundary_locked(key)
                 self._entries.pop(key, None)
             if removed_keys:
                 self._save()
@@ -3430,6 +3489,7 @@ class SessionStore:
 
             old_entry = self._entries[session_key]
             db_end_session_id = old_entry.session_id
+            self._clear_session_boundary_locked(session_key)
 
             now = _now()
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
@@ -3574,6 +3634,7 @@ class SessionStore:
                 return old_entry
 
             db_end_session_id = old_entry.session_id
+            self._clear_session_boundary_locked(session_key)
 
             now = _now()
             new_entry = SessionEntry(
@@ -3804,8 +3865,9 @@ class SessionStore:
                             # Publish routing only after the retry queue has moved,
                             # so new child writes cannot bypass older parent backlog.
                             with self._lock:
-                                for entry in self._entries.values():
+                                for route_key, entry in self._entries.items():
                                     if entry.session_id == session_id:
+                                        self._clear_session_boundary_locked(route_key)
                                         entry.session_id = child_id
                                 self._save()
                             if not pending:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3583,6 +3583,13 @@ class SessionStore:
         repairs the persisted gateway key→session mapping. Returning ``None``
         means the route moved after the caller's snapshot (for example /new),
         so the caller must fail closed instead of overwriting the newer route.
+
+        The compare, boundary cleanup, route mutation, and routing snapshot all
+        execute under ``SessionStore._lock``. Cleanup may acquire
+        ``clarify_gateway._lock``; bound callbacks enter through
+        :meth:`run_if_session_current`, so the process-wide total order remains
+        ``SessionStore._lock -> clarify_gateway._lock`` and no callback can
+        consume the old binding after this method publishes the new route.
         """
         if not session_key or not expected_session_id or not target_session_id:
             return None

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4561,6 +4561,7 @@ class GatewaySlashCommandsMixin:
                 # original messages and replace them with only the compressed
                 # summary (permanent data loss #44794, #39704).
                 if rotated:
+                    prior_session_id = session_entry.session_id
                     if not await self.async_session_store.rewrite_transcript(
                         new_session_id, compressed
                     ):
@@ -4568,8 +4569,18 @@ class GatewaySlashCommandsMixin:
                             f"failed to persist compressed transcript for "
                             f"session {new_session_id}"
                         )
-                    session_entry.session_id = new_session_id
-                    await self.async_session_store._save()
+                    advanced_entry = (
+                        await self.async_session_store.advance_compression_session(
+                            session_entry.session_key,
+                            prior_session_id,
+                            new_session_id,
+                        )
+                    )
+                    if advanced_entry is None:
+                        raise RuntimeError(
+                            "session route changed while compression was running"
+                        )
+                    session_entry = advanced_entry
                     await asyncio.to_thread(
                         self._sync_telegram_topic_binding,
                         source, session_entry, reason="compress-command",

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1434,8 +1434,16 @@ class GatewaySlashCommandsMixin:
 
         The session is preserved so the user can continue the conversation.
         """
-        from gateway.run import _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
+        from gateway.run import (
+            _AGENT_PENDING_SENTINEL,
+            _INTERRUPT_REASON_STOP,
+            _clear_pending_clarify_session,
+        )
         source = event.source
+        # Normal command dispatch can reach this handler without a running
+        # agent. Invalidate an orphan clarify before get_or_create_session can
+        # reuse or rotate the route.
+        _clear_pending_clarify_session(self._session_key_for_source(source))
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7610,6 +7610,7 @@ class DiscordAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        binding: Optional[Any] = None,
     ) -> SendResult:
         """Render a clarify prompt with one Discord button per choice.
 
@@ -9761,8 +9762,8 @@ def _define_discord_view_classes() -> None:
             # we round-trip the original value, not a button-label variant.
             resolved_text: Optional[str] = None
             try:
-                from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
-                entry = _clarify_entries.get(self.clarify_id)
+                from tools.clarify_gateway import get_entry
+                entry = get_entry(self.clarify_id)
                 if entry and entry.choices and 0 <= index < len(entry.choices):
                     resolved_text = entry.choices[index]
             except Exception:

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2195,6 +2195,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        binding: Optional[Any] = None,
     ) -> SendResult:
         if not choices:
             return await super().send_clarify(

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2015,6 +2015,7 @@ class PhotonAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        binding: Optional[Any] = None,
     ) -> SendResult:
         if not choices:
             # No choices → open-ended. Base behaviour (plain text; the next

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7349,6 +7349,7 @@ class SlackAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        binding: Optional[Any] = None,
     ) -> SendResult:
         """Render a clarify prompt as Block Kit interactive buttons.
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7890,7 +7890,7 @@ class SlackAdapter(BasePlatformAdapter):
         # timeout / session reset.
         resolved_text: Optional[str] = None
         try:
-            entry = _clarify_mod._entries.get(clarify_id)  # type: ignore[attr-defined]
+            entry = _clarify_mod.get_entry(clarify_id)
             if entry and entry.choices and 0 <= idx < len(entry.choices):
                 resolved_text = str(entry.choices[idx])
         except Exception:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -839,9 +839,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
-        # Clarify button state: clarify_id → session_key (for the clarify tool's
-        # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
-        self._clarify_state: Dict[str, str] = {}
+        # Clarify callback state lives only in tools.clarify_gateway; keeping
+        # no adapter-local fallback makes missing/legacy bindings fail closed.
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -6445,6 +6444,7 @@ class TelegramAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        binding: Optional[Any] = None,
     ) -> SendResult:
         """Render a clarify prompt with one inline button per choice.
 
@@ -6457,6 +6457,9 @@ class TelegramAdapter(BasePlatformAdapter):
         text — no buttons.  The next message in the session is captured by
         the gateway's text-intercept and resolves the clarify.
         """
+        from tools.clarify_gateway import ClarifyBinding
+        if not isinstance(binding, ClarifyBinding):
+            return SendResult(success=False, error="Missing immutable clarify binding")
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
@@ -6513,7 +6516,6 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
-            self._clarify_state[clarify_id] = session_key
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning("[%s] send_clarify failed: %s", self.name, _redact_telegram_error_text(e))
@@ -7425,10 +7427,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to answer this prompt.")
                     return
 
-                session_key = self._clarify_state.get(clarify_id)
-                if not session_key:
+                from tools.clarify_gateway import ClarifyBinding, ClarifyOrigin, get_binding
+
+                # Telegram callbacks cross an authenticated transport boundary
+                # and therefore require an immutable origin/session binding.
+                # Never fall back to adapter-local or legacy unbound state: a
+                # callback without a current binding fails closed.
+                clarify_binding = get_binding(clarify_id)
+                if not isinstance(clarify_binding, ClarifyBinding):
                     await query.answer(text="This prompt has already been resolved.")
                     return
+
+                observed_origin = ClarifyOrigin(
+                    caller_id,
+                    str(query_chat_id) if query_chat_id is not None else "",
+                    str(query_thread_id) if query_thread_id is not None else None,
+                )
 
                 user_display = getattr(query.from_user, "first_name", "User")
 
@@ -7436,20 +7450,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     # Flip into text-capture mode and tell the user to type
                     # their answer.  The gateway's text-intercept will pick
                     # up the next message in this session and resolve the
-                    # clarify.  Do NOT pop _clarify_state yet — we still
-                    # need it if the user is slow to respond and the entry
-                    # is cleared by something else.
+                    # clarify. The primitive retains the immutable binding
+                    # while the user is slow to respond.
                     flipped = False
                     try:
-                        from tools.clarify_gateway import mark_awaiting_text
-                        flipped = mark_awaiting_text(clarify_id)
+                        from tools.clarify_gateway import mark_bound_awaiting_text
+                        flipped = mark_bound_awaiting_text(
+                            clarify_id,
+                            binding=clarify_binding,
+                            observed_origin=observed_origin,
+                        )
                     except Exception as exc:
                         logger.warning("[%s] mark_awaiting_text failed: %s", self.name, exc)
 
                     if not flipped:
-                        # Entry evicted (clarify_timeout) or gateway restarted
-                        # between ask and tap — a typed answer would go nowhere.
-                        self._clarify_state.pop(clarify_id, None)
+                        # Never pop on a validation failure: a mismatched caller
+                        # must not invalidate the legitimate user's prompt.
                         await self._notify_clarify_expired(query, user_display)
                         return
 
@@ -7471,34 +7487,32 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="Invalid choice.")
                     return
 
-                # Look up the choice text from the entry registered in the
-                # clarify primitive.  Fall back to the index if the entry
-                # has been cleaned up (race with timeout / session reset).
+                # Resolve through the primitive so choice lookup, binding
+                # validation, active-session validation, and consumption share
+                # one lock. The public read is presentation-only.
                 resolved_text: Optional[str] = None
                 try:
-                    from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
-                    entry = _clarify_entries.get(clarify_id)
-                    if entry and entry.choices and 0 <= idx < len(entry.choices):
-                        resolved_text = entry.choices[idx]
+                    from tools.clarify_gateway import get_entry
+                    pending_entry = get_entry(clarify_id)
+                    if pending_entry and pending_entry.choices and 0 <= idx < len(pending_entry.choices):
+                        resolved_text = str(pending_entry.choices[idx])
                 except Exception:
-                    resolved_text = None
+                    pending_entry = None
 
-                if resolved_text is None:
-                    # Race: entry vanished. Echo the index as a number so
-                    # the agent at least sees an intentional response
-                    # rather than nothing.
-                    resolved_text = f"choice {idx + 1}"
-
-                # Pop state and resolve
-                self._clarify_state.pop(clarify_id, None)
                 try:
-                    from tools.clarify_gateway import resolve_gateway_clarify
-                    resolved = resolve_gateway_clarify(clarify_id, resolved_text)
+                    from tools.clarify_gateway import resolve_bound_choice
+                    resolved = resolve_bound_choice(
+                        clarify_id,
+                        idx,
+                        binding=clarify_binding,
+                        observed_origin=observed_origin,
+                    )
                 except Exception as exc:
-                    logger.error("[%s] resolve_gateway_clarify failed: %s", self.name, exc)
+                    logger.error("[%s] clarify resolution failed: %s", self.name, exc)
                     resolved = False
 
                 if resolved:
+                    resolved_text = resolved_text or f"choice {idx + 1}"
                     await query.answer(text=f"✓ {resolved_text[:60]}")
                     try:
                         await query.edit_message_text(

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1131,6 +1131,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        binding: Optional[Any] = None,
     ) -> SendResult:
         """Render multiple-choice clarify as a native WhatsApp poll.
 

--- a/tests/gateway/test_35994_reset_button_deadlock.py
+++ b/tests/gateway/test_35994_reset_button_deadlock.py
@@ -16,6 +16,7 @@ import logging
 import threading
 import time
 from datetime import datetime
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -87,6 +88,36 @@ def _make_runner_with_cached_agent(close_fn):
     agent.shutdown_memory_provider = MagicMock()
     runner._agent_cache = {session_key: agent}
     return runner
+
+
+@pytest.mark.asyncio
+async def test_new_invalidates_clarify_before_closing_old_agent():
+    """The real /new handler wakes its waiter before agent.close()."""
+    from tools import clarify_gateway as cm
+
+    cm.clear_all()
+    session_key = build_session_key(_make_source())
+    entry = cm.register("new-pending", session_key, "Pick", ["A"])
+
+    def _close_after_clear():
+        assert not cm.has_pending(session_key)
+        assert entry.event.is_set()
+
+    runner = _make_runner_with_cached_agent(_close_after_clear)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        waiter = pool.submit(cm.wait_for_response, entry.clarify_id, 5.0)
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            with cm._lock:
+                if entry.waiter_started:
+                    break
+            await asyncio.sleep(0)
+        assert entry.waiter_started
+        await runner._handle_reset_command(_make_event("/new"))
+        assert waiter.result(timeout=2.0) == ""
+
+    cm.clear_all()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_abandoned_turn_process_cleanup.py
+++ b/tests/gateway/test_abandoned_turn_process_cleanup.py
@@ -67,6 +67,65 @@ def test_thread_watchdog_reaps_only_processes_created_by_timed_out_turn(monkeypa
     ]
 
 
+def test_stale_thread_watchdog_preserves_replacement_clarify(monkeypatch):
+    """Detached inactivity cleanup owns only its captured run generation."""
+    from tools import clarify_gateway as cm
+
+    agent = _IdleAgent()
+    worker_done, timeout_fired, cleanup_lock = _state()
+    monkeypatch.setattr(
+        process_registry,
+        "kill_started_since",
+        lambda *_args, **_kwargs: 0,
+    )
+    cm.clear_all()
+    try:
+        old_entry = cm.register(
+            "watchdog-old",
+            "shared-session",
+            "Old prompt",
+            ["old"],
+            run_generation=1,
+        )
+        replacement = cm.register(
+            "watchdog-replacement",
+            old_entry.session_key,
+            "Replacement prompt",
+            ["new"],
+            run_generation=2,
+        )
+
+        watchdog = threading.Thread(
+            target=_watch_gateway_turn_inactivity,
+            kwargs={
+                "agent_holder": [agent],
+                "task_id": "session-a",
+                "process_baseline": frozenset(),
+                "timeout": 30.0,
+                "worker_done": worker_done,
+                "timeout_fired": timeout_fired,
+                "cleanup_lock": cleanup_lock,
+                "poll_interval": 0.01,
+                "is_still_current": lambda: False,
+                "session_key": old_entry.session_key,
+                "run_generation": 1,
+            },
+        )
+        watchdog.start()
+        watchdog.join(timeout=1.0)
+
+        assert not watchdog.is_alive()
+        assert timeout_fired.is_set()
+        assert old_entry.event.is_set()
+        assert cm.get_entry(old_entry.clarify_id) is None
+        assert cm.get_entry(replacement.clarify_id) is replacement
+        assert not replacement.event.is_set()
+        assert cm.resolve_gateway_clarify(replacement.clarify_id, "new") is True
+        assert cm.wait_for_response(replacement.clarify_id, timeout=0.1) == "new"
+    finally:
+        cm.clear_all()
+
+
 def test_completed_worker_wins_race_and_preserves_background_process(monkeypatch):
     agent = _IdleAgent()
     worker_done, timeout_fired, cleanup_lock = _state()

--- a/tests/gateway/test_clarify_send_timeout_ambiguity.py
+++ b/tests/gateway/test_clarify_send_timeout_ambiguity.py
@@ -15,6 +15,7 @@ today's teardown + sentinel behavior.
 """
 
 import concurrent.futures
+import threading
 from unittest.mock import MagicMock
 
 from gateway.run import _clarify_send_disposition, _clarify_send_then_wait
@@ -33,7 +34,10 @@ def test_timeout_keeps_registration_armed_and_proceeds_to_wait():
     fut.result.side_effect = concurrent.futures.TimeoutError()
     clarify_mod = MagicMock()
     disposition = _clarify_send_disposition(
-        fut, session_key="sk", clarify_mod=clarify_mod
+        fut,
+        clarify_id="cid123",
+        session_key="sk",
+        clarify_mod=clarify_mod,
     )
     assert disposition is None, (
         "a send timeout aborted the clarify wait — this is the "
@@ -48,7 +52,12 @@ def test_successful_send_proceeds_to_wait():
     fut.result.return_value = _Result(True)
     clarify_mod = MagicMock()
     assert (
-        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+        _clarify_send_disposition(
+            fut,
+            clarify_id="cid123",
+            session_key="sk",
+            clarify_mod=clarify_mod,
+        )
         is None
     )
     clarify_mod.clear_session.assert_not_called()
@@ -59,10 +68,18 @@ def test_definitive_error_result_tears_down_and_aborts():
     fut.result.return_value = _Result(False, "relay prompt op unavailable")
     clarify_mod = MagicMock()
     assert (
-        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+        _clarify_send_disposition(
+            fut,
+            clarify_id="cid123",
+            session_key="sk",
+            clarify_mod=clarify_mod,
+        )
         == SENTINEL
     )
-    clarify_mod.clear_session.assert_called_once_with("sk")
+    clarify_mod.clear_session.assert_called_once_with(
+        "sk",
+        clarify_id="cid123",
+    )
 
 
 def test_non_timeout_exception_tears_down_and_aborts():
@@ -70,19 +87,35 @@ def test_non_timeout_exception_tears_down_and_aborts():
     fut.result.side_effect = RuntimeError("loop unavailable")
     clarify_mod = MagicMock()
     assert (
-        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+        _clarify_send_disposition(
+            fut,
+            clarify_id="cid123",
+            session_key="sk",
+            clarify_mod=clarify_mod,
+        )
         == SENTINEL
     )
-    clarify_mod.clear_session.assert_called_once_with("sk")
+    clarify_mod.clear_session.assert_called_once_with(
+        "sk",
+        clarify_id="cid123",
+    )
 
 
 def test_missing_future_tears_down_and_aborts():
     clarify_mod = MagicMock()
     assert (
-        _clarify_send_disposition(None, session_key="sk", clarify_mod=clarify_mod)
+        _clarify_send_disposition(
+            None,
+            clarify_id="cid123",
+            session_key="sk",
+            clarify_mod=clarify_mod,
+        )
         == SENTINEL
     )
-    clarify_mod.clear_session.assert_called_once_with("sk")
+    clarify_mod.clear_session.assert_called_once_with(
+        "sk",
+        clarify_id="cid123",
+    )
 
 
 # --- Caller-path contract: the disposition feeds the bounded wait ---------
@@ -136,7 +169,63 @@ def test_definitive_failure_never_waits():
         == SENTINEL
     )
     clarify_mod.wait_for_response.assert_not_called()
-    clarify_mod.clear_session.assert_called_once_with("sk")
+    clarify_mod.clear_session.assert_called_once_with(
+        "sk",
+        clarify_id="cid123",
+    )
+
+
+def test_delayed_send_failure_cannot_clear_replacement_prompt():
+    """A failed old send owns only its ID, even after a replacement registers."""
+    from tools import clarify_gateway as cm
+
+    entered_result = threading.Event()
+    release_result = threading.Event()
+
+    class _DelayedFailureFuture:
+        def result(self, timeout):
+            assert timeout == 15
+            entered_result.set()
+            assert release_result.wait(2.0)
+            return _Result(False, "delayed transport failure")
+
+    cm.clear_all()
+    try:
+        old_entry = cm.register(
+            "old-send",
+            "shared-session",
+            "Old prompt",
+            ["old"],
+            run_generation=7,
+        )
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            old_send = pool.submit(
+                _clarify_send_disposition,
+                _DelayedFailureFuture(),
+                clarify_id=old_entry.clarify_id,
+                session_key=old_entry.session_key,
+                clarify_mod=cm,
+            )
+            assert entered_result.wait(2.0)
+            replacement = cm.register(
+                "replacement-send",
+                old_entry.session_key,
+                "Replacement prompt",
+                ["new"],
+                run_generation=7,
+            )
+            release_result.set()
+            assert old_send.result(timeout=2.0) == SENTINEL
+
+        assert old_entry.event.is_set()
+        assert cm.get_entry(old_entry.clarify_id) is None
+        assert cm.get_entry(replacement.clarify_id) is replacement
+        assert not replacement.event.is_set()
+        assert cm.resolve_gateway_clarify(replacement.clarify_id, "new") is True
+        assert cm.wait_for_response(replacement.clarify_id, timeout=0.1) == "new"
+    finally:
+        release_result.set()
+        cm.clear_all()
 
 
 def test_no_response_returns_timeout_sentinel():
@@ -162,7 +251,12 @@ def test_failed_send_exception_detail_is_logged(caplog):
     fut.result.side_effect = RuntimeError("loop unavailable")
     clarify_mod = MagicMock()
     with caplog.at_level("WARNING", logger="gateway.run"):
-        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+        _clarify_send_disposition(
+            fut,
+            clarify_id="cid123",
+            session_key="sk",
+            clarify_mod=clarify_mod,
+        )
     assert "loop unavailable" in caplog.text
 
 
@@ -171,5 +265,10 @@ def test_failed_send_result_error_detail_is_logged(caplog):
     fut.result.return_value = _Result(False, "relay prompt op unavailable")
     clarify_mod = MagicMock()
     with caplog.at_level("WARNING", logger="gateway.run"):
-        _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
+        _clarify_send_disposition(
+            fut,
+            clarify_id="cid123",
+            session_key="sk",
+            clarify_mod=clarify_mod,
+        )
     assert "relay prompt op unavailable" in caplog.text

--- a/tests/gateway/test_clarify_session_lifecycle.py
+++ b/tests/gateway/test_clarify_session_lifecycle.py
@@ -125,6 +125,164 @@ def test_turn_completion_release_invalidates_waiter():
     assert not cm.has_pending(session_key)
 
 
+def test_stale_turn_release_clears_only_its_owned_clarify():
+    """An old unwind cannot cancel a replacement turn's prompt."""
+    from tools import clarify_gateway as cm
+
+    runner, _adapter = make_restart_runner()
+    session_key = build_session_key(_source())
+    old_generation = runner._begin_session_run_generation(session_key)
+    old_entry = cm.register(
+        "old-generation-pending",
+        session_key,
+        "Old prompt",
+        ["old"],
+        run_generation=old_generation,
+    )
+
+    runner._invalidate_session_run_generation(session_key, reason="test_stop")
+    new_generation = runner._begin_session_run_generation(session_key)
+    fresh_agent = MagicMock()
+    runner._running_agents = {session_key: fresh_agent}
+    new_entry = cm.register(
+        "new-generation-pending",
+        session_key,
+        "New prompt",
+        ["new"],
+        run_generation=new_generation,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        old_waiter = pool.submit(cm.wait_for_response, old_entry.clarify_id, 5.0)
+        new_waiter = pool.submit(cm.wait_for_response, new_entry.clarify_id, 5.0)
+        _wait_until_waiter_started(old_entry)
+        _wait_until_waiter_started(new_entry)
+
+        released = runner._release_running_agent_state(
+            session_key,
+            run_generation=old_generation,
+        )
+
+        assert released is False
+        assert old_waiter.result(timeout=2.0) == ""
+        assert runner._running_agents[session_key] is fresh_agent
+        assert cm.get_entry(new_entry.clarify_id) is new_entry
+        assert not new_entry.event.is_set()
+
+        assert cm.resolve_gateway_clarify(new_entry.clarify_id, "new") is True
+        assert new_waiter.result(timeout=2.0) == "new"
+
+
+def test_turn_runner_old_unwind_preserves_new_generation_clarify():
+    """TurnRunner's real finally clears only the turn that is unwinding."""
+    from gateway.run import TurnRunner
+    from gateway.turn_context import TurnContext
+    from tools import clarify_gateway as cm
+
+    old_run_started = threading.Event()
+    allow_old_unwind = threading.Event()
+
+    class _OldTurnAgent:
+        def __init__(self, **kwargs):
+            self.model = kwargs["model"]
+            self.session_id = kwargs["session_id"]
+            self.tools = []
+            self.context_compressor = SimpleNamespace(
+                last_prompt_tokens=0,
+                context_length=200_000,
+            )
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+
+        def run_conversation(self, _message, **_kwargs):
+            old_run_started.set()
+            assert allow_old_unwind.wait(2.0)
+            return {
+                "final_response": "old turn finished",
+                "failed": False,
+                "messages": [],
+            }
+
+    runner = MagicMock()
+    runner.config = SimpleNamespace(streaming=None)
+    runner._provider_routing = {}
+    runner._agent_cache_lock = None
+    runner._agent_cache = {}
+    runner._session_db = None
+    runner._prefill_messages = None
+    runner._pending_model_notes = {}
+    runner._pending_skills_reload_notes = {}
+    runner.session_store._entries = {}
+    runner._running = True
+    runner._draining = False
+    runner._get_system_prompt_for_channel.return_value = None
+    runner._resolve_session_agent_runtime.return_value = ("test-model", {})
+    runner._resolve_session_reasoning_config.return_value = None
+    runner._resolve_session_service_tier.return_value = None
+    runner._resolve_turn_agent_config.return_value = {
+        "model": "test-model",
+        "runtime": {},
+    }
+    runner._agent_config_signature.return_value = ("test-signature",)
+    runner._extract_cache_busting_config.return_value = {}
+    runner._refresh_fallback_model.return_value = None
+    runner._consume_pending_native_image_paths.return_value = []
+    runner._consume_pending_turn_sidecar_notes.return_value = []
+    runner._is_telegram_topic_lane.return_value = False
+    runner._is_discord_auto_thread_lane.return_value = False
+    runner._is_relay_discord_channel_lane.return_value = False
+
+    session_key = build_session_key(_source())
+    ctx = TurnContext(
+        source=_source(),
+        message="old turn",
+        history=[],
+        session_id="old-session",
+        session_key=session_key,
+        run_generation=1,
+        user_config={},
+        AIAgent=_OldTurnAgent,
+        resolve_display_setting=lambda *_args: False,
+        _run_still_current=lambda: False,
+        _hooks_ref=SimpleNamespace(loaded_hooks=False),
+    )
+    old_entry = cm.register(
+        "turn-runner-old-pending",
+        session_key,
+        "Old prompt",
+        ["old"],
+        run_generation=1,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        old_run = pool.submit(TurnRunner(runner, ctx).run_sync)
+        try:
+            assert old_run_started.wait(2.0)
+            new_entry = cm.register(
+                "turn-runner-new-pending",
+                session_key,
+                "New prompt",
+                ["new"],
+                run_generation=2,
+            )
+            new_waiter = pool.submit(
+                cm.wait_for_response,
+                new_entry.clarify_id,
+                5.0,
+            )
+            _wait_until_waiter_started(new_entry)
+        finally:
+            allow_old_unwind.set()
+
+        assert old_run.result(timeout=2.0)["final_response"] == "old turn finished"
+        assert old_entry.event.is_set()
+        assert cm.get_entry(old_entry.clarify_id) is None
+        assert cm.get_entry(new_entry.clarify_id) is new_entry
+        assert not new_entry.event.is_set()
+        assert cm.resolve_gateway_clarify(new_entry.clarify_id, "new") is True
+        assert new_waiter.result(timeout=2.0) == "new"
+
+
 def test_idle_reset_exact_boundary_then_invalidates_before_rotation(tmp_path):
     """Idle policy remains strict-greater-than and clears on the first due tick."""
     from tools import clarify_gateway as cm

--- a/tests/gateway/test_clarify_session_lifecycle.py
+++ b/tests/gateway/test_clarify_session_lifecycle.py
@@ -283,6 +283,108 @@ def test_turn_runner_old_unwind_preserves_new_generation_clarify():
         assert new_waiter.result(timeout=2.0) == "new"
 
 
+def test_turn_runner_teardown_before_clarify_registration_fences_stale_prompt():
+    """A stopped turn cannot register after its generation teardown finished."""
+    from gateway.run import TurnRunner
+    from gateway.turn_context import TurnContext
+    from tools import clarify_gateway as cm
+
+    register_entered = threading.Event()
+    allow_register = threading.Event()
+    turn_alive = threading.Event()
+    turn_alive.set()
+    original_register = cm.register
+
+    def _register_after_teardown(*args, **kwargs):
+        register_entered.set()
+        assert allow_register.wait(2.0)
+        return original_register(*args, **kwargs)
+
+    class _ClarifyingAgent:
+        def __init__(self, **kwargs):
+            self.model = kwargs["model"]
+            self.session_id = kwargs["session_id"]
+            self.tools = []
+            self.context_compressor = SimpleNamespace(
+                last_prompt_tokens=0,
+                context_length=200_000,
+            )
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+
+        def run_conversation(self, _message, **_kwargs):
+            response = self.clarify_callback("Pick", ["A"])
+            return {
+                "final_response": response,
+                "failed": False,
+                "messages": [],
+            }
+
+    runner = MagicMock()
+    runner.config = SimpleNamespace(streaming=None)
+    runner._provider_routing = {}
+    runner._agent_cache_lock = None
+    runner._agent_cache = {}
+    runner._session_db = None
+    runner._prefill_messages = None
+    runner._pending_model_notes = {}
+    runner._pending_skills_reload_notes = {}
+    runner.session_store._entries = {}
+    runner._running = True
+    runner._draining = False
+    runner._get_system_prompt_for_channel.return_value = None
+    runner._resolve_session_agent_runtime.return_value = ("test-model", {})
+    runner._resolve_session_reasoning_config.return_value = None
+    runner._resolve_session_service_tier.return_value = None
+    runner._resolve_turn_agent_config.return_value = {
+        "model": "test-model",
+        "runtime": {},
+    }
+    runner._agent_config_signature.return_value = ("test-signature",)
+    runner._extract_cache_busting_config.return_value = {}
+    runner._refresh_fallback_model.return_value = None
+    runner._consume_pending_native_image_paths.return_value = []
+    runner._consume_pending_turn_sidecar_notes.return_value = []
+    runner._is_telegram_topic_lane.return_value = False
+    runner._is_discord_auto_thread_lane.return_value = False
+    runner._is_relay_discord_channel_lane.return_value = False
+
+    session_key = build_session_key(_source())
+    ctx = TurnContext(
+        source=_source(),
+        message="old turn",
+        history=[],
+        session_id="old-session",
+        session_key=session_key,
+        run_generation=1,
+        user_config={},
+        AIAgent=_ClarifyingAgent,
+        resolve_display_setting=lambda *_args: False,
+        _run_still_current=turn_alive.is_set,
+        _hooks_ref=SimpleNamespace(loaded_hooks=False),
+        _status_adapter=MagicMock(),
+        _status_chat_id="123456",
+    )
+
+    with (
+        patch.object(cm, "register", side_effect=_register_after_teardown),
+        patch(
+            "gateway.run.safe_schedule_threadsafe",
+            side_effect=AssertionError("stale clarify reached delivery"),
+        ),
+        ThreadPoolExecutor(max_workers=1) as pool,
+    ):
+        old_run = pool.submit(TurnRunner(runner, ctx).run_sync)
+        assert register_entered.wait(2.0)
+        turn_alive.clear()
+        assert cm.clear_session(session_key, run_generation=1) == 0
+        allow_register.set()
+        result = old_run.result(timeout=2.0)
+
+    assert "no longer active" in result["final_response"]
+    assert not cm.has_pending(session_key)
+
+
 def test_idle_reset_exact_boundary_then_invalidates_before_rotation(tmp_path):
     """Idle policy remains strict-greater-than and clears on the first due tick."""
     from tools import clarify_gateway as cm

--- a/tests/gateway/test_clarify_session_lifecycle.py
+++ b/tests/gateway/test_clarify_session_lifecycle.py
@@ -1,0 +1,288 @@
+"""Real gateway/session lifecycle coverage for pending clarifies."""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, SessionStore, build_session_key
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.fixture(autouse=True)
+def _isolated_clarifies():
+    from tools import clarify_gateway as cm
+
+    cm.clear_all()
+    yield
+    cm.clear_all()
+
+
+def _wait_until_waiter_started(entry, timeout: float = 2.0) -> None:
+    """Synchronize with wait_for_response without a timing-only sleep."""
+    from tools import clarify_gateway as cm
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with cm._lock:
+            if entry.waiter_started:
+                return
+        time.sleep(0.001)
+    raise AssertionError("clarify waiter did not start")
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123456",
+        chat_type="dm",
+        user_id="u1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_busy_stop_invalidates_waiter_before_agent_interrupt():
+    """The real busy /stop path wakes clarify before interrupting its agent."""
+    from tools import clarify_gateway as cm
+
+    runner, _adapter = make_restart_runner()
+    source = _source()
+    session_key = build_session_key(source)
+    entry = cm.register("stop-pending", session_key, "Pick", ["A"])
+    agent = MagicMock()
+
+    def _interrupt(_reason):
+        assert not cm.has_pending(session_key)
+        assert entry.event.is_set()
+
+    agent.interrupt.side_effect = _interrupt
+    runner._running_agents = {session_key: agent}
+    event = MessageEvent(text="/stop", source=source, message_id="m-stop")
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        waiter = pool.submit(cm.wait_for_response, entry.clarify_id, 5.0)
+        _wait_until_waiter_started(entry)
+        await runner._busy_stop_command(event, session_key, source)
+        assert waiter.result(timeout=2.0) == ""
+
+    agent.interrupt.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_idle_stop_invalidates_orphan_before_session_lookup():
+    """Normal /stop dispatch clears a waiter even when no agent slot exists."""
+    from tools import clarify_gateway as cm
+
+    runner, _adapter = make_restart_runner()
+    source = _source()
+    session_key = build_session_key(source)
+    entry = cm.register("idle-stop-pending", session_key, "Pick", ["A"])
+
+    async def _get_after_clear(_source_arg):
+        assert not cm.has_pending(session_key)
+        assert entry.event.is_set()
+        return SimpleNamespace(session_key=session_key)
+
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(side_effect=_get_after_clear),
+    )
+    runner._sibling_thread_run_keys = lambda _source_arg, _key: []
+    event = MessageEvent(text="/stop", source=source, message_id="m-stop-idle")
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        waiter = pool.submit(cm.wait_for_response, entry.clarify_id, 5.0)
+        _wait_until_waiter_started(entry)
+        result = await runner._handle_stop_command(event)
+        assert waiter.result(timeout=2.0) == ""
+
+    assert "no active" in str(result).lower()
+
+
+def test_turn_completion_release_invalidates_waiter():
+    """The gateway's common completion/release funnel owns clarify cleanup."""
+    from tools import clarify_gateway as cm
+
+    runner, _adapter = make_restart_runner()
+    session_key = build_session_key(_source())
+    runner._running_agents = {session_key: MagicMock()}
+    entry = cm.register("complete-pending", session_key, "Pick", ["A"])
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        waiter = pool.submit(cm.wait_for_response, entry.clarify_id, 5.0)
+        _wait_until_waiter_started(entry)
+        assert runner._release_running_agent_state(session_key) is True
+        assert waiter.result(timeout=2.0) == ""
+
+    assert not cm.has_pending(session_key)
+
+
+def test_idle_reset_exact_boundary_then_invalidates_before_rotation(tmp_path):
+    """Idle policy remains strict-greater-than and clears on the first due tick."""
+    from tools import clarify_gateway as cm
+
+    config = GatewayConfig(
+        default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=1)
+    )
+    store = SessionStore(
+        sessions_dir=tmp_path,
+        config=config,
+        session_boundary_cleanup_fn=cm.clear_session,
+    )
+    source = _source()
+    original = store.get_or_create_session(source, touch_activity=False)
+    boundary = datetime(2026, 8, 28, 12, 0, 0)
+    original.updated_at = boundary - timedelta(minutes=1)
+    entry = cm.register(
+        "idle-pending",
+        original.session_key,
+        "Pick",
+        ["A"],
+        origin=cm.ClarifyOrigin("u1", "123456"),
+        session_id=original.session_id,
+        active_session_transaction=lambda action: store.run_if_session_current(
+            original.session_key, original.session_id, action
+        ),
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        waiter = pool.submit(cm.wait_for_response, entry.clarify_id, 5.0)
+        _wait_until_waiter_started(entry)
+        with patch("gateway.session._now", return_value=boundary):
+            same = store.get_or_create_session(source, touch_activity=False)
+        assert same.session_id == original.session_id
+        assert cm.has_pending(original.session_key)
+
+        with patch(
+            "gateway.session._now",
+            return_value=boundary + timedelta(microseconds=1),
+        ):
+            rotated = store.get_or_create_session(source, touch_activity=False)
+        assert rotated.session_id != original.session_id
+        assert waiter.result(timeout=2.0) == ""
+
+
+def test_callback_consumption_is_atomic_against_concurrent_rotation(tmp_path):
+    """A callback holding the route transaction completes before reset rotates."""
+    from tools import clarify_gateway as cm
+
+    store = SessionStore(
+        sessions_dir=tmp_path,
+        config=GatewayConfig(),
+        session_boundary_cleanup_fn=cm.clear_session,
+    )
+    source = _source()
+    original = store.get_or_create_session(source)
+    callback_holds_route = threading.Event()
+    allow_callback = threading.Event()
+    rotation_done = threading.Event()
+
+    def _controlled_transaction(action):
+        def _inside_route():
+            callback_holds_route.set()
+            assert allow_callback.wait(2.0)
+            return action()
+
+        return store.run_if_session_current(
+            original.session_key, original.session_id, _inside_route
+        )
+
+    entry = cm.register(
+        "callback-wins",
+        original.session_key,
+        "Pick",
+        ["A"],
+        origin=cm.ClarifyOrigin("u1", "123456"),
+        session_id=original.session_id,
+        active_session_transaction=_controlled_transaction,
+    )
+
+    def _rotate():
+        try:
+            return store.reset_session(original.session_key)
+        finally:
+            rotation_done.set()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        callback = pool.submit(
+            cm.resolve_bound_choice,
+            entry.clarify_id,
+            0,
+            binding=entry.binding,
+            observed_origin=entry.binding.origin,
+        )
+        assert callback_holds_route.wait(2.0)
+        rotation = pool.submit(_rotate)
+        assert not rotation_done.wait(0.05), "rotation crossed the callback transaction"
+        allow_callback.set()
+        assert callback.result(timeout=2.0) is True
+        rotated = rotation.result(timeout=2.0)
+
+    assert rotated is not None
+    assert rotated.session_id != original.session_id
+    # Callback-before-wait is a supported first-writer-wins interleaving.
+    assert cm.wait_for_response(entry.clarify_id, timeout=0.1) == "A"
+
+
+def test_rotation_cleanup_wins_before_late_callback(tmp_path):
+    """A rotation already holding SessionStore invalidates before callback entry."""
+    from tools import clarify_gateway as cm
+
+    rotation_holds_route = threading.Event()
+    allow_rotation = threading.Event()
+    callback_attempted = threading.Event()
+
+    def _controlled_cleanup(session_key):
+        rotation_holds_route.set()
+        assert allow_rotation.wait(2.0)
+        return cm.clear_session(session_key)
+
+    store = SessionStore(
+        sessions_dir=tmp_path,
+        config=GatewayConfig(),
+        session_boundary_cleanup_fn=_controlled_cleanup,
+    )
+    source = _source()
+    original = store.get_or_create_session(source)
+
+    def _late_transaction(action):
+        callback_attempted.set()
+        return store.run_if_session_current(
+            original.session_key, original.session_id, action
+        )
+
+    entry = cm.register(
+        "rotation-wins",
+        original.session_key,
+        "Pick",
+        ["A"],
+        origin=cm.ClarifyOrigin("u1", "123456"),
+        session_id=original.session_id,
+        active_session_transaction=_late_transaction,
+    )
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        waiter = pool.submit(cm.wait_for_response, entry.clarify_id, 5.0)
+        _wait_until_waiter_started(entry)
+        rotation = pool.submit(store.reset_session, original.session_key)
+        assert rotation_holds_route.wait(2.0)
+        callback = pool.submit(
+            cm.resolve_bound_choice,
+            entry.clarify_id,
+            0,
+            binding=entry.binding,
+            observed_origin=entry.binding.origin,
+        )
+        assert callback_attempted.wait(2.0)
+        allow_rotation.set()
+        assert rotation.result(timeout=2.0) is not None
+        assert callback.result(timeout=2.0) is False
+        assert waiter.result(timeout=2.0) == ""

--- a/tests/gateway/test_clarify_session_lifecycle.py
+++ b/tests/gateway/test_clarify_session_lifecycle.py
@@ -283,16 +283,15 @@ def test_turn_runner_old_unwind_preserves_new_generation_clarify():
         assert new_waiter.result(timeout=2.0) == "new"
 
 
-def test_turn_runner_teardown_before_clarify_registration_fences_stale_prompt():
-    """A stopped turn cannot register after its generation teardown finished."""
-    from gateway.run import TurnRunner
+def test_turn_runner_interrupt_fence_before_clear_blocks_late_registration():
+    """The interrupt boundary fences admission before clearing old waiters."""
+    from gateway.run import TurnRunner, _fence_and_clear_pending_clarify
     from gateway.turn_context import TurnContext
     from tools import clarify_gateway as cm
 
     register_entered = threading.Event()
     allow_register = threading.Event()
-    turn_alive = threading.Event()
-    turn_alive.set()
+    agent_instances = []
     original_register = cm.register
 
     def _register_after_teardown(*args, **kwargs):
@@ -302,15 +301,21 @@ def test_turn_runner_teardown_before_clarify_registration_fences_stale_prompt():
 
     class _ClarifyingAgent:
         def __init__(self, **kwargs):
+            agent_instances.append(self)
             self.model = kwargs["model"]
             self.session_id = kwargs["session_id"]
             self.tools = []
+            self._interrupt_requested = False
             self.context_compressor = SimpleNamespace(
                 last_prompt_tokens=0,
                 context_length=200_000,
             )
             self.session_prompt_tokens = 0
             self.session_completion_tokens = 0
+
+        @property
+        def is_interrupted(self):
+            return self._interrupt_requested
 
         def run_conversation(self, _message, **_kwargs):
             response = self.clarify_callback("Pick", ["A"])
@@ -360,7 +365,7 @@ def test_turn_runner_teardown_before_clarify_registration_fences_stale_prompt():
         user_config={},
         AIAgent=_ClarifyingAgent,
         resolve_display_setting=lambda *_args: False,
-        _run_still_current=turn_alive.is_set,
+        _run_still_current=lambda: True,
         _hooks_ref=SimpleNamespace(loaded_hooks=False),
         _status_adapter=MagicMock(),
         _status_chat_id="123456",
@@ -376,12 +381,19 @@ def test_turn_runner_teardown_before_clarify_registration_fences_stale_prompt():
     ):
         old_run = pool.submit(TurnRunner(runner, ctx).run_sync)
         assert register_entered.wait(2.0)
-        turn_alive.clear()
-        assert cm.clear_session(session_key, run_generation=1) == 0
+        assert agent_instances
+        assert (
+            _fence_and_clear_pending_clarify(
+                agent_instances[0],
+                session_key,
+                run_generation=1,
+            )
+            == 0
+        )
         allow_register.set()
         result = old_run.result(timeout=2.0)
 
-    assert "no longer active" in result["final_response"]
+    assert "interrupted" in result["final_response"]
     assert not cm.has_pending(session_key)
 
 

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -9,7 +9,7 @@ import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
-from gateway.session import SessionEntry, SessionSource, build_session_key
+from gateway.session import SessionEntry, SessionSource, SessionStore, build_session_key
 
 
 def _make_source() -> SessionSource:
@@ -58,6 +58,110 @@ def _make_runner(history: list[dict[str, str]]):
     runner.session_store._save = MagicMock()
     runner._session_db = None
     return runner
+
+
+@pytest.mark.asyncio
+async def test_compress_rotation_invalidates_clarify_before_topic_rebind(
+    tmp_path,
+):
+    """The real /compress path must publish rotation through SessionStore CAS."""
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    history = _make_history()
+    compressed = [
+        history[0],
+        {"role": "assistant", "content": "compressed summary"},
+        history[-1],
+    ]
+    store = SessionStore(
+        sessions_dir=tmp_path,
+        config=GatewayConfig(),
+        session_boundary_cleanup_fn=cm.clear_session,
+    )
+    store._db = None
+    session_entry = store.get_or_create_session(_make_source())
+    original_session_id = session_entry.session_id
+    target_session_id = "manual-compression-child"
+    store.load_transcript = MagicMock(return_value=history)
+    store.rewrite_transcript = MagicMock(return_value=True)
+    store.update_session = MagicMock()
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.session_store = store
+    runner._session_db = None
+
+    pending = cm.register(
+        "manual-compress-pending",
+        session_entry.session_key,
+        "Pick",
+        ["A"],
+        origin=cm.ClarifyOrigin("u1", "c1"),
+        session_id=original_session_id,
+        active_session_transaction=lambda action: store.run_if_session_current(
+            session_entry.session_key,
+            original_session_id,
+            action,
+        ),
+    )
+    observations = []
+
+    def _topic_rebind(_source, advanced_entry, *, reason):
+        observations.append(
+            (
+                reason,
+                advanced_entry.session_id,
+                cm.resolve_bound_choice(
+                    pending.clarify_id,
+                    0,
+                    binding=pending.binding,
+                    observed_origin=pending.binding.origin,
+                ),
+            )
+        )
+
+    runner._sync_telegram_topic_binding = _topic_rebind
+
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.context_compressor._last_compress_aborted = False
+    agent_instance.context_compressor._last_aux_model_failure_model = None
+    agent_instance.session_id = target_session_id
+    agent_instance._last_compaction_in_place = False
+    agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
+
+    def _estimate(messages, **_kwargs):
+        return 100 if messages == history else 60
+
+    with (
+        patch(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            return_value={"api_key": "test-key"},
+        ),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch(
+            "agent.model_metadata.estimate_request_tokens_rough",
+            side_effect=_estimate,
+        ),
+    ):
+        result = await runner._handle_compress_command(_make_event())
+
+    assert "Compressed:" in result
+    assert store.peek_session_id(session_entry.session_key) == target_session_id
+    assert observations == [
+        ("compress-command", target_session_id, False)
+    ]
+    assert pending.event.is_set()
+    assert pending.response == ""
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -3,7 +3,7 @@ import sys
 import threading
 import types
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import gateway.run as gateway_run
 from gateway.config import Platform
@@ -84,6 +84,7 @@ class _CompressionThenFailureAgent:
             "api_calls": 1,
         }
 
+
     def interrupt(self, *_args, **_kwargs):
         pass
 
@@ -149,7 +150,9 @@ def _runner(session_store):
     runner._extract_cache_busting_config = lambda _config: ()
     runner._thread_metadata_for_source = lambda *_args, **_kwargs: None
     runner._sync_telegram_topic_binding = MagicMock()
-    runner._release_running_agent_state = MagicMock()
+    runner._release_running_agent_state = create_autospec(
+        runner._release_running_agent_state
+    )
     return runner
 
 
@@ -189,9 +192,10 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
 
     session_store = _SessionStore()
     runner = _runner(session_store)
+    runner._session_run_generation[SESSION_KEY] = 7
     source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
 
-    result = _run_compression_failure_turn(runner, source)
+    result = _run_compression_failure_turn(runner, source, run_generation=7)
 
     assert result["failed"] is True
     assert result["session_id"] == "session-after-compression"
@@ -211,6 +215,10 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
     ]
     runner._sync_telegram_topic_binding.assert_called_once_with(
         source, session_store.entry, reason="agent-run-compression"
+    )
+    runner._release_running_agent_state.assert_called_once_with(
+        SESSION_KEY,
+        run_generation=7,
     )
 
 
@@ -344,4 +352,3 @@ class _ProviderSwitchAgent(_CompressionThenFailureAgent):
             ],
             "api_calls": 1,
         }
-

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -20,7 +20,9 @@ class _SessionStore:
             session_id="session-before-compression",
         )
         self._entries = {SESSION_KEY: self.entry}
+        self._lock = threading.RLock()
         self.save_calls = 0
+        self.advance_calls = []
         self.peer_records = []
 
     def _save(self):
@@ -30,6 +32,30 @@ class _SessionStore:
         # #55300 records the child's gateway peer metadata after a compression
         # split; the fake tracks the call so tests can assert it fired.
         self.peer_records.append((session_id, session_key, source))
+
+    def advance_compression_session(
+        self, session_key, expected_session_id, target_session_id
+    ):
+        """Model SessionStore's atomic compression route compare-and-swap."""
+        self.advance_calls.append(
+            (session_key, expected_session_id, target_session_id)
+        )
+        with self._lock:
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            if entry.session_id == target_session_id:
+                return entry
+            if entry.session_id != expected_session_id:
+                return None
+            entry.session_id = target_session_id
+            self._save()
+            return entry
+
+    def peek_session_id(self, session_key):
+        with self._lock:
+            entry = self._entries.get(session_key)
+            return entry.session_id if entry is not None else None
 
 
 class _CompressionThenFailureAgent:
@@ -172,6 +198,13 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
     assert result["history_offset"] == 0
     assert session_store.entry.session_id == "session-after-compression"
     assert session_store.save_calls == 1
+    assert session_store.advance_calls == [
+        (
+            SESSION_KEY,
+            "session-before-compression",
+            "session-after-compression",
+        )
+    ]
     # #55300: the child's gateway peer metadata is recorded on the persist path.
     assert session_store.peer_records == [
         ("session-after-compression", SESSION_KEY, source)
@@ -179,6 +212,36 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
     runner._sync_telegram_topic_binding.assert_called_once_with(
         source, session_store.entry, reason="agent-run-compression"
     )
+
+
+def test_failed_turn_does_not_overwrite_newer_session_binding(monkeypatch):
+    _install_compression_failure_agent(monkeypatch)
+
+    session_store = _SessionStore()
+    session_store.entry.session_id = "newer-session"
+    runner = _runner(session_store)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+    result = _run_compression_failure_turn(runner, source)
+
+    assert result["failed"] is True
+    assert result["session_id"] == "session-after-compression"
+    assert session_store.entry.session_id == "newer-session"
+    assert session_store.save_calls == 0
+    assert session_store.advance_calls == [
+        (
+            SESSION_KEY,
+            "session-before-compression",
+            "session-after-compression",
+        )
+    ]
+    assert session_store.peer_records == []
+    runner._sync_telegram_topic_binding.assert_not_called()
 
 
 class _RateLimitFailureAgent(_CompressionThenFailureAgent):
@@ -281,5 +344,4 @@ class _ProviderSwitchAgent(_CompressionThenFailureAgent):
             ],
             "api_calls": 1,
         }
-
 

--- a/tests/gateway/test_compression_session_id_persistence.py
+++ b/tests/gateway/test_compression_session_id_persistence.py
@@ -1,184 +1,137 @@
-"""Regression tests for #29335 — gateway must persist ``session_entry.session_id``
-after the agent's compression path mutates it.
+"""Behavioral coverage for agent-result compression route publication."""
 
-When ``_compress_context()`` rolls the agent forward into a new session, the
-agent now returns the new ``session_id`` in its result dict. The gateway
-updates ``session_entry.session_id`` in memory AND must call
-``session_store._save()`` so the new mapping survives a gateway restart.
-Without ``_save()``, the next turn loads the OLD session's transcript and
-re-triggers compression forever.
+from unittest.mock import AsyncMock, MagicMock
 
-Three sites in ``gateway/run.py`` mutate ``session_entry.session_id`` after
-a compression-induced session split. All three MUST be followed by a
-``_save()`` call. This test pins that invariant.
+import pytest
 
-``TestCompressionSessionPropagation`` adds behavioral tests that exercise the
-actual propagation path inline, verifying that the mock session_entry update
-and _save() semantics are correct without requiring a live gateway.
-"""
-
-from __future__ import annotations
-
-import ast
-import inspect
-import textwrap
-from unittest.mock import MagicMock, call
-
-from gateway import run as gateway_run
-from gateway.session_context import set_current_session_id, get_session_env
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
 
 
-def _session_id_assignments_followed_by_save(source: str) -> list[tuple[int, bool]]:
-    """For each ``session_entry.session_id = ...`` assignment in *source*,
-    return ``(lineno, saved_within_5_stmts)`` — True iff a
-    ``self.session_store._save()`` call appears in the same block within the
-    next 5 statements (covers normal control flow without false-flagging
-    cleanup that lives 200 lines away).
-    """
-    tree = ast.parse(textwrap.dedent(source))
-    results: list[tuple[int, bool]] = []
-
-    class _Visitor(ast.NodeVisitor):
-        def _is_session_id_assign(self, node: ast.AST) -> bool:
-            if not isinstance(node, ast.Assign):
-                return False
-            for target in node.targets:
-                if (
-                    isinstance(target, ast.Attribute)
-                    and target.attr == "session_id"
-                    and isinstance(target.value, ast.Name)
-                    and target.value.id == "session_entry"
-                ):
-                    return True
-            return False
-
-        def _block_has_save_after(self, body: list[ast.stmt], idx: int) -> bool:
-            for stmt in body[idx : idx + 6]:
-                for sub in ast.walk(stmt):
-                    if (
-                        isinstance(sub, ast.Call)
-                        and isinstance(sub.func, ast.Attribute)
-                        and sub.func.attr == "_save"
-                    ):
-                        return True
-            return False
-
-        def _walk_body(self, body: list[ast.stmt]) -> None:
-            for i, stmt in enumerate(body):
-                if self._is_session_id_assign(stmt):
-                    results.append((stmt.lineno, self._block_has_save_after(body, i)))
-                # Recurse into the stmt itself when it is a control-flow node
-                # whose body/orelse/finalbody may carry assignments that are
-                # not also reachable as iter_child_nodes children of the stmt
-                # (e.g. an ``else`` block whose statements are all assigns).
-                if isinstance(stmt, (ast.If, ast.For, ast.While, ast.With,
-                                     ast.Try, ast.AsyncWith, ast.AsyncFor)):
-                    self._walk_node(stmt)
-                for child in ast.iter_child_nodes(stmt):
-                    if isinstance(child, (ast.If, ast.For, ast.While, ast.With,
-                                          ast.Try, ast.AsyncWith, ast.AsyncFor)):
-                        self._walk_node(child)
-
-        def _walk_node(self, node: ast.AST) -> None:
-            for attr in ("body", "orelse", "finalbody"):
-                inner = getattr(node, attr, None)
-                if isinstance(inner, list):
-                    self._walk_body(inner)
-            if hasattr(node, "handlers"):
-                for handler in node.handlers:
-                    self._walk_body(handler.body)
-
-        def visit(self, node: ast.AST) -> None:
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                self._walk_body(node.body)
-            for child in ast.iter_child_nodes(node):
-                self.visit(child)
-
-    _Visitor().visit(tree)
-    return results
-
-
-def test_every_post_compression_session_id_assignment_persists():
-    """Every ``session_entry.session_id = ...`` in gateway/run.py must be
-    followed by a ``session_store._save()`` call within the same block.
-
-    Regression for #29335 — the assignment at the end of
-    ``_handle_message_with_agent`` used to skip ``_save()`` while two sibling
-    sites (hygiene rewrite, manual /compress) already persisted. The agent
-    would compress correctly, the gateway would update its in-memory
-    session_id, then drop it on next gateway restart.
-    """
-    source = inspect.getsource(gateway_run)
-    assignments = _session_id_assignments_followed_by_save(source)
-    assert assignments, (
-        "No ``session_entry.session_id = ...`` assignments found in gateway/run.py — "
-        "either the structure changed or the AST walker is broken."
-    )
-    missing = [lineno for lineno, saved in assignments if not saved]
-    assert not missing, (
-        f"{len(missing)} ``session_entry.session_id = ...`` site(s) in gateway/run.py "
-        f"are not followed by ``session_store._save()`` within the same block "
-        f"(lines: {missing}). Every post-compression session_id update must persist "
-        f"or the next turn loads the pre-compression transcript and triggers an "
-        f"infinite compression loop. See issue #29335."
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        user_id="12345",
     )
 
 
-class TestCompressionSessionPropagation:
-    """Behavioral tests for post-compression session_id propagation.
+def _event() -> MessageEvent:
+    return MessageEvent(
+        text="compress during this turn",
+        source=_source(),
+        message_id="m1",
+    )
 
-    The structural AST test above pins that every ``session_entry.session_id``
-    assignment in gateway/run.py is followed by ``_save()``.  These tests
-    exercise the *behavior* of that propagation path inline, using mocks that
-    mirror the objects gateway/run.py works with (``session_entry`` and
-    ``session_store``), verifying the semantics are correct without requiring a
-    live gateway instance.
 
-    Ordering contract (from the comments added to the source in this PR):
-    1. The agent thread updates the contextvar in ``conversation_compression.py``
-       via ``set_current_session_id(agent.session_id)``.
-    2. After ``run_in_executor`` returns, the gateway propagates the new id to
-       ``session_entry.session_id`` and calls ``session_store._save()``.
-    Both halves must agree for the next turn to route correctly.
-    """
+def _runner(monkeypatch, tmp_path):
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source_arg: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = None
+    runner._recover_telegram_topic_thread_id = lambda _source_arg: None
+    runner._cache_session_source = lambda _key, _source_arg: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._reply_anchor_for_event = lambda _event_arg: None
+    runner._get_guild_id = lambda _event_arg: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
 
-    def test_gateway_session_entry_follows_compression_rotation(self) -> None:
-        """The gateway handler must update session_entry and call _save() when
-        the agent result carries a rotated session_id.
+    entry = runner.session_store.get_or_create_session(_source())
+    runner.session_store.load_transcript = MagicMock(return_value=[])
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._sync_telegram_topic_binding = MagicMock()
 
-        Simulates the inline propagation block in gateway/run.py:
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "fake"},
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner, entry
 
-            if agent_result.get("session_id") and \\
-                    agent_result["session_id"] != session_entry.session_id:
-                session_entry.session_id = agent_result["session_id"]
-                self.session_store._save()
 
-        Verifies that session_entry.session_id is mutated and _save is called
-        exactly once — the minimal contract that prevents the restart-loop bug.
-        """
-        old_sid = "20260101_000000_aaaaaa"
-        new_sid = "20260101_000001_bbbbbb"
+@pytest.mark.asyncio
+async def test_agent_result_rotation_invalidates_clarify_before_lease_rebind(
+    monkeypatch,
+    tmp_path,
+):
+    """The live post-agent path CAS-advances before using the rotated route."""
+    from tools import clarify_gateway as cm
 
-        session_entry = MagicMock()
-        session_entry.session_id = old_sid
+    runner, entry = _runner(monkeypatch, tmp_path)
+    original_session_id = entry.session_id
+    target_session_id = "agent-compression-child"
+    pending = cm.register(
+        "agent-result-pending",
+        entry.session_key,
+        "Pick",
+        ["A"],
+        origin=cm.ClarifyOrigin("12345", "-1001"),
+        session_id=original_session_id,
+        active_session_transaction=lambda action: runner.session_store.run_if_session_current(
+            entry.session_key,
+            original_session_id,
+            action,
+        ),
+    )
+    observations = []
 
-        session_store = MagicMock()
-
-        agent_result = {"session_id": new_sid, "response": "hello"}
-
-        # Inline the propagation logic exactly as it appears in gateway/run.py
-        # (around line 9459). This is the behavior we are pinning.
-        if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-            session_entry.session_id = agent_result["session_id"]
-            session_store._save()
-
-        assert session_entry.session_id == new_sid, (
-            "session_entry.session_id was not updated to the compressed session id. "
-            "The next turn would load the old transcript and re-trigger compression."
+    def _observe_rebind(_key, _generation, new_session_id):
+        observations.append(
+            (
+                new_session_id,
+                runner.session_store.peek_session_id(entry.session_key),
+                cm.resolve_bound_choice(
+                    pending.clarify_id,
+                    0,
+                    binding=pending.binding,
+                    observed_origin=pending.binding.origin,
+                ),
+            )
         )
-        session_store._save.assert_called_once_with(), (
-            "session_store._save() was not called after session_entry update. "
-            "The new session mapping would not survive a gateway restart."
-        )
 
+    runner._rebind_turn_lease = _observe_rebind
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "done",
+            "messages": [
+                {"role": "user", "content": "compress during this turn"},
+                {"role": "assistant", "content": "done"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "session_id": target_session_id,
+            "api_calls": 1,
+            "failed": False,
+        }
+    )
 
+    response = await runner._handle_message_with_agent(
+        _event(),
+        _source(),
+        entry.session_key,
+        1,
+    )
+
+    assert response == "done"
+    assert observations == [(target_session_id, target_session_id, False)]
+    assert runner.session_store.peek_session_id(entry.session_key) == target_session_id
+    assert pending.event.is_set()
+    assert pending.response == ""

--- a/tests/gateway/test_compression_session_id_persistence.py
+++ b/tests/gateway/test_compression_session_id_persistence.py
@@ -1,5 +1,6 @@
 """Behavioral coverage for agent-result compression route publication."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -7,7 +8,8 @@ import pytest
 import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
-from gateway.session import SessionSource
+from gateway.session import SessionSource, SessionStore
+from gateway.turn_context import TurnContext
 
 
 def _source() -> SessionSource:
@@ -135,3 +137,141 @@ async def test_agent_result_rotation_invalidates_clarify_before_lease_rebind(
     assert runner.session_store.peek_session_id(entry.session_key) == target_session_id
     assert pending.event.is_set()
     assert pending.response == ""
+
+
+def test_run_sync_stale_compression_child_cannot_overwrite_cas_winner(tmp_path):
+    """The real TurnRunner path must publish compression through store CAS.
+
+    The generation predicate is the deterministic interleaving point: the
+    old implementation had already snapshotted the parent route when this
+    callback published a different child, then directly overwrote that winner
+    from the stale snapshot after the callback returned.
+    """
+    from tools import clarify_gateway as cm
+
+    cm.clear_all()
+    try:
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            user_id="12345",
+        )
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+            session_boundary_cleanup_fn=cm.clear_session,
+        )
+        store._db = None
+        route = store.get_or_create_session(source)
+        session_key = route.session_key
+        parent_session_id = route.session_id
+        winner_session_id = "compression-winner"
+        stale_child_session_id = "stale-agent-child"
+
+        pending = cm.register(
+            "run-sync-stale-pending",
+            session_key,
+            "Pick",
+            ["A"],
+            origin=cm.ClarifyOrigin("12345", "-1001"),
+            session_id=parent_session_id,
+            active_session_transaction=lambda action: store.run_if_session_current(
+                session_key,
+                parent_session_id,
+                action,
+            ),
+        )
+
+        interleaving_calls = 0
+
+        def _publish_winner_during_current_run_check():
+            nonlocal interleaving_calls
+            interleaving_calls += 1
+            assert interleaving_calls == 1
+            advanced = store.advance_compression_session(
+                session_key,
+                parent_session_id,
+                winner_session_id,
+            )
+            assert advanced is route
+            assert pending.event.is_set()
+            return True
+
+        class _StaleRotatingAgent:
+            def __init__(self, **kwargs):
+                self.model = kwargs["model"]
+                self.session_id = kwargs["session_id"]
+                self.tools = []
+                self.context_compressor = SimpleNamespace(
+                    last_prompt_tokens=0,
+                    context_length=200_000,
+                )
+                self.session_prompt_tokens = 0
+                self.session_completion_tokens = 0
+                self._last_compaction_in_place = False
+
+            def run_conversation(self, _message, **_kwargs):
+                self.session_id = stale_child_session_id
+                return {
+                    "final_response": "stale result",
+                    "failed": False,
+                    "messages": [],
+                }
+
+        runner = MagicMock()
+        runner.config = SimpleNamespace(streaming=None)
+        runner._provider_routing = {}
+        runner._agent_cache_lock = None
+        runner._agent_cache = {}
+        runner._session_db = None
+        runner._prefill_messages = None
+        runner._pending_model_notes = {}
+        runner._pending_skills_reload_notes = {}
+        runner.session_store = store
+        runner._running = True
+        runner._draining = False
+        runner._get_system_prompt_for_channel.return_value = None
+        runner._resolve_session_agent_runtime.return_value = ("test-model", {})
+        runner._resolve_session_reasoning_config.return_value = None
+        runner._resolve_session_service_tier.return_value = None
+        runner._resolve_turn_agent_config.return_value = {
+            "model": "test-model",
+            "runtime": {},
+        }
+        runner._agent_config_signature.return_value = ("test-signature",)
+        runner._extract_cache_busting_config.return_value = {}
+        runner._refresh_fallback_model.return_value = None
+        runner._consume_pending_native_image_paths.return_value = []
+        runner._consume_pending_turn_sidecar_notes.return_value = []
+        runner._is_telegram_topic_lane.return_value = False
+        runner._is_discord_auto_thread_lane.return_value = False
+        runner._is_relay_discord_channel_lane.return_value = False
+
+        ctx = TurnContext(
+            source=source,
+            message="compress during this turn",
+            history=[],
+            session_id=parent_session_id,
+            session_key=session_key,
+            user_config={},
+            AIAgent=_StaleRotatingAgent,
+            resolve_display_setting=lambda *_args: False,
+            _run_still_current=_publish_winner_during_current_run_check,
+            _hooks_ref=SimpleNamespace(loaded_hooks=False),
+        )
+
+        result = gateway_run.TurnRunner(runner, ctx).run_sync()
+
+        assert result["session_id"] == stale_child_session_id
+        assert interleaving_calls == 1
+        assert store.peek_session_id(session_key) == winner_session_id
+        assert cm.resolve_bound_choice(
+            pending.clarify_id,
+            0,
+            binding=pending.binding,
+            observed_origin=pending.binding.origin,
+        ) is False
+        runner._sync_telegram_topic_binding.assert_not_called()
+    finally:
+        cm.clear_all()

--- a/tests/gateway/test_gateway_command_dispatch_minimal.py
+++ b/tests/gateway/test_gateway_command_dispatch_minimal.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
 
@@ -98,7 +98,20 @@ def _make_runner():
     runner._should_send_telegram_lobby_reminder = lambda _source: False
     runner._check_slash_access = lambda _source, _command: None
     runner._begin_session_run_generation = lambda _key: 1
-    runner._release_running_agent_state = lambda key: runner._running_agents.pop(key, None)
+    release_running_agent_state = create_autospec(
+        runner._release_running_agent_state
+    )
+
+    def _release_running_agent_state(
+        session_key,
+        *,
+        run_generation=None,
+        clarify_run_generation=None,
+    ):
+        return runner._running_agents.pop(session_key, None)
+
+    release_running_agent_state.side_effect = _release_running_agent_state
+    runner._release_running_agent_state = release_running_agent_state
     return runner, adapter
 
 
@@ -127,5 +140,8 @@ async def test_idle_queue_sends_payload_as_next_turn(command_text):
     assert captured["key"] == build_session_key(_make_source())
     assert captured["generation"] == 1
     assert runner._running_agents == {}
-
+    runner._release_running_agent_state.assert_called_once_with(
+        build_session_key(_make_source()),
+        clarify_run_generation=1,
+    )
 

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,5 +1,7 @@
 import asyncio
 import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -62,6 +64,9 @@ def test_cron_provider_stop_cannot_override_gateway_exit_code(caplog):
 
 @pytest.mark.asyncio
 async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks():
+    from tools import clarify_gateway as cm
+
+    cm.clear_all()
     runner, adapter = make_restart_runner()
     runner._pending_messages = {"session": "pending text"}
     runner._pending_approvals = {"session": {"command": "rm -rf /tmp/x"}}
@@ -82,18 +87,39 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
     adapter.disconnect = disconnect_mock
 
     session_key = build_session_key(event.source)
+    clarify_entry = cm.register(
+        "shutdown-pending", session_key, "Pick", ["A"]
+    )
     running_agent = MagicMock()
     runner._running_agents = {session_key: running_agent}
     # Simulate the agent exiting once interrupted so stop()'s 5s
     # interrupt-deadline poll loop returns immediately.
-    running_agent.interrupt.side_effect = lambda *a, **k: runner._running_agents.clear()
+    def _interrupt_after_clarify(*_args, **_kwargs):
+        assert not cm.has_pending(session_key)
+        assert clarify_entry.event.is_set()
+        runner._running_agents.clear()
 
-    with (
-        patch("gateway.status.remove_pid_file"),
-        patch("gateway.status.write_runtime_status"),
-        patch("agent.auxiliary_client.shutdown_cached_clients") as shutdown_cached_clients,
-    ):
-        await runner.stop()
+    running_agent.interrupt.side_effect = _interrupt_after_clarify
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        waiter = pool.submit(
+            cm.wait_for_response, clarify_entry.clarify_id, 5.0
+        )
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            with cm._lock:
+                if clarify_entry.waiter_started:
+                    break
+            await asyncio.sleep(0)
+        assert clarify_entry.waiter_started
+
+        with (
+            patch("gateway.status.remove_pid_file"),
+            patch("gateway.status.write_runtime_status"),
+            patch("agent.auxiliary_client.shutdown_cached_clients") as shutdown_cached_clients,
+        ):
+            await runner.stop()
+        assert waiter.result(timeout=2.0) == ""
 
     running_agent.interrupt.assert_called_once_with("Gateway shutting down")
     disconnect_mock.assert_awaited_once()
@@ -103,6 +129,7 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
     assert runner._pending_messages == {}
     assert runner._pending_approvals == {}
     assert runner._shutdown_event.is_set() is True
+    cm.clear_all()
 
 
 @pytest.mark.asyncio
@@ -343,5 +370,4 @@ def test_pid_exists_zombie_via_psutil_returns_false(monkeypatch):
     monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
 
     assert status._pid_exists(4242) is False
-
 

--- a/tests/gateway/test_matrix_project_context_isolation.py
+++ b/tests/gateway/test_matrix_project_context_isolation.py
@@ -6,7 +6,7 @@ import asyncio
 import time
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 
@@ -260,7 +260,9 @@ def _make_runner(current_source: SessionSource, entries: list[SessionEntry]):
     runner._session_run_generation = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
-    runner._release_running_agent_state = MagicMock()
+    runner._release_running_agent_state = create_autospec(
+        runner._release_running_agent_state
+    )
     runner._clear_session_boundary_security_state = MagicMock()
     runner._evict_cached_agent = MagicMock()
     runner._queue_depth = MagicMock(return_value=0)
@@ -338,5 +340,4 @@ async def test_matrix_resume_cross_room_requires_explicit_flag_and_warns():
     assert "Cross-room resume" in result
     assert PROJECT_B_NAME in result
     runner.session_store.switch_session.assert_called_once()
-
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
@@ -453,6 +454,50 @@ class DelayedInterimAgent:
             "messages": [],
             "api_calls": 1,
         }
+
+
+class InactivityOwnershipAgent:
+    """Park until the inline timeout path interrupts this exact old turn."""
+
+    started = threading.Event()
+    release = threading.Event()
+    timeout_ready = threading.Event()
+    instances = []
+
+    @classmethod
+    def reset(cls):
+        cls.started = threading.Event()
+        cls.release = threading.Event()
+        cls.timeout_ready = threading.Event()
+        cls.instances = []
+
+    def __init__(self, **_kwargs):
+        self.tools = []
+        self.interrupts = []
+        type(self).instances.append(self)
+
+    def run_conversation(self, _message, **_kwargs):
+        type(self).started.set()
+        assert type(self).release.wait(2.0)
+        return {
+            "final_response": "old turn unwound",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+    def get_activity_summary(self):
+        idle = 60.0 if type(self).timeout_ready.is_set() else 0.0
+        return {
+            "seconds_since_activity": idle,
+            "last_activity_desc": "parked test turn",
+            "current_tool": None,
+            "api_call_count": 1,
+            "max_iterations": 2,
+        }
+
+    def interrupt(self, reason):
+        self.interrupts.append(reason)
+        type(self).release.set()
 
 
 def _make_runner(adapter):
@@ -1557,6 +1602,119 @@ async def test_run_agent_drops_tool_progress_after_generation_invalidation(monke
     assert result["final_response"] == "done"
     assert 'first command' in all_progress_text
     assert 'second command' not in all_progress_text
+
+
+@pytest.mark.asyncio
+async def test_inline_inactivity_timeout_preserves_replacement_clarify(
+    monkeypatch,
+    tmp_path,
+):
+    """The asyncio timeout path cannot erase a post-/new replacement prompt."""
+    from tools import clarify_gateway as cm
+
+    InactivityOwnershipAgent.reset()
+    cm.clear_all()
+    run_task = None
+    try:
+        fake_dotenv = types.ModuleType("dotenv")
+        fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+        monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = InactivityOwnershipAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+        monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "0.01")
+        monkeypatch.setenv("HERMES_AGENT_TIMEOUT_WARNING", "0")
+
+        adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+        runner = _make_runner(adapter)
+        gateway_run = importlib.import_module("gateway.run")
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {"api_key": "***"},
+        )
+        # Isolate the asyncio poll branch: the detached watcher/reaper has its
+        # own regression above and must not be the actor that clears state here.
+        monkeypatch.setattr(
+            gateway_run,
+            "_watch_gateway_turn_inactivity",
+            lambda **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            gateway_run,
+            "_abandon_timed_out_gateway_turn",
+            lambda **_kwargs: False,
+        )
+        original_wait = asyncio.wait
+
+        async def _fast_wait(awaitables, timeout=None, **kwargs):
+            return await original_wait(awaitables, timeout=0.01, **kwargs)
+
+        monkeypatch.setattr(gateway_run.asyncio, "wait", _fast_wait)
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            thread_id=None,
+        )
+        session_key = "agent:main:telegram:dm:12345"
+        runner._session_run_generation[session_key] = 1
+        old_entry = cm.register(
+            "inline-timeout-old",
+            session_key,
+            "Old prompt",
+            ["old"],
+            run_generation=1,
+        )
+
+        run_task = asyncio.create_task(
+            runner._run_agent(
+                message="old turn",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="old-session",
+                session_key=session_key,
+                run_generation=1,
+            )
+        )
+        assert await asyncio.to_thread(InactivityOwnershipAgent.started.wait, 2.0)
+
+        # Model the /new ordering: the boundary clears the old prompt, bumps
+        # generation, then the replacement turn registers its prompt before
+        # the old timeout path resumes.
+        assert cm.clear_session(session_key) == 1
+        assert old_entry.event.is_set()
+        assert runner._invalidate_session_run_generation(
+            session_key,
+            reason="test_new",
+        ) == 2
+        replacement = cm.register(
+            "inline-timeout-replacement",
+            session_key,
+            "Replacement prompt",
+            ["new"],
+            run_generation=2,
+        )
+        InactivityOwnershipAgent.timeout_ready.set()
+
+        result = await asyncio.wait_for(run_task, timeout=2.0)
+        assert "inactive" in result["final_response"].lower()
+        assert InactivityOwnershipAgent.instances[0].interrupts == [
+            "Execution timed out (inactivity)"
+        ]
+        assert cm.get_entry(replacement.clarify_id) is replacement
+        assert not replacement.event.is_set()
+        assert cm.resolve_gateway_clarify(replacement.clarify_id, "new") is True
+        assert cm.wait_for_response(replacement.clarify_id, timeout=0.1) == "new"
+    finally:
+        InactivityOwnershipAgent.release.set()
+        if run_task is not None and not run_task.done():
+            await asyncio.wait_for(run_task, timeout=2.0)
+        cm.clear_all()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -215,6 +215,154 @@ class TestTokenEstimation:
 
 
 @pytest.mark.asyncio
+async def test_hygiene_rotation_invalidates_clarify_before_lease_rebind(
+    monkeypatch,
+    tmp_path,
+):
+    """The live hygiene path publishes its child through the locked CAS funnel."""
+    from tools import clarify_gateway as cm
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    target_session_id = "hygiene-compression-child"
+
+    class RotatingCompressAgent:
+        def __init__(self, **kwargs):
+            self.session_id = kwargs["session_id"]
+            self._session_db = kwargs.get("session_db")
+            self._last_compaction_in_place = False
+            self.context_compressor = SimpleNamespace(
+                bind_session_state=MagicMock(),
+                _last_compress_aborted=False,
+                _last_aux_model_failure_model=None,
+            )
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+
+        def _compress_context(self, _messages, *_args, **_kwargs):
+            self.session_id = target_session_id
+            return (
+                [
+                    {"role": "user", "content": "retained"},
+                    {"role": "assistant", "content": "short summary"},
+                ],
+                None,
+            )
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = RotatingCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+        user_id="12345",
+    )
+    event = MessageEvent(text="hello", source=source, message_id="1")
+    runner = gateway_run.GatewayRunner(
+        GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    token="fake-token",
+                )
+            }
+        )
+    )
+    runner.adapters = {Platform.TELEGRAM: HygieneCaptureAdapter()}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source_arg: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    session_entry = runner.session_store.get_or_create_session(source)
+    original_session_id = session_entry.session_id
+    runner.session_store.load_transcript = MagicMock(
+        return_value=_make_history(6, content_size=400)
+    )
+    runner.session_store.rewrite_transcript = MagicMock(return_value=True)
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._sync_telegram_topic_binding = MagicMock()
+
+    pending = cm.register(
+        "hygiene-pending",
+        session_entry.session_key,
+        "Pick",
+        ["A"],
+        origin=cm.ClarifyOrigin("12345", "-1001", "17585"),
+        session_id=original_session_id,
+        active_session_transaction=lambda action: runner.session_store.run_if_session_current(
+            session_entry.session_key,
+            original_session_id,
+            action,
+        ),
+    )
+    observations = []
+
+    def _observe_rebind(_key, _generation, new_session_id):
+        observations.append(
+            (
+                new_session_id,
+                runner.session_store.peek_session_id(session_entry.session_key),
+                cm.resolve_bound_choice(
+                    pending.clarify_id,
+                    0,
+                    binding=pending.binding,
+                    observed_origin=pending.binding.origin,
+                ),
+            )
+        )
+
+    runner._rebind_turn_lease = _observe_rebind
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "fake"},
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length_async",
+        AsyncMock(return_value=100),
+    )
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert observations == [
+        (target_session_id, target_session_id, False)
+    ]
+    assert runner.session_store.peek_session_id(session_entry.session_key) == (
+        target_session_id
+    )
+    assert pending.event.is_set()
+    assert pending.response == ""
+
+
+@pytest.mark.asyncio
 async def test_session_hygiene_preserves_transcript_when_no_rotation(monkeypatch, tmp_path):
     """Regression for #21301: the hygiene agent is built without a session_db,
     so _compress_context cannot rotate. When it neither rotates NOR compacts

--- a/tests/gateway/test_shutdown_cache_cleanup.py
+++ b/tests/gateway/test_shutdown_cache_cleanup.py
@@ -111,7 +111,13 @@ class _FakeGateway:
     def _evict_cached_agent(self, key):
         pass
 
-    def _release_running_agent_state(self, session_key, **_kwargs):
+    def _release_running_agent_state(
+        self,
+        session_key,
+        *,
+        run_generation=None,
+        clarify_run_generation=None,
+    ):
         agent = self._running_agents.pop(session_key, None)
         self._running_agents_ts.pop(session_key, None)
         self._cleanup_agent_resources(agent)

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -48,7 +48,7 @@ def _ensure_slack_mock():
 _ensure_slack_mock()
 
 from plugins.platforms.slack.adapter import SlackAdapter
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 
 
 def _make_adapter():
@@ -272,3 +272,51 @@ class TestBaseAdapterClarifyFallbackUnchanged:
         assert "Pick a fruit" in text
         assert "1." in text and "apple" in text
         assert "2." in text and "banana" in text
+
+    @pytest.mark.asyncio
+    async def test_dispatch_does_not_swallow_adapter_typeerror(self):
+        """A handler bug is propagated once, never mistaken for signature drift."""
+        from gateway.platforms.base import BasePlatformAdapter
+
+        class _BuggyLegacyOverride(BasePlatformAdapter):
+            def __init__(self):
+                super().__init__(
+                    PlatformConfig(enabled=True, token="test"),
+                    Platform.SLACK,
+                )
+                self.calls = 0
+
+            async def connect(self, *, is_reconnect: bool = False):
+                return True
+
+            async def disconnect(self):
+                return None
+
+            async def send(self, chat_id, content, **kwargs):
+                raise AssertionError("not used")
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id}
+
+            async def send_clarify(
+                self,
+                chat_id,
+                question,
+                choices,
+                clarify_id,
+                session_key,
+                metadata=None,
+            ):
+                self.calls += 1
+                raise TypeError("adapter implementation bug")
+
+        adapter = _BuggyLegacyOverride()
+        with pytest.raises(TypeError, match="implementation bug"):
+            await adapter.dispatch_clarify(
+                chat_id="C1",
+                question="Pick",
+                choices=["A"],
+                clarify_id="cid",
+                session_key="sk",
+            )
+        assert adapter.calls == 1

--- a/tests/gateway/test_slack_log_noise.py
+++ b/tests/gateway/test_slack_log_noise.py
@@ -246,13 +246,18 @@ class TestClarifyLogPrivacy:
         }
         action = {"action_id": "hermes_clarify_choice_1", "value": "cid-priv|1"}
 
-        with caplog.at_level(logging.DEBUG, logger=ADAPTER_LOGGER):
-            with patch.object(
+        with (
+            caplog.at_level(logging.DEBUG, logger=ADAPTER_LOGGER),
+            patch.object(
                 adapter,
                 "_is_interactive_user_authorized",
                 return_value=True,
-            ):
-                await adapter._handle_clarify_action(AsyncMock(), body, action)
+            ),
+            patch.object(cm, "get_entry", wraps=cm.get_entry) as get_entry,
+        ):
+            await adapter._handle_clarify_action(AsyncMock(), body, action)
+
+        get_entry.assert_called_once_with("cid-priv")
 
         info_and_above = [
             r.getMessage() for r in caplog.records if r.levelno >= logging.INFO

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -5,7 +5,9 @@ Mirrors test_telegram_approval_buttons.py for the new ``send_clarify`` and
 """
 
 import os
+import inspect
 import sys
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -39,8 +41,41 @@ def _clear_clarify_state():
     from tools import clarify_gateway as cm
     with cm._lock:
         cm._entries.clear()
+        cm._wait_entries.clear()
         cm._session_index.clear()
         cm._notify_cbs.clear()
+
+
+def _register_bound(
+    clarify_id="cidA",
+    *,
+    user_id="777",
+    chat_id="12345",
+    thread_id=None,
+    session_id="session-1",
+    active=None,
+    choices=None,
+):
+    from tools import clarify_gateway as cm
+
+    active = active if active is not None else {"session_id": session_id}
+    route_lock = active.setdefault("_lock", threading.RLock())
+
+    def _active_session_transaction(action):
+        with route_lock:
+            if active["session_id"] != session_id:
+                return False
+            return action()
+
+    return cm.register(
+        clarify_id,
+        "sk-cb",
+        "Pick",
+        choices or ["red", "green", "blue"],
+        origin=cm.ClarifyOrigin(user_id, chat_id, thread_id),
+        session_id=session_id,
+        active_session_transaction=_active_session_transaction,
+    )
 
 
 # ===========================================================================
@@ -60,12 +95,14 @@ class TestTelegramSendClarify:
         mock_msg.message_id = 100
         adapter._bot.send_message = AsyncMock(return_value=mock_msg)
 
+        entry = _register_bound("cid1", choices=["alpha", "beta", "gamma"])
         result = await adapter.send_clarify(
             chat_id="12345",
             question="Which option?",
             choices=["alpha", "beta", "gamma"],
             clarify_id="cid1",
             session_key="sk1",
+            binding=entry.binding,
         )
 
         assert result.success is True
@@ -81,10 +118,8 @@ class TestTelegramSendClarify:
         # InlineKeyboardMarkup with N+1 buttons (3 choices + Other)
         markup = kwargs["reply_markup"]
         assert markup is not None
-        # Mocked InlineKeyboardMarkup — just verify it was constructed
-        # with rows.  We check state instead of poking the mock structure.
-        assert "cid1" in adapter._clarify_state
-        assert adapter._clarify_state["cid1"] == "sk1"
+        # Binding lifecycle is owned only by the primitive.
+        assert not hasattr(adapter, "_clarify_state")
 
 
         # The button label should be short ("1"), not the long choice
@@ -98,17 +133,34 @@ class TestTelegramSendClarify:
         mock_msg.message_id = 103
         adapter._bot.send_message = AsyncMock(return_value=mock_msg)
 
+        entry = _register_bound("cid5", choices=["x"])
         await adapter.send_clarify(
             chat_id="12345",
             question="<script>alert(1)</script>",
             choices=["x"],
             clarify_id="cid5",
             session_key="sk5",
+            binding=entry.binding,
         )
         kwargs = adapter._bot.send_message.call_args[1]
         # Must NOT contain raw <script> — html.escape should have neutralized
         assert "<script>" not in kwargs["text"]
         assert "&lt;script&gt;" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_multi_choice_refuses_missing_binding(self):
+        adapter = _make_adapter()
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="Pick",
+            choices=["x"],
+            clarify_id="unbound",
+            session_key="sk",
+        )
+
+        assert result.success is False
+        assert "binding" in result.error.lower()
+        adapter._bot.send_message.assert_not_awaited()
 
 
 # ===========================================================================
@@ -126,14 +178,14 @@ class TestTelegramClarifyCallback:
         from tools import clarify_gateway as cm
 
         adapter = _make_adapter()
-        # Pre-register a clarify entry so the callback can look up the choice text
-        cm.register("cidA", "sk-cb", "Pick", ["red", "green", "blue"])
-        adapter._clarify_state["cidA"] = "sk-cb"
+        entry = _register_bound()
 
         query = AsyncMock()
         query.data = "cl:cidA:1"  # green
         query.message = MagicMock()
         query.message.chat_id = 12345
+        query.message.chat.type = "private"
+        query.message.message_thread_id = None
         query.message.text = "Pick"
         query.from_user = MagicMock()
         query.from_user.id = "777"
@@ -148,20 +200,122 @@ class TestTelegramClarifyCallback:
         with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
             await adapter._handle_callback_query(update, context)
 
-        # State popped
-        assert "cidA" not in adapter._clarify_state
-        # Wait shouldn't be needed — resolve_gateway_clarify is sync.
-        # The entry's response should be set.
-        # We test by reading the entry's response directly.
-        with cm._lock:
-            entry = cm._entries.get("cidA")
-        # Entry might be popped by wait_for_response, but here we never
-        # called wait — so it's still in _entries with response set.
-        assert entry is not None
+        # Bound callback consumption removes the active lookup atomically but
+        # preserves the waiter-owned entry and chosen response.
+        assert cm.get_entry("cidA") is None
         assert entry.response == "green"
         assert entry.event.is_set()
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_legacy_unbound_callback_fails_closed(self):
+        """Telegram must never resolve an unbound pre-binding prompt."""
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        entry = cm.register("legacy", "sk-cb", "Pick", ["red", "green"])
+        # Prove that even an old in-process adapter map cannot reopen the
+        # removed compatibility path.
+        adapter._clarify_state = {"legacy": "sk-cb"}
+        query = AsyncMock()
+        query.data = "cl:legacy:1"
+        query.message = MagicMock(chat_id=12345, message_thread_id=None, text="Pick")
+        query.message.chat.type = "private"
+        query.from_user = MagicMock(id="777", first_name="Tester")
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(
+                MagicMock(callback_query=query), MagicMock()
+            )
+
+        assert cm.get_entry("legacy") is entry
+        assert not entry.event.is_set()
+        assert "resolved" in query.answer.call_args.kwargs["text"].lower()
+        query.edit_message_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("user_id", "chat_id", "thread_id"),
+        [
+            ("778", 12345, None),
+            ("777", 54321, None),
+            ("777", 12345, 10),
+        ],
+    )
+    async def test_bound_callback_rejects_each_authenticated_origin_mismatch(
+        self, user_id, chat_id, thread_id,
+    ):
+        """Global allowlisting cannot bypass the prompt's observed origin."""
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        entry = _register_bound(thread_id="9" if thread_id is not None else None)
+        query = AsyncMock()
+        query.data = f"cl:{entry.clarify_id}:0"
+        query.message = MagicMock()
+        query.message.chat_id = chat_id
+        query.message.chat.type = "private"
+        query.message.message_thread_id = thread_id
+        query.message.text = "Pick"
+        query.from_user = MagicMock(id=user_id, first_name="Tester")
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(MagicMock(callback_query=query), MagicMock())
+
+        assert cm.get_entry(entry.clarify_id) is entry
+        assert not entry.event.is_set()
+        assert "expired" in query.answer.call_args.kwargs["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_bound_callback_rejects_stale_session_then_consumes_once(self):
+        from tools import clarify_gateway as cm
+
+        active = {"session_id": "session-1"}
+        adapter = _make_adapter()
+        entry = _register_bound(active=active)
+        query = AsyncMock()
+        query.data = f"cl:{entry.clarify_id}:0"
+        query.message = MagicMock(chat_id=12345, message_thread_id=None, text="Pick")
+        query.message.chat.type = "private"
+        query.from_user = MagicMock(id="777", first_name="Tester")
+
+        active["session_id"] = "session-2"
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(MagicMock(callback_query=query), MagicMock())
+        assert not entry.event.is_set()
+
+        active["session_id"] = "session-1"
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(MagicMock(callback_query=query), MagicMock())
+            await adapter._handle_callback_query(MagicMock(callback_query=query), MagicMock())
+
+        assert entry.response == "red"
+        assert entry.event.is_set()
+        assert cm.get_entry(entry.clarify_id) is None
+        assert query.answer.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_bound_other_callback_arms_text_once_without_adapter_state(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        entry = _register_bound()
+        query = AsyncMock()
+        query.data = f"cl:{entry.clarify_id}:other"
+        query.message = MagicMock(chat_id=12345, message_thread_id=None, text="Pick")
+        query.message.chat.type = "private"
+        query.from_user = MagicMock(id="777", first_name="Tester")
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(MagicMock(callback_query=query), MagicMock())
+            await adapter._handle_callback_query(MagicMock(callback_query=query), MagicMock())
+
+        assert entry.awaiting_text is True
+        assert entry.callback_consumed is True
+        assert not entry.event.is_set()
+        assert query.answer.call_count == 2
+        assert "expired" in query.answer.call_args.kwargs["text"].lower()
 
 
     @pytest.mark.asyncio
@@ -169,8 +323,9 @@ class TestTelegramClarifyCallback:
         from tools import clarify_gateway as cm
 
         adapter = _make_adapter()
-        cm.register("cidC", "sk-auth", "Pick", ["a", "b"])
-        adapter._clarify_state["cidC"] = "sk-auth"
+        entry = _register_bound(
+            clarify_id="cidC", user_id="999", choices=["a", "b"]
+        )
 
         # Hook up a runner that says NOT authorized
         class _DenyRunner:
@@ -200,14 +355,10 @@ class TestTelegramClarifyCallback:
         await adapter._handle_callback_query(update, context)
 
         # Must not resolve, must answer with not-authorized message
-        with cm._lock:
-            entry = cm._entries.get("cidC")
-        assert entry is not None
+        assert cm.get_entry("cidC") is entry
         assert not entry.event.is_set()
         query.answer.assert_called_once()
         assert "not authorized" in query.answer.call_args[1]["text"].lower()
-        # State preserved
-        assert adapter._clarify_state["cidC"] == "sk-auth"
 
 
 # ===========================================================================
@@ -254,3 +405,30 @@ class TestBaseAdapterClarifyFallback:
         assert "1." in text and "apple" in text
         assert "2." in text and "banana" in text
 
+
+def test_shared_send_clarify_contract_accepts_binding_across_adapters():
+    """Every shared consumer accepts the runner's immutable binding keyword."""
+    from gateway.platforms.base import BasePlatformAdapter
+    from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+    from gateway.relay.adapter import RelayAdapter
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    from plugins.platforms.google_chat.adapter import GoogleChatAdapter
+    from plugins.platforms.photon.adapter import PhotonAdapter
+    from plugins.platforms.slack.adapter import SlackAdapter
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapters = (
+        BasePlatformAdapter,
+        TelegramAdapter,
+        DiscordAdapter,
+        SlackAdapter,
+        WhatsAppAdapter,
+        WhatsAppCloudAdapter,
+        GoogleChatAdapter,
+        PhotonAdapter,
+        RelayAdapter,
+    )
+    for adapter_type in adapters:
+        parameter = inspect.signature(adapter_type.send_clarify).parameters.get("binding")
+        assert parameter is not None, adapter_type.__name__
+        assert parameter.default is None, adapter_type.__name__

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -96,13 +96,14 @@ class TestTelegramSendClarify:
         adapter._bot.send_message = AsyncMock(return_value=mock_msg)
 
         entry = _register_bound("cid1", choices=["alpha", "beta", "gamma"])
-        result = await adapter.send_clarify(
+        result = await adapter.dispatch_clarify(
             chat_id="12345",
             question="Which option?",
             choices=["alpha", "beta", "gamma"],
             clarify_id="cid1",
             session_key="sk1",
             binding=entry.binding,
+            require_binding=True,
         )
 
         assert result.success is True

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -6,7 +6,7 @@ Telegram topics act as independent Hermes session lanes.
 
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
 
@@ -160,7 +160,9 @@ def _make_runner(session_db=None):
     runner._read_user_config = lambda: {
         "approvals": {"destructive_slash_confirm": False}
     }
-    runner._release_running_agent_state = MagicMock()
+    runner._release_running_agent_state = create_autospec(
+        runner._release_running_agent_state
+    )
     runner._evict_cached_agent = MagicMock()
     runner._clear_session_boundary_security_state = MagicMock()
     runner._set_session_reasoning_override = MagicMock()
@@ -829,4 +831,3 @@ def test_get_telegram_topic_binding_by_session_returns_binding(tmp_path):
 # ---------------------------------------------------------------------------
 # Test for session-split thread_id recovery (issue #27166)
 # ---------------------------------------------------------------------------
-

--- a/tests/gateway/test_tool_response_drop_recovery.py
+++ b/tests/gateway/test_tool_response_drop_recovery.py
@@ -21,6 +21,7 @@ Salvaged and de-scoped from the superseded Discord-only PR #33842.
 
 import asyncio
 import logging
+from unittest.mock import create_autospec
 
 import pytest
 
@@ -293,10 +294,10 @@ class TestPostStopInterruptSwallow:
         runner._invalidate_session_run_generation = (
             lambda key, reason=None: invalidated.append((key, reason))
         )
-        released = []
-        runner._release_running_agent_state = (
-            lambda key, **kw: released.append(key)
+        release_running_agent_state = create_autospec(
+            runner._release_running_agent_state
         )
+        runner._release_running_agent_state = release_running_agent_state
         reaped = []
         reaped_event = threading.Event()
         from tools.process_registry import process_registry
@@ -316,7 +317,7 @@ class TestPostStopInterruptSwallow:
         )
 
         assert agent.interrupt_reasons == [_INTERRUPT_REASON_STOP]
-        assert released == [session_key]
+        release_running_agent_state.assert_called_once_with(session_key)
         assert reaped_event.wait(1)
         assert reaped == [
             (

--- a/tests/gateway/test_turn_context.py
+++ b/tests/gateway/test_turn_context.py
@@ -15,7 +15,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.session import SessionSource
 from gateway.turn_context import TurnContext
 
@@ -145,3 +146,145 @@ class TestTurnRunner:
             "Context length exceeded. Cannot compress further."
         )
         assert result["compression_exhausted"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("platform", "expected_fragment", "expected_send_calls"),
+        [
+            (Platform.SLACK, "legacy answer", 1),
+            (Platform.TELEGRAM, "could not be delivered", 0),
+        ],
+    )
+    async def test_clarify_dispatch_preserves_legacy_non_telegram_override(
+        self,
+        platform,
+        expected_fragment,
+        expected_send_calls,
+    ):
+        """Exercise TurnRunner's real clarify dispatch compatibility boundary."""
+        from gateway.run import TurnRunner
+        from tools import clarify_gateway as cm
+
+        cm.clear_all()
+
+        class _LegacyClarifyAdapter(BasePlatformAdapter):
+            """Frozen pre-binding override: deliberately has no binding kwarg."""
+
+            def __init__(self):
+                super().__init__(
+                    PlatformConfig(enabled=True, token="test"),
+                    platform,
+                )
+                self.calls = []
+
+            async def connect(self, *, is_reconnect: bool = False):
+                return True
+
+            async def disconnect(self):
+                return None
+
+            async def send(self, chat_id, content, **kwargs):
+                return SendResult(success=True, message_id="plain")
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id}
+
+            async def send_clarify(
+                self,
+                chat_id,
+                question,
+                choices,
+                clarify_id,
+                session_key,
+                metadata=None,
+            ):
+                self.calls.append(clarify_id)
+                assert cm.resolve_gateway_clarify(
+                    clarify_id,
+                    "legacy answer",
+                )
+                return SendResult(success=True, message_id="clarify")
+
+        class _ClarifyingAgent:
+            def __init__(self, **kwargs):
+                self.model = kwargs["model"]
+                self.session_id = kwargs["session_id"]
+                self.tools = []
+                self.context_compressor = SimpleNamespace(
+                    last_prompt_tokens=0,
+                    context_length=200_000,
+                )
+                self.session_prompt_tokens = 0
+                self.session_completion_tokens = 0
+
+            def run_conversation(self, _message, **_kwargs):
+                answer = self.clarify_callback("Pick", ["A", "B"])
+                return {
+                    "final_response": answer,
+                    "failed": False,
+                    "messages": [],
+                }
+
+        gateway_runner = MagicMock()
+        gateway_runner.config = SimpleNamespace(streaming=None)
+        gateway_runner._provider_routing = {}
+        gateway_runner._agent_cache_lock = None
+        gateway_runner._agent_cache = {}
+        gateway_runner._session_db = None
+        gateway_runner._prefill_messages = None
+        gateway_runner._pending_model_notes = {}
+        gateway_runner._pending_skills_reload_notes = {}
+        gateway_runner.session_store._entries = {}
+        gateway_runner._running = True
+        gateway_runner._draining = False
+        gateway_runner._get_system_prompt_for_channel.return_value = None
+        gateway_runner._resolve_session_agent_runtime.return_value = (
+            "test-model",
+            {},
+        )
+        gateway_runner._resolve_session_reasoning_config.return_value = None
+        gateway_runner._resolve_session_service_tier.return_value = None
+        gateway_runner._resolve_turn_agent_config.return_value = {
+            "model": "test-model",
+            "runtime": {},
+        }
+        gateway_runner._agent_config_signature.return_value = ("test-signature",)
+        gateway_runner._extract_cache_busting_config.return_value = {}
+        gateway_runner._refresh_fallback_model.return_value = None
+        gateway_runner._consume_pending_native_image_paths.return_value = []
+        gateway_runner._consume_pending_turn_sidecar_notes.return_value = []
+        gateway_runner._is_telegram_topic_lane.return_value = False
+        gateway_runner._is_discord_auto_thread_lane.return_value = False
+        gateway_runner._is_relay_discord_channel_lane.return_value = False
+
+        adapter = _LegacyClarifyAdapter()
+        source = SessionSource(
+            platform=platform,
+            chat_id="test-chat",
+            user_id="test-user",
+        )
+        ctx = TurnContext(
+            source=source,
+            message="continue",
+            history=[],
+            session_id="test-session",
+            session_key="test-session-key",
+            user_config={},
+            AIAgent=_ClarifyingAgent,
+            resolve_display_setting=lambda *_args: False,
+            _run_still_current=lambda: True,
+            _hooks_ref=SimpleNamespace(loaded_hooks=False),
+            _status_adapter=adapter,
+            _status_chat_id="test-chat",
+            _loop_for_step=asyncio.get_running_loop(),
+        )
+
+        try:
+            result = await asyncio.to_thread(
+                TurnRunner(gateway_runner, ctx).run_sync
+            )
+        finally:
+            cm.clear_all()
+
+        assert expected_fragment in result["final_response"]
+        assert len(adapter.calls) == expected_send_calls

--- a/tests/hermes_cli/test_pre_command_hook.py
+++ b/tests/hermes_cli/test_pre_command_hook.py
@@ -13,7 +13,7 @@ commands on an in-flight run must not be observable/veto-able by plugins.
 
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
 
@@ -283,10 +283,30 @@ def _make_runner():
     runner._should_send_telegram_lobby_reminder = lambda _source: False
     runner._check_slash_access = lambda _source, _command: None
     runner._begin_session_run_generation = lambda _key: 1
-    runner._release_running_agent_state = (
-        lambda key: runner._running_agents.pop(key, None)
+    release_running_agent_state = create_autospec(
+        runner._release_running_agent_state
     )
+
+    def _release_running_agent_state(
+        session_key,
+        *,
+        run_generation=None,
+        clarify_run_generation=None,
+    ):
+        return runner._running_agents.pop(session_key, None)
+
+    release_running_agent_state.side_effect = _release_running_agent_state
+    runner._release_running_agent_state = release_running_agent_state
     return runner, adapter
+
+
+def _assert_turn_release(runner):
+    from gateway.session import build_session_key
+
+    runner._release_running_agent_state.assert_called_once_with(
+        build_session_key(_make_source()),
+        clarify_run_generation=1,
+    )
 
 
 @pytest.mark.asyncio
@@ -314,6 +334,7 @@ async def test_gateway_fires_for_recognized_command(monkeypatch):
     assert captured["args_raw"] == "do it later"
     assert captured["platform"] == "telegram"
     assert captured["session_key"]
+    _assert_turn_release(runner)
 
 
 @pytest.mark.asyncio
@@ -338,6 +359,7 @@ async def test_gateway_reports_canonical_name_for_alias(monkeypatch):
 
     assert captured["command"] == "queue"
     assert captured["alias_used"] == "q"
+    _assert_turn_release(runner)
 
 
 @pytest.mark.asyncio
@@ -359,6 +381,7 @@ async def test_gateway_does_not_fire_for_plain_text(monkeypatch):
 
     await runner._handle_message(_make_event("just a normal message"))
     assert fired == []
+    _assert_turn_release(runner)
 
 
 @pytest.mark.asyncio
@@ -383,6 +406,7 @@ async def test_gateway_control_plane_intercept_excluded(monkeypatch):
     assert result == "busy-handled"
     runner._dispatch_busy_slash_command.assert_awaited_once()
     assert fired == []
+    runner._release_running_agent_state.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -407,3 +431,4 @@ async def test_gateway_hook_failure_is_non_fatal(monkeypatch):
     result = await runner._handle_message(_make_event("/queue still works"))
     assert result == {"final_response": "", "messages": []}
     assert captured["text"] == "still works"
+    _assert_turn_release(runner)

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -12,14 +12,31 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
+
 
 def _clear_clarify_state():
     """Reset module-level state between tests."""
     from tools import clarify_gateway as cm
     with cm._lock:
         cm._entries.clear()
+        cm._wait_entries.clear()
         cm._session_index.clear()
         cm._notify_cbs.clear()
+
+
+def _active_transaction(expected_session_id: str, active=None):
+    """Return a tiny SessionStore-shaped transaction for primitive tests."""
+    active = active if active is not None else {"session_id": expected_session_id}
+    route_lock = active.setdefault("_lock", threading.RLock())
+
+    def _transaction(action):
+        with route_lock:
+            if active["session_id"] != expected_session_id:
+                return False
+            return action()
+
+    return _transaction
 
 
 class TestClarifyPrimitive:
@@ -51,6 +68,147 @@ class TestClarifyPrimitive:
         assert cm.resolve_gateway_clarify("id-race", "A") is True
         assert cm.resolve_gateway_clarify("id-race", "") is False
         assert entry.response == "A"
+
+    def test_bound_choice_normalizes_origin_and_consumes_before_wakeup(self):
+        """A matching authenticated callback consumes the binding before resuming."""
+        from tools import clarify_gateway as cm
+
+        active = {"session_id": "session-1"}
+        entry = cm.register(
+            "bound-1",
+            " stable-key ",
+            "Pick one",
+            ["A", "B"],
+            origin=cm.ClarifyOrigin(" 777 ", " 12345 ", " 9 "),
+            session_id=" session-1 ",
+            active_session_transaction=_active_transaction("session-1", active),
+        )
+        binding = entry.binding
+
+        assert binding == cm.ClarifyBinding(
+            clarify_id="bound-1",
+            session_key="stable-key",
+            session_id="session-1",
+            origin=cm.ClarifyOrigin("777", "12345", "9"),
+        )
+        with pytest.raises(AttributeError):
+            binding.session_id = "changed"
+
+        class _ObservingEvent:
+            def __init__(self):
+                self.was_set = False
+
+            def is_set(self):
+                return self.was_set
+
+            def set(self):
+                assert cm.get_entry("bound-1") is None
+                assert cm.has_pending("stable-key") is False
+                self.was_set = True
+
+        entry.event = _ObservingEvent()
+        assert cm.resolve_bound_choice(
+            "bound-1",
+            1,
+            binding=binding,
+            observed_origin=cm.ClarifyOrigin("777", "12345", "9"),
+        ) is True
+        assert entry.response == "B"
+        assert entry.event.is_set()
+        assert cm.resolve_bound_choice(
+            "bound-1", 1, binding=binding, observed_origin=binding.origin,
+        ) is False
+
+    @pytest.mark.parametrize(
+        "observed",
+        [
+            ("778", "12345", "9"),
+            ("777", "54321", "9"),
+            ("777", "12345", "10"),
+        ],
+    )
+    def test_bound_choice_rejects_each_origin_mismatch(self, observed):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "bound-mismatch",
+            "stable-key",
+            "Pick",
+            ["A"],
+            origin=cm.ClarifyOrigin("777", "12345", "9"),
+            session_id="session-1",
+            active_session_transaction=_active_transaction("session-1"),
+        )
+
+        assert cm.resolve_bound_choice(
+            entry.clarify_id,
+            0,
+            binding=entry.binding,
+            observed_origin=cm.ClarifyOrigin(*observed),
+        ) is False
+        assert cm.get_entry(entry.clarify_id) is entry
+        assert not entry.event.is_set()
+
+    def test_bound_choice_rejects_stale_active_session_and_binding(self):
+        from tools import clarify_gateway as cm
+
+        active = {"session_id": "session-1"}
+        entry = cm.register(
+            "bound-stale",
+            "stable-key",
+            "Pick",
+            ["A"],
+            origin=cm.ClarifyOrigin("777", "12345", None),
+            session_id="session-1",
+            active_session_transaction=_active_transaction("session-1", active),
+        )
+        active["session_id"] = "session-2"
+
+        assert cm.resolve_bound_choice(
+            entry.clarify_id, 0, binding=entry.binding, observed_origin=entry.binding.origin,
+        ) is False
+        forged = cm.ClarifyBinding(
+            entry.clarify_id, "stable-key", "session-2", entry.binding.origin,
+        )
+        assert cm.resolve_bound_choice(
+            entry.clarify_id, 0, binding=forged, observed_origin=entry.binding.origin,
+        ) is False
+        assert cm.get_entry(entry.clarify_id) is entry
+        assert not entry.event.is_set()
+
+    def test_bound_other_callback_is_single_use_and_text_keeps_origin_binding(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "bound-other",
+            "stable-key",
+            "Pick",
+            ["A"],
+            origin=cm.ClarifyOrigin("777", "12345", "9"),
+            session_id="session-1",
+            active_session_transaction=_active_transaction("session-1"),
+        )
+        assert cm.mark_bound_awaiting_text(
+            entry.clarify_id,
+            binding=entry.binding,
+            observed_origin=entry.binding.origin,
+        ) is True
+        assert cm.mark_bound_awaiting_text(
+            entry.clarify_id,
+            binding=entry.binding,
+            observed_origin=entry.binding.origin,
+        ) is False
+        assert cm.attempt_text_response_for_session(
+            "stable-key",
+            "custom",
+            observed_origin=cm.ClarifyOrigin("778", "12345", "9"),
+        ) == cm.TEXT_NO_PENDING
+        assert not entry.event.is_set()
+        assert cm.attempt_text_response_for_session(
+            "stable-key", "custom", observed_origin=entry.binding.origin,
+        ) == cm.TEXT_RESOLVED
+        assert entry.response == "custom"
+        assert entry.event.is_set()
 
     def test_open_ended_auto_awaits_text(self):
         """Clarify with no choices is in text-capture mode immediately."""
@@ -100,6 +258,32 @@ class TestClarifyPrimitive:
             result = fut.result(timeout=10.0)
             # clear_session sets response="" then the wait returns it
             assert result == ""
+
+    def test_clear_session_removes_bound_callback_and_waiter_registration(self):
+        """Session boundaries invalidate both active callback and waiter lookup."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "bound-clear",
+            "stable-key",
+            "Pick",
+            ["A"],
+            origin=cm.ClarifyOrigin("777", "12345", None),
+            session_id="session-1",
+            active_session_transaction=_active_transaction("session-1"),
+        )
+
+        assert cm.clear_session("stable-key") == 1
+        assert cm.get_entry(entry.clarify_id) is None
+        with cm._lock:
+            assert entry.clarify_id not in cm._wait_entries
+        assert cm.wait_for_response(entry.clarify_id, timeout=0.01) is None
+        assert cm.resolve_bound_choice(
+            entry.clarify_id,
+            0,
+            binding=entry.binding,
+            observed_origin=entry.binding.origin,
+        ) is False
 
 
     def test_clear_session_preserves_resolved_response(self):

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -787,6 +787,7 @@ def clear_session(
     session_key: str,
     *,
     run_generation: Optional[int] = None,
+    clarify_id: Optional[str] = None,
 ) -> int:
     """Resolve and drop matching pending clarifies for a session.
 
@@ -801,6 +802,14 @@ def clear_session(
     without cancelling the replacement's prompt.  Omitting it remains the
     conversation-boundary operation and clears every generation.
 
+    When ``clarify_id`` is provided, only that exact prompt is cleared.  Prompt
+    delivery failure uses this narrower selector because its delayed future may
+    settle after a replacement prompt has already registered under the same
+    session and generation.  Selection and mutation happen in one primitive-
+    lock transaction.  This function never enters ``SessionStore``; callers
+    already inside a route transaction therefore preserve the process-wide
+    ``SessionStore._lock -> clarify_gateway._lock`` order.
+
     First-writer-wins: an entry whose event is already set has been resolved
     by a real response (button callback or text intercept).  Session cleanup
     must NOT overwrite that response with the empty cancellation sentinel —
@@ -814,6 +823,9 @@ def clear_session(
         for cid in ids:
             entry = _entries.get(cid)
             if entry is None:
+                continue
+            if clarify_id is not None and cid != clarify_id:
+                retained_ids.append(cid)
                 continue
             if (
                 run_generation is not None

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -93,6 +93,7 @@ class _ClarifyEntry:
     question: str
     choices: Optional[List[str]]
     multi_select: bool = False
+    run_generation: Optional[int] = None
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
@@ -135,6 +136,7 @@ def register(
     choices: Optional[List[str]],
     multi_select: bool = False,
     *,
+    run_generation: Optional[int] = None,
     origin: Optional[ClarifyOrigin] = None,
     session_id: Optional[str] = None,
     active_session_transaction: Optional[
@@ -169,6 +171,7 @@ def register(
         question=question,
         choices=list(choices) if choices else None,
         multi_select=bool(multi_select) and bool(choices),
+        run_generation=run_generation,
         awaiting_text=not bool(choices),
         binding=binding,
         active_session_transaction=active_session_transaction,
@@ -780,14 +783,23 @@ def has_pending(session_key: str) -> bool:
         return any(_entries.get(cid) is not None for cid in ids)
 
 
-def clear_session(session_key: str) -> int:
-    """Resolve and drop every pending clarify for a session.
+def clear_session(
+    session_key: str,
+    *,
+    run_generation: Optional[int] = None,
+) -> int:
+    """Resolve and drop matching pending clarifies for a session.
 
     Used by session-boundary cleanup (e.g. ``/new``, gateway shutdown,
     cached-agent eviction) so blocked agent threads don't hang past the
     end of their session.  Returns the number of entries actually
     cancelled (i.e. whose event had not yet been set).  Already-resolved
     entries are dropped from the registry but their response is preserved.
+
+    When ``run_generation`` is provided, only entries owned by that turn are
+    cleared.  This lets an old turn unwind after a replacement turn has begun
+    without cancelling the replacement's prompt.  Omitting it remains the
+    conversation-boundary operation and clears every generation.
 
     First-writer-wins: an entry whose event is already set has been resolved
     by a real response (button callback or text intercept).  Session cleanup
@@ -796,8 +808,24 @@ def clear_session(session_key: str) -> int:
     user answered.  Only unresolved entries are cancelled here.
     """
     with _lock:
-        ids = list(_session_index.pop(session_key, []) or [])
-        entries = [_entries.pop(cid, None) for cid in ids]
+        ids = list(_session_index.get(session_key, []) or [])
+        entries = []
+        retained_ids = []
+        for cid in ids:
+            entry = _entries.get(cid)
+            if entry is None:
+                continue
+            if (
+                run_generation is not None
+                and entry.run_generation != run_generation
+            ):
+                retained_ids.append(cid)
+                continue
+            entries.append(_entries.pop(cid))
+        if retained_ids:
+            _session_index[session_key] = retained_ids
+        else:
+            _session_index.pop(session_key, None)
         # The mutation loop must stay inside the lock: the pop above and the
         # event.is_set() check below have to be atomic with respect to
         # resolve_gateway_clarify, or a button callback could win between the

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -44,6 +44,47 @@ logger = logging.getLogger(__name__)
 # Module-level state
 # =========================================================================
 
+def _normalize_id(value: object, *, optional: bool = False) -> Optional[str]:
+    """Normalize a transport/session identifier at the trust boundary."""
+    if value is None:
+        return None if optional else ""
+    normalized = str(value).strip()
+    if optional and not normalized:
+        return None
+    return normalized
+
+
+@dataclass(frozen=True)
+class ClarifyOrigin:
+    """Authenticated transport origin observed for a prompt or callback."""
+
+    user_id: str
+    chat_id: str
+    thread_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "user_id", _normalize_id(self.user_id) or "")
+        object.__setattr__(self, "chat_id", _normalize_id(self.chat_id) or "")
+        object.__setattr__(self, "thread_id", _normalize_id(self.thread_id, optional=True))
+
+
+@dataclass(frozen=True)
+class ClarifyBinding:
+    """Immutable identity binding for one pending clarify callback."""
+
+    clarify_id: str
+    session_key: str
+    session_id: str
+    origin: ClarifyOrigin
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "clarify_id", _normalize_id(self.clarify_id) or "")
+        object.__setattr__(self, "session_key", _normalize_id(self.session_key) or "")
+        object.__setattr__(self, "session_id", _normalize_id(self.session_id) or "")
+        if not isinstance(self.origin, ClarifyOrigin):
+            raise TypeError("origin must be a ClarifyOrigin")
+
+
 @dataclass
 class _ClarifyEntry:
     """One pending clarify request inside a gateway session."""
@@ -55,6 +96,12 @@ class _ClarifyEntry:
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
+    binding: Optional[ClarifyBinding] = None
+    active_session_transaction: Optional[Callable[[Callable[[], bool]], bool]] = field(
+        default=None, repr=False, compare=False,
+    )
+    callback_consumed: bool = False
+    waiter_started: bool = False
 
     def signature(self) -> Dict[str, object]:
         return {
@@ -63,12 +110,16 @@ class _ClarifyEntry:
             "question": self.question,
             "choices": list(self.choices) if self.choices else None,
             "multi_select": bool(self.multi_select),
+            "binding": self.binding,
         }
 
 
 _lock = threading.RLock()
 # clarify_id → _ClarifyEntry  (primary lookup for button callbacks)
 _entries: Dict[str, _ClarifyEntry] = {}
+# Waiter-owned references survive atomic callback consumption. This closes the
+# race where a very fast callback resolves before wait_for_response starts.
+_wait_entries: Dict[str, _ClarifyEntry] = {}
 # session_key → list[clarify_id]  (FIFO; for text-fallback intercept and session cleanup)
 _session_index: Dict[str, List[str]] = {}
 
@@ -83,24 +134,49 @@ def register(
     question: str,
     choices: Optional[List[str]],
     multi_select: bool = False,
+    *,
+    origin: Optional[ClarifyOrigin] = None,
+    session_id: Optional[str] = None,
+    active_session_transaction: Optional[
+        Callable[[Callable[[], bool]], bool]
+    ] = None,
 ) -> _ClarifyEntry:
     """Register a pending clarify request and return the entry.
 
-    The caller (gateway clarify_callback) will then send the prompt to the
-    user and block on ``wait_for_response(clarify_id, timeout)``.
+    Supplying any binding field requires all binding fields. Bound identifiers
+    and origins are normalized once and retained in an immutable value object.
     """
+    normalized_clarify_id = _normalize_id(clarify_id) or ""
+    normalized_session_key = _normalize_id(session_key) or ""
+    binding = None
+    if origin is not None or session_id is not None or active_session_transaction is not None:
+        if not isinstance(origin, ClarifyOrigin):
+            raise ValueError("bound clarifies require an authenticated origin")
+        normalized_session_id = _normalize_id(session_id) or ""
+        if not normalized_clarify_id or not normalized_session_key or not normalized_session_id:
+            raise ValueError("bound clarify identifiers must be non-empty")
+        if not origin.user_id or not origin.chat_id:
+            raise ValueError("bound clarify origin user_id/chat_id must be non-empty")
+        if not callable(active_session_transaction):
+            raise ValueError("bound clarifies require an active session transaction")
+        binding = ClarifyBinding(
+            normalized_clarify_id, normalized_session_key, normalized_session_id, origin,
+        )
+
     entry = _ClarifyEntry(
-        clarify_id=clarify_id,
-        session_key=session_key,
+        clarify_id=normalized_clarify_id if binding else clarify_id,
+        session_key=normalized_session_key if binding else session_key,
         question=question,
         choices=list(choices) if choices else None,
         multi_select=bool(multi_select) and bool(choices),
-        # Open-ended (no choices) → next message IS the response, no buttons needed.
         awaiting_text=not bool(choices),
+        binding=binding,
+        active_session_transaction=active_session_transaction,
     )
     with _lock:
-        _entries[clarify_id] = entry
-        _session_index.setdefault(session_key, []).append(clarify_id)
+        _entries[entry.clarify_id] = entry
+        _wait_entries[entry.clarify_id] = entry
+        _session_index.setdefault(entry.session_key, []).append(entry.clarify_id)
     return entry
 
 
@@ -119,7 +195,9 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     Returns the resolved response string, or ``None`` on timeout.
     """
     with _lock:
-        entry = _entries.get(clarify_id)
+        entry = _wait_entries.get(clarify_id)
+        if entry is not None:
+            entry.waiter_started = True
     if entry is None:
         return None
 
@@ -148,6 +226,7 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     with _lock:
         # Remove from indices regardless of resolution outcome.
         _entries.pop(clarify_id, None)
+        _wait_entries.pop(clarify_id, None)
         ids = _session_index.get(entry.session_key)
         if ids and clarify_id in ids:
             ids.remove(clarify_id)
@@ -162,18 +241,161 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
 # =========================================================================
 
 def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
-    """Unblock the agent thread waiting on ``clarify_id``.
+    """Unblock an unbound/legacy entry waiting on ``clarify_id``.
 
-    Returns True if an entry was found and resolved, False otherwise
-    (already resolved, expired, or never existed).
+    Bound adapters must use the validating APIs below; this compatibility path
+    intentionally refuses to bypass an entry's origin/session binding.
     """
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None or entry.event.is_set():
+        if entry is None or entry.event.is_set() or entry.binding is not None:
             return False
         entry.response = str(response) if response is not None else ""
         entry.event.set()
         return True
+
+
+def get_entry(clarify_id: str) -> Optional[_ClarifyEntry]:
+    """Return an active callback entry without exposing primitive storage."""
+    with _lock:
+        return _entries.get(clarify_id)
+
+
+def get_binding(clarify_id: str) -> Optional[ClarifyBinding]:
+    """Return an active immutable callback binding, or None after invalidation."""
+    with _lock:
+        entry = _entries.get(clarify_id)
+        return entry.binding if entry is not None else None
+
+
+def is_multi_select(clarify_id: str) -> bool:
+    """Return whether an active clarify accepts multiple selections."""
+    with _lock:
+        entry = _entries.get(clarify_id)
+        return bool(entry and entry.multi_select)
+
+
+def _binding_matches_locked(
+    entry: _ClarifyEntry,
+    binding: Optional[ClarifyBinding],
+    observed_origin: Optional[ClarifyOrigin],
+    *,
+    allow_consumed_callback: bool = False,
+) -> bool:
+    """Validate immutable binding and authenticated origin. Primitive lock held."""
+    if (
+        entry.binding is None
+        or binding is None
+        or entry.binding != binding
+        or observed_origin is None
+        or entry.binding.origin != observed_origin
+        or (entry.callback_consumed and not allow_consumed_callback)
+    ):
+        return False
+    return callable(entry.active_session_transaction)
+
+
+def _run_bound_transaction(
+    clarify_id: str,
+    *,
+    binding: Optional[ClarifyBinding],
+    observed_origin: Optional[ClarifyOrigin],
+    mutate: Callable[[_ClarifyEntry], bool],
+    allow_consumed_callback: bool = False,
+) -> bool:
+    """Run one bound operation atomically with the active SessionStore route.
+
+    The transaction supplied at registration owns the outer SessionStore lock,
+    validates the expected session id, and calls ``_inside_store_lock`` while
+    still holding it.  The closure then acquires this module's lock.  The total
+    order is therefore always ``SessionStore._lock -> clarify_gateway._lock``.
+
+    The preliminary primitive-lock read only obtains the transaction callable;
+    it releases that lock before entering the SessionStore transaction.  The
+    entry and binding are re-read under both locks, so invalidation between the
+    two phases fails closed without introducing an inverse acquisition.
+    """
+    with _lock:
+        entry = _entries.get(clarify_id)
+        transaction = entry.active_session_transaction if entry is not None else None
+    if not callable(transaction):
+        return False
+
+    def _inside_store_lock() -> bool:
+        with _lock:
+            current = _entries.get(clarify_id)
+            if current is None or not _binding_matches_locked(
+                current,
+                binding,
+                observed_origin,
+                allow_consumed_callback=allow_consumed_callback,
+            ):
+                return False
+            return bool(mutate(current))
+
+    try:
+        return bool(transaction(_inside_store_lock))
+    except Exception:
+        logger.debug("Bound clarify transaction failed", exc_info=True)
+        return False
+
+
+def _remove_active_entry_locked(entry: _ClarifyEntry) -> None:
+    """Consume an active callback and its session index under the primitive lock."""
+    _entries.pop(entry.clarify_id, None)
+    ids = _session_index.get(entry.session_key)
+    if ids and entry.clarify_id in ids:
+        ids.remove(entry.clarify_id)
+        if not ids:
+            _session_index.pop(entry.session_key, None)
+
+
+def resolve_bound_choice(
+    clarify_id: str,
+    choice_index: int,
+    *,
+    binding: Optional[ClarifyBinding],
+    observed_origin: Optional[ClarifyOrigin],
+) -> bool:
+    """Validate and atomically consume a bound indexed callback exactly once."""
+    def _resolve(entry: _ClarifyEntry) -> bool:
+        if not entry.choices or not isinstance(choice_index, int):
+            return False
+        if choice_index < 0 or choice_index >= len(entry.choices):
+            return False
+        entry.callback_consumed = True
+        _remove_active_entry_locked(entry)
+        entry.response = str(entry.choices[choice_index])
+        # Wake only after the active binding and index have been consumed.
+        entry.event.set()
+        return True
+
+    return _run_bound_transaction(
+        clarify_id,
+        binding=binding,
+        observed_origin=observed_origin,
+        mutate=_resolve,
+    )
+
+
+def mark_bound_awaiting_text(
+    clarify_id: str,
+    *,
+    binding: Optional[ClarifyBinding],
+    observed_origin: Optional[ClarifyOrigin],
+) -> bool:
+    """Validate and single-consume an Other callback while retaining text state."""
+    def _mark(entry: _ClarifyEntry) -> bool:
+        entry.callback_consumed = True
+        entry.awaiting_text = True
+        return True
+
+    return _run_bound_transaction(
+        clarify_id,
+        binding=binding,
+        observed_origin=observed_origin,
+        mutate=_mark,
+    )
 
 
 def get_pending_for_session(
@@ -425,7 +647,74 @@ def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
     return _json.dumps(selected, ensure_ascii=False)
 
 
-def attempt_text_response_for_session(session_key: str, response: str) -> str:
+def _resolve_bound_text(
+    clarify_id: str,
+    response: str,
+    observed_origin: Optional[ClarifyOrigin],
+) -> bool:
+    """Validate a bound text reply and consume it inside the route transaction."""
+    binding = get_binding(clarify_id)
+
+    def _resolve(entry: _ClarifyEntry) -> bool:
+        # Other callbacks are consumed before the typed answer; direct typed
+        # choices and open-ended prompts are not. All three are valid after the
+        # origin/session check above.
+        _remove_active_entry_locked(entry)
+        entry.response = str(response) if response is not None else ""
+        entry.event.set()
+        return True
+
+    return _run_bound_transaction(
+        clarify_id,
+        binding=binding,
+        observed_origin=observed_origin,
+        mutate=_resolve,
+        allow_consumed_callback=True,
+    )
+
+
+def cancel_bound_clarify(
+    clarify_id: str,
+    *,
+    binding: Optional[ClarifyBinding],
+    observed_origin: Optional[ClarifyOrigin],
+) -> bool:
+    """Cancel a matching bound prompt without permitting a legacy bypass."""
+    def _cancel(entry: _ClarifyEntry) -> bool:
+        _remove_active_entry_locked(entry)
+        entry.response = ""
+        entry.event.set()
+        return True
+
+    return _run_bound_transaction(
+        clarify_id,
+        binding=binding,
+        observed_origin=observed_origin,
+        mutate=_cancel,
+        allow_consumed_callback=True,
+    )
+
+
+def _bound_entry_is_current(
+    entry: _ClarifyEntry,
+    observed_origin: Optional[ClarifyOrigin],
+) -> bool:
+    """Fail closed before classifying a typed reply for a bound prompt."""
+    return _run_bound_transaction(
+        entry.clarify_id,
+        binding=entry.binding,
+        observed_origin=observed_origin,
+        mutate=lambda _current: True,
+        allow_consumed_callback=True,
+    )
+
+
+def attempt_text_response_for_session(
+    session_key: str,
+    response: str,
+    *,
+    observed_origin: Optional[ClarifyOrigin] = None,
+) -> str:
     """Try to resolve the oldest pending clarify in ``session_key`` from typed text.
 
     Returns one of:
@@ -439,6 +728,10 @@ def attempt_text_response_for_session(session_key: str, response: str) -> str:
     entry = get_pending_for_session(session_key, include_choice_prompts=True)
     if entry is None:
         return TEXT_NO_PENDING
+    if entry.binding is not None and not _bound_entry_is_current(
+        entry, observed_origin
+    ):
+        return TEXT_NO_PENDING
 
     coerced, reason = _coerce_text_response_detailed(entry, response)
     if coerced is None:
@@ -446,7 +739,11 @@ def attempt_text_response_for_session(session_key: str, response: str) -> str:
             return TEXT_REJECTED_SELECTION
         return TEXT_REJECTED_PROSE
 
-    if resolve_gateway_clarify(entry.clarify_id, coerced):
+    if entry.binding is not None:
+        resolved = _resolve_bound_text(entry.clarify_id, coerced, observed_origin)
+    else:
+        resolved = resolve_gateway_clarify(entry.clarify_id, coerced)
+    if resolved:
         return TEXT_RESOLVED
     # Lost a race with a button/callback resolution — treat as no work left.
     return TEXT_NO_PENDING
@@ -470,7 +767,7 @@ def mark_awaiting_text(clarify_id: str) -> bool:
     """
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None:
+        if entry is None or entry.binding is not None:
             return False
         entry.awaiting_text = True
         return True
@@ -513,6 +810,11 @@ def clear_session(session_key: str) -> int:
             # state — a cleared session must not be resurrected by late
             # callbacks — but a resolved entry keeps its real response.
             if entry.event.is_set():
+                # A fast callback can resolve before wait_for_response starts.
+                # Preserve its waiter-owned reference until that waiter has a
+                # chance to observe the real first-writer-wins answer.
+                if entry.waiter_started:
+                    _wait_entries.pop(entry.clarify_id, None)
                 continue
             # Empty string sentinel — agent code can distinguish from a real
             # response by inspecting the wait_for_response return value
@@ -520,8 +822,32 @@ def clear_session(session_key: str) -> int:
             # falsy result as "user did not respond".
             entry.response = ""
             entry.event.set()
+            _wait_entries.pop(entry.clarify_id, None)
             cancelled += 1
     return cancelled
+
+
+def clear_all() -> int:
+    """Cancel every unresolved gateway clarify during process shutdown.
+
+    The mutation is one primitive-lock transaction so a callback either wins
+    first (its answer is preserved) or observes the cleared registry and fails.
+    """
+    with _lock:
+        entries = list(_entries.values())
+        _entries.clear()
+        _session_index.clear()
+        cancelled = 0
+        for entry in entries:
+            if entry.event.is_set():
+                if entry.waiter_started:
+                    _wait_entries.pop(entry.clarify_id, None)
+                continue
+            entry.response = ""
+            entry.event.set()
+            _wait_entries.pop(entry.clarify_id, None)
+            cancelled += 1
+        return cancelled
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
- bind clarify callbacks to normalized origin, session, and single-use identifiers
- make validation and consumption atomic across rotation and lifecycle boundaries
- fence late clarify admission before interrupt cleanup and preserve shared adapter compatibility

## Validation
- 223 changed tests passed on the exact final SHA
- focused lifecycle/race gates: 101 passed
- git diff --check passed
- independent exact-SHA review: SHIP

No merge or deployment is requested by this automation.