### PR TITLE
fix(background-review): share memory maintenance policy

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -462,9 +462,25 @@ def _digest_history(messages_snapshot: List[Dict], tail: int = 24) -> List[Dict]
 # the user-message that the forked review agent receives.  AIAgent exposes
 # them as class attributes (``_MEMORY_REVIEW_PROMPT`` etc.) for back-compat;
 # the actual text lives here so future edits are one-place.
+_MEMORY_MAINTENANCE_POLICY = (
+    "Memory maintenance policy: audit the existing memory entries before "
+    "deciding what to write. Classify candidates as exact duplicates, fully "
+    "subsumed entries, safe semantic unions, contradictions, or unrelated "
+    "context-dependent preferences. Consolidate only exact duplicates or "
+    "entries whose union preserves every unique fact, qualifier, exception, "
+    "preference strength, and temporal condition. Use one atomic operations "
+    "batch to replace redundant entries with the lossless union and remove "
+    "only the sources it replaces. Never merge contradictions or context-"
+    "dependent preferences speculatively; when equivalence is uncertain, "
+    "leave the entries unchanged and report the uncertainty. Then save any "
+    "new durable facts.\n\n"
+)
+
+
 _MEMORY_REVIEW_PROMPT = (
     "Review the conversation above and consider saving to memory if appropriate.\n\n"
-    "Focus on:\n"
+    + _MEMORY_MAINTENANCE_POLICY
+    + "Focus on:\n"
     "1. Has the user revealed things about themselves — their persona, desires, "
     "preferences, or personal details worth remembering?\n"
     "2. Has the user expressed expectations about how you should behave, their work "
@@ -618,7 +634,8 @@ _COMBINED_REVIEW_PROMPT = (
     "desires, preferences, personal details, or expectations about "
     "how you should behave? Save facts about the user and durable "
     "preferences with the memory tool.\n\n"
-    "**Skills**: how to do this class of task. Be ACTIVE — most "
+    + _MEMORY_MAINTENANCE_POLICY
+    + "**Skills**: how to do this class of task. Be ACTIVE — most "
     "sessions produce at least one skill update. A pass that does "
     "nothing is a missed learning opportunity, not a neutral outcome.\n\n"
     "Target shape of the skill library: CLASS-LEVEL skills with a rich "

--- a/tests/run_agent/test_review_prompt_class_first.py
+++ b/tests/run_agent/test_review_prompt_class_first.py
@@ -76,6 +76,25 @@ def test_combined_review_prompt_has_memory_section():
     assert "memory tool" in prompt
 
 
+def test_memory_maintenance_policy_is_shared_by_memory_review_paths():
+    """Combined reviews must not bypass the lossless memory workflow."""
+    required = (
+        "audit",
+        "classify",
+        "Consolidate",
+        "atomic operations batch",
+        "every unique fact",
+        "when equivalence is uncertain",
+    )
+    for label, prompt in (
+        ("memory-only", AIAgent._MEMORY_REVIEW_PROMPT),
+        ("combined", AIAgent._COMBINED_REVIEW_PROMPT),
+    ):
+        lower = prompt.lower()
+        for phrase in required:
+            assert phrase.lower() in lower, f"{label}: missing {phrase!r}"
+
+
 
 
 


### PR DESCRIPTION
Closes #97471

Share a conservative audit → classify → consolidate → save memory policy between memory-only and combined background reviews. The policy preserves qualifiers and refuses uncertain merges; tests cover both prompt paths.