### PR TITLE
fix(update): ignore successful receipt stop reasons

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2279,7 +2279,9 @@ def cmd_update(args):
         _finalize_update_receipt(1, f"{type(_update_exc).__name__}: {_update_exc}")
         raise
     else:
-        _finalize_update_receipt(0, "completed at command boundary")
+        from hermes_cli.update_receipt import COMMAND_BOUNDARY_STOP_REASON
+
+        _finalize_update_receipt(0, COMMAND_BOUNDARY_STOP_REASON)
         _update_handoff_exit_code = 0
     finally:
         _update_lock.release()

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -78,14 +78,27 @@ def _current_checkout_sha() -> str | None:
 
 
 def _receipt_looks_unfinished(receipt: dict) -> bool:
-    """True when *receipt* is from an update that did not finish cleanly."""
+    """True when *receipt* is from an update that did not finish cleanly.
+
+    ``stop_reason`` records *how* the command boundary closed the receipt
+    (``completed at command boundary``, ``sys.exit(0)``, even KeyboardInterrupt
+    on an otherwise successful run). A truthy stop_reason must not make a
+    successful receipt look unfinished, or the next ``hermes update`` retriggers
+    ``fleet_restart_pending`` from pre-pull plan SHAs.
+    """
+    exit_code = receipt.get("exit_code")
+    outcome = receipt.get("outcome")
+    if exit_code not in (0, None):
+        return True
+    if outcome in ("failed", "partial", "running"):
+        return True
     gateway_restart = receipt.get("gateway_restart")
-    return bool(
-        receipt.get("stop_reason")
-        or receipt.get("exit_code") not in (0, None)
-        or receipt.get("outcome") in ("failed", "partial", "running")
-        or (isinstance(gateway_restart, dict) and gateway_restart.get("incomplete"))
-    )
+    if isinstance(gateway_restart, dict) and gateway_restart.get("incomplete"):
+        return True
+    stop_reason = receipt.get("stop_reason")
+    if stop_reason and outcome != "success" and exit_code != 0:
+        return True
+    return False
 
 
 def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -19,6 +19,7 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 _RECEIPT_KEEP = 20  # keep the last N receipts per profile home
+COMMAND_BOUNDARY_STOP_REASON = "completed at command boundary"
 
 # ``hermes update`` is a single-threaded CLI command; a module singleton lets the 7k-line updater
 # record steps from any depth without threading a handle through every helper.

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -84,6 +84,12 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
     monkeypatch.setattr(main_install_repair, "_is_windows", lambda: False)
     monkeypatch.setattr(
+        update_cmd, "_restart_macos_launchd_gateways", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        update_cmd_fleet, "_restart_macos_launchd_gateways", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
         hermes_main,
         "_get_origin_url",
         lambda *a, **k: "https://github.com/NousResearch/hermes-agent.git",

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -27,6 +27,7 @@ import hermes_cli.main_install_repair as main_install_repair
 from hermes_cli import update_cmd
 import hermes_cli.update_cmd_fleet as update_cmd_fleet
 import hermes_cli.update_cmd_deps as update_cmd_deps
+from hermes_cli.update_receipt import COMMAND_BOUNDARY_STOP_REASON
 from hermes_constants import get_hermes_home
 
 
@@ -270,7 +271,7 @@ def test_successful_command_boundary_receipt_without_fleet_does_not_retrigger(
             {
                 "exit_code": 0,
                 "outcome": "success",
-                "stop_reason": "completed at command boundary",
+                "stop_reason": COMMAND_BOUNDARY_STOP_REASON,
                 "plan": {
                     "expected_sha": old_sha,
                     "runtimes": [

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -254,6 +254,67 @@ def test_successful_receipt_with_pre_update_plan_shas_does_not_retrigger(
     assert update_cmd._pending_fleet_restart_needed() is False
 
 
+def test_successful_command_boundary_receipt_without_fleet_does_not_retrigger(
+    monkeypatch,
+):
+    """A normal command-boundary stop is not an interrupted update."""
+    disk_sha = "n" * 40
+    old_sha = "o" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: disk_sha)
+
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "exit_code": 0,
+                "outcome": "success",
+                "stop_reason": "completed at command boundary",
+                "plan": {
+                    "expected_sha": old_sha,
+                    "runtimes": [
+                        {
+                            "kind": "gateway",
+                            "profile": "default",
+                            "pid": 1,
+                            "code_sha": old_sha,
+                        }
+                    ],
+                },
+                "fleet": [],
+                "gateway_restart": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+
+@pytest.mark.parametrize(
+    "receipt",
+    [
+        {"outcome": "success", "exit_code": 0, "stop_reason": "sys.exit(0)"},
+        {"outcome": "success", "stop_reason": "KeyboardInterrupt: "},
+        {"exit_code": 0, "stop_reason": "sys.exit(0)"},
+    ],
+)
+def test_successful_non_boundary_stop_reasons_are_finished(receipt):
+    """Successful sys.exit(0)/KeyboardInterrupt must not look unfinished."""
+    assert update_cmd._receipt_looks_unfinished(receipt) is False
+
+
+def test_failed_interrupt_stop_reason_is_unfinished():
+    assert update_cmd._receipt_looks_unfinished(
+        {
+            "outcome": "failed",
+            "exit_code": 1,
+            "stop_reason": "KeyboardInterrupt: ",
+        }
+    ) is True
+
+
 def test_stale_fleet_matrix_on_latest_receipt_is_pending(monkeypatch):
     disk_sha = "n" * 40
     monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)


### PR DESCRIPTION
Treat successful command-boundary update receipts as completed rather than stopped, using a shared receipt-reason constant across update paths. Add isolated fleet-restart coverage that does not depend on the host launchd state.