### PR TITLE
fix(cron): use gateway config for satellite delivery preflight

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5146,6 +5146,37 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     return None
 
 
+def _load_delivery_gateway_config():
+    """Load gateway delivery config from the owning gateway process.
+
+    A multiplexed satellite profile owns its cron store but not the gateway
+    credentials.  Its local ``config.yaml`` intentionally omits credentials
+    when delivery is routed through ``gateway.profile_routes`` on the default
+    gateway.  In that topology, preflight must inspect the default root's
+    gateway config, just as fire-time routing does.
+    """
+    from gateway.config import load_gateway_config
+
+    active_home = _get_hermes_home().resolve()
+    try:
+        from hermes_constants import (
+            get_default_hermes_root,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        default_root = Path(get_default_hermes_root()).resolve()
+        active_home.relative_to(default_root / "profiles")
+    except (ImportError, ValueError, OSError):
+        return load_gateway_config()
+
+    token = set_hermes_home_override(str(default_root))
+    try:
+        return load_gateway_config()
+    finally:
+        reset_hermes_home_override(token)
+
+
 def _preflight_check_delivery(job: dict) -> Optional[str]:
     """Check the job's delivery target(s) resolve to configured platforms.
 
@@ -5183,9 +5214,7 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
             )
         if connected is None:
             try:
-                from gateway.config import load_gateway_config
-
-                gateway_config = load_gateway_config()
+                gateway_config = _load_delivery_gateway_config()
                 connected = {
                     p.value for p in gateway_config.get_connected_platforms()
                 }

--- a/tests/cron/test_cron_relay_delivery_guards.py
+++ b/tests/cron/test_cron_relay_delivery_guards.py
@@ -108,6 +108,24 @@ def _gateway_config(connected_values):
 
 
 class TestPreflightRelayFronted:
+    def test_satellite_profile_uses_default_gateway_delivery_config(self, monkeypatch, tmp_path):
+        """Satellite cron jobs use credentials from the multiplexing gateway."""
+        default_root = tmp_path / "hermes"
+        satellite = default_root / "profiles" / "grant"
+        satellite.mkdir(parents=True)
+        monkeypatch.setattr(sched, "_hermes_home", satellite)
+        monkeypatch.setattr(
+            "hermes_constants.get_default_hermes_root",
+            lambda: default_root,
+        )
+        with patch(
+            "gateway.config.load_gateway_config",
+            return_value=_gateway_config({"telegram"}),
+        ):
+            assert _preflight_check_delivery(
+                {"deliver": "telegram:-1004306455751:14"}
+            ) is None
+
     def test_relay_fronted_slack_accepted(self, monkeypatch):
         """Relay-only topology fronting slack: slack:CHAT passes preflight."""
         monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "slack")


### PR DESCRIPTION
Closes #97476\n\nUse the multiplexing gateway's default-root delivery configuration when a cron job runs from a satellite profile, so profile-routed Telegram delivery is not falsely blocked before dispatch.