### PR TITLE
fix(desktop): unwrap Rolldown CJS-interop wrapper in discoverBundledPlugins

### DIFF
--- a/apps/desktop/src/contrib/plugins.test.ts
+++ b/apps/desktop/src/contrib/plugins.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { unwrapPluginDefault } from './plugins'
+
+vi.mock('./runtime-loader', () => ({ watchRuntimePlugins: vi.fn() }))
+vi.mock('./plugins-store', () => ({
+  publishPlugin: vi.fn(),
+  pluginActive: vi.fn().mockReturnValue(false)
+}))
+
+describe('unwrapPluginDefault', () => {
+  it('returns the plugin object when default is the ESM object form', () => {
+    const plugin = { id: 'accent', name: 'Accent', register: vi.fn() }
+    // Normal Vite/ESM glob result: `{ default: HermesPlugin }`
+    expect(unwrapPluginDefault({ default: plugin })).toBe(plugin)
+  })
+
+  it('invokes the default getter and returns the plugin when it is a Rolldown CJS-interop wrapper', () => {
+    const plugin = { id: 'hermes-bots', name: 'Bots', register: vi.fn() }
+    const getter = vi.fn(() => plugin)
+    // Rolldown CJS-interop: `{ default: () => HermesPlugin }`
+    const result = unwrapPluginDefault({ default: getter })
+
+    expect(getter).toHaveBeenCalledTimes(1)
+    expect(result).toBe(plugin)
+  })
+
+  it('returns null when the module shape has no default export', () => {
+    expect(unwrapPluginDefault({})).toBeNull()
+    expect(unwrapPluginDefault({ default: undefined })).toBeNull()
+    expect(unwrapPluginDefault(null)).toBeNull()
+    expect(unwrapPluginDefault(undefined)).toBeNull()
+  })
+
+  it('returns null (never throws) when the default getter throws', () => {
+    const broken = { default: () => { throw new Error('boom') } }
+    expect(unwrapPluginDefault(broken)).toBeNull()
+  })
+
+  it('returns null when the default getter resolves to a non-object value', () => {
+    // Defensive: a misbehaving wrapper could resolve to undefined/null
+    expect(unwrapPluginDefault({ default: () => undefined })).toBeNull()
+    expect(unwrapPluginDefault({ default: () => null })).toBeNull()
+  })
+})

--- a/apps/desktop/src/contrib/plugins.ts
+++ b/apps/desktop/src/contrib/plugins.ts
@@ -17,7 +17,30 @@ import { createPluginContext, type HermesPlugin } from './plugin'
 import { pluginActive, publishPlugin } from './plugins-store'
 import { watchRuntimePlugins } from './runtime-loader'
 
-const modules = import.meta.glob<{ default: HermesPlugin }>('../plugins/*/plugin.{js,ts,tsx}', { eager: true })
+const modules = import.meta.glob<{ default: HermesPlugin | (() => HermesPlugin) }>('../plugins/*/plugin.{js,ts,tsx}', { eager: true })
+
+// `import.meta.glob` is Vite-specific. Rolldown's CJS-interop wrapper
+// (rolldown-runtime `u({default: () => x})`) turns the default export into a
+// getter function; Vite/normal ESM keeps it as the object. Accept both shapes
+// so bundled plugins don't get skipped with
+// "[plugins] X has no valid default HermesPlugin export".
+export function unwrapPluginDefault(mod: unknown): HermesPlugin | null {
+  const raw = (mod as { default?: unknown } | null | undefined)?.default
+
+  if (typeof raw === 'function') {
+    try {
+      return (raw as () => HermesPlugin | null | undefined)() ?? null
+    } catch {
+      return null
+    }
+  }
+
+  if (raw && typeof raw === 'object') {
+    return raw as HermesPlugin
+  }
+
+  return null
+}
 
 // One-shot init guard. Contributions themselves register by id (re-registering
 // is idempotent), but the disk-door watcher setup below (watchRuntimePlugins)
@@ -33,7 +56,7 @@ export function discoverBundledPlugins(): void {
   loaded = true
 
   for (const [path, mod] of Object.entries(modules)) {
-    const plugin = mod.default
+    const plugin = unwrapPluginDefault(mod)
 
     if (!plugin?.id || typeof plugin.register !== 'function') {
       console.warn(`[plugins] ${path} has no valid default HermesPlugin export — skipped`)


### PR DESCRIPTION
## Summary

`discoverBundledPlugins()` reads `mod.default` from each `import.meta.glob` entry expecting a `HermesPlugin` object. Under Rolldown, that field is a **getter function** `{ default: () => HermesPlugin }` (the rolldown-runtime `u(e, t, n)` helper preserves the `default` key when the wrapper has no other source props to copy). The validation `!plugin?.id || typeof plugin.register !== 'function'` then sees a function reference (no `.id`, no `.register`) and silently skips every bundled plugin with `[plugins] X has no valid default HermesPlugin export — skipped`. Net result: `$pluginRecords` stays empty and Settings → Plugins → Desktop Plugins renders "No desktop plugins installed yet." on Windows packaged builds.

## Scope of this fix

This change only touches desktop bundled-plugin unwrapping (`apps/desktop/src/contrib/plugins.ts`). It does NOT touch:

- the backend `plugins.manage` RPC handler (`tui_gateway/methods_tools.py:2395`) — verified healthy on RackNerd, returns the expected 55-row payload
- the bottom Agent Plugins section's `isDesktopRelevantPlugin` filter — that filter intentionally returns `false` for any plugin with `source === 'bundled'`, which is why the bottom section correctly shows 0 even when 55 backend plugins are returned. This is curation behavior, not a bug.
- the gateway, OAuth, or any RPC layer

## Fix

Extract a small `unwrapPluginDefault(mod)` helper that calls the default export when it's a function and otherwise returns it directly. The `typeof === 'function'` test terminates unwrapping exactly when the helper sees the plugin object, so the helper is invariant to wrap depth and works for both the Rolldown-wrapped shape and a normal ESM direct export. The existing validation block is preserved immediately after the unwrap.

```ts
const plugin = unwrapPluginDefault(mod)

if (!plugin?.id || typeof plugin.register !== 'function') {
  console.warn(`[plugins] ${path} has no valid default HermesPlugin export — skipped`)
  continue
}
```

The `import.meta.glob<>` generic is widened to `{ default: HermesPlugin | (() => HermesPlugin) }` to accept either shape.

## Tests

- Added `apps/desktop/src/contrib/plugins.test.ts` covering: ESM shape, Rolldown shape, empty `{}` / `null` / `undefined` input, throwing getter, getter returning `null` / `undefined`.
- Standalone semantic verifier: the extracted `unwrapPluginDefault` was run against 6 cases including a regression test that replicates the original code path and confirms (a) `mod.default` fails validation for `{ default: () => realPlugin }`, (b) `unwrapPluginDefault(mod)` returns the real plugin and passes validation. All 6 pass.

## Verification status

- **Typecheck** (`tsc -p apps/desktop --noEmit`): clean for the two changed files.
- **Runtime semantics**: 6/6 standalone test cases pass.
- **Full desktop Vitest**: **not run on contributor's host** because the `apps/desktop` workspace's `node_modules` is partially absent (`driver.js`, `@tanstack/react-query`, `@testing-library/react`, desktop's own vitest binary are missing). Running `npm install --workspace apps/desktop` is heavy and OOM-prone; deferred to upstream CI.
- **Upstream CI is the authoritative test runner here.** Treat the new test as added but unverified locally; full CI must pass before merge.

## Files

| File | Change |
|------|--------|
| `apps/desktop/src/contrib/plugins.ts` | +25 / -2: widen `import.meta.glob` generic; add `unwrapPluginDefault`; use it at the existing call site |
| `apps/desktop/src/contrib/plugins.test.ts` | +45: new vitest covering both shapes and edge cases |

## Reproduction (Windows Desktop packaged build)

1. Install v0.20.6 (or v0.20.5, tag v2026.8.19) from the official installer.
2. Open Settings → Plugins. Header reads "0 installed".
3. Cmd-K → DevTools → console filter `[plugins]`: three `has no valid default HermesPlugin export — skipped` warnings.
4. After this fix is applied and a new build is installed, the same `$pluginRecords` contains three entries (accent, hermes-bots, kanban) and the section header reads "3 installed".

Closes the bundled-plugin half of #89591 / #94726 as observed on Windows packaged builds (the remote-gateway half on Linux/macOS source builds is a separate defect).