### PR TITLE
fix(desktop): route approvals by event owner scope

### DIFF
--- a/apps/desktop/src/store/session-states-runtime-map.test.ts
+++ b/apps/desktop/src/store/session-states-runtime-map.test.ts
@@ -9,6 +9,7 @@ import {
   clearAllSessionStates,
   knownOwnerForSession,
   publishSessionState,
+  recordSessionEventScope,
   requestForOwnedSession,
   storedSessionIdForRuntimeId
 } from '@/store/session-states'
@@ -107,6 +108,19 @@ describe('knownOwnerForSession / requestForOwnedSession', () => {
 
     setSessions([makeSessionInfo({ id: 'stored-main', profile: 'coder' })])
     expect(knownOwnerForSession('rt-main')).toBe('coder')
+  })
+
+  it('uses the exact inbound event owner when the runtime has no durable row yet', () => {
+    recordSessionEventScope({ connectionId: 'conn-approval', profile: 'work', session_id: 'rt-orphan' })
+
+    expect(knownOwnerForSession('rt-orphan')).toEqual({ connectionId: 'conn-approval', profile: 'work' })
+  })
+
+  it('keeps durable stored-session ownership ahead of a colliding runtime event', () => {
+    recordSessionEventScope({ connectionId: 'stale-source', profile: 'default', session_id: 'collision' })
+    setSessions([{ connection_id: 'durable-source', id: 'collision', profile: 'default' } as never])
+
+    expect(knownOwnerForSession('collision')).toEqual({ connectionId: 'durable-source', profile: 'default' })
   })
 
   it('fails closed with an explicit owner-resolution error instead of the ambient socket', async () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -82,10 +82,17 @@ export const $sessionStates = atom<Record<string, ClientSessionState>>({})
 // ---------------------------------------------------------------------------
 
 const sessionScopeByRuntimeId = new Map<string, string>()
+// Exact owner evidence from an inbound registry event. Keep this separately
+// from the liveness scope string so session-scoped RPCs can route an orphan
+// runtime through the socket that actually delivered its approval request.
+const sessionOwnerByRuntimeId = new Map<string, SessionOwnerRoute>()
 
 export function recordSessionEventScope(event: { connectionId?: string; profile?: string; session_id?: string }): void {
   if (event.session_id && event.connectionId) {
-    sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(event.connectionId, event.profile))
+    const connectionId = event.connectionId.trim()
+    const profile = normalizeProfileKey(event.profile)
+    sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(connectionId, profile))
+    sessionOwnerByRuntimeId.set(event.session_id, { connectionId, profile })
   }
 }
 
@@ -506,6 +513,7 @@ export function dropSessionState(runtimeId: string) {
   clearWatchdog(runtimeId)
   clearSessionProviderWait(runtimeId)
   sessionScopeByRuntimeId.delete(runtimeId)
+  sessionOwnerByRuntimeId.delete(runtimeId)
 
   const current = $sessionStates.get()
   setSessionStalled(current[runtimeId]?.storedSessionId, false)
@@ -532,6 +540,7 @@ export function clearAllSessionStates() {
   settledExpiry.clear()
   clearAllProviderWaits()
   sessionScopeByRuntimeId.clear()
+  sessionOwnerByRuntimeId.clear()
   $stalledSessionIds.set([])
   $sessionStates.set({})
 }
@@ -980,11 +989,15 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
 
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
 
-  return (
+  const durableOwner =
     sessionTileOwnerRoute(storedSessionId) ??
     getSessionOwnerHint(storedSessionId) ??
     knownSessionOwner(ownerLookupSessionRows(), storedSessionId)
-  )
+
+  // The inbound event's owner is exact even when the runtime/stored binding
+  // has not reached the session ledger yet. Durable tile/hint/row identity
+  // outranks it, so a stale runtime id can never override a stored collision.
+  return durableOwner ?? sessionOwnerByRuntimeId.get(sessionId)
 }
 
 /**


### PR DESCRIPTION
Closes #97511\n\nRemember the exact connection/profile that delivered a runtime event and use it as the fail-closed owner fallback for approval responses. Durable tile, hint, and stored-row ownership remains higher precedence.