### PR TITLE
fix(desktop): isolate local child from dashboard public URL

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19674,7 +19674,18 @@ def start_server(
     # request middleware never reloads config. Any non-loopback public hostname
     # engages the auth gate even when the backend itself remains on loopback;
     # otherwise the SPA's local session token would become remotely reachable.
-    app.state.trusted_public_hosts = _dashboard_public_hosts()
+    # A Desktop-owned headless child is a private loopback transport, not the
+    # machine dashboard behind dashboard.public_url. Applying that public URL
+    # here switches /api/ws to cookie/ticket auth and rejects the one-time
+    # session token Electron minted for this child.
+    desktop_loopback = (
+        headless
+        and os.environ.get("HERMES_DESKTOP") == "1"
+        and host in _LOOPBACK_HOST_VALUES
+    )
+    app.state.trusted_public_hosts = (
+        frozenset() if desktop_loopback else _dashboard_public_hosts()
+    )
     # Stash the auth-gate flag on app.state so middleware / SPA-token injection /
     # WS-auth paths can branch on it consistently. It also decides whether to
     # refuse startup, log the gate-on banner, and enable uvicorn proxy_headers.

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -384,6 +384,38 @@ def test_start_server_loopback_public_url_enables_gate(monkeypatch):
         clear_providers()
 
 
+def test_desktop_headless_loopback_ignores_dashboard_public_url(monkeypatch):
+    """Desktop's private child keeps token auth despite the machine public URL."""
+    from hermes_cli.dashboard_auth import clear_providers
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    clear_providers()
+    captured = _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(
+        monkeypatch,
+        "auth_required",
+        "bound_host",
+        "bound_port",
+        "trusted_public_hosts",
+    )
+
+    web_server.start_server(
+        host="127.0.0.1",
+        port=9119,
+        open_browser=False,
+        allow_public=False,
+        headless=True,
+    )
+
+    assert web_server.app.state.auth_required is False
+    assert web_server.app.state.trusted_public_hosts == frozenset()
+    assert captured["kwargs"].get("proxy_headers") is False
+
+
 def test_start_server_loopback_public_url_without_provider_fails_closed(monkeypatch):
     """Trusting an external Host must never expose the loopback token mode."""
     from hermes_cli.dashboard_auth import clear_providers


### PR DESCRIPTION
## Summary
- keep a Desktop-owned headless loopback child in session-token auth mode
- do not apply the machine dashboard public URL/OAuth gate to that private child
- preserve existing public URL gating for normal dashboard and non-loopback serve modes

## Root cause
When `dashboard.public_url` points to a non-loopback URL, `hermes serve` marked Desktop’s private `127.0.0.1` child as OAuth-gated. The child omitted the injected session token and rejected Electron’s `/api/ws?token=...` handshake with HTTP 403, leaving Desktop on “Hermes couldn’t start.”

## Verification
- `uv run --extra dev pytest tests/hermes_cli/test_dashboard_auth_gate.py -q -o addopts=` — 34 passed
- `npm --workspace apps/desktop run test:desktop:platforms -- --run electron/dashboard-token.test.ts electron/gateway-ws-probe.test.ts` — 22 passed
- live `hermes serve --isolated --host 127.0.0.1 --port 0` with `HERMES_DESKTOP=1` and the configured non-loopback public URL: injected token matched and `/api/ws` emitted `gateway.ready`
- relaunched packaged macOS Desktop and verified bots, sessions, chats, and composers loaded