### PR TITLE
fix(cli): keep the canonical id when saving a built-in providers: entry

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1512,7 +1512,7 @@ def _model_flow_named_custom(config, provider_info):
     Falls back to the saved model if probing fails.
     """
     from hermes_cli.main import _custom_provider_api_key_config_value, _custom_provider_base_url_config_value, _save_custom_provider
-    from hermes_cli.auth import _save_model_choice, deactivate_provider
+    from hermes_cli.auth import _save_model_choice, deactivate_provider, is_known_auth_provider
     from hermes_cli.config import load_config, normalize_extra_headers, save_config
     from hermes_cli.model_switch import (
         _entry_models_discovered,
@@ -1740,7 +1740,16 @@ def _model_flow_named_custom(config, provider_info):
         model = {"default": model} if model else {}
         cfg["model"] = model
     if provider_key:
-        model["provider"] = custom_provider_slug(name, provider_key)
+        # A ``providers:`` entry keyed by a built-in provider id (e.g.
+        # ``ollama-cloud``) must keep that canonical id: the ``custom:``
+        # prefix makes runtime resolution skip the built-in lookup and use
+        # the generic custom-endpoint path, dropping provider-specific
+        # credential/transport handling (#97544).
+        normalized_key = provider_key.strip().lower().replace(" ", "-")
+        if is_known_auth_provider(normalized_key):
+            model["provider"] = normalized_key
+        else:
+            model["provider"] = custom_provider_slug(name, provider_key)
         model.pop("base_url", None)
         model.pop("api_key", None)
     else:

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -340,6 +340,61 @@ class TestCustomProviderModelSwitch:
         # The synthesized template is also redundant here — key_env owns it.
         assert "${HERMES_CRS_HENKEE_KEY}" not in saved_text
 
+    def test_builtin_provider_key_keeps_canonical_id(self, config_home):
+        """Regression for #97544: a ``providers:`` entry keyed by a built-in
+        provider id must keep that canonical id on save.
+
+        Before the fix, ``_model_flow_named_custom`` unconditionally wrote
+        ``custom:<key>``. Runtime resolution deliberately skips the built-in
+        lookup for ``custom:``-prefixed ids, so the provider was routed
+        through the generic custom-endpoint path and lost provider-specific
+        credential/transport handling (upstream 401s for ``ollama-cloud``).
+        """
+        import yaml
+        from hermes_cli.main import _model_flow_named_custom
+
+        config_path = config_home / "config.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  default: kimi-k2.7-code\n"
+            "  provider: ollama-cloud\n"
+            "providers:\n"
+            "  ollama-cloud:\n"
+            "    api: https://ollama.com/v1\n"
+            "    default_model: kimi-k2.7-code\n"
+            "custom_providers: []\n"
+        )
+
+        # provider_info as built by _named_custom_provider_map for the
+        # ``providers:`` entry above.
+        provider_info = {
+            "name": "Ollama Cloud",
+            "base_url": "https://ollama.com/v1",
+            "api_key": "",
+            "key_env": "",
+            "model": "kimi-k2.7-code",
+            "api_mode": "",
+            "provider_key": "ollama-cloud",
+            "api_key_ref": "",
+        }
+
+        with patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["glm-5.2", "kimi-k2.7-code"],
+        ), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
+             patch("builtins.input", return_value="1"), \
+             patch("builtins.print"):
+            _model_flow_named_custom({}, provider_info)
+
+        saved = yaml.safe_load(config_path.read_text()) or {}
+        # The canonical built-in id must survive the switch untouched.
+        assert saved["model"]["provider"] == "ollama-cloud"
+        assert "base_url" not in saved["model"]
+        assert "api_key" not in saved["model"]
+        # The selected model is persisted back to the providers entry.
+        assert saved["providers"]["ollama-cloud"]["default_model"] == "glm-5.2"
+
     @pytest.mark.parametrize(
         "stored_provider",
         [


### PR DESCRIPTION
## What does this PR do?

Fixes #97544: when a built-in provider is declared under `providers:` in `config.yaml`, the interactive `hermes model` picker saved `model.provider` with a forced `custom:` prefix (e.g. `custom:ollama-cloud`).

`custom:`-prefixed ids are treated by runtime resolution (`hermes_cli/runtime_provider.py`) as explicit menu keys that always target the saved custom-provider config scan — the built-in lookup is deliberately skipped for them. So the rewritten id routed `ollama-cloud` through the generic custom-endpoint path, which only reads the config entry's inline `key_env`/`api_key` and drops the provider-specific credential/transport handling from the auth store, producing upstream `401: Unauthorized` responses (surfaced through front-ends such as Open WebUI).

The fix: when the `providers:` key normalizes to a known auth provider (`is_known_auth_provider()` — the existing helper covering `PROVIDER_REGISTRY` + `SERVICE_PROVIDER_NAMES`), keep the canonical id on save. Genuine user-defined endpoints are unchanged and still get the `custom:` prefix.

## Related Issue

Fixes #97544

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_setup_flows.py` — in `_model_flow_named_custom()`'s save block, normalize the `providers:` key and keep it verbatim when `is_known_auth_provider()` recognizes it; only non-built-in keys fall through to `custom_provider_slug()`. The `model.pop("base_url")` / `model.pop("api_key")` pruning is unchanged.
- `tests/hermes_cli/test_custom_provider_model_switch.py` — regression test `test_builtin_provider_key_keeps_canonical_id`: mirrors the issue repro (a `providers: ollama-cloud` entry switched via the picker) and asserts `model.provider` stays `ollama-cloud` with no `base_url`/`api_key` leakage, plus the `default_model` write-back. The pre-existing `test_key_env_providers_dict_entry_does_not_add_api_key` serves as the negative control (non-built-in key `crs-henkee` still saves `custom:crs-henkee`).

## How to Test

1. `uv run --extra dev pytest tests/hermes_cli/test_custom_provider_model_switch.py -q` — 14 passed (includes the new regression test and the `custom:crs-henkee` negative control).
2. `uv run --extra dev pytest tests/hermes_cli/test_setup.py tests/hermes_cli/test_canonical_custom_identity.py tests/hermes_cli/test_normalize_main_model_assignment.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_models.py -q` — 167 passed.
3. `uv run --extra dev ruff check hermes_cli/model_setup_flows.py tests/hermes_cli/test_custom_provider_model_switch.py` — all checks passed.
4. Manual repro from the issue (config with `providers: ollama-cloud:` + `model.provider: ollama-cloud`): running the picker on that entry previously rewrote the provider to `custom:ollama-cloud`; after this change the canonical id survives the switch, so requests keep using the built-in provider's auth handling.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (config-file write behavior; covered by the regression test).
