### PR TITLE
feat(desktop): add open-folder project affordance

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -95,6 +95,7 @@ import {
   enterProject,
   exitProjectScope,
   fetchProjectSessions,
+  openFolderAsProject,
   openProjectCreate,
   refreshProjects,
   refreshProjectTree,
@@ -1768,6 +1769,26 @@ export function ChatSidebar({
                       </div>
                     ) : (
                       <>
+                        {agentsGrouped && !showAllProfiles ? (
+                          <Tip
+                            label={
+                              <TipKeybindLabel actionId="workspace.openFolder" text={t.commandCenter.openFolder} />
+                            }
+                          >
+                            <Button
+                              aria-label={t.commandCenter.openFolder}
+                              className={HEADER_ACTION_BTN}
+                              onClick={event => {
+                                event.stopPropagation()
+                                void openFolderAsProject()
+                              }}
+                              size="icon-xs"
+                              variant="ghost"
+                            >
+                              <Codicon name="folder-opened" size="0.75rem" />
+                            </Button>
+                          </Tip>
+                        ) : null}
                         {!showAllProfiles ? (
                           <Tip label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}>
                             <Button


### PR DESCRIPTION
Closes #97478\n\nAdd a visible Projects-sidebar button for opening a folder as a project. The tooltip uses the live workspace.openFolder keybinding hint and invokes the same remote-aware folder workflow as the command/keybinding path.