### PR TITLE
feat(doctor): report optional skill scanner readiness

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -3169,6 +3169,31 @@ def run_doctor(args):
             issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
+
+    _section("Skill Security Advisory")
+    try:
+        from tools.skillevaluator_scan import scanner_readiness
+
+        readiness = scanner_readiness()
+        if readiness["state"] == "disabled":
+            check_ok("Tier 1 advisory disabled")
+        elif readiness["state"] == "ready":
+            check_ok("Tier 1 advisory ready", "(SkillEvaluator + SkillSpector)")
+        else:
+            missing = ", ".join(readiness.get("missing") or [])
+            check_warn("Tier 1 advisory incomplete", f"(missing {missing})")
+            check_info(
+                "Install the optional scanners with: "
+                "uv tool install --python 3.13 "
+                "'skillevaluator @ git+https://github.com/NVIDIA/SkillEvaluator.git@v0.1.0' "
+                "and `uv tool install 'git+https://github.com/NVIDIA/SkillSpector.git@v2.9.5'`."
+            )
+            issues.append(
+                "Tier 1 skill advisory is incomplete; install the missing "
+                "SkillEvaluator/SkillSpector scanner(s) or disable skills.tier1_advisory"
+            )
+    except Exception as e:
+        check_warn("Could not check skill advisory readiness", f"({e})")
     
     _section("Skills Hub")
     hub_dir = HERMES_HOME / "skills" / ".hub"

--- a/tests/tools/test_skillevaluator_scan.py
+++ b/tests/tools/test_skillevaluator_scan.py
@@ -23,6 +23,7 @@ from tools.skillevaluator_scan import (  # noqa: E402
     _parse_report,
     format_tier1_report,
     run_tier1_scan,
+    scanner_readiness,
     tier1_advisory_enabled,
 )
 
@@ -46,6 +47,27 @@ def _finding(check, severity="high", message="msg", file="SKILL.md", line=3):
         "line_number": line,
         "suggestion": "fix it",
     }
+
+
+class TestScannerReadiness:
+    def test_disabled_does_not_probe_or_install(self):
+        with mock.patch("tools.skillevaluator_scan.tier1_advisory_enabled", return_value=False), \
+             mock.patch("tools.skillevaluator_scan.shutil.which") as which:
+            assert scanner_readiness() == {"state": "disabled", "missing": []}
+        which.assert_not_called()
+
+    def test_reports_each_missing_optional_scanner(self):
+        def which(name):
+            return "/usr/bin/skillevaluator" if name == "skillevaluator" else None
+
+        with mock.patch("tools.skillevaluator_scan.tier1_advisory_enabled", return_value=True), \
+             mock.patch("tools.skillevaluator_scan.shutil.which", side_effect=which):
+            assert scanner_readiness() == {"state": "incomplete", "missing": ["skillspector"]}
+
+    def test_ready_when_both_scanners_are_on_path(self):
+        with mock.patch("tools.skillevaluator_scan.tier1_advisory_enabled", return_value=True), \
+             mock.patch("tools.skillevaluator_scan.shutil.which", return_value="/usr/bin/scanner"):
+            assert scanner_readiness() == {"state": "ready", "missing": []}
 
 
 class TestParseReport:

--- a/tools/skillevaluator_scan.py
+++ b/tools/skillevaluator_scan.py
@@ -119,6 +119,28 @@ def scanner_available() -> bool:
     return shutil.which(SCANNER_BIN) is not None
 
 
+def scanner_readiness() -> dict:
+    """Describe whether the configured advisory scanner layer is usable.
+
+    This is intentionally a cheap, read-only PATH probe. It does not install
+    either optional NVIDIA scanner and does not run a skill scan. The returned
+    shape is suitable for ``hermes doctor`` and other health surfaces.
+    """
+    if not tier1_advisory_enabled():
+        return {"state": "disabled", "missing": []}
+
+    missing = []
+    if shutil.which(SCANNER_BIN) is None:
+        missing.append(SCANNER_BIN)
+    if shutil.which("skillspector") is None:
+        missing.append("skillspector")
+
+    return {
+        "state": "ready" if not missing else "incomplete",
+        "missing": missing,
+    }
+
+
 def tier1_advisory_enabled() -> bool:
     """Read skills.tier1_advisory from config (default True).
 


### PR DESCRIPTION
Closes #97485\n\nMake the configured Tier 1 skill advisory posture visible in `hermes doctor`: disabled, ready, or incomplete with the missing optional scanner names and pinned install guidance. No third-party scanner is auto-installed.