### PR TITLE
fix(tools): propagate database errors in session_search instead of masking as not-found

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -10,6 +10,7 @@ All run zero LLM calls.
 """
 import inspect
 import json
+import sqlite3
 import time
 
 import pytest
@@ -1155,4 +1156,27 @@ class TestNewResetLineageBrowse:
         result = json.loads(session_search(db=db, current_session_id="s_other"))
         sids = [r["session_id"] for r in result["results"]]
         assert "s_legacy_child" in sids
+
+
+class TestSessionSearchErrorPropagation:
+    def test_read_shape_propagates_db_exception(self, monkeypatch):
+        class BrokenDB:
+            def get_session(self, session_id):
+                raise sqlite3.OperationalError("database is locked")
+
+        res = json.loads(session_search(session_id="s_test", db=BrokenDB()))
+        assert res["success"] is False
+        assert "failed to load session: database is locked" in res["error"]
+
+    def test_scroll_shape_propagates_db_exception(self, monkeypatch):
+        class BrokenDB:
+            def get_session(self, session_id):
+                raise sqlite3.OperationalError("disk I/O error")
+            def get_messages_around(self, *args, **kwargs):
+                return {"window": []}
+
+        res = json.loads(session_search(session_id="s_test", around_message_id=1, db=BrokenDB()))
+        assert res["success"] is False
+        assert "failed to load session: disk I/O error" in res["error"]
+
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -367,7 +367,10 @@ def _locate_session_db(session_id: str):
 
 def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_profile: str = None) -> str:
     """Read shape: whole session, or ``head`` + ``tail`` messages with a scroll pointer."""
-    meta = _get_session_meta(db, session_id)
+    meta, err = _loud(lambda: db.get_session(session_id), "get_session failed for %s: %s", "failed to load session",
+                      session_id)
+    if err:
+        return err
     if not meta:
         return tool_error(f"session_id not found: {session_id}", success=False)
     rows, err = _loud(lambda: db.get_messages(session_id), "get_messages failed for %s: %s", "failed to load session",
@@ -461,7 +464,10 @@ def _scroll(db, session_id: str, around_message_id: int, window: int = 5,
     owning = (anchor_state or {}).get("session_id")
     if current_session_id and _anchor_in_live_context(db, anchor_state, owning or session_id, current_session_id):
         return tool_error("scroll rejected: anchor lives in the current session lineage (already in your active context)", success=False)
-    session_meta = _get_session_meta(db, session_id)
+    session_meta, err = _loud(lambda: db.get_session(session_id), "get_session failed for %s: %s",
+                              "failed to load session", session_id)
+    if err:
+        return err
     if not session_meta:
         return tool_error(f"session_id not found: {session_id}", success=False)
     view, err = _loud(lambda: db.get_messages_around(session_id, around_message_id, window=window),


### PR DESCRIPTION
### Summary

In `session_search` (both `read` and `scroll` shapes), `db.get_session()` was wrapped in a broad try/except block that logged only at `DEBUG` level and swallowed any exception into an empty `meta = {}`, immediately leading to `tool_error(f"session_id not found: {session_id}")`.

This caused transient storage issues (e.g. SQLite locks, disk I/O errors, pool contention) to be misreported as "session does not exist". In production, this misleads agents into believing a valid session was deleted and triggers unnecessary fallbacks.

### Changes
- In `_read_session` and `_scroll`, catch unexpected `Exception` from `db.get_session()`, log at `ERROR` level, and return `tool_error(f"failed to load session: {e}", success=False)` to clearly distinguish DB failures from actual missing sessions.
- Add regression test cases in `tests/tools/test_session_search.py`.
