### PR TITLE
fix(compression): cancel lean digests before session reset

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1197,6 +1197,24 @@ def _digest_worthy(role: str, content: str) -> bool:
     return True
 
 
+def _compression_cancelled(compressor: Any) -> bool:
+    """Return whether the host has cancelled this compression attempt.
+
+    The progress-aware host cannot kill a provider request that is already in
+    flight, but it can prevent the next request in a multi-call compaction
+    plan. Keep this check callback-based so detached workers do not need to
+    share mutable host state beyond the commit fence.
+    """
+    check = getattr(compressor, "_compression_cancelled_check", None)
+    if not callable(check):
+        return False
+    try:
+        return bool(check())
+    except Exception:
+        logger.debug("compression cancellation check failed", exc_info=True)
+        return False
+
+
 def _serialize_turns_for_digest(
     turns: List[Dict[str, Any]],
     pristine: "dict[str, str] | None" = None,
@@ -4762,6 +4780,12 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             try:
                 from agent.auxiliary_client import call_llm
 
+                # Lean compaction can issue many independent digest requests.
+                # Once the host-owned fence cancels the candidate, do not
+                # start another request against the unchanged session.
+                if _compression_cancelled(self):
+                    raise AuxiliaryExplicitCancellation()
+
                 # During a stall-fallback retry, follow the summary onto the
                 # pinned healthy route (non-consuming read) instead of
                 # re-addressing the stalled task backend (#96634 follow-up).
@@ -4774,6 +4798,8 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
                     max_tokens=_LEAN_DIGEST_MAX_TOKENS,
                     **attempt_summary_route_kwargs(),
                 )
+                if _compression_cancelled(self):
+                    raise AuxiliaryExplicitCancellation()
                 body = (
                     resp.choices[0].message.content
                     if hasattr(resp, "choices") else str(resp)
@@ -5243,6 +5269,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             try:
                 with aux_interrupt_protection():
                     response = call_llm(**call_kwargs)
+                if _compression_cancelled(self):
+                    raise AuxiliaryExplicitCancellation()
             finally:
                 route_known = bool(_aux_route.get("provider") and _aux_route.get("model"))
                 _aux_provider = _aux_route.get("provider") or self.provider or ""
@@ -5325,6 +5353,11 @@ This compaction should PRIORITISE preserving all information related to the focu
             self._last_summary_empty_content_failure = False
             return self._with_summary_prefix(summary)
         except Exception as e:
+            # A cancelled host must not let a failed summary enter the normal
+            # fallback recursion, which would issue a fresh provider request
+            # after the timeout has already been returned to the caller.
+            if _compression_cancelled(self):
+                raise AuxiliaryExplicitCancellation()
             # ``call_llm`` raises ``RuntimeError`` for two very different cases:
             #   1. No provider configured ("No LLM provider configured ...") —
             #      a permanent misconfiguration, long cooldown is correct.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1311,19 +1311,23 @@ def run_compress_context_with_progress_timeout(
     # settle admission themselves (worker result returned, or fence cancel
     # won); everything else revokes in the ``finally``.
     handled_exit = False
+    timeout_reason = None
     try:
         while True:
             waited = time.monotonic() - wait_started
             remaining_ceiling = ceiling - waited
             if remaining_ceiling <= 0:
+                timeout_reason = "total_ceiling"
                 break
             # #76354 S3 analogue for this wait: charge the idle budget from
             # the LAST PROGRESS event, not from the start of this wait slice.
             # Waiting a full ``idle`` after progress that landed early in the
             # previous slice would allow silence to approach 2x the budget.
             since_progress = fence.seconds_since_progress()
+            idle_wait = max(idle - since_progress, 0.005)
+            ceiling_limited = remaining_ceiling <= idle_wait
             wait_slice = min(
-                max(idle - since_progress, 0.005), remaining_ceiling
+                idle_wait, remaining_ceiling
             )
             try:
                 result = future.result(timeout=wait_slice)
@@ -1342,6 +1346,12 @@ def run_compress_context_with_progress_timeout(
                         ceiling,
                     )
                     continue
+                # Use the boundary that limited this wait rather than an
+                # exact wall-clock comparison: Future.result() can return a
+                # few milliseconds before/after its requested timeout.
+                timeout_reason = (
+                    "total_ceiling" if ceiling_limited else "inactivity"
+                )
                 break
 
         # F6: a not-yet-started future must not linger as a stale queued job.
@@ -1426,19 +1436,25 @@ def run_compress_context_with_progress_timeout(
                     continue
 
         # Idle-timeout path: cancellation won before the commit boundary.
-        # The fence already blocks any future commit; F4 additionally frees
-        # the timed-out worker's durable lease via the holder-qualified hook
-        # so a NEW compressor can acquire the lock immediately (no ABA: the
-        # DB release is holder-scoped).
+        # A total-ceiling cancellation is different from ordinary inactivity:
+        # lean compaction may still be inside a long sequence of healthy digest
+        # calls. Keep its holder-qualified lease until the worker observes the
+        # cancelled fence and unwinds, preventing a second automatic attempt
+        # from starting against the same unchanged transcript. The worker's
+        # normal cleanup releases the lease; if the provider never returns,
+        # the lease refresher keeps the session fail-closed instead of allowing
+        # overlapping compactions.
         handled_exit = True
-        fence.release_cancelled_compression_lock()
         waited = time.monotonic() - wait_started
         since_progress = fence.seconds_since_progress()
+        total_ceiling_expired = timeout_reason == "total_ceiling"
+        if not total_ceiling_expired:
+            fence.release_cancelled_compression_lock()
         # The durable lease is free again (above), so a fallback attempt can
         # acquire it immediately. Run it BEFORE on_timeout: that callback
         # records the summary-failure cooldown, which would make the retry's
         # own summary call a no-op.
-        if stall_fallback:
+        if stall_fallback and not total_ceiling_expired:
             recovered = _retry_compression_on_fallback_chain(
                 worker=worker,
                 messages=messages,
@@ -1609,6 +1625,34 @@ def compression_skipped_due_to_lock(agent: Any) -> bool:
     """
     _sig = getattr(agent, "_compression_skipped_due_to_lock", None)
     return _sig is True or isinstance(_sig, str)
+
+
+def compression_deferred_reason(agent: Any) -> Optional[str]:
+    """Return the temporary guard that made compression a no-op.
+
+    Context-overflow recovery must distinguish a temporary automatic
+    compression guard from a compressor that actually ran and made no
+    progress. The latter is permanent exhaustion for this turn; lock
+    contention and a live summary-failure cooldown are retryable conditions
+    that must never trigger the gateway's session auto-reset.
+    """
+    if compression_skipped_due_to_lock(agent):
+        return "lock"
+    compressor = getattr(agent, "context_compressor", None)
+    getter = getattr(compressor, "get_active_compression_failure_cooldown", None)
+    if not callable(getter):
+        return None
+    try:
+        state = getter()
+    except Exception:
+        return None
+    if not isinstance(state, dict):
+        return None
+    try:
+        remaining = float(state.get("remaining_seconds") or 0.0)
+    except (TypeError, ValueError):
+        return None
+    return "cooldown" if remaining > 0 else None
 
 
 def _adopt_live_compression_child(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -33,6 +33,7 @@ from agent.conversation_compression import (
     COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
+    compression_deferred_reason,
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
@@ -1468,15 +1469,16 @@ def _compression_deferred_result(
     agent,
     messages: List[Dict],
     api_call_count: int,
+    *,
+    reason: str = "lock",
 ) -> Dict[str, Any]:
-    """Build the soft turn result for a lock-contended compression defer.
+    """Build the soft turn result for a temporary compression defer.
 
-    Another path (a sibling turn, a background review fork, a manual
-    ``/compress``) holds this session's compression lock, so every
-    compression pass this turn no-oped and the request still does not fit.
-    This is a TEMPORARY condition — the lock winner is actively shrinking
-    the same session — so the turn must end as a soft defer
-    (``compression_deferred``), never as ``compression_exhausted``: the
+    Another path may hold this session's compression lock, or a prior timeout
+    may have installed a live summary-failure cooldown. In either case every
+    automatic compression pass this turn no-oped and the request still does
+    not fit. This is a TEMPORARY condition, so the turn must end as a soft
+    defer (``compression_deferred``), never as ``compression_exhausted``: the
     gateway auto-resets (wipes) the session on exhaustion (#9893/#35809),
     which would destroy a session that the concurrent compressor is about
     to make healthy again.
@@ -1485,21 +1487,34 @@ def _compression_deferred_result(
     branch) and retry-next-message semantics apply.
     """
     holder = getattr(agent, "_compression_skipped_due_to_lock", None)
-    logger.info(
-        "turn deferred: compression lock held by another path "
-        "(session=%s holder=%s) — not counting as compression exhaustion",
-        agent.session_id or "none",
-        holder if isinstance(holder, str) else "unconfirmed",
-    )
+    if reason == "cooldown":
+        logger.info(
+            "turn deferred: automatic compression cooldown is active "
+            "(session=%s) — not counting as compression exhaustion",
+            agent.session_id or "none",
+        )
+    else:
+        logger.info(
+            "turn deferred: compression lock held by another path "
+            "(session=%s holder=%s) — not counting as compression exhaustion",
+            agent.session_id or "none",
+            holder if isinstance(holder, str) else "unconfirmed",
+        )
     try:
         agent._flush_status_buffer()
     except Exception:
         pass
-    _final = (
-        "Context compression is already running for this session. "
-        "Please retry in a moment — your next message will be processed "
-        "once the concurrent compression finishes."
-    )
+    if reason == "cooldown":
+        _final = (
+            "Context compression is temporarily cooling down after a previous "
+            "timeout. Please retry in a moment; your session was preserved."
+        )
+    else:
+        _final = (
+            "Context compression is already running for this session. "
+            "Please retry in a moment — your next message will be processed "
+            "once the concurrent compression finishes."
+        )
     return {
         "final_response": _final,
         "messages": messages,
@@ -5714,7 +5729,12 @@ def run_conversation(
                         approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
                         task_id=effective_task_id,
                     )
-                    if messages is _overflow_input and compression_skipped_due_to_lock(agent):
+                    _deferred_reason = (
+                        compression_deferred_reason(agent)
+                        if messages is _overflow_input
+                        else None
+                    )
+                    if _deferred_reason:
                         # #69870 lock-skip: the provider proved the request
                         # does not fit, but this compression pass no-oped only
                         # because another path holds the session's compression
@@ -5724,7 +5744,10 @@ def run_conversation(
                         compression_attempts -= 1
                         agent._persist_session(messages, conversation_history)
                         return _compression_deferred_result(
-                            agent, messages, api_call_count
+                            agent,
+                            messages,
+                            api_call_count,
+                            reason=_deferred_reason,
                         )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history
@@ -5878,11 +5901,19 @@ def run_conversation(
                                 approx_tokens=request_input_estimate,
                                 task_id=effective_task_id,
                             )
-                            if messages is _overflow_input and compression_skipped_due_to_lock(agent):
+                            _deferred_reason = (
+                                compression_deferred_reason(agent)
+                                if messages is _overflow_input
+                                else None
+                            )
+                            if _deferred_reason:
                                 compression_attempts -= 1
                                 agent._persist_session(messages, conversation_history)
                                 return _compression_deferred_result(
-                                    agent, messages, api_call_count
+                                    agent,
+                                    messages,
+                                    api_call_count,
+                                    reason=_deferred_reason,
                                 )
                             conversation_history = conversation_history_after_compression(
                                 agent, messages, conversation_history
@@ -6032,7 +6063,12 @@ def run_conversation(
                         approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
                         task_id=effective_task_id,
                     )
-                    if messages is _overflow_input and compression_skipped_due_to_lock(agent):
+                    _deferred_reason = (
+                        compression_deferred_reason(agent)
+                        if messages is _overflow_input
+                        else None
+                    )
+                    if _deferred_reason:
                         # #69870 lock-skip: the provider proved the request
                         # does not fit, but this compression pass no-oped only
                         # because another path holds the session's compression
@@ -6042,7 +6078,10 @@ def run_conversation(
                         compression_attempts -= 1
                         agent._persist_session(messages, conversation_history)
                         return _compression_deferred_result(
-                            agent, messages, api_call_count
+                            agent,
+                            messages,
+                            api_call_count,
+                            reason=_deferred_reason,
                         )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history

--- a/run_agent.py
+++ b/run_agent.py
@@ -8139,12 +8139,19 @@ class AIAgent:
                         return system_message or ""
 
                 def _on_timeout(idle, waited, since_progress):
+                    total_ceiling_expired = waited >= total_ceiling
+                    timeout_reason = (
+                        "total ceiling"
+                        if total_ceiling_expired
+                        else "inactivity window"
+                    )
                     logger.warning(
-                        "Context compression made no progress for %.1fs "
-                        "(total wait %.1fs, ceiling %.1fs); continuing without "
-                        "compression",
-                        since_progress,
+                        "Context compression exceeded its %s after %.1fs "
+                        "(last progress %.1fs ago, ceiling %.1fs); continuing "
+                        "without compression",
+                        timeout_reason,
                         waited,
+                        since_progress,
                         total_ceiling,
                     )
                     touch = getattr(self, "_touch_activity", None)
@@ -8168,7 +8175,7 @@ class AIAgent:
                             try:
                                 record(
                                     "host compress_context timeout "
-                                    "(no summary progress)"
+                                    f"({timeout_reason})"
                                 )
                             except Exception:
                                 logger.debug(
@@ -8178,13 +8185,22 @@ class AIAgent:
                                 )
                     emit = getattr(self, "_emit_warning", None)
                     if callable(emit):
-                        emit(
-                            "⚠ Context compression timed out "
-                            f"after {idle:.1f}s with no output from the summary "
-                            "model. No messages were dropped — continuing without "
-                            "compression. Run /compress to retry, /new for a clean "
-                            "session, or check auxiliary.compression."
-                        )
+                        if total_ceiling_expired:
+                            emit(
+                                "⚠ Context compression reached the total "
+                                f"ceiling after {waited:.1f}s (ceiling "
+                                f"{total_ceiling:.1f}s). No messages were dropped "
+                                "— continuing without compression. Run /compress "
+                                "to retry, or check auxiliary.compression."
+                            )
+                        else:
+                            emit(
+                                "⚠ Context compression timed out after "
+                                f"{idle:.1f}s with no output from the summary model. "
+                                "No messages were dropped — continuing without "
+                                "compression. Run /compress to retry, /new for a "
+                                "clean session, or check auxiliary.compression."
+                            )
 
                 def _on_commit_overrun(waited, ceiling):
                     # Commit-phase ceiling breach: the SessionDB mutation is in

--- a/tests/agent/test_compression_cancellation_97488.py
+++ b/tests/agent/test_compression_cancellation_97488.py
@@ -1,0 +1,118 @@
+"""Regressions for compression cancellation and cooldown overflow recovery.
+
+The total host ceiling bounds the complete lean compaction plan, including
+chunk digests.  A cancelled plan must stop before starting another digest, and
+its still-running worker must keep the session lease until it unwinds.  A
+context overflow observed during the resulting cooldown is temporary and must
+not be reported as permanent compression exhaustion.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import agent.context_compressor as context_compressor_module
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.context_compressor import ContextCompressor
+from agent.conversation_compression import (
+    CompressionCommitFence,
+    compression_deferred_reason,
+    run_compress_context_with_progress_timeout,
+)
+from agent.conversation_loop import _compression_deferred_result
+
+
+def _digest_response():
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="digest"))]
+    )
+
+
+def test_cancelled_lean_digest_does_not_start_the_next_request(monkeypatch):
+    compressor = object.__new__(ContextCompressor)
+    cancelled = threading.Event()
+    compressor._compression_cancelled_check = cancelled.is_set
+    monkeypatch.setattr(
+        context_compressor_module, "_LEAN_DIGEST_CHUNK_CHARS", 10
+    )
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        cancelled.set()
+        return _digest_response()
+
+    turns = [{"role": "user", "content": "x" * 40}]
+    with patch("agent.auxiliary_client.call_llm", side_effect=fake_call_llm):
+        with pytest.raises(AuxiliaryExplicitCancellation):
+            compressor._build_chunk_digests(turns)
+
+    assert len(calls) == 1
+
+
+def test_total_ceiling_keeps_cancelled_worker_lease_until_unwind():
+    original = [{"role": "user", "content": "keep"}]
+    started = threading.Event()
+    release_worker = threading.Event()
+    worker_done = threading.Event()
+    fence = CompressionCommitFence()
+    release_lease = MagicMock()
+    fence.release_cancelled_compression_lock = release_lease
+
+    def worker(_fence):
+        started.set()
+        try:
+            while not release_worker.wait(0.005):
+                # Simulate healthy sequential digest progress. The total
+                # ceiling, rather than the inactivity window, must win.
+                _fence.touch_progress()
+            return original, "fallback"
+        finally:
+            worker_done.set()
+
+    result = run_compress_context_with_progress_timeout(
+        worker=worker,
+        messages=original,
+        system_prompt_fallback="fallback",
+        idle_timeout_seconds=0.02,
+        total_ceiling_seconds=0.08,
+        fence=fence,
+        stall_fallback=False,
+    )
+    assert started.wait(timeout=1)
+    assert result == (original, "fallback")
+
+    # The total-ceiling path leaves the lease for the worker's own cleanup;
+    # releasing it from the host would allow an overlapping compaction.
+    assert not release_lease.called
+    release_worker.set()
+    assert worker_done.wait(timeout=1)
+
+
+def test_active_cooldown_is_a_soft_overflow_defer():
+    compressor = SimpleNamespace(
+        get_active_compression_failure_cooldown=lambda: {
+            "remaining_seconds": 30,
+        }
+    )
+    agent = SimpleNamespace(
+        session_id="cooldown-session",
+        context_compressor=compressor,
+        _compression_skipped_due_to_lock=None,
+        _flush_status_buffer=lambda: None,
+    )
+
+    assert compression_deferred_reason(agent) == "cooldown"
+    result = _compression_deferred_result(
+        agent, [{"role": "user"}], 1, reason="cooldown"
+    )
+
+    assert result["compression_deferred"] is True
+    assert "compression_exhausted" not in result
+    assert result["failed"] is False
+    assert "cooling down" in result["final_response"]


### PR DESCRIPTION
## Summary
- stop a cancelled lean compaction before it starts another chunk digest request
- retain the session compression lease through total-ceiling worker unwind to prevent overlapping retries
- report total-ceiling timeouts accurately
- classify cooldown-blocked context-overflow recovery as a soft deferred result instead of permanent exhaustion

## Validation
- `python -m py_compile agent/context_compressor.py agent/conversation_compression.py agent/conversation_loop.py run_agent.py`
- `python -m pytest -q tests/agent/test_compression_cancellation_97488.py tests/agent/test_compression_stall_fallback_78981.py tests/agent/test_compress_context_progress_timeout.py -k 'not owned_timeout_skips_hung_compress and not fallback_prompt_resolved_lazily_on_timeout and not caller_fence_bypasses_owned_wrapper'`
- Result: 26 passed; 3 existing environment-blocked tests require `python-dotenv`.