### PR TITLE
feat(browser): real-profile browsing can keep banking/email/SSO logins out of the agent's snapshot (Cowork-inspired)

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -627,6 +627,177 @@ def _mirror_profile_auth(src: str, dst: str, source_profile: str) -> int:
     return failed_dbs
 
 
+# ---------------------------------------------------------------------------
+# Sensitive-domain exclusions for the real-profile snapshot
+#
+# Inspired by Claude Cowork's built-in-browser cookie import (Aug 2026):
+# "Banking, email, and single sign-on sites stay unchecked by default" when
+# logins are brought over from the user's own browser. Hermes' equivalent is
+# deterministic, not UI-driven: after the snapshot copies the auth DBs, rows
+# whose domain matches an exclusion pattern are DELETED from the copy before
+# the browser ever launches on it. The user's real profile is never touched —
+# only the hermes-owned snapshot is scrubbed.
+#
+# Two config knobs (both under ``browser:`` in config.yaml):
+#   real_profile_exclude_sensitive: opt-in curated list below (banking /
+#       payments, email, SSO/identity providers). Off by default so existing
+#       consented setups that rely on e.g. a Gmail session keep working.
+#   real_profile_cookie_excludes: user-supplied domain list, always applied
+#       when non-empty (e.g. ["mybank.example", "google.com"]).
+#
+# Matching is suffix-per-label: pattern ``chase.com`` matches ``chase.com``
+# and ``www.chase.com`` (and Chromium's leading-dot ``.chase.com`` host_key
+# form) but never ``notchase.com``. This is best-effort curation, not a
+# security boundary by itself — the enforcement property is that the scrub
+# runs at the single choke point every real-profile launch goes through
+# (snapshot_real_profile) and the launch FAILS CLOSED if the scrub cannot be
+# applied while exclusions are configured.
+# ---------------------------------------------------------------------------
+
+_SENSITIVE_COOKIE_DOMAINS: tuple = (
+    # Banking / brokerage / payments
+    "chase.com", "bankofamerica.com", "wellsfargo.com", "citi.com",
+    "citibank.com", "capitalone.com", "usbank.com", "pnc.com", "truist.com",
+    "schwab.com", "fidelity.com", "vanguard.com", "americanexpress.com",
+    "discover.com", "paypal.com", "venmo.com", "wise.com", "revolut.com",
+    "coinbase.com", "kraken.com", "binance.com", "robinhood.com",
+    "barclays.co.uk", "hsbc.com", "lloydsbank.com", "natwest.com",
+    "santander.com", "ing.com", "bnpparibas.com", "deutschebank.de",
+    "ubs.com", "monzo.com", "starlingbank.com", "n26.com",
+    # Email providers (webmail hosts; add e.g. "google.com" yourself to cut
+    # the whole Google session — domain-wide cookies also carry other apps)
+    "mail.google.com", "outlook.live.com", "outlook.office.com",
+    "outlook.office365.com", "mail.yahoo.com", "proton.me", "protonmail.com",
+    "fastmail.com", "zoho.com", "gmx.net", "gmx.com", "web.de", "mail.ru",
+    "aol.com", "icloud.com",
+    # SSO / identity providers
+    "accounts.google.com", "login.microsoftonline.com", "login.live.com",
+    "okta.com", "onelogin.com", "auth0.com", "duosecurity.com",
+    "pingidentity.com", "jumpcloud.com", "id.me", "login.gov",
+)
+
+# Auth DBs inside the snapshot's Default/ that carry domain-scoped rows we can
+# scrub. ("Web Data" holds autofill, which is not domain-keyed the same way —
+# out of scope here.)
+_SCRUB_TARGETS: tuple = (
+    ("Cookies", "cookies"),
+    (os.path.join("Network", "Cookies"), "cookies"),
+    ("Login Data", "logins"),
+    ("Login Data For Account", "logins"),
+)
+
+
+def _cookie_exclude_patterns() -> tuple:
+    """Resolve the active exclusion patterns from config (normalized, deduped)."""
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {}) if isinstance(cfg, dict) else {}
+        if not isinstance(browser_cfg, dict):
+            browser_cfg = {}
+        pats: list = []
+        if browser_cfg.get("real_profile_exclude_sensitive", False):
+            pats.extend(_SENSITIVE_COOKIE_DOMAINS)
+        extra = browser_cfg.get("real_profile_cookie_excludes") or ()
+        if isinstance(extra, (list, tuple)):
+            for p in extra:
+                p = str(p).strip().lower().lstrip(".")
+                if p:
+                    pats.append(p)
+        seen: set = set()
+        out: list = []
+        for p in pats:
+            if p not in seen:
+                seen.add(p)
+                out.append(p)
+        return tuple(out)
+    except Exception as e:  # config unreadable → treat as no exclusions
+        logger.debug("real-profile: exclude-pattern config read failed: %s", e)
+        return ()
+
+
+def _host_matches_exclude(host: str | None, patterns) -> bool:
+    """True when ``host`` equals a pattern or is a subdomain of one.
+
+    Handles Chromium's leading-dot ``host_key`` form (``.chase.com``).
+    Suffix matches are label-anchored so ``notchase.com`` never matches
+    ``chase.com``.
+    """
+    h = (host or "").strip().lower().lstrip(".")
+    if not h:
+        return False
+    for p in patterns:
+        if h == p or h.endswith("." + p):
+            return True
+    return False
+
+
+def _scrub_auth_db(db_path: str, kind: str, patterns) -> int:
+    """Delete excluded-domain rows from one snapshot auth DB. Returns rows removed.
+
+    ``kind`` is ``"cookies"`` (match ``cookies.host_key``) or ``"logins"``
+    (match the hostname of ``logins.origin_url`` / ``logins.signon_realm``).
+    Raises on any failure — the caller decides fail-closed policy.
+    """
+    if not os.path.isfile(db_path):
+        return 0
+    import sqlite3
+    from urllib.parse import urlsplit
+
+    con = sqlite3.connect(db_path, timeout=5)
+    removed = 0
+    try:
+        cur = con.cursor()
+        if kind == "cookies":
+            hosts = [r[0] for r in cur.execute("SELECT DISTINCT host_key FROM cookies")]
+            for h in hosts:
+                if _host_matches_exclude(h, patterns):
+                    cur.execute("DELETE FROM cookies WHERE host_key = ?", (h,))
+                    removed += max(cur.rowcount, 0)
+        else:
+            rows = cur.execute("SELECT id, origin_url, signon_realm FROM logins").fetchall()
+            for rid, origin, realm in rows:
+                hit = False
+                for u in (origin, realm):
+                    if not u:
+                        continue
+                    try:
+                        host = urlsplit(str(u)).hostname
+                    except ValueError:
+                        host = None
+                    if host and _host_matches_exclude(host, patterns):
+                        hit = True
+                        break
+                if hit:
+                    cur.execute("DELETE FROM logins WHERE id = ?", (rid,))
+                    removed += 1
+        con.commit()
+    finally:
+        con.close()
+    return removed
+
+
+def scrub_snapshot_auth(dst: str, patterns) -> tuple:
+    """Remove excluded-domain auth rows from the snapshot at ``dst``.
+
+    Returns ``(rows_removed, None)`` on success, ``(rows_removed, error)``
+    when any DB could not be scrubbed — callers must fail closed on error
+    (never launch a session carrying credentials the user excluded).
+    """
+    if not patterns:
+        return 0, None
+    total = 0
+    dst_default = os.path.join(dst, "Default")
+    for rel, kind in _SCRUB_TARGETS:
+        path = os.path.join(dst_default, rel)
+        try:
+            total += _scrub_auth_db(path, kind, patterns)
+        except Exception as e:
+            return total, f"could not scrub excluded domains from {rel!r}: {e}"
+    return total, None
+
+
 _SNAPSHOT_DONE_MARKER = ".hermes-snapshot-complete"
 
 # Prefix stamped on the "profile is locked" error so the calling layer can
@@ -899,6 +1070,26 @@ def snapshot_real_profile(browser: str, src: str | None = None) -> tuple[str | N
                 f"({failed_dbs} database(s) locked). Close {browser} and retry, "
                 "or turn browser.use_real_profile off."
             )
+
+        # Sensitive-domain exclusions (Cowork-inspired): scrub excluded
+        # domains' cookies/logins OUT of the copy before any launch. Runs
+        # after every auth re-sync so refreshed logins can't reintroduce an
+        # excluded domain. Fail closed: if the user configured exclusions and
+        # we cannot apply them, no session launches on this snapshot.
+        patterns = _cookie_exclude_patterns()
+        if patterns:
+            removed, scrub_err = scrub_snapshot_auth(dst, patterns)
+            if scrub_err:
+                return None, (
+                    f"real-profile snapshot for '{browser}' could not honor the "
+                    f"configured domain exclusions ({scrub_err}). Refusing to "
+                    "launch with excluded credentials present."
+                )
+            if removed:
+                logger.info(
+                    "real-profile: scrubbed %d excluded-domain auth row(s) "
+                    "from the '%s' snapshot", removed, browser,
+                )
 
         # Never carry live-instance leftovers into the copy.
         for leftover in ("SingletonLock", "SingletonSocket", "SingletonCookie"):

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -611,6 +611,23 @@ DEFAULT_CONFIG = {
         # retry. Still locked afterward → stays blocked, no loop, no auto-kill.
         # OFF by default. No effect on macOS/Linux (copy-while-running works).
         "real_profile_autoclose": False,
+        # Sensitive-domain exclusions for real-profile browsing (inspired by
+        # Claude Cowork's cookie import, which leaves banking / email / SSO
+        # sites unchecked by default). After each snapshot auth re-sync,
+        # cookies and saved logins whose domain matches an exclusion are
+        # DELETED from the hermes-owned copy before the browser launches on
+        # it — the user's real profile is never modified. If exclusions are
+        # configured and cannot be applied, the launch fails closed.
+        #   real_profile_exclude_sensitive: opt in to the curated built-in
+        #       list (banking/payments, webmail, SSO/identity providers).
+        #       OFF by default so consented setups relying on e.g. a Gmail
+        #       session keep working.
+        #   real_profile_cookie_excludes: your own domain list, always
+        #       applied when non-empty. Suffix-matched per label:
+        #       "example.com" also excludes "www.example.com" but never
+        #       "notexample.com".
+        "real_profile_exclude_sensitive": False,
+        "real_profile_cookie_excludes": [],
         "allow_unsafe_evaluate": False,  # Legacy override: when true, browser_console(expression=...) bypasses the restrict_evaluate denylist entirely
         "restrict_evaluate": False,  # Opt-in denylist blocking sensitive JS primitives (cookies/storage/clipboard/network/form values) in browser_console(expression=...)
         # CDP supervisor — dialog + frame detection via a persistent WebSocket.

--- a/tests/hermes_cli/test_real_profile_domain_excludes.py
+++ b/tests/hermes_cli/test_real_profile_domain_excludes.py
@@ -1,0 +1,222 @@
+"""Tests for sensitive-domain exclusions in the real-profile snapshot.
+
+Inspired by Claude Cowork's cookie import (banking/email/SSO unchecked by
+default): Hermes scrubs excluded domains' cookies and saved logins out of the
+hermes-owned snapshot copy before any launch. Real SQLite I/O throughout —
+the DBs are genuine Chromium-shaped ``cookies`` / ``logins`` tables.
+"""
+import os
+import sqlite3
+
+import pytest
+
+import hermes_cli.browser_connect as bc
+
+
+def _make_cookie_db(path, hosts):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE cookies (host_key TEXT, name TEXT, value TEXT)")
+    con.executemany(
+        "INSERT INTO cookies VALUES (?, ?, ?)",
+        [(h, "sid", "v") for h in hosts],
+    )
+    con.commit()
+    con.close()
+
+
+def _make_login_db(path, origins):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    con = sqlite3.connect(path)
+    con.execute(
+        "CREATE TABLE logins (id INTEGER PRIMARY KEY, origin_url TEXT, signon_realm TEXT)"
+    )
+    con.executemany(
+        "INSERT INTO logins (origin_url, signon_realm) VALUES (?, ?)",
+        [(o, o) for o in origins],
+    )
+    con.commit()
+    con.close()
+
+
+def _cookie_hosts(path):
+    con = sqlite3.connect(path)
+    try:
+        return sorted(r[0] for r in con.execute("SELECT host_key FROM cookies"))
+    finally:
+        con.close()
+
+
+def _login_origins(path):
+    con = sqlite3.connect(path)
+    try:
+        return sorted(r[0] for r in con.execute("SELECT origin_url FROM logins"))
+    finally:
+        con.close()
+
+
+class TestHostMatching:
+    def test_exact_and_subdomain(self):
+        pats = ("chase.com",)
+        assert bc._host_matches_exclude("chase.com", pats)
+        assert bc._host_matches_exclude("www.chase.com", pats)
+        assert bc._host_matches_exclude(".chase.com", pats)  # Chromium host_key form
+        assert bc._host_matches_exclude("SECURE.CHASE.COM", pats)
+
+    def test_label_anchored_no_suffix_bleed(self):
+        pats = ("chase.com",)
+        assert not bc._host_matches_exclude("notchase.com", pats)
+        assert not bc._host_matches_exclude("chase.com.evil.example", pats)
+
+    def test_empty_host_or_patterns(self):
+        assert not bc._host_matches_exclude("", ("a.com",))
+        assert not bc._host_matches_exclude(None, ("a.com",))
+        assert not bc._host_matches_exclude("a.com", ())
+
+
+class TestPatternResolution:
+    def test_defaults_are_empty(self):
+        with pytest.MonkeyPatch.context() as mp:
+            import hermes_cli.config as cfg
+            mp.setattr(cfg, "read_raw_config", lambda: {"browser": {}})
+            assert bc._cookie_exclude_patterns() == ()
+
+    def test_curated_list_via_opt_in(self):
+        with pytest.MonkeyPatch.context() as mp:
+            import hermes_cli.config as cfg
+            mp.setattr(cfg, "read_raw_config",
+                       lambda: {"browser": {"real_profile_exclude_sensitive": True}})
+            pats = bc._cookie_exclude_patterns()
+        assert "chase.com" in pats
+        assert "accounts.google.com" in pats
+        assert "mail.google.com" in pats
+
+    def test_user_list_normalized_and_deduped(self):
+        with pytest.MonkeyPatch.context() as mp:
+            import hermes_cli.config as cfg
+            mp.setattr(cfg, "read_raw_config", lambda: {"browser": {
+                "real_profile_cookie_excludes": [" .MyBank.example ", "mybank.example", ""],
+            }})
+            pats = bc._cookie_exclude_patterns()
+        assert pats == ("mybank.example",)
+
+    def test_config_error_means_no_patterns(self):
+        with pytest.MonkeyPatch.context() as mp:
+            import hermes_cli.config as cfg
+            def boom():
+                raise OSError("no config")
+            mp.setattr(cfg, "read_raw_config", boom)
+            assert bc._cookie_exclude_patterns() == ()
+
+
+class TestScrub:
+    def test_scrubs_cookies_and_logins(self, tmp_path):
+        dst = tmp_path / "copy"
+        _make_cookie_db(str(dst / "Default" / "Cookies"),
+                        [".chase.com", "www.chase.com", "github.com"])
+        _make_cookie_db(str(dst / "Default" / "Network" / "Cookies"),
+                        ["accounts.google.com", "example.org"])
+        _make_login_db(str(dst / "Default" / "Login Data"),
+                       ["https://www.chase.com/login", "https://github.com/login"])
+
+        removed, err = bc.scrub_snapshot_auth(
+            str(dst), ("chase.com", "accounts.google.com"))
+        assert err is None
+        assert removed == 4
+        assert _cookie_hosts(str(dst / "Default" / "Cookies")) == ["github.com"]
+        assert _cookie_hosts(str(dst / "Default" / "Network" / "Cookies")) == ["example.org"]
+        assert _login_origins(str(dst / "Default" / "Login Data")) == ["https://github.com/login"]
+
+    def test_no_patterns_is_noop(self, tmp_path):
+        dst = tmp_path / "copy"
+        _make_cookie_db(str(dst / "Default" / "Cookies"), [".chase.com"])
+        removed, err = bc.scrub_snapshot_auth(str(dst), ())
+        assert (removed, err) == (0, None)
+        assert _cookie_hosts(str(dst / "Default" / "Cookies")) == [".chase.com"]
+
+    def test_missing_dbs_are_fine(self, tmp_path):
+        removed, err = bc.scrub_snapshot_auth(str(tmp_path / "empty"), ("chase.com",))
+        assert (removed, err) == (0, None)
+
+    def test_corrupt_db_reports_error(self, tmp_path):
+        dst = tmp_path / "copy"
+        p = dst / "Default" / "Cookies"
+        p.parent.mkdir(parents=True)
+        p.write_text("this is not sqlite")
+        removed, err = bc.scrub_snapshot_auth(str(dst), ("chase.com",))
+        assert err is not None and "Cookies" in err
+
+
+class TestSnapshotIntegration:
+    """End-to-end through snapshot_real_profile with a real profile tree."""
+
+    def _make_profile(self, root):
+        (root / "Default" / "Network").mkdir(parents=True)
+        (root / "Local State").write_text('{"profile": {"last_used": "Default"}}')
+        _make_cookie_db(str(root / "Default" / "Cookies"),
+                        [".chase.com", "github.com"])
+        _make_cookie_db(str(root / "Default" / "Network" / "Cookies"),
+                        ["mail.google.com", "docs.python.org"])
+        _make_login_db(str(root / "Default" / "Login Data"),
+                       ["https://chase.com/", "https://github.com/"])
+        (root / "Default" / "Preferences").write_text("{}")
+        return root
+
+    def _patch_config(self, monkeypatch, browser_cfg):
+        import hermes_cli.config as cfg
+        monkeypatch.setattr(cfg, "read_raw_config", lambda: {"browser": browser_cfg})
+
+    def test_snapshot_scrubs_excluded_domains(self, tmp_path, monkeypatch):
+        src = self._make_profile(tmp_path / "real")
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: tmp_path / "hh")
+        self._patch_config(monkeypatch, {
+            "real_profile_exclude_sensitive": True,
+            "real_profile_cookie_excludes": ["github.com"],
+        })
+
+        dst, err = bc.snapshot_real_profile("chrome", src=str(src))
+        assert err is None and dst is not None
+
+        # Copy scrubbed: chase (curated), mail.google.com (curated), github (user).
+        assert _cookie_hosts(os.path.join(dst, "Default", "Cookies")) == []
+        assert _cookie_hosts(os.path.join(dst, "Default", "Network", "Cookies")) == ["docs.python.org"]
+        assert _login_origins(os.path.join(dst, "Default", "Login Data")) == []
+
+        # Source profile is NEVER modified.
+        assert _cookie_hosts(str(src / "Default" / "Cookies")) == sorted([".chase.com", "github.com"])
+        assert _login_origins(str(src / "Default" / "Login Data")) == sorted(
+            ["https://chase.com/", "https://github.com/"])
+
+    def test_refresh_resync_cannot_reintroduce_excluded(self, tmp_path, monkeypatch):
+        src = self._make_profile(tmp_path / "real")
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: tmp_path / "hh")
+        self._patch_config(monkeypatch, {"real_profile_cookie_excludes": ["chase.com"]})
+
+        dst, err = bc.snapshot_real_profile("chrome", src=str(src))
+        assert err is None and dst is not None
+        # Second launch: the per-launch auth re-sync copies chase back in from
+        # the live profile; the scrub must remove it again.
+        dst2, err2 = bc.snapshot_real_profile("chrome", src=str(src))
+        assert err2 is None and dst2 == dst
+        assert _cookie_hosts(os.path.join(dst, "Default", "Cookies")) == ["github.com"]
+
+    def test_no_exclusions_leaves_snapshot_untouched(self, tmp_path, monkeypatch):
+        src = self._make_profile(tmp_path / "real")
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: tmp_path / "hh")
+        self._patch_config(monkeypatch, {})
+
+        dst, err = bc.snapshot_real_profile("chrome", src=str(src))
+        assert err is None and dst is not None
+        assert _cookie_hosts(os.path.join(dst, "Default", "Cookies")) == sorted(
+            [".chase.com", "github.com"])
+
+    def test_scrub_failure_fails_closed(self, tmp_path, monkeypatch):
+        src = self._make_profile(tmp_path / "real")
+        monkeypatch.setattr(bc, "get_hermes_home", lambda: tmp_path / "hh")
+        self._patch_config(monkeypatch, {"real_profile_cookie_excludes": ["chase.com"]})
+        monkeypatch.setattr(bc, "scrub_snapshot_auth",
+                            lambda dst, pats: (0, "boom"))
+
+        dst, err = bc.snapshot_real_profile("chrome", src=str(src))
+        assert dst is None
+        assert err is not None and "domain exclusions" in err

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -209,6 +209,37 @@ to fully quit the browser — it won't loop or kill again on its own.
 - **Supported browsers:** Chrome, Edge, Brave, Chromium (whichever is your OS
   default). A non-Chromium default (e.g. Firefox) fails closed with a clear
   message rather than guessing.
+
+### Keep sensitive sites out of the snapshot
+
+You can exclude specific domains — banking, email, single sign-on — from
+real-profile browsing while keeping everything else signed in (the same
+default posture Claude Cowork applies to its cookie import). Excluded domains'
+cookies and saved logins are **deleted from the Hermes-owned snapshot copy**
+after every auth re-sync, before the browser launches on it. Your real browser
+profile is never modified.
+
+```yaml
+# ~/.hermes/config.yaml
+browser:
+  use_real_profile: true
+  # Opt in to the curated built-in list: major banks/payment providers,
+  # webmail hosts, and SSO/identity providers (accounts.google.com,
+  # login.microsoftonline.com, okta.com, ...). Off by default.
+  real_profile_exclude_sensitive: true
+  # Your own exclusions — always applied when non-empty. "example.com"
+  # also matches "www.example.com" (never "notexample.com").
+  real_profile_cookie_excludes:
+    - mybank.example
+    - internal.corp.example
+```
+
+If exclusions are configured and the scrub can't be applied (e.g. a corrupt
+copied database), the launch **fails closed** — no session starts carrying
+credentials you excluded. Note the curated email entries target webmail hosts
+(`mail.google.com`); excluding a provider's whole session (all Google apps)
+means listing the root domain (`google.com`) yourself.
+
 - **Works on any backend.** On a local backend it's automatic once the toggle
   is on. Under a **cloud** browser backend, the agent can still open a
   real-profile local session on demand via the `browser_exec` tool's `local`


### PR DESCRIPTION
## Summary
Real-profile browsing can now exclude sensitive domains — banking, email, SSO — from the snapshot the agent browses with, matching the default posture of Claude Cowork's built-in-browser cookie import ("Banking, email, and single sign-on sites stay unchecked by default").

## Source
- Cowork built-in browser announcement (Aug 26, 2026): https://claude.com/blog/cowork-built-in-browser
- Support doc with the import semantics: https://support.claude.com/en/articles/16607400-use-the-built-in-browser-in-claude-cowork

Cowork implements this as per-site checkboxes in a cookie-import UI. Hermes' real-profile path is consent-gated and automatic (no per-site UI), so the adaptation is deterministic config-driven scrubbing: after every auth re-sync into the hermes-owned snapshot (`~/.hermes/browser-profile/<browser>/`), cookies and saved-login rows whose domain matches an exclusion are deleted from the copy before the browser ever launches on it. The user's real profile is never modified.

## Changes
- `hermes_cli/browser_connect.py`: curated sensitive-domain list (banking/payments, webmail, SSO/identity), `_cookie_exclude_patterns()` config resolution, label-anchored host matching (handles Chromium's `.chase.com` host_key form; `notchase.com` never matches `chase.com`), SQLite scrub of `Cookies`, `Network/Cookies`, `Login Data`, `Login Data For Account`; wired into `snapshot_real_profile` (the single choke point every real-profile launch goes through). Fails closed: configured exclusions that can't be applied block the launch.
- `hermes_cli/config_defaults.py`: `browser.real_profile_exclude_sensitive` (opt-in curated list, default off so existing consented setups keep e.g. their Gmail session) and `browser.real_profile_cookie_excludes` (user list, always applied when non-empty).
- `website/docs/user-guide/features/browser.md`: new "Keep sensitive sites out of the snapshot" section.
- `tests/hermes_cli/test_real_profile_domain_excludes.py`: 15 tests, real SQLite I/O with Chromium-shaped `cookies`/`logins` tables — matching, config resolution, scrub, end-to-end through `snapshot_real_profile` (incl. re-sync-cannot-reintroduce and fail-closed), source-profile-untouched.

## Validation
| | Result |
|---|---|
| New tests | 15/15 pass |
| `test_browser_real_profile.py` + `test_browser_connect_default_chromium.py` + new | 118/118 pass |
| Sabotage run (scrub wiring disabled) | 3 integration tests fail as expected |

Deterministic mechanism with a real choke point (rows physically deleted from the only profile copy the launched browser reads) — not an LLM-judged or bypassable tool-layer guard.

## Infographic

![Sensitive-domain exclusions for real-profile browsing](https://v3b.fal.media/files/b/0aa83825/Wz59KzM1kyEYqkv_oVC44_TDyiNtTk.png)
