### PR TITLE
fix(memory): extract single-word proper nouns in holographic store

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -83,9 +83,28 @@ _TRUST_MIN       =  0.0
 _TRUST_MAX       =  1.0
 
 # Entity extraction patterns
-_RE_CAPITALIZED  = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b')
+# One or more title-case words. The trailing group is `*` (not `+`) so a lone
+# proper noun ("Michael") is also a candidate; single-token matches are then
+# filtered by the sentence-position + stopword heuristic in _extract_entities.
+_RE_CAPITALIZED  = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b')
 _RE_DOUBLE_QUOTE = re.compile(r'"([^"]+)"')
 _RE_SINGLE_QUOTE = re.compile(r"'([^']+)'")
+
+# Common capitalized words that routinely open a sentence but are not proper
+# nouns. A single title-case token in sentence-initial position is only kept as
+# an entity when it is NOT one of these. This is a deliberately imperfect
+# heuristic (a proper-noun/POS source would be more robust) that trades a small
+# amount of residual noise for covering the dominant "Name prefers X" shape.
+_CAP_SENTENCE_STOPWORDS = frozenset({
+    "The", "A", "An", "This", "That", "These", "Those", "It", "Its",
+    "He", "She", "They", "We", "You", "His", "Her", "Their", "Our", "Your", "My",
+    "Please", "Remember", "Note", "Review", "Update", "Add", "Remove", "Delete",
+    "Create", "Make", "Set", "Use", "Check", "Ensure", "Consider", "Keep", "Let",
+    "Also", "Then", "Now", "Here", "There", "However", "Meanwhile", "Otherwise",
+    "When", "Where", "What", "Why", "How", "Who", "Which", "If", "But", "And",
+    "Or", "So", "Because", "Although", "Though", "While", "Since", "After",
+    "Before", "During", "Today", "Tomorrow", "Yesterday",
+})
 _RE_AKA          = re.compile(
     r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)',
     re.IGNORECASE,
@@ -449,7 +468,9 @@ class MemoryStore:
         """Extract entity candidates from text using simple regex rules.
 
         Rules applied (in order):
-        1. Capitalized multi-word phrases  e.g. "John Doe"
+        1. Capitalized phrases             e.g. "John Doe", or a lone
+           proper noun ("Michael") when it is not a sentence-initial
+           common word (see _CAP_SENTENCE_STOPWORDS)
         2. Double-quoted terms             e.g. "Python"
         3. Single-quoted terms             e.g. 'pytest'
         4. AKA patterns                    e.g. "Guido aka BDFL" -> two entities
@@ -466,7 +487,18 @@ class MemoryStore:
                 candidates.append(stripped)
 
         for m in _RE_CAPITALIZED.finditer(text):
-            _add(m.group(1))
+            phrase = m.group(1)
+            if " " not in phrase:
+                # Lone title-case token: keep it only when it is a plausible
+                # proper noun. A word mid-sentence (preceded by anything other
+                # than sentence-ending punctuation) is almost always a name;
+                # a sentence-initial word is ambiguous ("Michael" vs "Review"),
+                # so drop it when it is a known non-proper-noun opener.
+                preceding = text[: m.start(1)].rstrip()
+                sentence_initial = not preceding or preceding[-1] in ".!?"
+                if sentence_initial and phrase in _CAP_SENTENCE_STOPWORDS:
+                    continue
+            _add(phrase)
 
         for m in _RE_DOUBLE_QUOTE.finditer(text):
             _add(m.group(1))

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -45,6 +45,47 @@ def db_path(tmp_path):
     return tmp_path / "memory_store.db"
 
 
+class TestEntityExtraction:
+    """_extract_entities must recover lone proper nouns (the dominant shape in a
+    personal fact store, e.g. "Michael prefers X") without regressing multi-word
+    phrases or admitting sentence-initial common words as spurious entities."""
+
+    def test_single_word_proper_noun_is_extracted(self, db_path):
+        store = MemoryStore(db_path)
+        try:
+            assert store._extract_entities("Michael prefers dark roast coffee.") == ["Michael"]
+            assert store._extract_entities("Anne maintains the memory vault.") == ["Anne"]
+        finally:
+            store.close()
+
+    def test_multi_word_phrase_is_not_split(self, db_path):
+        store = MemoryStore(db_path)
+        try:
+            # Must stay a single entity — not ["Michael Jones", "Michael", "Jones"].
+            assert store._extract_entities(
+                "Michael Jones prefers dark roast coffee."
+            ) == ["Michael Jones"]
+        finally:
+            store.close()
+
+    def test_mid_sentence_capital_is_kept(self, db_path):
+        store = MemoryStore(db_path)
+        try:
+            assert store._extract_entities("We spoke to Michael yesterday.") == ["Michael"]
+        finally:
+            store.close()
+
+    def test_sentence_initial_common_words_are_not_entities(self, db_path):
+        store = MemoryStore(db_path)
+        try:
+            assert store._extract_entities("The user likes coffee.") == []
+            assert store._extract_entities("Please remember this.") == []
+            assert store._extract_entities("Review the deployment guide.") == []
+            assert store._extract_entities("Update the backup plan.") == []
+        finally:
+            store.close()
+
+
 class TestSharedConnection:
     def test_same_path_shares_one_connection(self, db_path):
         a = MemoryStore(db_path)


### PR DESCRIPTION
## What does this PR do?

`_extract_entities` in the holographic memory store never produced an entity
from a single-word proper noun, because `_RE_CAPITALIZED` required two or more
title-case words. In a personal fact store the dominant shape is a lone given
name ("Michael prefers dark roast coffee."), so `probe` / `related` /
compositional retrieval silently degraded.

The fix relaxes `_RE_CAPITALIZED` to match one *or more* title-case words, then
keeps a lone token only when it is a plausible proper noun: a mid-sentence
capital is taken as-is, while a sentence-initial one is kept only when it is not
a known common opener (`_CAP_SENTENCE_STOPWORDS`). Multi-word phrases are matched
as one unit and never re-split. Heuristic by design (a POS / proper-noun source
would be more robust), but it avoids two failure modes:
- sentence-initial common words ("The", "Please", "Review") becoming entities;
- multi-word names re-emitted as duplicate single tokens
  ("Michael Jones" -> ["Michael Jones", "Michael", "Jones"]).

Related: #97520 and #97534 also target #97493; this version additionally guards
against the two failure modes above, verified by the added tests.

## Related Issue

Fixes #97493

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py` — allow single title-case tokens in
  `_RE_CAPITALIZED`; add `_CAP_SENTENCE_STOPWORDS`; filter lone tokens by
  sentence position + stopword in `_extract_entities`.
- `tests/plugins/memory/test_holographic_store.py` — add `TestEntityExtraction`.

## How to Test

1. `pytest tests/plugins/memory/test_holographic_store.py::TestEntityExtraction -q`
2. All 4 cases pass: single-word name extracted, multi-word phrase not split,
   mid-sentence capital kept, sentence-initial common words rejected.

## Checklist

### Code

- [√] I've read the Contributing Guide
- [√] My commit messages follow Conventional Commits
- [√] I searched for existing PRs (see the "Related" note above — disclosing #97520 / #97534)
- [√] My PR contains only changes related to this fix
- [√] I've run `pytest tests/ -q` and all tests pass
- [√] I've added tests for my changes
- [√] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [√] I've updated relevant documentation (docstring of `_extract_entities`)
- [√] `cli-config.yaml.example` — N/A
- [√] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [√] I've considered cross-platform impact — pure regex logic, platform-independent
- [√] Tool descriptions/schemas — N/A
