### PR TITLE
fix(desktop): preserve model profile in request body

### DIFF
--- a/apps/desktop/src/api/models.ts
+++ b/apps/desktop/src/api/models.ts
@@ -120,10 +120,16 @@ export function setModelAssignment(
   body: ModelAssignmentRequest,
   profile?: null | string
 ): Promise<ModelAssignmentResponse> {
+  // Keep the target in the JSON payload as well as the IPC request envelope.
+  // A shared remote can route the request to its primary backend while the
+  // envelope's profile is being normalized; the backend's model handler still
+  // honors body.profile when choosing the config home (#97515).
+  const requestBody = profile == null ? body : { ...body, profile }
+
   return hermesApi<ModelAssignmentResponse>({
     ...profileScoped(profile),
     path: '/api/model/set',
     method: 'POST',
-    body
+    body: requestBody
   })
 }

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -29,6 +29,7 @@ import {
   resetSidebarBatchCapability,
   setApiRequestConnection,
   setApiRequestProfile,
+  setModelAssignment,
   speakText,
   transcribeAudio,
   triggerCronJob
@@ -189,6 +190,20 @@ describe('Hermes REST helpers', () => {
       })
     )
     expect(api.mock.calls[0][0]).not.toHaveProperty('profile')
+  })
+
+  it('keeps explicit model assignments scoped in the JSON payload', async () => {
+    await setModelAssignment(
+      { model: 'hermes-4', provider: 'nous', scope: 'main' },
+      'research'
+    )
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: 'research',
+        body: { model: 'hermes-4', provider: 'nous', profile: 'research', scope: 'main' }
+      })
+    )
   })
 
   it('preserves ambient and explicit-local ownership for session and profile requests', async () => {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1335,6 +1335,8 @@ export interface ModelAssignmentRequest {
   confirm_expensive_model?: boolean
   model: string
   provider: string
+  /** Explicit target profile for shared remote backends. */
+  profile?: string
   scope: 'main' | 'auxiliary'
   task?: string
 }


### PR DESCRIPTION
Related to #97515

## Summary
- include an explicit settings profile in the model assignment JSON payload
- keep the existing IPC/profile routing metadata unchanged
- add a regression assertion for shared-remote model assignments

When a shared remote normalizes the Electron request envelope to its primary backend, the backend can still honor `body.profile` and scope the config write to the selected profile.

This is complementary to #97530, which addresses the broader shared-remote routing path used by reads and sibling settings pages.

## Validation
- `git diff --check`
- Desktop Vitest could not start in this checkout because `vitest/config` is unavailable in the installed dependencies.