### PR TITLE
fix(desktop): hide CLI-only voice shortcut setting

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -743,7 +743,9 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.elevenlabs.language_code',
       'stt.elevenlabs.tag_audio_events',
       'stt.elevenlabs.diarize',
-      'voice.record_key',
+      // `voice.record_key` is the CLI prompt_toolkit shortcut. Desktop voice
+      // capture uses the renderer keybind (`composer.voice`) instead, so do
+      // not expose a setting that desktop cannot consume.
       'voice.max_recording_seconds',
       'voice.client_direct'
     ]

--- a/apps/desktop/src/app/settings/voice-provider-fields.test.ts
+++ b/apps/desktop/src/app/settings/voice-provider-fields.test.ts
@@ -6,6 +6,10 @@ import { voiceProviderKeys } from './voice-provider-fields'
 const voiceKeys = SECTIONS.find(s => s.id === 'voice')?.keys ?? []
 
 describe('voiceProviderKeys', () => {
+  it('does not expose the CLI-only recording shortcut in desktop settings', () => {
+    expect(voiceKeys).not.toContain('voice.record_key')
+  })
+
   it('derives per-provider field keys from the curated Voice section', () => {
     expect(voiceProviderKeys('tts', 'openai')).toEqual(['tts.openai.model', 'tts.openai.voice'])
     expect(voiceProviderKeys('tts', 'elevenlabs')).toEqual(['tts.elevenlabs.voice_id', 'tts.elevenlabs.model_id'])


### PR DESCRIPTION
Closes #97473

Related to #75774, which covers the same underlying UI/config mismatch for the older closed report #40855. This PR stays focused on the current open reproduction and removes the CLI-only key from the Desktop settings list with a targeted regression test.

## Summary
- remove the CLI-only `voice.record_key` field from Desktop Settings
- keep desktop voice capture discoverable through the rebindable `composer.voice` shortcut
- add a regression assertion for the curated Voice settings list

The desktop renderer does not consume `voice.record_key`; hiding it prevents users from saving a setting that has no effect in the Desktop app.

## Validation
- `git diff --check`
- Desktop Vitest could not start in this checkout because `vitest/config` is unavailable in the installed dependencies.