### PR TITLE
fix(cron): tri-state fire-claim heartbeat — lock timeout is 'unverifiable', not ownership loss

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3373,10 +3373,25 @@ def _sweep_completed_oneshots(
     return removed
 
 
-def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
+def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> Optional[bool]:
+    """Confirm or refresh an active ``fire_claim`` for ``expected_owner``.
+
+    Returns tri-state so callers can distinguish a *positively observed* loss
+    from a transient failure to verify:
+
+    - ``True`` — the claim is still owned by ``expected_owner`` and was
+      refreshed.
+    - ``False`` — ownership is positively observed to have changed (the claim
+      is absent or belongs to another owner). Callers may interrupt the run.
+    - ``None`` — ownership could NOT be verified (the per-job fire fence could
+      not be acquired within ``_JOBS_LOCK_TIMEOUT_SECONDS``). This is NOT
+      evidence of loss: under memory/CPU starvation a healthy owner can fail
+      to reach the lock. Callers should treat ``None`` as "unknown" and feed
+      the existing grace path, not the immediate-kill path.
+    """
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
-            return False
+            return None
         return _heartbeat_fire_claim_locked(
             job_id,
             expected_owner=expected_owner,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6978,36 +6978,50 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         _finish_unstarted("Fire claim ownership lost before execution started.")
         return True
 
+    if owns_fire_claim is None:
+        logger.warning(
+            "Job '%s': fire claim ownership could not be verified before execution; "
+            "aborting as unverifiable (not claiming loss)",
+            job_id,
+        )
+        _finish_unstarted(
+            "Fire claim ownership could not be validated before execution started."
+        )
+        return True
+
     def _heartbeat_loop() -> None:
         last_confirmed = time.monotonic()
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
             try:
-                if not heartbeat_fire_claim(job_id, expected_owner=owner):
-                    lost_ownership.set()
-                    logger.warning(
-                        "Job '%s': fire claim ownership lost; interrupting stale run",
-                        job_id,
-                    )
-                    return
-                last_confirmed = time.monotonic()
+                claim = heartbeat_fire_claim(job_id, expected_owner=owner)
             except Exception:
                 logger.debug(
                     "Job '%s': fire_claim heartbeat failed",
                     job_id,
                     exc_info=True,
                 )
-                if (
-                    time.monotonic() - last_confirmed
-                    >= _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS
-                ):
-                    lost_ownership.set()
-                    logger.warning(
-                        "Job '%s': fire_claim could not be renewed within %.1fs; "
-                        "interrupting uncertain run",
-                        job_id,
-                        _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS,
-                    )
-                    return
+                claim = None
+            if claim is False:
+                lost_ownership.set()
+                logger.warning(
+                    "Job '%s': fire claim ownership lost; interrupting stale run",
+                    job_id,
+                )
+                return
+            if claim is True:
+                last_confirmed = time.monotonic()
+            elif (
+                time.monotonic() - last_confirmed
+                >= _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS
+            ):
+                lost_ownership.set()
+                logger.warning(
+                    "Job '%s': fire_claim could not be renewed within %.1fs; "
+                    "interrupting uncertain run",
+                    job_id,
+                    _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS,
+                )
+                return
 
     heartbeat_thread = threading.Thread(
         target=heartbeat_context.run,
@@ -7134,8 +7148,7 @@ def _run_one_job_body(
         if fire_owner is None:
             return False
         try:
-            if heartbeat_fire_claim(job["id"], expected_owner=fire_owner):
-                return False
+            claim = heartbeat_fire_claim(job["id"], expected_owner=fire_owner)
         except Exception:
             logger.debug(
                 "Job '%s': fire_claim ownership validation failed",
@@ -7143,9 +7156,15 @@ def _run_one_job_body(
                 exc_info=True,
             )
             return False
-        if fire_claim_lost is not None:
-            fire_claim_lost.set()
-        return True
+        if claim is True:
+            return False
+        if claim is False:
+            if fire_claim_lost is not None:
+                fire_claim_lost.set()
+            return True
+        # claim is None — could not verify. Do NOT claim loss without a
+        # positive observation (same fail-closed lie as the heartbeat path).
+        return False
 
     execution_id = job.get("execution_id")
     if not execution_id:
@@ -7242,7 +7261,7 @@ def _run_one_job_body(
             # interruption through the owner-fenced terminal write.
             if fire_owner is not None and heartbeat_fire_claim(
                 job["id"], expected_owner=fire_owner,
-            ):
+            ) is True:
                 mark_job_run(
                     job["id"],
                     False,
@@ -7428,7 +7447,7 @@ def _run_one_job_body(
             # discarding silently (lingering claim + stale last_status).
             if fire_owner is not None and heartbeat_fire_claim(
                 job["id"], expected_owner=fire_owner,
-            ):
+            ) is True:
                 mark_job_run(
                     job["id"],
                     False,

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -539,6 +539,110 @@ def test_repeated_heartbeat_errors_cancel_after_bounded_grace(monkeypatch):
     assert calls >= 3
 
 
+def test_unverifiable_fire_claim_not_killed_immediately(monkeypatch):
+    """A None (could-not-verify) heartbeat must NOT interrupt a live run.
+
+    The original defect treated lock-timeout as ownership loss and killed a
+    healthy run. Tri-state None means "could not verify", which routes to the
+    grace path: the run keeps going until grace expires.
+    """
+    import cron.scheduler as scheduler
+
+    calls = 0
+
+    def heartbeat(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return True
+        return None  # fire fence could not be acquired (starvation), not theft
+
+    body_entered = threading.Event()
+    body_finished = threading.Event()
+
+    def run_body(_job, **kwargs):
+        body_entered.set()
+        # Give the heartbeat thread time to run at least twice with None
+        # results. The old code killed the run after the first None; the
+        # fixed code must still be alive here.
+        time.sleep(0.1)
+        body_finished.set()
+        return True
+
+    job = {
+        "id": "unverifiable-heartbeat",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "owner"},
+    }
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", heartbeat)
+    monkeypatch.setattr(scheduler, "_run_one_job_body", run_body)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 5.0)
+
+    assert scheduler.run_one_job(job) is True
+    assert body_entered.is_set()
+    assert body_finished.is_set()
+    assert calls >= 3
+
+
+def test_unverifiable_fire_claim_cancels_after_bounded_grace(monkeypatch):
+    """Sustained None (unverifiable) past grace must still cancel the run."""
+    import cron.scheduler as scheduler
+
+    calls = 0
+
+    def heartbeat(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return True
+        return None
+
+    def run_body(_job, **kwargs):
+        assert kwargs["fire_claim_lost"].wait(timeout=0.5)
+        return True
+
+    job = {
+        "id": "unverifiable-grace",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "owner"},
+    }
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", heartbeat)
+    monkeypatch.setattr(scheduler, "_run_one_job_body", run_body)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 0.03)
+
+    assert scheduler.run_one_job(job) is True
+    assert calls >= 3
+
+
+def test_initially_unverifiable_fire_claim_finishes_without_running(monkeypatch):
+    """Unverifiable initial ownership must fail closed without claiming loss."""
+    import cron.scheduler as scheduler
+
+    run_body = MagicMock(return_value=True)
+    finish = MagicMock()
+    job = {
+        "id": "initially-unverifiable",
+        "execution_id": "unverifiable-execution",
+        "fire_claim": {"at": "2026-07-12T12:00:00+00:00", "by": "owner"},
+    }
+    monkeypatch.setattr(
+        scheduler,
+        "heartbeat_fire_claim",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(scheduler, "_run_one_job_body", run_body)
+    monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+    assert scheduler.run_one_job(job) is True
+
+    run_body.assert_not_called()
+    finish.assert_called_once_with(
+        "unverifiable-execution",
+        success=False,
+        error="Fire claim ownership could not be validated before execution started.",
+    )
+
+
 def test_terminal_owner_cas_failure_marks_ledger_ownership_lost(monkeypatch):
     """A replacement owner cannot leave the stale ledger recorded as success."""
     import cron.scheduler as scheduler


### PR DESCRIPTION
## Problem

`heartbeat_fire_claim()` in `cron/jobs.py:3376` returns `False` in **two distinct situations**:

1. ownership is *positively observed* to have changed (claim absent / owned by another), and
2. the per-job fire fence could not be acquired within `_JOBS_LOCK_TIMEOUT_SECONDS` (30s) — a fail-closed "could not verify".

`cron/scheduler.py:6985` collapses both into `fire claim ownership lost; interrupting stale run` and **kills a healthy run**, which is then recorded as a cron FAILURE.

Under cgroup memory/CPU starvation (measured: PSI full avg10 26–37%, `memory.current == memory.high`, swap exhausted), a 30s lock wait is routine — so a single heartbeat tick can false-positive "ownership lost" and kill a run that was never stolen.

## Fix

Change the contract to **tri-state `Optional[bool]`**:

- `True` — claim still owned by `expected_owner` and refreshed
- `False` — ownership **positively observed** changed (claim absent/other owner)
- `None` — could **not verify** (fence lock unavailable) — NOT evidence of loss

Callers updated:

- **fire-claim heartbeat loop** (scheduler): `False` interrupts immediately; `None` feeds the existing `_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS` grace path (same as exceptions), so a run is interrupted only when ownership is positively observed changed **or** verification has failed continuously past the grace window.
- **initial validation**: `None` fails closed as `Fire claim ownership could not be validated...` (not "lost").
- **shutdown probes** (`_fire_claim_ownership_lost`, shutdown `mark_job_run` paths): only `True` counts as owned; `None` is not treated as loss.

## Verification

- 3 new regression tests in `tests/cron/test_script_claim_heartbeat.py`:
  - `test_unverifiable_fire_claim_not_killed_immediately` — the exact incident: None heartbeats must NOT interrupt a live run.
  - `test_unverifiable_fire_claim_cancels_after_bounded_grace` — sustained None past grace still cancels.
  - `test_initially_unverifiable_fire_claim_finishes_without_running` — initial None fails closed without claiming loss.
- Full `tests/cron/` suite: 1035 passed, 1 skipped. The single failure (`test_run_job_cron_execute_code_deny_does_not_pollute_later_gateway_execute_code`) is **pre-existing on `main`** (verified by stash) and unrelated (execute-code approval session isolation).

## Related

- Fleet incident: cron 'fire claim ownership lost' is a fail-closed lock timeout, not claim theft (2026-08-29) — `heartbeat_fire_claim()` returns False on lock timeout and the scheduler kills a healthy run.