### PR TITLE
fix(chronos): use hosted agent credential

### DIFF
--- a/plugins/cron_providers/chronos/__init__.py
+++ b/plugins/cron_providers/chronos/__init__.py
@@ -83,7 +83,10 @@ class ChronosCronScheduler(CronScheduler):
         try:
             from hermes_cli.auth import get_provider_auth_state
             state = get_provider_auth_state("nous") or {}
-            return bool(state.get("access_token"))
+            # Hosted installs may persist the bootstrap/invoke credential as
+            # ``agent_key`` while the refreshable user token is absent. Both
+            # are valid signals for the lazy runtime resolver below.
+            return bool(state.get("access_token") or state.get("agent_key"))
         except Exception:
             return False
 

--- a/plugins/cron_providers/chronos/_nas_client.py
+++ b/plugins/cron_providers/chronos/_nas_client.py
@@ -41,9 +41,22 @@ class NasCronClient:
     # -- auth -------------------------------------------------------------
 
     def _access_token(self) -> str:
-        """The agent's existing Nous Portal access token (refresh-aware)."""
-        from hermes_cli.auth import resolve_nous_access_token
-        return resolve_nous_access_token()
+        """Resolve the agent-scoped Nous credential used by managed services.
+
+        ``resolve_nous_access_token`` exposes the refreshable user session,
+        while hosted gateways may need the runtime ``agent_key`` (the
+        bootstrap/invoke JWT seeded for that gateway). The runtime resolver
+        refreshes and selects that credential consistently with inference, and
+        prevents Chronos from presenting a generic user token to
+        ``agent-cron`` (#97494).
+        """
+        from hermes_cli.auth import resolve_nous_runtime_credentials
+
+        credentials = resolve_nous_runtime_credentials()
+        token = credentials.get("api_key")
+        if not isinstance(token, str) or not token.strip():
+            raise NasCronClientError("Nous runtime credentials did not contain an access token")
+        return token.strip()
 
     def _headers(self) -> Dict[str, str]:
         return {

--- a/tests/plugins/test_chronos_cron.py
+++ b/tests/plugins/test_chronos_cron.py
@@ -61,6 +61,34 @@ def test_is_available_false_without_config(temp_home, monkeypatch):
     assert ChronosCronScheduler().is_available() is False
 
 
+def test_is_available_accepts_hosted_agent_key(temp_home, monkeypatch):
+    from plugins.cron_providers.chronos import ChronosCronScheduler
+
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos._cfg",
+        lambda *k, default="": "https://agent.example/"
+        if k[-1] == "callback_url"
+        else "https://portal.test",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_provider_auth_state",
+        lambda _provider: {"agent_key": "bootstrap-jwt"},
+    )
+
+    assert ChronosCronScheduler().is_available() is True
+
+
+def test_nas_client_uses_runtime_agent_credential(monkeypatch):
+    from plugins.cron_providers.chronos._nas_client import NasCronClient
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_nous_runtime_credentials",
+        lambda: {"api_key": "bootstrap-jwt"},
+    )
+
+    assert NasCronClient("https://portal.test")._access_token() == "bootstrap-jwt"
+
+
 # -- arming -------------------------------------------------------------------
 
 def test_arm_one_shot_sends_provision(chronos):


### PR DESCRIPTION
Closes #97494

## Summary
- accept persisted hosted `agent_key` credentials when deciding Chronos availability
- resolve the same runtime agent credential used by Nous inference for NAS calls
- add regression coverage for hosted bootstrap credentials

Chronos provisioning must authenticate with the gateway's agent-scoped bootstrap/invoke credential. Using the generic session token can be rejected by `/api/agent-cron/provision` even while inference continues to work.

## Validation
- `python -m pytest -q tests/plugins/test_chronos_cron.py` (15 passed)
- `git diff --check`
- the existing JWT verifier tests remain dependency-blocked here because PyJWT is not installed.