### PR TITLE
fix(cron): isolate desktop profile persistence

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6368,7 +6368,16 @@ def run_job(
 
             if _session_db_timeout > 0:
                 _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-                _session_db_future = _session_db_pool.submit(SessionDB)
+                # ThreadPoolExecutor does not inherit ContextVars.  The
+                # multiplex desktop ticker installs the owning profile's
+                # HERMES_HOME in the dispatch context, but SessionDB is
+                # constructed in this nested worker.  Preserve that context
+                # or a profile cron run silently opens the dashboard
+                # process's state.db instead (#97489).
+                _session_db_context = contextvars.copy_context()
+                _session_db_future = _session_db_pool.submit(
+                    _session_db_context.run, SessionDB
+                )
                 try:
                     _session_db = _session_db_future.result(timeout=_session_db_timeout)
                 except concurrent.futures.TimeoutError:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -302,6 +302,9 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
             profile_homes = list(profiles_to_serve(multiplex=True))
             if len(profile_homes) > 1:
                 start_kwargs["profile_homes"] = profile_homes
+                from hermes_logging import enable_profile_log_routing
+
+                enable_profile_log_routing(profile_homes)
                 _log.info(
                     "Desktop cron scheduler will tick %d profile(s): %s",
                     len(profile_homes),

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -201,6 +201,14 @@ def _install_session_record_factory() -> None:
         record = current_factory(*args, **kwargs)
         sid = getattr(_session_context, "session_id", None)
         record.session_tag = f" [{sid}]" if sid else ""  # type: ignore[attr-defined]
+        # QueueListener formats records on its own thread, after the
+        # profile-scoped ContextVar has gone out of scope. Keep the resolved
+        # home on the record so a multiplex desktop ticker can route the log
+        # to the job owner's files (#97489).
+        try:
+            record.hermes_home = str(get_hermes_home().resolve())  # type: ignore[attr-defined]
+        except Exception:
+            record.hermes_home = ""  # type: ignore[attr-defined]
         return record
 
     _session_record_factory._hermes_session_injector = True  # type: ignore[attr-defined]
@@ -547,6 +555,97 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         self._record_stream_stat()
 
 
+class _ProfileRoutingFileHandler(logging.Handler):
+    """Route queued records to the log file for their Hermes home.
+
+    Dashboard logging is initialized once for the process that launched it,
+    while the desktop cron ticker can execute jobs for several profile homes.
+    A normal ``RotatingFileHandler`` therefore pins every cron record to the
+    dashboard profile. This handler keeps one rotating file handler per live
+    profile and selects it from the home captured by the record factory.
+
+    The handler itself is used only behind the existing QueueListener, so its
+    small routing lock never blocks an agent or dashboard event loop. The
+    underlying handlers retain the existing rotation, redaction, and managed
+    permission behavior.
+    """
+
+    def __init__(
+        self,
+        *,
+        default_path: Path,
+        profile_homes: Sequence[Path],
+        level: int,
+        max_bytes: int,
+        backup_count: int,
+        formatter: logging.Formatter | None,
+        log_filters: Sequence[logging.Filter],
+    ) -> None:
+        super().__init__(level=level)
+        self.baseFilename = str(default_path.resolve())
+        self._hermes_routed_log_path = Path(self.baseFilename)
+        self._default_home = Path(self.baseFilename).parent.parent.resolve()
+        self._profile_homes = {
+            Path(home).expanduser().resolve()
+            for home in profile_homes
+        }
+        self._filename = Path(self.baseFilename).name
+        self._max_bytes = max_bytes
+        self._backup_count = backup_count
+        self._profile_handlers: dict[Path, _ManagedRotatingFileHandler] = {}
+        self._profile_handlers_lock = threading.RLock()
+        if formatter is not None:
+            self.setFormatter(formatter)
+        for log_filter in log_filters:
+            self.addFilter(log_filter)
+
+    def _home_for_record(self, record: logging.LogRecord) -> Path:
+        raw_home = getattr(record, "hermes_home", "")
+        try:
+            candidate = Path(raw_home).expanduser().resolve()
+        except (TypeError, ValueError, OSError):
+            candidate = self._default_home
+        return candidate if candidate in self._profile_homes else self._default_home
+
+    def _handler_for_home(self, home: Path) -> _ManagedRotatingFileHandler:
+        with self._profile_handlers_lock:
+            handler = self._profile_handlers.get(home)
+            if handler is not None:
+                return handler
+
+            path = home / "logs" / self._filename
+            from hermes_constants import mkdir_under_hermes_home
+
+            mkdir_under_hermes_home(path.parent)
+            handler = _ManagedRotatingFileHandler(
+                str(path),
+                maxBytes=self._max_bytes,
+                backupCount=self._backup_count,
+                encoding="utf-8",
+            )
+            handler.setLevel(self.level)
+            handler.setFormatter(self.formatter)
+            self._profile_handlers[home] = handler
+            return handler
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self._handler_for_home(self._home_for_record(record)).handle(record)
+        except Exception:
+            self.handleError(record)
+
+    def close(self) -> None:
+        with self._profile_handlers_lock:
+            handlers = list(self._profile_handlers.values())
+            self._profile_handlers.clear()
+        for handler in handlers:
+            try:
+                handler.close()
+            except Exception:
+                pass
+        super().close()
+
+
 # ---------------------------------------------------------------------------
 # Asynchronous file logging — keep the cross-process rotation lock off the loop
 #
@@ -700,6 +799,73 @@ def rotating_file_handlers() -> list:
     return list(_queued_file_handlers)
 
 
+def enable_profile_log_routing(profile_homes: Sequence[str | Path]) -> bool:
+    """Make the queued file logs follow a desktop profile context.
+
+    ``setup_logging`` normally binds handlers to one process home. The
+    desktop dashboard is the exception: its embedded cron ticker may run
+    jobs for every profile. Replace the existing static file handlers with
+    profile routers after that profile list is known.
+
+    Returns ``True`` when routing is enabled or was already enabled. A
+    single-profile caller is left untouched because its existing handlers are
+    already correctly scoped.
+    """
+    global _queue_listener
+
+    homes = []
+    for entry in profile_homes:
+        home = entry[1] if isinstance(entry, tuple) else entry
+        try:
+            resolved = Path(home).expanduser().resolve()
+        except (TypeError, ValueError, OSError):
+            continue
+        if resolved not in homes:
+            homes.append(resolved)
+    if len(homes) < 2:
+        return False
+
+    with _queue_state_lock:
+        if not _queued_file_handlers:
+            return False
+        if any(isinstance(h, _ProfileRoutingFileHandler) for h in _queued_file_handlers):
+            return True
+
+        listener = _queue_listener
+        if listener is not None:
+            listener.stop()
+
+        replacement = []
+        for existing in _queued_file_handlers:
+            if not isinstance(existing, RotatingFileHandler):
+                replacement.append(existing)
+                continue
+
+            default_path = Path(existing.baseFilename)
+            router = _ProfileRoutingFileHandler(
+                default_path=default_path,
+                profile_homes=homes,
+                level=existing.level,
+                max_bytes=getattr(existing, "maxBytes", 0),
+                backup_count=getattr(existing, "backupCount", 0),
+                formatter=existing.formatter,
+                log_filters=list(existing.filters),
+            )
+            replacement.append(router)
+            try:
+                existing.close()
+            except Exception:
+                pass
+
+        _queued_file_handlers[:] = replacement
+        if listener is not None:
+            _queue_listener = QueueListener(
+                _log_queue, *_queued_file_handlers, respect_handler_level=True
+            )
+            _queue_listener.start()
+        return True
+
+
 def _reset_queued_handlers() -> None:
     """Tear down the async logging queue + listener (test-isolation helper)."""
     global _log_queue
@@ -744,6 +910,8 @@ def _add_rotating_handler(
             and Path(getattr(existing, "baseFilename", "")).resolve() == resolved
         ):
             return  # already attached
+        if getattr(existing, "_hermes_routed_log_path", None) == resolved:
+            return  # already covered by the profile router
 
     from hermes_constants import mkdir_under_hermes_home
     mkdir_under_hermes_home(path.parent)

--- a/tests/cron/test_sessiondb_init_hang.py
+++ b/tests/cron/test_sessiondb_init_hang.py
@@ -21,8 +21,10 @@ suite stays free of timing flakes under parallel load.
 """
 
 import concurrent.futures
+import sys
 import threading
 import time
+import types
 from unittest.mock import MagicMock, patch
 
 from cron.scheduler import run_job
@@ -75,6 +77,60 @@ def _session_db_executor(timeouts: list, *, instant_timeout: bool = True):
 
 
 class TestSessionDbInitTimeout:
+    def test_sessiondb_init_keeps_multiplex_profile_context(self, tmp_path, monkeypatch):
+        """A nested SessionDB worker must open the cron owner's state.db.
+
+        The desktop ticker carries the profile home in a ContextVar.  The
+        SessionDB timeout worker is another thread, so this catches the
+        regression where it silently fell back to the dashboard process home.
+        """
+        from hermes_constants import (
+            get_hermes_home,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        dashboard_home = tmp_path / "dashboard"
+        profile_home = tmp_path / "profiles" / "north-caribbean"
+        dashboard_home.mkdir()
+        profile_home.mkdir(parents=True)
+        seen_homes = []
+
+        def capture_session_db():
+            seen_homes.append(get_hermes_home())
+            return MagicMock()
+
+        job = {"id": "profile-sessiondb", "name": "test", "prompt": "hello"}
+        fake_env_loader = types.ModuleType("hermes_cli.env_loader")
+        fake_env_loader.load_hermes_dotenv = lambda **_kwargs: None
+        fake_env_loader.reset_secret_source_cache = lambda: None
+        monkeypatch.setitem(sys.modules, "hermes_cli.env_loader", fake_env_loader)
+        import hermes_cli
+        monkeypatch.setattr(hermes_cli, "env_loader", fake_env_loader, raising=False)
+        profile_token = set_hermes_home_override(profile_home)
+        try:
+            with patch("cron.scheduler._hermes_home", None), \
+                 patch("cron.scheduler._resolve_origin", return_value=None), \
+                 patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+                 patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+                 patch("hermes_state.SessionDB", side_effect=capture_session_db), \
+                 patch(
+                     "hermes_cli.runtime_provider.resolve_runtime_provider",
+                     return_value=_RUNTIME,
+                 ), \
+                 patch("run_agent.AIAgent") as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "ok"}
+                mock_agent_cls.return_value = mock_agent
+
+                success, output, final_response, error = run_job(job)
+        finally:
+            reset_hermes_home_override(profile_token)
+
+        assert success is True
+        assert final_response == "ok"
+        assert seen_homes == [profile_home]
+
     def test_run_job_does_not_hang_when_sessiondb_init_wedges(self, tmp_path, monkeypatch):
         """run_job proceeds without a session store when SessionDB init times out."""
         monkeypatch.setenv("HERMES_CRON_SESSION_DB_TIMEOUT", "0.2")

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -116,6 +116,32 @@ class TestSetupLogging:
         content = agent_log.read_text()
         assert "test message for agent.log" in content
 
+    def test_profile_routing_follows_context_home(self, hermes_home, tmp_path):
+        """Desktop multiplex cron records are written to their owning profile."""
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        profile_home = tmp_path / "profile-b"
+        profile_home.mkdir()
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        assert hermes_logging.enable_profile_log_routing(
+            [hermes_home, profile_home]
+        ) is True
+
+        logger = logging.getLogger("cron.scheduler.profile-routing-test")
+        token = set_hermes_home_override(profile_home)
+        try:
+            logger.info("profile-routed cron record")
+        finally:
+            reset_hermes_home_override(token)
+        hermes_logging.flush_log_queue()
+
+        assert "profile-routed cron record" in (
+            profile_home / "logs" / "agent.log"
+        ).read_text()
+        assert "profile-routed cron record" not in (
+            hermes_home / "logs" / "agent.log"
+        ).read_text()
+
 
 
 
@@ -676,5 +702,4 @@ class TestAsyncQueueLogging:
             "agent.log" in getattr(h, "baseFilename", "")
             for h in hermes_logging.rotating_file_handlers()
         )
-
 


### PR DESCRIPTION
Closes #97489

## Summary
- propagate the profile-scoped ContextVar into the nested SessionDB timeout worker so multiplexed desktop cron runs open the owning profile's state.db
- add profile-aware routing for queued agent/errors/gui logs when the desktop ticker serves multiple profiles, preserving rotation, redaction, and managed permissions
- enable the routing only for the desktop multi-profile ticker and add regression coverage

## Validation
- `python -m py_compile cron/scheduler.py hermes_logging.py hermes_cli/web_server.py tests/cron/test_sessiondb_init_hang.py tests/test_hermes_logging.py`
- `git diff --check`
- `python -m pytest -q tests/cron/test_sessiondb_init_hang.py -k multiplex_profile_context` (1 passed)
- `python -m pytest -q tests/test_hermes_logging.py -k 'profile_routing_follows_context_home or gateway_log_attached_after_external_rotation_then_re_setup'` (2 passed)
- dashboard profile suite was dependency-blocked in this environment during collection (`fastapi` is not installed)

The nested-worker context boundary was the persistence bug: the outer multiplex dispatch had the correct profile home, but `ThreadPoolExecutor.submit(SessionDB)` did not inherit it. The log router carries the resolved home on each record because QueueListener formats records on a separate thread.