### PR TITLE
fix(gemini): strip 'models/' and nested provider prefixes in bare_gem…

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -51,13 +51,18 @@ GEMINI_DEFAULT_MAX_OUTPUT_TOKENS = 65535
 
 
 def bare_gemini_model_id(model: str) -> str:
-    """Strip Gemini's own provider prefix from an aggregator-style model id."""
+    """Strip provider and endpoint prefixes ('google/', 'gemini/', 'models/') from a model id."""
     name = (model or "").strip()
-    lowered = name.lower()
-    for prefix in ("google/", "gemini/"):
-        if lowered.startswith(prefix):
-            return name[len(prefix):].strip() or name
-    return name
+    changed = True
+    while changed:
+        changed = False
+        lowered = name.lower()
+        for prefix in ("google/", "gemini/", "models/"):
+            if lowered.startswith(prefix):
+                name = name[len(prefix):].strip()
+                changed = True
+                break
+    return name or (model or "").strip()
 
 
 def _gemini_major_version(model: str) -> Optional[int]:

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -675,3 +675,19 @@ def test_text_only_tool_result_has_no_parts():
     )
     fr = request["contents"][1]["parts"][0]["functionResponse"]
     assert "parts" not in fr
+
+
+def test_bare_gemini_model_id_strips_models_and_provider_prefixes():
+    from agent.gemini_native_adapter import bare_gemini_model_id, gemini_requires_tool_call_ids
+
+    assert bare_gemini_model_id("models/gemini-2.5-flash") == "gemini-2.5-flash"
+    assert bare_gemini_model_id("google/models/gemini-3.1-pro") == "gemini-3.1-pro"
+    assert bare_gemini_model_id("gemini/models/gemini-3-flash-preview") == "gemini-3-flash-preview"
+    assert bare_gemini_model_id("google/gemini-3.6-flash") == "gemini-3.6-flash"
+    assert bare_gemini_model_id("gemini-2.5-pro") == "gemini-2.5-pro"
+
+    # Test tool call ID requirement gating with models/ prefix
+    assert gemini_requires_tool_call_ids("models/gemini-3.6-flash") is True
+    assert gemini_requires_tool_call_ids("google/models/gemini-3.1-pro") is True
+    assert gemini_requires_tool_call_ids("models/gemini-2.5-flash") is False
+


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in [`agent/gemini_native_adapter.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/gemini_native_adapter.py) where canonical Google AI Studio model IDs prefixed with `models/` (e.g., `models/gemini-2.5-flash` or `models/gemini-3.1-pro`), or nested aggregator strings (e.g. `google/models/...`), were not stripped of the `models/` segment by `bare_gemini_model_id()`.

This caused two issues:
1. **Gemini 3 Tool-Call ID Gating Failure**: `_gemini_major_version()` failed its regex pattern on `models/gemini-3...`, causing `gemini_requires_tool_call_ids()` to return `False` instead of `True`. This omitted required functionCall/functionResponse `id` parameters in replayed turns on Gemini 3+ models.
2. **Duplicate `/models/models/` URL 404s**: REST endpoint construction (`f"{self.base_url}/models/{model}:generateContent"`) constructed invalid URLs like `.../models/models/gemini-2.5-flash:generateContent`.

The fix updates `bare_gemini_model_id()` to recursively strip `google/`, `gemini/`, and `models/` prefixes cleanly.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/gemini_native_adapter.py`: Updated `bare_gemini_model_id()` to iteratively strip `google/`, `gemini/`, and `models/` prefixes from input model identifiers.
- `tests/agent/test_gemini_native_adapter.py`: Added tests asserting prefix stripping across `models/`, `google/models/`, `gemini/models/`, and verified `gemini_requires_tool_call_ids()` correctly activates for `models/gemini-3...` identifiers.

## How to Test

Run the Gemini adapter and provider test suite:
```bash
uv run --with pytest --with pytest-asyncio pytest tests/agent/test_gemini_native_adapter.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gemini): strip 'models/' and nested provider prefixes in bare_gemini_model_id`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.12.1
collected 30 items

tests/agent/test_gemini_native_adapter.py .............................. [100%]

============================= 30 passed in 5.41s ==============================
```
