### PR TITLE
fix(auxiliary): skip same-provider retry on a vision full-budget timeout

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4697,6 +4697,14 @@ def _is_invalid_aux_response_error(exc: Exception) -> bool:
     )
 
 
+# Auxiliary tasks that sit on a user-visible critical path. A same-provider
+# retry after a full-budget timeout costs another whole ``timeout`` window
+# before the fallback chain is reached, so these skip it and fall through
+# immediately. Fast blips (a streaming-close or a 5xx) still retry, since
+# those are cheap. See issue #54465 for the compression case.
+_TIMEOUT_NO_RETRY_TASKS = frozenset({"compression", "vision"})
+
+
 def _evict_cached_clients(provider: str) -> None:
     """Drop cached auxiliary clients for a provider so fresh creds are used."""
     normalized = _normalize_aux_provider(provider)
@@ -9978,18 +9986,21 @@ def _call_llm_impl(
             if not _is_transient_transport_error(transient_err):
                 raise
             # Compression is on the critical preflight path: a user cannot
-            # continue or resume an oversized session until it compacts. A
-            # same-provider retry on a timeout means another full ``timeout``-
-            # long wall-clock block before the except-chain below can fall
-            # back — doubling the user-visible stall (issue #54465). Skip the
-            # same-provider retry for compression on a full-budget timeout and
+            # continue or resume an oversized session until it compacts.
+            # Vision is on the interactive path: the turn holding the image
+            # cannot answer, and because turns are serialised the following
+            # user messages stall behind it. In both cases a same-provider
+            # retry on a timeout means another full ``timeout``-long
+            # wall-clock block before the except-chain below can fall back —
+            # doubling the user-visible stall (issue #54465). Skip the
+            # same-provider retry for those tasks on a full-budget timeout and
             # fall straight through to provider/model fallback; fast blips (a
             # streaming-close or a 5xx) still retry, since those are cheap.
-            if task == "compression" and _is_timeout_error(transient_err):
+            if task in _TIMEOUT_NO_RETRY_TASKS and _is_timeout_error(transient_err):
                 logger.info(
-                    "Auxiliary compression: timeout on the critical path; "
+                    "Auxiliary %s: timeout on the critical path; "
                     "skipping same-provider retry and falling back: %s",
-                    transient_err,
+                    task, transient_err,
                 )
                 raise
             _max_transient_retries = _transient_retry_count()
@@ -10752,14 +10763,14 @@ async def _async_call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
-            # See call_llm(): compression is on the critical preflight path,
-            # so skip the same-provider retry on a full-budget timeout and
-            # fall straight through to fallback (issue #54465).
-            if task == "compression" and _is_timeout_error(transient_err):
+            # See call_llm(): compression and vision both sit on a critical
+            # path, so skip the same-provider retry on a full-budget timeout
+            # and fall straight through to fallback (issue #54465).
+            if task in _TIMEOUT_NO_RETRY_TASKS and _is_timeout_error(transient_err):
                 logger.info(
-                    "Auxiliary compression (async): timeout on the critical "
+                    "Auxiliary %s (async): timeout on the critical "
                     "path; skipping same-provider retry and falling back: %s",
-                    transient_err,
+                    task, transient_err,
                 )
                 raise
             logger.info(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2092,6 +2092,70 @@ class TestTransientTransportRetry:
         assert primary.chat.completions.create.call_count == 1
         assert fb_client.chat.completions.create.call_count == 1
 
+    def test_vision_skips_same_provider_retry_on_timeout(self):
+        """Vision is on the interactive critical path: the turn holding the
+        image cannot answer, and because turns are serialised the following
+        user messages stall behind it. A full-budget timeout must therefore
+        fall straight through to fallback rather than spending a second
+        ``timeout`` window on the same provider (same reasoning as #54465).
+        """
+        class _Timeout(Exception):
+            pass
+        _Timeout.__name__ = "APITimeoutError"
+
+        primary = MagicMock()
+        primary.base_url = "https://openrouter.ai/api/v1"
+        primary.chat.completions.create.side_effect = _Timeout("Request timed out.")
+
+        fb_client = MagicMock()
+        fb_client.base_url = "https://api.openai.com/v1"
+        fb_client.chat.completions.create.return_value = {"fallback": True}
+
+        p1, p2, p3 = self._patches(primary)
+        with (
+            p1, p2, p3,
+            # Vision resolves its client through resolve_vision_provider_client(),
+            # not _get_cached_client(); the retry block under test is shared.
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                return_value=("openrouter", primary, "some-model"),
+            ),
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+                return_value=(fb_client, "fb-model", "openai"),
+            ),
+        ):
+            result = call_llm(task="vision", messages=[{"role": "user", "content": "hi"}])
+        assert result == {"fallback": True}
+        assert primary.chat.completions.create.call_count == 1
+        assert fb_client.chat.completions.create.call_count == 1
+
+    def test_non_critical_task_still_retries_same_provider_on_timeout(self):
+        """The skip is scoped to critical-path tasks. Everything else keeps the
+        existing one-shot same-provider retry, so this is not a blanket change.
+        """
+        class _Timeout(Exception):
+            pass
+        _Timeout.__name__ = "APITimeoutError"
+
+        primary = MagicMock()
+        primary.base_url = "https://openrouter.ai/api/v1"
+        primary.chat.completions.create.side_effect = [
+            _Timeout("Request timed out."),
+            {"retried": True},
+        ]
+
+        p1, p2, p3 = self._patches(primary)
+        with p1, p2, p3:
+            result = call_llm(task="title", messages=[{"role": "user", "content": "hi"}])
+        assert result == {"retried": True}
+        # Same provider was retried once — unchanged behaviour off the critical path.
+        assert primary.chat.completions.create.call_count == 2
+
     def test_timeout_forwards_failed_model_to_configured_chain(self):
         """A timeout is model-specific, so call_llm must forward the failed
         model to the configured chain (failed_model=<model>, not None). This


### PR DESCRIPTION
## What does this PR do?

Issue #54465 established that a same-provider retry after a **full-budget timeout** costs a second whole `timeout` window before the fallback chain is reached — doubling the user-visible stall — and that compression must not pay it because it sits on a critical path.

The guard added for that is spelled `task == "compression"`, at both retry sites:

```python
if task == "compression" and _is_timeout_error(transient_err):
```

So **vision still retries**, and vision sits on the interactive path. The cost is identical and the stall is more visible: the turn holding the image cannot answer, and because turns are serialised the following user messages queue behind it. Two sequential full-budget timeouts against an unhealthy vision provider is a long stall for something the fallback chain could have served immediately.

This replaces the string comparison at both sites (sync `call_llm` and `async_call_llm`) with a shared `_TIMEOUT_NO_RETRY_TASKS = frozenset({"compression", "vision"})`, so the two paths cannot drift apart again.

Behaviour is unchanged for every other task. Fast blips (a streaming-close or a 5xx) still retry — only full-budget timeouts on those two tasks skip straight to fallback.

Found while running a deployment with a configured `auxiliary.vision` provider on a link that times out intermittently.

## Related Issue

Precedent and rationale: #54465

Not a duplicate of #51513 — that fixes five separate defects **inside** the vision fallback chain (capability detection, sync/async client misuse, geo-block and `RemoteProtocolError` classification, chain iteration). This is about the wasted timeout window **before** that chain is reached, and the two changes are independent.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py` — added `_TIMEOUT_NO_RETRY_TASKS`; both retry sites now test membership instead of comparing to the literal `"compression"`; comments updated to state why vision qualifies. Log lines carry the task name rather than hardcoding it.
- `tests/agent/test_auxiliary_client.py` — two tests in `TestTransientTransportRetry`:
  - `test_vision_skips_same_provider_retry_on_timeout` — primary is tried exactly once, then fallback.
  - `test_non_critical_task_still_retries_same_provider_on_timeout` — an ordinary task keeps its one same-provider retry, proving the change is scoped rather than blanket.

## Testing

The vision test has teeth: reverting the source change fails it while leaving the scoping test green.

`pytest tests/agent/test_auxiliary_client.py`:

- without this change: **5 failed, 180 passed**
- with this change: **5 failed, 182 passed** (the +2 are the new tests)

The 5 pre-existing failures are unrelated to this path and reproduce on a clean checkout of `main`.

One note for review: vision resolves its client through `resolve_vision_provider_client()` rather than `_get_cached_client()`, so the new test patches that instead — the retry block under test is shared by both paths.
