### PR TITLE
fix(cron): keep explicit delivery output in its target thread

### DIFF
--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -99,7 +99,9 @@ class TestBackgroundDispatch:
                  patch("cron.scheduler.run_one_job", return_value=True), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None,
-                                     "next_run_at": "2026-08-07T09:00:00"}):
+                                     "next_run_at": "2026-08-07T09:00:00"}), \
+                 patch("tools.cronjob_tools._latest_job_output_excerpt",
+                       return_value="LOCAL JOB PAYLOAD"):
                 res = _try_dispatch_background_run(_job('job-bg-02'))
                 assert res["dispatched"] is True
 
@@ -121,6 +123,55 @@ class TestBackgroundDispatch:
         assert found["status"] == "completed"
         assert "bg run" in (found.get("summary") or "")
         assert "Next scheduled run" in found["summary"]
+        assert "LOCAL JOB PAYLOAD" in found["summary"]
+
+    def test_external_delivery_completion_does_not_echo_job_output(self):
+        """A manual run's completion returns to the invoking session, which may
+        be unrelated to the job's explicit destination. Once the scheduler has
+        delivered externally, the completion must report status without copying
+        the payload into that other session.
+        """
+        import time
+
+        from tools.process_registry import process_registry
+
+        job = {
+            **_job("job-bg-explicit-target"),
+            "deliver": "telegram:170829464:539316",
+        }
+        with _bound_session_key("agent:main:telegram:dm:170829464:581299"):
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire",
+                return_value={**job, "fire_claim": {"by": "bg-owner"}},
+            ), patch(
+                "cron.scheduler.run_one_job", return_value=True
+            ), patch(
+                "tools.cronjob_tools.get_job",
+                return_value={"last_status": "ok", "last_error": None},
+            ), patch(
+                "tools.cronjob_tools._latest_job_output_excerpt",
+                return_value="PAYLOAD FOR THREAD 539316",
+            ):
+                res = _try_dispatch_background_run(job)
+                assert res["dispatched"] is True
+
+                found = None
+                for _ in range(100):
+                    try:
+                        evt = process_registry.completion_queue.get_nowait()
+                    except Exception:
+                        time.sleep(0.05)
+                        continue
+                    if evt.get("delegation_id") == res["delegation_id"]:
+                        found = evt
+                        break
+                    process_registry.completion_queue.put(evt)
+                    time.sleep(0.05)
+
+        assert found is not None
+        assert found["session_key"].endswith(":581299")
+        assert "Delivery target: telegram:170829464:539316" in found["summary"]
+        assert "PAYLOAD FOR THREAD 539316" not in found["summary"]
 
     def test_failed_run_reports_error_status_in_event(self):
         import time

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1353,10 +1353,15 @@ def _try_dispatch_background_run(
         ]
         if refreshed.get("next_run_at"):
             lines.append(f"Next scheduled run: {refreshed['next_run_at']}")
-        excerpt = _latest_job_output_excerpt(job_id)
-        if excerpt:
-            lines.append("--- JOB OUTPUT ---")
-            lines.append(excerpt)
+        # This completion re-enters the session that invoked action='run', not
+        # the job's delivery target. Repeating an externally delivered payload
+        # here leaks it into a second, potentially unrelated chat/thread. Local
+        # jobs have no other user-facing destination, so retain their excerpt.
+        if deliver == "local":
+            excerpt = _latest_job_output_excerpt(job_id)
+            if excerpt:
+                lines.append("--- JOB OUTPUT ---")
+                lines.append(excerpt)
         return {
             "status": "completed" if res.get("success") else "error",
             "summary": "\n".join(lines),


### PR DESCRIPTION
## What does this PR do?

Manual `cronjob(action="run")` completions no longer copy an externally delivered job payload into the session that invoked the run. An explicit Telegram target such as `telegram:<chat_id>:<thread_id>` now remains the only chat receiving the payload, while the invoking session receives status and target details only.

### Symptom

A job configured for one Telegram thread could appear to deliver its output into another active thread after a manual run.

### Impact

Externally delivered cron output was duplicated into the invoking session. When that session belonged to another thread, the duplicate exposed the payload in the wrong conversation and made the explicit target appear to have been ignored.

### Bug Cause

**Trigger:** `tools/cronjob_tools.py:1356` / `_try_dispatch_background_run()` completion runner

**Causal chain:**
1. `cronjob(action="run")` dispatches the job asynchronously and captures the invoking session as the completion return address.
2. The scheduler delivers the payload to the job's configured target, but the completion runner always appends the saved job-output excerpt to its status summary.
3. The completion summary re-enters the invoking session, copying the payload into a second Telegram thread unrelated to the configured target.

**Why it is wrong:** The background completion and the job delivery have different routing contracts. Completion status belongs to the invoker, but externally delivered content belongs only to the configured target.

**Working sibling / contrast:** `deliver="local"` jobs have no external user-facing destination, so their completion continues to include the saved output excerpt.

**Ruled out:** Explicit Telegram target parsing already resolves `telegram:<chat_id>:<thread_id>` to the exact chat and thread, and the existing scheduler routing regression test remains green. The cross-thread copy occurs after delivery in the manual-run completion path.

### Fix

Only attach the saved output excerpt to a manual-run completion when `deliver="local"`. External targets still report completion status and the exact destination without repeating the payload. A queue-level regression test models distinct target and invoking Telegram threads and verifies that only status returns to the invoker.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/cronjob_tools.py` - keep externally delivered payloads out of manual-run completion summaries.
- `tests/tools/test_cronjob_run_background.py` - cover distinct Telegram target/invoker threads and preserve local-only excerpts.

## How to Test

1. Configure a cron job with `deliver="telegram:<chat_id>:<thread_A_id>"`.
2. Trigger it with `cronjob(action="run")` from thread B.
3. Verify thread A receives the job payload and thread B receives completion status without a copy of the payload.
4. Run the automated coverage:

```bash
scripts/run_tests.sh tests/tools/test_cronjob_run_background.py -q
scripts/run_tests.sh tests/cron/test_scheduler.py -k 'unresolved_target_still_delivered_as_written or live_adapter_forum_topic_in_private_chat_routes_via_message_thread_id' -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

The targeted test file passes 14 tests. The explicit Telegram scheduler routing regression also passes.
