### PR TITLE
feat(image-gen): add direct Gemini backend

### DIFF
--- a/plugins/image_gen/gemini/__init__.py
+++ b/plugins/image_gen/gemini/__init__.py
@@ -281,7 +281,7 @@ class GeminiImageGenProvider(ImageGenProvider):
             response = requests.post(
                 endpoint,
                 params={"key": api_key},
-                headers={"Content-Type": "application/json"},
+                headers={"x-goog-api-key": api_key, "Content-Type": "application/json"},
                 json=payload,
                 timeout=timeout,
             )

--- a/plugins/image_gen/gemini/__init__.py
+++ b/plugins/image_gen/gemini/__init__.py
@@ -40,16 +40,29 @@ _ASPECT_RATIOS = {
     "portrait": "9:16",
 }
 _MODELS: Dict[str, Dict[str, str]] = {
-    "gemini-3-pro-image-preview": {
+    "gemini-3.1-flash-lite-image": {
+        "display": "Nano Banana 2 Lite (Gemini 3.1 Flash Lite Image)",
+        "speed": "fast",
+        "strengths": "Lowest latency and cost; efficient image generation and editing",
+    },
+    "gemini-3.1-flash-image": {
+        "display": "Nano Banana 2 (Gemini 3.1 Flash Image)",
+        "speed": "balanced",
+        "strengths": "General-purpose generation, 4K output, and multi-reference editing",
+    },
+    "gemini-3-pro-image": {
         "display": "Nano Banana Pro (Gemini 3 Pro Image)",
-        "speed": "~30s",
-        "strengths": "Highest fidelity, prompt adherence, and image editing",
+        "speed": "premium",
+        "strengths": "Highest fidelity, reasoning, 4K output, and search grounding",
     },
     "gemini-2.5-flash-image": {
         "display": "Nano Banana (Gemini 2.5 Flash Image)",
-        "speed": "~10s",
-        "strengths": "Fast generation and image editing",
+        "speed": "fast",
+        "strengths": "Legacy fast generation and image editing",
     },
+}
+_MODEL_REFERENCE_LIMITS = {
+    "gemini-2.5-flash-image": 3,
 }
 
 
@@ -91,7 +104,9 @@ def _resolve_model(explicit: Optional[str] = None) -> str:
 def _api_key() -> Optional[str]:
     """Return the direct Google key, keeping the text-provider precedence."""
     try:
-        return (get_secret("GOOGLE_API_KEY") or get_secret("GEMINI_API_KEY") or "").strip() or None
+        return (
+            get_secret("GOOGLE_API_KEY") or get_secret("GEMINI_API_KEY") or ""
+        ).strip() or None
     except Exception as exc:  # noqa: BLE001 - scoped-secret failures are auth failures
         logger.debug("Google AI Studio credential lookup failed: %s", exc)
         return None
@@ -107,8 +122,12 @@ def _load_reference_image(reference: str) -> Tuple[bytes, str]:
 
         response = requests.get(reference, timeout=60)
         response.raise_for_status()
-        content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip()
-        return response.content, content_type if content_type.startswith("image/") else "image/png"
+        content_type = (
+            (response.headers.get("Content-Type") or "").split(";", 1)[0].strip()
+        )
+        return response.content, content_type if content_type.startswith(
+            "image/"
+        ) else "image/png"
 
     if lower.startswith("data:"):
         header, separator, encoded = reference.partition(",")
@@ -233,7 +252,8 @@ class GeminiImageGenProvider(ImageGenProvider):
         if isinstance(image_url, str) and image_url.strip():
             sources.append(image_url.strip())
         sources.extend(normalize_reference_images(reference_image_urls) or [])
-        sources = sources[:_MAX_REFERENCE_IMAGES]
+        reference_limit = _MODEL_REFERENCE_LIMITS.get(model, _MAX_REFERENCE_IMAGES)
+        sources = sources[:reference_limit]
 
         parts: List[Dict[str, Any]] = [{"text": prompt}]
         for source in sources:
@@ -248,32 +268,25 @@ class GeminiImageGenProvider(ImageGenProvider):
                     prompt=prompt,
                     aspect_ratio=aspect,
                 )
-            parts.append(
-                {
-                    "inlineData": {
-                        "mimeType": mime,
-                        "data": base64.b64encode(data).decode("ascii"),
-                    }
+            parts.append({
+                "inlineData": {
+                    "mimeType": mime,
+                    "data": base64.b64encode(data).decode("ascii"),
                 }
-            )
+            })
 
         payload = {
             "contents": [{"role": "user", "parts": parts}],
             "generationConfig": {
                 "responseModalities": ["TEXT", "IMAGE"],
                 "imageConfig": {"aspectRatio": _ASPECT_RATIOS[aspect]},
-                "imageConfig": {"aspectRatio": _ASPECT_RATIOS[aspect]},
             },
         }
-        timeout = kwargs.get("timeout", 120)
         timeout = kwargs.get("timeout", 180)
         try:
             timeout = max(1.0, float(timeout))
         except (TypeError, ValueError):
             timeout = 180
-            timeout = max(1.0, float(timeout))
-        except (TypeError, ValueError):
-            timeout = 120
 
         endpoint = f"{BASE_URL}/models/{quote(model, safe='')}:generateContent"
         try:
@@ -281,7 +294,6 @@ class GeminiImageGenProvider(ImageGenProvider):
 
             response = requests.post(
                 endpoint,
-                params={"key": api_key},
                 headers={"x-goog-api-key": api_key, "Content-Type": "application/json"},
                 json=payload,
                 timeout=timeout,
@@ -333,11 +345,14 @@ class GeminiImageGenProvider(ImageGenProvider):
 
         image_data = None
         image_mime = "image/png"
+        response_text: List[str] = []
         candidates = body.get("candidates") if isinstance(body, dict) else None
         for candidate in candidates if isinstance(candidates, list) else []:
             content = candidate.get("content") if isinstance(candidate, dict) else None
             response_parts = content.get("parts") if isinstance(content, dict) else None
             for part in response_parts if isinstance(response_parts, list) else []:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    response_text.append(part["text"].strip())
                 inline = part.get("inlineData") if isinstance(part, dict) else None
                 if isinstance(inline, dict) and isinstance(inline.get("data"), str):
                     image_data = inline["data"]
@@ -347,8 +362,12 @@ class GeminiImageGenProvider(ImageGenProvider):
                 break
 
         if not image_data:
+            detail = " ".join(text for text in response_text if text)
+            message = "Google AI Studio returned no inline image data"
+            if detail:
+                message = f"{message}: {detail}"
             return error_response(
-                error="Google AI Studio returned no inline image data",
+                error=message,
                 error_type="empty_response",
                 provider=self.name,
                 model=model,

--- a/plugins/image_gen/gemini/__init__.py
+++ b/plugins/image_gen/gemini/__init__.py
@@ -265,7 +265,11 @@ class GeminiImageGenProvider(ImageGenProvider):
             },
         }
         timeout = kwargs.get("timeout", 120)
+        timeout = kwargs.get("timeout", 180)
         try:
+            timeout = max(1.0, float(timeout))
+        except (TypeError, ValueError):
+            timeout = 180
             timeout = max(1.0, float(timeout))
         except (TypeError, ValueError):
             timeout = 120

--- a/plugins/image_gen/gemini/__init__.py
+++ b/plugins/image_gen/gemini/__init__.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 DEFAULT_MODEL = "gemini-3-pro-image-preview"
-_MAX_REFERENCE_IMAGES = 3
+_MAX_REFERENCE_IMAGES = 14
 _ASPECT_RATIOS = {
     "landscape": "16:9",
     "square": "1:1",

--- a/plugins/image_gen/gemini/__init__.py
+++ b/plugins/image_gen/gemini/__init__.py
@@ -260,7 +260,8 @@ class GeminiImageGenProvider(ImageGenProvider):
         payload = {
             "contents": [{"role": "user", "parts": parts}],
             "generationConfig": {
-                "responseModalities": ["IMAGE"],
+                "responseModalities": ["TEXT", "IMAGE"],
+                "imageConfig": {"aspectRatio": _ASPECT_RATIOS[aspect]},
                 "imageConfig": {"aspectRatio": _ASPECT_RATIOS[aspect]},
             },
         }

--- a/plugins/image_gen/gemini/__init__.py
+++ b/plugins/image_gen/gemini/__init__.py
@@ -32,7 +32,7 @@ from agent.secret_scope import get_secret
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
-DEFAULT_MODEL = "gemini-3-pro-image-preview"
+DEFAULT_MODEL = "gemini-3.1-flash-image"
 _MAX_REFERENCE_IMAGES = 14
 _ASPECT_RATIOS = {
     "landscape": "16:9",

--- a/plugins/image_gen/gemini/__init__.py
+++ b/plugins/image_gen/gemini/__init__.py
@@ -1,0 +1,388 @@
+"""Native Google AI Studio image generation backend.
+
+This backend calls Gemini's ``generateContent`` REST API directly with a
+``GOOGLE_API_KEY`` or ``GEMINI_API_KEY``. It intentionally does not depend on
+FAL, OpenRouter, or the Gemini text provider's OpenAI-compatible transport.
+Generated inline image data is materialized under Hermes' image cache so the
+rest of the image-generation pipeline sees the same stable path as other
+providers.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    normalize_reference_images,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+from agent.secret_scope import get_secret
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_MODEL = "gemini-3-pro-image-preview"
+_MAX_REFERENCE_IMAGES = 3
+_ASPECT_RATIOS = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+}
+_MODELS: Dict[str, Dict[str, str]] = {
+    "gemini-3-pro-image-preview": {
+        "display": "Nano Banana Pro (Gemini 3 Pro Image)",
+        "speed": "~30s",
+        "strengths": "Highest fidelity, prompt adherence, and image editing",
+    },
+    "gemini-2.5-flash-image": {
+        "display": "Nano Banana (Gemini 2.5 Flash Image)",
+        "speed": "~10s",
+        "strengths": "Fast generation and image editing",
+    },
+}
+
+
+def _load_image_gen_config() -> Dict[str, Any]:
+    """Read ``image_gen`` from config.yaml without making configuration fatal."""
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        section = config.get("image_gen") if isinstance(config, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:  # noqa: BLE001 - config is best effort
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+def _resolve_model(explicit: Optional[str] = None) -> str:
+    """Resolve the model: call override, env, scoped config, global config."""
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+
+    env_model = os.environ.get("GEMINI_IMAGE_MODEL", "").strip()
+    if env_model:
+        return env_model
+
+    config = _load_image_gen_config()
+    scoped = config.get("gemini")
+    if isinstance(scoped, dict):
+        model = scoped.get("model")
+        if isinstance(model, str) and model.strip():
+            return model.strip()
+
+    model = config.get("model")
+    if isinstance(model, str) and model.strip():
+        return model.strip()
+    return DEFAULT_MODEL
+
+
+def _api_key() -> Optional[str]:
+    """Return the direct Google key, keeping the text-provider precedence."""
+    try:
+        return (get_secret("GOOGLE_API_KEY") or get_secret("GEMINI_API_KEY") or "").strip() or None
+    except Exception as exc:  # noqa: BLE001 - scoped-secret failures are auth failures
+        logger.debug("Google AI Studio credential lookup failed: %s", exc)
+        return None
+
+
+def _load_reference_image(reference: str) -> Tuple[bytes, str]:
+    """Load a URL, data URI, or safe local path as ``(bytes, mime_type)``."""
+    reference = reference.strip()
+    lower = reference.lower()
+
+    if lower.startswith(("http://", "https://")):
+        import requests
+
+        response = requests.get(reference, timeout=60)
+        response.raise_for_status()
+        content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip()
+        return response.content, content_type if content_type.startswith("image/") else "image/png"
+
+    if lower.startswith("data:"):
+        header, separator, encoded = reference.partition(",")
+        if not separator:
+            raise ValueError("image data URI is missing its payload")
+        mime = header[5:].split(";", 1)[0].strip() or "image/png"
+        return base64.b64decode(encoded, validate=True), mime
+
+    from agent.file_safety import raise_if_read_blocked
+
+    raise_if_read_blocked(reference)
+    path = Path(reference)
+    data = path.read_bytes()
+    mime = mimetypes.guess_type(path.name)[0] or "image/png"
+    return data, mime if mime.startswith("image/") else "image/png"
+
+
+def _error_message(response: Any) -> str:
+    try:
+        body = response.json()
+        error = body.get("error") if isinstance(body, dict) else None
+        if isinstance(error, dict) and error.get("message"):
+            return str(error["message"])
+        if isinstance(body, dict) and body.get("message"):
+            return str(body["message"])
+    except Exception:
+        pass
+    return getattr(response, "reason", None) or "unknown Google AI Studio error"
+
+
+class GeminiImageGenProvider(ImageGenProvider):
+    """Direct Gemini image generation through Google AI Studio."""
+
+    @property
+    def name(self) -> str:
+        return "gemini"
+
+    @property
+    def display_name(self) -> str:
+        return "Google AI Studio"
+
+    def is_available(self) -> bool:
+        return _api_key() is not None
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": metadata["display"],
+                "speed": metadata["speed"],
+                "strengths": metadata["strengths"],
+                "price": "varies",
+            }
+            for model_id, metadata in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {
+            "modalities": ["text", "image"],
+            "max_reference_images": _MAX_REFERENCE_IMAGES,
+        }
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Google AI Studio (direct)",
+            "badge": "API key",
+            "tag": "Native Gemini image generation with GOOGLE_API_KEY or GEMINI_API_KEY",
+            "env_vars": [
+                {
+                    "key": "GOOGLE_API_KEY",
+                    "prompt": "Google AI Studio API key",
+                    "url": "https://aistudio.google.com/apikey",
+                },
+                {
+                    "key": "GEMINI_API_KEY",
+                    "prompt": "Gemini API key (alternative)",
+                    "url": "https://aistudio.google.com/apikey",
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        *,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        model = _resolve_model(kwargs.get("model"))
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider=self.name,
+                model=model,
+                aspect_ratio=aspect,
+            )
+
+        api_key = _api_key()
+        if not api_key:
+            return error_response(
+                error=(
+                    "GOOGLE_API_KEY or GEMINI_API_KEY not set. Run `hermes tools` "
+                    "→ Image Generation → Google AI Studio to configure it."
+                ),
+                error_type="auth_required",
+                provider=self.name,
+                model=model,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        sources: List[str] = []
+        if isinstance(image_url, str) and image_url.strip():
+            sources.append(image_url.strip())
+        sources.extend(normalize_reference_images(reference_image_urls) or [])
+        sources = sources[:_MAX_REFERENCE_IMAGES]
+
+        parts: List[Dict[str, Any]] = [{"text": prompt}]
+        for source in sources:
+            try:
+                data, mime = _load_reference_image(source)
+            except Exception as exc:  # noqa: BLE001 - stable tool error
+                return error_response(
+                    error=f"Could not load reference image for editing: {exc}",
+                    error_type="io_error",
+                    provider=self.name,
+                    model=model,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            parts.append(
+                {
+                    "inlineData": {
+                        "mimeType": mime,
+                        "data": base64.b64encode(data).decode("ascii"),
+                    }
+                }
+            )
+
+        payload = {
+            "contents": [{"role": "user", "parts": parts}],
+            "generationConfig": {
+                "responseModalities": ["IMAGE"],
+                "imageConfig": {"aspectRatio": _ASPECT_RATIOS[aspect]},
+            },
+        }
+        timeout = kwargs.get("timeout", 120)
+        try:
+            timeout = max(1.0, float(timeout))
+        except (TypeError, ValueError):
+            timeout = 120
+
+        endpoint = f"{BASE_URL}/models/{quote(model, safe='')}:generateContent"
+        try:
+            import requests
+
+            response = requests.post(
+                endpoint,
+                params={"key": api_key},
+                headers={"Content-Type": "application/json"},
+                json=payload,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            response = exc.response
+            status = response.status_code if response is not None else 0
+            message = _error_message(response) if response is not None else str(exc)
+            error_type = "auth_error" if status in (401, 403) else "api_error"
+            return error_response(
+                error=f"Google AI Studio image generation failed ({status}): {message}",
+                error_type=error_type,
+                provider=self.name,
+                model=model,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.Timeout:
+            return error_response(
+                error=f"Google AI Studio image generation timed out ({int(timeout)}s)",
+                error_type="timeout",
+                provider=self.name,
+                model=model,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.RequestException as exc:
+            return error_response(
+                error=f"Google AI Studio request failed: {exc}",
+                error_type="api_error",
+                provider=self.name,
+                model=model,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            body = response.json()
+        except Exception as exc:  # noqa: BLE001
+            return error_response(
+                error=f"Google AI Studio returned invalid JSON: {exc}",
+                error_type="invalid_response",
+                provider=self.name,
+                model=model,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        image_data = None
+        image_mime = "image/png"
+        candidates = body.get("candidates") if isinstance(body, dict) else None
+        for candidate in candidates if isinstance(candidates, list) else []:
+            content = candidate.get("content") if isinstance(candidate, dict) else None
+            response_parts = content.get("parts") if isinstance(content, dict) else None
+            for part in response_parts if isinstance(response_parts, list) else []:
+                inline = part.get("inlineData") if isinstance(part, dict) else None
+                if isinstance(inline, dict) and isinstance(inline.get("data"), str):
+                    image_data = inline["data"]
+                    image_mime = str(inline.get("mimeType") or image_mime)
+                    break
+            if image_data:
+                break
+
+        if not image_data:
+            return error_response(
+                error="Google AI Studio returned no inline image data",
+                error_type="empty_response",
+                provider=self.name,
+                model=model,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        extension = {
+            "image/jpeg": "jpg",
+            "image/webp": "webp",
+            "image/gif": "gif",
+        }.get(image_mime.lower(), "png")
+        try:
+            image_path = save_b64_image(
+                image_data,
+                prefix=f"gemini_{model.replace('/', '_')}",
+                extension=extension,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return error_response(
+                error=f"Could not save generated image: {exc}",
+                error_type="io_error",
+                provider=self.name,
+                model=model,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        return success_response(
+            image=str(image_path),
+            model=model,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider=self.name,
+            modality="image" if sources else "text",
+            extra={"api": "google-ai-studio"},
+        )
+
+
+def register(ctx: Any) -> None:
+    """Register the direct Google AI Studio provider."""
+    ctx.register_image_gen_provider(GeminiImageGenProvider())

--- a/plugins/image_gen/gemini/plugin.yaml
+++ b/plugins/image_gen/gemini/plugin.yaml
@@ -1,0 +1,5 @@
+name: gemini-image-gen
+kind: backend
+version: 1.0.0
+description: Native Google AI Studio Gemini image generation using GOOGLE_API_KEY or GEMINI_API_KEY.
+author: Nous Research

--- a/tests/plugins/image_gen/test_gemini_provider.py
+++ b/tests/plugins/image_gen/test_gemini_provider.py
@@ -35,24 +35,22 @@ def _tmp_hermes_home(tmp_path, monkeypatch):
 
 
 def _image_response(data: bytes = b"image-bytes"):
-    return _Response(
-        {
-            "candidates": [
-                {
-                    "content": {
-                        "parts": [
-                            {
-                                "inlineData": {
-                                    "mimeType": "image/png",
-                                    "data": base64.b64encode(data).decode("ascii"),
-                                }
+    return _Response({
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "inlineData": {
+                                "mimeType": "image/png",
+                                "data": base64.b64encode(data).decode("ascii"),
                             }
-                        ]
-                    }
+                        }
+                    ]
                 }
-            ]
-        }
-    )
+            }
+        ]
+    })
 
 
 def test_metadata_and_setup_schema():
@@ -60,14 +58,15 @@ def test_metadata_and_setup_schema():
 
     assert provider.name == "gemini"
     assert provider.display_name == "Google AI Studio"
-    assert provider.default_model() == "gemini-3-pro-image-preview"
-    assert {item["id"] for item in provider.list_models()} == {
-        "gemini-3-pro-image-preview",
-        "gemini-2.5-flash-image",
-    }
+    models = provider.list_models()
+    assert provider.default_model() == gemini_plugin.DEFAULT_MODEL
+    assert gemini_plugin.DEFAULT_MODEL in {item["id"] for item in models}
+    assert all(
+        {"id", "display", "speed", "strengths", "price"} <= set(item) for item in models
+    )
     assert provider.capabilities() == {
         "modalities": ["text", "image"],
-        "max_reference_images": 3,
+        "max_reference_images": 14,
     }
     assert [item["key"] for item in provider.get_setup_schema()["env_vars"]] == [
         "GOOGLE_API_KEY",
@@ -89,7 +88,9 @@ def test_model_precedence(monkeypatch):
     monkeypatch.delenv("GEMINI_IMAGE_MODEL")
     assert gemini_plugin._resolve_model() == "from-config"
 
-    monkeypatch.setattr(gemini_plugin, "_load_image_gen_config", lambda: {"model": "from-top-level"})
+    monkeypatch.setattr(
+        gemini_plugin, "_load_image_gen_config", lambda: {"model": "from-top-level"}
+    )
     assert gemini_plugin._resolve_model() == "from-top-level"
 
 
@@ -115,19 +116,15 @@ def test_generate_posts_native_gemini_payload_and_caches_inline_image(
     assert Path(result["image"]).read_bytes() == b"image-bytes"
 
     post.assert_called_once()
-    endpoint, = post.call_args.args
+    (endpoint,) = post.call_args.args
     assert endpoint.endswith("/models/gemini-2.5-flash-image:generateContent")
-    assert post.call_args.kwargs["params"] == {"key": "google-test-key"}
+    assert "params" not in post.call_args.kwargs
     assert post.call_args.kwargs["headers"]["x-goog-api-key"] == "google-test-key"
+    assert post.call_args.kwargs["headers"]["Content-Type"] == "application/json"
     payload = post.call_args.kwargs["json"]
     assert payload["contents"] == [{"role": "user", "parts": [{"text": "a red kite"}]}]
     assert payload["generationConfig"] == {
         "responseModalities": ["TEXT", "IMAGE"],
-        "imageConfig": {"aspectRatio": "9:16"},
-    }
-    assert payload["contents"] == [{"role": "user", "parts": [{"text": "a red kite"}]}]
-    assert payload["generationConfig"] == {
-        "responseModalities": ["IMAGE"],
         "imageConfig": {"aspectRatio": "9:16"},
     }
 
@@ -150,6 +147,60 @@ def test_generate_inlines_reference_image(monkeypatch, tmp_path):
     assert parts[0] == {"text": "make it snowy"}
     assert parts[1]["inlineData"]["mimeType"] == "image/png"
     assert base64.b64decode(parts[1]["inlineData"]["data"]) == b"reference"
+
+
+def test_generate_respects_legacy_model_reference_limit(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-test-key")
+    reference = "data:image/png;base64," + base64.b64encode(b"reference").decode(
+        "ascii"
+    )
+    post = MagicMock(return_value=_image_response())
+
+    with patch("requests.post", post):
+        result = gemini_plugin.GeminiImageGenProvider().generate(
+            "combine these references",
+            model="gemini-2.5-flash-image",
+            reference_image_urls=[reference] * 5,
+        )
+
+    assert result["success"] is True
+    parts = post.call_args.kwargs["json"]["contents"][0]["parts"]
+    assert len(parts) == 4
+
+
+def test_empty_response_includes_model_text(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-test-key")
+    response = _Response({
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": "The request was blocked by safety filters."}]
+                },
+                "finishReason": "SAFETY",
+            }
+        ]
+    })
+
+    with patch("requests.post", MagicMock(return_value=response)):
+        result = gemini_plugin.GeminiImageGenProvider().generate("a disallowed image")
+
+    assert result["success"] is False
+    assert result["error_type"] == "empty_response"
+    assert "safety filters" in result["error"]
+
+
+def test_invalid_json_response_returns_error(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-test-key")
+
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("not json")
+
+    with patch("requests.post", MagicMock(return_value=response)):
+        result = gemini_plugin.GeminiImageGenProvider().generate("a cat")
+
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_response"
 
 
 def test_missing_key_returns_auth_error(monkeypatch):

--- a/tests/plugins/image_gen/test_gemini_provider.py
+++ b/tests/plugins/image_gen/test_gemini_provider.py
@@ -118,7 +118,13 @@ def test_generate_posts_native_gemini_payload_and_caches_inline_image(
     endpoint, = post.call_args.args
     assert endpoint.endswith("/models/gemini-2.5-flash-image:generateContent")
     assert post.call_args.kwargs["params"] == {"key": "google-test-key"}
+    assert post.call_args.kwargs["headers"]["x-goog-api-key"] == "google-test-key"
     payload = post.call_args.kwargs["json"]
+    assert payload["contents"] == [{"role": "user", "parts": [{"text": "a red kite"}]}]
+    assert payload["generationConfig"] == {
+        "responseModalities": ["TEXT", "IMAGE"],
+        "imageConfig": {"aspectRatio": "9:16"},
+    }
     assert payload["contents"] == [{"role": "user", "parts": [{"text": "a red kite"}]}]
     assert payload["generationConfig"] == {
         "responseModalities": ["IMAGE"],

--- a/tests/plugins/image_gen/test_gemini_provider.py
+++ b/tests/plugins/image_gen/test_gemini_provider.py
@@ -1,0 +1,153 @@
+"""Tests for the native Google AI Studio image-generation plugin."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import plugins.image_gen.gemini as gemini_plugin
+
+
+class _Response:
+    status_code = 200
+    reason = "OK"
+
+    def __init__(self, body):
+        self._body = body
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._body
+
+
+@pytest.fixture(autouse=True)
+def _tmp_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_IMAGE_MODEL", raising=False)
+    yield tmp_path
+
+
+def _image_response(data: bytes = b"image-bytes"):
+    return _Response(
+        {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inlineData": {
+                                    "mimeType": "image/png",
+                                    "data": base64.b64encode(data).decode("ascii"),
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    )
+
+
+def test_metadata_and_setup_schema():
+    provider = gemini_plugin.GeminiImageGenProvider()
+
+    assert provider.name == "gemini"
+    assert provider.display_name == "Google AI Studio"
+    assert provider.default_model() == "gemini-3-pro-image-preview"
+    assert {item["id"] for item in provider.list_models()} == {
+        "gemini-3-pro-image-preview",
+        "gemini-2.5-flash-image",
+    }
+    assert provider.capabilities() == {
+        "modalities": ["text", "image"],
+        "max_reference_images": 3,
+    }
+    assert [item["key"] for item in provider.get_setup_schema()["env_vars"]] == [
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+    ]
+
+
+def test_model_precedence(monkeypatch):
+    monkeypatch.setenv("GEMINI_IMAGE_MODEL", "from-env")
+    monkeypatch.setattr(
+        gemini_plugin,
+        "_load_image_gen_config",
+        lambda: {"gemini": {"model": "from-config"}, "model": "from-top-level"},
+    )
+
+    assert gemini_plugin._resolve_model("from-call") == "from-call"
+    assert gemini_plugin._resolve_model() == "from-env"
+
+    monkeypatch.delenv("GEMINI_IMAGE_MODEL")
+    assert gemini_plugin._resolve_model() == "from-config"
+
+    monkeypatch.setattr(gemini_plugin, "_load_image_gen_config", lambda: {"model": "from-top-level"})
+    assert gemini_plugin._resolve_model() == "from-top-level"
+
+
+def test_generate_posts_native_gemini_payload_and_caches_inline_image(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-test-key")
+    response = _image_response()
+    post = MagicMock(return_value=response)
+
+    with patch("requests.post", post):
+        result = gemini_plugin.GeminiImageGenProvider().generate(
+            "a red kite",
+            aspect_ratio="portrait",
+            model="gemini-2.5-flash-image",
+        )
+
+    assert result["success"] is True
+    assert result["provider"] == "gemini"
+    assert result["model"] == "gemini-2.5-flash-image"
+    assert result["aspect_ratio"] == "portrait"
+    assert result["modality"] == "text"
+    assert Path(result["image"]).read_bytes() == b"image-bytes"
+
+    post.assert_called_once()
+    endpoint, = post.call_args.args
+    assert endpoint.endswith("/models/gemini-2.5-flash-image:generateContent")
+    assert post.call_args.kwargs["params"] == {"key": "google-test-key"}
+    payload = post.call_args.kwargs["json"]
+    assert payload["contents"] == [{"role": "user", "parts": [{"text": "a red kite"}]}]
+    assert payload["generationConfig"] == {
+        "responseModalities": ["IMAGE"],
+        "imageConfig": {"aspectRatio": "9:16"},
+    }
+
+
+def test_generate_inlines_reference_image(monkeypatch, tmp_path):
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    reference = tmp_path / "reference.png"
+    reference.write_bytes(b"reference")
+    post = MagicMock(return_value=_image_response())
+
+    with patch("requests.post", post):
+        result = gemini_plugin.GeminiImageGenProvider().generate(
+            "make it snowy",
+            image_url=str(reference),
+        )
+
+    assert result["success"] is True
+    assert result["modality"] == "image"
+    parts = post.call_args.kwargs["json"]["contents"][0]["parts"]
+    assert parts[0] == {"text": "make it snowy"}
+    assert parts[1]["inlineData"]["mimeType"] == "image/png"
+    assert base64.b64decode(parts[1]["inlineData"]["data"]) == b"reference"
+
+
+def test_missing_key_returns_auth_error(monkeypatch):
+    result = gemini_plugin.GeminiImageGenProvider().generate("a cat")
+
+    assert result["success"] is False
+    assert result["error_type"] == "auth_required"

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -51,8 +51,10 @@ The direct backend offers these models:
 
 | Model | Strengths |
 |---|---|
-| `gemini-3-pro-image-preview` | Nano Banana Pro; highest fidelity and editing |
-| `gemini-2.5-flash-image` | Nano Banana; faster generation and editing |
+| `gemini-3.1-flash-lite-image` | Nano Banana 2 Lite; lowest latency and cost; 1K output |
+| `gemini-3.1-flash-image` | Nano Banana 2; balanced quality, speed, 4K output, and multi-reference editing |
+| `gemini-3-pro-image` | Nano Banana Pro; highest fidelity, reasoning, 4K output, and search grounding |
+| `gemini-2.5-flash-image` | Legacy Nano Banana; fast generation and editing |
 
 The selection is stored as:
 
@@ -60,7 +62,7 @@ The selection is stored as:
 image_gen:
   provider: gemini
   gemini:
-    model: gemini-3-pro-image-preview
+    model: gemini-3.1-flash-image
 ```
 
 You can override the model for scripts with `GEMINI_IMAGE_MODEL`.
@@ -175,7 +177,7 @@ Two inputs drive the edit:
 | **Krea** (`Krea 2`) | ✓ | up to 10 | reference-guided generation (`image_style_references`) |
 | **OpenAI (Codex auth)** | ✓ | up to 16 | Codex Responses `image_generation` tool with `input_image` content parts |
 | **OpenRouter** (Image API models) | ✓ | up to 14–16 (per model) | `input_references` on `POST /images/generations`; chat-served models use `image_url` content parts (up to 3) |
-| **Google AI Studio** (Gemini image models) | ✓ | up to 3 | Native Gemini `generateContent` with `inlineData` image parts |
+| **Google AI Studio** (Gemini image models) | ✓ | up to 14 (up to 3 on Gemini 2.5) | Native Gemini `generateContent` with `inlineData` image parts |
 
 FAL models with an editing endpoint: `flux-2/klein/9b`, `flux-2-pro`,
 `nano-banana-pro`, `gpt-image-1.5`, `gpt-image-2`, `ideogram/v3`, and

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -40,6 +40,31 @@ If the managed gateway returns `HTTP 4xx` for a specific model, that model isn't
 1. Sign up at [fal.ai](https://fal.ai/)
 2. Generate an API key from your dashboard
 
+### Google AI Studio (direct)
+
+If you have a Google AI Studio key, Hermes can call Gemini's native image
+endpoint directly — no FAL, OpenRouter, or Nous Portal account is required.
+Set either `GOOGLE_API_KEY` or `GEMINI_API_KEY`, then choose **Google AI
+Studio (direct)** under **🎨 Image Generation** in `hermes tools`.
+
+The direct backend offers these models:
+
+| Model | Strengths |
+|---|---|
+| `gemini-3-pro-image-preview` | Nano Banana Pro; highest fidelity and editing |
+| `gemini-2.5-flash-image` | Nano Banana; faster generation and editing |
+
+The selection is stored as:
+
+```yaml
+image_gen:
+  provider: gemini
+  gemini:
+    model: gemini-3-pro-image-preview
+```
+
+You can override the model for scripts with `GEMINI_IMAGE_MODEL`.
+
 ### Configure and Pick a Model
 
 Run the tools command:
@@ -67,7 +92,7 @@ image_gen:
   max_parallel_requests: 4      # concurrent images in one tool-call batch
 ```
 
-`image_gen.provider` is the single selection key: `nous` routes through the managed Tool Gateway; a vendor name (`fal`, `openai`, `xai`, `krea`, ...) goes direct with your own key. The runtime always follows this stored selection — a `FAL_KEY` in `.env` is ignored while `provider: nous`, and `provider: fal` without `FAL_KEY` errors with `image_gen is configured to use fal (set via hermes tools), but FAL_KEY is not set. Run 'hermes tools' to change it.` rather than silently rerouting. Change providers via `hermes tools`, not by adding/removing keys. (The old `use_gateway` boolean is legacy — still read as `nous` when `true`, but never written anymore.)
+`image_gen.provider` is the single selection key: `nous` routes through the managed Tool Gateway; a vendor name (`fal`, `gemini`, `openai`, `xai`, `krea`, ...) goes direct with your own key. The runtime always follows this stored selection — a `FAL_KEY` in `.env` is ignored while `provider: nous`, and `provider: fal` without `FAL_KEY` errors with `image_gen is configured to use fal (set via hermes tools), but FAL_KEY is not set. Run 'hermes tools' to change it.` rather than silently rerouting. Change providers via `hermes tools`, not by adding/removing keys. (The old `use_gateway` boolean is legacy — still read as `nous` when `true`, but never written anymore.)
 
 `max_parallel_requests` defaults to `4`. Hermes clamps it to at least one and
 to the global tool-worker limit, so image providers receive bounded parallel
@@ -150,6 +175,7 @@ Two inputs drive the edit:
 | **Krea** (`Krea 2`) | ✓ | up to 10 | reference-guided generation (`image_style_references`) |
 | **OpenAI (Codex auth)** | ✓ | up to 16 | Codex Responses `image_generation` tool with `input_image` content parts |
 | **OpenRouter** (Image API models) | ✓ | up to 14–16 (per model) | `input_references` on `POST /images/generations`; chat-served models use `image_url` content parts (up to 3) |
+| **Google AI Studio** (Gemini image models) | ✓ | up to 3 | Native Gemini `generateContent` with `inlineData` image parts |
 
 FAL models with an editing endpoint: `flux-2/klein/9b`, `flux-2-pro`,
 `nano-banana-pro`, `gpt-image-1.5`, `gpt-image-2`, `ideogram/v3`, and
@@ -256,7 +282,7 @@ Debug logs go to `./logs/image_tools_debug_<session_id>.json` with per-call deta
 
 ## Limitations
 
-- **Requires credentials** for the active backend (FAL `FAL_KEY` / Nous Subscription, `OPENAI_API_KEY`, xAI OAuth, `KREA_API_KEY`)
+- **Requires credentials** for the active backend (FAL `FAL_KEY` / Nous Subscription, Google `GOOGLE_API_KEY` or `GEMINI_API_KEY`, `OPENAI_API_KEY`, xAI OAuth, `KREA_API_KEY`)
 - **Editing is model-dependent** — image-to-image works only on edit-capable models (see the table above); text-to-image-only models reject image inputs with a clear error
 - **Temporary URLs** — backends return hosted URLs that expire after hours/days; Hermes materializes them to the local cache so delivery still works after expiry
 - **Per-model constraints** — some models don't support `seed`, `num_inference_steps`, etc. The `supports` / `edit_supports` filter silently drops unsupported params; this is expected behavior


### PR DESCRIPTION
Closes #97474

## Summary

- add a native Google AI Studio image-generation provider using GOOGLE_API_KEY or GEMINI_API_KEY
- call Gemini generateContent directly with the x-goog-api-key header instead of placing credentials in the request URL
- request both TEXT and IMAGE modalities so safety blocks and text-only responses remain diagnosable
- expose the current stable Gemini image-model catalog, including Gemini 3.1 Flash Image as the default
- enforce the legacy Gemini 2.5 reference-image limit while retaining the 14-image capability for newer Gemini image models
- support URL/data/local reference images through inlineData and cache generated base64 output under HERMES_HOME
- expose the backend and model catalog through the existing plugin/picker registry and document setup

## Validation

| Command | Result |
|---|---|
| `python -m py_compile plugins/image_gen/gemini/__init__.py tests/plugins/image_gen/test_gemini_provider.py` | Passed |
| `uv run --extra dev pytest -q tests/plugins/image_gen/test_gemini_provider.py tests/agent/test_image_gen_registry.py` | 12 passed |
| `uv run --extra dev pytest -q tests/tools/test_image_generate_schema.py` | 9 passed, 29 subtests passed |
| `uv run ruff check plugins/image_gen/gemini/__init__.py tests/plugins/image_gen/test_gemini_provider.py` | All checks passed |
| `git diff --check` | Passed |
| Fail-before regression run against the pre-fix implementation | 4 failed, 4 passed |
| Pass-after regression run | 12 passed |

The fail-before run reproduced the missing header assertion, the legacy reference-limit failure, the missing diagnostic text, and the stale catalog assertion. The pass-after run covers those cases, the registry integration, and the schema contract.

Desktop/editor and full dashboard suites were not part of this backend change; the local environment lacks some optional frontend dependencies (notably `vitest/config` and `fastapi`).