### PR TITLE
fix(desktop): recover group replies after renderer restart

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
@@ -143,8 +143,17 @@ describe('disband', () => {
     room.chat.$groupChats.set({
       Gone: { log: [{ at: 2, from: { kind: 'user', name: 'You' }, id: 'g1', text: 'hello goners' }], watermarks: {} },
       Keep: {
+        holds: { remote: { at: 7 } },
         log: [{ at: 1, from: { kind: 'user', name: 'You' }, id: 'k1', text: 'hello keepers' }],
         members: [{ connectionId: 'remote-1', name: 'remote', remoteSource: true, sourceScoped: true }],
+        stranded: {
+          remote: {
+            before: 1,
+            phase: 'submitted',
+            recoveryId: 'recovery-keep',
+            thread: 't-keep'
+          }
+        },
         watermarks: {}
       }
     } as unknown as Record<string, GroupChat>)
@@ -171,6 +180,8 @@ describe('disband', () => {
     expect('Gone' in durable(room)).toBe(false)
     expect(durable(room).Keep.members).toHaveLength(1)
     expect(durable(room).Keep.members?.[0].connectionId).toBe('remote-1')
+    expect(durable(room).Keep.stranded?.remote).toMatchObject({ recoveryId: 'recovery-keep' })
+    expect(durable(room).Keep.holds?.remote).toEqual({ at: 7 })
   })
 
   it('cannot leave a metadata-only group row behind when the rendered roster is empty', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -65,6 +65,7 @@ import {
   $groupNeedsYou,
   groupSpeakerLabel,
   groupThreadOf,
+  persistGroupChatRooms,
   scheduleGroupChatServerSync,
   setGroupChatImage,
   updateGroupChat
@@ -97,7 +98,7 @@ import { clearGroupClarify } from './group-turns'
 import { botsText, useBots } from './i18n'
 import { displayName, slugify, stripPreviewMarkdown } from './labels'
 import { botRosterMeta, setBotsWorkspaceOwner } from './routing'
-import { bumpBotOpenGeneration, getPluginCtx, ID } from './shared'
+import { bumpBotOpenGeneration, ID } from './shared'
 import type { Attachment, BotMeta, GroupChat, GroupMember, GroupMessage, RosterRow } from './types'
 
 const Streamdown = typeof sdk === 'undefined' ? undefined : sdk.Streamdown
@@ -179,28 +180,7 @@ export async function disbandGroupChat(group: string, members: RosterRow[]) {
 
   // Persist the room map WITHOUT the disbanded room so it can't come back
   // on the next window load.
-  try {
-    const durable: Record<string, GroupChat> = {}
-
-    for (const [name, room] of Object.entries($groupChats.get())) {
-      if (name !== group && Array.isArray(room.log)) {
-        durable[name] = {
-          log: room.log,
-          watermarks: room.watermarks,
-          sessions: room.sessions || {},
-          sessionOwners: room.sessionOwners || {},
-          members: Array.isArray(room.members) ? room.members : [],
-          roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
-          image: room.image || null,
-          syncRevision: Math.max(0, Number(room.syncRevision || 0))
-        }
-      }
-    }
-
-    await Promise.resolve(getPluginCtx()?.storage?.set?.('group-chats', durable))
-  } catch {
-    /* storage unavailable — the atom reset above still empties the room */
-  }
+  await persistGroupChatRooms()
 
   scheduleGroupChatServerSync($groupChats.get(), {
     allowEmpty: true,

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
@@ -368,6 +368,25 @@ describe('durable projection', () => {
 
     expect(durable(room).Persist.stranded?.research).toBe(3)
   })
+
+  it('the awaited durability fence preserves session ownership and stop holds', async () => {
+    const room = await loadRoom()
+
+    await room.chat.persistGroupChatRooms({
+      Persist: {
+        holds: { research: { at: 42 } },
+        log: [],
+        members: [{ name: 'research' }],
+        sessionOwners: { research: { name: 'research' } },
+        sessions: { research: 'session-secret' },
+        stranded: { research: 3 },
+        watermarks: {}
+      }
+    } as unknown as Record<string, GroupChat>)
+
+    expect(durable(room).Persist.sessionOwners).toEqual({ research: { name: 'research' } })
+    expect(durable(room).Persist.holds).toEqual({ research: { at: 42 } })
+  })
 })
 
 describe('gateway mirror', () => {
@@ -433,6 +452,32 @@ describe('gateway mirror', () => {
 
     expect(chat.groupChatGatewayJsonSize(snapshot)).toBeLessThanOrEqual(48000)
     expect(snapshot.rooms['name:Unicode'].log.at(-1)?.thread).toBe('thread-15')
+  })
+
+  it('keeps recovery metadata out of the cross-client ui_meta projection', async () => {
+    const { chat } = await loadRoom()
+
+    const snapshot = chat.groupChatSyncSnapshot({
+      Private: {
+        log: [{ at: 1, from: { kind: 'user', name: 'You' }, text: 'keep working', thread: 't1' }],
+        sessions: { research: 'private-session-id' },
+        stranded: {
+          research: {
+            before: 0,
+            phase: 'submitted',
+            recoveryId: 'recovery-private',
+            thread: 't1'
+          }
+        },
+        watermarks: {}
+      }
+    } as unknown as Record<string, GroupChat>)
+
+    expect(snapshot.rooms['name:Private']).not.toHaveProperty('sessions')
+    expect(snapshot.rooms['name:Private']).not.toHaveProperty('stranded')
+    expect(JSON.stringify(snapshot)).not.toContain('private-session-id')
+    expect(JSON.stringify(snapshot)).not.toContain('recovery-private')
+    expect(chat.groupChatGatewayJsonSize(snapshot)).toBeLessThanOrEqual(48000)
   })
 
   it('omits empty runtime rooms', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -740,7 +740,9 @@ export function durableGroupChatRooms(all: Record<string, GroupChat> = $groupCha
       log: room.log,
       watermarks: room.watermarks || {},
       sessions: room.sessions || {},
+      sessionOwners: room.sessionOwners || {},
       stranded: room.stranded || {},
+      holds: room.holds || {},
       members: Array.isArray(room.members) ? room.members : [],
       // Immutable room identity: without this, a room merged in via the
       // remote-sync path (the only caller of this function) loses its
@@ -1333,9 +1335,9 @@ export function updateGroupChat(
         watermarks: room.watermarks,
         sessions: room.sessions || {},
         sessionOwners: room.sessionOwners || {},
-        // Timed-out turns awaiting a late reply — keyed by member, valued
-        // with the pre-turn message baseline. Survives reloads so finished
-        // work is still harvested after a window restart.
+        // In-flight turns awaiting reconciliation — keyed by member and
+        // carrying the pre-turn message baseline. Survives reloads so
+        // finished work is still harvested after a window restart.
         stranded: room.stranded || {},
         // #93129: sticky per-member stop holds. Watermarks persist, so holds
         // must too — otherwise a window restart silently releases a bot the
@@ -1421,10 +1423,11 @@ export function appendGroupChatEntry(
   from: GroupMessageAuthor,
   text: string,
   thread?: null | string,
-  images?: Attachment[]
+  images?: Attachment[],
+  entryId?: string
 ): GroupMessage {
   const entry: GroupMessage = {
-    id: groupChatEntryId(),
+    id: entryId || groupChatEntryId(),
     at: Date.now(),
     from,
     text: normalizeGroupChatText(text),
@@ -1442,6 +1445,12 @@ export function appendGroupChatEntry(
   // byte-identical. Drop the echo instead of flooding the room. User
   // entries and non-adjacent repeats are never touched.
   const priorLog = ($groupChats.get()[group] || {}).log || []
+  const committed = entryId ? priorLog.find(prior => prior?.id === entryId) : undefined
+
+  if (committed) {
+    return committed
+  }
+
   const lastEntry = priorLog[priorLog.length - 1]
 
   if (isDuplicateGroupAppend(lastEntry, from, entry.text, entry.thread)) {

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -162,6 +162,7 @@ describe('round lifecycle', () => {
     expect(log(room, 'Quiet')[0].from.kind).toBe('user')
     // Every member took exactly one turn (round 1), then the settle exit fired.
     expect(room.gateway.calls).toHaveLength(3)
+    expect(room.chat.$groupChats.get().Quiet.stranded).toEqual({})
   })
 
   it('stops chatty members at GROUP_CHAT_MAX_MESSAGES', async () => {
@@ -189,8 +190,11 @@ describe('round lifecycle', () => {
     room.rounds.sendToGroupChat('Flaky', MEMBERS, 'anyone around?')
     await settle(room, 'Flaky')
 
-    // Just the user message; no error entries.
-    expect(log(room, 'Flaky')).toHaveLength(1)
+    // The raw exception stays out of the room, but the ambiguous submitted
+    // turn resolves visibly instead of disappearing as a silent pass.
+    expect(log(room, 'Flaky')).toHaveLength(2)
+    expect(log(room, 'Flaky')[1].text).toMatch(/status is unknown/i)
+    expect(room.chat.$groupChats.get().Flaky.stranded?.builder).toBeUndefined()
   })
 
   it('badges needs-you when a member addresses @user, and clears it on the next user send', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -22,9 +22,14 @@ import {
 } from './group-chat'
 import type { GroupChatRoom, GroupHoldStamp } from './group-chat'
 import { durableGroupChatMembers, groupMemberKey } from './group-membership'
-import { harvestStrandedGroupReply, isGroupPassText, runGroupChatMemberTurn } from './group-turns'
+import {
+  harvestStrandedGroupReply,
+  isGroupPassText,
+  runGroupChatMemberTurn,
+  settleGroupTurnRecovery
+} from './group-turns'
 import { requestForBot } from './routing'
-import type { Attachment, GroupMember, GroupMessage } from './types'
+import type { Attachment, GroupMember, GroupMessage, GroupTurnRecovery } from './types'
 
 // ── group chats: bounded round-robin coordination over a shared room log ─────
 //
@@ -638,9 +643,13 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
           return r
         })
         let reply: null | string = null
+        const recoveryState: { current: GroupTurnRecovery | null } = { current: null }
+        let turnFailed = false
 
         try {
-          reply = await runGroupChatMemberTurn(group, member, prompt, thread, deltaImages)
+          reply = await runGroupChatMemberTurn(group, member, prompt, thread, deltaImages, marker => {
+            recoveryState.current = marker
+          })
 
           // Needs-attention hook (#93091 item 3): a turn that produced a real
           // reply (or an explicit pass) is a good turn — clear the badge.
@@ -650,6 +659,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
             clearBotAttention(groupMemberKey(member))
           }
         } catch (error: any) {
+          turnFailed = true
           const reason = String(error?.data?.reason || '').trim()
           recordGroupActivity(group, {
             kind: 'failed',
@@ -698,6 +708,10 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
             thread
           })
 
+          if (!turnFailed && recoveryState.current && recoveryState.current.phase !== 'timed-out') {
+            settleGroupTurnRecovery(group, member, recoveryState.current.recoveryId)
+          }
+
           return
         }
 
@@ -721,7 +735,9 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                 : {})
             },
             reply,
-            thread
+            thread,
+            undefined,
+            recoveryState.current?.recoveryId
           )
           // Its own message counts as seen too.
           updateGroupChat(group, (r: GroupChatRoom) => {
@@ -731,6 +747,10 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
           })
           posted += 1
           spokeThisRound += 1
+        }
+
+        if (!turnFailed && recoveryState.current && recoveryState.current.phase !== 'timed-out') {
+          settleGroupTurnRecovery(group, member, recoveryState.current.recoveryId)
         }
       }
 
@@ -805,14 +825,19 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                 return r
               })
               let continuationReply: null | string = null
+              const continuationRecoveryState: { current: GroupTurnRecovery | null } = { current: null }
+              let continuationFailed = false
 
               try {
-                continuationReply = await runGroupChatMemberTurn(group, member, prompt, thread)
+                continuationReply = await runGroupChatMemberTurn(group, member, prompt, thread, undefined, marker => {
+                  continuationRecoveryState.current = marker
+                })
 
                 if (continuationReply !== null) {
                   clearBotAttention(memberKey)
                 }
               } catch (error: any) {
+                continuationFailed = true
                 recordGroupActivity(group, {
                   kind: 'failed',
                   member: member.name,
@@ -823,6 +848,14 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
               }
 
               if (!isCurrent()) {
+                if (
+                  !continuationFailed &&
+                  continuationRecoveryState.current &&
+                  continuationRecoveryState.current.phase !== 'timed-out'
+                ) {
+                  settleGroupTurnRecovery(group, member, continuationRecoveryState.current.recoveryId)
+                }
+
                 return
               }
 
@@ -845,7 +878,9 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                       : {})
                   },
                   continuationReply,
-                  thread
+                  thread,
+                  undefined,
+                  continuationRecoveryState.current?.recoveryId
                 )
                 updateGroupChat(group, (r: GroupChatRoom) => {
                   r.watermarks[markKey] = r.log.length
@@ -860,6 +895,14 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                 // continues rather than settling; the outer for-loop's next
                 // iteration re-evaluates everything.
                 spokeThisRound += 1
+              }
+
+              if (
+                !continuationFailed &&
+                continuationRecoveryState.current &&
+                continuationRecoveryState.current.phase !== 'timed-out'
+              ) {
+                settleGroupTurnRecovery(group, member, continuationRecoveryState.current.recoveryId)
               }
             }
           }

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
@@ -189,6 +189,153 @@ describe('session resolution', () => {
 })
 
 describe('session-gone classification', () => {
+  it('persists a recovery marker before a submitted turn can outlive the window', async () => {
+    const room = await loadRoom({ turn: () => 'finished while the window was gone' })
+    const request = host.request as (method: string, params: Record<string, unknown>) => Promise<unknown>
+
+    host.request = async (method: string, params: Record<string, unknown>) => {
+      if (method === 'prompt.submit') {
+        const durableBeforeSubmit = (room.gateway.storage.get('group-chats') || {}) as Record<string, GroupChat>
+
+        expect(durableBeforeSubmit.Room.stranded?.helper).toMatchObject({
+          before: 0,
+          phase: 'prepared',
+          thread: 't1'
+        })
+      }
+
+      return request(method, params)
+    }
+
+    const reply = await room.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'keep working', 't1', [])
+
+    expect(reply).toBe('finished while the window was gone')
+    expect(room.gateway.calls).toHaveLength(1)
+
+    const durable = (room.gateway.storage.get('group-chats') || {}) as Record<string, GroupChat>
+    const marker = durable.Room.stranded?.helper
+
+    expect(marker).toMatchObject({
+      before: 0,
+      phase: 'submitted',
+      thread: 't1'
+    })
+    expect(typeof (marker as { recoveryId?: unknown }).recoveryId).toBe('string')
+  })
+
+  it('does not submit when the recovery boundary cannot be read back', async () => {
+    const room = await loadRoom({ turn: () => 'must never run' })
+    const shared = await import('./shared')
+
+    shared.setPluginCtx({
+      storage: {
+        get: async () => null,
+        set: async () => undefined
+      }
+    } as never)
+
+    await expect(room.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'keep working', 't1', [])).rejects.toThrow(
+      /recovery state.*not sent/i
+    )
+    expect(room.gateway.calls).toHaveLength(0)
+  })
+
+  it('keeps polling when the post-submit persistence refresh fails', async () => {
+    const room = await loadRoom({ turn: () => 'already accepted' })
+    const shared = await import('./shared')
+    const storage = new Map<string, unknown>()
+
+    shared.setPluginCtx({
+      storage: {
+        get: async (key: string) => storage.get(key) ?? null,
+        set: async (key: string, value: Record<string, GroupChat>) => {
+          const marker = value?.Room?.stranded?.helper as { phase?: string } | undefined
+
+          if (marker?.phase === 'submitted') {
+            throw new Error('storage refresh failed')
+          }
+
+          storage.set(key, structuredClone(value))
+        }
+      }
+    } as never)
+
+    await expect(room.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'keep working', 't1', [])).resolves.toBe(
+      'already accepted'
+    )
+    expect(room.gateway.calls).toHaveLength(1)
+    expect((storage.get('group-chats') as Record<string, GroupChat>).Room.stranded?.helper).toMatchObject({
+      phase: 'prepared'
+    })
+  })
+
+  it('reconciles a completed post-submit turn once after a simulated restart', async () => {
+    const room = await loadRoom({ turn: () => 'finished while the window was gone' })
+
+    await room.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'keep working', 't1', [])
+
+    const marker = room.chat.$groupChats.get().Room.stranded?.helper as { recoveryId: string }
+
+    expect(log(room, 'Room')).toHaveLength(0)
+
+    // The process-local poller is gone; cold hydration sees only the durable
+    // room marker and the backend session that completed independently.
+    await room.turns.recoverInterruptedGroupTurns()
+    await room.turns.recoverInterruptedGroupTurns()
+
+    expect(log(room, 'Room')).toHaveLength(1)
+    expect(log(room, 'Room')[0]).toMatchObject({
+      from: { kind: 'member', name: 'helper' },
+      id: marker.recoveryId,
+      text: 'finished while the window was gone',
+      thread: 't1'
+    })
+    expect(room.chat.$groupChats.get().Room.stranded?.helper).toBeUndefined()
+  })
+
+  it('serializes overlapping turns for one room member until the first marker settles', async () => {
+    const room = await loadRoom({ turn: ({ n }) => `reply ${n}` })
+    const request = host.request as (method: string, params: Record<string, unknown>) => Promise<unknown>
+    let releaseStart: () => void = () => undefined
+
+    const blockedStart = new Promise<void>(resolve => {
+      releaseStart = resolve
+    })
+
+    let starts = 0
+
+    host.request = async (method: string, params: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        starts += 1
+
+        if (starts === 1) {
+          await blockedStart
+        }
+      }
+
+      return request(method, params)
+    }
+
+    const first = room.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'first', 't1', [])
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const second = room.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'second', 't1', [])
+
+    await new Promise(resolve => setImmediate(resolve))
+    expect(starts).toBe(1)
+
+    releaseStart()
+    await expect(first).resolves.toBe('reply 1')
+    expect(room.gateway.calls).toHaveLength(1)
+
+    const marker = room.chat.$groupChats.get().Room.stranded?.helper as { recoveryId: string }
+
+    room.turns.settleGroupTurnRecovery('Room', LOCAL_MEMBER, marker.recoveryId)
+    await expect(second).resolves.toBe('reply 2')
+    expect(room.gateway.calls).toHaveLength(2)
+  })
+
   it('treats 4001 and "not in memory" as recoverable, 4007 as not', async () => {
     const { turns } = await loadRoom()
 
@@ -544,6 +691,444 @@ describe('stranded harvest', () => {
     expect(log(room, 'Late')[0].from.name).toBe('research')
     expect(log(room, 'Late')[0].text).toMatch(/delivered late/)
     expect(room.chat.$groupChats.get().Late.stranded?.research).toBeUndefined()
+  })
+
+  it('recovers exactly once when the reply append persisted before marker cleanup', async () => {
+    const room = await loadRoom()
+    const recoveryId = 'recovery-cold-1'
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.log = [
+        {
+          at: 1,
+          from: { kind: 'member', name: 'research' },
+          id: recoveryId,
+          text: 'Recovered after restart.',
+          thread: 't-cold'
+        }
+      ]
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: 1,
+          phase: 'submitted',
+          recoveryId,
+          thread: 't-cold'
+        }
+      }
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: Cold', [
+      ['user', 'the turn prompt'],
+      ['assistant', 'Recovered after restart.']
+    ])
+
+    await room.turns.harvestStrandedGroupReply('Cold', { name: 'research', title: '' })
+
+    expect(log(room, 'Cold')).toHaveLength(1)
+    expect(log(room, 'Cold')[0].id).toBe(recoveryId)
+    expect(room.chat.$groupChats.get().Cold.stranded?.research).toBeUndefined()
+  })
+
+  it('does not clear a newer turn marker while an older reply is being harvested', async () => {
+    const room = await loadRoom()
+    const request = host.request as (method: string, params: Record<string, unknown>) => Promise<unknown>
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [{ name: 'research', title: '' }]
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: 0,
+          phase: 'submitted',
+          recoveryId: 'recovery-old',
+          thread: 't-old'
+        }
+      }
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: Cold', [
+      ['user', 'the old prompt'],
+      ['assistant', 'the old reply']
+    ])
+
+    host.request = async (method: string, params: Record<string, unknown>) => {
+      const result = await request(method, params)
+
+      if (method === 'session.resume') {
+        room.chat.updateGroupChat('Cold', current => {
+          current.stranded = {
+            research: {
+              before: 2,
+              phase: 'submitted',
+              recoveryId: 'recovery-new',
+              thread: 't-new'
+            }
+          }
+
+          return current
+        })
+      }
+
+      return result
+    }
+
+    await room.turns.harvestStrandedGroupReply('Cold', { name: 'research', title: '' })
+
+    expect(log(room, 'Cold')).toHaveLength(0)
+    expect(room.chat.$groupChats.get().Cold.stranded?.research).toMatchObject({ recoveryId: 'recovery-new' })
+  })
+
+  it('only recovers markers that existed when cold reconciliation started', async () => {
+    const room = await loadRoom({ busyResumes: { research: 1 } })
+    let injected = false
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [
+        { name: 'research', title: '' },
+        { name: 'builder', title: '' }
+      ]
+      current.sessions = { research: 'sid-research', builder: 'sid-builder' }
+      current.stranded = {
+        research: {
+          before: 0,
+          phase: 'submitted',
+          recoveryId: 'recovery-on-hydrate',
+          thread: 't-old'
+        }
+      }
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: Cold', [])
+    seedSession(room, 'sid-builder', 'builder', 'Group: Cold', [])
+    vi.stubGlobal('setTimeout', (fn: () => void) => {
+      if (!injected) {
+        injected = true
+        room.chat.updateGroupChat('Cold', current => {
+          current.stranded = {
+            ...(current.stranded || {}),
+            builder: {
+              before: 0,
+              phase: 'submitted',
+              recoveryId: 'recovery-after-hydrate',
+              thread: 't-new'
+            }
+          }
+
+          return current
+        })
+      }
+
+      fn()
+
+      return 0
+    })
+
+    await room.turns.recoverInterruptedGroupTurns()
+
+    expect(log(room, 'Cold').map(entry => entry.id)).not.toContain('recovery-after-hydrate')
+    expect(room.chat.$groupChats.get().Cold.stranded?.builder).toMatchObject({
+      recoveryId: 'recovery-after-hydrate'
+    })
+  })
+
+  it('waits through a running submitted turn and recovers its reply once', async () => {
+    const room = await loadRoom({ busyResumes: { research: 2 } })
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [{ name: 'research', title: '' }]
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: 1,
+          phase: 'submitted',
+          recoveryId: 'recovery-running',
+          thread: 't-cold'
+        }
+      }
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: Cold', [
+      ['user', 'the turn prompt'],
+      ['assistant', 'finished after reconnect']
+    ])
+
+    await room.turns.recoverInterruptedGroupTurns()
+
+    expect(room.gateway.rpcFor('session.resume')).toHaveLength(3)
+    expect(log(room, 'Cold').map(entry => entry.id)).toEqual(['recovery-running'])
+    expect(room.chat.$groupChats.get().Cold.stranded?.research).toBeUndefined()
+  })
+
+  it('ends a permanently busy recovery after the bounded poll budget', async () => {
+    const room = await loadRoom({ busyResumes: { research: 100 } })
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [{ name: 'research', title: '' }]
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: 0,
+          phase: 'submitted',
+          recoveryId: 'recovery-bounded',
+          thread: 't-cold'
+        }
+      }
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: Cold', [])
+
+    await room.turns.recoverInterruptedGroupTurns()
+
+    expect(room.gateway.rpcFor('session.resume')).toHaveLength(60)
+    expect(log(room, 'Cold').map(entry => entry.id)).toEqual(['recovery-bounded'])
+    expect(room.chat.$groupChats.get().Cold.stranded?.research).toBeUndefined()
+  })
+
+  it('ends a permanently unreachable recovery after the same bounded poll budget', async () => {
+    const room = await loadRoom()
+    const request = host.request as (method: string, params: Record<string, unknown>) => Promise<unknown>
+    let resumes = 0
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [{ name: 'research', title: '' }]
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: 0,
+          phase: 'submitted',
+          recoveryId: 'recovery-unreachable',
+          thread: 't-cold'
+        }
+      }
+
+      return current
+    })
+
+    host.request = async (method: string, params: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        resumes += 1
+        throw new Error('source offline')
+      }
+
+      return request(method, params)
+    }
+
+    await room.turns.recoverInterruptedGroupTurns()
+
+    expect(resumes).toBe(60)
+    expect(log(room, 'Cold').map(entry => entry.id)).toEqual(['recovery-unreachable'])
+    expect(room.chat.$groupChats.get().Cold.stranded?.research).toBeUndefined()
+  })
+
+  it('cancels a pending recovery delay on plugin disposal', async () => {
+    const room = await loadRoom({ busyResumes: { research: 100 } })
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [{ name: 'research', title: '' }]
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: 0,
+          phase: 'submitted',
+          recoveryId: 'recovery-disposed',
+          thread: 't-cold'
+        }
+      }
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: Cold', [])
+    vi.stubGlobal('setTimeout', () => 1)
+    vi.stubGlobal('clearTimeout', () => undefined)
+
+    const recovery = room.turns.recoverInterruptedGroupTurns()
+
+    await new Promise(resolve => setImmediate(resolve))
+    expect(room.gateway.rpcFor('session.resume')).toHaveLength(1)
+
+    room.turns.stopInterruptedGroupTurnRecovery()
+    await recovery
+
+    expect(room.gateway.rpcFor('session.resume')).toHaveLength(1)
+    expect(log(room, 'Cold')).toHaveLength(0)
+    expect(room.chat.$groupChats.get().Cold.stranded?.research).toMatchObject({
+      recoveryId: 'recovery-disposed'
+    })
+  })
+
+  it('rejects malformed recovery metadata without reading hidden session history', async () => {
+    const room = await loadRoom()
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [{ name: 'research', title: '' }]
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: -1,
+          phase: 'submitted',
+          recoveryId: 'malformed-recovery',
+          thread: 't-cold'
+        }
+      } as never
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: Cold', [
+      ['assistant', 'private prior session answer']
+    ])
+
+    await room.turns.recoverInterruptedGroupTurns()
+
+    expect(room.gateway.rpcFor('session.resume')).toHaveLength(0)
+    expect(log(room, 'Cold')).toHaveLength(1)
+    expect(log(room, 'Cold')[0].text).toMatch(/status is unknown/i)
+    expect(log(room, 'Cold')[0].text).not.toContain('private prior session answer')
+    expect(room.chat.$groupChats.get().Cold.stranded?.research).toBeUndefined()
+  })
+
+  it('classifies a pre-dispatch process loss as terminally unknown', async () => {
+    const room = await loadRoom()
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [{ name: 'research', title: '' }]
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: 0,
+          phase: 'prepared',
+          recoveryId: 'recovery-pre-dispatch',
+          thread: 't-cold'
+        }
+      }
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: Cold', [])
+
+    await room.turns.recoverInterruptedGroupTurns()
+
+    expect(log(room, 'Cold')).toHaveLength(1)
+    expect(log(room, 'Cold')[0]).toMatchObject({
+      from: { kind: 'member', name: 'research' },
+      id: 'recovery-pre-dispatch',
+      thread: 't-cold'
+    })
+    expect(log(room, 'Cold')[0].text).toMatch(/status is unknown.*restarted/i)
+    expect(room.chat.$groupChats.get().Cold.stranded?.research).toBeUndefined()
+  })
+
+  it('commits a recovered reply to the immutable room after a rename', async () => {
+    const room = await loadRoom()
+    const request = host.request as (method: string, params: Record<string, unknown>) => Promise<unknown>
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [{ name: 'research', title: '' }]
+      current.roomId = 'room-cold'
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: 1,
+          phase: 'submitted',
+          recoveryId: 'recovery-renamed',
+          thread: 't-cold'
+        }
+      }
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: room-cold', [
+      ['user', 'the turn prompt'],
+      ['assistant', 'finished after rename']
+    ])
+
+    host.request = async (method: string, params: Record<string, unknown>) => {
+      const result = await request(method, params)
+
+      if (method === 'session.resume') {
+        const rooms = { ...room.chat.$groupChats.get() }
+
+        rooms.Renamed = rooms.Cold
+        delete rooms.Cold
+        room.chat.$groupChats.set(rooms)
+      }
+
+      return result
+    }
+
+    await room.turns.harvestStrandedGroupReply('Cold', { name: 'research', title: '' })
+
+    expect(room.chat.$groupChats.get().Cold).toBeUndefined()
+    expect(log(room, 'Renamed').map(entry => entry.id)).toEqual(['recovery-renamed'])
+    expect(room.chat.$groupChats.get().Renamed.stranded?.research).toBeUndefined()
+  })
+
+  it('does not recreate a room disbanded while recovery is awaiting the backend', async () => {
+    const room = await loadRoom()
+    const request = host.request as (method: string, params: Record<string, unknown>) => Promise<unknown>
+
+    room.chat.updateGroupChat('Cold', current => {
+      current.members = [{ name: 'research', title: '' }]
+      current.roomId = 'room-cold'
+      current.sessions = { research: 'sid-research' }
+      current.stranded = {
+        research: {
+          before: 1,
+          phase: 'submitted',
+          recoveryId: 'recovery-disbanded',
+          thread: 't-cold'
+        }
+      }
+
+      return current
+    })
+    seedSession(room, 'sid-research', 'research', 'Group: room-cold', [
+      ['user', 'the turn prompt'],
+      ['assistant', 'must not resurrect']
+    ])
+
+    host.request = async (method: string, params: Record<string, unknown>) => {
+      const result = await request(method, params)
+
+      if (method === 'session.resume') {
+        room.chat.$groupChats.set({})
+      }
+
+      return result
+    }
+
+    await room.turns.harvestStrandedGroupReply('Cold', { name: 'research', title: '' })
+
+    expect(room.chat.$groupChats.get()).toEqual({})
+  })
+
+  it('persists a real timed-out phase before returning control to the room', async () => {
+    const room = await loadRoom({ turn: () => 'finished beyond the local deadline' })
+    let now = 0
+
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      now += 200000
+
+      return now
+    })
+
+    await expect(room.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'keep working', 't1', [])).resolves.toBeNull()
+
+    expect(room.chat.$groupChats.get().Room.stranded?.helper).toMatchObject({
+      before: 0,
+      phase: 'timed-out',
+      thread: 't1'
+    })
+
+    await room.turns.harvestStrandedGroupReply('Room', LOCAL_MEMBER)
+
+    expect(log(room, 'Room')[0].text).toBe('finished beyond the local deadline')
+    expect(room.chat.$groupChats.get().Room.stranded?.helper).toBeUndefined()
   })
 
   it('prefers the substantive answer over a trailing synthetic (pass)', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -9,11 +9,27 @@
 import { host } from '@hermes/plugin-sdk'
 
 import { recordGroupActivity } from './group-activity'
-import { $groupChats, $groupClarify, $groupNeedsYou, appendGroupChatEntry, updateGroupChat } from './group-chat'
+import {
+  $groupChats,
+  $groupClarify,
+  $groupNeedsYou,
+  appendGroupChatEntry,
+  persistGroupChatRooms,
+  updateGroupChat
+} from './group-chat'
 import type { GroupChatRoom } from './group-chat'
 import { groupMemberKey, groupSessionOwner } from './group-membership'
+import { botsText } from './i18n'
 import { botConnectionRoute, requestForBot } from './routing'
-import type { Attachment, GroupMember, GroupPrompt, GroupPromptQuestion, ProfileRoute } from './types'
+import { getPluginCtx } from './shared'
+import type {
+  Attachment,
+  GroupMember,
+  GroupPrompt,
+  GroupPromptQuestion,
+  GroupTurnRecovery,
+  ProfileRoute
+} from './types'
 
 /** "(pass)" (loosely: pass / (pass) / pass.) or empty = the member stayed silent. */
 export function isGroupPassText(text: unknown) {
@@ -232,6 +248,396 @@ export async function ensureGroupChatSession(group: string, member: GroupMember)
 
 const GROUP_TURN_TIMEOUT_MS = 180000
 const GROUP_TURN_POLL_MS = 2000
+
+function mintGroupTurnRecoveryId(): string {
+  if (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID()
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+function groupTurnRecovery(marker: unknown): GroupTurnRecovery | null {
+  if (!marker || typeof marker !== 'object') {
+    return null
+  }
+
+  const candidate = marker as Record<string, unknown>
+  const before = candidate.before
+  const phase = candidate.phase
+  const recoveryId = candidate.recoveryId
+  const thread = candidate.thread
+
+  if (
+    typeof before !== 'number' ||
+    !Number.isSafeInteger(before) ||
+    before < 0 ||
+    (phase !== 'prepared' && phase !== 'submitted' && phase !== 'timed-out') ||
+    typeof recoveryId !== 'string' ||
+    !recoveryId ||
+    recoveryId.length > 160 ||
+    recoveryId.trim() !== recoveryId ||
+    (thread !== undefined && (typeof thread !== 'string' || thread.length > 128))
+  ) {
+    return null
+  }
+
+  return {
+    before,
+    phase,
+    recoveryId,
+    ...(typeof thread === 'string' ? { thread } : {})
+  }
+}
+
+function isInvalidStructuredRecovery(marker: unknown): marker is Record<string, unknown> {
+  return Boolean(marker && typeof marker === 'object' && 'recoveryId' in marker && !groupTurnRecovery(marker))
+}
+
+function sameGroupTurnRecoveryMarker(current: unknown, expected: unknown): boolean {
+  const recovery = groupTurnRecovery(expected)
+
+  return recovery ? groupTurnRecovery(current)?.recoveryId === recovery.recoveryId : current === expected
+}
+
+function resolveGroupTurnRoom(
+  originalGroup: string,
+  roomId: null | string | undefined,
+  memberKey: string,
+  marker: unknown
+): string | null {
+  const rooms = $groupChats.get()
+
+  const matches = Object.entries(rooms).filter(([name, room]) => {
+    if (room.tombstone || !sameGroupTurnRecoveryMarker(room.stranded?.[memberKey], marker)) {
+      return false
+    }
+
+    return roomId ? room.roomId === roomId : name === originalGroup || !rooms[originalGroup]
+  })
+
+  return matches.length === 1 ? matches[0][0] : null
+}
+
+interface GroupTurnReservation {
+  done: Promise<void>
+  recoveryId: string
+  release: () => void
+}
+
+const groupTurnReservations = new Map<string, GroupTurnReservation>()
+
+function groupTurnReservationKey(group: string, memberKey: string): string {
+  const roomId = $groupChats.get()[group]?.roomId
+
+  return `${roomId ? `id:${roomId}` : `name:${group}`}\u0000${memberKey}`
+}
+
+async function reserveGroupTurn(group: string, memberKey: string, recoveryId: string): Promise<void> {
+  const key = groupTurnReservationKey(group, memberKey)
+
+  while (groupTurnReservations.has(key)) {
+    await groupTurnReservations.get(key)!.done
+  }
+
+  let finish: () => void = () => undefined
+
+  const done = new Promise<void>(resolve => {
+    finish = resolve
+  })
+
+  groupTurnReservations.set(key, {
+    done,
+    recoveryId,
+    release: finish
+  })
+}
+
+function releaseGroupTurnReservation(group: string, memberKey: string, recoveryId?: string): void {
+  let key = groupTurnReservationKey(group, memberKey)
+  let reservation = groupTurnReservations.get(key)
+
+  if (recoveryId && reservation?.recoveryId !== recoveryId) {
+    const match = [...groupTurnReservations.entries()].find(([, item]) => item.recoveryId === recoveryId)
+
+    if (match) {
+      key = match[0]
+      reservation = match[1]
+    }
+  }
+
+  if (!reservation || (recoveryId && reservation.recoveryId !== recoveryId)) {
+    return
+  }
+
+  groupTurnReservations.delete(key)
+  reservation.release()
+}
+
+function settleGroupTurnRecoveryKey(group: string, memberKey: string, recoveryId?: string): void {
+  if (!$groupChats.get()[group]) {
+    releaseGroupTurnReservation(group, memberKey, recoveryId)
+
+    return
+  }
+
+  let settledRecoveryId: string | undefined
+
+  updateGroupChat(
+    group,
+    room => {
+      const currentRecovery = groupTurnRecovery(room.stranded?.[memberKey])
+
+      if (recoveryId && currentRecovery?.recoveryId !== recoveryId) {
+        return room
+      }
+
+      settledRecoveryId = currentRecovery?.recoveryId
+
+      const stranded = {
+        ...(room.stranded || {})
+      }
+
+      delete stranded[memberKey]
+      room.stranded = stranded
+
+      return room
+    },
+    { sync: false }
+  )
+
+  if (settledRecoveryId || !recoveryId) {
+    releaseGroupTurnReservation(group, memberKey, recoveryId || settledRecoveryId)
+  }
+}
+
+function settleGroupTurnRecoveryMarker(group: string, memberKey: string, marker: unknown): void {
+  if (!$groupChats.get()[group]) {
+    return
+  }
+
+  updateGroupChat(
+    group,
+    room => {
+      if (room.stranded?.[memberKey] !== marker) {
+        return room
+      }
+
+      const stranded = {
+        ...(room.stranded || {})
+      }
+
+      delete stranded[memberKey]
+      room.stranded = stranded
+
+      return room
+    },
+    { sync: false }
+  )
+}
+
+/** Persist and read back the recovery boundary before prompt.submit can
+ *  outlive this renderer. Plugin storage is best-effort and can swallow a
+ *  quota/permission failure, so awaiting set alone is not a durability fence. */
+async function persistGroupTurnRecovery(
+  group: string,
+  memberKey: string,
+  recovery: GroupTurnRecovery,
+  { required = false }: { required?: boolean } = {}
+): Promise<void> {
+  updateGroupChat(
+    group,
+    room => {
+      room.stranded = {
+        ...(room.stranded || {}),
+        [memberKey]: recovery
+      }
+
+      return room
+    },
+    { sync: false }
+  )
+  await persistGroupChatRooms()
+
+  if (!required) {
+    return
+  }
+
+  const persisted = await Promise.resolve(
+    getPluginCtx()?.storage?.get<Record<string, GroupChatRoom>>('group-chats', {})
+  )
+
+  if (groupTurnRecovery(persisted?.[group]?.stranded?.[memberKey])?.recoveryId !== recovery.recoveryId) {
+    settleGroupTurnRecoveryKey(group, memberKey, recovery.recoveryId)
+    throw new Error('Hermes could not save reply recovery state; the turn was not sent.')
+  }
+}
+
+export function settleGroupTurnRecovery(group: string, member: GroupMember, recoveryId?: string): void {
+  settleGroupTurnRecoveryKey(group, groupMemberKey(member), recoveryId)
+}
+
+function appendGroupRecoveryUnknown(
+  group: string,
+  memberKey: string,
+  member: GroupMember,
+  recovery: GroupTurnRecovery
+): void {
+  appendGroupChatEntry(
+    group,
+    {
+      kind: 'member',
+      name: member.name,
+      ...(member.remoteSource
+        ? {
+            source: member.connectionLabel || member.connectionId
+          }
+        : {})
+    },
+    botsText().group.recoveryUnknown,
+    recovery.thread || 'legacy',
+    undefined,
+    recovery.recoveryId
+  )
+  settleGroupTurnRecoveryKey(group, memberKey, recovery.recoveryId)
+}
+
+function appendInvalidGroupRecoveryUnknown(
+  group: string,
+  memberKey: string,
+  member: GroupMember,
+  marker: unknown
+): void {
+  appendGroupChatEntry(
+    group,
+    {
+      kind: 'member',
+      name: member.name,
+      ...(member.remoteSource
+        ? {
+            source: member.connectionLabel || member.connectionId
+          }
+        : {})
+    },
+    botsText().group.recoveryUnknown,
+    'legacy',
+    undefined,
+    mintGroupTurnRecoveryId()
+  )
+  settleGroupTurnRecoveryMarker(group, memberKey, marker)
+}
+
+const INTERRUPTED_RECOVERY_POLL_MS = 5000
+const INTERRUPTED_RECOVERY_MAX_TRIES = 60
+let interruptedRecoveryGeneration = 0
+const interruptedRecoveryWaiters = new Set<() => void>()
+
+function waitForInterruptedRecoveryPoll(): Promise<void> {
+  return new Promise(resolve => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const finish = () => {
+      if (timer !== null) {
+        clearTimeout(timer)
+      }
+
+      interruptedRecoveryWaiters.delete(finish)
+      resolve()
+    }
+
+    interruptedRecoveryWaiters.add(finish)
+    timer = setTimeout(finish, INTERRUPTED_RECOVERY_POLL_MS)
+  })
+}
+
+export function stopInterruptedGroupTurnRecovery(): void {
+  interruptedRecoveryGeneration += 1
+
+  for (const finish of [...interruptedRecoveryWaiters]) {
+    finish()
+  }
+
+  for (const [key, reservation] of [...groupTurnReservations]) {
+    groupTurnReservations.delete(key)
+    reservation.release()
+  }
+}
+
+/** Reconcile turns that survived the renderer process. Runs once immediately,
+ *  then polls boundedly while a member session is still working or its source
+ *  is reconnecting. Every exit is visible: reply, pass, or terminal unknown. */
+export async function recoverInterruptedGroupTurns(): Promise<void> {
+  const generation = ++interruptedRecoveryGeneration
+  const interrupted: Array<{ group: string; key: string; member: GroupMember; recovery: GroupTurnRecovery }> = []
+
+  for (const [group, room] of Object.entries($groupChats.get())) {
+    const candidates = [
+      ...(Array.isArray(room.members) ? room.members : []),
+      ...Object.values(room.sessionOwners || {})
+    ].filter(candidate => candidate && typeof candidate.name === 'string') as GroupMember[]
+
+    for (const [key, marker] of Object.entries(room.stranded || {})) {
+      const recovery = groupTurnRecovery(marker)
+      const member = candidates.find(candidate => groupMemberKey(candidate) === key) || { name: key }
+
+      if (!recovery) {
+        if (isInvalidStructuredRecovery(marker)) {
+          appendInvalidGroupRecoveryUnknown(group, key, member, marker)
+        }
+
+        continue
+      }
+
+      if (!candidates.some(candidate => groupMemberKey(candidate) === key)) {
+        appendGroupRecoveryUnknown(group, key, member, recovery)
+
+        continue
+      }
+
+      interrupted.push({ group, key, member, recovery })
+    }
+  }
+
+  for (let attempt = 0; attempt < INTERRUPTED_RECOVERY_MAX_TRIES; attempt++) {
+    const pending = interrupted.filter(item => {
+      const current = groupTurnRecovery($groupChats.get()[item.group]?.stranded?.[item.key])
+
+      return current?.recoveryId === item.recovery.recoveryId
+    })
+
+    if (!pending.length || generation !== interruptedRecoveryGeneration) {
+      return
+    }
+
+    for (const item of pending) {
+      await harvestStrandedGroupReply(item.group, item.member)
+    }
+
+    const remaining = pending.filter(item => {
+      const current = groupTurnRecovery($groupChats.get()[item.group]?.stranded?.[item.key])
+
+      return current?.recoveryId === item.recovery.recoveryId
+    })
+
+    if (!remaining.length || generation !== interruptedRecoveryGeneration) {
+      return
+    }
+
+    if (attempt === INTERRUPTED_RECOVERY_MAX_TRIES - 1) {
+      for (const item of remaining) {
+        const recovery = groupTurnRecovery($groupChats.get()[item.group]?.stranded?.[item.key])
+
+        if (recovery?.recoveryId === item.recovery.recoveryId) {
+          appendGroupRecoveryUnknown(item.group, item.key, item.member, recovery)
+        }
+      }
+
+      return
+    }
+
+    await waitForInterruptedRecoveryPoll()
+  }
+}
 
 // --- group-turn session-lease helpers (#93602) ------------------------------
 // A member turn is a session-scoped RPC SEQUENCE (resume → attach → submit →
@@ -512,26 +918,40 @@ export async function answerGroupClarify(
  *  the member's per-group session, then poll the session until a NEW
  *  assistant message lands (or timeout → pass). While the session visibly
  *  reports work in flight the deadline extends (bounded by the hard cap),
- *  so slow models aren't cut off mid-run. A turn that still times out
- *  records a stranded marker so the finished reply can be harvested into
- *  the room at the member's next turn instead of being lost. */
+ *  so slow models aren't cut off mid-run. Every submitted turn records a
+ *  recovery marker before dispatch so a renderer restart can reconcile it
+ *  to one visible reply, pass, or terminal unknown state. */
 export async function runGroupChatMemberTurn(
   group: string,
   member: GroupMember,
   prompt: string,
   thread: string,
-  images?: Attachment[]
+  images?: Attachment[],
+  onRecovery?: (recovery: GroupTurnRecovery) => void
 ): Promise<null | string> {
+  const memberKey = groupMemberKey(member)
+  const recoveryId = mintGroupTurnRecoveryId()
+
+  await reserveGroupTurn(group, memberKey, recoveryId)
+
   // #93602: hold the member's route socket for the whole turn. Without the
   // lease, every RPC below rides its own request-scoped socket lease; the
   // socket that minted `runtime` can close between RPCs, the gateway reaps
   // the runtime session, and prompt.submit dies 4001 — the bot goes silent.
-  const releaseTurnLease = await retainGroupTurnRoute(member)
-
   try {
-    return await runGroupChatMemberTurnLeased(group, member, prompt, thread, images)
+    const releaseTurnLease = await retainGroupTurnRoute(member)
+
+    try {
+      return await runGroupChatMemberTurnLeased(group, member, prompt, thread, recoveryId, images, onRecovery)
+    } finally {
+      releaseTurnLease()
+    }
   } finally {
-    releaseTurnLease()
+    const current = groupTurnRecovery($groupChats.get()[group]?.stranded?.[memberKey])
+
+    if (current?.recoveryId !== recoveryId) {
+      releaseGroupTurnReservation(group, memberKey, recoveryId)
+    }
   }
 }
 
@@ -540,7 +960,9 @@ async function runGroupChatMemberTurnLeased(
   member: GroupMember,
   prompt: string,
   thread: string,
-  images?: Attachment[]
+  recoveryId: string,
+  images?: Attachment[],
+  onRecovery?: (recovery: GroupTurnRecovery) => void
 ): Promise<null | string> {
   const { runtime, stored } = await ensureGroupChatSession(group, member)
 
@@ -571,6 +993,16 @@ async function runGroupChatMemberTurnLeased(
   } catch {
     /* lazy session — zero messages */
   }
+
+  const recovery: GroupTurnRecovery = {
+    before,
+    phase: 'prepared',
+    recoveryId,
+    thread
+  }
+
+  await persistGroupTurnRecovery(group, memberKey, recovery, { required: true })
+  onRecovery?.({ ...recovery })
 
   // Stage this delta's attachments into the member's session so the model
   // receives the actual payload with the prompt — the same attach RPCs the
@@ -625,6 +1057,9 @@ async function runGroupChatMemberTurnLeased(
   // minting and submitting. Tracks the runtime id the submit landed on so
   // the poll fallback below targets a live session.
   const liveRuntime = await submitGroupTurnPrompt(member, runtime, stored, turnText)
+  recovery.phase = 'submitted'
+  await persistGroupTurnRecovery(group, memberKey, recovery)
+  onRecovery?.({ ...recovery })
   const started = Date.now()
   let deadline = started + GROUP_TURN_TIMEOUT_MS
 
@@ -702,17 +1137,12 @@ async function runGroupChatMemberTurnLeased(
     thread
   })
   syncGroupClarify(group, member, null)
-  updateGroupChat(group, (r: GroupChatRoom) => {
-    r.stranded = {
-      ...(r.stranded || {}),
-      [groupMemberKey(member)]: {
-        before,
-        thread
-      }
-    }
-
-    return r
-  })
+  recovery.phase = 'timed-out'
+  await persistGroupTurnRecovery(group, memberKey, recovery)
+  onRecovery?.({ ...recovery })
+  // The pre-submit recovery marker already carries the baseline + thread and
+  // is now durably `timed-out`; keep it until the room commits the late reply
+  // (or classifies the turn terminally).
 
   return null
 }
@@ -724,9 +1154,11 @@ export async function harvestStrandedGroupReply(group: string, member: GroupMemb
   const memberKey = groupMemberKey(member)
   const room = $groupChats.get()[group] || {}
   const marker = room.stranded?.[memberKey]
+  const roomId = room.roomId
   // Markers were a bare number before threads; normalize both shapes.
   const strandedBefore = typeof marker === 'number' ? marker : marker?.before
   const strandedThread = (typeof marker === 'object' && marker?.thread) || 'legacy'
+  const recovery = groupTurnRecovery(marker)
 
   if (typeof strandedBefore !== 'number') {
     return
@@ -744,43 +1176,54 @@ export async function harvestStrandedGroupReply(group: string, member: GroupMemb
     return // source unreachable — leave the marker for the next boundary
   }
 
+  const currentGroup = resolveGroupTurnRoom(group, roomId, memberKey, marker)
+
+  if (!currentGroup) {
+    return
+  }
+
   if (state?.inflight || state?.running) {
     return // still grinding — keep waiting
   }
 
   // A stranded member blocked on a clarify is not "grinding" — surface the
   // question card (#90694) and keep the marker until it resolves.
-  if (syncGroupClarify(group, member, state)) {
+  if (syncGroupClarify(currentGroup, member, state)) {
     return
   }
 
-  // Done (or dead): the marker is consumed either way.
-  updateGroupChat(group, (r: GroupChatRoom) => {
-    const next = {
-      ...(r.stranded || {})
-    }
-
-    delete next[memberKey]
-    r.stranded = next
-
-    return r
-  })
   const messages = Array.isArray(state?.messages) ? state.messages : []
 
   if (messages.length <= strandedBefore) {
+    if (recovery) {
+      appendGroupRecoveryUnknown(currentGroup, memberKey, member, recovery)
+    } else {
+      settleGroupTurnRecoveryMarker(currentGroup, memberKey, marker)
+    }
+
     return
   }
 
   const reply = pickGroupTurnReply(messages, strandedBefore)
 
-  if (reply && !isGroupPassText(reply)) {
-    recordGroupActivity(group, {
+  if (!reply) {
+    if (recovery) {
+      appendGroupRecoveryUnknown(currentGroup, memberKey, member, recovery)
+    } else {
+      settleGroupTurnRecoveryMarker(currentGroup, memberKey, marker)
+    }
+
+    return
+  }
+
+  if (!isGroupPassText(reply)) {
+    recordGroupActivity(currentGroup, {
       kind: 'delivered',
       member: member.name,
       thread: strandedThread
     })
     appendGroupChatEntry(
-      group,
+      currentGroup,
       {
         kind: 'member',
         name: member.name,
@@ -791,12 +1234,20 @@ export async function harvestStrandedGroupReply(group: string, member: GroupMemb
           : {})
       },
       reply,
-      strandedThread
+      strandedThread,
+      undefined,
+      recovery?.recoveryId
     )
-    updateGroupChat(group, (r: GroupChatRoom) => {
+    updateGroupChat(currentGroup, (r: GroupChatRoom) => {
       r.watermarks[`${strandedThread}::${memberKey}`] = r.log.length
 
       return r
     })
+  }
+
+  if (recovery) {
+    settleGroupTurnRecovery(currentGroup, member, recovery.recoveryId)
+  } else {
+    settleGroupTurnRecoveryMarker(currentGroup, memberKey, marker)
   }
 }

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -180,6 +180,7 @@ type BotsMessages = {
     waitingForAnswer: string
     memberThinking: (name: string) => string
     roomWorking: string
+    recoveryUnknown: string
     messageRoom: (group: string) => string
     newThreadPlaceholder: (group: string) => string
     everyoneMeta: string
@@ -376,6 +377,7 @@ const en: BotsMessages = {
     waitingForAnswer: 'Waiting for your answer…',
     memberThinking: name => `${name} is thinking…`,
     roomWorking: 'The room is working…',
+    recoveryUnknown: '⚠️ Reply status is unknown after the app restarted. Send the message again to retry.',
     messageRoom: group => `Message ${group}`,
     newThreadPlaceholder: group => `New thread in ${group}… (@name to direct, @everyone for all)`,
     everyoneMeta: 'Every bot in the room',
@@ -566,6 +568,7 @@ const ja: BotsMessages = {
     waitingForAnswer: 'あなたの回答を待っています…',
     memberThinking: name => `${name}が考えています…`,
     roomWorking: 'ルームが作業中です…',
+    recoveryUnknown: '⚠️ アプリの再起動後、この返信の状態を確認できません。もう一度送信して再試行してください。',
     messageRoom: group => `${group}にメッセージ`,
     newThreadPlaceholder: group => `${group}で新しいスレッド…（@名前で個別、@everyoneで全員）`,
     everyoneMeta: 'ルーム内のすべてのボット',
@@ -755,6 +758,7 @@ const zh: BotsMessages = {
     waitingForAnswer: '等待你的回答…',
     memberThinking: name => `${name} 正在思考…`,
     roomWorking: '房间正在处理…',
+    recoveryUnknown: '⚠️ 应用重启后无法确认此回复的状态。请重新发送消息以重试。',
     messageRoom: group => `发消息给 ${group}`,
     newThreadPlaceholder: group => `在 ${group} 中开启新讨论串…（@名称指定，@everyone 全体）`,
     everyoneMeta: '房间里的所有机器人',
@@ -944,6 +948,7 @@ const zhHant: BotsMessages = {
     waitingForAnswer: '等待你的回答…',
     memberThinking: name => `${name} 正在思考…`,
     roomWorking: '房間正在處理…',
+    recoveryUnknown: '⚠️ 應用程式重新啟動後，無法確認此回覆的狀態。請重新傳送訊息以重試。',
     messageRoom: group => `傳訊息給 ${group}`,
     newThreadPlaceholder: group => `在 ${group} 中開啟新討論串…（@名稱指定，@everyone 全體）`,
     everyoneMeta: '房間裡的所有機器人',

--- a/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
@@ -27,8 +27,10 @@ import type * as RoutingModule from './routing'
 const mocks = vi.hoisted(() => ({
   botChatOwnsWorkspace: vi.fn(() => false),
   paneVisibility: vi.fn(),
+  recoverInterruptedGroupTurns: vi.fn(async () => undefined),
   sessionOwnsWorkspace: vi.fn(() => false),
-  setWorkspaceScope: vi.fn()
+  setWorkspaceScope: vi.fn(),
+  stopInterruptedGroupTurnRecovery: vi.fn()
 }))
 
 vi.mock('@hermes/plugin-sdk', async importOriginal => {
@@ -77,6 +79,10 @@ vi.mock('./group-chat', async () => {
     updateGroupChat: vi.fn()
   }
 })
+vi.mock('./group-turns', () => ({
+  recoverInterruptedGroupTurns: mocks.recoverInterruptedGroupTurns,
+  stopInterruptedGroupTurnRecovery: mocks.stopInterruptedGroupTurnRecovery
+}))
 vi.mock('./data', async importOriginal => {
   const original = await importOriginal<typeof DataModule>()
 
@@ -97,7 +103,7 @@ interface Registration {
 }
 
 /** A recording `PluginContext`: registrations, their disposers, teardown. */
-function recordingContext() {
+function recordingContext(groupChats?: unknown) {
   const disposers: (() => void)[] = []
   const registrations: Registration[] = []
   const unregisters = new Map<string, () => void>()
@@ -116,7 +122,7 @@ function recordingContext() {
 
       return unregister
     },
-    storage: { get: async () => undefined, set: async () => undefined }
+    storage: { get: async (key: string) => (key === 'group-chats' ? groupChats : undefined), set: async () => undefined }
   }
 
   return {
@@ -126,6 +132,68 @@ function recordingContext() {
     unregisters
   }
 }
+
+describe('cold group-turn recovery', () => {
+  it('starts reconciliation after persisted rooms hydrate', async () => {
+    paneStores()
+
+    const harness = recordingContext({
+      Cold: {
+        log: [],
+        members: [{ name: 'research' }],
+        sessions: { research: 'sid-research' },
+        stranded: {
+          research: {
+            before: 0,
+            phase: 'submitted',
+            recoveryId: 'recovery-cold',
+            thread: 't-cold'
+          }
+        },
+        watermarks: {}
+      }
+    })
+
+    plugin.register(harness.ctx)
+    await settle()
+
+    expect(mocks.recoverInterruptedGroupTurns).toHaveBeenCalledTimes(1)
+    harness.dispose()
+    expect(mocks.stopInterruptedGroupTurnRecovery).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not start recovery after disposal wins the hydration race', async () => {
+    paneStores()
+
+    let finishHydration: (value: unknown) => void = () => undefined
+
+    const hydration = new Promise(resolve => {
+      finishHydration = resolve
+    })
+
+    const harness = recordingContext(hydration)
+
+    plugin.register(harness.ctx)
+    harness.dispose()
+    finishHydration({
+      Cold: {
+        log: [],
+        members: [{ name: 'research' }],
+        stranded: {
+          research: {
+            before: 0,
+            phase: 'submitted',
+            recoveryId: 'recovery-cold'
+          }
+        },
+        watermarks: {}
+      }
+    })
+    await settle()
+
+    expect(mocks.recoverInterruptedGroupTurns).toHaveBeenCalledTimes(0)
+  })
+})
 
 /** Nanostore stand-ins for the SDK's per-pane visibility stores. */
 function paneStores() {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -55,6 +55,7 @@ import {
   updateGroupChat
 } from './group-chat'
 import { groupWorkspaceOwnerKey } from './group-membership'
+import { recoverInterruptedGroupTurns, stopInterruptedGroupTurnRecovery } from './group-turns'
 import { annotateOrphanedGroupChatMembers } from './hygiene'
 import { BOTS_LOCALES } from './i18n'
 import { displayName } from './labels'
@@ -94,6 +95,8 @@ export default {
   description:
     'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
   register(ctx: PluginContext) {
+    let disposed = false
+
     setPluginCtx(ctx)
     const disposeLocales = ctx.i18n.register(BOTS_LOCALES)
     setGroupChatSyncDisposed(false)
@@ -105,6 +108,9 @@ export default {
     // Disabling the plugin (or a hot reload) must actually stop the clock —
     // before this, the rAF loop + 1Hz document scan ran until app restart.
     if (typeof ctx.onDispose === 'function') {
+      ctx.onDispose(() => {
+        disposed = true
+      })
       ctx.onDispose(disposeLocales)
       ctx.onDispose(stopFaceClock)
       ctx.onDispose(stopBotRelay)
@@ -264,6 +270,10 @@ export default {
                   ? await Promise.resolve(window.hermesDesktop?.connections?.list?.()).catch(() => null)
                   : null
 
+              if (disposed) {
+                return
+              }
+
               const liveIds = Array.isArray(registry?.connections)
                 ? new Set(registry.connections.map(connection => String(connection?.id || '').trim()).filter(Boolean))
                 : null
@@ -287,10 +297,20 @@ export default {
             }
           }
 
+          if (disposed) {
+            return
+          }
+
           // Receive before publish. A fresh Desktop with no local room cache
           // must hydrate the gateway projection instead of merely avoiding an
           // empty overwrite and then rendering an empty conversation.
           await pullGroupChatServerState().catch(() => false)
+
+          if (disposed) {
+            return
+          }
+
+          void recoverInterruptedGroupTurns().catch(() => undefined)
           scheduleGroupChatServerSync($groupChats.get())
         })
         .catch(() => undefined)
@@ -334,6 +354,7 @@ export default {
 
     if (typeof ctx.onDispose === 'function') {
       ctx.onDispose(() => {
+        stopInterruptedGroupTurnRecovery()
         stopGroupChatServerSync()
 
         if (typeof unbindProfileListener === 'function') {

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -151,6 +151,13 @@ export interface GroupHold {
   noted?: boolean
 }
 
+export interface GroupTurnRecovery {
+  before: number
+  phase: 'prepared' | 'submitted' | 'timed-out'
+  recoveryId: string
+  thread?: string
+}
+
 export interface GroupChat {
   /** Bumped to abandon in-flight member turns from a previous round. */
   epoch?: number
@@ -166,7 +173,7 @@ export interface GroupChat {
    *  `{ name }`, and the sweep re-validates the route before trusting one. */
   sessionOwners?: Record<string, Partial<RosterRow>>
   sessions?: Record<string, string | true>
-  stranded?: Record<string, number | { before: number; thread?: string }>
+  stranded?: Record<string, number | GroupTurnRecovery | { before: number; thread?: string }>
   syncRevision?: number
   /** Left behind when a room is disbanded, so sync can't resurrect it. */
   tombstone?: boolean


### PR DESCRIPTION
## Summary

- persist a recovery marker before dispatching a group-member prompt
- reconcile interrupted replies after renderer restart with bounded polling and exact-ID deduplication
- preserve lifecycle safety across overlapping turns, room rename/disband, hydration, and plugin disposal
- keep recovery/session metadata out of gateway-visible room metadata
- surface a localized explicit unknown outcome when recovery cannot prove a reply or pass

## Validation

- `npm exec --workspace apps/desktop vitest run -- src/plugins/hermes-bots/group-turns.test.ts src/plugins/hermes-bots/group-rounds.test.ts src/plugins/hermes-bots/group-chat-view.test.ts src/plugins/hermes-bots/group-chat.test.ts src/plugins/hermes-bots/plugin-panes.test.tsx` — 150 passed
- `npm run typecheck --workspace apps/desktop`
- scoped ESLint on all changed files
- `npm run test:ui --workspace apps/desktop` — 6,732 passed across 680 files