### PR TITLE
feat(gateway): route profiles by source scope

### DIFF
--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -9,7 +9,8 @@
 By default a single gateway run uses one profile (memory, persona, tools). **Profile-based
 routing** lets one gateway instance serve **multiple isolated profiles**, selecting which
 profile handles an inbound message based on *where the message came from* — the platform,
-server (`guild_id`), channel (`chat_id`), and/or thread (`thread_id`).
+adapter-defined account or tenant (`scope_id`), server (`guild_id`), channel (`chat_id`),
+and/or thread (`thread_id`).
 
 This is the inbound counterpart to multiplexing: instead of running N gateways, run one
 gateway and route per-community / per-channel / per-thread to a dedicated profile. Each
@@ -52,6 +53,12 @@ profile_routes:
     chat_id: "9876543210"
     thread_id: "1111111111"
     profile: standup
+
+  # Route an adapter-defined account or tenant to its own profile.
+  - name: sales-account
+    platform: support-phone
+    scope_id: sales
+    profile: sales-agent
 ```
 
 ### Fields
@@ -61,6 +68,7 @@ profile_routes:
 | `name` | yes | Human-readable route identifier (used in logs). |
 | `platform` | yes | Adapter platform: `discord`, `telegram`, `feishu`, `slack`, … |
 | `profile` | yes | Target profile name (must exist under `~/.hermes/profiles/<name>`). |
+| `scope_id` | no | Stable adapter-defined account, tenant, or workspace id. |
 | `guild_id` | no | Server/guild (Discord). |
 | `chat_id` | no | Channel/group/DM id. |
 | `thread_id` | no | Thread id within a channel. |
@@ -72,6 +80,7 @@ A route matches an inbound source when **every discriminator the route declares 
 (conjunctive / AND). A field the route leaves unset is ignored.
 
 - **`platform`** must equal the source platform exactly.
+- **`scope_id`** (if set) must equal the source scope id.
 - **`thread_id`** (if set) must equal the source thread id.
 - **`chat_id`** (if set) must match the source channel **or** its parent — a thread in a
   channel matches the channel's route (hierarchical match for Discord forums/threads).
@@ -87,10 +96,12 @@ When multiple routes match, the **most specific** one wins. Specificity is addit
 | `thread_id` | 8 |
 | `chat_id` | 4 |
 | `guild_id` | 2 |
+| `scope_id` | 1 |
 | (platform only) | 0 |
 
-So a thread route (8) beats a channel route (4) beats a guild route (2) within the same server.
-If no route matches, the message uses the default/active profile.
+So a thread route (8) beats a channel route (4), which beats a guild route (2), which
+beats a scope-only route (1). Combined discriminators add their weights. If no route
+matches, the message uses the default/active profile.
 
 ## How it works at runtime
 
@@ -113,5 +124,5 @@ every platform goes through this path — not just Discord.
 `profile_routes` requires `gateway.multiplex_profiles: true`. Multiplexing is what
 activates the per-profile runtime scope (per-profile `HERMES_HOME`, secret scope, and
 profile-namespaced session keys); routing is the decision layer that picks *which*
-profile a given guild/channel/thread lands in. With multiplexing off, `profile_routes`
+profile a given scope/guild/channel/thread lands in. With multiplexing off, `profile_routes`
 is ignored entirely — behavior is byte-identical to a single-profile gateway.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1024,9 +1024,10 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
-    # Profile-based routing: route specific guilds/channels/threads to
+    # Profile-based routing: route specific scopes/guilds/channels/threads to
     # different profiles. See gateway/profile_routing.py. Each entry is a
-    # dict with: name, platform, profile, and optional guild_id/chat_id/thread_id.
+    # dict with: name, platform, profile, and optional
+    # scope_id/guild_id/chat_id/thread_id.
     profile_routes: list = field(default_factory=list)
 
     def __post_init__(self) -> None:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -7287,10 +7287,10 @@ class BasePlatformAdapter(ABC):
         """Helper to build a SessionSource for this platform.
 
         When ``gateway.profile_routes`` is configured, the routing engine
-        resolves the matching profile from guild/chat/thread and stamps it on
-        ``source.profile``. Downstream code (``_resolve_profile_home_for_source``
-        in run.py) reads that field to enter ``_profile_runtime_scope`` for
-        per-profile HERMES_HOME isolation.
+        resolves the matching profile from scope/guild/chat/thread and stamps it
+        on ``source.profile``. Downstream code
+        (``_resolve_profile_home_for_source`` in run.py) reads that field to
+        enter ``_profile_runtime_scope`` for per-profile HERMES_HOME isolation.
         """
         # Normalize empty topic to None
         if chat_topic is not None and not chat_topic.strip():

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -7,7 +7,8 @@ Matching priority (most specific first):
   1. platform + chat_id + thread_id (exact thread)  — specificity 14
   2. platform + chat_id (channel route)             — specificity 6
   3. platform + guild_id (guild/server route)       — specificity 2
-  4. No match                                       → default profile
+  4. platform + scope_id (platform account/tenant)  — specificity 1
+  5. No match                                       → default profile
 
 Parent-chain matching:
 For Discord threads and forum posts, ``parent_chat_id`` carries the
@@ -62,11 +63,14 @@ class ProfileRoute:
     chat_id: Optional[str] = None
     thread_id: Optional[str] = None
     enabled: bool = True
+    scope_id: Optional[str] = None
 
     @property
     def specificity(self) -> int:
         """Higher value = more specific match."""
         s = 0
+        if self.scope_id:
+            s += 1
         if self.guild_id:
             s += 2
         if self.chat_id:
@@ -82,6 +86,7 @@ class ProfileRoute:
         chat_id: Optional[str] = None,
         thread_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
+        scope_id: Optional[str] = None,
     ) -> bool:
         """Return True if this route matches the given source fields.
 
@@ -96,6 +101,8 @@ class ProfileRoute:
         if not self.enabled:
             return False
         if self.platform != platform:
+            return False
+        if self.scope_id and self.scope_id != scope_id:
             return False
         if self.thread_id and self.thread_id != thread_id:
             return False
@@ -143,6 +150,7 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
                 name=name,
                 platform=platform,
                 profile=profile,
+                scope_id=entry.get("scope_id"),
                 guild_id=entry.get("guild_id"),
                 chat_id=entry.get("chat_id"),
                 thread_id=entry.get("thread_id"),
@@ -162,9 +170,17 @@ def match_profile_route(
     chat_id: Optional[str] = None,
     thread_id: Optional[str] = None,
     parent_chat_id: Optional[str] = None,
+    scope_id: Optional[str] = None,
 ) -> Optional[ProfileRoute]:
     """Return the best-matching route, or None for no match."""
     for route in routes:
-        if route.matches(platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id, parent_chat_id=parent_chat_id):
+        if route.matches(
+            platform,
+            scope_id=scope_id,
+            guild_id=guild_id,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            parent_chat_id=parent_chat_id,
+        ):
             return route
     return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28912,8 +28912,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         no route matches. Callers (``build_source``,
         ``_resolve_profile_home_for_source``) treat ``None`` as "use the
         default/active profile". When ``gateway.profile_routes`` is configured,
-        the most specific matching route wins (guild < channel < thread). See
-        :mod:`gateway.profile_routing` for matching rules.
+        the most specific matching route wins
+        (scope < guild < channel < thread). See :mod:`gateway.profile_routing`
+        for matching rules.
 
         Gated on ``gateway.multiplex_profiles``: routing stamps
         ``source.profile``, which selects the session-key namespace and batch
@@ -28933,6 +28934,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             matched = match_profile_route(
                 routes,
                 platform=source.platform.value,
+                scope_id=getattr(source, "scope_id", None),
                 guild_id=getattr(source, "guild_id", None),
                 chat_id=source.chat_id,
                 thread_id=getattr(source, "thread_id", None),
@@ -28964,9 +28966,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 raise ProfileRouteRejected(matched.name)
             return matched.profile
         logger.debug(
-            "No profile route matched: platform=%s chat_id=%s thread_id=%s parent_chat_id=%s",
-            source.platform.value, source.chat_id,
-            getattr(source, "thread_id", None), getattr(source, "parent_chat_id", None),
+            "No profile route matched: platform=%s scope_id=%s chat_id=%s "
+            "thread_id=%s parent_chat_id=%s",
+            source.platform.value,
+            getattr(source, "scope_id", None),
+            source.chat_id,
+            getattr(source, "thread_id", None),
+            getattr(source, "parent_chat_id", None),
         )
         return None
 

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -20,6 +20,23 @@ class TestProfileRoute:
         with pytest.raises(AttributeError):
             r.name = "y"
 
+    def test_scope_route_is_more_specific_than_platform_only(self):
+        r = ProfileRoute(
+            name="line",
+            platform="custom-phone",
+            profile="sales",
+            scope_id="sales-line",
+        )
+        assert r.specificity == 1
+
+    def test_existing_positional_constructor_order_is_preserved(self):
+        r = ProfileRoute("r", "discord", "p", "g", "c", "t", False)
+        assert r.guild_id == "g"
+        assert r.chat_id == "c"
+        assert r.thread_id == "t"
+        assert r.enabled is False
+        assert r.scope_id is None
+
 
 class TestProfileRouteMatching:
     def test_exact_thread_match(self):
@@ -44,11 +61,57 @@ class TestProfileRouteMatching:
         # guild matches but chat differs -> NO match
         assert not r.matches("discord", guild_id="111", chat_id="333")
 
+    def test_scope_id_must_match(self):
+        r = ProfileRoute(
+            name="line",
+            platform="custom-phone",
+            profile="sales",
+            scope_id="sales-line",
+        )
+        assert r.matches("custom-phone", scope_id="sales-line")
+        assert not r.matches("custom-phone", scope_id="support-line")
+        assert not r.matches("custom-phone")
+
+    def test_scope_and_chat_are_conjunctive(self):
+        r = ProfileRoute(
+            name="line-channel",
+            platform="custom-phone",
+            profile="sales",
+            scope_id="sales-line",
+            chat_id="call-1",
+        )
+        assert r.specificity == 5
+        assert r.matches("custom-phone", scope_id="sales-line", chat_id="call-1")
+        assert not r.matches("custom-phone", scope_id="sales-line", chat_id="call-2")
+        assert not r.matches("custom-phone", scope_id="support-line", chat_id="call-1")
+
+    def test_existing_positional_match_order_is_preserved(self):
+        r = ProfileRoute(
+            name="thread",
+            platform="discord",
+            profile="p",
+            guild_id="g",
+            chat_id="c",
+            thread_id="t",
+        )
+        assert r.matches("discord", "g", "c", "t", "parent")
+
 
 class TestParseProfileRoutes:
     def test_empty(self):
         assert parse_profile_routes(None) == []
         assert parse_profile_routes([]) == []
+
+    def test_scope_id_is_parsed(self):
+        routes = parse_profile_routes([
+            {
+                "name": "sales-line",
+                "platform": "custom-phone",
+                "scope_id": "sales",
+                "profile": "sales-agent",
+            }
+        ])
+        assert routes[0].scope_id == "sales"
 
 
 class TestMatchProfileRoute:
@@ -59,6 +122,53 @@ class TestMatchProfileRoute:
             ProfileRoute(name="r", platform="telegram", profile="p"),
         ]
         assert match_profile_route(routes, "discord") is None
+
+    def test_scope_route_is_selected(self):
+        routes = [
+            ProfileRoute(
+                name="sales",
+                platform="custom-phone",
+                profile="sales-agent",
+                scope_id="sales-line",
+            ),
+        ]
+        matched = match_profile_route(
+            routes,
+            "custom-phone",
+            scope_id="sales-line",
+        )
+        assert matched is not None
+        assert matched.profile == "sales-agent"
+
+
+def test_gateway_runner_routes_scope_to_served_profile(monkeypatch, tmp_path):
+    from gateway.config import GatewayConfig, Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        multiplex_profiles=True,
+        profile_routes=[
+            ProfileRoute(
+                name="sales",
+                platform="telegram",
+                profile="sales-agent",
+                scope_id="sales-line",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "gateway.run._multiplex_profile_homes",
+        lambda _config: [("default", tmp_path), ("sales-agent", tmp_path / "sales-agent")],
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="call-1",
+        scope_id="sales-line",
+    )
+
+    assert runner._profile_name_for_source(source) == "sales-agent"
 
 
 class TestSessionKeyIntegration:


### PR DESCRIPTION
## What does this PR do?

Adds generic `scope_id` matching to `gateway.profile_routes`. Dynamic platforms can use an existing `SessionSource.scope_id` value as a stable route discriminator while retaining the multiplex profile allowlist and served-profile validation.

Configured route fields remain conjunctive. Scope-specific routes gain one specificity point, so they outrank otherwise equivalent platform-only routes without changing the existing guild, chat, or thread ordering.

This change is generic and does not add any product-specific integration to Hermes core.

## Related Issue

No issue; duplicate searches across open and closed PRs and issues returned no matching work.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add optional `scope_id` parsing, matching, and specificity in `gateway/profile_routing.py`.
- Forward `SessionSource.scope_id` through `GatewayRunner` route selection in `gateway/run.py`.
- Document the generic scope route field in `gateway/config.py` and `docs/profile-routing.md`.
- Add parsing, matching, conjunctive-field, specificity, runtime-forwarding, and positional-compatibility tests.

## How to Test

1. Run `.venv/bin/pytest tests/gateway/test_profile_routing.py -q` (18 passed locally).
2. Run `.venv/bin/ruff check gateway/profile_routing.py gateway/run.py gateway/platforms/base.py gateway/config.py tests/gateway/test_profile_routing.py`.
3. Run `git diff --check`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this feature.
- [ ] I've run `pytest tests/ -q` and all tests pass. The focused profile-routing suite is green; the broader gateway suite has unrelated optional-platform dependency/test failures in this isolated environment.
- [x] I've added tests for my changes.
- [x] I've tested on Arch Linux.

### Documentation & Housekeeping

- [x] I've updated relevant documentation.
- [x] `cli-config.yaml.example` is N/A; the existing gateway configuration comments are updated.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A.
- [x] I've considered cross-platform impact; the change is platform-independent Python routing logic.
- [x] Tool descriptions/schemas are N/A.

## Screenshots / Logs

```text
18 passed in 0.44s
All checks passed!
```
