### PR TITLE
fix(weixin): dedup re-delivered messages that arrive without a messag…

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -956,6 +956,48 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return default
 
 
+# Envelope fields that iLink keeps stable across a re-delivery. ``context_token``
+# is deliberately absent: it rotates by design. Unknown extension fields are
+# excluded for the same reason — a rotating field would give the same message a
+# fresh identity on every retry, which is the bug this is meant to close.
+_SYNTHETIC_ID_FIELDS = (
+    "from_user_id", "create_time", "sequence", "seq",
+    "client_id", "message_type",
+)
+# At least one of these must be present. Sender plus payload alone cannot tell a
+# resend from someone genuinely sending the same sticker twice.
+_SYNTHETIC_ID_ORDINALS = ("create_time", "sequence", "seq")
+
+
+def _synthetic_message_id(message: Dict[str, Any]) -> str:
+    """Derive a replay identity for an inbound message that carries no ``message_id``.
+
+    iLink does not always populate ``message_id``. When it is absent the primary
+    dedup is skipped, and the content-fingerprint fallback only covers text — so
+    a re-delivered image or voice note is processed again on every arrival.
+
+    Including an ordinal field keeps two legitimately identical messages from the
+    same sender distinct, so this does not widen the over-aggressive dedup
+    behaviour reported in #29779 and #36750.
+
+    Returns an empty string when no ordinal field is present, leaving the caller
+    on its existing path rather than risking a wrong identity.
+    """
+    if not any(str(message.get(key) or "").strip() for key in _SYNTHETIC_ID_ORDINALS):
+        return ""
+    identity: Dict[str, Any] = {
+        key: message.get(key)
+        for key in _SYNTHETIC_ID_FIELDS
+        if message.get(key) is not None
+    }
+    identity["item_list"] = message.get("item_list") or []
+    encoded = json.dumps(
+        identity, ensure_ascii=False, sort_keys=True,
+        separators=(",", ":"), default=str,
+    ).encode()
+    return "weixin-synthetic-" + hashlib.sha256(encoded).hexdigest()
+
+
 def _extract_text(item_list: List[Dict[str, Any]]) -> str:
     for item in item_list:
         if item.get("type") == ITEM_TEXT:
@@ -1475,6 +1517,11 @@ class WeixinAdapter(BasePlatformAdapter):
             return
 
         message_id = str(message.get("message_id") or "").strip()
+        if not message_id:
+            # No platform id: fall back to an envelope-derived identity so a
+            # re-delivered non-text message is not reprocessed. Empty when the
+            # envelope carries nothing stable enough to key on.
+            message_id = _synthetic_message_id(message)
         if message_id and self._dedup.is_duplicate(message_id):
             return
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -828,3 +828,71 @@ class TestWeixinVoiceGatewayHandoff:
             "the wrong transcript instead of re-transcribing (#27300)."
         )
 
+
+
+class TestWeixinSyntheticMessageId:
+    """iLink does not always populate ``message_id``. When it is absent the
+    primary dedup is skipped and the content-fingerprint fallback only covers
+    text, so a re-delivered image or voice note is reprocessed on every
+    arrival. ``_synthetic_message_id`` closes that hole.
+    """
+
+    def _image_message(self, **overrides):
+        message = {
+            "from_user_id": "wxid_user1",
+            "create_time": 1756000000,
+            "sequence": 42,
+            "message_type": 3,
+            "item_list": [{"type": 3, "image_item": {"cdn_url": "https://cdn/x.jpg"}}],
+        }
+        message.update(overrides)
+        return message
+
+    def test_same_envelope_yields_same_id(self):
+        """A re-delivery of the same message must collapse onto one identity."""
+        first = weixin._synthetic_message_id(self._image_message())
+        second = weixin._synthetic_message_id(self._image_message())
+        assert first
+        assert first == second
+        assert first.startswith("weixin-synthetic-")
+
+    def test_rotating_context_token_does_not_change_identity(self):
+        """context_token rotates between retries; keying on it would give each
+        retry a fresh identity and defeat the dedup entirely.
+        """
+        a = weixin._synthetic_message_id(self._image_message(context_token="tok-a"))
+        b = weixin._synthetic_message_id(self._image_message(context_token="tok-b"))
+        assert a == b
+
+    def test_unknown_extension_fields_do_not_change_identity(self):
+        a = weixin._synthetic_message_id(self._image_message())
+        b = weixin._synthetic_message_id(self._image_message(some_future_field="x"))
+        assert a == b
+
+    def test_ordinal_field_keeps_legitimate_repeats_distinct(self):
+        """Sending the same sticker twice is not a duplicate delivery — the
+        ordinal fields must keep the two apart (see #29779 / #36750).
+        """
+        a = weixin._synthetic_message_id(self._image_message(create_time=1756000000, sequence=42))
+        b = weixin._synthetic_message_id(self._image_message(create_time=1756000009, sequence=43))
+        assert a != b
+
+    def test_different_payload_yields_different_id(self):
+        a = weixin._synthetic_message_id(self._image_message())
+        b = weixin._synthetic_message_id(self._image_message(
+            item_list=[{"type": 3, "image_item": {"cdn_url": "https://cdn/y.jpg"}}]))
+        assert a != b
+
+    def test_no_ordinal_field_returns_empty(self):
+        """Sender plus payload alone cannot tell a resend from a genuine
+        repeat, so the caller is left on its existing path instead.
+        """
+        message = self._image_message()
+        for key in ("create_time", "sequence", "seq"):
+            message.pop(key, None)
+        assert weixin._synthetic_message_id(message) == ""
+
+    def test_blank_ordinal_values_count_as_absent(self):
+        message = self._image_message(create_time="", sequence="")
+        message.pop("seq", None)
+        assert weixin._synthetic_message_id(message) == ""


### PR DESCRIPTION
## What does this PR do?

iLink does not always populate `message_id`, and both dedup paths are conditional on something this case lacks:

```python
message_id = str(message.get("message_id") or "").strip()
if message_id and self._dedup.is_duplicate(message_id):   # skipped when absent
    return

item_list = message.get("item_list") or []
text = _extract_text(item_list)
if text:                                                   # skipped for media
    content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
```

A message with **no `message_id` and no text** — an image, a voice note, a sticker — passes both and is processed again on every re-delivery.

Adds `_synthetic_message_id()`, used only when `message_id` is absent. It hashes transport-stable envelope fields plus the payload.

Two deliberate exclusions: `context_token` rotates by design, and unknown extension fields may rotate too. Keying on either would hand every retry a fresh identity and defeat the dedup it is meant to provide.

An ordinal field (`create_time` / `sequence` / `seq`) must be present and participates in the hash, so two legitimately identical messages from the same sender stay distinct — this does **not** widen the over-aggressive content dedup reported in #29779 and #36750. When no ordinal field is present the helper returns `""` and the caller stays on its existing path rather than risking a wrong identity.

The synthesised value also flows into `build_source(message_id=...)`, so the session and tool idempotency layers get a stable key for these messages instead of `None`.

Found on a deployment where image messages were being ingested twice.

## Related Issue

Related to #56026 (Weixin adapter re-delivers old messages after a container restart). That is a sync-cursor problem and this does not fix it — but the two compound, because the messages it re-delivers are exactly the ones this dedup currently misses. This is defence in depth, not a replacement.

Deliberately **not** touching #29779 / #36750: those ask for the text content-fingerprint dedup to be *less* aggressive. That path is untouched here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/weixin.py` — new module-level `_synthetic_message_id()` plus `_SYNTHETIC_ID_FIELDS` / `_SYNTHETIC_ID_ORDINALS`; `_process_message` calls it only when `message_id` is empty. **Pure addition — no existing branch is modified.**
- `tests/gateway/test_weixin.py` — `TestWeixinSyntheticMessageId`, 7 cases: stable identity across re-delivery, rotating `context_token` ignored, unknown extension fields ignored, ordinal fields keep legitimate repeats distinct, payload changes change the id, and the two "no usable ordinal" cases returning `""`.

## Testing

The tests have teeth: reverting the source change fails all 7.

`pytest tests/gateway/test_weixin.py tests/gateway/test_weixin_typing.py tests/gateway/test_weixin_secret_scope.py`:

- without this change: **7 failed, 35 passed**
- with this change: **7 failed, 42 passed** (the +7 are the new tests)

The 7 pre-existing failures are unrelated (typing-ticket and secret-scope cases) and reproduce on a clean checkout of `main`.

A note for review: the field list is the part most worth a second opinion. I picked the envelope fields that looked transport-stable, but a maintainer who knows the iLink contract may want to add or remove entries — the helper is deliberately small so that list is easy to change.
