### PR TITLE
fix(cli): handle list navigation errors cleanly in hermes config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1265,7 +1265,20 @@ def _set_nested(config, dotted_key: str, value):
         if isinstance(current, list):
             part = remaining[0]
             if at_leaf:
-                current[int(part)] = value
+                try:
+                    idx = int(part)
+                except (TypeError, ValueError):
+                    raise TypeError(
+                        f"Cannot navigate into list at key {dotted_key!r}: "
+                        f"segment {part!r} is not a numeric index"
+                    )
+                try:
+                    current[idx] = value
+                except IndexError:
+                    raise IndexError(
+                        f"Cannot assign to list at key {dotted_key!r}: "
+                        f"index {idx} is out of bounds (length {len(current)})"
+                    )
                 return
             try:
                 idx = int(part)
@@ -1274,7 +1287,13 @@ def _set_nested(config, dotted_key: str, value):
                     f"Cannot navigate into list at key {dotted_key!r}: "
                     f"segment {part!r} is not a numeric index"
                 )
-            current = current[idx]
+            try:
+                current = current[idx]
+            except IndexError:
+                raise IndexError(
+                    f"Cannot navigate into list at key {dotted_key!r}: "
+                    f"index {idx} is out of bounds (length {len(current)})"
+                )
             i += 1
         elif isinstance(current, dict):
             match = _greedy_literal_match(current, remaining)
@@ -6163,8 +6182,8 @@ def set_config_value(key: str, value: str, force: bool = False):
                 sys.exit(1)
     try:
         _set_nested(user_config, key, value)
-    except ValueError as e:
-        print(f"✗ {e}", file=sys.stderr)
+    except (TypeError, IndexError, ValueError) as exc:
+        print(f"✗ Cannot set {key!r}: {exc}", file=sys.stderr)
         sys.exit(1)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -307,6 +307,51 @@ class TestListNavigation:
         assert allowlist[0] == {"name": "alice", "role": "admin"}
         assert allowlist[1] == {"name": "bob", "role": "admin"}
 
+    def test_non_numeric_intermediate_segment_fails_cleanly(self, _isolated_hermes_home, capsys):
+        """Non-numeric segment on a list node exits with clean error and no traceback."""
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: provider-a\n"
+        ))
+
+        with pytest.raises(SystemExit) as exc_info:
+            set_config_value("custom_providers.notanint.api_key", "val")
+        assert exc_info.value.code == 1
+
+        err = capsys.readouterr().err
+        assert "Cannot navigate into list" in err
+        assert "not a numeric index" in err
+
+    def test_non_numeric_leaf_segment_fails_cleanly(self, _isolated_hermes_home, capsys):
+        """Non-numeric leaf segment on a list node exits with clean error and no traceback."""
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: provider-a\n"
+        ))
+
+        with pytest.raises(SystemExit) as exc_info:
+            set_config_value("custom_providers.api_key", "val")
+        assert exc_info.value.code == 1
+
+        err = capsys.readouterr().err
+        assert "Cannot navigate into list" in err
+        assert "not a numeric index" in err
+
+    def test_out_of_bounds_index_fails_cleanly(self, _isolated_hermes_home, capsys):
+        """Out of bounds index on list navigation exits with clean error and no traceback."""
+        self._write_config(_isolated_hermes_home, (
+            "custom_providers:\n"
+            "- name: provider-a\n"
+        ))
+
+        with pytest.raises(SystemExit) as exc_info:
+            set_config_value("custom_providers.99.api_key", "val")
+        assert exc_info.value.code == 1
+
+        err = capsys.readouterr().err
+        assert "out of bounds" in err
+        assert "length 1" in err
+
 
 # ---------------------------------------------------------------------------
 # Cron drift guard warning — regression tests for #59031


### PR DESCRIPTION
## What does this PR do?

Fixes an unhandled exception bug in [`hermes_cli/config.py`](file:///c:/Users/EricM/Dev/hermes-agent/hermes_cli/config.py) where setting non-numeric or out-of-bounds keys on list-typed configuration elements (e.g. `hermes config set custom_providers.name foo` or `hermes config set custom_providers.99.api_key foo`) leaked raw `ValueError` / `IndexError` / `TypeError` tracebacks to stderr instead of returning clean, formatted CLI errors with exit code 1.

The fix:
1. **Validates list indices at the leaf position**: Ensures non-numeric leaf segments on list nodes raise a descriptive `TypeError` with contextual path info instead of an unhandled `ValueError` from `int()`.
2. **Bounds checking on list assignments**: Catches out-of-bounds list accesses during intermediate and leaf navigation in `_set_nested()`, raising an `IndexError` that explicitly names the index and current list length.
3. **Graceful CLI error reporting**: In `set_config_value()`, wraps `_set_nested()` in `try...except (TypeError, IndexError)` and outputs a clean `✗ Cannot set 'key': ...` error message to stderr.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: Added bounds checking and non-numeric segment handling in `_set_nested()`, and caught navigation exceptions in `set_config_value()` to print user-friendly errors on stderr.
- `tests/hermes_cli/test_set_config_value.py`: Added regression tests verifying that invalid intermediate segments, non-numeric leaf segments, and out-of-bounds indices exit cleanly with exit code 1 and formatted stderr messages.

## How to Test

Run the configuration test suite:
```bash
uv run --with pytest pytest tests/hermes_cli/test_set_config_value.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): handle list navigation errors cleanly in hermes config set`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
collected 89 items

tests/hermes_cli/test_set_config_value.py ............................... [100%]

============================= 89 passed in 15.03s =============================
```
