### PR TITLE
fix(gateway): keep sender context on mid-turn messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10414,6 +10414,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return text
         return (enriched_text or text).strip()
 
+    async def _prepare_busy_active_turn_text(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        running_agent: Any,
+    ) -> Optional[str]:
+        """Prepare a busy follow-up with the normal inbound metadata pipeline."""
+        history = getattr(running_agent, "_session_messages", None) or []
+        return await self._prepare_profile_scoped_inbound_message_text(
+            event=event,
+            source=event.source,
+            history=history,
+            session_key=session_key,
+        )
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -10606,7 +10621,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         steered = False
         redirected = False
         if effective_mode == "steer":
-            steer_text = await self._prepare_busy_steer_text(event)
+            await self._prepare_busy_steer_text(event)
+            steer_text = await self._prepare_busy_active_turn_text(
+                event,
+                session_key,
+                running_agent,
+            )
+            if steer_text is None:
+                return True
             # A follow-up qualifies for steering when it is plain text, OR
             # when every attachment is STT-eligible voice media whose
             # transcript was just folded into steer_text — otherwise a voice
@@ -10648,8 +10670,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             and getattr(running_agent, "_supports_active_turn_redirect", False) is True
             and hasattr(running_agent, "redirect")
         ):
+            redirect_text = await self._prepare_busy_active_turn_text(
+                event,
+                session_key,
+                running_agent,
+            )
+            if redirect_text is None:
+                return True
             try:
-                redirected = bool(running_agent.redirect((event.text or "").strip()))
+                redirected = bool(running_agent.redirect(redirect_text))
             except Exception as exc:
                 logger.warning("Gateway redirect failed for session %s: %s", session_key, exc)
                 redirected = False

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -226,6 +226,51 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["steer", "interrupt"])
+    async def test_active_turn_text_uses_normal_inbound_preprocessing(
+        self, monkeypatch, mode
+    ):
+        """Successful steer/redirect must retain sender and reply context."""
+        import gateway.run as _gr
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = mode
+        adapter = _make_adapter()
+        event = _make_event(text="also check the tests")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        prepared = '[Alice] [Replying to: "the failing test"]\n\nalso check the tests'
+        runner._prepare_profile_scoped_inbound_message_text = AsyncMock(
+            return_value=prepared
+        )
+
+        agent = MagicMock()
+        agent._session_messages = [{"role": "user", "content": "original"}]
+        agent._supports_active_turn_redirect = True
+        agent.steer.return_value = True
+        agent.redirect.return_value = True
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        runner._prepare_profile_scoped_inbound_message_text.assert_awaited_once_with(
+            event=event,
+            source=event.source,
+            history=agent._session_messages,
+            session_key=sk,
+        )
+        if mode == "steer":
+            agent.steer.assert_called_once_with(prepared)
+            agent.redirect.assert_not_called()
+        else:
+            agent.redirect.assert_called_once_with(prepared)
+            agent.steer.assert_not_called()
+        assert sk not in adapter._pending_messages
+
+    @pytest.mark.asyncio
     async def test_steer_mode_transcribes_voice_before_injection(self, monkeypatch):
         """A busy voice follow-up is transcribed and steered, never queued."""
         import gateway.run as _gr


### PR DESCRIPTION
## What does this PR do?

Busy-session steer and redirect messages now retain the same sender, reply, message-id, forwarding, and inbound context enrichment as normal messages. Previously shared chats could durably lose who spoke and what they replied to.

### Bug Cause

**Trigger:** `gateway/run.py` / `_handle_active_session_busy_message()` when `steer` or active-turn `interrupt` redirect succeeds.

**Causal chain:**
1. A structured `MessageEvent` arrives during a running turn.
2. The busy handler passes only raw `event.text` to `steer()` or `redirect()`.
3. Successful injection skips the pending queue, so normal inbound preprocessing never runs and the degraded text is persisted.

**Why it is wrong:** The busy path discarded event context before the shared preprocessing boundary.

**Working contrast:** Queue mode retains the full event and preprocesses it before the next turn.

**Ruled out:** Adapters already populate these fields; focused handler tests place the loss after adapter normalization.

### Fix

Run active-turn steer and redirect payloads through the profile-scoped normal inbound preprocessor with the running agent's history. Voice steering still transcribes once first, then the shared preprocessor consumes the cached transcript.

## Related Issue


N/A

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `gateway/run.py` - preprocess busy steer and redirect payloads through the normal inbound pipeline.
- `tests/gateway/test_busy_session_ack.py` - cover enriched injection for both modes.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_busy_session_ack.py -q
```

Result: 12 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs
- [x] My PR contains only related changes
- [x] Relevant tests pass
- [x] Tests cover the fix
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation - N/A; existing behavior contract restored
- [x] Config example - N/A; no config changed
- [x] Contributor docs - N/A; no architecture changed
- [x] Cross-platform impact considered
- [x] Tool schemas - N/A; no tool changed
