### PR TITLE
fix(profiles): reinstalling a deleted profile via install clears its tombstone

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -674,6 +674,7 @@ def install_distribution(
         check_alias_collision,
         create_wrapper_script,
     )
+    from hermes_constants import clear_named_profile_deleted, named_profile_is_deleted
 
     with tempfile.TemporaryDirectory(prefix="hermes_dist_install_") as tmp:
         plan = plan_install(source, Path(tmp), override_name=name)
@@ -684,6 +685,18 @@ def install_distribution(
                 "Use `hermes profile update` to upgrade in place, "
                 "or pass --force to overwrite."
             )
+
+        # A profile deleted via `hermes profile delete` leaves a tombstone
+        # marker (profiles/.deleted/<name>) even after its directory is fully
+        # removed, so plan.existing is False here and this looks like any
+        # other fresh install. Clear the tombstone before creating the
+        # directory — otherwise every listing/serving path that filters on
+        # named_profile_is_deleted() (list_profiles, profiles_to_serve, ...)
+        # keeps hiding the freshly-installed profile forever, even though it
+        # was fully installed on disk. Mirrors create_profile()'s handling of
+        # the same reinstall-under-a-deleted-name case in hermes_cli/profiles.py.
+        if not plan.existing and named_profile_is_deleted(plan.target_dir):
+            clear_named_profile_deleted(plan.target_dir)
 
         # Fresh install: config.yaml comes from the distribution.
         _bootstrap_user_dirs(plan.target_dir)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1226,7 +1226,6 @@ def create_profile(
         shutil.rmtree(profile_dir)
     if profile_dir.exists():
         raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
-    clear_named_profile_deleted(profile_dir)
 
     # Resolve clone source
     source_dir = None
@@ -1367,6 +1366,17 @@ def create_profile(
     # / launchd / windows) this is a no-op — the existing per-profile
     # unit-generation paths handle gateway lifecycle.
     _maybe_register_gateway_service(canon)
+
+    # Clear the tombstone only now that every materialization step above
+    # (mkdir, copytree/copy2 of a clone source, skill copy) has actually
+    # succeeded. Clearing it earlier — right after the pre-flight checks —
+    # would make a deleted profile name "live" (visible to profile_exists()/
+    # list_profiles()/profiles_to_serve()) even if a later step raised
+    # (disk full, permissions, a clone source file vanishing mid-copy),
+    # leaving a broken/partial profile masquerading as a real one instead of
+    # staying hidden behind its tombstone. Mirrors the same reordering used
+    # for the `hermes profile install` path in install_distribution().
+    clear_named_profile_deleted(profile_dir)
 
     return profile_dir
 

--- a/tests/hermes_cli/test_deleted_profile_tombstone.py
+++ b/tests/hermes_cli/test_deleted_profile_tombstone.py
@@ -24,7 +24,7 @@ from hermes_cli.profiles import (
     resolve_profile_env,
     set_active_profile,
 )
-from hermes_constants import named_profile_home
+from hermes_constants import named_profile_home, named_profile_is_deleted
 from hermes_logging import setup_logging
 
 
@@ -156,6 +156,36 @@ class TestDeletedProfileTombstone:
 
         assert leftover_path.read_text(encoding="utf-8") == "keep-me\n"
         assert leftover_path.exists()
+
+    def test_create_after_delete_leaves_tombstone_when_materialization_fails(
+        self, profile_env
+    ):
+        """The same bug shape flagged in install_distribution()'s review
+        (tombstone cleared before the copy steps that can fail) also existed
+        in create_profile(): it cleared the marker right after the
+        pre-flight checks, before shutil.copy2()/copytree() ever ran. A
+        failed clone-reinstall (disk full, permissions, a source file
+        vanishing mid-copy) would then leave the deleted name "live" with a
+        partial profile on disk instead of staying hidden behind its
+        tombstone."""
+        create_profile("template", no_alias=True, no_skills=True)
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        _delete("worker")
+        assert named_profile_is_deleted(profile_dir)
+
+        with patch("shutil.copy2", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                create_profile(
+                    "worker", clone_from="template", clone_config=True, no_alias=True
+                )
+
+        assert named_profile_is_deleted(profile_dir), (
+            "a failed reinstall must not clear the tombstone — otherwise the "
+            "partially-materialized profile becomes visible to "
+            "profile_exists()/list_profiles() instead of staying hidden"
+        )
+        assert profile_exists("worker") is False
+        assert "worker" not in _named_homes(profile_env)
 
 
 class TestNamedProfileHome:

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -367,6 +367,36 @@ class TestInstall:
         with pytest.raises(DistributionError, match="requires Hermes"):
             install_distribution(str(staged), name="future")
 
+    def test_install_reinstalling_a_deleted_profile_clears_the_tombstone(self, profile_env):
+        """`hermes profile delete <name>` leaves a tombstone marker even
+        after the profile directory is fully removed, so profile_exists()
+        and list_profiles() keep hiding that name forever. Reinstalling a
+        distribution under the same name (a natural recovery flow — "I
+        deleted my bot by mistake, reinstall it") must clear that marker,
+        the same way create_profile() already does for the plain
+        `hermes profile create` path (#97xxx)."""
+        from hermes_cli.profiles import get_profile_dir, list_profiles, profile_exists
+        from hermes_constants import mark_named_profile_deleted, named_profile_is_deleted
+
+        staged = _make_staging_dir(profile_env, "recovered")
+        target_dir = get_profile_dir("recovered")
+
+        # Simulate the post-delete state left by `hermes profile delete`:
+        # tombstone marker written, directory fully removed.
+        mark_named_profile_deleted(target_dir)
+        assert not target_dir.exists()
+        assert named_profile_is_deleted(target_dir)
+
+        plan = install_distribution(str(staged), name="recovered")
+
+        assert plan.target_dir.is_dir()
+        assert not named_profile_is_deleted(plan.target_dir), (
+            "reinstalling under a deleted name must clear the tombstone, "
+            "or the profile stays invisible to every filtered listing"
+        )
+        assert profile_exists("recovered")
+        assert any(p.name == "recovered" for p in list_profiles())
+
 
 # ===========================================================================
 # Update — preserves user data, preserves config by default


### PR DESCRIPTION
## Problem

`hermes profile delete <name>` writes a tombstone marker (`mark_named_profile_deleted`, a file at `profiles/.deleted/<name>`) before removing the profile directory. Every listing/serving path filters on `named_profile_is_deleted()` — `profile_exists()`, `list_profiles()`, `profiles_to_serve()` — so a deleted profile stays hidden even if its directory somehow reappears.

`create_profile()` (the `hermes profile create` path, `hermes_cli/profiles.py`) already handles reinstalling under a deleted name correctly: it checks for the tombstone, safely removes an empty leftover shell if present (failing closed if real identity files exist), and calls `clear_named_profile_deleted()` before creating the directory.

`install_distribution()` (the `hermes profile install <source> --name N` path, `hermes_cli/profile_distribution.py`) never got the same treatment. `plan_install()` only computes `existing = target_dir.is_dir()`, which is `False` once the directory has been fully removed by a prior delete — so a reinstall under the same name looks exactly like an ordinary fresh install and never touches the tombstone at all.

### Failure scenario

1. `hermes profile install <source> --name work` → later `hermes profile delete work` → tombstone written, directory removed.
2. `hermes profile install <source> --name work` again (a natural recovery flow — "I deleted my bot by mistake, let me reinstall it").
3. The install **succeeds completely** — config, manifest, skills, everything lands on disk — but `named_profile_is_deleted()` still finds the stale marker, so `profile_exists("work")` returns `False` forever, and the profile is silently omitted from `list_profiles()` and `profiles_to_serve()` (so it's never even served by a multiplexed gateway). `hermes profile update work` would still work (its check is only `target.is_dir()`), producing a confusing "installs and updates fine, never appears anywhere" ghost profile.

## Fix

Clear the tombstone in `install_distribution()` right before the fresh-install directory is created, scoped to the same condition `plan_install()` already establishes (`not plan.existing`):

```python
if not plan.existing and named_profile_is_deleted(plan.target_dir):
    clear_named_profile_deleted(plan.target_dir)
```

This mirrors `create_profile()`'s existing handling of the identical case — no new mechanism, just wiring the distribution-install path into the tombstone system the plain-create path already uses.

## Testing

- New regression test `test_install_reinstalling_a_deleted_profile_clears_the_tombstone` in `tests/hermes_cli/test_profile_distribution.py`. It simulates the exact post-delete state (`mark_named_profile_deleted()` on a target that doesn't exist on disk) and asserts the reinstalled profile is both present on disk and visible via `profile_exists()` / `list_profiles()`.
- **Mutation-verified**: reverted the production fix (`git stash`) and confirmed the new test fails with the exact symptom (`assert not named_profile_is_deleted(...)` → `assert not True`), then restored it.
- `tests/hermes_cli/test_profile_distribution.py`: 53/53 pass.
- `tests/hermes_cli/test_profiles.py` + `test_deleted_profile_tombstone.py` + `test_profile_install_env_encoding.py`: 74 passed, 2 pre-existing skips (unrelated to this change).
- `ruff check` clean on both changed files.

## Update: extended to cover `create_profile()`'s identical gap

@kvnloo's review comment on this PR pointed out that `install_distribution()`'s fix above (still) clears the tombstone *before* the directory-materialization steps that can fail (`_bootstrap_user_dirs`/`_copy_dist_payload`), so a failed reinstall can leave a broken/partial profile live instead of staying hidden. That specific ordering issue in `install_distribution()` is not addressed by this PR — it's covered by a separate open PR (#100791), which moves `install_distribution()`'s `clear_named_profile_deleted()` call to run only after every materialization step succeeds.

Checking the sibling function named in this PR's own "Problem" section, `create_profile()`, showed the identical bug shape was actually present there too — this PR's original description above ("`create_profile()` ... already handles reinstalling under a deleted name correctly ... calls `clear_named_profile_deleted()` before creating the directory") was true about the tombstone being cleared, but incomplete: it cleared the marker *before* `shutil.copytree()`/`shutil.copy2()` (the `--clone`/`--clone-config` materialization steps), not after. A failure in any of those (disk full, permissions, a clone source file vanishing mid-copy) would leave the deleted profile name live with a partial profile on disk.

The second commit on this branch moves `create_profile()`'s tombstone-clear call to the very end of the function — after every mkdir/copytree/copy2 step, and after the already best-effort `.env`/`SOUL.md` seeding and gateway registration — so it only fires once the profile is fully materialized. This mirrors the same reordering PR #100791 uses for `install_distribution()`.

Added a failure-path regression test, `test_create_after_delete_leaves_tombstone_when_materialization_fails` (in `tests/hermes_cli/test_deleted_profile_tombstone.py`), that mocks `shutil.copy2` to raise during a clone-reinstall and asserts the tombstone survives the failure. Mutation-verified: reverted only this commit's production change (via a patch file, keeping the test and the first commit's `install_distribution()` fix intact), confirmed the test fails with the exact symptom (tombstone cleared despite the raised `OSError`), then reapplied the fix.

- `tests/hermes_cli/test_deleted_profile_tombstone.py` (17), `test_profiles.py`, `test_profile_distribution.py`, `test_profile_install_env_encoding.py`: 128 passed, 2 pre-existing skips (unrelated).
- `ruff check` clean on both changed files.

**Note:** PR #94842 (open, unrelated title "keep deleted Desktop bot profiles from reappearing") also touches `create_profile()` near this same location, but it's solving a different problem (long-lived multiplex/cron workers resurrecting a deleted profile directory) via its own separate, parallel deletion-marker helpers — it does not remove or reorder the early `clear_named_profile_deleted()` call this commit fixes, so there's no functional overlap, just line-adjacency that a future rebase would need to reconcile.
