### PR TITLE
fix(agent): preserve reasoning and reasoning_details in repair_messag…

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -713,12 +713,16 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             elif not prev_content and new_content is not None:
                 prev["content"] = new_content
                 content_rewritten = new_content != prev_content
-            # Carry reasoning_content from the later turn only if the
-            # earlier turn lacks it (strict thinking providers require a
-            # reasoning_content on the merged tool-call turn; the first
-            # non-empty one suffices).
+            # Carry reasoning fields from the later turn only if the
+            # earlier turn lacks them (strict thinking providers require
+            # reasoning on the merged tool-call turn; the first non-empty
+            # one suffices).
             if not prev.get("reasoning_content") and msg.get("reasoning_content"):
                 prev["reasoning_content"] = msg["reasoning_content"]
+            if not prev.get("reasoning") and msg.get("reasoning"):
+                prev["reasoning"] = msg["reasoning"]
+            if not prev.get("reasoning_details") and msg.get("reasoning_details"):
+                prev["reasoning_details"] = msg["reasoning_details"]
             # ``prev`` may carry an ``api_content`` sidecar (the exact bytes
             # previously sent to the API, e.g. a sanitize-divergence stamp —
             # see ``_flush_messages_to_session_db``) from BEFORE this merge.

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -775,11 +775,51 @@ def test_repair_drops_stale_empty_tool_calls_on_merged_assistant():
     # A dummy agent object is enough — repair only reads message roles/content.
     agent = type("Agent", (), {})()
     n = repair_message_sequence(agent, messages)
-    assert n >= 0
     assistants = [m for m in messages if m.get("role") == "assistant"]
     assert len(assistants) == 1
     assert "tool_calls" not in assistants[0]
     assert "second" in assistants[0]["content"]
+
+
+def test_repair_preserves_reasoning_and_reasoning_details_on_merged_assistant():
+    """repair_message_sequence must preserve canonical reasoning and reasoning_details
+    when merging consecutive assistant messages if earlier message lacked them."""
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    agent = type("Agent", (), {})()
+
+    # Case 1: second message carries reasoning
+    messages_1 = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "thinking scaffold..."},
+        {"role": "assistant", "content": "final answer", "reasoning": "thought trace here"},
+    ]
+    repair_message_sequence(agent, messages_1)
+    assistants_1 = [m for m in messages_1 if m.get("role") == "assistant"]
+    assert len(assistants_1) == 1
+    assert assistants_1[0]["reasoning"] == "thought trace here"
+
+    # Case 2: second message carries reasoning_details
+    messages_2 = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "start"},
+        {"role": "assistant", "content": "end", "reasoning_details": [{"type": "thought", "text": "details"}]},
+    ]
+    repair_message_sequence(agent, messages_2)
+    assistants_2 = [m for m in messages_2 if m.get("role") == "assistant"]
+    assert len(assistants_2) == 1
+    assert assistants_2[0]["reasoning_details"] == [{"type": "thought", "text": "details"}]
+
+    # Case 3: first message already has reasoning, keep first
+    messages_3 = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "start", "reasoning": "first reasoning"},
+        {"role": "assistant", "content": "end", "reasoning": "second reasoning"},
+    ]
+    repair_message_sequence(agent, messages_3)
+    assistants_3 = [m for m in messages_3 if m.get("role") == "assistant"]
+    assert len(assistants_3) == 1
+    assert assistants_3[0]["reasoning"] == "first reasoning"
 
 
 def test_repair_keeps_tool_result_when_tool_calls_are_sdk_objects():


### PR DESCRIPTION
## What does this PR do?

Fixes a core loop data-loss bug in [`agent/agent_runtime_helpers.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/agent_runtime_helpers.py) where merging consecutive assistant turns during pre-call message sequence repair (`repair_message_sequence()`) dropped canonical `reasoning` and `reasoning_details` payload fields from the second assistant turn when the earlier turn had no reasoning.

In Hermes Agent:
1. `assistant_msg["reasoning"]` is the canonical storage key for model reasoning/thinking tokens (along with `reasoning_details` for structured OpenRouter reasoning).
2. When two adjacent assistant turns are collapsed in Pass 0, the logic previously only copied `reasoning_content`. If an agent turn generated thinking tokens under `reasoning` (standard across DeepSeek, Qwen, OpenRouter, and Hermes persistence), those tokens were silently lost.
3. This also caused an inconsistency with `_msg_has_payload()`, which treats `reasoning` and `reasoning_details` as first-class message payloads.

The fix updates Pass 0 in `repair_message_sequence()` to preserve `reasoning` and `reasoning_details` onto the surviving message when the earlier turn lacks them.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_runtime_helpers.py`: Updated Pass 0 in `repair_message_sequence()` to transfer `reasoning` and `reasoning_details` from the incoming turn when `prev` has no reasoning.
- `tests/run_agent/test_message_sequence_repair.py`: Added unit test coverage verifying that `reasoning` and `reasoning_details` are preserved on the merged turn.

## How to Test

Run the message sequence repair test suite:
```bash
uv run --with pytest pytest tests/run_agent/test_message_sequence_repair.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): preserve reasoning and reasoning_details in repair_message_sequence merge`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 54 items

tests/run_agent/test_message_sequence_repair.py ........................ [100%]

============================= 54 passed in 9.90s ==============================
```
