### PR TITLE
fix(web): scope duplicate memory provider fields

### DIFF
--- a/web/src/pages/PluginsPage.test.tsx
+++ b/web/src/pages/PluginsPage.test.tsx
@@ -1,0 +1,316 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { I18nProvider } from "@/i18n";
+import type {
+  MemoryProviderConfig,
+  MemoryProviderField,
+  PluginsHubResponse,
+} from "@/lib/api";
+import PluginsPage from "./PluginsPage";
+
+const apiMocks = vi.hoisted(() => ({
+  getMemoryProviderConfig: vi.fn(),
+  getPluginsHub: vi.fn(),
+  setupMemoryProvider: vi.fn(),
+  updateMemoryProviderConfig: vi.fn(),
+}));
+const uiMocks = vi.hoisted(() => ({
+  setAfterTitle: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMocks }));
+vi.mock("@/plugins", () => ({ PluginSlot: () => null }));
+vi.mock("@/contexts/usePageHeader", () => ({
+  usePageHeader: () => ({ setAfterTitle: uiMocks.setAfterTitle }),
+}));
+vi.mock("@nous-research/ui/hooks/use-toast", () => ({
+  useToast: () => ({ showToast: uiMocks.showToast, toast: null }),
+}));
+
+const hub: PluginsHubResponse = {
+  orphan_dashboard_plugins: [],
+  plugins: [],
+  providers: {
+    context_engine: "compressor",
+    context_options: [],
+    memory_provider: "hindsight",
+    memory_options: [
+      {
+        available: true,
+        configured: true,
+        description: "Hindsight memory",
+        name: "hindsight",
+        status: "ready",
+      },
+    ],
+  },
+};
+
+function field(
+  key: string,
+  kind: MemoryProviderField["kind"],
+  value: MemoryProviderField["value"],
+  when: MemoryProviderField["when"] = null,
+): MemoryProviderField {
+  return {
+    description: key,
+    is_set: false,
+    key,
+    kind,
+    label: key,
+    options:
+      key === "mode"
+        ? [
+            { label: "cloud", value: "cloud" },
+            { label: "local_external", value: "local_external" },
+          ]
+        : [],
+    placeholder: "",
+    required: false,
+    url: "",
+    value,
+    when,
+  };
+}
+
+const config: MemoryProviderConfig = {
+  fields: [
+    field("mode", "select", "local_external"),
+    field("api_url", "text", "https://api.hindsight.vectorize.io", { mode: "cloud" }),
+    field("api_key", "secret", "", { mode: "cloud" }),
+    field("api_url", "text", "http://localhost:8888", { mode: "local_external" }),
+    field("api_key", "secret", "", { mode: "local_external" }),
+    field("bank_id", "text", "hermes"),
+    field("bank_mission", "text", ""),
+  ],
+  label: "Hindsight",
+  name: "hindsight",
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function renderPage() {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MemoryRouter>
+        <I18nProvider>
+          <PluginsPage />
+        </I18nProvider>
+      </MemoryRouter>,
+    );
+  });
+  await flushEffects();
+}
+
+async function setInput(id: string, value: string) {
+  const input = container.querySelector(`#${id}`) as HTMLInputElement | null;
+  expect(input).not.toBeNull();
+  const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  await act(async () => {
+    setValue?.call(input, value);
+    input?.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function selectOption(id: string, label: string) {
+  const select = container.querySelector(`#${id}`);
+  const trigger = select?.querySelector('[role="combobox"]') as HTMLButtonElement | null;
+  expect(trigger).not.toBeNull();
+  await act(async () => trigger?.click());
+
+  const option = Array.from(select?.querySelectorAll('[role="option"]') ?? []).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  ) as HTMLElement | undefined;
+  expect(option).toBeDefined();
+  await act(async () => option?.click());
+}
+
+beforeEach(() => {
+  apiMocks.getPluginsHub.mockReset();
+  apiMocks.getPluginsHub.mockResolvedValue(hub);
+  apiMocks.getMemoryProviderConfig.mockReset();
+  apiMocks.getMemoryProviderConfig.mockResolvedValue(config);
+  apiMocks.setupMemoryProvider.mockReset();
+  apiMocks.setupMemoryProvider.mockResolvedValue({ ok: true, provider: "hindsight", results: [] });
+  apiMocks.updateMemoryProviderConfig.mockReset();
+  apiMocks.updateMemoryProviderConfig.mockResolvedValue(undefined);
+  uiMocks.setAfterTitle.mockReset();
+  uiMocks.showToast.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+});
+
+describe("PluginsPage memory provider config", () => {
+  it("keeps duplicate-key drafts scoped when switching provider modes", async () => {
+    await renderPage();
+
+    await setInput("memory-api_url", "http://hindsight.internal:8888");
+    await setInput("memory-api_key", "local-secret");
+    await selectOption("memory-mode", "cloud");
+
+    expect((container.querySelector("#memory-api_url") as HTMLInputElement | null)?.value).toBe(
+      "https://api.hindsight.vectorize.io",
+    );
+    expect((container.querySelector("#memory-api_key") as HTMLInputElement | null)?.value).toBe(
+      "",
+    );
+
+    const saveButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Save memory provider",
+    );
+    expect(saveButton).toBeDefined();
+    await act(async () => saveButton?.click());
+    await flushEffects();
+    expect(apiMocks.updateMemoryProviderConfig).toHaveBeenCalledWith("hindsight", {
+      api_key: "",
+      api_url: "https://api.hindsight.vectorize.io",
+      bank_id: "hermes",
+      bank_mission: "",
+      mode: "cloud",
+    });
+
+    await selectOption("memory-mode", "local_external");
+
+    expect((container.querySelector("#memory-api_url") as HTMLInputElement | null)?.value).toBe(
+      "http://hindsight.internal:8888",
+    );
+    expect((container.querySelector("#memory-api_key") as HTMLInputElement | null)?.value).toBe(
+      "local-secret",
+    );
+  });
+
+  it("initializes duplicate-key fields from the active provider mode", async () => {
+    apiMocks.getMemoryProviderConfig.mockResolvedValue({
+      ...config,
+      fields: config.fields.map((candidate) =>
+        candidate.key === "mode" ? { ...candidate, value: "cloud" } : candidate,
+      ),
+    });
+
+    await renderPage();
+
+    const apiUrl = container.querySelector("#memory-api_url") as HTMLInputElement | null;
+    expect(apiUrl?.value).toBe("https://api.hindsight.vectorize.io");
+  });
+
+  it("keeps an already-set active secret write-only when saving", async () => {
+    apiMocks.getMemoryProviderConfig.mockResolvedValue({
+      ...config,
+      fields: config.fields.map((candidate) =>
+        candidate.key === "api_key" && candidate.when?.mode === "local_external"
+          ? { ...candidate, is_set: true, value: "" }
+          : candidate,
+      ),
+    });
+
+    await renderPage();
+
+    const apiKey = container.querySelector("#memory-api_key") as HTMLInputElement | null;
+    expect(apiKey?.value).toBe("");
+    expect(apiKey?.placeholder).toBe("Leave blank to keep existing value");
+
+    const saveButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Save memory provider",
+    );
+    expect(saveButton).toBeDefined();
+    await act(async () => saveButton?.click());
+    await flushEffects();
+
+    expect(apiMocks.updateMemoryProviderConfig).toHaveBeenCalledWith("hindsight", {
+      api_key: "",
+      api_url: "http://localhost:8888",
+      bank_id: "hermes",
+      bank_mission: "",
+      mode: "local_external",
+    });
+  });
+
+  it("saves duplicate-key fields from the active provider mode", async () => {
+    await renderPage();
+
+    await setInput("memory-api_url", "http://hindsight.internal:8888");
+    await setInput("memory-api_key", "local-secret");
+    await setInput("memory-bank_id", "security-team");
+    await setInput("memory-bank_mission", "Retain security decisions");
+
+    const saveButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Save memory provider",
+    );
+    expect(saveButton).toBeDefined();
+    await act(async () => saveButton?.click());
+    await flushEffects();
+
+    expect(apiMocks.updateMemoryProviderConfig).toHaveBeenCalledWith("hindsight", {
+      api_key: "local-secret",
+      api_url: "http://hindsight.internal:8888",
+      bank_id: "security-team",
+      bank_mission: "Retain security decisions",
+      mode: "local_external",
+    });
+  });
+
+  it("passes duplicate-key fields from the active mode to provider setup", async () => {
+    apiMocks.getPluginsHub.mockResolvedValue({
+      ...hub,
+      providers: {
+        ...hub.providers,
+        memory_options: [
+          {
+            ...hub.providers.memory_options[0],
+            available: false,
+            configured: false,
+            setup: {
+              dependencies_installed: false,
+              external_dependencies: [],
+              pip_dependencies: ["hindsight-embed"],
+              required_env: [],
+            },
+            status: "unavailable",
+          },
+        ],
+      },
+    });
+    await renderPage();
+
+    await setInput("memory-api_url", "http://hindsight.internal:8888");
+    await setInput("memory-api_key", "local-secret");
+    await setInput("memory-bank_id", "security-team");
+    await setInput("memory-bank_mission", "Retain security decisions");
+
+    const setupButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Install provider dependencies",
+    );
+    expect(setupButton).toBeDefined();
+    await act(async () => setupButton?.click());
+    await flushEffects();
+
+    expect(apiMocks.setupMemoryProvider).toHaveBeenCalledWith("hindsight", {
+      api_key: "local-secret",
+      api_url: "http://hindsight.internal:8888",
+      bank_id: "security-team",
+      bank_mission: "Retain security decisions",
+      mode: "local_external",
+    });
+  });
+});

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -62,6 +62,45 @@ function fieldIsVisible(field: MemoryProviderField, values: Record<string, Memor
   });
 }
 
+function getInitialMemoryValues(fields: MemoryProviderField[]) {
+  return fields.map(fieldInitialValue);
+}
+
+function getMemoryValuesByKey(
+  fields: MemoryProviderField[],
+  fieldValues: MemoryFormValue[],
+) {
+  const valuesByKey: Record<string, MemoryFormValue> = Object.fromEntries(
+    fields.map((field, index) => [
+      field.key,
+      fieldValues[index] ?? fieldInitialValue(field),
+    ]),
+  );
+
+  for (const [index, field] of fields.entries()) {
+    if (fieldIsVisible(field, valuesByKey)) {
+      valuesByKey[field.key] = fieldValues[index] ?? fieldInitialValue(field);
+    }
+  }
+  return valuesByKey;
+}
+
+function getVisibleMemoryValues(
+  fields: MemoryProviderField[] | undefined,
+  fieldValues: MemoryFormValue[],
+) {
+  if (!fields) return {};
+  const valuesByKey = getMemoryValuesByKey(fields, fieldValues);
+  const visibleValues: Record<string, MemoryFormValue> = {};
+
+  for (const [index, field] of fields.entries()) {
+    if (fieldIsVisible(field, valuesByKey)) {
+      visibleValues[field.key] = fieldValues[index] ?? fieldInitialValue(field);
+    }
+  }
+  return visibleValues;
+}
+
 function setupHasDetails(setup?: MemoryProviderSetupInfo) {
   if (!setup) return false;
   return Boolean(
@@ -288,7 +327,7 @@ export default function PluginsPage() {
   const [rescanBusy, setRescanBusy] = useState(false);
   const [memorySel, setMemorySel] = useState(MEMORY_PROVIDER_BUILTIN);
   const [memoryConfig, setMemoryConfig] = useState<MemoryProviderConfig | null>(null);
-  const [memoryValues, setMemoryValues] = useState<Record<string, MemoryFormValue>>({});
+  const [memoryValues, setMemoryValues] = useState<MemoryFormValue[]>([]);
   const [memoryConfigBusy, setMemoryConfigBusy] = useState(false);
   const [secretVisible, setSecretVisible] = useState<Record<string, boolean>>({});
   const [contextSel, setContextSel] = useState("compressor");
@@ -331,7 +370,7 @@ export default function PluginsPage() {
 
       if (!provider) {
         setMemoryConfig(null);
-        setMemoryValues({});
+        setMemoryValues([]);
         setMemoryConfigBusy(false);
         return;
       }
@@ -342,16 +381,12 @@ export default function PluginsPage() {
         .then((config) => {
           if (cancelled) return;
           setMemoryConfig(config);
-          setMemoryValues(
-            Object.fromEntries(
-              config.fields.map((field) => [field.key, fieldInitialValue(field)]),
-            ),
-          );
+          setMemoryValues(getInitialMemoryValues(config.fields));
         })
         .catch((e) => {
           if (!cancelled) {
             setMemoryConfig(null);
-            setMemoryValues({});
+            setMemoryValues([]);
             showToast(e instanceof Error ? e.message : "Failed to load provider config", "error");
           }
         })
@@ -430,12 +465,7 @@ export default function PluginsPage() {
       if (!provider) {
         await api.setMemoryProvider("");
       } else {
-        const visibleValues = Object.fromEntries(
-          Object.entries(memoryValues).filter(([key]) => {
-            const field = memoryConfig?.fields.find((candidate) => candidate.key === key);
-            return field ? fieldIsVisible(field, memoryValues) : true;
-          }),
-        );
+        const visibleValues = getVisibleMemoryValues(memoryConfig?.fields, memoryValues);
         await api.updateMemoryProviderConfig(provider, visibleValues);
       }
       showToast(t.pluginsPage.savedProviders, "success");
@@ -448,12 +478,7 @@ export default function PluginsPage() {
   };
 
   const currentVisibleMemoryValues = () =>
-    Object.fromEntries(
-      Object.entries(memoryValues).filter(([key]) => {
-        const field = memoryConfig?.fields.find((candidate) => candidate.key === key);
-        return field ? fieldIsVisible(field, memoryValues) : true;
-      }),
-    );
+    getVisibleMemoryValues(memoryConfig?.fields, memoryValues);
 
   const onSetupMemoryProvider = async () => {
     const provider = memorySel === MEMORY_PROVIDER_BUILTIN ? "" : memorySel;
@@ -513,8 +538,20 @@ export default function PluginsPage() {
   const activeMemoryInfo = providers?.memory_provider
     ? providers.memory_options.find((provider) => provider.name === providers.memory_provider)
     : null;
+  const memoryValuesByKey = memoryConfig
+    ? getMemoryValuesByKey(memoryConfig.fields, memoryValues)
+    : {};
   const visibleMemoryFields =
-    memoryConfig?.fields.filter((field) => fieldIsVisible(field, memoryValues)) ?? [];
+    memoryConfig?.fields
+      .map((field, index) => ({ field, index }))
+      .filter(({ field }) => fieldIsVisible(field, memoryValuesByKey)) ?? [];
+  const setMemoryFieldValue = (index: number, value: MemoryFormValue) => {
+    setMemoryValues((current) => {
+      const next = [...current];
+      next[index] = value;
+      return next;
+    });
+  };
 
   return (
     <div className="flex flex-col gap-4">
@@ -615,11 +652,11 @@ export default function PluginsPage() {
 
                   {selectedMemoryName && !memoryConfigBusy && visibleMemoryFields.length > 0 && (
                     <div className="grid gap-4 border border-border p-4">
-                      {visibleMemoryFields.map((field) => {
-                        const value = memoryValues[field.key];
-                        const secretIsVisible = !!secretVisible[field.key];
+                      {visibleMemoryFields.map(({ field, index: fieldIndex }) => {
+                        const value = memoryValues[fieldIndex];
+                        const secretIsVisible = !!secretVisible[fieldIndex];
                         return (
-                          <div key={field.key} className="grid gap-2 min-w-0">
+                          <div key={`${field.key}-${fieldIndex}`} className="grid gap-2 min-w-0">
                             <div className="flex flex-wrap items-center gap-2">
                               <Label htmlFor={`memory-${field.key}`}>{field.label}</Label>
                               {field.required && <Badge tone="outline">required</Badge>}
@@ -643,9 +680,7 @@ export default function PluginsPage() {
                                 id={`memory-${field.key}`}
                                 className="w-full"
                                 value={String(value ?? "")}
-                                onValueChange={(next) =>
-                                  setMemoryValues((current) => ({ ...current, [field.key]: next }))
-                                }
+                                onValueChange={(next) => setMemoryFieldValue(fieldIndex, next)}
                               >
                                 {field.options.map((option) => (
                                   <SelectOption key={option.value} value={option.value}>
@@ -656,9 +691,7 @@ export default function PluginsPage() {
                             ) : field.kind === "boolean" ? (
                               <Switch
                                 checked={Boolean(value)}
-                                onCheckedChange={(next) =>
-                                  setMemoryValues((current) => ({ ...current, [field.key]: next }))
-                                }
+                                onCheckedChange={(next) => setMemoryFieldValue(fieldIndex, next)}
                               />
                             ) : (
                               <div className="flex items-center gap-2">
@@ -683,10 +716,7 @@ export default function PluginsPage() {
                                       : field.placeholder
                                   }
                                   onChange={(event) =>
-                                    setMemoryValues((current) => ({
-                                      ...current,
-                                      [field.key]: event.target.value,
-                                    }))
+                                    setMemoryFieldValue(fieldIndex, event.target.value)
                                   }
                                 />
                                 {field.kind === "secret" && (
@@ -697,7 +727,7 @@ export default function PluginsPage() {
                                     onClick={() =>
                                       setSecretVisible((current) => ({
                                         ...current,
-                                        [field.key]: !current[field.key],
+                                        [fieldIndex]: !current[fieldIndex],
                                       }))
                                     }
                                   >


### PR DESCRIPTION
## What does this PR do?

Fixes the web dashboard's handling of memory-provider schemas that reuse a runtime key across mutually exclusive modes. Hindsight declares `api_url` and `api_key` for both `cloud` and `local_external`; the page previously initialized the shared key from the last schema row and used only the first row when deciding whether to include it in save/setup payloads. In `local_external` mode that first row is hidden, so both values were silently dropped.

The page now keeps form state per schema row, resolves visibility against the active mode, and maps only visible rows back to runtime keys. Mode switches therefore preserve separate drafts without leaking inactive values into save/setup payloads. The same selection logic is used for normal saves and provider setup.

## Related Issue

Fixes #96691

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/pages/PluginsPage.tsx`: scope form state by schema row and submit only the active variant of each runtime key.
- `web/src/pages/PluginsPage.test.tsx`: add component regressions for mode switching, active-mode initialization, save/setup payloads, and an already-set write-only secret.

## How to Test

1. Configure the Hindsight provider in `local_external` mode.
2. Enter `api_url`, `api_key`, `bank_id`, and `bank_mission`, save, then refresh the dashboard.
3. Confirm the active mode's API URL is shown while the already-set `api_key` remains blank and carries the `set` badge.
4. Save again without entering a new key and confirm the provider remains configured.
5. Run `cd web && npm test -- src/pages/PluginsPage.test.tsx`.
6. Run `cd web && npm run check && npm run build`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: the repository change classifier marks this two-file web diff as `python=false`
- [x] Complete web validation passes: typecheck, 283-test Vitest suite, targeted ESLint, and production build
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (Linux x86_64), Node 22.23.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: no user-facing workflow or config key changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: no config key changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A: no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — browser-only logic has no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A: no tool behavior changed

## Screenshots / Logs

No screenshots. The targeted component suite passes 5/5 tests, including an already-set write-only secret. A separate automated jsdom real-path E2E passed against an isolated `HERMES_HOME`, the real dashboard server, the real React page, and the real memory-provider endpoint. A literal manual graphical-browser run was not performed because this host has no usable graphical browser session.
