### PR TITLE
fix(update): retain lock across Windows shim handoff

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9340,11 +9340,23 @@ def _reexec_dependency_sync_off_windows_shim() -> bool:
     cmd = [str(python_exe), "-m", "hermes_cli.main", *sys.argv[1:]]
     if python_exe.is_file():
         try:
-            subprocess.Popen(
+            from hermes_cli.update_lock import (
+                UPDATE_LOCK_TAKEOVER_PID_ENV,
+                transfer_update_lock_to,
+            )
+
+            child = subprocess.Popen(
                 cmd,
-                env={**os.environ, _UPDATE_REEXEC_ENV: "1"},
+                env={
+                    **os.environ,
+                    _UPDATE_REEXEC_ENV: "1",
+                    UPDATE_LOCK_TAKEOVER_PID_ENV: str(os.getpid()),
+                },
                 stdin=subprocess.DEVNULL,
             )
+            if not transfer_update_lock_to(child.pid):
+                child.terminate()
+                raise OSError("could not transfer the update lock to the hand-off child")
             print(
                 f"→ Windows: {shim.name} cannot replace itself while it runs; "
                 "finishing the dependency install under the venv Python."

--- a/hermes_cli/update_lock.py
+++ b/hermes_cli/update_lock.py
@@ -46,6 +46,13 @@ Two mechanisms recognize the orchestrating parent, and either suffices:
   HANDOFF_PID_ENV export runs an old parent against a new child. Without the
   ancestry check those users get exit 2 ("Hermes is still running") on every
   GUI update forever, with no Hermes process actually running.
+
+The Windows console-shim re-exec is different: its parent must exit so the
+child can replace ``hermes.exe``. That parent transfers its marker to the
+spawned venv-Python child before returning the prompt. The child receives
+:data:`UPDATE_LOCK_TAKEOVER_PID_ENV`, adopts the transferred claim, and owns
+the marker until the update tail finishes. A second terminal update therefore
+cannot enter during the handoff gap.
 """
 
 from __future__ import annotations
@@ -72,6 +79,11 @@ MARKER_NAME = ".hermes-update-in-progress"
 # own parent's lock and the GUI update can never complete. See update_child_env
 # in apps/bootstrap-installer/src-tauri/src/update.rs — keep the name in sync.
 HANDOFF_PID_ENV = "HERMES_UPDATE_HANDOFF_PID"
+
+# Set only by the Windows console-shim re-exec parent. Unlike
+# HANDOFF_PID_ENV, this parent is about to exit and must transfer ownership to
+# its child rather than keep the child running under the parent's claim.
+UPDATE_LOCK_TAKEOVER_PID_ENV = "HERMES_UPDATE_LOCK_TAKEOVER_PID"
 
 # Exit code meaning "another updater/instance owns this install right now".
 # Already the de-facto contract: the Windows shim + venv-holder guards in
@@ -135,6 +147,94 @@ def _handoff_pid() -> int | None:
     except ValueError:
         return None
     return pid if pid > 0 else None
+
+
+def _takeover_pid() -> int | None:
+    """Pid of the console-shim parent whose claim this child must adopt."""
+    raw = os.environ.get(UPDATE_LOCK_TAKEOVER_PID_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        pid = int(raw)
+    except ValueError:
+        return None
+    return pid if pid > 0 else None
+
+
+def _replace_marker_owner(
+    expected_pid: int,
+    new_pid: int,
+    *,
+    path: Path,
+) -> bool:
+    """Replace only ``expected_pid`` with ``new_pid`` in a marker.
+
+    The remaining marker fields are preserved so this stays compatible with
+    readers that extend the two-line format. A temporary file plus
+    :func:`os.replace` prevents another updater from observing a partial
+    handoff marker.
+    """
+    if expected_pid <= 0 or new_pid <= 0:
+        return False
+    try:
+        raw = path.read_text(encoding="utf-8")
+        lines = raw.splitlines()
+        owner = int(lines[0].strip())
+    except (OSError, IndexError, ValueError):
+        return False
+    if owner == new_pid:
+        return True
+    if owner != expected_pid or len(lines) < 2:
+        return False
+
+    replacement = path.with_name(
+        f"{path.name}.handoff-{os.getpid()}-{new_pid}-{time.time_ns()}"
+    )
+    try:
+        replacement.write_text(
+            "\n".join([str(new_pid), *lines[1:]]) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(replacement, path)
+        return True
+    except OSError as exc:
+        logger.debug(
+            "Could not transfer update marker %s from pid %s to %s: %s",
+            path,
+            expected_pid,
+            new_pid,
+            exc,
+        )
+        return False
+    finally:
+        try:
+            replacement.unlink()
+        except OSError:
+            pass
+
+
+def transfer_update_lock_to(pid: int, *, path: Path | None = None) -> bool:
+    """Transfer this process's live update claim to ``pid``.
+
+    Returns True when the marker now names the child or when another
+    orchestrating ancestor owns it. The latter needs no transfer because that
+    owner remains alive across the console-shim parent's exit.
+    """
+    marker = path or update_marker_path()
+    try:
+        raw = marker.read_text(encoding="utf-8")
+        owner = int(raw.splitlines()[0].strip())
+    except (OSError, IndexError, ValueError):
+        # Marker publication is already best-effort. If this invocation has no
+        # claim to transfer, preserve the existing behavior.
+        return True
+    if owner == pid:
+        return True
+    if owner != os.getpid():
+        # Tauri/install-mode parents keep their own marker across both Python
+        # processes, so the shim parent must not steal that claim.
+        return True
+    return _replace_marker_owner(os.getpid(), pid, path=marker)
 
 
 def _is_ancestor_pid(pid: int) -> bool:
@@ -242,8 +342,25 @@ class UpdateLock:
         the parent's marker untouched. The ancestry path exists because staged
         updaters older than the HANDOFF_PID_ENV export never send the env var.
         """
+        takeover_pid = _takeover_pid()
+        os.environ.pop(UPDATE_LOCK_TAKEOVER_PID_ENV, None)
         existing = read_live_update(path=self.path)
         if existing is not None:
+            if takeover_pid is not None and existing.pid == os.getpid():
+                # The shim parent published our pid before returning. Adopt
+                # that exact claim so our release removes it after the update.
+                self.acquired = True
+                return True
+            if (
+                takeover_pid is not None
+                and existing.pid == takeover_pid
+                and _is_ancestor_pid(existing.pid)
+                and _replace_marker_owner(existing.pid, os.getpid(), path=self.path)
+            ):
+                # We reached the lock before the parent published our pid.
+                # Taking it over here makes both scheduling orders safe.
+                self.acquired = True
+                return True
             if existing.pid == _handoff_pid() or _is_ancestor_pid(existing.pid):
                 return True
             self.holder = existing

--- a/tests/hermes_cli/test_update_lock.py
+++ b/tests/hermes_cli/test_update_lock.py
@@ -23,11 +23,13 @@ import pytest
 
 from hermes_cli.update_lock import (
     HANDOFF_PID_ENV,
+    UPDATE_LOCK_TAKEOVER_PID_ENV,
     UPDATE_MARKER_MAX_AGE_SECONDS,
     UpdateLock,
     describe_holder,
     read_live_update,
     update_marker_path,
+    transfer_update_lock_to,
 )
 
 # A pid no live process owns. os.kill(pid, 0) must report it dead so a crashed
@@ -102,6 +104,65 @@ def test_release_leaves_a_marker_a_handoff_partner_now_owns(marker):
     lock.release()
 
     assert marker.exists(), "the partner's marker is not ours to remove"
+
+
+def test_console_handoff_keeps_second_update_refused(marker, monkeypatch):
+    """Returning the prompt must not reopen the update gate."""
+    parent = UpdateLock(path=marker)
+    assert parent.acquire() is True
+
+    child_pid = 424242
+    assert transfer_update_lock_to(child_pid, path=marker) is True
+    parent.release()
+
+    monkeypatch.setattr(
+        "hermes_cli.update_lock._pid_alive", lambda pid: pid == child_pid
+    )
+    contender = UpdateLock(path=marker)
+    assert contender.acquire() is False
+    assert contender.holder is not None
+    assert contender.holder.pid == child_pid
+
+
+def test_console_handoff_leaves_an_orchestrator_claim_unchanged(marker):
+    orchestrator_pid = 424240
+    marker.write_text(
+        f"{orchestrator_pid}\n{int(time.time())}\n", encoding="utf-8"
+    )
+
+    assert transfer_update_lock_to(424242, path=marker) is True
+    assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == orchestrator_pid
+
+
+def test_console_handoff_child_adopts_transferred_claim(marker, monkeypatch):
+    marker.write_text(f"{os.getpid()}\n{int(time.time())}\n", encoding="utf-8")
+    monkeypatch.setenv(UPDATE_LOCK_TAKEOVER_PID_ENV, str(os.getppid()))
+
+    child = UpdateLock(path=marker)
+    assert child.acquire() is True
+    assert child.acquired is True
+    assert UPDATE_LOCK_TAKEOVER_PID_ENV not in os.environ
+
+    child.release()
+    assert not marker.exists()
+
+
+def test_console_handoff_child_can_win_the_transfer_race(marker, monkeypatch):
+    parent_pid = 424241
+    marker.write_text(f"{parent_pid}\n{int(time.time())}\n", encoding="utf-8")
+    monkeypatch.setenv(UPDATE_LOCK_TAKEOVER_PID_ENV, str(parent_pid))
+    monkeypatch.setattr("hermes_cli.update_lock._pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        "hermes_cli.update_lock._is_ancestor_pid", lambda pid: pid == parent_pid
+    )
+
+    child = UpdateLock(path=marker)
+    assert child.acquire() is True
+    assert child.acquired is True
+    assert int(marker.read_text(encoding="utf-8").splitlines()[0]) == os.getpid()
+
+    child.release()
+    assert not marker.exists()
 
 
 def test_dead_owner_is_reclaimed_not_honored(marker):

--- a/tests/hermes_cli/test_update_shim_self_lock.py
+++ b/tests/hermes_cli/test_update_shim_self_lock.py
@@ -16,6 +16,7 @@ off at all.
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 from pathlib import Path
@@ -23,6 +24,7 @@ from pathlib import Path
 import pytest
 
 from hermes_cli import main as cli_main
+from hermes_cli.update_lock import UPDATE_LOCK_TAKEOVER_PID_ENV
 
 SHIM_NAMES = ["hermes.exe", "hermes-agent.exe", "hermes-acp.exe", "hermes-gateway.exe"]
 
@@ -37,6 +39,10 @@ def venv(tmp_path, monkeypatch):
     monkeypatch.setattr(cli_main, "_venv_scripts_dir", lambda: scripts)
     monkeypatch.setattr(sys, "argv", ["hermes", "update"])
     monkeypatch.delenv(cli_main._UPDATE_REEXEC_ENV, raising=False)
+    monkeypatch.delenv(UPDATE_LOCK_TAKEOVER_PID_ENV, raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.update_lock.transfer_update_lock_to", lambda pid: True
+    )
     _fake_psutil(monkeypatch, [])
     return scripts
 
@@ -66,7 +72,7 @@ def _capture_popen(monkeypatch, raises: Exception | None = None):
         if raises is not None:
             raise raises
         calls.append((list(cmd), dict(env or {}), kwargs))
-        return object()
+        return types.SimpleNamespace(pid=4242, terminate=lambda: None)
 
     monkeypatch.setattr(cli_main.subprocess, "Popen", fake_popen)
     return calls
@@ -140,7 +146,42 @@ def test_reexec_runs_same_args_under_venv_python(venv, monkeypatch, capsys):
         str(venv / "python.exe"), "-m", "hermes_cli.main", "update", "--yes",
     ]
     assert env[cli_main._UPDATE_REEXEC_ENV] == "1"
+    assert env[UPDATE_LOCK_TAKEOVER_PID_ENV] == str(os.getpid())
     assert "under the venv Python" in capsys.readouterr().out
+
+
+def test_reexec_transfers_the_update_claim_before_returning(venv, monkeypatch):
+    monkeypatch.setattr(sys, "argv", [str(venv / "hermes.exe"), "update"])
+    transfers = []
+    monkeypatch.setattr(
+        "hermes_cli.update_lock.transfer_update_lock_to",
+        lambda pid: transfers.append(pid) or True,
+    )
+    _capture_popen(monkeypatch)
+
+    assert cli_main._reexec_dependency_sync_off_windows_shim() is True
+    assert transfers == [4242]
+
+
+def test_reexec_falls_back_when_the_update_claim_cannot_transfer(
+    venv, monkeypatch, capsys
+):
+    monkeypatch.setattr(sys, "argv", [str(venv / "hermes.exe"), "update"])
+    terminated = []
+    monkeypatch.setattr(
+        cli_main.subprocess,
+        "Popen",
+        lambda *args, **kwargs: types.SimpleNamespace(
+            pid=4242, terminate=lambda: terminated.append(True)
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_lock.transfer_update_lock_to", lambda pid: False
+    )
+
+    assert cli_main._reexec_dependency_sync_off_windows_shim() is False
+    assert terminated == [True]
+    assert "Could not hand the dependency install off" in capsys.readouterr().out
 
 
 def test_reexec_child_runs_unattended(venv, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Keeps the shared update marker owned across the Windows console-shim handoff. The shim parent now transfers its claim to the spawned venv-Python child before returning the shell prompt, and the child adopts that claim until the update tail actually finishes.

Without that ownership transfer, the parent removed the marker as it exited even though the child was still updating. A second `hermes update` could then start on top of the in-flight child.

## Related Issue

Reported through Discord support; no linked GitHub issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Transfer the live Windows update marker from the console shim to its venv-Python handoff child.
- Let the child adopt the transferred claim in either parent-first or child-first scheduling order.
- Leave an outer installer/orchestrator marker untouched.
- Add regressions for retained exclusion, both handoff races, outer ownership, and transfer failure fallback.

## How to Test

1. On Windows, start `hermes update` through a managed console shim and let it hand dependency sync to the venv Python child.
2. While that child is still finishing, start a second `hermes update`.
3. Confirm the second update is refused as concurrent, then confirm the marker is removed when the first update finishes.

Local verification performed: staged diff whitespace check, Python syntax parsing for all four changed files, and `scripts/check-windows-footguns.py` over the staged patch. Focused pytest was not run locally under the workstation test policy; the regression tests are included for GitHub CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Windows 11 static verification only; runtime coverage is delegated to GitHub CI

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. This changes CLI update-lock ownership and has no visual UI change.