### PR TITLE
fix(anthropic): invalidate thinking signature when merging consecutiv…

### DIFF
--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -841,6 +841,14 @@ def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any
                 # surviving (prev) dict so _manage_thinking_signatures still sees it.
                 if m.get("_thinking_signature_invalidated"):
                     fixed[-1]["_thinking_signature_invalidated"] = True
+                # If the surviving message carried a thinking block, merging new
+                # content into it mutates the turn payload and invalidates the
+                # cryptographic signature computed for the original turn boundary.
+                if isinstance(fixed[-1].get("content"), list) and any(
+                    isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"}
+                    for b in fixed[-1]["content"]
+                ):
+                    fixed[-1]["_thinking_signature_invalidated"] = True
                 # Drop thinking blocks from the *second* message: their
                 # signature was computed against a different turn boundary
                 # and becomes invalid once merged.

--- a/tests/agent/test_anthropic_thinking_merge.py
+++ b/tests/agent/test_anthropic_thinking_merge.py
@@ -1,0 +1,61 @@
+"""Tests for thinking signature invalidation when merging consecutive assistant messages."""
+
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+SIG = "valid_cryptographic_signature_abc123"
+
+
+def test_consecutive_assistant_merge_invalidates_thinking_signature():
+    """When an assistant message carrying signed thinking is merged with another assistant message,
+    its signature is invalidated and demoted to text to prevent HTTP 400."""
+    messages = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "first thought", "signature": SIG},
+                {"type": "text", "text": "part 1"},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "part 2"},
+            ],
+        },
+    ]
+
+    _sys, out = convert_messages_to_anthropic(messages)
+    assert len(out) == 2  # user + merged assistant
+    assistant = out[1]
+    assert assistant["role"] == "assistant"
+
+    # Signature must be dead / demoted to text block
+    types = [b.get("type") for b in assistant["content"] if isinstance(b, dict)]
+    assert "thinking" not in types
+    texts = [b.get("text") for b in assistant["content"] if isinstance(b, dict) and b.get("type") == "text"]
+    assert "first thought" in texts
+    assert "part 1" in texts
+    assert "part 2" in texts
+
+
+def test_single_assistant_message_preserves_thinking_signature():
+    """A standalone assistant message retains its valid thinking signature."""
+    messages = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "first thought", "signature": SIG},
+                {"type": "text", "text": "part 1"},
+            ],
+        },
+    ]
+
+    _sys, out = convert_messages_to_anthropic(messages)
+    assert len(out) == 2
+    assistant = out[1]
+    types = [b.get("type") for b in assistant["content"] if isinstance(b, dict)]
+    assert "thinking" in types
+    thinking_block = [b for b in assistant["content"] if isinstance(b, dict) and b.get("type") == "thinking"][0]
+    assert thinking_block["signature"] == SIG


### PR DESCRIPTION
## What does this PR do?

Fixes an Anthropic Messages API HTTP 400 rejection bug in [`agent/anthropic_adapter.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/anthropic_adapter.py) where merging consecutive assistant turns during role alternation normalization (`_merge_consecutive_roles()`) modified the payload of the first assistant message without marking its thinking signature as invalidated (`_thinking_signature_invalidated`).

In Anthropic Messages API:
1. Thinking blocks on Claude 3.7 / Claude 4.x are cryptographically signed against the exact full turn content. Any mutation to the turn payload invalidates that signature.
2. In `_merge_consecutive_roles()`, when adjacent assistant turns were merged together, new content blocks were appended to the surviving first message.
3. While thinking blocks from the *second* message were dropped, `_merge_consecutive_roles()` did not set `_thinking_signature_invalidated = True` on the *first* message when merging new content into it.
4. As a result, `_manage_thinking_signatures()` replayed the first message's thinking signature verbatim over the altered content, causing Anthropic to reject the request with HTTP 400 (`"Invalid signature in thinking block"`).

The fix marks `_thinking_signature_invalidated = True` on the surviving assistant message whenever new content is merged into a turn carrying thinking blocks, allowing `_manage_thinking_signatures()` to demote the invalidated signature into a standard text block.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py`: Set `_thinking_signature_invalidated = True` on the surviving assistant turn in `_merge_consecutive_roles()` if it contains thinking blocks before merging new content into it.
- `tests/agent/test_anthropic_thinking_merge.py`: Added unit tests verifying that thinking signatures on merged assistant messages are safely invalidated and demoted to text, while unaffected single turns keep their valid signatures.

## How to Test

Run the Anthropic test suite:
```bash
uv run --with pytest pytest tests/agent/test_anthropic_thinking_merge.py tests/agent/test_anthropic_kimi_signed_thinking_replay.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(anthropic): invalidate thinking signature when merging consecutive assistant messages`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 5 items

tests/agent/test_anthropic_thinking_merge.py::test_consecutive_assistant_merge_invalidates_thinking_signature PASSED [ 20%]
tests/agent/test_anthropic_thinking_merge.py::test_single_assistant_message_preserves_thinking_signature PASSED [ 40%]
tests/agent/test_anthropic_kimi_signed_thinking_replay.py::test_moonshot_keeps_signed_thinking PASSED [ 60%]
tests/agent/test_anthropic_kimi_signed_thinking_replay.py::test_kimi_model_name_on_foreign_gateway_keeps_thinking PASSED [ 80%]
tests/agent/test_anthropic_kimi_signed_thinking_replay.py::test_orphan_tool_turn_demotes_and_leaks_no_internal_marker PASSED [100%]

============================== 5 passed in 4.99s ==============================
```
