### PR TITLE
fix(gateway): stop Telegram voice notes from crashing Windows gateways

### DIFF
--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -220,6 +220,9 @@ class TestLocalFallback:
             "tools.transcription_tools._HAS_FASTER_WHISPER",
             True,
         ), patch(
+            "tools.transcription_tools._allow_inprocess_faster_whisper_fallback",
+            return_value=True,
+        ), patch(
             "tools.transcription_tools._transcribe_local",
             return_value={"success": True, "transcript": "local result"},
         ) as mock_local:
@@ -243,6 +246,31 @@ class TestLocalFallback:
 
         assert result["success"] is False
         assert "installed local STT" in result["error"]
+
+    @pytest.mark.windows_only
+    def test_cloud_fallback_does_not_enter_faster_whisper_on_windows(self, tmp_path):
+        audio_file = tmp_path / "telegram-voice.ogg"
+        audio_file.write_bytes(b"fake audio")
+
+        with patch(
+            "tools.transcription_tools._load_stt_config",
+            return_value={"provider": "openai", "local": {"model": "small"}},
+        ), patch(
+            "tools.transcription_tools._HAS_FASTER_WHISPER",
+            True,
+        ), patch(
+            "tools.transcription_tools._has_local_command",
+            return_value=False,
+        ), patch(
+            "tools.transcription_tools._transcribe_local",
+        ) as mock_local:
+            from tools.transcription_tools import transcribe_audio_local_fallback
+
+            result = transcribe_audio_local_fallback(str(audio_file))
+
+        assert result["success"] is False
+        assert result["provider"] == "local"
+        mock_local.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -3285,7 +3285,14 @@ def transcribe_audio_local_fallback(
     local_cfg = stt_config.get("local") or {}
     local_model = model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
 
-    if _HAS_FASTER_WHISPER:
+    # This fallback is opportunistic: the user selected another provider and
+    # did not opt the long-lived gateway process into a native STT runtime.
+    # On Windows, CTranslate2/faster-whisper access violations terminate the
+    # whole process before Python can catch them. Keep explicit local-provider
+    # selection unchanged, but never enter that native stack as a cloud-failure
+    # fallback. A local command remains safe because it already runs out of
+    # process.
+    if _HAS_FASTER_WHISPER and _allow_inprocess_faster_whisper_fallback():
         return _transcribe_local(
             file_path,
             _normalize_local_model(local_model),
@@ -3295,12 +3302,27 @@ def transcribe_audio_local_fallback(
             file_path,
             _normalize_local_command_model(local_model),
         )
+    if _HAS_FASTER_WHISPER and not _allow_inprocess_faster_whisper_fallback():
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                "In-process faster-whisper fallback is disabled on Windows; "
+                "the configured STT provider error was preserved."
+            ),
+            "provider": "local",
+        }
     return {
         "success": False,
         "transcript": "",
         "error": "No installed local STT backend is available.",
         "provider": "local",
     }
+
+
+def _allow_inprocess_faster_whisper_fallback() -> bool:
+    """Return whether opportunistic native STT is safe in this process."""
+    return os.name != "nt"
 
 
 def _resolve_openai_audio_client_config() -> tuple[str, str]:


### PR DESCRIPTION
## What does this PR do?

Windows gateways no longer enter the in-process faster-whisper/CTranslate2 fallback when a configured cloud STT provider fails on an inbound voice note. A native access violation in that opportunistic fallback could terminate the entire gateway, so Windows now preserves the configured provider failure and degrades to the existing agent-visible audio marker; explicitly selected local STT remains unchanged.

### Symptom

On Windows 11, a Telegram `.ogg`/Opus voice note can terminate `python.exe` with exception code `0xc0000005` in `MSVCP140.dll`. The gateway logs stop immediately after caching and accepting the inbound voice message, with no Python traceback.

### Impact

Affected Windows Telegram users lose the whole gateway process when the native fallback faults, so no reply is delivered and every later message is unavailable until an external supervisor or operator restarts the gateway.

### Bug Cause

**Trigger:** `gateway/run.py:25692` / configured STT returns a recoverable failure for an inbound voice note.

**Causal chain:**
1. The gateway sends the cached voice note to the explicitly configured cloud STT provider.
2. Any unsuccessful result unconditionally enters `transcribe_audio_local_fallback`, which prefers installed faster-whisper and loads CTranslate2 inside the long-lived gateway process.
3. A Windows native access violation bypasses Python exception handling and terminates the gateway.

**Why it is wrong:** A cloud-provider failure should remain recoverable. It must not implicitly opt the gateway into an in-process native runtime whose faults cannot be caught by the surrounding `try/except`.

**Working sibling / contrast:** Local command STT already runs out of process and remains available as a safe fallback. Users who explicitly select the local provider retain the existing direct faster-whisper path.

**Ruled out:** The loop-tick shutdown watchdog warning is independent. Current main catches the unsupported Windows Unix-socket API and deliberately disables only that liveness witness; it does not terminate the gateway at voice-transcription time.

### Fix

Gate only the opportunistic faster-whisper fallback on native Windows. Keep the command fallback and explicit local-provider dispatch unchanged, and add a host-native Windows regression test that proves a cloud-selected fallback never invokes `_transcribe_local`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/transcription_tools.py` - prevent implicit in-process faster-whisper fallback on Windows while preserving command and explicit-local paths.
- `tests/tools/test_transcription.py` - cover the Windows cloud-fallback boundary and retain the generic allowed-fallback contract.

## How to Test

1. On Windows, configure `stt.provider: openai` and install faster-whisper.
2. Make the configured STT request fail, then send a Telegram voice note; verify the gateway remains alive and reports the controlled transcription failure.
3. Run the automated regression suites:

```bash
scripts/run_tests.sh tests/tools/test_transcription.py -q
scripts/run_tests.sh tests/gateway/test_stt_config.py -q
```

Local result: 21 tests passed on Windows 11.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant inline documentation is updated; user documentation is N/A
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; non-Windows and explicit-local behavior remain unchanged
- [x] Tool descriptions and schemas are N/A because no model-tool contract changed

## Screenshots / Logs

N/A. The host-native Windows regression test captures the unsafe dispatch boundary.

