### PR TITLE
feat(skills): opportunity-radar — cross-source proactive suggestions from posts, inbox, and calendar (Energy-inspired)

### DIFF
--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -386,6 +386,52 @@ CATALOG: List[AutomationBlueprint] = [
         tags=("competitors", "news", "monitor", "research"),
     ),
     AutomationBlueprint(
+        # Inspired by Energy's (getenergy.com) proactive suggestions: the
+        # assistant watches the user's own activity streams (posts, inbox,
+        # calendar) and suggests timely cross-source actions — suggest-only.
+        key="opportunity-radar",
+        title="Opportunity radar",
+        description="A recurring scan of your posts, inbox, and calendar that "
+        "suggests timely actions — where a need in one place meets an "
+        "opening in another.",
+        category="general",
+        schedule_template="{minute} {hour} * * {dow}",
+        prompt_template=(
+            "Load the opportunity-radar skill and run the scan tick for this "
+            "radar. Sources: {sources}. Opportunity focus: {focus}. Collect "
+            "new signals from each source since its stored cutoff, cross-link "
+            "needs against openings, dedup against the suggestion ledger, and "
+            "deliver at most 3 evidenced suggestions — propose only, never "
+            "act. If nothing clears the bar, respond with [SILENT]. On the "
+            "first run, execute the skill's setup phase first: pin the radar "
+            "contract, verify one live read per source, and write the state "
+            "file under ~/.hermes/opportunity-radar/."
+        ),
+        slots=[
+            BlueprintSlot(
+                name="sources", type="text", label="What should it watch?",
+                default="my public posts, my inbox, and my calendar",
+                help="activity streams to scan — posts (X handle), email, "
+                "calendar, recent Hermes sessions",
+            ),
+            BlueprintSlot(
+                name="focus", type="text",
+                label="What counts as an opportunity?",
+                default="intros I should ask for, unanswered asks, deadlines "
+                "I can act on, follow-ups going cold",
+            ),
+            _TIME("09:00"),
+            BlueprintSlot(
+                name="recurrence", type="weekdays", label="Scan on",
+                default="weekdays",
+                options=tuple(WEEKDAY_PRESETS.keys()),
+            ),
+            _DELIVER,
+        ],
+        skills=("opportunity-radar",),
+        tags=("proactive", "suggestions", "monitor"),
+    ),
+    AutomationBlueprint(
         key="habit-checkin",
         title="Habit check-in",
         description="A recurring nudge to keep a habit on track and reflect "

--- a/skills/productivity/opportunity-radar/SKILL.md
+++ b/skills/productivity/opportunity-radar/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: opportunity-radar
+description: "Cross-source scan that suggests timely, evidenced actions."
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Proactivity, Suggestions, Email, Social, Automation]
+    related_skills: [email-inbox-triage, google-workspace, weekly-review-planning, himalaya]
+---
+
+# Opportunity Radar
+
+Watch the user's own activity streams — public posts, inbox, calendar, recent Hermes sessions — and surface the moments where two of them connect: a need voiced in one place while the opening to solve it sits unanswered in another ("you posted about needing app signing help; there's an unreplied email from a Microsoft contact in your inbox — reply and ask for an intro"). Inspired by Energy's (getenergy.com) proactive suggestions, adapted to Hermes's cron + connector architecture as a strictly suggest-only radar.
+
+Setup runs once in the foreground; the recurring scan runs as a `cronjob` tick (the `opportunity-radar` automation blueprint scaffolds this). The radar proposes; the user disposes. It never sends, replies, posts, books, or buys — surfacing a suggestion does not imply permission to act on it.
+
+## When to Use
+
+- "Watch my posts and inbox and tell me when there's something I should act on."
+- "Connect the dots across my email / X / calendar and suggest next moves."
+- "Nudge me when someone in my inbox can solve something I said I needed."
+- A cron tick fires for an existing radar (steps 5-7).
+
+Don't use for: routine inbox triage (use `email-inbox-triage`), weekly planning recaps (use `weekly-review-planning`), or company/news tracking (use `competitor-news-monitor`).
+
+## Procedure — Setup (foreground, once)
+
+### 1. Define the radar contract
+
+Pin down with the user: which sources to watch (their public posts via `x_search` with their handle, inbox via connector skills, calendar, recent session history via `session_search`), what kinds of opportunities matter to them (intros, unanswered asks, deadlines meeting capabilities, follow-ups going cold), the suggestion bar (only cross-source or time-sensitive items — never single-source restatements), the scan cadence, and the delivery destination. Done when the contract names every source and states the suggestion bar in one sentence.
+
+### 2. Verify each source with one live read
+
+For each source, do one bounded foreground read now: posts via `x_search` scoped to the user's handle and a date window, email/calendar via the connector skills (`himalaya`, `google-workspace`), session history via `session_search`. Auth walls, missing handles, or empty results surface here, not on the first scheduled run. Drop or renegotiate sources that fail. Done when every contracted source returned real data or was explicitly removed.
+
+### 3. Run a baseline scan and write the state file
+
+Do one full scan now: collect recent signals per source (needs, asks, offers, expiring windows), then look for cross-source links. Write the radar contract plus state to `~/.hermes/opportunity-radar/<slug>.json`: sources with per-source cutoff timestamps, a seen-signal ledger, and a suggestion ledger (each entry: the suggestion, its evidence refs, status `proposed`/`acted`/`dismissed`, and the date). The state file is the source of truth; delivered messages are projections of it. Present any baseline findings to the user. Done when the state file exists with a cutoff for every source and every baseline suggestion is in the ledger.
+
+### 4. Schedule the scan
+
+Only after step 3 succeeded, create the job:
+
+```
+cronjob(action="create",
+        schedule=<cadence from the contract, e.g. "0 9 * * 1-5">,
+        prompt="Load the opportunity-radar skill and run the scan tick for the radar at ~/.hermes/opportunity-radar/<slug>.json.",
+        deliver=<user's destination>)
+```
+
+Pick a cadence gentle on source rate limits — daily is usually right. Done when the job exists and its prompt names the state-file path.
+
+## Procedure — Tick (each scheduled run)
+
+### 5. Collect new signals since the last cutoff
+
+Load the state file and re-read each source from its stored cutoff: new posts, new or still-unanswered inbound mail, upcoming calendar items, notable recent sessions. A failed source read means unknown state: keep that source's old cutoff, note the failure, and never advance a cutoff past data you did not actually read. Done when every source is either collected-and-advanced or explicitly marked failed with the old cutoff intact.
+
+### 6. Cross-link signals into candidate suggestions
+
+Match needs against openings across sources: a stated problem × a person in the inbox who can help; an expiring window × free calendar time; an inbound offer × a goal from recent sessions. Score each candidate against the contract's suggestion bar, and dedup against the suggestion ledger — a dismissed suggestion stays dismissed unless material new evidence arrives (say so explicitly when reviving one). Done when every surviving candidate carries evidence refs from at least two sources or a concrete time trigger.
+
+### 7. Deliver suggestions with evidence, else stay silent
+
+Deliver at most 3 suggestions, each as: what to do, why now, and the evidence (quote or link the post, name the email thread, cite the date). Append them to the suggestion ledger as `proposed` and update cutoffs. Take no action on any suggestion — even ones that look safe — unless the user replies asking for it. If nothing cleared the bar, respond with `[SILENT]`. Done when delivery matches the ledger and no source action was executed.
+
+## Pitfalls
+
+- Acting on a suggestion instead of proposing it — the radar is read-only against the outside world.
+- Single-source restatements ("you got an email from X") — a suggestion needs a cross-source link or a time trigger.
+- Re-suggesting dismissed items every run — trust dies in a week.
+- Advancing a source cutoff after a failed read, silently skipping the missed window.
+- Flooding: more than ~3 suggestions per tick means the bar is set too low.
+
+## Verification
+
+- [ ] Every contracted source passed one foreground read before scheduling.
+- [ ] The state file carries per-source cutoffs, a seen-signal ledger, and a suggestion ledger that replays radar history alone.
+- [ ] Every delivered suggestion cites evidence from ≥2 sources or a concrete time trigger.
+- [ ] Dismissed suggestions were not re-proposed without new evidence.
+- [ ] No tick ever executed an external action; no-signal runs were `[SILENT]`.

--- a/tests/skills/test_opportunity_radar_skill.py
+++ b/tests/skills/test_opportunity_radar_skill.py
@@ -1,0 +1,147 @@
+"""Tests for the opportunity-radar skill and its opportunity-radar blueprint.
+
+Inspired by Energy's (getenergy.com) proactive suggestions — the assistant
+watches the user's own activity streams (public posts, inbox, calendar) and
+suggests timely cross-source actions, suggest-only.
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "productivity"
+    / "opportunity-radar"
+    / "SKILL.md"
+)
+
+
+def _frontmatter_and_body():
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert content.startswith("---")
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, "frontmatter must close with ---"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    body = content[m.end() + 3 :]
+    return fm, body
+
+
+def test_skill_file_exists():
+    assert SKILL_PATH.is_file()
+
+
+def test_frontmatter_required_fields():
+    fm, _ = _frontmatter_and_body()
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert field in fm, f"missing frontmatter field: {field}"
+    assert fm["name"] == "opportunity-radar"
+
+
+def test_description_hardline():
+    fm, _ = _frontmatter_and_body()
+    desc = fm["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars; hardline is 60"
+    assert desc.endswith(".")
+
+
+def test_related_skills_resolve_in_repo():
+    fm, _ = _frontmatter_and_body()
+    repo_root = SKILL_PATH.parents[3]
+    for name in fm["metadata"]["hermes"]["related_skills"]:
+        hits = (
+            list(repo_root.glob(f"skills/*/{name}/SKILL.md"))
+            + list(repo_root.glob(f"optional-skills/*/{name}/SKILL.md"))
+            + list(repo_root.glob(f"skills/*/*/{name}/SKILL.md"))
+        )
+        assert hits, f"related_skills entry does not resolve in-repo: {name}"
+
+
+def test_setup_tick_split():
+    """The skill must separate one-time setup from the recurring cron tick."""
+    _, body = _frontmatter_and_body()
+    assert "Setup (foreground, once)" in body
+    assert "Tick (each scheduled run)" in body
+    assert "cronjob(action=" in body, "must wire scheduling through the cronjob tool"
+
+
+def test_suggest_only_boundary_explicit():
+    """The radar must never act on the outside world — propose only."""
+    _, body = _frontmatter_and_body()
+    assert "never sends, replies, posts, books, or buys" in body
+    assert "does not imply permission" in body
+    assert "read-only against the outside world" in body
+
+
+def test_state_discipline_present():
+    """State-file source of truth + failed-read cutoff handling must be explicit."""
+    _, body = _frontmatter_and_body()
+    assert "source of truth" in body
+    assert "suggestion ledger" in body
+    assert "never advance a cutoff past data you did not actually read" in body
+
+
+def test_source_verification_before_scheduling():
+    _, body = _frontmatter_and_body()
+    assert "Only after step 3 succeeded" in body
+    assert "one bounded foreground read" in body
+
+
+def test_cross_source_evidence_bar():
+    """Suggestions need cross-source links or time triggers, capped per tick."""
+    _, body = _frontmatter_and_body()
+    assert "at most 3 suggestions" in body
+    assert "two sources or a concrete time trigger" in body
+    assert "dismissed suggestion stays dismissed" in body
+
+
+def test_silent_path_explicit():
+    _, body = _frontmatter_and_body()
+    assert "[SILENT]" in body, "no-signal ticks must stay silent"
+
+
+def test_steps_have_completion_criteria():
+    _, body = _frontmatter_and_body()
+    steps = re.findall(r"^### \d+\..*?(?=^### \d+\.|^## )", body, re.MULTILINE | re.DOTALL)
+    assert len(steps) >= 6
+    for step in steps:
+        assert "Done when" in step, f"step missing completion criterion: {step[:60]!r}"
+
+
+def test_opportunity_radar_blueprint_registered():
+    from cron.blueprint_catalog import CATALOG
+
+    bp = next((b for b in CATALOG if b.key == "opportunity-radar"), None)
+    assert bp is not None, "opportunity-radar blueprint missing from catalog"
+    assert "opportunity-radar" in bp.skills, "blueprint must load the skill"
+    slot_names = {s.name for s in bp.slots}
+    assert {"sources", "focus", "time", "recurrence", "deliver"} <= slot_names
+    assert "[SILENT]" in bp.prompt_template, "silent path must be explicit"
+    assert "{sources}" in bp.prompt_template and "{focus}" in bp.prompt_template
+    assert "never" in bp.prompt_template and "act" in bp.prompt_template, (
+        "suggest-only boundary must survive into the cron prompt"
+    )
+
+
+def test_opportunity_radar_blueprint_fills():
+    """fill_blueprint must produce a valid cron job kwargs dict."""
+    from cron.blueprint_catalog import CATALOG, fill_blueprint
+
+    bp = next(b for b in CATALOG if b.key == "opportunity-radar")
+    job = fill_blueprint(
+        bp,
+        {
+            "sources": "my X posts and my inbox",
+            "focus": "intros and unanswered asks",
+            "time": "09:30",
+            "recurrence": "weekdays",
+            "deliver": "origin",
+        },
+    )
+    assert "my X posts and my inbox" in job["prompt"]
+    assert "intros and unanswered asks" in job["prompt"]
+    fields = job["schedule"].split()
+    assert len(fields) == 5, f"invalid cron expr: {job['schedule']}"
+    assert fields[0] == "30" and fields[1] == "9"
+    assert fields[4] == "1-5"

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -109,6 +109,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`nano-pdf`](/docs/user-guide/skills/bundled/productivity/productivity-nano-pdf) | Edit text in existing PDFs via natural-language prompts. | `productivity/nano-pdf` |
 | [`notion`](/docs/user-guide/skills/bundled/productivity/productivity-notion) | Notion API + ntn CLI: pages, databases, markdown, Workers. | `productivity/notion` |
 | [`ocr-and-documents`](/docs/user-guide/skills/bundled/productivity/productivity-ocr-and-documents) | Extract text from PDFs/scans (pymupdf, marker-pdf). | `productivity/ocr-and-documents` |
+| [`opportunity-radar`](/docs/user-guide/skills/bundled/productivity/productivity-opportunity-radar) | Cross-source scan that suggests timely, evidenced actions. | `productivity/opportunity-radar` |
 | [`pdf`](/docs/user-guide/skills/bundled/productivity/productivity-pdf) | Create, read, merge, fill, and secure PDF files. | `productivity/pdf` |
 | [`powerpoint`](/docs/user-guide/skills/bundled/productivity/productivity-powerpoint) | Create, read, edit .pptx decks with python-pptx. | `productivity/powerpoint` |
 | [`product-price-monitor`](/docs/user-guide/skills/bundled/productivity/productivity-product-price-monitor) | Watch product, flight, or listing prices; alert on target. | `productivity/product-price-monitor` |

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-opportunity-radar.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-opportunity-radar.md
@@ -1,0 +1,102 @@
+---
+title: "Opportunity Radar — Cross-source scan that suggests timely, evidenced actions"
+sidebar_label: "Opportunity Radar"
+description: "Cross-source scan that suggests timely, evidenced actions"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Opportunity Radar
+
+Cross-source scan that suggests timely, evidenced actions.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/productivity/opportunity-radar` |
+| Version | `0.1.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Proactivity`, `Suggestions`, `Email`, `Social`, `Automation` |
+| Related skills | [`email-inbox-triage`](/docs/user-guide/skills/bundled/email/email-email-inbox-triage), [`google-workspace`](/docs/user-guide/skills/bundled/productivity/productivity-google-workspace), [`weekly-review-planning`](/docs/user-guide/skills/bundled/productivity/productivity-weekly-review-planning), [`himalaya`](/docs/user-guide/skills/bundled/email/email-himalaya) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Opportunity Radar
+
+Watch the user's own activity streams — public posts, inbox, calendar, recent Hermes sessions — and surface the moments where two of them connect: a need voiced in one place while the opening to solve it sits unanswered in another ("you posted about needing app signing help; there's an unreplied email from a Microsoft contact in your inbox — reply and ask for an intro"). Inspired by Energy's (getenergy.com) proactive suggestions, adapted to Hermes's cron + connector architecture as a strictly suggest-only radar.
+
+Setup runs once in the foreground; the recurring scan runs as a `cronjob` tick (the `opportunity-radar` automation blueprint scaffolds this). The radar proposes; the user disposes. It never sends, replies, posts, books, or buys — surfacing a suggestion does not imply permission to act on it.
+
+## When to Use
+
+- "Watch my posts and inbox and tell me when there's something I should act on."
+- "Connect the dots across my email / X / calendar and suggest next moves."
+- "Nudge me when someone in my inbox can solve something I said I needed."
+- A cron tick fires for an existing radar (steps 5-7).
+
+Don't use for: routine inbox triage (use `email-inbox-triage`), weekly planning recaps (use `weekly-review-planning`), or company/news tracking (use `competitor-news-monitor`).
+
+## Procedure — Setup (foreground, once)
+
+### 1. Define the radar contract
+
+Pin down with the user: which sources to watch (their public posts via `x_search` with their handle, inbox via connector skills, calendar, recent session history via `session_search`), what kinds of opportunities matter to them (intros, unanswered asks, deadlines meeting capabilities, follow-ups going cold), the suggestion bar (only cross-source or time-sensitive items — never single-source restatements), the scan cadence, and the delivery destination. Done when the contract names every source and states the suggestion bar in one sentence.
+
+### 2. Verify each source with one live read
+
+For each source, do one bounded foreground read now: posts via `x_search` scoped to the user's handle and a date window, email/calendar via the connector skills (`himalaya`, `google-workspace`), session history via `session_search`. Auth walls, missing handles, or empty results surface here, not on the first scheduled run. Drop or renegotiate sources that fail. Done when every contracted source returned real data or was explicitly removed.
+
+### 3. Run a baseline scan and write the state file
+
+Do one full scan now: collect recent signals per source (needs, asks, offers, expiring windows), then look for cross-source links. Write the radar contract plus state to `~/.hermes/opportunity-radar/<slug>.json`: sources with per-source cutoff timestamps, a seen-signal ledger, and a suggestion ledger (each entry: the suggestion, its evidence refs, status `proposed`/`acted`/`dismissed`, and the date). The state file is the source of truth; delivered messages are projections of it. Present any baseline findings to the user. Done when the state file exists with a cutoff for every source and every baseline suggestion is in the ledger.
+
+### 4. Schedule the scan
+
+Only after step 3 succeeded, create the job:
+
+```
+cronjob(action="create",
+        schedule=<cadence from the contract, e.g. "0 9 * * 1-5">,
+        prompt="Load the opportunity-radar skill and run the scan tick for the radar at ~/.hermes/opportunity-radar/<slug>.json.",
+        deliver=<user's destination>)
+```
+
+Pick a cadence gentle on source rate limits — daily is usually right. Done when the job exists and its prompt names the state-file path.
+
+## Procedure — Tick (each scheduled run)
+
+### 5. Collect new signals since the last cutoff
+
+Load the state file and re-read each source from its stored cutoff: new posts, new or still-unanswered inbound mail, upcoming calendar items, notable recent sessions. A failed source read means unknown state: keep that source's old cutoff, note the failure, and never advance a cutoff past data you did not actually read. Done when every source is either collected-and-advanced or explicitly marked failed with the old cutoff intact.
+
+### 6. Cross-link signals into candidate suggestions
+
+Match needs against openings across sources: a stated problem × a person in the inbox who can help; an expiring window × free calendar time; an inbound offer × a goal from recent sessions. Score each candidate against the contract's suggestion bar, and dedup against the suggestion ledger — a dismissed suggestion stays dismissed unless material new evidence arrives (say so explicitly when reviving one). Done when every surviving candidate carries evidence refs from at least two sources or a concrete time trigger.
+
+### 7. Deliver suggestions with evidence, else stay silent
+
+Deliver at most 3 suggestions, each as: what to do, why now, and the evidence (quote or link the post, name the email thread, cite the date). Append them to the suggestion ledger as `proposed` and update cutoffs. Take no action on any suggestion — even ones that look safe — unless the user replies asking for it. If nothing cleared the bar, respond with `[SILENT]`. Done when delivery matches the ledger and no source action was executed.
+
+## Pitfalls
+
+- Acting on a suggestion instead of proposing it — the radar is read-only against the outside world.
+- Single-source restatements ("you got an email from X") — a suggestion needs a cross-source link or a time trigger.
+- Re-suggesting dismissed items every run — trust dies in a week.
+- Advancing a source cutoff after a failed read, silently skipping the missed window.
+- Flooding: more than ~3 suggestions per tick means the bar is set too low.
+
+## Verification
+
+- [ ] Every contracted source passed one foreground read before scheduling.
+- [ ] The state file carries per-source cutoffs, a seen-signal ledger, and a suggestion ledger that replays radar history alone.
+- [ ] Every delivered suggestion cites evidence from ≥2 sources or a concrete time trigger.
+- [ ] Dismissed suggestions were not re-proposed without new evidence.
+- [ ] No tick ever executed an external action; no-signal runs were `[SILENT]`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -272,6 +272,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/productivity/productivity-nano-pdf',
                     'user-guide/skills/bundled/productivity/productivity-notion',
                     'user-guide/skills/bundled/productivity/productivity-ocr-and-documents',
+                    'user-guide/skills/bundled/productivity/productivity-opportunity-radar',
                     'user-guide/skills/bundled/productivity/productivity-pdf',
                     'user-guide/skills/bundled/productivity/productivity-powerpoint',
                     'user-guide/skills/bundled/productivity/productivity-product-price-monitor',


### PR DESCRIPTION
## Summary
Users can now schedule a suggest-only "opportunity radar" that scans their own activity streams — public posts, inbox, calendar, recent sessions — and surfaces timely cross-source suggestions ("you posted about needing X; there's an unanswered email from someone who can help — reply and ask").

Inspired by Energy's (getenergy.com) proactive suggestions: their assistant watched the founder's X posts and, after he posted about needing Windows code-signing help, suggested replying to an unreplied Microsoft VC email to ask for a contact ([founder demo](https://x.com/gabriel1/status/2090861412616904965)). Adapted to Hermes's cron + connector + skill architecture as a strictly propose-only radar — no core code, no new model tool.

## Changes
- `skills/productivity/opportunity-radar/SKILL.md`: setup/tick skill — pin a radar contract, verify each source with one foreground read (posts via `x_search`, mail/calendar via `himalaya`/`google-workspace`, history via `session_search`), keep per-source cutoffs + a seen-signal ledger + a suggestion ledger in `~/.hermes/opportunity-radar/<slug>.json`, deliver ≤3 evidenced suggestions per tick (each needs ≥2 sources or a concrete time trigger), `[SILENT]` otherwise, dismissed suggestions stay dismissed, and the radar never acts externally
- `cron/blueprint_catalog.py`: `opportunity-radar` automation blueprint (`sources`/`focus`/`time`/`recurrence`/`deliver` slots) so every surface — dashboard form, `/blueprint` command, agent seed — can scaffold one
- `tests/skills/test_opportunity_radar_skill.py`: skill contract tests (suggest-only boundary, cutoff/ledger discipline, evidence bar, silent path) + blueprint registration/fill tests
- Docs: skills-catalog row, sidebar entry, generated per-skill page

## Validation
| Check | Result |
|---|---|
| `pytest tests/skills/test_opportunity_radar_skill.py tests/skills/test_authoring_standards.py tests/cron/test_blueprint_catalog.py` | 1242 passed |
| Live `fill_blueprint` + `blueprint_slash_command` + `blueprint_form_schema` on the new entry | valid cron kwargs (`0 9 * * 1-5`), correct slot order, prompt carries sources/focus |
| `scripts/audit_pr_attribution.py --fix` | all emails mapped |

## Infographic

![Opportunity Radar infographic](https://v3b.fal.media/files/b/0aa8399e/0GhAnY8pG20bfTrM2-6w8_rRnLeibF.png)
