### PR TITLE
fix(kanban): preserve worker failures and breaker trips

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8860,7 +8860,11 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection,
+    *,
+    failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and restores the task's source phase.
@@ -9108,7 +9112,13 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     conn, tid,
                     error=error_text,
                     outcome="crashed",
-                    failure_limit=violation_limit,
+                    # The violation streak decides *when* to force-trip, while
+                    # recompute_ready() uses the dispatcher's configured
+                    # failure limit to decide whether a blocked task may be
+                    # promoted. Persist at least both thresholds so a valid
+                    # forced trip stays blocked even when an operator raises
+                    # kanban.failure_limit above the violation streak bound.
+                    failure_limit=max(violation_limit, int(failure_limit)),
                     force_trip=True,
                     release_claim=False,
                     end_run=False,
@@ -9243,6 +9253,14 @@ def _record_task_failure(
         else:
             effective_limit = int(failure_limit)
             limit_source = "dispatcher"
+
+        # A forced trip is a terminal breaker decision made by a caller that
+        # already exhausted its own bounded policy (for example the clean-exit
+        # protocol-violation streak).  Keep the persisted counter consistent
+        # with that decision so recompute_ready() cannot immediately undo the
+        # block merely because the independent unified counter was lower.
+        if force_trip:
+            failures = max(failures, effective_limit)
 
         if force_trip or failures >= effective_limit:
             # Trip the breaker.
@@ -9962,7 +9980,7 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(conn, failure_limit=failure_limit)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
@@ -10887,14 +10905,13 @@ def _default_spawn(
     cmd.extend([
         "chat",
         "-q", prompt,
+        # All dispatcher workers need the result-preserving fully-quiet path.
+        # The ordinary single-query path prints provider errors but returns
+        # rc=0; -Q preserves structured failures so rate-limit/billing exits
+        # reach the dispatcher as EX_TEMPFAIL (75) instead of false protocol
+        # violations. Goal-mode workers also consume this same path.
+        "-Q",
     ])
-    if task.goal_mode:
-        # Goal-mode workers must take the fully-quiet single-query path:
-        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
-        # cli.py's quiet branch. Without -Q the worker gets exactly one
-        # turn, prints text, exits rc=0, and the dispatcher records a
-        # protocol violation (incident 2026-06-09 t_d9cbe312).
-        cmd.append("-Q")
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,41 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+def test_pass_artifact_and_text_are_not_terminal(clear_kanban_env):
+    """Evidence files never replace the transactional board transition."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_pass_only")
+    messages = [
+        {"role": "user", "content": "work kanban task"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "write-1",
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": '{"path":"PASS.md","content":"PASS"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "write_file",
+            "tool_call_id": "write-1",
+            "content": "written",
+        },
+        {"role": "assistant", "content": "PASS"},
+    ]
+
+    assert session_called_kanban_terminal(messages) is False
+    nudge = build_kanban_stop_nudge(messages=messages)
+    assert nudge is not None
+    assert "kanban_complete" in nudge
+    assert "kanban_block" in nudge
+
+
 
 
 

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -133,18 +133,31 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
     ]
 
 
-def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatch):
+@pytest.mark.parametrize(
+    ("failure_reason", "kanban_task", "expected_exit"),
+    [
+        (None, None, 1),
+        ("rate_limit", "t_rate_limited", 75),
+        ("billing", "t_billing_wall", 75),
+    ],
+)
+def test_quiet_single_query_main_finalizes_while_preserving_exit_code(
+    monkeypatch, failure_reason, kanban_task, expected_exit
+):
     calls = []
 
     import cli as cli_mod
 
     def run_conversation(*, user_message, conversation_history):
         calls.append(("run", user_message, conversation_history))
-        return {
+        result = {
             "final_response": "",
             "error": "provider failed",
             "failed": True,
         }
+        if failure_reason is not None:
+            result["failure_reason"] = failure_reason
+        return result
 
     class FakeCLI:
         def __init__(self, **_kwargs):
@@ -184,7 +197,10 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
             calls.append(("init", kwargs))
             return True
 
-    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    if kanban_task is None:
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_KANBAN_TASK", kanban_task)
     monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
     monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
     monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
@@ -197,7 +213,7 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
     with pytest.raises(SystemExit) as exc_info:
         cli_mod.main(query="hello", quiet=True, toolsets="terminal")
 
-    assert exc_info.value.code == 1
+    assert exc_info.value.code == expected_exit
     assert ("claim", "cli", True) in calls
     assert ("run", "hello", []) in calls
     assert calls[-1] == ("finalize", "quiet-session")

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1279,7 +1279,7 @@ def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
 
 
 
-def _drive_worker_exit(conn, tid, fake_pid, raw_status):
+def _drive_worker_exit(conn, tid, fake_pid, raw_status, *, failure_limit=2):
     """Claim ``tid``, record ``raw_status`` for its dead worker pid, and run
     one reaper pass.
 
@@ -1299,17 +1299,19 @@ def _drive_worker_exit(conn, tid, fake_pid, raw_status):
     original_alive = _kb._pid_alive
     _kb._pid_alive = lambda p: False
     try:
-        return _kb.detect_crashed_workers(conn)
+        return _kb.detect_crashed_workers(conn, failure_limit=failure_limit)
     finally:
         _kb._pid_alive = original_alive
 
 
-def _drive_protocol_violation(conn, tid, fake_pid):
+def _drive_protocol_violation(conn, tid, fake_pid, *, failure_limit=2):
     """One clean-exit protocol violation reaper pass for ``tid``.
 
     os.W_EXITCODE(status=0, signal=0) == 0 on POSIX.
     """
-    return _drive_worker_exit(conn, tid, fake_pid, 0)
+    return _drive_worker_exit(
+        conn, tid, fake_pid, 0, failure_limit=failure_limit
+    )
 
 
 def _drive_nonzero_crash(conn, tid, fake_pid):
@@ -1357,13 +1359,39 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
             )
 
         # Third consecutive violation: streak hits the bound — blocked.
-        _drive_protocol_violation(conn, tid, 991003)
+        configured_failure_limit = 5
+        _drive_protocol_violation(
+            conn, tid, 991003, failure_limit=configured_failure_limit
+        )
         task = kb.get_task(conn, tid)
+        assert task is not None
         assert task.status == "blocked"
+        assert task.consecutive_failures >= configured_failure_limit
         gave_up = [e for e in kb.list_events(conn, tid) if e.kind == "gave_up"]
         assert len(gave_up) == 1
         assert (gave_up[0].payload or {}).get("protocol_violations") == \
             _kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
+
+        # A forced breaker trip must be stable under the same promotion pass
+        # that follows crash detection in dispatch_once(). Live incident
+        # t_8dd9ecb5 emitted gave_up and then immediately promoted/spawned a
+        # fourth worker because the persisted counter stayed below the limit.
+        before_promotions = len([
+            e for e in kb.list_events(conn, tid) if e.kind == "promoted"
+        ])
+        assert kb.recompute_ready(
+            conn, failure_limit=configured_failure_limit
+        ) == 0
+        assert kb.recompute_ready(
+            conn, failure_limit=configured_failure_limit
+        ) == 0
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        after_promotions = len([
+            e for e in kb.list_events(conn, tid) if e.kind == "promoted"
+        ])
+        assert after_promotions == before_promotions
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -87,6 +87,7 @@ agent:
     pinned = captured["cmd"][captured["cmd"].index("--toolsets") + 1].split(",")
     for required in ("terminal", "web", "file", "skills", "code_execution", "delegation"):
         assert required in pinned
+    assert captured["cmd"].count("-Q") == 1
 
 
 def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_path):
@@ -112,6 +113,7 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
 
     def fake_popen(cmd, *args, **kwargs):
         captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs.get("env") or {})
         return FakeProc()
 
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
@@ -132,6 +134,16 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
     assert args.command == "chat"
     assert args.model == "gpt-5.6-sol"
     assert args.query == "work kanban task t_spawn_tools"
+    assert args.quiet is True
+
+    goal_task = _make_task(kb, assignee="elias")
+    goal_task.goal_mode = True
+    kb._default_spawn(goal_task, str(workspace))
+    assert captured["cmd"].count("-Q") == 1
+    assert captured["env"]["HERMES_KANBAN_GOAL_MODE"] == "1"
+    goal_args = parser.parse_args(captured["cmd"][3:])
+    assert goal_args.query == "work kanban task t_spawn_tools"
+    assert goal_args.quiet is True
 
 
 def test_resolve_worker_cli_toolsets_uses_profile_home_not_parent_config(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fix two coupled Hermes Kanban failure modes discovered from repeated workers that exited without terminal task transitions:

- run dispatcher workers through the existing result-preserving `chat -Q` path so provider `rate_limit`/`billing` failures exit with sentinel 75 instead of being misclassified as clean `rc=0` protocol violations;
- make forced protocol-violation breaker trips persist a failure count at or above both the violation threshold and configured dispatcher threshold, preventing `recompute_ready()` from immediately promoting a task after `gave_up`.

## Incident classification

The affected workers never reached the model or tools. A provider HTTP 429/quota response produced zero tool calls, but the ordinary `chat -q` path returned process status 0. The dispatcher therefore classified provider failure as a clean-exit protocol violation. On retry exhaustion, `force_trip=True` persisted `consecutive_failures=1` while the effective dispatcher limit was higher, allowing immediate re-promotion.

This change does not weaken the lifecycle rule: writing `PASS.md` or returning text such as `PASS` remains nonterminal unless the worker calls `kanban_complete` or `kanban_block`.

## Validation

- focused worker/spawn/breaker/stop/single-query tests: 40 passed;
- isolated exit-75 requeue/cooldown test: 1 passed;
- total publication canary: **41 passed**;
- exact-tree independent review and publication attestation passed;
- broad Kanban subset still has 27 failures that reproduce as the identical test-ID set on the unpatched base and this branch; no full-suite green is claimed.

Additional regression coverage proves:

- ordinary and goal-mode workers each receive exactly one parser-valid `-Q`;
- the incident's actual `billing` classification maps to exit 75;
- exit 75 requeues without incrementing the failure counter and activates cooldown;
- forced trips remain blocked even with configured `failure_limit=5`;
- ordinary breaker recovery remains unchanged;
- PASS artifact/text alone remains nonterminal.

## Operational notes

- Non-quota `failed=True` workers now correctly consume the unified failure budget rather than being treated as clean-exit protocol violations.
- Quiet worker logs are intentionally thinner because interactive tool-progress callbacks are disabled.
- No schema or database migration is required; rollback is a normal commit revert plus dispatcher restart.
