### PR TITLE
fix(config): stop unrelated config writes from restoring stale model routing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4918,13 +4918,21 @@ def save_config_value(key_path: str, value: any) -> bool:
     config_path = get_hermes_home() / 'config.yaml'
     
     try:
-        # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Save back atomically while preserving comments, ordering, quotes, and
-        # readable Unicode in user-edited config.yaml.
-        from utils import atomic_roundtrip_yaml_update
-        atomic_roundtrip_yaml_update(config_path, key_path, value)
+        from hermes_cli import config as config_module
+
+        with config_module._CONFIG_LOCK:
+            # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Save back atomically while preserving comments, ordering, quotes, and
+            # readable Unicode in user-edited config.yaml.
+            from utils import atomic_roundtrip_yaml_update
+            atomic_roundtrip_yaml_update(config_path, key_path, value)
+
+            # The atomic replace invalidates stat-keyed caches naturally, but
+            # discard the raw cache eagerly for coarse-mtime filesystems.
+            config_module._RAW_CONFIG_CACHE.pop(str(config_path), None)
+            config_module._LOAD_CONFIG_CACHE.pop(str(config_path), None)
         
         # Enforce owner-only permissions on config files (contain API keys)
         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -318,6 +318,12 @@ class _LoadedConfig(dict):
     def __init__(self, value: Dict[str, Any]):
         super().__init__(value)
         self._baseline = copy.deepcopy(value)
+
+    def copy(self) -> "_LoadedConfig":
+        """Return a shallow snapshot without losing stale-write tracking."""
+        cloned = _LoadedConfig(dict(self))
+        cloned._baseline = copy.deepcopy(self._baseline)
+        return cloned
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
@@ -387,6 +393,11 @@ _EXTRA_ENV_KEYS = frozenset({
     "COPILOT_ACP_BASE_URL",
 })
 import yaml
+
+yaml.SafeDumper.add_representer(
+    _LoadedConfig,
+    yaml.representer.SafeRepresenter.represent_dict,
+)
 
 from hermes_cli.colors import Colors, color
 from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -400,8 +400,10 @@ def _represent_loaded_config(dumper, value):
     return dumper.represent_dict(value)
 
 
-yaml.SafeDumper.add_representer(_LoadedConfig, _represent_loaded_config)
-yaml.Dumper.add_representer(_LoadedConfig, _represent_loaded_config)
+for _dumper_name in ("SafeDumper", "Dumper", "CSafeDumper", "CDumper"):
+    _dumper = getattr(yaml, _dumper_name, None)
+    if _dumper is not None:
+        _dumper.add_representer(_LoadedConfig, _represent_loaded_config)
 
 from hermes_cli.colors import Colors, color
 from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2709,17 +2709,16 @@ def _merge_loaded_config_snapshot(base: Any, requested: Any, current: Any) -> An
             return _CONFIG_MISSING
         return copy.deepcopy(current)
 
-    if (
-        isinstance(base, dict)
-        and isinstance(requested, dict)
-        and isinstance(current, dict)
+    if isinstance(base, dict) and isinstance(requested, dict) and (
+        isinstance(current, dict) or current is _CONFIG_MISSING
     ):
+        current_mapping = {} if current is _CONFIG_MISSING else current
         merged: Dict[str, Any] = {}
-        for key in base.keys() | requested.keys() | current.keys():
+        for key in base.keys() | requested.keys() | current_mapping.keys():
             value = _merge_loaded_config_snapshot(
                 base.get(key, _CONFIG_MISSING),
                 requested.get(key, _CONFIG_MISSING),
-                current.get(key, _CONFIG_MISSING),
+                current_mapping.get(key, _CONFIG_MISSING),
             )
             if value is not _CONFIG_MISSING:
                 merged[key] = value

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2705,6 +2705,8 @@ def _merge_loaded_config_snapshot(base: Any, requested: Any, current: Any) -> An
         return _CONFIG_MISSING
 
     if base is not _CONFIG_MISSING and requested == base:
+        if current is _CONFIG_MISSING:
+            return _CONFIG_MISSING
         return copy.deepcopy(current)
 
     if (

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -304,6 +304,20 @@ _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
 # calls read_raw_config. Also covers mutation of the module-level cache
 # dicts above.
 _CONFIG_LOCK = threading.RLock()
+
+
+class _LoadedConfig(dict):
+    """Mutable config snapshot carrying the state it was loaded from.
+
+    ``save_config`` uses the baseline for a three-way merge so a caller that
+    saves an older snapshot does not overwrite keys changed on disk since its
+    ``load_config`` call. It remains a dict subclass to preserve the public
+    return contract and normal deepcopy behavior.
+    """
+
+    def __init__(self, value: Dict[str, Any]):
+        super().__init__(value)
+        self._baseline = copy.deepcopy(value)
 # Env var names written to .env that aren't in OPTIONAL_ENV_VARS
 # (managed by setup/provider flows directly).
 _EXTRA_ENV_KEYS = frozenset({
@@ -2664,6 +2678,43 @@ def _merge_partial_save(raw: dict, override: dict) -> dict:
     return result
 
 
+_CONFIG_MISSING = object()
+
+
+def _merge_loaded_config_snapshot(base: Any, requested: Any, current: Any) -> Any:
+    """Merge a loaded snapshot without clobbering newer on-disk values.
+
+    Caller changes relative to *base* win. Paths the caller left untouched
+    take their value from *current*, including additions and deletions made by
+    another config writer after the caller loaded its snapshot.
+    """
+    if requested is _CONFIG_MISSING:
+        if base is _CONFIG_MISSING:
+            return copy.deepcopy(current)
+        return _CONFIG_MISSING
+
+    if base is not _CONFIG_MISSING and requested == base:
+        return copy.deepcopy(current)
+
+    if (
+        isinstance(base, dict)
+        and isinstance(requested, dict)
+        and isinstance(current, dict)
+    ):
+        merged: Dict[str, Any] = {}
+        for key in base.keys() | requested.keys() | current.keys():
+            value = _merge_loaded_config_snapshot(
+                base.get(key, _CONFIG_MISSING),
+                requested.get(key, _CONFIG_MISSING),
+                current.get(key, _CONFIG_MISSING),
+            )
+            if value is not _CONFIG_MISSING:
+                merged[key] = value
+        return merged
+
+    return copy.deepcopy(requested)
+
+
 def _deep_merge(base: dict, override: dict) -> dict:
     """Recursively merge *override* into *base*, preserving nested defaults.
 
@@ -3581,7 +3632,7 @@ def load_config() -> Dict[str, Any]:
     defensive deepcopy — that path matters in agent-loop hot spots like
     ``get_provider_request_timeout`` which is called once per API turn.
     """
-    return _load_config_impl(want_deepcopy=True)
+    return _LoadedConfig(_load_config_impl(want_deepcopy=True))
 
 
 def load_config_readonly() -> Dict[str, Any]:
@@ -4038,6 +4089,17 @@ def save_config(
         if is_managed():
             managed_error("save configuration")
             return
+
+        tracked_config = config if isinstance(config, _LoadedConfig) else None
+        loaded_baseline = getattr(tracked_config, "_baseline", None)
+        requested_snapshot = copy.deepcopy(dict(config))
+        if isinstance(loaded_baseline, dict):
+            current = _load_config_impl(want_deepcopy=True)
+            config = _merge_loaded_config_snapshot(
+                loaded_baseline,
+                requested_snapshot,
+                current,
+            )
         # Managed scope: strip any leaf the managed layer pins, so a bulk write
         # (wizard / programmatic save) never persists a user value that would
         # silently lose to managed on the next load. Single-key `config set`
@@ -4127,6 +4189,11 @@ def save_config(
         _secure_file(config_path)
         _RAW_CONFIG_CACHE.pop(str(config_path), None)
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+        if tracked_config is not None:
+            # Track what this caller requested, not the merged disk state. This
+            # keeps a reused stale object from treating a preserved concurrent
+            # value as its own edit on the next save.
+            tracked_config._baseline = copy.deepcopy(requested_snapshot)
 
 
 def _parse_env_value(raw_value: str) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -394,10 +394,14 @@ _EXTRA_ENV_KEYS = frozenset({
 })
 import yaml
 
-yaml.SafeDumper.add_representer(
-    _LoadedConfig,
-    yaml.representer.SafeRepresenter.represent_dict,
-)
+
+def _represent_loaded_config(dumper, value):
+    """Serialize tracked snapshots as ordinary YAML mappings."""
+    return dumper.represent_dict(value)
+
+
+yaml.SafeDumper.add_representer(_LoadedConfig, _represent_loaded_config)
+yaml.Dumper.add_representer(_LoadedConfig, _represent_loaded_config)
 
 from hermes_cli.colors import Colors, color
 from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -47,6 +47,49 @@ class TestSaveConfigValueAtomic:
         result = yaml.safe_load(config_env.read_text())
         assert result["auxiliary"]["compression"]["model"] == "google/gemini-3-flash-preview"
 
+    def test_uses_shared_config_lock(self, config_env, monkeypatch):
+        """Single-key writes serialize with full save_config writes."""
+        from hermes_cli import config as config_module
+
+        class RecordingLock:
+            active = False
+
+            def __enter__(self):
+                self.active = True
+
+            def __exit__(self, *_args):
+                self.active = False
+
+        lock = RecordingLock()
+        monkeypatch.setattr(config_module, "_CONFIG_LOCK", lock)
+
+        def assert_locked(*_args):
+            assert lock.active is True
+
+        monkeypatch.setattr("utils.atomic_roundtrip_yaml_update", assert_locked)
+
+        from cli import save_config_value
+
+        assert save_config_value("display.skin", "mono") is True
+
+    def test_stale_loaded_snapshot_preserves_newer_single_key_write(
+        self, config_env
+    ):
+        """A later full save must not revert a value written after its load."""
+        from cli import save_config_value
+        from hermes_cli.config import load_config, save_config
+
+        stale = load_config()
+        assert stale["approvals"]["destructive_slash_confirm"] is True
+
+        assert save_config_value("approvals.destructive_slash_confirm", False) is True
+        stale["agent"]["max_turns"] = 42
+        save_config(stale)
+
+        saved = yaml.safe_load(config_env.read_text())
+        assert saved["approvals"]["destructive_slash_confirm"] is False
+        assert saved["agent"]["max_turns"] == 42
+
 
 
     def test_model_write_runs_shared_cron_drift_warning(self, config_env, monkeypatch):

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -90,6 +90,34 @@ class TestSaveConfigValueAtomic:
         assert saved["approvals"]["destructive_slash_confirm"] is False
         assert saved["agent"]["max_turns"] == 42
 
+    def test_copied_stale_snapshot_preserves_newer_single_key_write(
+        self, config_env
+    ):
+        """A normal dict-style copy must retain the loaded baseline."""
+        from cli import save_config_value
+        from hermes_cli.config import load_config, save_config
+
+        stale = load_config().copy()
+        assert stale["approvals"]["destructive_slash_confirm"] is True
+
+        assert save_config_value("approvals.destructive_slash_confirm", False) is True
+        stale["agent"]["max_turns"] = 42
+        save_config(stale)
+
+        saved = yaml.safe_load(config_env.read_text())
+        assert saved["approvals"]["destructive_slash_confirm"] is False
+        assert saved["agent"]["max_turns"] == 42
+
+    def test_loaded_config_remains_safe_yaml_serializable(self, config_env):
+        """The tracked mapping preserves the former plain-dict YAML contract."""
+        from hermes_cli.config import load_config
+
+        dumped = yaml.safe_dump(load_config())
+
+        assert yaml.safe_load(dumped)["model"]["default"] == "test-model"
+        assert "_baseline" not in dumped
+        assert "!!python" not in dumped
+
 
 
     def test_model_write_runs_shared_cron_drift_warning(self, config_env, monkeypatch):

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -90,6 +90,31 @@ class TestSaveConfigValueAtomic:
         assert saved["approvals"]["destructive_slash_confirm"] is False
         assert saved["agent"]["max_turns"] == 42
 
+    def test_unrelated_config_set_does_not_restore_stale_session_model(
+        self, config_env
+    ):
+        """A stale session save must preserve repaired routing and the new key."""
+        from hermes_cli.config import load_config, save_config, set_config_value
+
+        stale_session = load_config()
+        assert stale_session["model"]["provider"] == "openrouter"
+
+        set_config_value("model.provider", "litellm")
+        set_config_value(
+            "mcp_servers.gbrain",
+            '{"url":"http://127.0.0.1:8737/mcp","enabled":true}',
+        )
+        stale_session["agent"]["max_turns"] = 42
+        save_config(stale_session)
+
+        saved = yaml.safe_load(config_env.read_text())
+        assert saved["model"]["provider"] == "litellm"
+        assert saved["mcp_servers"]["gbrain"] == {
+            "url": "http://127.0.0.1:8737/mcp",
+            "enabled": True,
+        }
+        assert saved["agent"]["max_turns"] == 42
+
     def test_copied_stale_snapshot_preserves_newer_single_key_write(
         self, config_env
     ):

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -133,6 +133,26 @@ class TestSaveConfigValueAtomic:
         assert saved["approvals"]["destructive_slash_confirm"] is False
         assert saved["agent"]["max_turns"] == 42
 
+    def test_stale_snapshot_preserves_concurrent_nested_deletion(self, config_env):
+        """A stale sibling edit must not restore a concurrently deleted key."""
+        from hermes_cli.config import load_config, save_config
+
+        initial = yaml.safe_load(config_env.read_text())
+        initial["custom"] = {"keep": "before", "delete_me": True}
+        config_env.write_text(yaml.safe_dump(initial))
+
+        deleting_snapshot = load_config()
+        stale_snapshot = load_config()
+
+        del deleting_snapshot["custom"]["delete_me"]
+        save_config(deleting_snapshot)
+
+        stale_snapshot["custom"]["keep"] = "after"
+        save_config(stale_snapshot)
+
+        saved = yaml.safe_load(config_env.read_text())
+        assert saved["custom"] == {"keep": "after"}
+
     def test_loaded_config_remains_safe_yaml_serializable(self, config_env):
         """The tracked mapping preserves the former plain-dict YAML contract."""
         from hermes_cli.config import load_config

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -177,11 +177,12 @@ class TestSaveConfigValueAtomic:
         """The tracked mapping preserves the former plain-dict YAML contract."""
         from hermes_cli.config import load_config
 
-        dumped = yaml.safe_dump(load_config())
+        for dump in (yaml.safe_dump, yaml.dump):
+            dumped = dump(load_config())
 
-        assert yaml.safe_load(dumped)["model"]["default"] == "test-model"
-        assert "_baseline" not in dumped
-        assert "!!python" not in dumped
+            assert yaml.safe_load(dumped)["model"]["default"] == "test-model"
+            assert "_baseline" not in dumped
+            assert "!!python" not in dumped
 
 
 

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -177,8 +177,13 @@ class TestSaveConfigValueAtomic:
         """The tracked mapping preserves the former plain-dict YAML contract."""
         from hermes_cli.config import load_config
 
-        for dump in (yaml.safe_dump, yaml.dump):
-            dumped = dump(load_config())
+        dumpers = (
+            getattr(yaml, name)
+            for name in ("SafeDumper", "Dumper", "CSafeDumper", "CDumper")
+            if hasattr(yaml, name)
+        )
+        for dumper in dumpers:
+            dumped = yaml.dump(load_config(), Dumper=dumper)
 
             assert yaml.safe_load(dumped)["model"]["default"] == "test-model"
             assert "_baseline" not in dumped

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -153,6 +153,26 @@ class TestSaveConfigValueAtomic:
         saved = yaml.safe_load(config_env.read_text())
         assert saved["custom"] == {"keep": "after"}
 
+    def test_stale_snapshot_preserves_deleted_parent_siblings(self, config_env):
+        """A stale child edit must not restore siblings from a deleted section."""
+        from hermes_cli.config import load_config, save_config
+
+        initial = yaml.safe_load(config_env.read_text())
+        initial["custom"] = {"keep": "before", "delete_me": True}
+        config_env.write_text(yaml.safe_dump(initial))
+
+        deleting_snapshot = load_config()
+        stale_snapshot = load_config()
+
+        del deleting_snapshot["custom"]
+        save_config(deleting_snapshot)
+
+        stale_snapshot["custom"]["keep"] = "after"
+        save_config(stale_snapshot)
+
+        saved = yaml.safe_load(config_env.read_text())
+        assert saved["custom"] == {"keep": "after"}
+
     def test_loaded_config_remains_safe_yaml_serializable(self, config_env):
         """The tracked mapping preserves the former plain-dict YAML contract."""
         from hermes_cli.config import load_config


### PR DESCRIPTION
## What does this PR do?

Stops unrelated configuration writes from restoring a stale session's model routing over newer values in `config.yaml`. A long-lived session can retain an older loaded snapshot; before this change, a later full save wrote that snapshot verbatim and could undo an operator's repaired provider while preserving no warning that model routing had changed.

### Symptom

After `hermes config set mcp_servers.gbrain ...`, `model.provider` or `model.default` can revert to the values held by an older session snapshot. If that snapshot names an unavailable custom provider, new agent and gateway initialization fails until the profile configuration is repaired.

### Impact

Operators can lose a repaired model route while changing an unrelated setting. The stale provider can then prevent new sessions from resolving credentials or initializing a provider.

### Bug Cause

**Trigger:** `hermes_cli/config.py:save_config` saves a mutable snapshot returned by `load_config()` after another writer has changed `config.yaml`.

**Causal chain:**
1. A long-lived session loads configuration containing its then-current model route.
2. Another writer repairs the model route and `hermes config set` adds an unrelated key.
3. The long-lived session later saves its older full snapshot, replacing the repaired model route and the newly added key with stale values.

**Why it is wrong:** `save_config()` could not distinguish caller changes from untouched values inherited from an old load, so every value in the stale snapshot won over newer on-disk state.

**Working sibling / contrast:** Direct `set_config_value()` writes only the requested key and does not read session model state. The corruption occurs when a later full-snapshot save overwrites that correct single-key write.

**Ruled out:** Session model environment variables do not alter the direct `hermes config set` path. Running the reported CLI and Console commands with different `HERMES_MODEL` and `HERMES_INFERENCE_MODEL` values preserved the existing model block.

### Fix

Track the baseline on mutable configurations returned by `load_config()` and perform a three-way merge during `save_config()`: caller changes win, while untouched paths take their latest on-disk values. Serialize single-key and full-document writes with the shared config lock, preserve baseline tracking through normal `.copy()` calls, and keep the tracked mapping compatible with safe YAML serialization.

## Related Issue

Closes #97579

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` - track loaded baselines and merge stale snapshots without clobbering newer values.
- `cli.py` - serialize runtime single-key writes with the shared configuration lock and invalidate caches eagerly.
- `tests/cli/test_cli_save_config_value.py` - cover stale writes, copied snapshots, YAML compatibility, and the reported unrelated `config set` model-routing regression.

## How to Test

1. Load a configuration snapshot containing provider `openrouter`.
2. Change `model.provider` to `litellm`, add `mcp_servers.gbrain`, then save the older snapshot with an unrelated agent change.
3. Verify the saved file retains `litellm`, retains `mcp_servers.gbrain`, and includes the intended agent change.
4. Run the relevant test files:

```bash
scripts/run_tests.sh tests/cli/test_cli_save_config_value.py -q
scripts/run_tests.sh tests/hermes_cli/test_config.py -q
```

Result: 125 tests passed. A baseline run of the focused regression failed with `openrouter` restored instead of `litellm`; the fixed tip passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and regression coverage are self-contained
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] Cross-platform impact considered; the merge and locking behavior is platform-independent
- [x] Tool description and schema updates are N/A; no model tool changed

## Screenshots / Logs

N/A. The focused regression test captures the stale provider restoration before the fix and the preserved routing after the fix.
