### PR TITLE
fix(bedrock): support SDK objects and dicts in convert_messages_to_co…

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -967,8 +967,8 @@ def convert_messages_to_converse(
     converse_msgs: List[Dict] = []
 
     for msg in messages:
-        role = msg.get("role", "")
-        content = msg.get("content")
+        role = msg.get("role", "") if isinstance(msg, dict) else getattr(msg, "role", "")
+        content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", None)
 
         if role == "system":
             # System messages become the system prompt. Blank/whitespace-only
@@ -988,11 +988,11 @@ def convert_messages_to_converse(
 
         if role == "tool":
             # Tool result messages → merge into the preceding user turn
-            tool_call_id = msg.get("tool_call_id", "")
+            tool_call_id = msg.get("tool_call_id", "") if isinstance(msg, dict) else getattr(msg, "tool_call_id", "")
             result_content = content if isinstance(content, str) else json.dumps(content)
             tool_result_block = {
                 "toolResult": {
-                    "toolUseId": tool_call_id,
+                    "toolUseId": str(tool_call_id or ""),
                     "content": [{"text": _safe_text(result_content)}],
                 }
             }
@@ -1008,7 +1008,7 @@ def convert_messages_to_converse(
 
         if role == "assistant":
             content_blocks = []
-            ordered_blocks = msg.get("bedrock_content_blocks")
+            ordered_blocks = msg.get("bedrock_content_blocks") if isinstance(msg, dict) else getattr(msg, "bedrock_content_blocks", None)
             if isinstance(ordered_blocks, list) and ordered_blocks:
                 # Rebuild the exact Bedrock block sequence captured at
                 # normalization time. Redacted bytes are stored as base64 so
@@ -1052,7 +1052,7 @@ def convert_messages_to_converse(
                 # Bedrock may return opaque encrypted reasoning instead of text.
                 # Preserve the payload in the provider-neutral reasoning_details
                 # envelope so the next tool turn can replay it byte-for-byte.
-                for detail in (msg.get("reasoning_details") or []):
+                for detail in (msg.get("reasoning_details") or [] if isinstance(msg, dict) else getattr(msg, "reasoning_details", []) or []):
                     if not isinstance(detail, dict) or detail.get("type") != "redacted_thinking":
                         continue
                     encoded = detail.get("data") or detail.get("redactedContentBase64")
@@ -1071,18 +1071,30 @@ def convert_messages_to_converse(
                     content_blocks.extend(_convert_content_to_converse(content))
 
                 # Convert tool calls
-                tool_calls = msg.get("tool_calls", [])
+                tool_calls = msg.get("tool_calls", []) if isinstance(msg, dict) else getattr(msg, "tool_calls", [])
                 for tc in (tool_calls or []):
-                    fn = tc.get("function", {})
-                    args_str = fn.get("arguments", "{}")
+                    if isinstance(tc, dict):
+                        fn = tc.get("function", {}) or {}
+                        call_id = tc.get("id", "")
+                    else:
+                        fn = getattr(tc, "function", {}) or {}
+                        call_id = getattr(tc, "id", "")
+                    if isinstance(fn, dict):
+                        args_str = fn.get("arguments", "{}")
+                        fn_name = fn.get("name", "")
+                    else:
+                        args_str = getattr(fn, "arguments", "{}")
+                        fn_name = getattr(fn, "name", "")
                     try:
                         args_dict = json.loads(args_str) if isinstance(args_str, str) else args_str
                     except (json.JSONDecodeError, TypeError):
                         args_dict = {}
+                    if not isinstance(args_dict, dict):
+                        args_dict = {"_value": args_dict}
                     content_blocks.append({
                         "toolUse": {
-                            "toolUseId": tc.get("id", ""),
-                            "name": fn.get("name", ""),
+                            "toolUseId": str(call_id or ""),
+                            "name": str(fn_name or ""),
                             "input": args_dict,
                         }
                     })

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -265,6 +265,46 @@ class TestConvertMessagesToConverse:
         # Empty string should get a space placeholder
         assert msgs[0]["content"][0]["text"].strip() != "" or msgs[0]["content"][0]["text"] == " "
 
+    def test_sdk_object_tool_calls_convert_cleanly(self):
+        from types import SimpleNamespace
+        from agent.bedrock_adapter import convert_messages_to_converse
+
+        tc_obj = SimpleNamespace(
+            id="call_sdk_123",
+            type="function",
+            function=SimpleNamespace(name="search", arguments='{"q": "hermes"}'),
+        )
+        msg_obj = SimpleNamespace(
+            role="assistant",
+            content=None,
+            tool_calls=[tc_obj],
+        )
+        tool_result_obj = SimpleNamespace(
+            role="tool",
+            tool_call_id="call_sdk_123",
+            content="search result text",
+        )
+
+        messages = [
+            {"role": "user", "content": "find something"},
+            msg_obj,
+            tool_result_obj,
+        ]
+
+        system, msgs = convert_messages_to_converse(messages)
+        assistant_msgs = [m for m in msgs if m["role"] == "assistant"]
+        assert len(assistant_msgs) == 1
+        tu = assistant_msgs[0]["content"][0]["toolUse"]
+        assert tu["toolUseId"] == "call_sdk_123"
+        assert tu["name"] == "search"
+        assert tu["input"] == {"q": "hermes"}
+
+        user_msgs = [m for m in msgs if m["role"] == "user"]
+        assert len(user_msgs) >= 1
+        tr = [b["toolResult"] for m in user_msgs for b in m["content"] if "toolResult" in b][0]
+        assert tr["toolUseId"] == "call_sdk_123"
+        assert tr["content"][0]["text"] == "search result text"
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError` crash bug in [`agent/bedrock_adapter.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/bedrock_adapter.py) where `convert_messages_to_converse()` assumed message entries, `tool_calls` items, and nested `function` objects are plain Python dicts, raising `AttributeError: 'ChatCompletionMessageToolCall' object has no attribute 'get'` whenever pre-serialized messages, SDK objects (`SimpleNamespace` / `ChatCompletionMessageToolCall`), or gateway replay queues are passed.

In Hermes Agent:
1. Pre-serialization histories, gateway replay queues, and subagent handoffs can carry SDK tool_call objects or `SimpleNamespace` instances.
2. In `convert_messages_to_converse()`, direct `.get()` calls on `msg`, `tc`, and `fn` caused unhandled `AttributeError` crashes when handling object-based inputs.
3. Bedrock Converse API strictly requires `toolUse.input` to be a valid JSON dictionary (`Document`).

The fix:
- Adds dict-and-object tolerance to `convert_messages_to_converse()` across `msg`, `tool_calls`, and `function`.
- Guarantees `toolUse.input` is always a `dict` and `toolUseId` / `name` are strings.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/bedrock_adapter.py`: Made `convert_messages_to_converse()` dict-and-object tolerant for `msg`, `tool_calls`, and `function`.
- `tests/agent/test_bedrock_adapter.py`: Added unit test coverage verifying that message lists and tool calls containing `SimpleNamespace` / SDK objects convert cleanly without `AttributeError`.

## How to Test

Run the Bedrock test suite:
```bash
uv run --with pytest pytest tests/agent/test_bedrock_adapter.py tests/agent/transports/test_bedrock_transport.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(bedrock): support SDK objects and dicts in convert_messages_to_converse`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 78 items

tests/agent/test_bedrock_adapter.py .................................... [100%]

======================== 73 passed, 5 skipped in 8.92s ========================
```
