### PR TITLE
fix(gemini): support SDK objects and dicts in native adapter request translation

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -302,8 +302,8 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
     return parts
 
 
-def _tool_call_extra_signature(tool_call: Dict[str, Any]) -> Optional[str]:
-    extra = tool_call.get("extra_content") or {}
+def _tool_call_extra_signature(tool_call: Any) -> Optional[str]:
+    extra = tool_call.get("extra_content") if isinstance(tool_call, dict) else getattr(tool_call, "extra_content", None)
     if not isinstance(extra, dict):
         return None
     google = extra.get("google") or extra.get("thought_signature")
@@ -326,11 +326,12 @@ _INTERRUPTED_RESPONSE_PLACEHOLDER = (
 
 
 def _translate_tool_call_to_gemini(
-    tool_call: Dict[str, Any],
+    tool_call: Any,
     include_ids: bool = False,
 ) -> Dict[str, Any]:
-    fn = tool_call.get("function") or {}
-    args_raw = fn.get("arguments", "")
+    fn = tool_call.get("function") if isinstance(tool_call, dict) else getattr(tool_call, "function", None)
+    fn = fn or {}
+    args_raw = fn.get("arguments", "") if isinstance(fn, dict) else getattr(fn, "arguments", "")
     try:
         args = json.loads(args_raw) if isinstance(args_raw, str) and args_raw else {}
     except json.JSONDecodeError:
@@ -338,16 +339,21 @@ def _translate_tool_call_to_gemini(
     if not isinstance(args, dict):
         args = {"_value": args}
 
+    fn_name = fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", "")
     part: Dict[str, Any] = {
         "functionCall": {
-            "name": str(fn.get("name") or ""),
+            "name": str(fn_name or ""),
             "args": args,
         }
     }
     if include_ids:
         # Gemini 3+ requires explicit tool call IDs so replayed parallel tool
         # calls pair with their functionResponses (earendil-works/pi#7494).
-        tool_call_id = str(tool_call.get("id") or tool_call.get("call_id") or "")
+        if isinstance(tool_call, dict):
+            raw_id = tool_call.get("id") or tool_call.get("call_id") or ""
+        else:
+            raw_id = getattr(tool_call, "id", None) or getattr(tool_call, "call_id", None) or ""
+        tool_call_id = str(raw_id)
         if tool_call_id:
             part["functionCall"]["id"] = tool_call_id
     thought_signature = _tool_call_extra_signature(tool_call)
@@ -388,25 +394,27 @@ def _looks_like_json_schema(node: Any) -> bool:
 
 
 def _translate_tool_result_to_gemini(
-    message: Dict[str, Any],
+    message: Any,
     tool_name_by_call_id: Optional[Dict[str, str]] = None,
     include_ids: bool = False,
     *,
     is_gemini3: bool = False,
 ) -> Dict[str, Any]:
     tool_name_by_call_id = tool_name_by_call_id or {}
-    tool_call_id = str(message.get("tool_call_id") or "")
+    raw_call_id = message.get("tool_call_id") if isinstance(message, dict) else getattr(message, "tool_call_id", "")
+    tool_call_id = str(raw_call_id or "")
     # A tool result can carry the unwrapped internal tool name (for example,
     # an MCP tool invoked through the `tool_call` bridge). Gemini requires
     # functionResponse.name to echo the matching functionCall.name, so the
     # call-id mapping must take precedence over the internal result name.
+    msg_name = message.get("name") if isinstance(message, dict) else getattr(message, "name", None)
     name = str(
         tool_name_by_call_id.get(tool_call_id)
-        or message.get("name")
+        or msg_name
         or tool_call_id
         or "tool"
     )
-    raw_content = message.get("content")
+    raw_content = message.get("content") if isinstance(message, dict) else getattr(message, "content", None)
     content = _coerce_content_to_text(raw_content)
     try:
         parsed = json.loads(content) if content.strip().startswith(("{", "[")) else None
@@ -444,7 +452,7 @@ def _translate_tool_result_to_gemini(
 
 
 def _build_gemini_contents(
-    messages: List[Dict[str, Any]],
+    messages: List[Any],
     include_tool_call_ids: bool = False,
     *,
     is_gemini3: bool = False,
@@ -454,12 +462,11 @@ def _build_gemini_contents(
     tool_name_by_call_id: Dict[str, str] = {}
 
     for msg in messages:
-        if not isinstance(msg, dict):
-            continue
-        role = str(msg.get("role") or "user")
+        role = str((msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", "user")) or "user")
+        content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", None)
 
         if role == "system":
-            system_text_parts.append(_coerce_content_to_text(msg.get("content")))
+            system_text_parts.append(_coerce_content_to_text(content))
             continue
 
         if role in {"tool", "function"}:
@@ -481,22 +488,27 @@ def _build_gemini_contents(
         gemini_role = "model" if role == "assistant" else "user"
         parts: List[Dict[str, Any]] = []
 
-        content_parts = _extract_multimodal_parts(msg.get("content"))
+        content_parts = _extract_multimodal_parts(content)
         parts.extend(content_parts)
 
-        tool_calls = msg.get("tool_calls") or []
+        tool_calls = (msg.get("tool_calls") if isinstance(msg, dict) else getattr(msg, "tool_calls", None)) or []
         if isinstance(tool_calls, list):
             for tool_call in tool_calls:
                 if isinstance(tool_call, dict):
                     tool_call_id = str(tool_call.get("id") or tool_call.get("call_id") or "")
-                    tool_name = str(((tool_call.get("function") or {}).get("name") or ""))
-                    if tool_call_id and tool_name:
-                        tool_name_by_call_id[tool_call_id] = tool_name
-                    parts.append(
-                        _translate_tool_call_to_gemini(
-                            tool_call, include_ids=include_tool_call_ids
-                        )
+                    tool_fn = tool_call.get("function") or {}
+                    tool_name = str((tool_fn.get("name") if isinstance(tool_fn, dict) else getattr(tool_fn, "name", "")) or "")
+                else:
+                    tool_call_id = str(getattr(tool_call, "id", None) or getattr(tool_call, "call_id", None) or "")
+                    tool_fn = getattr(tool_call, "function", None) or {}
+                    tool_name = str((tool_fn.get("name") if isinstance(tool_fn, dict) else getattr(tool_fn, "name", "")) or "")
+                if tool_call_id and tool_name:
+                    tool_name_by_call_id[tool_call_id] = tool_name
+                parts.append(
+                    _translate_tool_call_to_gemini(
+                        tool_call, include_ids=include_tool_call_ids
                     )
+                )
 
         if parts:
             contents.append({"role": gemini_role, "parts": parts})

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -675,3 +675,45 @@ def test_text_only_tool_result_has_no_parts():
     )
     fr = request["contents"][1]["parts"][0]["functionResponse"]
     assert "parts" not in fr
+
+
+def test_sdk_object_messages_and_tool_calls_convert_cleanly():
+    """SimpleNamespace / SDK objects for messages and tool calls convert without dropping or crashing."""
+    from agent.gemini_native_adapter import _build_gemini_contents
+
+    tc_obj = SimpleNamespace(
+        id="call_sdk_gemini_1",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments='{"query": "hermes agent"}'),
+    )
+    msg_model = SimpleNamespace(
+        role="assistant",
+        content="",
+        tool_calls=[tc_obj],
+    )
+    msg_tool = SimpleNamespace(
+        role="tool",
+        tool_call_id="call_sdk_gemini_1",
+        name="web_search",
+        content="search results here",
+    )
+    messages = [
+        {"role": "user", "content": "search query"},
+        msg_model,
+        msg_tool,
+    ]
+
+    contents, _sys = _build_gemini_contents(messages, include_tool_call_ids=True, is_gemini3=True)
+    assert len(contents) == 3
+    assert contents[0]["role"] == "user"
+    assert contents[1]["role"] == "model"
+    fc = contents[1]["parts"][0]["functionCall"]
+    assert fc["name"] == "web_search"
+    assert fc["args"] == {"query": "hermes agent"}
+    assert fc["id"] == "call_sdk_gemini_1"
+
+    assert contents[2]["role"] == "user"
+    fr = contents[2]["parts"][0]["functionResponse"]
+    assert fr["name"] == "web_search"
+    assert fr["id"] == "call_sdk_gemini_1"
+    assert fr["response"] == {"output": "search results here"}


### PR DESCRIPTION
## What does this PR do?

Fixes a silent message and tool-call dropping bug in [`agent/gemini_native_adapter.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/gemini_native_adapter.py) where `_build_gemini_contents()`, `_translate_tool_call_to_gemini()`, and `_translate_tool_result_to_gemini()` strictly asserted `isinstance(..., dict)`, causing `SimpleNamespace` / SDK message objects (`ChatCompletionMessageToolCall` / `FunctionCall`) to be silently omitted from the contents sent to Google AI Studio or raise `AttributeError`.

In Hermes Agent:
1. Pre-serialization histories, gateway multi-queues, and subagent handoffs frequently pass SDK objects or `SimpleNamespace` instances in `messages` and `tool_calls`.
2. `_build_gemini_contents()` had `if not isinstance(msg, dict): continue` and `if isinstance(tool_call, dict): ...`, silently dropping entire turns and tool calls from Gemini's request payload when object shapes were passed.
3. Direct `.get()` calls on `tool_call`, `function`, and `message` raised unhandled `AttributeError` when non-dict structures were accessed.

The fix:
- Adds dict-and-object tolerance to `_build_gemini_contents()`, `_translate_tool_call_to_gemini()`, `_tool_call_extra_signature()`, and `_translate_tool_result_to_gemini()`.
- Guarantees message histories and tool call IDs are completely preserved regardless of whether inputs are dicts or objects.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/gemini_native_adapter.py`: Updated `_build_gemini_contents()`, `_translate_tool_call_to_gemini()`, `_tool_call_extra_signature()`, and `_translate_tool_result_to_gemini()` to safely support dict and object property extraction.
- `tests/agent/test_gemini_native_adapter.py`: Added unit tests verifying that messages and tool calls containing `SimpleNamespace` / SDK objects convert cleanly without being dropped or crashing.

## How to Test

Run the Gemini native test suite:
```bash
uv run --with pytest --with pytest-asyncio pytest tests/agent/test_gemini_native_adapter.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gemini): support SDK objects and dicts in native adapter request translation`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.12.1
collected 30 items

tests/agent/test_gemini_native_adapter.py .............................. [100%]

============================= 30 passed in 3.91s ==============================
```
