### PR TITLE
docs(opencode): add Kimi dual-endpoint and headless-auth pitfalls to skill

### DIFF
--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -195,6 +195,8 @@ terminal(command="opencode stats --days 7 --models anthropic/claude-sonnet-4")
   - `process(action="log", session_id="<id>")`
 - Avoid sharing one working directory across parallel OpenCode sessions.
 - Enter may need to be pressed twice to submit in the TUI (once to finalize text, once to send).
+- Kimi/Moonshot has TWO provider IDs with different endpoints, and the key prefix tells them apart: `sk-kimi-*` keys belong to `kimi-for-coding` (api.kimi.com/coding), legacy `sk-*` keys belong to `moonshotai` (api.moonshot.ai/v1). A key against the wrong endpoint fails with a 401 "API Key appears to be invalid or may have expired" that looks like a bad key — check the prefix before rotating anything.
+- `opencode auth login` is interactive (TUI). For headless setup, write `~/.local/share/opencode/auth.json` directly as `{"<provider>": {"type": "api", "key": "..."}}` (chmod 600), and optionally pin a default model in `~/.config/opencode/opencode.json` with `{"model": "<provider>/<model>"}` so `opencode run` needs no `--model` flag.
 
 ## Verification
 


### PR DESCRIPTION
# Contexto

Durante a configuracao real do OpenCode numa estacao de trabalho (Ubuntu, usuario root, chave API Kimi), dois tropecos nao cobertos pela skill custaram tempo de diagnostico. Este PR adiciona os dois a secao `## Pitfalls` — so corpo de texto, sem mudanca de frontmatter nem de estrutura.

## O que foi adicionado

1. **Kimi/Moonshot tem DOIS provider IDs com endpoints distintos** e o prefixo da chave os distingue: chaves `sk-kimi-*` pertencem ao `kimi-for-coding` (api.kimi.com/coding); chaves legacy `sk-*` pertencem ao `moonshotai` (api.moonshot.ai/v1). Uma chave no endpoint errado falha com 401 "API Key appears to be invalid or may have expired" — erro que parece chave ruim e induz a rotacionar a credencial desnecessariamente.

2. **Setup headless**: `opencode auth login` e interativo (TUI). Para automacao, documenta-se o caminho de escrever `~/.local/share/opencode/auth.json` diretamente (`{"<provider>": {"type": "api", "key": "..."}}`, chmod 600) e o modelo padrao em `~/.config/opencode/opencode.json`, dispensando `--model` em todo `opencode run`.

## Verificacao

- Ambos os cenarios foram reproduzidos de fato: o 401 com a chave legacy contra `kimi-for-coding`, e o sucesso do mesmo key material contra `moonshotai` (smoke test `opencode run 'Respond with exactly: OPENCODE_SMOKE_OK'` → OK).
- Os checks mecanicos de `tests/skills/test_authoring_standards.py` foram replicados manualmente contra o arquivo editado (frontmatter, campos obrigatorios, description <=60 chars com ponto final e sem marketing words, related_skills resolvem, sem machine-local paths, tamanho) — a estacao nao tinha pytest instalado; todos passam.

Sem mudanca de comportamento; diff de 2 linhas em um unico SKILL.md.