### PR TITLE
fix(gateway/shutdown_watchdog): guard start_unix_server behind posix check

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -569,9 +569,10 @@ async def loop_heartbeat_forever(
                 logger.debug(
                     "stale loop-tick socket sweep failed", exc_info=True
                 )
-        tick_server = await asyncio.start_unix_server(
-            _tick_socket_handler, path=str(tick_socket_path)
-        )
+        if os.name == "posix":
+            tick_server = await asyncio.start_unix_server(
+                _tick_socket_handler, path=str(tick_socket_path)
+            )
     except Exception:
         tick_server = None
         logger.warning(


### PR DESCRIPTION
# PR 草稿：修复 Windows 上 asyncio.start_unix_server 导致的网关心跳崩溃告警

> 对应本地修复：R5（Hermes Agent Windows 桌面端 / 网关）
> 本地备份：`C:\Users\aoxuanheng\AppData\Local\hermes\hermes-agent\gateway\shutdown_watchdog.py.bak.asyncio-fix`

---

## 标题建议

fix(gateway/shutdown_watchdog): guard asyncio.start_unix_server behind os.name == "posix"

## 摘要（Summary）

在 Windows（及任何无 AF_UNIX 的平台）上，`asyncio.start_unix_server` 不可用，
`loop_heartbeat_forever` 每次启动/心跳都会抛出 `AttributeError: module 'asyncio'
has no attribute 'start_unix_server'`。该异常被外层 try/except 吞掉并打 warning
"Loop tick socket unavailable"，导致 liveness probe 的 loop-scheduling witness 失效
（监控降级），且每次启动都在日志里留下噪声。

文件第 552 行已用 `if os.name == "posix":` 守卫了"扫陈旧 socket"逻辑，但第 572 行的
`start_unix_server` 调用却留在了 posix 守卫之外，与第 565 行注释
"AF_UNIX server nodes are never created there anyway"自相矛盾。

## 复现步骤（Reproduction）

1. 在 Windows 上运行 Hermes Agent（Python 3.11+ / 3.14）
2. 启动网关：`hermes gateway run`（或桌面端自动拉起网关）
3. 观察 `logs/gateway.log`：
   ```
   AttributeError: module 'asyncio' has no attribute 'start_unix_server'
   ...
   WARNING gateway.shutdown_watchdog: Loop tick socket unavailable — liveness probes
   will have no loop-scheduling witness and will not escalate on a stale heartbeat
   ```
4. 每次网关启动/心跳都会重复上述错误。

## 预期行为

Windows 上跳过 unix socket 创建（与第 565 行注释一致），不再抛 AttributeError，
loop-tick socket 在 Windows 上保持 `None`（已在 except 分支和 `write_loop_heartbeat`
的 `extra={"loop_tick_socket": tick_server is not None}` 中正确处理）。

## 实际行为（修复前）

Windows 上无条件调用 `asyncio.start_unix_server` → AttributeError → 被 except 吞掉 →
打 warning，liveness witness 失效。

## 根因（Root Cause）

`shutdown_watchdog.py` 的 `loop_heartbeat_forever` 中，创建 loop-tick unix socket server
的调用未置于既有的 `if os.name == "posix":` 守卫内。Windows 无 AF_UNIX 支持，
`asyncio.start_unix_server` 不可用（在 Python 3.14 上该 API 在 Windows 行为进一步收紧）。

## 修复（Patch）

文件：`hermes-agent/gateway/shutdown_watchdog.py`
函数：`loop_heartbeat_forever`（约第 572 行）

```diff
         except Exception:
             logger.debug(
                 "stale loop-tick socket sweep failed", exc_info=True
             )
-        tick_server = await asyncio.start_unix_server(
-            _tick_socket_handler, path=str(tick_socket_path)
-        )
+        if os.name == "posix":
+            tick_server = await asyncio.start_unix_server(
+                _tick_socket_handler, path=str(tick_socket_path)
+            )
     except Exception:
         tick_server = None
         logger.warning(
```

注意：`tick_server` 在 Windows 上保持 `None`，与上方 stale-socket 扫描的
`if os.name == "posix":` 守卫及第 565 行注释完全自洽；`write_loop_heartbeat` 已通过
`extra={"loop_tick_socket": tick_server is not None}` 正确处理 `None` 情形。

## 验证（Verification）

- [x] 本地修复后 `hermes gateway restart`，重启后（08:57+ 新日志）
      `start_unix_server` 报错计数 = 0
      `Loop tick socket unavailable` 警告计数 = 0
- [x] 4 平台（weixin/qqbot/feishu/webhook）全部重新 connected
- [x] Windows + Python 3.14.7 实测通过
- [ ] 建议在 CI 增加 Windows  runner 启动网关的 smoke test，断言日志无该 AttributeError

## 影响范围

- 仅影响 Windows（及无 AF_UNIX 的平台）上的 liveness probe 辅助 socket，
  不影响网关主功能、消息收发、平台连接。
- 修复为纯守卫收紧，posix 行为完全不变。

## 提交信息（Commit Message）

```
fix(gateway/shutdown_watchdog): guard start_unix_server behind posix check

On Windows asyncio.start_unix_server is unavailable (no AF_UNIX), causing
loop_heartbeat_forever to raise AttributeError every heartbeat. The stale-socket
sweep immediately above is already guarded by `if os.name == "posix":`; move the
server creation into the same guard so Windows skips it (consistent with the
(consistent with the existing "AF_UNIX server nodes are never created there anyway" comment).
```

---

## 提交步骤（本地执行清单）

> 当前仓库：`C:\Users\aoxuanheng\AppData\Local\hermes\hermes-agent`（main 分支）
> 注意：工作树还有**其他未提交改动**（package-lock.json / checkpoint_manager.py / nul），
> 以下步骤**只提交 R5 修复这一个文件**，绝不带上其他改动。

### 第 1 步：开一个干净分支（基于当前 main）
```bash
cd "C:\Users\aoxuanheng\AppData\Local\hermes\hermes-agent"
git switch -c fix/windows-asyncio-start-unix-server-guard
```

### 第 2 步：只暂存 R5 修复文件
```bash
git add gateway/shutdown_watchdog.py
git status --short        # 确认只有 shutdown_watchdog.py 是 staged（M 在左侧）
```

### 第 3 步：提交（用上方 commit message）
```bash
git commit -m "fix(gateway/shutdown_watchdog): guard start_unix_server behind posix check

On Windows asyncio.start_unix_server is unavailable (no AF_UNIX), causing
loop_heartbeat_forever to raise AttributeError every heartbeat. The stale-socket
sweep immediately above is already guarded by if os.name == \"posix\":; move the
server creation into the same guard so Windows skips it (consistent with the
existing \"AF_UNIX server nodes are never created there anyway\" comment)."
```

### 第 4 步：添加你的 fork 远程（把下面的 URL 换成你自己的 fork）
```bash
# 先去 https://github.com/NousResearch/hermes-agent 点 Fork，得到你的 fork 地址
git remote add myfork https://github.com/<你的GitHub用户名>/hermes-agent.git
```

### 第 5 步：推到 fork
```bash
git push -u myfork fix/windows-asyncio-start-unix-server-guard
```

### 第 6 步：在 GitHub 开 PR
浏览器打开：
```
https://github.com/<你的GitHub用户名>/hermes-agent/pull/new/fix/windows-asyncio-start-unix-server-guard
```
- base 选 `NousResearch/hermes-agent:main`
- 标题粘贴上面的 commit message 第一行
- 正文粘贴本文件「摘要 / 复现 / 根因 / 修复 / 验证」各节

### 备选：不想动当前仓库？用独立 patch 文件
如果你怕动这个工作副本，可以直接用 `E:\Agent\Hermes X\PR-R5-asyncio-fix.patch`：
```bash
# 在干净的 fork 克隆里：
git apply "E:\Agent\Hermes X\PR-R5-asyncio-fix.patch"
git add gateway/shutdown_watchdog.py
git commit -m "fix(gateway/shutdown_watchdog): guard start_unix_server behind posix check"
git push
```

---

## 验证清单（PR 合入前自检）
- [ ] `git diff --cached --stat` 只含 `gateway/shutdown_watchdog.py`（1 file, +4 -3）
- [ ] 未带入 package-lock.json / checkpoint_manager.py / nul
- [ ] commit message 首行 ≤ 70 字符
- [ ] PR 描述含 Windows 复现步骤 + 验证结果（重启后 0 报错）

