### PR TITLE
fix(tools/checkpoint_manager): use empty-string GIT_CONFIG on Windows

### DIFF
--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -324,9 +324,17 @@ def _git_env(
         env["GIT_INDEX_FILE"] = str(index_file)
     else:
         env.pop("GIT_INDEX_FILE", None)
-    env["GIT_CONFIG_GLOBAL"] = os.devnull
-    env["GIT_CONFIG_SYSTEM"] = os.devnull
-    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    # Windows: os.devnull is 'nul', which git can't stat as a config path.
+    # Also, GIT_CONFIG_NOSYSTEM=1 triggers a MSYS path-translation bug on
+    # Windows that makes git try to stat 'nul' — avoid it there.
+    if os.name == "nt":
+        env["GIT_CONFIG_GLOBAL"] = ""
+        env["GIT_CONFIG_SYSTEM"] = ""
+        # Do NOT set GIT_CONFIG_NOSYSTEM on Windows — it causes 'stat nul' error
+    else:
+        env["GIT_CONFIG_GLOBAL"] = os.devnull
+        env["GIT_CONFIG_SYSTEM"] = os.devnull
+        env["GIT_CONFIG_NOSYSTEM"] = "1"
     return env
 
 
@@ -501,9 +509,17 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
     # subprocess with just the config-isolation env vars.
     from tools.environments.local import build_subprocess_env
     init_env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-    init_env["GIT_CONFIG_GLOBAL"] = os.devnull
-    init_env["GIT_CONFIG_SYSTEM"] = os.devnull
-    init_env["GIT_CONFIG_NOSYSTEM"] = "1"
+    # Windows: os.devnull is 'nul', which git can't stat as a config path.
+    # Also, GIT_CONFIG_NOSYSTEM=1 triggers a MSYS path-translation bug on
+    # Windows that makes git try to stat 'nul' — avoid it there.
+    if os.name == "nt":
+        init_env["GIT_CONFIG_GLOBAL"] = ""
+        init_env["GIT_CONFIG_SYSTEM"] = ""
+        # Do NOT set GIT_CONFIG_NOSYSTEM on Windows
+    else:
+        init_env["GIT_CONFIG_GLOBAL"] = os.devnull
+        init_env["GIT_CONFIG_SYSTEM"] = os.devnull
+        init_env["GIT_CONFIG_NOSYSTEM"] = "1"
     # Drop any inherited GIT_* that would interfere.
     for k in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_NAMESPACE",
               "GIT_ALTERNATE_OBJECT_DIRECTORIES"):


### PR DESCRIPTION
# PR 草稿：修复 Windows 上 checkpoint_manager 的 GIT_CONFIG devnull bug

> 对应本地修复：R14（Hermes Agent Windows 桌面端 / checkpoint 功能）
> 本地备份：无需（diff 即修复，见 `PR-R14-checkpoint-git-config-win.patch`）

---

## 标题建议

fix(tools/checkpoint_manager): use empty-string GIT_CONFIG on Windows instead of os.devnull

## 摘要（Summary）

`tools/checkpoint_manager.py` 在隔离 git 配置时，对所有平台都用
`env["GIT_CONFIG_GLOBAL"] = os.devnull` 和 `env["GIT_CONFIG_NOSYSTEM"] = "1"`。
在 Windows 上 `os.devnull == "nul"`，而 git 会把 `GIT_CONFIG_GLOBAL=nul` 当成
**文件路径**去 `stat`，导致 `fatal: unable to stat 'nul': No such file or directory`，
`git add -A` 返回 rc=128 —— **checkpoint 功能在 Windows 上完全失效**
（每次 checkpoint 提交都失败）。

同时 `GIT_CONFIG_NOSYSTEM=1` 在 MSYS/git-bash 下会触发路径转换 bug，
进一步让 git 尝试 stat `nul`。

## 复现步骤（Reproduction）

1. Windows 上运行 Hermes Agent（任意版本，main 分支未修复）
2. 触发 checkpoint 提交（对话 checkpoints / `tools.checkpoint_manager` 的 `_git_env` / `_init_store`）
3. 观察 `logs/gateway-stdio.log`：
   ```
   ERROR tools.checkpoint_manager: Git command failed: git add -A (rc=128)
   stderr=fatal: unable to stat 'nul': No such file or directory
   ```
4. 8/28 实测：该错误一天内反复出现数十次，checkpoint 提交全部失败。

## 预期行为

Windows 上 git 配置文件隔离使用空串（`GIT_CONFIG_GLOBAL=` / `GIT_CONFIG_SYSTEM=`），
跳过 `GIT_CONFIG_NOSYSTEM`，git 不再 stat `nul`，checkpoint 正常提交。

## 实际行为（修复前）

Windows 上 `GIT_CONFIG_GLOBAL=nul` → git stat `nul` 失败 → rc=128 → checkpoint 失效；
且会遗留一个名为 `nul` 的 0 字节文件（devnull 设备名被误当路径创建）。

## 根因（Root Cause）

`tools/checkpoint_manager.py` 的 `_git_env`（~324 行）与 `_init_store`（~509 行）两处
无条件设置 `GIT_CONFIG_GLOBAL=os.devnull`。Windows 的 `os.devnull` 是 `'nul'`，
git 把它当文件路径 stat → 失败。需平台分支：Windows 用空串，posix 用 `os.devnull`。

## 修复（Patch）

文件：`hermes-agent/tools/checkpoint_manager.py`
两处（函数 `_git_env` 与 `_init_store`）：

```diff
-    env["GIT_CONFIG_GLOBAL"] = os.devnull
-    env["GIT_CONFIG_SYSTEM"] = os.devnull
-    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    # Windows: os.devnull is 'nul', which git can't stat as a config path.
+    # Also, GIT_CONFIG_NOSYSTEM=1 triggers a MSYS path-translation bug on
+    # Windows that makes git try to stat 'nul' — avoid it there.
+    if os.name == "nt":
+        env["GIT_CONFIG_GLOBAL"] = ""
+        env["GIT_CONFIG_SYSTEM"] = ""
+        # Do NOT set GIT_CONFIG_NOSYSTEM on Windows — it causes 'stat nul' error
+    else:
+        env["GIT_CONFIG_GLOBAL"] = os.devnull
+        env["GIT_CONFIG_SYSTEM"] = os.devnull
+        env["GIT_CONFIG_NOSYSTEM"] = "1"
```

## 验证（Verification）

- [x] 8/28 日志：`Git command failed ... unable to stat 'nul'` 反复出现（数十次）
- [x] 应用修复后，8/29 日志：0 条 checkpoint/git/stat nul 报错 → checkpoint 恢复
- [x] 顺带清理了 bug 副产物：仓库根的 0 字节 `nul` 文件（已 `rm -f`）
- [x] Windows 11 + git-bash(MSYS) 实测通过
- [ ] 建议 CI 增加 Windows runner 跑一次 checkpoint 提交的 smoke test

## 影响范围

- 仅影响 Windows 上的 checkpoint git 配置隔离；posix 行为完全不变。
- 修复后 checkpoint 功能在 Windows 恢复（之前静默失效）。

## 提交信息（Commit Message）

```
fix(tools/checkpoint_manager): use empty-string GIT_CONFIG on Windows

On Windows os.devnull == "nul", which git stat()s as a file path, causing
"fatal: unable to stat 'nul'" and rc=128 on every checkpoint git commit
(GIT_CONFIG_NOSYSTEM=1 also trips an MSYS path-translation bug). Branch on
os.name: Windows uses empty strings and skips GIT_CONFIG_NOSYSTEM; posix keeps
the devnull + NOSYSTEM isolation.
```

---

## 提交步骤（本地执行清单）

> 当前仓库：`C:\Users\aoxuanheng\AppData\Local\hermes\hermes-agent`（main 分支）
> 注意：与 R5 的 `shutdown_watchdog.py` 改动**互相独立**，请分开分支提交，避免一个 PR 混两个修复。

```bash
cd "C:\Users\aoxuanheng\AppData\Local\hermes\hermes-agent"
# 干净分支
git switch -c fix/windows-checkpoint-git-config-devnull
# 只暂存 R14 文件
git add tools/checkpoint_manager.py
git status --short        # 确认只有 checkpoint_manager.py 是 staged
# 提交
git commit -m "fix(tools/checkpoint_manager): use empty-string GIT_CONFIG on Windows

On Windows os.devnull == \"nul\", which git stat()s as a file path, causing
\"fatal: unable to stat 'nul'\" and rc=128 on every checkpoint git commit
(GIT_CONFIG_NOSYSTEM=1 also trips an MSYS path-translation bug). Branch on
os.name: Windows uses empty strings and skips GIT_CONFIG_NOSYSTEM; posix keeps
the devnull + NOSYSTEM isolation."
# 推到你的 fork（替换 <用户名>）
git remote add myfork https://github.com/<你的GitHub用户名>/hermes-agent.git
git push -u myfork fix/windows-checkpoint-git-config-devnull
```

备选（不打扰当前工作副本）：用 `E:\Agent\Hermes X\PR-R14-checkpoint-git-config-win.patch`：
```bash
# 在干净的 fork 克隆里：
git apply "E:\Agent\Hermes X\PR-R14-checkpoint-git-config-win.patch"
git add tools/checkpoint_manager.py
git commit -m "fix(tools/checkpoint_manager): use empty-string GIT_CONFIG on Windows"
git push
```

## 验证清单（PR 合入前自检）
- [ ] `git diff --cached --stat` 只含 `tools/checkpoint_manager.py`（1 file）
- [ ] 未带入 shutdown_watchdog.py / package-lock.json
- [ ] commit message 首行 ≤ 70 字符
- [ ] PR 描述含 Windows 复现 + 8/28 日志证据 + 8/29 验证（0 报错）
