### PR TITLE
fix(buzz): reply at channel level with --broadcast instead of nesting threads

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -613,7 +613,12 @@ class BuzzAdapter(BasePlatformAdapter):
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
-            args += ["--reply-to", str(reply_target)]
+            # Reply with --broadcast so the message keeps its NIP-10 reply
+            # linkage (notifications, thread summary) but renders at channel
+            # level instead of nesting into a collapsed thread. Both Buzz
+            # Desktop and Mobile treat a ["broadcast","1"] tag as a
+            # top-level timeline entry.
+            args += ["--reply-to", str(reply_target), "--broadcast"]
         code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
             return SendResult(
@@ -684,7 +689,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--content", "-",
             ]
             if reply_to:
-                args += ["--reply-to", str(reply_to)]
+                args += ["--reply-to", str(reply_to), "--broadcast"]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -1389,7 +1394,7 @@ async def _standalone_send(
 
     args = ["messages", "send", "--channel", target, "--content", "-"]
     if thread_id:
-        args += ["--reply-to", str(thread_id)]
+        args += ["--reply-to", str(thread_id), "--broadcast"]
     for path in media_files or []:
         args += ["--file", str(path)]
     try:


### PR DESCRIPTION
## Summary
- Pass `--broadcast` alongside `--reply-to` on all three Buzz send paths (`send()`, `send_image()`, standalone media sender) so agent replies keep NIP-10 linkage but render as top-level timeline entries.
- Previously every adapter reply nested as a collapsed thread under the user's message.

## Root cause
The buzz CLI emits a NIP-10 `e`-tag reply for `--reply-to` with no `broadcast` tag. Both Buzz clients classify such messages as thread replies:
- Desktop: `desktop/src/features/messages/lib/threading.ts` — `isThreadReply()` returns true when a parent `e`-tag exists **and** `isBroadcastReply()` (a `["broadcast","1"]` tag) is false.
- Mobile: `mobile/lib/features/channels/timeline_message.dart` — main timeline includes a message only when `parentId == null || _isBroadcastReply(msg)`.

Native `buzz-acp` agents reply with the broadcast tag, which is why native agents' answers appear at channel level while adapter replies nested. Adding the tag aligns the adapter with native behavior; reply linkage (notifications, thread summary counts) is preserved by the `e`-tag.

## Verification
- `venv/bin/python -m pytest tests/gateway/test_buzz_adapter.py -o addopts= -q` — 23 passed
- `venv/bin/python -m pytest tests/gateway/test_buzz_websocket.py -o addopts= -q` — 4 passed
- Client-behavior claims verified against Buzz Desktop and Mobile source (linked above).

Related but distinct: #84492 (inbound thread context propagation — why replies had `--reply-to` targets at all) and #91567 (mention gating for thread continuation).
