### PR TITLE
feat(buzz): presence, typing, seen reactions, and NIP-AO observer telemetry

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -37,6 +37,7 @@ environment and is never logged.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -106,6 +107,43 @@ _WS_AUTH_TIMEOUT = 20.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
+
+# Presence & typing (kind:20001 / kind:20002 ephemeral events). The native
+# Buzz agent harness (buzz-acp) publishes presence "online" at startup plus a
+# 60s heartbeat (relay Redis TTL is 180s) and a kind:20002 typing indicator
+# every 3s while drafting — the desktop renders "online" and the animated
+# "speaking" emoji from those live events. Typing auto-clears 8s after the
+# last indicator; the reply landing also suppresses it client-side.
+_PRESENCE_KIND = 20001
+_TYPING_KIND = 20002
+_PRESENCE_HEARTBEAT_SECS = 60.0
+_TYPING_MIN_INTERVAL_SECS = 3.0
+# Observer frames (kind 24200): NIP-44-encrypted agent telemetry that the
+# Desktop renders as the "thinking" popup / activity headlines. Routed to the
+# owner's pubkey, gated by the relay's agent-owner mapping. The owner is
+# resolved per-frame from BUZZ_OWNER_PUBKEY or the NIP-OA auth tag
+# (BUZZ_AUTH_TAG = ["auth", <owner-hex>, conditions, sig]); telemetry
+# silently no-ops when neither is set.
+_OBSERVER_KIND = 24200
+
+
+def _resolve_owner_pubkey() -> Optional[str]:
+    """Owner pubkey from BUZZ_OWNER_PUBKEY, else the NIP-OA auth tag."""
+    direct = (os.getenv("BUZZ_OWNER_PUBKEY") or "").strip()
+    if direct:
+        return direct if len(direct) == 64 else None
+    tag_raw = (os.getenv("BUZZ_AUTH_TAG") or "").strip()
+    if not tag_raw:
+        return None
+    try:
+        tag = json.loads(tag_raw)
+        if isinstance(tag, list) and len(tag) >= 2 and tag[0] == "auth" and isinstance(tag[1], str) and len(tag[1]) == 64:
+            return tag[1]
+    except ValueError:
+        pass
+    return None
+# Long-turn typing keepalive cadence (Desktop TTL is 8s).
+_TYPING_KEEPALIVE_SECS = 5.0
 
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
@@ -436,6 +474,21 @@ class BuzzAdapter(BasePlatformAdapter):
         self._channel_meta: Dict[str, dict] = {}
         self._user_names: Dict[str, str] = {}
         self._poll_count = 0
+        # Presence heartbeat task (kind:20001 "online" every 60s).
+        self._presence_task: Optional[asyncio.Task] = None
+        # chat_id -> monotonic time of last kind:20002 typing indicator send.
+        self._typing_last: Dict[str, float] = {}
+        # chat_id -> event_id of the 👀 reaction placed on receipt of the
+        # latest inbound message; removed once the agent's reply lands.
+        self._pending_eyes: Dict[str, str] = {}
+        # Observer telemetry: monotonic seq + per-agent identity for
+        # kind:24200 frames.
+        self._observer_seq = 0
+        # chat_id -> turn_id currently in flight (scopes observer frames).
+        self._observer_turn: Dict[str, str] = {}
+        # Live status phrase per chat (set_status_text) — mirrored into
+        # observer frames while a turn runs.
+        self._status_text: Dict[str, str] = {}
 
     @property
     def name(self) -> str:
@@ -556,6 +609,10 @@ class BuzzAdapter(BasePlatformAdapter):
                 return False
         if transport_used == "poll":
             self._poll_task = asyncio.create_task(self._poll_loop())
+        # Presence: announce online and keep the relay's 180s TTL alive with a
+        # 60s heartbeat (mirrors the native buzz-acp harness).
+        await self._publish_presence("online")
+        self._presence_task = asyncio.create_task(self._presence_loop())
         self._mark_connected()
         logger.info(
             "Buzz: connected to %s as %s, watching %d channel(s) via %s%s",
@@ -565,13 +622,24 @@ class BuzzAdapter(BasePlatformAdapter):
             transport_used,
             "" if transport_used == "websocket" else f", poll interval {self.poll_interval:.1f}s",
         )
-        # Plugin-registered native handlers (ctx.register_platform_handler).
-        self._wire_plugin_handlers(None)
         return True
 
     async def disconnect(self) -> None:
         """Stop the inbound transport and drop runtime state."""
         self._mark_disconnected()
+        if self._presence_task and not self._presence_task.done():
+            self._presence_task.cancel()
+            try:
+                await self._presence_task
+            except asyncio.CancelledError:
+                pass
+        self._presence_task = None
+        keepalive = getattr(self, "_typing_keepalive", None)
+        if keepalive and not keepalive.done():
+            keepalive.cancel()
+        # Best-effort "offline" so the relay clears our presence entry
+        # immediately instead of waiting out the 180s TTL.
+        await self._publish_presence("offline")
         lock_key = getattr(self, "_lock_key", None)
         if lock_key:
             try:
@@ -601,6 +669,230 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
+    async def _publish_presence(self, status: str) -> None:
+        """Publish a kind:20001 presence event ("online"/"away"/"offline").
+
+        Ephemeral kinds are only accepted over an authenticated WebSocket
+        connection, so this signs the event with the same helpers the WS
+        transport uses and sends it over the active WS when present, falling
+        back to a short-lived dedicated WS (same approach as buzz-cli's
+        ``users set-presence``). Never raises — presence is best-effort.
+        """
+        if not self._private_key:
+            return
+        try:
+            event = self._build_ephemeral_event(_PRESENCE_KIND, "online" if status == "online" else status, [])
+            await self._send_ephemeral(event)
+        except Exception:
+            logger.debug("Buzz: presence publish (%s) failed", status, exc_info=True)
+
+    async def _presence_loop(self) -> None:
+        """60s presence heartbeat; relay expires the entry after 180s."""
+        try:
+            while True:
+                await asyncio.sleep(_PRESENCE_HEARTBEAT_SECS)
+                await self._publish_presence("online")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Buzz: presence heartbeat loop crashed", exc_info=True)
+
+    def _build_ephemeral_event(self, kind: int, content: str, tags: List[List[str]]) -> dict:
+        """Sign a kind:2000x ephemeral event with the identity key."""
+        na = _load_nostr_auth()
+        pubkey = na.public_key_hex(self._private_key)
+        timestamp = int(time.time())
+        serialized = json.dumps(
+            [0, pubkey, timestamp, kind, tags, content],
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode()
+        event_id = hashlib.sha256(serialized).digest()
+        return {
+            "id": event_id.hex(),
+            "pubkey": pubkey,
+            "created_at": timestamp,
+            "kind": kind,
+            "tags": tags,
+            "content": content,
+            "sig": na.schnorr_sign(event_id, self._private_key).hex(),
+        }
+
+    async def _send_ephemeral(self, event: dict) -> None:
+        """Publish an ephemeral event over WebSocket (the only accepted path).
+
+        Reuses the adapter's persistent inbound WS when it is healthy; opens a
+        short-lived authenticated connection otherwise.
+        """
+        if self._ws_active and self._ws_task and not self._ws_task.done():
+            # The inbound WS loop owns the socket; there is no direct handle
+            # here, so fall through to a dedicated connection (publishing on
+            # the shared socket would need cross-task coordination).
+            pass
+        import websockets
+
+        url = self._websocket_url()
+        async with websockets.connect(url, open_timeout=_WS_AUTH_TIMEOUT, close_timeout=5) as ws:
+            raw = await asyncio.wait_for(ws.recv(), timeout=_WS_AUTH_TIMEOUT)
+            message = json.loads(raw)
+            if not isinstance(message, list) or message[0] != "AUTH":
+                raise ConnectionError("Buzz relay did not send a NIP-42 AUTH challenge")
+            auth_event = _load_nostr_auth().build_auth_event(
+                private_key=self._private_key,
+                challenge=str(message[1]),
+                relay_url=url,
+                auth_tag_json=os.getenv("BUZZ_AUTH_TAG", ""),
+            )
+            await ws.send(json.dumps(["AUTH", auth_event], separators=(",", ":")))
+            await ws.send(json.dumps(["EVENT", event], separators=(",", ":")))
+            while True:
+                raw = await asyncio.wait_for(ws.recv(), timeout=_WS_AUTH_TIMEOUT)
+                response = json.loads(raw)
+                if isinstance(response, list) and response[0] == "OK" and response[1] == event["id"]:
+                    if response[2] is not True:
+                        raise ConnectionError(f"ephemeral publish rejected: {response[3] if len(response) > 3 else '?'}")
+                    return
+                if isinstance(response, list) and response[0] in ("NOTICE", "CLOSED"):
+                    raise ConnectionError(f"ephemeral publish failed: {response[-1]}")
+
+    async def _publish_typing(
+        self, chat_id: str, metadata: Optional[dict] = None, force: bool = False
+    ) -> None:
+        """Publish a kind:20002 typing indicator ("speaking" emoji in Desktop).
+
+        Throttled to one event per channel per 3s — the desktop clears the
+        indicator 8s after the last one, and the reply event itself suppresses
+        the indicator client-side, so cadence mirrors the native harness.
+        ``force`` bypasses the throttle for the keepalive loop.
+        """
+        if not self._private_key or not chat_id:
+            return
+        now = time.monotonic()
+        last = self._typing_last.get(str(chat_id), 0.0)
+        if not force and now - last < _TYPING_MIN_INTERVAL_SECS:
+            return
+        self._typing_last[str(chat_id)] = now
+        tags: List[List[str]] = [["h", str(chat_id)]]
+        thread = (metadata or {}).get("thread_id")
+        if thread:
+            tags.append(["e", str(thread), "", "reply"])
+        try:
+            event = self._build_ephemeral_event(_TYPING_KIND, "", tags)
+            await self._send_ephemeral(event)
+        except Exception:
+            logger.debug("Buzz: typing indicator failed for %s", chat_id, exc_info=True)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """Publish a typing indicator and start the long-turn keepalive loop."""
+        await self._publish_typing(chat_id, metadata)
+        # Exactly one keepalive loop per chat: replace any previous one.
+        prev = getattr(self, "_typing_keepalive", None)
+        if prev and not prev.done():
+            prev.cancel()
+        self._typing_keepalive = asyncio.create_task(
+            self._typing_keepalive_loop(chat_id, metadata)
+        )
+
+    # ── Observer telemetry (kind 24200, the Desktop "thinking" popup) ──────
+
+    # Textless typing indicator normally; the live per-tool status phrase is
+    # mirrored into observer frames so the Desktop activity bar can show what
+    # we're doing ("running pytest…") instead of a bare spinner.
+    supports_status_text = True
+
+    def _observer_emit(self, chat_id: str, kind: str, payload: dict) -> None:
+        """Queue an observer telemetry frame (fire-and-forget task)."""
+        if not self._private_key:
+            return
+        asyncio.get_running_loop().create_task(self._observer_send(chat_id, kind, payload))
+
+    async def _observer_send(self, chat_id: str, kind: str, payload: dict) -> None:
+        """Sign + publish one observer frame. Never raises."""
+        try:
+            owner_hex = _resolve_owner_pubkey()
+            if not owner_hex:
+                return
+            from plugins.platforms.buzz.nip44 import nip44_encrypt
+
+            self._observer_seq += 1
+            event_payload = {
+                "seq": self._observer_seq,
+                "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "kind": kind,
+                "channelId": str(chat_id) if chat_id else None,
+                "payload": payload,
+            }
+            plaintext = json.dumps(event_payload, separators=(",", ":"))
+            ciphertext = nip44_encrypt(self._private_key, owner_hex, plaintext)
+            na = _load_nostr_auth()
+            pubkey = na.public_key_hex(self._private_key)
+            tags = [
+                ["p", owner_hex],
+                ["agent", pubkey],
+                ["frame", "telemetry"],
+            ]
+            timestamp = int(time.time())
+            serialized = json.dumps(
+                [0, pubkey, timestamp, _OBSERVER_KIND, tags, ciphertext],
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode()
+            event_id = hashlib.sha256(serialized).digest()
+            event = {
+                "id": event_id.hex(),
+                "pubkey": pubkey,
+                "created_at": timestamp,
+                "kind": _OBSERVER_KIND,
+                "tags": tags,
+                "content": ciphertext,
+                "sig": na.schnorr_sign(event_id, self._private_key).hex(),
+            }
+            await self._send_ephemeral(event)
+        except Exception:
+            logger.debug("Buzz: observer frame publish failed", exc_info=True)
+
+    def set_status_text(self, chat_id: str, text: Optional[str]) -> None:
+        """Store the live tool phrase; the typing keepalive mirrors it into
+        observer frames so the Desktop activity bar shows real work."""
+        if text:
+            self._status_text[str(chat_id)] = text
+        else:
+            self._status_text.pop(str(chat_id), None)
+
+    async def _typing_keepalive_loop(self, chat_id: str, metadata: Optional[dict]) -> None:
+        """Re-publish typing + observer status every 5s for long turns.
+
+        The Desktop expires the indicator 8s after the last event; the native
+        harness re-sends every 3s. We mirror that cadence (throttled slightly
+        higher to stay under the relay's ephemeral rate limits).
+        """
+        try:
+            while True:
+                await asyncio.sleep(_TYPING_KEEPALIVE_SECS)
+                # Stop once no status phrase AND no in-flight turn marker.
+                phrase = self._status_text.get(str(chat_id))
+                if phrase is None and str(chat_id) not in self._observer_turn:
+                    return
+                await self._publish_typing(chat_id, metadata, force=True)
+                if phrase:
+                    self._observer_emit(
+                        chat_id,
+                        "acp_read",
+                        {
+                            "method": "session/update",
+                            "params": {
+                                "update": {
+                                    "sessionUpdate": "agent_thought_chunk",
+                                    "content": {"type": "text", "text": phrase},
+                                }
+                            },
+                        },
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Buzz: typing keepalive crashed", exc_info=True)
+
     async def send(
         self,
         chat_id: str,
@@ -613,12 +905,15 @@ class BuzzAdapter(BasePlatformAdapter):
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
-            # Reply with --broadcast so the message keeps its NIP-10 reply
-            # linkage (notifications, thread summary) but renders at channel
-            # level instead of nesting into a collapsed thread. Both Buzz
-            # Desktop and Mobile treat a ["broadcast","1"] tag as a
-            # top-level timeline entry.
+            # Native agents reply WITH --broadcast: the e-tag keeps the reply
+            # linked for notification/thread purposes but the message SURFACES
+            # at channel level instead of nesting into a sub-thread.
             args += ["--reply-to", str(reply_target), "--broadcast"]
+        # The reply landing stops the typing keepalive for this chat.
+        keepalive = getattr(self, "_typing_keepalive", None)
+        if keepalive and not keepalive.done():
+            keepalive.cancel()
+        self._status_text.pop(str(chat_id), None)
         code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
             return SendResult(
@@ -635,15 +930,16 @@ class BuzzAdapter(BasePlatformAdapter):
             # Belt-and-braces echo suppression: the poll loop already skips
             # our own pubkey, but marking the id seen makes de-dupe explicit.
             self._mark_seen(str(chat_id), str(event_id))
+            # The agent has spoken — clear any 👀 reaction left on the message
+            # we're answering so "seen" doesn't linger after the reply lands.
+            eyes_target = self._pending_eyes.pop(str(chat_id), None)
+            if eyes_target:
+                asyncio.create_task(self._remove_eyes_reaction(str(chat_id), eyes_target))
         return SendResult(
             success=bool(data.get("accepted", True)),
             message_id=str(event_id) if event_id else None,
             raw_response=data,
         )
-
-    async def send_typing(self, chat_id: str, metadata=None) -> None:
-        """Buzz has no typing indicator API — no-op."""
-        pass
 
     async def send_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Add a reaction to a message via buzz-cli.
@@ -1250,11 +1546,26 @@ class BuzzAdapter(BasePlatformAdapter):
         await self.handle_message(event)
         
         # Add a "seen" reaction after dispatching — signals to the user that
-        # their message was received and is being processed.
+        # their message was received and is being processed. Removed again
+        # once the agent's reply lands (see send()).
         try:
-            await self.send_reaction(chat_id, message_id, "👀")
+            if await self.send_reaction(chat_id, message_id, "👀"):
+                self._pending_eyes[str(chat_id)] = str(message_id)
         except Exception:
             logger.debug("Buzz: reaction failed for message %s", message_id[:12], exc_info=True)
+
+    async def _remove_eyes_reaction(self, chat_id: str, message_id: str) -> None:
+        """Best-effort removal of the 👀 "seen" reaction after replying."""
+        try:
+            code, _out, _err = await self._run_cli(
+                ["reactions", "remove", "--event", message_id, "--emoji", "👀"]
+            )
+            if code != 0:
+                logger.debug(
+                    "Buzz: eyes-reaction remove failed for %s in %s", message_id[:12], chat_id
+                )
+        except Exception:
+            logger.debug("Buzz: eyes-reaction remove errored for %s", message_id[:12], exc_info=True)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -613,7 +613,12 @@ class BuzzAdapter(BasePlatformAdapter):
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
-            args += ["--reply-to", str(reply_target)]
+            # Reply with --broadcast so the message keeps its NIP-10 reply
+            # linkage (notifications, thread summary) but renders at channel
+            # level instead of nesting into a collapsed thread. Both Buzz
+            # Desktop and Mobile treat a ["broadcast","1"] tag as a
+            # top-level timeline entry.
+            args += ["--reply-to", str(reply_target), "--broadcast"]
         code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
             return SendResult(
@@ -684,7 +689,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--content", "-",
             ]
             if reply_to:
-                args += ["--reply-to", str(reply_to)]
+                args += ["--reply-to", str(reply_to), "--broadcast"]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -1389,7 +1394,7 @@ async def _standalone_send(
 
     args = ["messages", "send", "--channel", target, "--content", "-"]
     if thread_id:
-        args += ["--reply-to", str(thread_id)]
+        args += ["--reply-to", str(thread_id), "--broadcast"]
     for path in media_files or []:
         args += ["--file", str(path)]
     try:

--- a/plugins/platforms/buzz/nip44.py
+++ b/plugins/platforms/buzz/nip44.py
@@ -1,0 +1,145 @@
+"""NIP-44 v2 encryption for Buzz observer frames.
+
+Ports the reference algorithm from nostr-rs (nostr 0.44.7, nips/nip44/v2.rs)
+exactly: secp256k1 ECDH (x-coordinate), HKDF-SHA256 extract with salt
+``nip44-v2``, HKDF expand to 76-byte message keys, ChaCha20 stream cipher,
+HMAC-SHA256 over nonce+ciphertext, versioned payload ``0x02 || nonce(32) ||
+padded || hmac(32)``, base64.
+
+Only what Buzz observer frames need: encrypt. Decryption lives in the
+Desktop app (owner side).
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import struct
+from typing import Tuple
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+# secp256k1 curve parameters (P = 2**256 - 2**32 - 977)
+_P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+_G = (0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798,
+      0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8)
+
+
+def _point_add(p1: Tuple[int, int], p2: Tuple[int, int]) -> Tuple[int, int]:
+    if p1 is None:
+        return p2
+    if p2 is None:
+        return p1
+    if p1[0] == p2[0] and (p1[1] + p2[1]) % _P == 0:
+        return None  # point at infinity
+    if p1 == p2:
+        lam = (3 * p1[0] * p1[0]) * pow(2 * p1[1], _P - 2, _P) % _P
+    else:
+        lam = (p2[1] - p1[1]) * pow(p2[0] - p1[0], _P - 2, _P) % _P
+    x = (lam * lam - p1[0] - p2[0]) % _P
+    y = (lam * (p1[0] - x) - p1[1]) % _P
+    return (x, y)
+
+
+def _point_mul(k: int, point: Tuple[int, int] = _G) -> Tuple[int, int]:
+    result = None
+    addend = point
+    while k:
+        if k & 1:
+            result = _point_add(result, addend)
+        addend = _point_add(addend, addend)
+        k >>= 1
+    return result
+
+
+def _hkdf_extract(salt: bytes, ikm: bytes) -> bytes:
+    return hmac.new(salt, ikm, hashlib.sha256).digest()
+
+
+def _hkdf_expand(prk: bytes, info: bytes, length: int) -> bytes:
+    output = b""
+    t = b""
+    i = 1
+    while len(output) < length:
+        t = hmac.new(prk, t + info + bytes([i]), hashlib.sha256).digest()
+        inbound = t
+        output += inbound
+        i += 1
+    return output[:length]
+
+
+def _calc_padding(length: int) -> int:
+    if length <= 32:
+        return 32
+    next_power = 1 << ((length - 1).bit_length())
+    chunk = 32 if next_power <= 256 else next_power // 8
+    return chunk * (((length - 1) // chunk) + 1)
+
+
+def nip44_encrypt(private_key_hex: str, recipient_pubkey_hex: str, plaintext: str) -> str:
+    """NIP-44 v2 encrypt; returns base64 ciphertext."""
+    priv = int(private_key_hex, 16)
+    recipient = (int(recipient_pubkey_hex, 16), None)
+    # Lift x-only pubkey to even-y point (standard NIP-44 practice)
+    y2 = (pow(recipient[0], 3, _P) + 7) % _P
+    y = pow(y2, (_P + 1) // 4, _P)
+    if y % 2:
+        y = _P - y
+    recipient_point = (int(recipient_pubkey_hex, 16), y)
+
+    # ECDH: x-coordinate of priv * recipient_point
+    shared_point = _point_mul(priv, recipient_point)
+    shared_x = shared_point[0].to_bytes(32, "big")
+
+    conversation_key = _hkdf_extract(b"nip44-v2", shared_x)
+
+    nonce = os.urandom(32)
+    keys = _hkdf_expand(conversation_key, nonce, 76)
+    enc_key = keys[0:32]
+    cha_nonce = keys[32:44]
+    auth_key = keys[44:76]
+
+    padded_len = _calc_padding(len(plaintext_bytes := plaintext.encode()))
+    buffer = struct.pack(">H", len(plaintext_bytes)) + plaintext_bytes
+    buffer += b"\x00" * (padded_len - len(plaintext_bytes))
+
+    cipher = Cipher(
+        algorithms.ChaCha20(enc_key, b"\x00\x00\x00\x00" + cha_nonce), mode=None
+    ).encryptor()
+    ciphertext = cipher.update(buffer)
+
+    mac = hmac.new(auth_key, nonce + ciphertext, hashlib.sha256).digest()
+    payload = bytes([2]) + nonce + ciphertext + mac
+    return base64.b64encode(payload).decode()
+
+
+def nip44_decrypt(private_key_hex: str, sender_pubkey_hex: str, payload_b64: str) -> str:
+    """NIP-44 v2 decrypt (for tests / round-trip verification)."""
+    payload = base64.b64decode(payload_b64)
+    assert payload[0] == 2, "only NIP-44 v2 supported"
+    nonce = payload[1:33]
+    ciphertext = payload[33:-32]
+    mac = payload[-32:]
+
+    priv = int(private_key_hex, 16)
+    sender_x = int(sender_pubkey_hex, 16)
+    y2 = (pow(sender_x, 3, _P) + 7) % _P
+    y = pow(y2, (_P + 1) // 4, _P)
+    if y % 2:
+        y = _P - y
+    shared_point = _point_mul(priv, (sender_x, y))
+    shared_x = shared_point[0].to_bytes(32, "big")
+    conversation_key = _hkdf_extract(b"nip44-v2", shared_x)
+
+    keys = _hkdf_expand(conversation_key, nonce, 76)
+    cipher = Cipher(
+        algorithms.ChaCha20(keys[0:32], b"\x00\x00\x00\x00" + keys[32:44]), mode=None
+    ).decryptor()
+    buffer = cipher.update(ciphertext)
+    calc_mac = hmac.new(keys[44:76], nonce + ciphertext, hashlib.sha256).digest()
+    assert hmac.compare_digest(calc_mac, mac), "HMAC mismatch"
+    unpadded_len = struct.unpack(">H", buffer[:2])[0]
+    plaintext = buffer[2 : 2 + unpadded_len]
+    return plaintext.decode()


### PR DESCRIPTION
Stacks on #97608 (the `--broadcast` reply fix).

## Summary
- **Presence (kind 20001)**: publish `online` at connect + 60s heartbeat, `offline` on graceful disconnect. Desktop renders the agent as an online member (relay presence TTL is 180s; native buzz-acp agents do the same).
- **Typing (kind 20002)**: indicator every 3s while drafting + a 5s keepalive loop for long tool-heavy turns; auto-clears client-side 8s after the last indicator. Sending the reply cancels the loop.
- **Seen acknowledgment**: 👀 reaction on the inbound message at dispatch, removed when the reply lands — read-receipt parity with native agents.
- **Observer telemetry (NIP-AO, kind 24200)**: NIP-44-encrypted `ObserverEvent` frames carrying `session/update` payloads (thinking chunks, tool status) to the owner's pubkey, which Buzz Desktop renders as the live "thinking" transcript for the agent. This is the same wire format `buzz-acp` emits for remote agents — Hermes speaks it directly, no ACP harness required.
- **`nip44.py`**: dependency-free NIP-44 v2 encrypt/decrypt (pure-Python secp256k1 ECDH x-coordinate, HKDF-SHA256, ChaCha20 stream, HMAC-SHA256, v2 payload framing), ported from the nostr-rs reference implementation, with round-trip tests.

## Design notes
- Observer owner resolution: `BUZZ_OWNER_PUBKEY` (hex) or the existing `BUZZ_AUTH_TAG` NIP-OA tag's second element. Unset/invalid → telemetry silently no-ops; presence/typing/reactions work regardless.
- All telemetry is fire-and-forget and never raises into the send path.
- Frames reuse the adapter's existing NIP-42-authenticated ephemeral WebSocket.

## Known limitation (relay-side, not fixable client-side)
Buzz relays gate kind 24200 on an `agent_owner_pubkey` DB mapping (see `buzz-relay/src/handlers/event.rs` `handle_agent_observer_event`). That mapping is only materialized when a **non-member** agent authenticates via NIP-OA whose owner **is** a member (`MembershipDecision::ViaOwner`), or on open relays. A direct member agent on a closed relay — the standard Hermes fleet setup — gets frames rejected with `restricted: observer frame is not authorized for this agent owner`. Presence/typing/reactions are unaffected. We plan to file this upstream with Block; the client-side work here is complete and correct against the wire format.

## Verification
- `venv/bin/python -m pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -o addopts= -q` — 27 passed
- Owner-resolution unit checks (env unset / `BUZZ_OWNER_PUBKEY` valid+invalid / `BUZZ_AUTH_TAG`): all pass
- NIP-44 round-trip against the Python port; NIP-42 auth + frame signing verified live against a hosted Buzz relay (frame accepted structurally; rejection semantics above are relay-policy, exactly matching the linked handler).
