### PR TITLE
Add `tencent/hy4-preview` to model pickers

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -573,6 +573,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "solar-pro3": 131072,
     "solar-pro2": 65536,
     "solar-mini": 32768,
+    # Tencent — Hy4 Preview (Hunyuan), 1M context window per OpenRouter
+    # live metadata (2026-08-28). Longest-key-first so this wins over any
+    # future shorter hy* catch-all.
+    "hy4-preview": 1_048_576,
     # Tencent — Hy3 Preview (Hunyuan) with 256K context window.
     # OpenRouter live metadata reports 262144 (256 × 1024); align the
     # static fallback so cache and offline both agree (issue #22268).

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -123,6 +123,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Xiaomi
     ("xiaomi/mimo-v2.5-pro",                   ""),
     # Tencent
+    ("tencent/hy4-preview",                    ""),
     ("tencent/hy3",                            ""),
     # StepFun
     ("stepfun/step-3.7-flash",                 ""),
@@ -304,6 +305,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # Xiaomi
         "xiaomi/mimo-v2.5-pro",
         # Tencent
+        "tencent/hy4-preview",
         "tencent/hy3",
         # StepFun
         "stepfun/step-3.7-flash",

--- a/run_agent.py
+++ b/run_agent.py
@@ -7697,7 +7697,7 @@ class AIAgent:
             "google/gemini-2",
             "google/gemma-4",
             "qwen/qwen3",
-            "tencent/hy3",
+            "tencent/hy",
             "xiaomi/",
         )
         return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-28T07:53:26Z",
+  "updated_at": "2026-08-29T02:38:32Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -135,6 +135,10 @@
         },
         {
           "id": "xiaomi/mimo-v2.5-pro",
+          "description": ""
+        },
+        {
+          "id": "tencent/hy4-preview",
           "description": ""
         },
         {
@@ -292,6 +296,9 @@
         },
         {
           "id": "xiaomi/mimo-v2.5-pro"
+        },
+        {
+          "id": "tencent/hy4-preview"
         },
         {
           "id": "tencent/hy3"


### PR DESCRIPTION
Adds Tencent’s Hy4 preview model to the OpenRouter and Nous Portal catalogs (right above Hy3) and wires it so a 1M context window and reasoning still work when the live catalog isn’t available