### PR TITLE
feat(gateway): opt-in reaction-based busy acks (busy_ack_reaction)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10745,6 +10745,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._session_state(session_key).turn.busy_ack_ts = now
 
+        # Reaction-first busy ack: when the adapter supports send_reaction
+        # and the platform opt-in is enabled, acknowledge with a mode-aware
+        # emoji reaction on the user's message instead of a text bubble.
+        # Falls back to the text bubble when the reaction cannot be
+        # delivered (unsupported adapter, missing message id, send failure).
+        _BUSY_ACK_REACTIONS = {
+            "redirect": "↪️",
+            "steer": "⏩",
+            "queue": "⏳",
+            "interrupt": "⚡",
+        }
+        _ack_mode = (
+            "steer" if is_steer_mode
+            else "redirect" if is_redirect_mode
+            else "queue" if is_queue_mode
+            else "interrupt"
+        )
+        _reaction_ack_enabled = bool(
+            resolve_display_setting(
+                _load_gateway_config(),
+                platform_key,
+                "busy_ack_reaction",
+                False,
+            )
+        )
+        if (
+            _reaction_ack_enabled
+            and event.message_id
+            and getattr(adapter, "send_reaction", None) is not None
+        ):
+            try:
+                reacted = await adapter.send_reaction(
+                    chat_id=event.source.chat_id,
+                    message_id=event.message_id,
+                    emoji=_BUSY_ACK_REACTIONS.get(_ack_mode, "⚡"),
+                )
+                if reacted:
+                    return True
+                logger.debug(
+                    "Busy reaction-ack not accepted for session %s; using text bubble",
+                    session_key,
+                )
+            except Exception:
+                logger.debug("Busy reaction-ack failed; falling back to text", exc_info=True)
+
         # Build a status-rich acknowledgment. Mobile chat defaults keep this
         # terse; detailed iteration/tool state is still available in logs and
         # can be opted in per platform via display.platforms.<platform>.busy_ack_detail.

--- a/tests/gateway/test_busy_ack_reaction.py
+++ b/tests/gateway/test_busy_ack_reaction.py
@@ -1,0 +1,172 @@
+"""Regression tests for reaction-based busy acks (busy_ack_reaction).
+
+When display.platforms.<platform>.busy_ack_reaction is enabled and the
+adapter implements send_reaction(chat_id, message_id, emoji), a busy-input
+acknowledgment is delivered as a mode-aware emoji reaction on the user's
+message instead of the usual text bubble. Failure or absence falls back to
+the text bubble.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Minimal telegram stubs so gateway imports cleanly (mirrors sibling tests).
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.platforms.base import (  # noqa: E402
+    MessageEvent,
+    MessageType,
+    SessionSource,
+    build_session_key,
+)
+from gateway.run import GatewayRunner  # noqa: E402
+
+
+def _make_event() -> MessageEvent:
+    source = SessionSource(
+        platform=MagicMock(value="buzz"),
+        chat_id="chan-1",
+        chat_type="group",
+        user_id="user1",
+    )
+    return MessageEvent(
+        text="turn left instead",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="ev-42",
+    )
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    runner._busy_input_mode = "interrupt"
+    runner._session_db = MagicMock()
+    runner._session_db._db = MagicMock()
+    runner._session_db._db.get_compression_lock_holder.return_value = None
+    return runner
+
+
+def _make_adapter(with_reaction: bool) -> MagicMock:
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = MagicMock(value="buzz")
+    if with_reaction:
+        adapter.send_reaction = AsyncMock(return_value=True)
+    else:
+        del adapter.send_reaction  # base adapters lack the method
+    return adapter
+
+
+def _make_running_parent() -> MagicMock:
+    parent = MagicMock()
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent.get_activity_summary.return_value = {
+        "api_call_count": 4,
+        "max_iterations": 150,
+        "current_tool": "terminal",
+    }
+    # Advertise active-turn redirect support so interrupt-mode messages are
+    # redirected (the "↪️" ack path) rather than plain interrupted ("⚡").
+    parent._supports_active_turn_redirect = True
+    parent.redirect = MagicMock(return_value=True)
+    return parent
+
+
+async def _drive_busy_path(
+    monkeypatch, *, with_reaction: bool, display_cfg: dict, reaction_mock=None
+) -> tuple[MagicMock, MagicMock]:
+    """Run the busy handler end-to-end and return (adapter, parent)."""
+    runner = _make_runner()
+    adapter = _make_adapter(with_reaction=with_reaction)
+    if reaction_mock is not None:
+        adapter.send_reaction = reaction_mock
+    event = _make_event()
+    sk = build_session_key(event.source)
+    parent = _make_running_parent()
+    runner._running_agents[sk] = parent
+    runner._running_agents_ts[sk] = 1.0
+    runner.adapters[event.source.platform] = adapter
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"display": display_cfg},
+    )
+    handled = await runner._handle_active_session_busy_message(event, sk)
+    assert handled is True
+    return adapter, parent
+
+
+@pytest.mark.asyncio
+async def test_redirect_ack_uses_reaction_when_enabled(monkeypatch) -> None:
+    adapter, _ = await _drive_busy_path(
+        monkeypatch,
+        with_reaction=True,
+        display_cfg={"platforms": {"buzz": {"busy_ack_reaction": True}}},
+    )
+    adapter.send_reaction.assert_awaited_once()
+    kwargs = adapter.send_reaction.await_args.kwargs
+    assert kwargs["message_id"] == "ev-42"
+    assert kwargs["emoji"] == "↪️"
+    # No text bubble may follow a successful reaction ack.
+    adapter._send_with_retry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reaction_ack_falls_back_to_text_when_unsupported(monkeypatch) -> None:
+    adapter, _ = await _drive_busy_path(
+        monkeypatch,
+        with_reaction=False,
+        display_cfg={"platforms": {"buzz": {"busy_ack_reaction": True}}},
+    )
+    adapter._send_with_retry.assert_awaited_once()  # text bubble used
+
+
+@pytest.mark.asyncio
+async def test_reaction_ack_skipped_when_disabled(monkeypatch) -> None:
+    adapter, _ = await _drive_busy_path(
+        monkeypatch,
+        with_reaction=True,
+        display_cfg={},
+    )
+    adapter.send_reaction.assert_not_awaited()
+    adapter._send_with_retry.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reaction_ack_failure_falls_back_to_text(monkeypatch) -> None:
+    adapter, _ = await _drive_busy_path(
+        monkeypatch,
+        with_reaction=True,
+        display_cfg={"platforms": {"buzz": {"busy_ack_reaction": True}}},
+        reaction_mock=AsyncMock(side_effect=RuntimeError("relay down")),
+    )
+    adapter._send_with_retry.assert_awaited_once()  # fallback bubble sent


### PR DESCRIPTION
## Summary
- New opt-in display setting `display.platforms.<platform>.busy_ack_reaction` (default `false`): when enabled and the platform adapter implements `send_reaction()`, the busy-input acknowledgment becomes a mode-aware emoji **reaction on the user's message** instead of a text bubble.
- Mode mapping: redirect / steer / queue / interrupt each get a distinct emoji, so the user can tell at a glance how their message was handled while the agent is mid-turn.
- Strict fallback: unsupported adapter, missing message id, a reaction that returns falsy, or any exception falls back to the existing text-bubble ack. Behavior when the setting is off is byte-identical to today.

## Why
On reaction-capable platforms (Buzz, Discord, Slack), a text bubble per busy ack clutters the timeline — the info fits naturally in a reaction, and reaction read-receipt UX already exists there.

## Implementation
- `gateway/run.py`: after the busy-ack timestamp latch, resolve `busy_ack_reaction` through the standard `resolve_display_setting` platform-scoped path; on success, short-circuit the text ack.
- `tests/gateway/test_busy_ack_reaction.py`: 4 regression tests — reaction ack when enabled, text fallback on missing `send_reaction`, fallback when the reaction send fails/returns false, and no-op when the setting is disabled.

## Verification
- `venv/bin/python -m pytest tests/gateway/test_busy_ack_reaction.py -o addopts= -q` — 4 passed
