### PR TITLE
fix(caching): prevent whitespace-only text blocks in prompt cache prefix splits

### DIFF
--- a/agent/prompt_cache_boundary.py
+++ b/agent/prompt_cache_boundary.py
@@ -67,10 +67,11 @@ def register_stable_prefix(prefix: str) -> None:
 
 
 def find_stable_prefix(content: str) -> Optional[str]:
-    """Longest registered prefix that is a *proper* prefix of ``content``.
+    """Longest registered prefix that is a *proper* prefix of ``content`` with non-whitespace tail.
 
-    Proper (``len(content) > len(prefix)``) so the split never produces an
-    empty volatile text block, which Anthropic rejects on the wire.
+    Proper with non-whitespace tail (``bool(content[len(prefix):].strip())``) so the
+    split never produces an empty or whitespace-only volatile text block, which
+    Anthropic rejects on the wire (HTTP 400).
 
     A hit refreshes the entry's LRU position: a scaffold fired every minute
     by cron must not be evicted by a burst of one-off skill invocations,
@@ -79,7 +80,7 @@ def find_stable_prefix(content: str) -> Optional[str]:
     with _lock:
         best: Optional[str] = None
         for prefix in _prefixes:
-            if len(content) > len(prefix) and content.startswith(prefix):
+            if content.startswith(prefix) and bool(content[len(prefix):].strip()):
                 if best is None or len(prefix) > len(best):
                     best = prefix
         if best is not None:

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -63,20 +63,22 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
         if role == "user":
             stable_prefix = find_stable_prefix(content)
             if stable_prefix is not None:
-                # Builder-declared boundary (#81867): the scaffold carries the
-                # breakpoint, the volatile invocation tail rides unmarked so a
-                # changed ticket ID or timestamp no longer invalidates the
-                # whole skill body. Request-local only — the canonical session
-                # message stays a plain string.
-                msg["content"] = [
-                    {
-                        "type": "text",
-                        "text": stable_prefix,
-                        "cache_control": cache_marker,
-                    },
-                    {"type": "text", "text": content[len(stable_prefix):]},
-                ]
-                return
+                suffix = content[len(stable_prefix):]
+                if suffix.strip():
+                    # Builder-declared boundary (#81867): the scaffold carries the
+                    # breakpoint, the volatile invocation tail rides unmarked so a
+                    # changed ticket ID or timestamp no longer invalidates the
+                    # whole skill body. Request-local only — the canonical session
+                    # message stays a plain string.
+                    msg["content"] = [
+                        {
+                            "type": "text",
+                            "text": stable_prefix,
+                            "cache_control": cache_marker,
+                        },
+                        {"type": "text", "text": suffix},
+                    ]
+                    return
         msg["content"] = [
             {"type": "text", "text": content, "cache_control": cache_marker}
         ]
@@ -204,7 +206,7 @@ def _apply_system_cache_markers(
         and content.startswith(static_system_prefix)
     ):
         suffix = content[len(static_system_prefix):]
-        if suffix:
+        if suffix.strip():
             suffix_part: dict = {"type": "text", "text": suffix}
             if mark_suffix:
                 suffix_part["cache_control"] = cache_marker
@@ -217,7 +219,7 @@ def _apply_system_cache_markers(
                 suffix_part,
             ]
             return 2 if mark_suffix else 1
-        # Empty suffix: the stored prompt IS the static prefix. Mark it as
+        # Empty/whitespace-only suffix: the stored prompt IS the static prefix. Mark it as
         # one whole block — a [marked-prefix, ""] split would put an empty
         # text block on the wire (HTTP 400 on native Anthropic).
         _apply_cache_marker(message, cache_marker, native_anthropic=native_anthropic)

--- a/tests/agent/test_prompt_cache_boundary.py
+++ b/tests/agent/test_prompt_cache_boundary.py
@@ -80,8 +80,10 @@ class TestRegistry:
     def test_requires_proper_prefix(self):
         register_stable_prefix("scaffold")
         assert find_stable_prefix("scaffold volatile") == "scaffold"
-        # Exact match would leave an empty volatile block — never split.
+        # Exact match or whitespace-only tail would leave an empty/whitespace volatile block — never split.
         assert find_stable_prefix("scaffold") is None
+        assert find_stable_prefix("scaffold   ") is None
+        assert find_stable_prefix("scaffold\n\n\t") is None
         assert find_stable_prefix("other") is None
 
     def test_longest_registered_prefix_wins(self):


### PR DESCRIPTION
## What does this PR do?

Fixes an Anthropic Messages API HTTP 400 Bad Request error in [`agent/prompt_cache_boundary.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/prompt_cache_boundary.py) and [`agent/prompt_caching.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/prompt_caching.py) where prompt cache prefix splitting created secondary text blocks containing only whitespace (e.g. `{"type": "text", "text": "  \n"}`), causing Anthropic to reject the request with HTTP 400 (`"text content blocks must contain non-whitespace text"`).

In Anthropic Messages API:
1. Anthropic strictly requires that all `text` blocks contain non-whitespace text (`text.strip() != ""`).
2. `find_stable_prefix(content)` checked `len(content) > len(prefix)` without verifying that the trailing tail (`content[len(prefix):]`) was non-whitespace.
3. If a skill invocation, cron job, or system prompt ended with trailing whitespace (e.g. `prefix + "\n\n"`), `_apply_cache_marker()` and `_apply_system_cache_markers()` split the message into two text blocks, generating a second block like `{"type": "text", "text": "\n\n"}`.
4. When sent to Anthropic, the request immediately crashed with an unrecoverable HTTP 400 error.

The fix:
- Updates `find_stable_prefix()` to verify `bool(content[len(prefix):].strip())`.
- Updates `_apply_cache_marker()` and `_apply_system_cache_markers()` to verify `suffix.strip()` before creating a two-part split, cleanly falling back to whole-message caching if the suffix is empty or whitespace-only.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/prompt_cache_boundary.py`: Added non-whitespace tail check in `find_stable_prefix()`.
- `agent/prompt_caching.py`: Added `suffix.strip()` checks in `_apply_cache_marker()` and `_apply_system_cache_markers()`.
- `tests/agent/test_prompt_cache_boundary.py`: Added unit tests asserting that whitespace-only tails return `None` in `find_stable_prefix()` and do not create invalid split text blocks.

## How to Test

Run the prompt caching test suite:
```bash
uv run --with pytest pytest tests/agent/test_prompt_cache_boundary.py tests/agent/test_prompt_caching.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(caching): prevent whitespace-only text blocks in prompt cache prefix splits`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 52 items

tests/agent/test_prompt_cache_boundary.py .....................          [ 40%]
tests/agent/test_prompt_caching.py ...............................      [100%]

============================= 52 passed in 12.85s =============================
```
