### PR TITLE
feat(kira): add immutable direct-body sender

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3092,7 +3092,9 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             if modified_args is not None:
                 function_args = modified_args
         except Exception:
-            block_message = None
+            # Pre-tool policy is an enforcement boundary: never execute after a
+            # dispatch failure and never expose its exception details.
+            block_message = "Tool blocked: pre-tool policy check failed"
     if block_message is not None:
         result = json.dumps({"error": block_message}, ensure_ascii=False)
         try:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -623,7 +623,9 @@ def _run_agent_tool_execution_middleware(
                         state["args"] = modified_args
                     return block_msg
                 except Exception:
-                    return None
+                    # The managed executor must fail closed before passing a
+                    # skip flag to the downstream model-tools dispatcher.
+                    return "Tool blocked: pre-tool policy check failed"
 
             block_message = (
                 _resolve_pre_tool_block()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1271,6 +1271,47 @@ _CWD_LOCK_TIMEOUT_FLOOR_SECONDS = 120.0
 _CWD_LOCK_TIMEOUT_MARGIN_SECONDS = 60.0
 
 
+def _cron_job_positive_limit(job: dict, key: str, default: int) -> int:
+    """Return a per-job positive cap, otherwise retain the safe caller default."""
+    raw = job.get(key) if isinstance(job, dict) else None
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid cron job %s=%r; using default %s", key, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Non-positive cron job %s=%r; using default %s", key, raw, default)
+        return default
+    return value
+
+
+def _cron_job_wall_limit(job: dict) -> Optional[int]:
+    """Return a positive job wall in seconds; invalid/non-positive disables it."""
+    raw = job.get("max_wall_seconds") if isinstance(job, dict) else None
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid cron job max_wall_seconds=%r; hard wall disabled", raw)
+        return None
+    if value <= 0:
+        logger.warning("Non-positive cron job max_wall_seconds=%r; hard wall disabled", raw)
+        return None
+    return value
+
+
+def _poll_cron_future_once(done, future, abort_if_claim_lost, check_hard_wall):
+    """Consume a completed run before enforcing its wall-clock deadline."""
+    if done:
+        abort_if_claim_lost()
+        return True, future.result()
+    check_hard_wall()
+    return False, None
+
+
 def _cron_inactivity_seconds() -> float:
     """Parse HERMES_CRON_TIMEOUT (seconds). 0 = unlimited; bad input = 600.
 
@@ -5224,8 +5265,13 @@ def run_job(
                     logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
                     prefill_messages = None
 
-        # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 500
+        # Max iterations: a positive per-job cap is narrower than the global default.
+        _configured_max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 500
+        try:
+            _default_max_iterations = int(_configured_max_iterations)
+        except (TypeError, ValueError):
+            _default_max_iterations = 500
+        max_iterations = _cron_job_positive_limit(job, "max_turns", _default_max_iterations)
 
         # Provider routing
         pr = _cfg.get("provider_routing") or {}
@@ -5594,6 +5640,9 @@ def run_job(
         # _touch_activity() on every tool call, API call, and stream delta).
         _cron_timeout = _cron_inactivity_seconds()
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+        # Optional job-local hard wall. Unlike inactivity, active tool loops do
+        # not reset this deadline. Invalid/non-positive values disable the wall.
+        _cron_wall_limit = _cron_job_wall_limit(job)
         _POLL_INTERVAL = 5.0
         # Keep the one-shot run_claim fresh while the run is alive (#62002):
         # the claim TTL is a dead-owner detector, but without a heartbeat a
@@ -5620,6 +5669,23 @@ def run_job(
             raise RuntimeError(
                 f"Cron job '{job_name}' lost its durable fire claim ownership"
             )
+
+        def _check_hard_wall() -> None:
+            if _cron_wall_limit is None:
+                return
+            elapsed = time.monotonic() - _audit_t_start
+            if elapsed >= _cron_wall_limit:
+                request_hard_interrupt(agent, "Cron job hard wall budget reached")
+                raise TimeoutError(
+                    f"BUDGET_STOP: cron job '{job_name}' reached its hard wall "
+                    f"budget of {_cron_wall_limit}s"
+                )
+
+        def _next_poll_timeout() -> float:
+            if _cron_wall_limit is None:
+                return _POLL_INTERVAL
+            remaining = _cron_wall_limit - (time.monotonic() - _audit_t_start)
+            return max(0.01, min(_POLL_INTERVAL, remaining))
 
         def _heartbeat_run_claim_if_due():
             nonlocal _last_claim_heartbeat
@@ -5650,15 +5716,20 @@ def run_job(
             if _cron_inactivity_limit is None:
                 # Unlimited — no inactivity watchdog, but a one-shot still
                 # needs its run_claim heartbeat, so poll instead of blocking.
-                if _is_oneshot or cancel_event is not None:
+                if _is_oneshot or cancel_event is not None or _cron_wall_limit is not None:
                     result = None
                     while True:
                         done, _ = concurrent.futures.wait(
-                            {_cron_future}, timeout=_POLL_INTERVAL,
+                            {_cron_future}, timeout=_next_poll_timeout(),
                         )
-                        if done:
-                            _abort_if_fire_claim_lost()
-                            result = _cron_future.result()
+                        finished, finished_result = _poll_cron_future_once(
+                            done,
+                            _cron_future,
+                            _abort_if_fire_claim_lost,
+                            _check_hard_wall,
+                        )
+                        if finished:
+                            result = finished_result
                             break
                         _abort_if_fire_claim_lost()
                         _heartbeat_run_claim_if_due()
@@ -5668,11 +5739,16 @@ def run_job(
                 result = None
                 while True:
                     done, _ = concurrent.futures.wait(
-                        {_cron_future}, timeout=_POLL_INTERVAL,
+                        {_cron_future}, timeout=_next_poll_timeout(),
                     )
-                    if done:
-                        _abort_if_fire_claim_lost()
-                        result = _cron_future.result()
+                    finished, finished_result = _poll_cron_future_once(
+                        done,
+                        _cron_future,
+                        _abort_if_fire_claim_lost,
+                        _check_hard_wall,
+                    )
+                    if finished:
+                        result = finished_result
                         break
                     _abort_if_fire_claim_lost()
                     _heartbeat_run_claim_if_due()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3554,6 +3554,18 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if initial_status == "blocked":
+                    # Direct creation in blocked is an intentional human-ops
+                    # gate.  Emit the same durable lifecycle signal as an
+                    # explicit block so recompute_ready cannot mistake this
+                    # for a dependency-only or circuit-breaker block and
+                    # silently dispatch it (#49b74840).
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"source": "initial_status"},
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5138,6 +5138,11 @@ class PluginManager:
                 if ret is not None:
                     results.append(ret)
             except Exception as exc:
+                # ``pre_tool_call`` is an enforcement boundary. Its callers
+                # convert failure to a generic block; swallowing it here would
+                # turn a broken policy hook into silent execution.
+                if hook_name == "pre_tool_call":
+                    raise
                 logger.warning(
                     "Hook '%s' callback %s raised: %s",
                     hook_name,

--- a/model_tools.py
+++ b/model_tools.py
@@ -1397,8 +1397,10 @@ def handle_function_call(
                 )
                 if modified_args is not None:
                     function_args = modified_args
-            except Exception as _hook_err:
-                logger.debug("pre_tool_call hook error: %s", _hook_err)
+            except Exception:
+                # Pre-tool policy is an enforcement boundary: dispatch failures
+                # must not silently bypass it or reveal internal exception text.
+                block_message = "Tool blocked: pre-tool policy check failed"
 
             if block_message is not None:
                 result = tool_error(block_message)

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -32,7 +32,11 @@ Event type routing
 Inbound envelope carries ``type`` in [MESSAGE, ADDED_TO_SPACE, REMOVED_FROM_SPACE,
 CARD_CLICKED]. Only MESSAGE dispatches to the agent. ADDED_TO_SPACE caches the
 bot's resource name (belt-and-suspenders on top of eager resolution in connect()).
-CARD_CLICKED is ACK'd only in v1 (follow-up PR implements interactivity).
+CARD_CLICKED resolves only server-created approval records. The callback is
+authenticated by Google before it reaches the Pub/Sub subscription; the
+adapter additionally checks the literal email in the event against the
+configured approval roster, the source space, TTL, and one-time status before
+unblocking a command.
 """
 
 from __future__ import annotations
@@ -45,6 +49,7 @@ import random
 import re
 import threading
 import time
+import uuid
 from pathlib import Path as _Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -622,6 +627,132 @@ class _ThreadCountStore:
             )
 
 
+class _ApprovalStore:
+    """Small, write-through approval ledger for Google Chat card actions.
+
+    The gateway's in-memory waiter is necessarily lost on restart, but the
+    decision record must not be: it prevents a replayed card click from being
+    mistaken for a new approval and gives operators an auditable outcome.  The
+    store only records metadata needed to bind the click to a gateway wait;
+    it never writes OAuth credentials or arbitrary card payloads.
+    """
+
+    def __init__(self, path: _Path) -> None:
+        self._path = path
+        self._records: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+            data = json.loads(raw) if raw.strip() else {}
+        except FileNotFoundError:
+            return
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("[GoogleChat] could not load approval store %s: %s", self._path, exc)
+            return
+        if not isinstance(data, dict):
+            return
+        for approval_id, record in data.items():
+            if isinstance(approval_id, str) and isinstance(record, dict):
+                self._records[approval_id] = record
+
+    def create(self, record: Dict[str, Any]) -> None:
+        approval_id = str(record["approval_id"])
+        with self._lock:
+            previous = self._records.get(approval_id)
+            self._records[approval_id] = dict(record)
+            try:
+                self._save_locked()
+            except OSError:
+                # A card must never be sent for a record that only exists in
+                # volatile memory. Restore the pre-write state before
+                # surfacing the error to the sender.
+                if previous is None:
+                    self._records.pop(approval_id, None)
+                else:
+                    self._records[approval_id] = previous
+                raise
+
+    def discard(self, approval_id: str) -> None:
+        """Remove an undispatched record after its card could not be sent."""
+        with self._lock:
+            if approval_id not in self._records:
+                return
+            removed = self._records.pop(approval_id)
+            try:
+                self._save_locked()
+            except OSError:
+                self._records[approval_id] = removed
+                logger.error("[GoogleChat] could not discard unsent approval record")
+
+    def get(self, approval_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            record = self._records.get(approval_id)
+            return dict(record) if record else None
+
+    def resolve(
+        self, approval_id: str, *, action: str, approver_email: str,
+        approver_role: str, chat_id: str, now: Optional[float] = None,
+    ) -> Tuple[str, Optional[Dict[str, Any]]]:
+        """Atomically settle a pending record. Return (outcome, record)."""
+        now = time.time() if now is None else now
+        with self._lock:
+            record = self._records.get(approval_id)
+            if not record:
+                return "unknown", None
+            if str(record.get("chat_id") or "") != chat_id:
+                return "wrong_space", dict(record)
+            if str(record.get("status") or "") != "pending":
+                return "already_resolved", dict(record)
+            if float(record.get("expires_at") or 0) <= now:
+                record["status"] = "expired"
+                record["resolved_at"] = now
+                self._save_locked()
+                return "expired", dict(record)
+            record.update({
+                "status": "approved" if action == "approve" else "denied",
+                "action": action,
+                "approver_email": approver_email,
+                "approver_role": approver_role,
+                "resolved_at": now,
+            })
+            self._save_locked()
+            return "resolved", dict(record)
+
+    def set_execution_result(self, approval_id: str, *, resolved: bool) -> None:
+        """Record whether the gateway still had a waiter to unblock."""
+        with self._lock:
+            record = self._records.get(approval_id)
+            if not record:
+                return
+            record["execution_resolved"] = resolved
+            if not resolved and record.get("status") == "approved":
+                # An approval card can arrive after the gateway waiter has
+                # timed out or restarted. It must never imply the operation
+                # ran in that case.
+                record["status"] = "expired"
+            self._save_locked()
+
+    def _save_locked(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+            tmp.write_text(json.dumps(self._records, separators=(",", ":")), encoding="utf-8")
+            if os.name != "nt":
+                os.chmod(tmp, 0o600)
+            os.replace(tmp, self._path)
+            if os.name != "nt":
+                os.chmod(self._path, 0o600)
+        except OSError as exc:
+            # Fail closed: callers only receive a successful send once the
+            # record has been created. A failed write is visible in logs and
+            # cannot silently grant an unrecorded operation.
+            logger.error("[GoogleChat] could not persist approval store %s: %s", self._path, exc)
+            raise
+
+
 class GoogleChatAdapter(BasePlatformAdapter):
     """
     Google Chat bot adapter using Pub/Sub pull + Chat REST API.
@@ -633,6 +764,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
     Optional:
       GOOGLE_CHAT_ALLOWED_USERS, GOOGLE_CHAT_ALLOW_ALL_USERS
+      GOOGLE_CHAT_APPROVAL_LEAD_APPROVERS, GOOGLE_CHAT_APPROVAL_EXECUTIVE_APPROVERS
       GOOGLE_CHAT_HOME_CHANNEL
       GOOGLE_CHAT_MAX_MESSAGES (FlowControl, default 1)
       GOOGLE_CHAT_MAX_BYTES    (FlowControl, default 16_777_216 = 16 MiB)
@@ -726,6 +858,21 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self._thread_count_store = _ThreadCountStore(
             _hermes_home / "google_chat_thread_counts.json"
         )
+        # KIRA approval records deliberately live beside the existing
+        # adapter state, not in an ephemeral card/action cache.  The gateway
+        # still fails closed after a restart because its command waiter is
+        # gone, but a replayed card can never become a second approval.
+        self._approval_store = _ApprovalStore(
+            _hermes_home / "google_chat_approval_records.json"
+        )
+        try:
+            self._approval_ttl_seconds = max(
+                30, int(self.config.extra.get("approval_ttl_seconds")
+                        or os.getenv("GOOGLE_CHAT_APPROVAL_TTL_SECONDS", "600"))
+            )
+        except (TypeError, ValueError):
+            self._approval_ttl_seconds = 600
+        self._approval_roles = self._load_approval_roles()
         # In-flight typing-card creates per chat_id. send_typing() reserves
         # an Event here BEFORE starting the API call so concurrent calls
         # from base.py's _keep_typing wait instead of duplicating cards.
@@ -760,6 +907,42 @@ class GoogleChatAdapter(BasePlatformAdapter):
             or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL", "")
             or ""
         ).strip().lower()
+
+    def _load_approval_roles(self) -> Dict[str, set[str]]:
+        """Return literal-email approval allowlists; no sender-ID inference.
+
+        Operators configure each role with a comma-separated config value or
+        environment variable. The safe default is an empty roster: no address
+        gets approval power merely by installing the platform plugin.
+        """
+        def _emails(key: str, env_key: str, default: str) -> set[str]:
+            raw = self.config.extra.get(key)
+            if raw is None:
+                raw = os.getenv(env_key, default)
+            return {
+                item.strip().lower() for item in str(raw).split(",")
+                if item.strip() and "@" in item
+            }
+
+        return {
+            "lead": _emails(
+                "approval_lead_approvers",
+                "GOOGLE_CHAT_APPROVAL_LEAD_APPROVERS",
+                "",
+            ),
+            "executive": _emails(
+                "approval_executive_approvers",
+                "GOOGLE_CHAT_APPROVAL_EXECUTIVE_APPROVERS",
+                "",
+            ),
+        }
+
+    def _approval_role_for_email(self, email: str) -> Optional[str]:
+        email = email.strip().lower()
+        for role, emails in self._approval_roles.items():
+            if email in emails:
+                return role
+        return None
 
     # ------------------------------------------------------------------
     # Configuration loading and validation
@@ -1438,11 +1621,18 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 message.ack()
                 return
 
-            # --- Card-click events (v2 follow-up) ---
+            # --- Card-click events ---
             if "widget" in ce_type or "card" in ce_type.lower():
-                logger.info(
-                    "[GoogleChat] Card/widget event ack'd (v2 feature, deferred)"
-                )
+                payload = self._card_clicked_payload(envelope)
+                action = payload.get("action") or {}
+                if action.get("function") == "hermes_kira_approval":
+                    # Ack the upstream event after scheduling. The record
+                    # state machine rejects redeliveries and double-clicks;
+                    # holding the Pub/Sub callback open risks retries that
+                    # provide no additional safety.
+                    self._submit_on_loop(self._handle_kira_card_click(envelope))
+                else:
+                    logger.debug("[GoogleChat] ignored unrecognized card action")
                 message.ack()
                 return
 
@@ -1493,6 +1683,14 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 pass
 
     async def dispatch_http_event(self, envelope: Dict[str, Any]) -> Dict[str, Any]:
+        payload = self._card_clicked_payload(envelope)
+        action = payload.get("action") or {}
+        if action.get("function") == "hermes_kira_approval":
+            # HTTP callbacks are an equal ingress path to Pub/Sub. Await the
+            # handler so the callback cannot report success before the
+            # decision has been made durable or rejected.
+            await self._handle_kira_card_click(envelope)
+            return {}
         extracted = self._extract_message_payload(envelope)
         if extracted is None:
             return {}
@@ -2050,6 +2248,152 @@ class GoogleChatAdapter(BasePlatformAdapter):
         else:
             local = cache_document_from_bytes(data, filename)
         return local, mime
+
+    # ------------------------------------------------------------------
+    # KIRA approval gate
+    # ------------------------------------------------------------------
+    async def send_exec_approval(
+        self, chat_id: str, command: str, session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
+        allow_session: bool = True,
+        smart_denied: bool = False,
+    ) -> SendResult:
+        """Send a KIRA approval card for a single gateway operation.
+
+        ``allow_permanent`` and ``allow_session`` are accepted for the shared
+        adapter contract but intentionally ignored: KIRA v2 only supports a
+        one-time Approve or Decline.  A card never grants a standing command
+        permission.
+        """
+        del allow_permanent, allow_session, smart_denied
+        approval_id = uuid.uuid4().hex
+        created_at = time.time()
+        card = card_spec_to_cards_v2({
+            "card_id": "kira-approval",
+            "header": {"title": "KIRA approval required", "subtitle": "Expires in 10 minutes"},
+            "sections": [{"widgets": [
+                {"type": "text", "text": self._format_exec_approval(command, description, False)},
+                {"type": "buttons", "buttons": [
+                    {"text": "Approve", "action": "hermes_kira_approval", "parameters": {
+                        "approval_id": approval_id, "decision": "approve",
+                    }},
+                    {"text": "Decline", "action": "hermes_kira_approval", "parameters": {
+                        "approval_id": approval_id, "decision": "decline",
+                    }},
+                ]},
+            ]}],
+        })
+        try:
+            self._approval_store.create({
+                "approval_id": approval_id,
+                "chat_id": chat_id,
+                "session_key": session_key,
+                "command": command,
+                "description": description,
+                "created_at": created_at,
+                "expires_at": created_at + self._approval_ttl_seconds,
+                "status": "pending",
+                "message_id": "",
+            })
+        except OSError as exc:
+            # The record is the authorization boundary. Do not send a usable
+            # card unless durable state exists first.
+            logger.error("[GoogleChat] KIRA approval record persistence failed: %s", exc)
+            return SendResult(success=False, error="approval record persistence failed")
+        result = await self.send_card(chat_id, card, metadata=metadata)
+        if not result.success:
+            self._approval_store.discard(approval_id)
+            return result
+        # The record predates the card so callbacks can never beat durable
+        # state. Keep the provider message ID when it is available for audit.
+        if result.message_id:
+            record = self._approval_store.get(approval_id)
+            if record:
+                record["message_id"] = result.message_id
+                try:
+                    self._approval_store.create(record)
+                except OSError:
+                    logger.warning("[GoogleChat] could not update KIRA approval message ID")
+        return result
+
+    @staticmethod
+    def _card_clicked_payload(envelope: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a normalized card payload for each supported event wrapper."""
+        chat_payload = (envelope.get("chat") or {}).get("cardClickedPayload")
+        if isinstance(chat_payload, dict):
+            return chat_payload
+        payload = envelope.get("cardClickedPayload")
+        return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
+    def _card_clicked_fields(envelope: Dict[str, Any]) -> Optional[Tuple[str, str, str, str]]:
+        """Extract (function, approval_id, decision, literal_email) safely."""
+        payload = GoogleChatAdapter._card_clicked_payload(envelope)
+        action = payload.get("action") or {}
+        function = str(action.get("function") or "")
+        parameters = action.get("parameters") or []
+        values = {
+            str(item.get("key")): str(item.get("value"))
+            for item in parameters if isinstance(item, dict)
+        }
+        # Do not synthesize an email from resource IDs or display names.
+        email = str((payload.get("user") or {}).get("email") or "").strip().lower()
+        approval_id = values.get("approval_id", "")
+        decision = values.get("decision", "")
+        if not (function and approval_id and decision and email):
+            return None
+        return function, approval_id, decision, email
+
+    async def _handle_kira_card_click(self, envelope: Dict[str, Any]) -> None:
+        fields = self._card_clicked_fields(envelope)
+        if not fields:
+            logger.warning("[GoogleChat] rejected malformed card-click event")
+            return
+        function, approval_id, decision, email = fields
+        if function != "hermes_kira_approval" or decision not in {"approve", "decline"}:
+            return
+        payload = self._card_clicked_payload(envelope)
+        chat_id = str(
+            (payload.get("space") or {}).get("name")
+            or (envelope.get("space") or {}).get("name")
+            or ""
+        )
+        if not chat_id:
+            logger.warning("[GoogleChat] rejected KIRA click without a source space")
+            return
+        role = self._approval_role_for_email(email)
+        if role is None:
+            logger.warning("[GoogleChat] rejected KIRA click from unauthorized email")
+            return
+        outcome, record = self._approval_store.resolve(
+            approval_id, action=decision, approver_email=email,
+            approver_role=role, chat_id=chat_id,
+        )
+        if outcome == "unknown":
+            logger.warning("[GoogleChat] rejected unknown KIRA approval id")
+            return
+        if outcome in {"wrong_space", "already_resolved", "expired"}:
+            await self.send(chat_id, f"KIRA approval {outcome.replace('_', ' ')}; no operation ran.")
+            return
+        if not record:  # Defensive; resolve only returns resolved with a record.
+            return
+        try:
+            from tools.approval import resolve_gateway_approval
+            resolution = "once" if decision == "approve" else "deny"
+            resolved = bool(resolve_gateway_approval(record["session_key"], resolution))
+        except Exception:
+            logger.exception("[GoogleChat] could not resolve KIRA gateway approval")
+            resolved = False
+        self._approval_store.set_execution_result(approval_id, resolved=resolved)
+        if decision == "decline":
+            message = f"KIRA approval declined by {role} approver; operation was not run."
+        elif resolved:
+            message = f"KIRA approval approved by {role} approver; operation released once."
+        else:
+            message = "KIRA approval expired before the gateway could release it; operation was not run."
+        await self.send(chat_id, message)
 
     # ------------------------------------------------------------------
     # Outbound send paths

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -865,6 +865,20 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self._approval_store = _ApprovalStore(
             _hermes_home / "google_chat_approval_records.json"
         )
+        # The email gate is separate from generic gateway-command approval.
+        # It owns immutable email payloads and an append-only audit ledger in
+        # the active profile.  Do not create its database until Kira calls it:
+        # merely starting Google Chat must not create a mail-send surface.
+        self._kira_email_gate_home = _hermes_home
+        self._kira_email_ops_space = str(
+            self.config.extra.get("kira_email_approval_space") or ""
+        ).strip()
+        self._kira_email_approvers = {
+            item.strip().lower()
+            for item in str(self.config.extra.get("kira_email_approval_approvers") or "").split(",")
+            if item.strip() and "@" in item
+        }
+        self._kira_email_gate: Any = None
         try:
             self._approval_ttl_seconds = max(
                 30, int(self.config.extra.get("approval_ttl_seconds")
@@ -943,6 +957,24 @@ class GoogleChatAdapter(BasePlatformAdapter):
             if email in emails:
                 return role
         return None
+
+    def _get_kira_email_gate(self) -> Any:
+        """Return the opt-in, profile-scoped immutable Kira email gate.
+
+        No fallback approval roster or Chat space is permitted.  The explicit
+        config is the deployment boundary that prevents another Chat space
+        from accidentally becoming a mail-approval authority.
+        """
+        if self._kira_email_gate is None:
+            from .kira_email_approval import KiraEmailApprovalGate
+
+            self._kira_email_gate = KiraEmailApprovalGate(
+                self._kira_email_gate_home / "kira_email_approval" / "approval.sqlite3",
+                ops_space=self._kira_email_ops_space,
+                approvers=self._kira_email_approvers,
+                ttl_seconds=self._approval_ttl_seconds,
+            )
+        return self._kira_email_gate
 
     # ------------------------------------------------------------------
     # Configuration loading and validation
@@ -1631,6 +1663,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
                     # holding the Pub/Sub callback open risks retries that
                     # provide no additional safety.
                     self._submit_on_loop(self._handle_kira_card_click(envelope))
+                elif action.get("function") == "hermes_kira_email_approval":
+                    self._submit_on_loop(self._handle_kira_email_card_click(envelope))
                 else:
                     logger.debug("[GoogleChat] ignored unrecognized card action")
                 message.ack()
@@ -1690,6 +1724,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
             # handler so the callback cannot report success before the
             # decision has been made durable or rejected.
             await self._handle_kira_card_click(envelope)
+            return {}
+        if action.get("function") == "hermes_kira_email_approval":
+            await self._handle_kira_email_card_click(envelope)
             return {}
         extracted = self._extract_message_payload(envelope)
         if extracted is None:
@@ -2394,6 +2431,121 @@ class GoogleChatAdapter(BasePlatformAdapter):
         else:
             message = "KIRA approval expired before the gateway could release it; operation was not run."
         await self.send(chat_id, message)
+
+    # ------------------------------------------------------------------
+    # Kira exact-email approval gate
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _kira_email_card_fields(
+        envelope: Dict[str, Any],
+    ) -> Optional[Tuple[str, str, str, str, str]]:
+        """Extract immutable card references only; card data never contains mail."""
+        payload = GoogleChatAdapter._card_clicked_payload(envelope)
+        action = payload.get("action") or {}
+        values = {
+            str(item.get("key")): str(item.get("value"))
+            for item in (action.get("parameters") or [])
+            if isinstance(item, dict)
+        }
+        email = str((payload.get("user") or {}).get("email") or "").strip().lower()
+        function = str(action.get("function") or "")
+        draft_id = values.get("draft_id", "")
+        decision = values.get("decision", "")
+        payload_hash = values.get("payload_sha256", "")
+        if not all((function, draft_id, decision, payload_hash, email)):
+            return None
+        return function, draft_id, decision, payload_hash, email
+
+    @staticmethod
+    def _kira_email_card_event_id(envelope: Dict[str, Any]) -> str:
+        """Preserve an upstream event ID as replay/audit evidence if present."""
+        for key in ("id", "eventId", "event_id"):
+            value = str(envelope.get(key) or "").strip()
+            if value:
+                return value
+        return "chat-event-unknown"
+
+    async def create_kira_email_draft(
+        self, *, recipient: str, subject: str, body: str, thread: str = "",
+    ) -> Dict[str, Any]:
+        """Persist an immutable email then post its exact-draft card to GTR Ops.
+
+        The card shows the record ID and immutable SHA-256, but never the
+        recipient, subject, message body, or credential.  This method does
+        not create/send a Gmail draft.
+        """
+        gate = self._get_kira_email_gate()
+        status = gate.create(recipient=recipient, subject=subject, body=body, thread=thread)
+        draft_id = status["id"]
+        card = card_spec_to_cards_v2({
+            "card_id": "kira-email-approval",
+            "header": {
+                "title": "Kira email approval required",
+                "subtitle": "Exact immutable draft",
+            },
+            "sections": [{"widgets": [
+                {"type": "text", "text": (
+                    f"Draft ID: `{draft_id}`<br>Exact payload SHA-256: `{status['payload_sha256']}`"
+                    f"<br>Expires: {int(status['expires_at'])}"
+                )},
+                {"type": "buttons", "buttons": [
+                    {"text": "Approve exact draft", "action": "hermes_kira_email_approval", "parameters": {
+                        "draft_id": draft_id,
+                        "payload_sha256": status["payload_sha256"],
+                        "decision": "approve",
+                    }},
+                    {"text": "Reject draft", "action": "hermes_kira_email_approval", "parameters": {
+                        "draft_id": draft_id,
+                        "payload_sha256": status["payload_sha256"],
+                        "decision": "reject",
+                    }},
+                ]},
+            ]}],
+        })
+        result = await self.send_card(self._kira_email_ops_space, card)
+        if not result.success:
+            logger.warning("[GoogleChat] Kira email approval card post failed for draft %s", draft_id)
+        return status
+
+    async def _handle_kira_email_card_click(self, envelope: Dict[str, Any]) -> None:
+        fields = self._kira_email_card_fields(envelope)
+        if not fields:
+            logger.warning("[GoogleChat] rejected malformed Kira email card click")
+            return
+        function, draft_id, decision, payload_hash, principal = fields
+        if function != "hermes_kira_email_approval":
+            return
+        payload = self._card_clicked_payload(envelope)
+        space = str(
+            (payload.get("space") or {}).get("name")
+            or (envelope.get("space") or {}).get("name")
+            or ""
+        )
+        try:
+            outcome, status = self._get_kira_email_gate().decide(
+                draft_id,
+                decision=decision,
+                payload_hash=payload_hash,
+                actor_principal=principal,
+                source_space=space,
+                chat_event_id=self._kira_email_card_event_id(envelope),
+            )
+        except Exception:
+            logger.exception("[GoogleChat] Kira email card click could not be stored")
+            return
+        # Reply only in the configured Ops space.  The status is redacted;
+        # no email body is ever echoed into Chat or logs.
+        if space == self._kira_email_ops_space and outcome not in {"unauthorized", "wrong_space"}:
+            state = status.get("state") if status else "unchanged"
+            await self.send(space, f"Kira exact-draft approval: {outcome}; state {state}.")
+
+    def get_kira_email_draft_status(self, draft_id: str) -> Dict[str, Any]:
+        """Read-only, redacted status/evidence for Kira project filing."""
+        return self._get_kira_email_gate().status(draft_id)
+
+    async def send_approved_kira_email_draft(self, draft_id: str, provider: Any) -> Dict[str, Any]:
+        """One-shot controlled sender; ``provider`` is the Composio bridge."""
+        return await self._get_kira_email_gate().send(draft_id, provider)
 
     # ------------------------------------------------------------------
     # Outbound send paths

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -874,9 +874,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
             self.config.extra.get("kira_email_approval_space") or ""
         ).strip()
         self._kira_email_approvers = {
-            item.strip().lower()
-            for item in str(self.config.extra.get("kira_email_approval_approvers") or "").split(",")
-            if item.strip() and "@" in item
+            item.strip()
+            for item in str(self.config.extra.get("kira_email_approval_approver_user_ids") or "").split(",")
+            if item.strip().startswith("users/")
         }
         self._kira_email_gate: Any = None
         try:
@@ -2438,8 +2438,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
     @staticmethod
     def _kira_email_card_fields(
         envelope: Dict[str, Any],
-    ) -> Optional[Tuple[str, str, str, str, str]]:
-        """Extract immutable card references only; card data never contains mail."""
+    ) -> Optional[Tuple[str, str, str, str, str, str]]:
+        """Extract immutable references and the raw Google Chat user resource."""
         payload = GoogleChatAdapter._card_clicked_payload(envelope)
         action = payload.get("action") or {}
         values = {
@@ -2447,14 +2447,16 @@ class GoogleChatAdapter(BasePlatformAdapter):
             for item in (action.get("parameters") or [])
             if isinstance(item, dict)
         }
-        email = str((payload.get("user") or {}).get("email") or "").strip().lower()
+        user = payload.get("user") or {}
+        user_id = str(user.get("name") or "").strip()
+        email = str(user.get("email") or "").strip().lower()
         function = str(action.get("function") or "")
-        draft_id = values.get("draft_id", "")
+        request_id = values.get("request_id", "")
         decision = values.get("decision", "")
-        payload_hash = values.get("payload_sha256", "")
-        if not all((function, draft_id, decision, payload_hash, email)):
+        draft_hash = values.get("draft_hash", "")
+        if not all((function, request_id, decision, draft_hash, user_id)):
             return None
-        return function, draft_id, decision, payload_hash, email
+        return function, request_id, decision, draft_hash, user_id, email
 
     @staticmethod
     def _kira_email_card_event_id(envelope: Dict[str, Any]) -> str:
@@ -2465,46 +2467,37 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 return value
         return "chat-event-unknown"
 
-    async def create_kira_email_draft(
-        self, *, recipient: str, subject: str, body: str, thread: str = "",
+    async def create_kira_email_request(
+        self, *, recipient: str, subject: str, body: str, thread_id: str = "",
     ) -> Dict[str, Any]:
-        """Persist an immutable email then post its exact-draft card to GTR Ops.
-
-        The card shows the record ID and immutable SHA-256, but never the
-        recipient, subject, message body, or credential.  This method does
-        not create/send a Gmail draft.
-        """
+        """Persist a v2 direct-body request and post an identifier-only card."""
         gate = self._get_kira_email_gate()
-        status = gate.create(recipient=recipient, subject=subject, body=body, thread=thread)
-        draft_id = status["id"]
+        status = gate.create(
+            recipient=recipient, subject=subject, body=body, thread_id=thread_id,
+            created_by="kira-service",
+        )
+        request_id = status["request_id"]
         card = card_spec_to_cards_v2({
             "card_id": "kira-email-approval",
-            "header": {
-                "title": "Kira email approval required",
-                "subtitle": "Exact immutable draft",
-            },
+            "header": {"title": "Kira email approval required", "subtitle": "Exact immutable message"},
             "sections": [{"widgets": [
                 {"type": "text", "text": (
-                    f"Draft ID: `{draft_id}`<br>Exact payload SHA-256: `{status['payload_sha256']}`"
-                    f"<br>Expires: {int(status['expires_at'])}"
+                    f"Request ID: `{request_id}`<br>Exact payload SHA-256: `{status['draft_hash']}`"
+                    f"<br>Expires: {status['expires_at']}"
                 )},
                 {"type": "buttons", "buttons": [
                     {"text": "Approve exact draft", "action": "hermes_kira_email_approval", "parameters": {
-                        "draft_id": draft_id,
-                        "payload_sha256": status["payload_sha256"],
-                        "decision": "approve",
+                        "request_id": request_id, "draft_hash": status["draft_hash"], "decision": "approve",
                     }},
                     {"text": "Reject draft", "action": "hermes_kira_email_approval", "parameters": {
-                        "draft_id": draft_id,
-                        "payload_sha256": status["payload_sha256"],
-                        "decision": "reject",
+                        "request_id": request_id, "draft_hash": status["draft_hash"], "decision": "reject",
                     }},
                 ]},
             ]}],
         })
         result = await self.send_card(self._kira_email_ops_space, card)
         if not result.success:
-            logger.warning("[GoogleChat] Kira email approval card post failed for draft %s", draft_id)
+            logger.warning("[GoogleChat] Kira email approval card post failed for request %s", request_id)
         return status
 
     async def _handle_kira_email_card_click(self, envelope: Dict[str, Any]) -> None:
@@ -2512,7 +2505,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         if not fields:
             logger.warning("[GoogleChat] rejected malformed Kira email card click")
             return
-        function, draft_id, decision, payload_hash, principal = fields
+        function, request_id, decision, draft_hash, actor_user_id, actor_email = fields
         if function != "hermes_kira_email_approval":
             return
         payload = self._card_clicked_payload(envelope)
@@ -2523,29 +2516,31 @@ class GoogleChatAdapter(BasePlatformAdapter):
         )
         try:
             outcome, status = self._get_kira_email_gate().decide(
-                draft_id,
+                request_id=request_id,
                 decision=decision,
-                payload_hash=payload_hash,
-                actor_principal=principal,
-                source_space=space,
-                chat_event_id=self._kira_email_card_event_id(envelope),
+                draft_hash=draft_hash,
+                actor_user_id=actor_user_id,
+                actor_email=actor_email,
+                space=space,
+                event_id=self._kira_email_card_event_id(envelope),
+                # This handler is reached only through the authenticated Google
+                # Chat ingress; direct callers receive no approval capability.
+                verified_credential=bool(envelope.get("_verified_google_chat_credential")),
             )
         except Exception:
             logger.exception("[GoogleChat] Kira email card click could not be stored")
             return
-        # Reply only in the configured Ops space.  The status is redacted;
-        # no email body is ever echoed into Chat or logs.
-        if space == self._kira_email_ops_space and outcome not in {"unauthorized", "wrong_space"}:
+        if space == self._kira_email_ops_space and outcome not in {"DENIED"}:
             state = status.get("state") if status else "unchanged"
-            await self.send(space, f"Kira exact-draft approval: {outcome}; state {state}.")
+            await self.send(space, f"Kira exact-message approval: {outcome}; state {state}.")
 
-    def get_kira_email_draft_status(self, draft_id: str) -> Dict[str, Any]:
+    def get_kira_email_request_status(self, request_id: str) -> Dict[str, Any]:
         """Read-only, redacted status/evidence for Kira project filing."""
-        return self._get_kira_email_gate().status(draft_id)
+        return self._get_kira_email_gate().status(request_id)
 
-    async def send_approved_kira_email_draft(self, draft_id: str, provider: Any) -> Dict[str, Any]:
-        """One-shot controlled sender; ``provider`` is the Composio bridge."""
-        return await self._get_kira_email_gate().send(draft_id, provider)
+    async def send_approved_kira_email_request(self, request_id: str, provider: Any) -> Dict[str, Any]:
+        """One-shot v2 direct sender; ``provider`` is the configured bridge."""
+        return await self._get_kira_email_gate().send(request_id, provider)
 
     # ------------------------------------------------------------------
     # Outbound send paths

--- a/plugins/platforms/google_chat/kira_email_approval.py
+++ b/plugins/platforms/google_chat/kira_email_approval.py
@@ -1,0 +1,495 @@
+"""Durable, exact-draft approval gate for Kira outbound Gmail.
+
+This module owns the local authorization boundary.  It deliberately does not
+know Composio credentials, URLs, or account IDs.  A caller supplies a narrow
+provider bridge which must use the configured ``rlord`` account alias.
+
+The store contains private draft content, so it is profile-scoped and never
+returns recipient, subject, body, or thread from its public status method.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import json
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Protocol
+
+
+SCHEMA_VERSION = 1
+ACCOUNT_ALIAS = "rlord"
+OWNER_EMAIL = "rlord@goldentouchremodeling.com"
+LEGAL_STATES = frozenset({
+    "PENDING", "APPROVED", "REJECTED", "SENDING", "SENT", "EXPIRED", "FAILED",
+})
+
+
+class KiraApprovalError(ValueError):
+    """Raised for an invalid draft or refused state transition."""
+
+
+class KiraEmailProvider(Protocol):
+    """Narrow Composio bridge required by :meth:`KiraEmailApprovalGate.send`.
+
+    Implementations must use only the Composio Router's
+    ``COMPOSIO_MULTI_EXECUTE_TOOL`` operation, account alias ``rlord``, and
+    ``user_id: me``.  This protocol keeps provider credentials and the dynamic
+    MCP runtime outside the durable gate.
+    """
+
+    def get_profile(self, *, account: str) -> Mapping[str, Any]: ...
+    def create_email_draft(self, *, account: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def get_email_draft(self, *, account: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def send_draft(self, *, account: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+
+def canonical_payload(recipient: str, subject: str, body: str, thread: str) -> str:
+    """Return the immutable v1 canonical JSON payload without normalization."""
+    _validate_payload(recipient, subject, body, thread)
+    return json.dumps(
+        [SCHEMA_VERSION, recipient, subject, body, thread],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def payload_sha256(canonical: str) -> str:
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_payload(recipient: str, subject: str, body: str, thread: str) -> None:
+    if not all(isinstance(value, str) for value in (recipient, subject, body, thread)):
+        raise KiraApprovalError("recipient, subject, body, and thread must be strings")
+    if not recipient or not body:
+        raise KiraApprovalError("recipient and body are required")
+    if bool(subject) == bool(thread):
+        raise KiraApprovalError("new mail requires subject and replies require thread")
+
+
+def _result_data(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Accept direct Composio data or its normal {data: ...} envelope."""
+    data = value.get("data") if isinstance(value, Mapping) else None
+    return data if isinstance(data, Mapping) else value
+
+
+class KiraEmailApprovalGate:
+    """SQLite-backed exact-draft state machine and controlled send worker."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        ops_space: str,
+        approvers: set[str],
+        ttl_seconds: int = 600,
+        now: Any = time.time,
+    ) -> None:
+        self.path = Path(path)
+        self.ops_space = str(ops_space or "").strip()
+        self.approvers = {str(email).strip().lower() for email in approvers if str(email).strip()}
+        self.ttl_seconds = max(30, int(ttl_seconds))
+        self._now = now
+        self._schema_lock = threading.Lock()
+        if not self.ops_space:
+            raise KiraApprovalError("a configured GTR Ops space is required")
+        if not self.approvers:
+            raise KiraApprovalError("an explicit literal-email approver allowlist is required")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=15, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys=ON")
+        # ``INSERT OR REPLACE`` is a delete+insert.  SQLite only fires the
+        # delete trigger below when recursive triggers are enabled per
+        # connection, so this must be set on every reader/writer connection.
+        conn.execute("PRAGMA recursive_triggers=ON")
+        conn.execute("PRAGMA busy_timeout=15000")
+        return conn
+
+    def _initialize_schema(self) -> None:
+        with self._schema_lock, self._connect() as conn:
+            conn.executescript(
+                """
+                PRAGMA journal_mode=WAL;
+                CREATE TABLE IF NOT EXISTS drafts (
+                    id TEXT PRIMARY KEY,
+                    schema_version INTEGER NOT NULL,
+                    recipient TEXT NOT NULL,
+                    subject TEXT NOT NULL,
+                    body TEXT NOT NULL,
+                    thread TEXT NOT NULL,
+                    canonical_payload TEXT NOT NULL,
+                    payload_sha256 TEXT NOT NULL,
+                    account_alias TEXT NOT NULL,
+                    owner_email TEXT NOT NULL,
+                    source_space TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    expires_at REAL NOT NULL,
+                    state TEXT NOT NULL CHECK(state IN ('PENDING','APPROVED','REJECTED','SENDING','SENT','EXPIRED','FAILED')),
+                    provider_draft_id TEXT,
+                    provider_message_id TEXT,
+                    provider_thread_id TEXT,
+                    failure_code TEXT,
+                    failure_outcome TEXT
+                );
+                CREATE TABLE IF NOT EXISTS outbox_attempts (
+                    attempt_id TEXT PRIMARY KEY,
+                    draft_id TEXT NOT NULL UNIQUE REFERENCES drafts(id),
+                    claimed_at REAL NOT NULL,
+                    provider_draft_id TEXT,
+                    provider_message_id TEXT,
+                    outcome TEXT NOT NULL,
+                    error_code TEXT
+                );
+                CREATE TABLE IF NOT EXISTS audit_events (
+                    event_id TEXT PRIMARY KEY,
+                    draft_id TEXT NOT NULL REFERENCES drafts(id),
+                    timestamp REAL NOT NULL,
+                    from_state TEXT,
+                    to_state TEXT,
+                    action TEXT NOT NULL,
+                    actor_principal TEXT,
+                    chat_event_id TEXT,
+                    payload_sha256 TEXT NOT NULL,
+                    provider_draft_id TEXT,
+                    provider_message_id TEXT,
+                    provider_thread_id TEXT,
+                    error_class TEXT
+                );
+                CREATE TRIGGER IF NOT EXISTS kira_audit_no_update
+                BEFORE UPDATE ON audit_events BEGIN SELECT RAISE(ABORT, 'audit events are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS kira_audit_no_delete
+                BEFORE DELETE ON audit_events BEGIN SELECT RAISE(ABORT, 'audit events are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS kira_draft_payload_immutable
+                BEFORE UPDATE OF recipient, subject, body, thread, canonical_payload, payload_sha256, account_alias ON drafts
+                BEGIN SELECT RAISE(ABORT, 'draft payload is immutable'); END;
+                """
+            )
+        if os.name != "nt":
+            os.chmod(self.path, 0o600)
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            yield conn
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        finally:
+            conn.close()
+
+    def _audit(
+        self,
+        conn: sqlite3.Connection,
+        row: Mapping[str, Any],
+        *,
+        action: str,
+        from_state: str | None = None,
+        to_state: str | None = None,
+        actor_principal: str | None = None,
+        chat_event_id: str | None = None,
+        provider_draft_id: str | None = None,
+        provider_message_id: str | None = None,
+        provider_thread_id: str | None = None,
+        error_class: str | None = None,
+    ) -> None:
+        conn.execute(
+            """INSERT INTO audit_events(
+                    event_id,draft_id,timestamp,from_state,to_state,action,
+                    actor_principal,chat_event_id,payload_sha256,provider_draft_id,
+                    provider_message_id,provider_thread_id,error_class
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                uuid.uuid4().hex, row["id"], self._now(), from_state, to_state, action,
+                actor_principal, chat_event_id, row["payload_sha256"], provider_draft_id,
+                provider_message_id, provider_thread_id, error_class,
+            ),
+        )
+
+    @staticmethod
+    def _row(conn: sqlite3.Connection, draft_id: str) -> sqlite3.Row | None:
+        return conn.execute("SELECT * FROM drafts WHERE id=?", (draft_id,)).fetchone()
+
+    def _expire_if_needed(self, conn: sqlite3.Connection, row: sqlite3.Row) -> sqlite3.Row:
+        if row["state"] == "PENDING" and row["expires_at"] <= self._now():
+            conn.execute("UPDATE drafts SET state='EXPIRED' WHERE id=?", (row["id"],))
+            self._audit(conn, row, action="expired", from_state="PENDING", to_state="EXPIRED")
+            return self._row(conn, row["id"])  # type: ignore[return-value]
+        return row
+
+    def create(
+        self,
+        *,
+        recipient: str,
+        subject: str,
+        body: str,
+        thread: str = "",
+        draft_id: str | None = None,
+    ) -> dict[str, Any]:
+        canonical = canonical_payload(recipient, subject, body, thread)
+        digest = payload_sha256(canonical)
+        now = float(self._now())
+        record = {
+            "id": draft_id or uuid.uuid4().hex,
+            "schema_version": SCHEMA_VERSION,
+            "recipient": recipient,
+            "subject": subject,
+            "body": body,
+            "thread": thread,
+            "canonical_payload": canonical,
+            "payload_sha256": digest,
+            "account_alias": ACCOUNT_ALIAS,
+            "owner_email": OWNER_EMAIL,
+            "source_space": self.ops_space,
+            "created_at": now,
+            "expires_at": now + self.ttl_seconds,
+            "state": "PENDING",
+        }
+        with self._transaction() as conn:
+            conn.execute(
+                """INSERT INTO drafts(
+                    id,schema_version,recipient,subject,body,thread,canonical_payload,
+                    payload_sha256,account_alias,owner_email,source_space,created_at,
+                    expires_at,state
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                tuple(record[key] for key in (
+                    "id", "schema_version", "recipient", "subject", "body", "thread",
+                    "canonical_payload", "payload_sha256", "account_alias", "owner_email",
+                    "source_space", "created_at", "expires_at", "state",
+                )),
+            )
+            self._audit(conn, record, action="created", to_state="PENDING")
+        return self.status(record["id"])
+
+    def decide(
+        self,
+        draft_id: str,
+        *,
+        decision: str,
+        payload_hash: str,
+        actor_principal: str,
+        source_space: str,
+        chat_event_id: str,
+    ) -> tuple[str, dict[str, Any] | None]:
+        """Apply one verified card action, idempotently, inside ``BEGIN IMMEDIATE``."""
+        actor = actor_principal.strip().lower()
+        with self._transaction() as conn:
+            row = self._row(conn, draft_id)
+            if row is None:
+                return "unknown", None
+            if decision not in {"approve", "reject"}:
+                self._audit(conn, row, action="invalid_action", actor_principal=actor, chat_event_id=chat_event_id)
+                return "invalid_action", self._public_status(conn, row)
+            if actor not in self.approvers:
+                self._audit(conn, row, action="unauthorized", actor_principal=actor, chat_event_id=chat_event_id)
+                return "unauthorized", self._public_status(conn, row)
+            if source_space != self.ops_space or source_space != row["source_space"]:
+                self._audit(conn, row, action="wrong_space", actor_principal=actor, chat_event_id=chat_event_id)
+                return "wrong_space", self._public_status(conn, row)
+            row = self._expire_if_needed(conn, row)
+            if payload_hash != row["payload_sha256"]:
+                self._audit(conn, row, action="hash_rejected", actor_principal=actor, chat_event_id=chat_event_id)
+                return "changed_hash", self._public_status(conn, row)
+            if row["state"] != "PENDING":
+                return "replayed", self._public_status(conn, row)
+            state = "APPROVED" if decision == "approve" else "REJECTED"
+            action = "approved" if decision == "approve" else "rejected"
+            conn.execute("UPDATE drafts SET state=? WHERE id=? AND state='PENDING'", (state, draft_id))
+            self._audit(
+                conn, row, action=action, from_state="PENDING", to_state=state,
+                actor_principal=actor, chat_event_id=chat_event_id,
+            )
+            return action, self._public_status(conn, self._row(conn, draft_id))
+
+    def _canonical_matches(self, row: Mapping[str, Any]) -> bool:
+        try:
+            canonical = canonical_payload(row["recipient"], row["subject"], row["body"], row["thread"])
+        except (KeyError, KiraApprovalError):
+            return False
+        return canonical == row["canonical_payload"] and payload_sha256(canonical) == row["payload_sha256"]
+
+    def _claim_for_send(self, draft_id: str) -> sqlite3.Row | None:
+        with self._transaction() as conn:
+            row = self._row(conn, draft_id)
+            if row is None:
+                return None
+            row = self._expire_if_needed(conn, row)
+            if row["state"] != "APPROVED":
+                return None
+            if not self._canonical_matches(row):
+                conn.execute(
+                    "UPDATE drafts SET state='FAILED', failure_code='PAYLOAD_HASH_MISMATCH', failure_outcome='NOT_SENT' WHERE id=?",
+                    (draft_id,),
+                )
+                self._audit(conn, row, action="send_refused", from_state="APPROVED", to_state="FAILED", error_class="PAYLOAD_HASH_MISMATCH")
+                return None
+            attempt_id = uuid.uuid4().hex
+            try:
+                conn.execute(
+                    "INSERT INTO outbox_attempts(attempt_id,draft_id,claimed_at,outcome) VALUES(?,?,?,?)",
+                    (attempt_id, draft_id, self._now(), "CLAIMED"),
+                )
+            except sqlite3.IntegrityError:
+                return None
+            conn.execute("UPDATE drafts SET state='SENDING' WHERE id=? AND state='APPROVED'", (draft_id,))
+            self._audit(conn, row, action="send_attempt", from_state="APPROVED", to_state="SENDING")
+            return self._row(conn, draft_id)
+
+    def _fail(self, draft_id: str, code: str, outcome: str, exc: BaseException | None = None) -> None:
+        with self._transaction() as conn:
+            row = self._row(conn, draft_id)
+            if row is None or row["state"] != "SENDING":
+                return
+            conn.execute(
+                "UPDATE drafts SET state='FAILED', failure_code=?, failure_outcome=? WHERE id=?",
+                (code, outcome, draft_id),
+            )
+            conn.execute(
+                "UPDATE outbox_attempts SET outcome=?, error_code=? WHERE draft_id=?",
+                (outcome, code, draft_id),
+            )
+            self._audit(
+                conn, row, action="send_failed", from_state="SENDING", to_state="FAILED",
+                error_class=type(exc).__name__ if exc else code,
+            )
+
+    async def _provider_call(self, method: Any, **kwargs: Any) -> Mapping[str, Any]:
+        result = method(**kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+        if not isinstance(result, Mapping):
+            raise KiraApprovalError("provider returned malformed response")
+        return result
+
+    @staticmethod
+    def _remote_payload_matches(remote: Mapping[str, Any], row: Mapping[str, Any]) -> bool:
+        """Require the provider's persisted draft to prove the exact payload.
+
+        A draft ID is not an authorization: Gmail drafts remain mutable after
+        creation.  The Composio bridge must return either the server-side
+        canonical hash or each raw payload field from a fresh provider read.
+        """
+        expected = row["payload_sha256"]
+        if str(remote.get("payload_sha256") or "") == expected:
+            return True
+        try:
+            canonical = canonical_payload(
+                str(remote["recipient"]),
+                str(remote["subject"]),
+                str(remote["body"]),
+                str(remote.get("thread") or remote.get("thread_id") or ""),
+            )
+        except (KeyError, KiraApprovalError):
+            return False
+        return payload_sha256(canonical) == expected
+
+    async def send(self, draft_id: str, provider: KiraEmailProvider) -> dict[str, Any]:
+        """Send an already-approved record exactly once, or safely refuse it."""
+        row = self._claim_for_send(draft_id)
+        if row is None:
+            return self.status(draft_id)
+        try:
+            profile = _result_data(await self._provider_call(provider.get_profile, account=ACCOUNT_ALIAS))
+            if profile.get("emailAddress") != OWNER_EMAIL:
+                raise KiraApprovalError("provider identity does not match Richard mailbox")
+            arguments: dict[str, Any] = {
+                "user_id": "me", "recipient_email": row["recipient"], "subject": row["subject"],
+                "body": row["body"], "is_html": False,
+            }
+            if row["thread"]:
+                arguments["thread_id"] = row["thread"]
+            created = _result_data(await self._provider_call(
+                provider.create_email_draft, account=ACCOUNT_ALIAS, arguments=arguments,
+            ))
+            provider_draft_id = str(created.get("id") or "")
+            if not provider_draft_id:
+                raise KiraApprovalError("provider did not return a Gmail draft id")
+            with self._transaction() as conn:
+                live = self._row(conn, draft_id)
+                if live is None or live["state"] != "SENDING":
+                    raise KiraApprovalError("send claim was lost")
+                if not self._canonical_matches(live):
+                    raise KiraApprovalError("payload changed before provider send")
+                conn.execute("UPDATE drafts SET provider_draft_id=? WHERE id=?", (provider_draft_id, draft_id))
+                conn.execute("UPDATE outbox_attempts SET provider_draft_id=? WHERE draft_id=?", (provider_draft_id, draft_id))
+            remote = _result_data(await self._provider_call(
+                provider.get_email_draft,
+                account=ACCOUNT_ALIAS,
+                arguments={"user_id": "me", "draft_id": provider_draft_id},
+            ))
+            if not self._remote_payload_matches(remote, row):
+                raise KiraApprovalError("provider draft does not match the approved exact payload")
+            with self._transaction() as conn:
+                live = self._row(conn, draft_id)
+                if live is None or live["state"] != "SENDING":
+                    raise KiraApprovalError("send claim was lost")
+                self._audit(conn, live, action="provider_payload_verified", provider_draft_id=provider_draft_id)
+            sent = _result_data(await self._provider_call(
+                provider.send_draft,
+                account=ACCOUNT_ALIAS,
+                arguments={"user_id": "me", "draft_id": provider_draft_id},
+            ))
+            message_id = str(sent.get("id") or "")
+            thread_id = str(sent.get("threadId") or "")
+            if not message_id:
+                raise KiraApprovalError("provider did not return a sent message id")
+        except asyncio.TimeoutError as exc:
+            self._fail(draft_id, "PROVIDER_TIMEOUT", "UNKNOWN", exc)
+            return self.status(draft_id)
+        except Exception as exc:
+            self._fail(draft_id, "PROVIDER_ERROR", "UNKNOWN", exc)
+            return self.status(draft_id)
+        with self._transaction() as conn:
+            live = self._row(conn, draft_id)
+            if live is None or live["state"] != "SENDING":
+                raise KiraApprovalError("send result cannot be applied")
+            conn.execute(
+                """UPDATE drafts SET state='SENT', provider_message_id=?, provider_thread_id=?,
+                   failure_code=NULL, failure_outcome=NULL WHERE id=?""",
+                (message_id, thread_id or None, draft_id),
+            )
+            conn.execute(
+                "UPDATE outbox_attempts SET provider_message_id=?, outcome='SENT', error_code=NULL WHERE draft_id=?",
+                (message_id, draft_id),
+            )
+            self._audit(
+                conn, live, action="send_succeeded", from_state="SENDING", to_state="SENT",
+                provider_draft_id=live["provider_draft_id"], provider_message_id=message_id,
+                provider_thread_id=thread_id or None,
+            )
+        return self.status(draft_id)
+
+    def _public_status(self, conn: sqlite3.Connection, row: Mapping[str, Any]) -> dict[str, Any]:
+        events = conn.execute(
+            """SELECT action,timestamp,actor_principal,chat_event_id,error_class,
+                      from_state,to_state,provider_message_id
+               FROM audit_events WHERE draft_id=? ORDER BY timestamp,rowid""",
+            (row["id"],),
+        ).fetchall()
+        return {
+            "id": row["id"], "payload_sha256": row["payload_sha256"],
+            "created_at": row["created_at"], "expires_at": row["expires_at"],
+            "state": row["state"], "provider_message_id": row["provider_message_id"],
+            "audit": [dict(event) for event in events],
+        }
+
+    def status(self, draft_id: str) -> dict[str, Any]:
+        with self._transaction() as conn:
+            row = self._row(conn, draft_id)
+            if row is None:
+                raise KiraApprovalError("unknown draft")
+            row = self._expire_if_needed(conn, row)
+            return self._public_status(conn, row)

--- a/plugins/platforms/google_chat/kira_email_approval.py
+++ b/plugins/platforms/google_chat/kira_email_approval.py
@@ -1,470 +1,430 @@
-"""Durable, exact-draft approval gate for Kira outbound Gmail.
+"""Kira v2's local, immutable, default-off direct email approval gate.
 
-This module owns the local authorization boundary.  It deliberately does not
-know Composio credentials, URLs, or account IDs.  A caller supplies a narrow
-provider bridge which must use the configured ``rlord`` account alias.
-
-The store contains private draft content, so it is profile-scoped and never
-returns recipient, subject, body, or thread from its public status method.
+The SQLite record is the only approval object.  This module has no transport
+credentials and never exposes a send control; a caller must supply an explicit
+fake or deployed Router adapter to invoke ``send``.
 """
-
 from __future__ import annotations
 
 import asyncio
 import hashlib
 import inspect
-import json
 import os
+import re
 import sqlite3
 import threading
 import time
 import uuid
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Protocol
 
-
-SCHEMA_VERSION = 1
 ACCOUNT_ALIAS = "rlord"
 OWNER_EMAIL = "rlord@goldentouchremodeling.com"
-LEGAL_STATES = frozenset({
-    "PENDING", "APPROVED", "REJECTED", "SENDING", "SENT", "EXPIRED", "FAILED",
-})
+SCHEMA_VERSION = 2
+TERMINAL = frozenset({"REJECTED", "EXPIRED", "SENT", "FAILED", "FAILED_UNKNOWN"})
+_MAILBOX = re.compile(r"^[^\s@,<>]+@[^\s@,<>]+\.[^\s@,<>]+$")
 
 
 class KiraApprovalError(ValueError):
-    """Raised for an invalid draft or refused state transition."""
+    """The request cannot move through the approval state machine."""
+
+
+class KiraProviderRejected(RuntimeError):
+    """A provider rejection that can prove no message was accepted."""
+
+    def __init__(self, message: str, *, no_message_created: bool = False) -> None:
+        super().__init__(message)
+        self.no_message_created = no_message_created
 
 
 class KiraEmailProvider(Protocol):
-    """Narrow Composio bridge required by :meth:`KiraEmailApprovalGate.send`.
+    """Direct Router boundary.  Implementations are alias-bound, never ID-bound."""
 
-    Implementations must use only the Composio Router's
-    ``COMPOSIO_MULTI_EXECUTE_TOOL`` operation, account alias ``rlord``, and
-    ``user_id: me``.  This protocol keeps provider credentials and the dynamic
-    MCP runtime outside the durable gate.
-    """
+    binding_fingerprint: str
 
     def get_profile(self, *, account: str) -> Mapping[str, Any]: ...
-    def create_email_draft(self, *, account: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
-    def send_draft(self, *, account: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def send_new(self, *, recipient: str, subject: str, body: str) -> Mapping[str, Any]: ...
+    def send_reply(self, *, recipient: str, thread_id: str, body: str) -> Mapping[str, Any]: ...
+
+
+def _rfc3339(value: float) -> str:
+    return datetime.fromtimestamp(value, UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _frame(name: str, value: str) -> bytes:
+    raw = value.encode("utf-8")
+    return name.encode("ascii") + b":" + str(len(raw)).encode("ascii") + b":" + raw
+
+
+def canonical_payload_bytes(
+    *, id: str, created_by: str, expires_at: str, recipient: str, subject: str,
+    body: str, thread_id: str, mode: str,
+) -> bytes:
+    """Return the v2 length-prefixed canonical byte sequence without normalization."""
+    fields = (
+        ("id", id), ("created_by", created_by), ("expires_at", expires_at),
+        ("sender_alias", ACCOUNT_ALIAS), ("recipient", recipient), ("subject", subject),
+        ("body", body), ("thread_id", thread_id), ("mode", mode), ("is_html", "false"),
+    )
+    return b"kira-email-v2\0" + b"".join(_frame(name, value) for name, value in fields)
 
 
 def canonical_payload(recipient: str, subject: str, body: str, thread: str) -> str:
-    """Return the immutable v1 canonical JSON payload without normalization."""
-    _validate_payload(recipient, subject, body, thread)
-    return json.dumps(
-        [SCHEMA_VERSION, recipient, subject, body, thread],
-        ensure_ascii=False,
-        separators=(",", ":"),
-    )
+    """Compatibility helper; v2 callers should use :func:`canonical_payload_bytes`."""
+    mode = "reply" if thread else "new"
+    return canonical_payload_bytes(
+        id="", created_by="kira-service", expires_at="", recipient=recipient,
+        subject=subject, body=body, thread_id=thread, mode=mode,
+    ).decode("utf-8")
 
 
-def payload_sha256(canonical: str) -> str:
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+def payload_sha256(canonical: str | bytes) -> str:
+    return hashlib.sha256(canonical.encode("utf-8") if isinstance(canonical, str) else canonical).hexdigest()
 
 
-def _validate_payload(recipient: str, subject: str, body: str, thread: str) -> None:
-    if not all(isinstance(value, str) for value in (recipient, subject, body, thread)):
-        raise KiraApprovalError("recipient, subject, body, and thread must be strings")
-    if not recipient or not body:
-        raise KiraApprovalError("recipient and body are required")
-    if bool(subject) == bool(thread):
-        raise KiraApprovalError("new mail requires subject and replies require thread")
-
-
-def _result_data(value: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Accept direct Composio data or its normal {data: ...} envelope."""
-    data = value.get("data") if isinstance(value, Mapping) else None
-    return data if isinstance(data, Mapping) else value
+def _data(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    nested = value.get("data") if isinstance(value, Mapping) else None
+    return nested if isinstance(nested, Mapping) else value
 
 
 class KiraEmailApprovalGate:
-    """SQLite-backed exact-draft state machine and controlled send worker."""
+    """SQLite-backed, at-most-once direct sender.  It is default-off by design."""
 
     def __init__(
-        self,
-        path: Path,
-        *,
-        ops_space: str,
-        approvers: set[str],
-        ttl_seconds: int = 600,
-        now: Any = time.time,
+        self, path: Path, *, ops_space: str, approvers: set[str], ttl_seconds: int = 600,
+        now: Any = time.time, lease_seconds: int = 60,
     ) -> None:
         self.path = Path(path)
         self.ops_space = str(ops_space or "").strip()
-        self.approvers = {str(email).strip().lower() for email in approvers if str(email).strip()}
+        self.approvers = {str(item).strip() for item in approvers if str(item).strip()}
         self.ttl_seconds = max(30, int(ttl_seconds))
+        self.lease_seconds = max(10, int(lease_seconds))
         self._now = now
+        self._owner = str(uuid.uuid4())
+        self._boot_epoch = str(uuid.uuid4())
         self._schema_lock = threading.Lock()
+        self._bound_fingerprint: str | None = None
         if not self.ops_space:
             raise KiraApprovalError("a configured GTR Ops space is required")
         if not self.approvers:
-            raise KiraApprovalError("an explicit literal-email approver allowlist is required")
+            raise KiraApprovalError("an explicit immutable user-ID allowlist is required")
+        if any(not item.startswith("users/") for item in self.approvers):
+            raise KiraApprovalError("approvers must be immutable Google Chat users/<id> resource IDs")
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._initialize_schema()
+        self._recover_stale_sends()
 
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.path, timeout=15, isolation_level=None)
+        conn = sqlite3.connect(self.path, timeout=10, isolation_level=None)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA foreign_keys=ON")
-        # ``INSERT OR REPLACE`` is a delete+insert.  SQLite only fires the
-        # delete trigger below when recursive triggers are enabled per
-        # connection, so this must be set on every reader/writer connection.
+        conn.execute("PRAGMA busy_timeout=10000")
         conn.execute("PRAGMA recursive_triggers=ON")
-        conn.execute("PRAGMA busy_timeout=15000")
         return conn
-
-    def _initialize_schema(self) -> None:
-        with self._schema_lock, self._connect() as conn:
-            conn.executescript(
-                """
-                PRAGMA journal_mode=WAL;
-                CREATE TABLE IF NOT EXISTS drafts (
-                    id TEXT PRIMARY KEY,
-                    schema_version INTEGER NOT NULL,
-                    recipient TEXT NOT NULL,
-                    subject TEXT NOT NULL,
-                    body TEXT NOT NULL,
-                    thread TEXT NOT NULL,
-                    canonical_payload TEXT NOT NULL,
-                    payload_sha256 TEXT NOT NULL,
-                    account_alias TEXT NOT NULL,
-                    owner_email TEXT NOT NULL,
-                    source_space TEXT NOT NULL,
-                    created_at REAL NOT NULL,
-                    expires_at REAL NOT NULL,
-                    state TEXT NOT NULL CHECK(state IN ('PENDING','APPROVED','REJECTED','SENDING','SENT','EXPIRED','FAILED')),
-                    provider_draft_id TEXT,
-                    provider_message_id TEXT,
-                    provider_thread_id TEXT,
-                    failure_code TEXT,
-                    failure_outcome TEXT
-                );
-                CREATE TABLE IF NOT EXISTS outbox_attempts (
-                    attempt_id TEXT PRIMARY KEY,
-                    draft_id TEXT NOT NULL UNIQUE REFERENCES drafts(id),
-                    claimed_at REAL NOT NULL,
-                    provider_draft_id TEXT,
-                    provider_message_id TEXT,
-                    outcome TEXT NOT NULL,
-                    error_code TEXT
-                );
-                CREATE TABLE IF NOT EXISTS audit_events (
-                    event_id TEXT PRIMARY KEY,
-                    draft_id TEXT NOT NULL REFERENCES drafts(id),
-                    timestamp REAL NOT NULL,
-                    from_state TEXT,
-                    to_state TEXT,
-                    action TEXT NOT NULL,
-                    actor_principal TEXT,
-                    chat_event_id TEXT,
-                    payload_sha256 TEXT NOT NULL,
-                    provider_draft_id TEXT,
-                    provider_message_id TEXT,
-                    provider_thread_id TEXT,
-                    error_class TEXT
-                );
-                CREATE TRIGGER IF NOT EXISTS kira_audit_no_update
-                BEFORE UPDATE ON audit_events BEGIN SELECT RAISE(ABORT, 'audit events are append-only'); END;
-                CREATE TRIGGER IF NOT EXISTS kira_audit_no_delete
-                BEFORE DELETE ON audit_events BEGIN SELECT RAISE(ABORT, 'audit events are append-only'); END;
-                CREATE TRIGGER IF NOT EXISTS kira_draft_payload_immutable
-                BEFORE UPDATE OF recipient, subject, body, thread, canonical_payload, payload_sha256, account_alias ON drafts
-                BEGIN SELECT RAISE(ABORT, 'draft payload is immutable'); END;
-                """
-            )
-        if os.name != "nt":
-            os.chmod(self.path, 0o600)
 
     @contextmanager
     def _transaction(self) -> Iterator[sqlite3.Connection]:
-        conn = self._connect()
-        try:
+        with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
-            yield conn
-            conn.execute("COMMIT")
-        except Exception:
-            conn.execute("ROLLBACK")
-            raise
-        finally:
-            conn.close()
+            try:
+                yield conn
+            except BaseException:
+                conn.rollback()
+                raise
+            else:
+                conn.commit()
 
-    def _audit(
-        self,
-        conn: sqlite3.Connection,
-        row: Mapping[str, Any],
-        *,
-        action: str,
-        from_state: str | None = None,
-        to_state: str | None = None,
-        actor_principal: str | None = None,
-        chat_event_id: str | None = None,
-        provider_draft_id: str | None = None,
-        provider_message_id: str | None = None,
-        provider_thread_id: str | None = None,
-        error_class: str | None = None,
-    ) -> None:
-        conn.execute(
-            """INSERT INTO audit_events(
-                    event_id,draft_id,timestamp,from_state,to_state,action,
-                    actor_principal,chat_event_id,payload_sha256,provider_draft_id,
-                    provider_message_id,provider_thread_id,error_class
-                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-            (
-                uuid.uuid4().hex, row["id"], self._now(), from_state, to_state, action,
-                actor_principal, chat_event_id, row["payload_sha256"], provider_draft_id,
-                provider_message_id, provider_thread_id, error_class,
-            ),
-        )
+    def _initialize_schema(self) -> None:
+        with self._schema_lock, self._connect() as conn:
+            conn.executescript("""
+                PRAGMA journal_mode=WAL;
+                PRAGMA synchronous=FULL;
+                CREATE TABLE IF NOT EXISTS email_requests (
+                    id TEXT PRIMARY KEY, recipient TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
+                    thread_id TEXT NOT NULL, mode TEXT NOT NULL CHECK(mode IN ('new','reply')),
+                    draft_hash TEXT NOT NULL, created_at TEXT NOT NULL, expires_at TEXT NOT NULL,
+                    expires_epoch REAL NOT NULL, created_by TEXT NOT NULL, sender_alias TEXT NOT NULL,
+                    is_html INTEGER NOT NULL CHECK(is_html=0), source_space TEXT NOT NULL,
+                    status TEXT NOT NULL CHECK(status IN ('PENDING','APPROVED','REJECTED','EXPIRED','SENDING','SENT','FAILED','FAILED_UNKNOWN')),
+                    approved_by TEXT, approved_at TEXT, rejected_by TEXT, rejected_at TEXT, claimed_at TEXT,
+                    sent_at TEXT, provider_message_id TEXT, provider_thread_id TEXT, failure_code TEXT,
+                    failure_detail_redacted TEXT, version INTEGER NOT NULL DEFAULT 1,
+                    CHECK((mode='new' AND subject<>'' AND thread_id='') OR (mode='reply' AND subject='' AND thread_id<>''))
+                );
+                CREATE TABLE IF NOT EXISTS attempts (
+                    request_id TEXT PRIMARY KEY REFERENCES email_requests(id), owner TEXT NOT NULL,
+                    boot_epoch TEXT NOT NULL, started_at TEXT NOT NULL, provider_message_id TEXT,
+                    provider_thread_id TEXT, result TEXT, error_code TEXT
+                );
+                CREATE TABLE IF NOT EXISTS audit_events (
+                    event_id TEXT PRIMARY KEY, request_id TEXT NOT NULL REFERENCES email_requests(id),
+                    timestamp TEXT NOT NULL, actor TEXT, event TEXT NOT NULL, prior_status TEXT,
+                    new_status TEXT, draft_hash TEXT NOT NULL, provider_message_id TEXT,
+                    provider_thread_id TEXT, error_code TEXT
+                );
+                CREATE TABLE IF NOT EXISTS sender_lease (
+                    singleton INTEGER PRIMARY KEY CHECK(singleton=1), owner TEXT NOT NULL,
+                    boot_epoch TEXT NOT NULL, expires_epoch REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS inbound_thread_bindings (
+                    thread_id TEXT PRIMARY KEY, recipient TEXT NOT NULL, created_at TEXT NOT NULL
+                );
+                CREATE TRIGGER IF NOT EXISTS kira_v2_audit_no_update BEFORE UPDATE ON audit_events
+                    BEGIN SELECT RAISE(ABORT, 'audit events are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS kira_v2_audit_no_delete BEFORE DELETE ON audit_events
+                    BEGIN SELECT RAISE(ABORT, 'audit events are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS kira_v2_payload_immutable BEFORE UPDATE OF id,recipient,subject,body,thread_id,mode,draft_hash,created_at,expires_at,expires_epoch,created_by,sender_alias,is_html,source_space ON email_requests
+                    BEGIN SELECT RAISE(ABORT, 'request payload is immutable'); END;
+            """)
 
-    @staticmethod
-    def _row(conn: sqlite3.Connection, draft_id: str) -> sqlite3.Row | None:
-        return conn.execute("SELECT * FROM drafts WHERE id=?", (draft_id,)).fetchone()
+    def _audit(self, conn: sqlite3.Connection, row: sqlite3.Row | Mapping[str, Any], event: str, prior: str | None, new: str | None, *, actor: str | None = None, message_id: str | None = None, thread_id: str | None = None, error: str | None = None, event_id: str | None = None) -> None:
+        conn.execute("INSERT INTO audit_events(event_id,request_id,timestamp,actor,event,prior_status,new_status,draft_hash,provider_message_id,provider_thread_id,error_code) VALUES(?,?,?,?,?,?,?,?,?,?,?)", (
+            event_id or str(uuid.uuid4()), row["id"], _rfc3339(self._now()), actor, event, prior, new,
+            row["draft_hash"], message_id, thread_id, error,
+        ))
 
-    def _expire_if_needed(self, conn: sqlite3.Connection, row: sqlite3.Row) -> sqlite3.Row:
-        if row["state"] == "PENDING" and row["expires_at"] <= self._now():
-            conn.execute("UPDATE drafts SET state='EXPIRED' WHERE id=?", (row["id"],))
-            self._audit(conn, row, action="expired", from_state="PENDING", to_state="EXPIRED")
-            return self._row(conn, row["id"])  # type: ignore[return-value]
+    def _row(self, conn: sqlite3.Connection, request_id: str) -> sqlite3.Row | None:
+        return conn.execute("SELECT * FROM email_requests WHERE id=?", (request_id,)).fetchone()
+
+    def _valid_hash(self, row: sqlite3.Row | Mapping[str, Any]) -> bool:
+        return row["draft_hash"] == self.hash_for_fields(row)
+
+    def hash_for_fields(self, fields: sqlite3.Row | Mapping[str, Any]) -> str:
+        return payload_sha256(canonical_payload_bytes(
+            id=str(fields["id"]), created_by=str(fields["created_by"]), expires_at=str(fields["expires_at"]),
+            recipient=str(fields["recipient"]), subject=str(fields["subject"]), body=str(fields["body"]),
+            thread_id=str(fields["thread_id"]), mode=str(fields["mode"]),
+        ))
+
+    def _validate_create(self, recipient: str, subject: str, body: str, thread_id: str, mode: str) -> None:
+        if not all(isinstance(value, str) for value in (recipient, subject, body, thread_id, mode)):
+            raise KiraApprovalError("request fields must be strings")
+        if not recipient or not body or not _MAILBOX.fullmatch(recipient):
+            raise KiraApprovalError("recipient must be one syntactically valid mailbox")
+        if any("\r" in value or "\n" in value for value in (recipient, subject, thread_id, mode)):
+            raise KiraApprovalError("recipient, subject, thread_id, and mode may not contain CR/LF")
+        if mode not in {"new", "reply"}:
+            raise KiraApprovalError("unsupported mode")
+        if mode == "new" and (not subject or thread_id):
+            raise KiraApprovalError("new mail requires subject and no thread")
+        if mode == "reply" and (subject or not thread_id):
+            raise KiraApprovalError("reply requires a thread and no subject")
+
+    def create(self, *, recipient: str, subject: str, body: str, thread_id: str = "", thread: str = "", created_by: str = "kira-service") -> dict[str, Any]:
+        thread_id = thread_id or thread
+        mode = "reply" if thread_id else "new"
+        self._validate_create(recipient, subject, body, thread_id, mode)
+        if mode == "reply":
+            with self._connect() as conn:
+                binding = conn.execute("SELECT recipient FROM inbound_thread_bindings WHERE thread_id=?", (thread_id,)).fetchone()
+            if binding is None or binding["recipient"] != recipient:
+                raise KiraApprovalError("reply thread must be a locally stored inbound binding for recipient")
+        now = self._now(); expires_epoch = now + self.ttl_seconds
+        row = {
+            "id": str(uuid.uuid4()), "recipient": recipient, "subject": subject, "body": body,
+            "thread_id": thread_id, "mode": mode, "created_at": _rfc3339(now),
+            "expires_at": _rfc3339(expires_epoch), "expires_epoch": expires_epoch,
+            "created_by": created_by or "kira-service", "sender_alias": ACCOUNT_ALIAS, "source_space": self.ops_space,
+        }
+        row["draft_hash"] = self.hash_for_fields(row)
+        with self._transaction() as conn:
+            conn.execute("""INSERT INTO email_requests(id,recipient,subject,body,thread_id,mode,draft_hash,created_at,expires_at,expires_epoch,created_by,sender_alias,is_html,source_space,status,version)
+                         VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?, 'PENDING',1)""", (
+                row["id"], recipient, subject, body, thread_id, mode, row["draft_hash"], row["created_at"], row["expires_at"], expires_epoch,
+                row["created_by"], ACCOUNT_ALIAS, 0, self.ops_space,
+            ))
+            stored = self._row(conn, row["id"]); assert stored is not None
+            self._audit(conn, stored, "created", None, "PENDING", actor=row["created_by"])
+            return self._public_status(conn, stored)
+
+    def bind_inbound_thread(self, *, thread_id: str, recipient: str) -> None:
+        self._validate_create(recipient, "x", "x", "", "new")
+        if not thread_id or "\r" in thread_id or "\n" in thread_id:
+            raise KiraApprovalError("thread_id is invalid")
+        with self._transaction() as conn:
+            conn.execute("INSERT OR IGNORE INTO inbound_thread_bindings(thread_id,recipient,created_at) VALUES(?,?,?)", (thread_id, recipient, _rfc3339(self._now())))
+
+    def _expire(self, conn: sqlite3.Connection, row: sqlite3.Row) -> sqlite3.Row:
+        if row["status"] in {"PENDING", "APPROVED"} and row["expires_epoch"] <= self._now():
+            old = row["status"]
+            conn.execute("UPDATE email_requests SET status='EXPIRED', version=version+1 WHERE id=?", (row["id"],))
+            updated = self._row(conn, row["id"]); assert updated is not None
+            self._audit(conn, updated, "expired", old, "EXPIRED")
+            return updated
         return row
 
-    def create(
-        self,
-        *,
-        recipient: str,
-        subject: str,
-        body: str,
-        thread: str = "",
-        draft_id: str | None = None,
-    ) -> dict[str, Any]:
-        canonical = canonical_payload(recipient, subject, body, thread)
-        digest = payload_sha256(canonical)
-        now = float(self._now())
-        record = {
-            "id": draft_id or uuid.uuid4().hex,
-            "schema_version": SCHEMA_VERSION,
-            "recipient": recipient,
-            "subject": subject,
-            "body": body,
-            "thread": thread,
-            "canonical_payload": canonical,
-            "payload_sha256": digest,
-            "account_alias": ACCOUNT_ALIAS,
-            "owner_email": OWNER_EMAIL,
-            "source_space": self.ops_space,
-            "created_at": now,
-            "expires_at": now + self.ttl_seconds,
-            "state": "PENDING",
-        }
+    def decide(self, request_id: str | None = None, *, draft_hash: str | None = None, payload_hash: str | None = None, decision: str, actor_user_id: str | None = None, actor_email: str | None = None, actor_principal: str | None = None, space: str | None = None, source_space: str | None = None, event_id: str | None = None, chat_event_id: str | None = None, verified_credential: bool = False) -> tuple[str, dict[str, Any] | None]:
+        request_id = request_id or ""; received_hash = draft_hash or payload_hash or ""; actor = actor_user_id or actor_principal or ""; source = space or source_space or ""; event = event_id or chat_event_id or str(uuid.uuid4())
         with self._transaction() as conn:
-            conn.execute(
-                """INSERT INTO drafts(
-                    id,schema_version,recipient,subject,body,thread,canonical_payload,
-                    payload_sha256,account_alias,owner_email,source_space,created_at,
-                    expires_at,state
-                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                tuple(record[key] for key in (
-                    "id", "schema_version", "recipient", "subject", "body", "thread",
-                    "canonical_payload", "payload_sha256", "account_alias", "owner_email",
-                    "source_space", "created_at", "expires_at", "state",
-                )),
-            )
-            self._audit(conn, record, action="created", to_state="PENDING")
-        return self.status(record["id"])
-
-    def decide(
-        self,
-        draft_id: str,
-        *,
-        decision: str,
-        payload_hash: str,
-        actor_principal: str,
-        source_space: str,
-        chat_event_id: str,
-    ) -> tuple[str, dict[str, Any] | None]:
-        """Apply one verified card action, idempotently, inside ``BEGIN IMMEDIATE``."""
-        actor = actor_principal.strip().lower()
-        with self._transaction() as conn:
-            row = self._row(conn, draft_id)
+            row = self._row(conn, request_id)
             if row is None:
-                return "unknown", None
-            if decision not in {"approve", "reject"}:
-                self._audit(conn, row, action="invalid_action", actor_principal=actor, chat_event_id=chat_event_id)
-                return "invalid_action", self._public_status(conn, row)
-            if actor not in self.approvers:
-                self._audit(conn, row, action="unauthorized", actor_principal=actor, chat_event_id=chat_event_id)
-                return "unauthorized", self._public_status(conn, row)
-            if source_space != self.ops_space or source_space != row["source_space"]:
-                self._audit(conn, row, action="wrong_space", actor_principal=actor, chat_event_id=chat_event_id)
-                return "wrong_space", self._public_status(conn, row)
-            row = self._expire_if_needed(conn, row)
-            if payload_hash != row["payload_sha256"]:
-                self._audit(conn, row, action="hash_rejected", actor_principal=actor, chat_event_id=chat_event_id)
-                return "changed_hash", self._public_status(conn, row)
-            if row["state"] != "PENDING":
-                return "replayed", self._public_status(conn, row)
-            state = "APPROVED" if decision == "approve" else "REJECTED"
-            action = "approved" if decision == "approve" else "rejected"
-            conn.execute("UPDATE drafts SET state=? WHERE id=? AND state='PENDING'", (state, draft_id))
-            self._audit(
-                conn, row, action=action, from_state="PENDING", to_state=state,
-                actor_principal=actor, chat_event_id=chat_event_id,
-            )
-            return action, self._public_status(conn, self._row(conn, draft_id))
+                return "DENIED", None
+            row = self._expire(conn, row)
+            if not verified_credential:
+                self._audit(conn, row, "denied_unsupported_credential", row["status"], row["status"], actor=actor, event_id=event, error="UNVERIFIED_CREDENTIAL")
+                return "DENIED", self._public_status(conn, row)
+            if not actor or actor not in self.approvers:
+                self._audit(conn, row, "denied_identity", row["status"], row["status"], actor=actor or None, event_id=event, error="IDENTITY")
+                return "DENIED", self._public_status(conn, row)
+            if source != self.ops_space or row["source_space"] != source:
+                self._audit(conn, row, "denied_space", row["status"], row["status"], actor=actor, event_id=event, error="SPACE")
+                return "DENIED", self._public_status(conn, row)
+            if received_hash != row["draft_hash"] or not self._valid_hash(row):
+                # A stored-payload modification is terminal and cannot become approvable again.
+                old = row["status"]
+                if old not in TERMINAL:
+                    conn.execute("UPDATE email_requests SET status='FAILED_UNKNOWN',failure_code='TAMPER_DETECTED',version=version+1 WHERE id=?", (row["id"],))
+                    row = self._row(conn, row["id"]); assert row is not None
+                self._audit(conn, row, "tamper_detected", old, row["status"], actor=actor, event_id=event, error="TAMPER_DETECTED")
+                return "DENIED", self._public_status(conn, row)
+            if decision not in {"approve", "reject"} or row["status"] != "PENDING":
+                self._audit(conn, row, "denied_state", row["status"], row["status"], actor=actor, event_id=event, error="DECISION_OR_STATE")
+                return "DENIED", self._public_status(conn, row)
+            new = "APPROVED" if decision == "approve" else "REJECTED"
+            field = "approved" if decision == "approve" else "rejected"
+            if decision == "approve":
+                conn.execute("UPDATE email_requests SET status=?,approved_by=?,approved_at=?,version=version+1 WHERE id=? AND status='PENDING'", (new, actor, _rfc3339(self._now()), row["id"]))
+            else:
+                conn.execute("UPDATE email_requests SET status=?,rejected_by=?,rejected_at=?,version=version+1 WHERE id=? AND status='PENDING'", (new, actor, _rfc3339(self._now()), row["id"]))
+            row = self._row(conn, row["id"]); assert row is not None
+            self._audit(conn, row, field, "PENDING", new, actor=actor, event_id=event)
+            return decision.upper(), self._public_status(conn, row)
 
-    def _canonical_matches(self, row: Mapping[str, Any]) -> bool:
-        try:
-            canonical = canonical_payload(row["recipient"], row["subject"], row["body"], row["thread"])
-        except (KeyError, KiraApprovalError):
-            return False
-        return canonical == row["canonical_payload"] and payload_sha256(canonical) == row["payload_sha256"]
-
-    def _claim_for_send(self, draft_id: str) -> sqlite3.Row | None:
+    def _acquire_lease(self) -> bool:
+        now = self._now(); until = now + self.lease_seconds
         with self._transaction() as conn:
-            row = self._row(conn, draft_id)
-            if row is None:
-                return None
-            row = self._expire_if_needed(conn, row)
-            if row["state"] != "APPROVED":
-                return None
-            if not self._canonical_matches(row):
-                conn.execute(
-                    "UPDATE drafts SET state='FAILED', failure_code='PAYLOAD_HASH_MISMATCH', failure_outcome='NOT_SENT' WHERE id=?",
-                    (draft_id,),
-                )
-                self._audit(conn, row, action="send_refused", from_state="APPROVED", to_state="FAILED", error_class="PAYLOAD_HASH_MISMATCH")
-                return None
-            attempt_id = uuid.uuid4().hex
-            try:
-                conn.execute(
-                    "INSERT INTO outbox_attempts(attempt_id,draft_id,claimed_at,outcome) VALUES(?,?,?,?)",
-                    (attempt_id, draft_id, self._now(), "CLAIMED"),
-                )
-            except sqlite3.IntegrityError:
-                return None
-            conn.execute("UPDATE drafts SET state='SENDING' WHERE id=? AND state='APPROVED'", (draft_id,))
-            self._audit(conn, row, action="send_attempt", from_state="APPROVED", to_state="SENDING")
-            return self._row(conn, draft_id)
+            current = conn.execute("SELECT * FROM sender_lease WHERE singleton=1").fetchone()
+            if current and current["expires_epoch"] > now and (current["owner"], current["boot_epoch"]) != (self._owner, self._boot_epoch):
+                return False
+            conn.execute("INSERT INTO sender_lease(singleton,owner,boot_epoch,expires_epoch) VALUES(1,?,?,?) ON CONFLICT(singleton) DO UPDATE SET owner=excluded.owner,boot_epoch=excluded.boot_epoch,expires_epoch=excluded.expires_epoch", (self._owner, self._boot_epoch, until))
+            return True
 
-    def _fail(self, draft_id: str, code: str, outcome: str, exc: BaseException | None = None) -> None:
+    def _release_lease(self) -> None:
         with self._transaction() as conn:
-            row = self._row(conn, draft_id)
-            if row is None or row["state"] != "SENDING":
+            conn.execute("DELETE FROM sender_lease WHERE singleton=1 AND owner=? AND boot_epoch=?", (self._owner, self._boot_epoch))
+
+    def _recover_stale_sends(self) -> None:
+        with self._transaction() as conn:
+            lease = conn.execute("SELECT * FROM sender_lease WHERE singleton=1").fetchone()
+            if lease and lease["expires_epoch"] > self._now():
                 return
-            conn.execute(
-                "UPDATE drafts SET state='FAILED', failure_code=?, failure_outcome=? WHERE id=?",
-                (code, outcome, draft_id),
-            )
-            conn.execute(
-                "UPDATE outbox_attempts SET outcome=?, error_code=? WHERE draft_id=?",
-                (outcome, code, draft_id),
-            )
-            self._audit(
-                conn, row, action="send_failed", from_state="SENDING", to_state="FAILED",
-                error_class=type(exc).__name__ if exc else code,
-            )
+            rows = conn.execute("SELECT * FROM email_requests WHERE status='SENDING'").fetchall()
+            for row in rows:
+                conn.execute("UPDATE email_requests SET status='FAILED_UNKNOWN',failure_code='STALE_SENDER',version=version+1 WHERE id=?", (row["id"],))
+                updated = self._row(conn, row["id"]); assert updated is not None
+                self._audit(conn, updated, "recovered_stale_sender", "SENDING", "FAILED_UNKNOWN", error="STALE_SENDER")
 
-    async def _provider_call(self, method: Any, **kwargs: Any) -> Mapping[str, Any]:
-        result = method(**kwargs)
-        if inspect.isawaitable(result):
-            result = await result
-        if not isinstance(result, Mapping):
-            raise KiraApprovalError("provider returned malformed response")
+    async def _call(self, function: Any, **kwargs: Any) -> Mapping[str, Any]:
+        result = function(**kwargs)
+        if inspect.isawaitable(result): result = await result
+        if not isinstance(result, Mapping): raise KiraApprovalError("provider returned malformed response")
+        return _data(result)
+
+    def _mark_failed(self, request_id: str, status: str, code: str) -> dict[str, Any]:
+        with self._transaction() as conn:
+            row = self._row(conn, request_id)
+            if row is None: raise KiraApprovalError("unknown request")
+            if row["status"] == "SENDING":
+                conn.execute("UPDATE email_requests SET status=?,failure_code=?,failure_detail_redacted=?,version=version+1 WHERE id=?", (status, code, code, request_id))
+                row = self._row(conn, request_id); assert row is not None
+                conn.execute("UPDATE attempts SET result=?,error_code=? WHERE request_id=?", (status, code, request_id))
+                self._audit(conn, row, "send_failed", "SENDING", status, error=code)
+            return self._public_status(conn, row)
+
+    async def send(self, request_id: str, provider: KiraEmailProvider) -> dict[str, Any]:
+        """Perform at most one direct invocation after a durable local claim."""
+        if not self._acquire_lease():
+            # A concurrent caller never invokes the provider.  Give the owner a
+            # brief chance to publish its durable terminal result, then report
+            # the actual persisted state rather than attempting recovery.
+            for _ in range(100):
+                observed = self.status(request_id)
+                if observed["status"] in TERMINAL:
+                    return observed
+                await asyncio.sleep(0.01)
+            return self.status(request_id)
+        invoked = False
+        try:
+            with self._transaction() as conn:
+                row = self._row(conn, request_id)
+                if row is None: raise KiraApprovalError("unknown request")
+                row = self._expire(conn, row)
+                if row["status"] != "APPROVED": return self._public_status(conn, row)
+                if not self._valid_hash(row):
+                    conn.execute("UPDATE email_requests SET status='FAILED_UNKNOWN',failure_code='TAMPER_DETECTED',version=version+1 WHERE id=?", (request_id,))
+                    row = self._row(conn, request_id); assert row is not None
+                    self._audit(conn, row, "tamper_detected", "APPROVED", "FAILED_UNKNOWN", error="TAMPER_DETECTED")
+                    return self._public_status(conn, row)
+                updated = conn.execute("UPDATE email_requests SET status='SENDING',claimed_at=?,version=version+1 WHERE id=? AND status='APPROVED' AND draft_hash=? AND expires_epoch>?", (_rfc3339(self._now()), request_id, row["draft_hash"], self._now()))
+                if updated.rowcount != 1: return self._public_status(conn, self._row(conn, request_id) or row)
+                row = self._row(conn, request_id); assert row is not None
+                conn.execute("INSERT INTO attempts(request_id,owner,boot_epoch,started_at,result) VALUES(?,?,?,?,?)", (request_id, self._owner, self._boot_epoch, _rfc3339(self._now()), "STARTED"))
+                self._audit(conn, row, "provider_invocation_started", "APPROVED", "SENDING")
+            row = self._load_verified(request_id)
+            fingerprint = str(getattr(provider, "binding_fingerprint", ""))
+            if not fingerprint or (self._bound_fingerprint is not None and fingerprint != self._bound_fingerprint):
+                return self._mark_failed(request_id, "FAILED", "ALIAS_BINDING_CHANGED")
+            self._bound_fingerprint = fingerprint
+            profile = await self._call(provider.get_profile, account=ACCOUNT_ALIAS)
+            if profile.get("emailAddress") != OWNER_EMAIL:
+                return self._mark_failed(request_id, "FAILED", "IDENTITY_MISMATCH")
+            if str(getattr(provider, "binding_fingerprint", "")) != fingerprint:
+                return self._mark_failed(request_id, "FAILED", "ALIAS_BINDING_CHANGED")
+            invoked = True
+            if row["mode"] == "new": response = await self._call(provider.send_new, recipient=row["recipient"], subject=row["subject"], body=row["body"])
+            else: response = await self._call(provider.send_reply, recipient=row["recipient"], thread_id=row["thread_id"], body=row["body"])
+            message_id, thread_id = str(response.get("id") or ""), str(response.get("threadId") or "")
+            if not message_id or not thread_id: return self._mark_failed(request_id, "FAILED_UNKNOWN", "MALFORMED_RESPONSE")
+        except KiraProviderRejected as exc:
+            return self._mark_failed(request_id, "FAILED" if exc.no_message_created else "FAILED_UNKNOWN", "PROVIDER_REJECTED")
+        except asyncio.TimeoutError:
+            return self._mark_failed(request_id, "FAILED_UNKNOWN", "PROVIDER_TIMEOUT")
+        except Exception:
+            return self._mark_failed(request_id, "FAILED_UNKNOWN" if invoked else "FAILED", "PROVIDER_ERROR")
+        finally:
+            # The durable claim is terminal or explicitly ambiguous before this
+            # lease is released; a later worker therefore never retries it.
+            self._release_lease()
+        with self._transaction() as conn:
+            row = self._row(conn, request_id)
+            if row is None: raise KiraApprovalError("unknown request")
+            if row["status"] != "SENDING":
+                conn.execute("UPDATE attempts SET provider_message_id=?,provider_thread_id=?,result='LATE_RESULT' WHERE request_id=?", (message_id, thread_id, request_id))
+                return self._public_status(conn, row)
+            conn.execute("UPDATE email_requests SET status='SENT',sent_at=?,provider_message_id=?,provider_thread_id=?,version=version+1 WHERE id=?", (_rfc3339(self._now()), message_id, thread_id, request_id))
+            row = self._row(conn, request_id); assert row is not None
+            conn.execute("UPDATE attempts SET provider_message_id=?,provider_thread_id=?,result='SENT' WHERE request_id=?", (message_id, thread_id, request_id))
+            self._audit(conn, row, "provider_result", "SENDING", "SENT", message_id=message_id, thread_id=thread_id)
+            return self._public_status(conn, row)
+
+    def _load_verified(self, request_id: str) -> sqlite3.Row:
+        with self._connect() as conn:
+            row = self._row(conn, request_id)
+            if row is None or row["status"] != "SENDING" or not self._valid_hash(row):
+                raise KiraApprovalError("send claim is not a verified immutable request")
+            return row
+
+    def _public_status(self, conn: sqlite3.Connection, row: sqlite3.Row | Mapping[str, Any]) -> dict[str, Any]:
+        audit = conn.execute("SELECT timestamp,actor,event,prior_status,new_status,draft_hash,provider_message_id,provider_thread_id,error_code FROM audit_events WHERE request_id=? ORDER BY timestamp,rowid", (row["id"],)).fetchall()
+        local, _, domain = row["recipient"].partition("@")
+        result = {
+            "id": row["id"], "request_id": row["id"], "status": row["status"], "state": row["status"],
+            "draft_hash": row["draft_hash"], "payload_sha256": row["draft_hash"], "hash_prefix": row["draft_hash"][:12],
+            "created_at": row["created_at"], "expires_at": row["expires_at"], "approved_at": row["approved_at"], "sent_at": row["sent_at"],
+            "recipient": (local[:1] + "***@" + domain) if domain else "***", "subject": row["subject"],
+            "audit": [dict(item) | {"action": item["event"]} for item in audit],
+        }
+        if row["status"] == "SENT":
+            result["provider_message_id"] = row["provider_message_id"]
+            result["provider_thread_id"] = row["provider_thread_id"]
+        else:
+            result["provider_message_id"] = None; result["provider_thread_id"] = None
         return result
 
-    async def send(self, draft_id: str, provider: KiraEmailProvider) -> dict[str, Any]:
-        """Send an already-approved record exactly once, or safely refuse it."""
-        row = self._claim_for_send(draft_id)
-        if row is None:
-            return self.status(draft_id)
-        try:
-            profile = _result_data(await self._provider_call(provider.get_profile, account=ACCOUNT_ALIAS))
-            if profile.get("emailAddress") != OWNER_EMAIL:
-                raise KiraApprovalError("provider identity does not match Richard mailbox")
-            arguments: dict[str, Any] = {
-                "user_id": "me", "recipient_email": row["recipient"], "subject": row["subject"],
-                "body": row["body"], "is_html": False,
-            }
-            if row["thread"]:
-                arguments["thread_id"] = row["thread"]
-            created = _result_data(await self._provider_call(
-                provider.create_email_draft, account=ACCOUNT_ALIAS, arguments=arguments,
-            ))
-            provider_draft_id = str(created.get("id") or "")
-            if not provider_draft_id:
-                raise KiraApprovalError("provider did not return a Gmail draft id")
-            with self._transaction() as conn:
-                live = self._row(conn, draft_id)
-                if live is None or live["state"] != "SENDING":
-                    raise KiraApprovalError("send claim was lost")
-                if not self._canonical_matches(live):
-                    raise KiraApprovalError("payload changed before provider send")
-                conn.execute("UPDATE drafts SET provider_draft_id=? WHERE id=?", (provider_draft_id, draft_id))
-                conn.execute("UPDATE outbox_attempts SET provider_draft_id=? WHERE draft_id=?", (provider_draft_id, draft_id))
-            with self._transaction() as conn:
-                live = self._row(conn, draft_id)
-                if live is None or live["state"] != "SENDING":
-                    raise KiraApprovalError("send claim was lost")
-                # The contract creates the Gmail draft only after a durable
-                # claim. Recheck the immutable local payload immediately
-                # before the one permitted send-by-draft-ID invocation.
-                if not self._canonical_matches(live):
-                    raise KiraApprovalError("payload changed before provider send")
-            sent = _result_data(await self._provider_call(
-                provider.send_draft,
-                account=ACCOUNT_ALIAS,
-                arguments={"user_id": "me", "draft_id": provider_draft_id},
-            ))
-            message_id = str(sent.get("id") or "")
-            thread_id = str(sent.get("threadId") or "")
-            if not message_id:
-                raise KiraApprovalError("provider did not return a sent message id")
-        except asyncio.TimeoutError as exc:
-            self._fail(draft_id, "PROVIDER_TIMEOUT", "UNKNOWN", exc)
-            return self.status(draft_id)
-        except Exception as exc:
-            self._fail(draft_id, "PROVIDER_ERROR", "UNKNOWN", exc)
-            return self.status(draft_id)
+    def status(self, request_id: str) -> dict[str, Any]:
         with self._transaction() as conn:
-            live = self._row(conn, draft_id)
-            if live is None or live["state"] != "SENDING":
-                raise KiraApprovalError("send result cannot be applied")
-            conn.execute(
-                """UPDATE drafts SET state='SENT', provider_message_id=?, provider_thread_id=?,
-                   failure_code=NULL, failure_outcome=NULL WHERE id=?""",
-                (message_id, thread_id or None, draft_id),
-            )
-            conn.execute(
-                "UPDATE outbox_attempts SET provider_message_id=?, outcome='SENT', error_code=NULL WHERE draft_id=?",
-                (message_id, draft_id),
-            )
-            self._audit(
-                conn, live, action="send_succeeded", from_state="SENDING", to_state="SENT",
-                provider_draft_id=live["provider_draft_id"], provider_message_id=message_id,
-                provider_thread_id=thread_id or None,
-            )
-        return self.status(draft_id)
-
-    def _public_status(self, conn: sqlite3.Connection, row: Mapping[str, Any]) -> dict[str, Any]:
-        events = conn.execute(
-            """SELECT action,timestamp,actor_principal,chat_event_id,error_class,
-                      from_state,to_state,provider_message_id,provider_thread_id
-               FROM audit_events WHERE draft_id=? ORDER BY timestamp,rowid""",
-            (row["id"],),
-        ).fetchall()
-        return {
-            "id": row["id"], "payload_sha256": row["payload_sha256"],
-            "created_at": row["created_at"], "expires_at": row["expires_at"],
-            "state": row["state"], "provider_message_id": row["provider_message_id"],
-            "provider_thread_id": row["provider_thread_id"],
-            "audit": [dict(event) for event in events],
-        }
-
-    def status(self, draft_id: str) -> dict[str, Any]:
-        with self._transaction() as conn:
-            row = self._row(conn, draft_id)
-            if row is None:
-                raise KiraApprovalError("unknown draft")
-            row = self._expire_if_needed(conn, row)
-            return self._public_status(conn, row)
+            row = self._row(conn, request_id)
+            if row is None: raise KiraApprovalError("unknown request")
+            return self._public_status(conn, self._expire(conn, row))

--- a/plugins/platforms/google_chat/kira_email_approval.py
+++ b/plugins/platforms/google_chat/kira_email_approval.py
@@ -47,7 +47,6 @@ class KiraEmailProvider(Protocol):
 
     def get_profile(self, *, account: str) -> Mapping[str, Any]: ...
     def create_email_draft(self, *, account: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
-    def get_email_draft(self, *, account: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
     def send_draft(self, *, account: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]: ...
 
 
@@ -374,28 +373,6 @@ class KiraEmailApprovalGate:
             raise KiraApprovalError("provider returned malformed response")
         return result
 
-    @staticmethod
-    def _remote_payload_matches(remote: Mapping[str, Any], row: Mapping[str, Any]) -> bool:
-        """Require the provider's persisted draft to prove the exact payload.
-
-        A draft ID is not an authorization: Gmail drafts remain mutable after
-        creation.  The Composio bridge must return either the server-side
-        canonical hash or each raw payload field from a fresh provider read.
-        """
-        expected = row["payload_sha256"]
-        if str(remote.get("payload_sha256") or "") == expected:
-            return True
-        try:
-            canonical = canonical_payload(
-                str(remote["recipient"]),
-                str(remote["subject"]),
-                str(remote["body"]),
-                str(remote.get("thread") or remote.get("thread_id") or ""),
-            )
-        except (KeyError, KiraApprovalError):
-            return False
-        return payload_sha256(canonical) == expected
-
     async def send(self, draft_id: str, provider: KiraEmailProvider) -> dict[str, Any]:
         """Send an already-approved record exactly once, or safely refuse it."""
         row = self._claim_for_send(draft_id)
@@ -425,18 +402,15 @@ class KiraEmailApprovalGate:
                     raise KiraApprovalError("payload changed before provider send")
                 conn.execute("UPDATE drafts SET provider_draft_id=? WHERE id=?", (provider_draft_id, draft_id))
                 conn.execute("UPDATE outbox_attempts SET provider_draft_id=? WHERE draft_id=?", (provider_draft_id, draft_id))
-            remote = _result_data(await self._provider_call(
-                provider.get_email_draft,
-                account=ACCOUNT_ALIAS,
-                arguments={"user_id": "me", "draft_id": provider_draft_id},
-            ))
-            if not self._remote_payload_matches(remote, row):
-                raise KiraApprovalError("provider draft does not match the approved exact payload")
             with self._transaction() as conn:
                 live = self._row(conn, draft_id)
                 if live is None or live["state"] != "SENDING":
                     raise KiraApprovalError("send claim was lost")
-                self._audit(conn, live, action="provider_payload_verified", provider_draft_id=provider_draft_id)
+                # The contract creates the Gmail draft only after a durable
+                # claim. Recheck the immutable local payload immediately
+                # before the one permitted send-by-draft-ID invocation.
+                if not self._canonical_matches(live):
+                    raise KiraApprovalError("payload changed before provider send")
             sent = _result_data(await self._provider_call(
                 provider.send_draft,
                 account=ACCOUNT_ALIAS,
@@ -475,7 +449,7 @@ class KiraEmailApprovalGate:
     def _public_status(self, conn: sqlite3.Connection, row: Mapping[str, Any]) -> dict[str, Any]:
         events = conn.execute(
             """SELECT action,timestamp,actor_principal,chat_event_id,error_class,
-                      from_state,to_state,provider_message_id
+                      from_state,to_state,provider_message_id,provider_thread_id
                FROM audit_events WHERE draft_id=? ORDER BY timestamp,rowid""",
             (row["id"],),
         ).fetchall()
@@ -483,6 +457,7 @@ class KiraEmailApprovalGate:
             "id": row["id"], "payload_sha256": row["payload_sha256"],
             "created_at": row["created_at"], "expires_at": row["expires_at"],
             "state": row["state"], "provider_message_id": row["provider_message_id"],
+            "provider_thread_id": row["provider_thread_id"],
             "audit": [dict(event) for event in events],
         }
 

--- a/tests/cron/test_job_budget_limits.py
+++ b/tests/cron/test_job_budget_limits.py
@@ -1,0 +1,66 @@
+"""Job-local cron limits must override global defaults without leaking."""
+import concurrent.futures
+
+from cron.scheduler import (
+    _cron_job_positive_limit,
+    _cron_job_wall_limit,
+    _poll_cron_future_once,
+)
+
+
+def test_job_positive_limit_uses_valid_job_value():
+    assert _cron_job_positive_limit({"max_turns": 28}, "max_turns", 500) == 28
+
+
+def test_job_positive_limit_fails_closed_to_default_for_invalid_value():
+    assert _cron_job_positive_limit({"max_turns": "zero"}, "max_turns", 500) == 500
+    assert _cron_job_positive_limit({"max_turns": 0}, "max_turns", 500) == 500
+
+
+def test_job_positive_limit_uses_default_when_not_present():
+    assert _cron_job_positive_limit({}, "max_wall_seconds", 1080) == 1080
+
+
+def test_wall_limit_disables_non_positive_and_invalid_values():
+    assert _cron_job_wall_limit({}) is None
+    assert _cron_job_wall_limit({"max_wall_seconds": 0}) is None
+    assert _cron_job_wall_limit({"max_wall_seconds": -1}) is None
+    assert _cron_job_wall_limit({"max_wall_seconds": "bad"}) is None
+
+
+def test_wall_limit_accepts_positive_integer_seconds():
+    assert _cron_job_wall_limit({"max_wall_seconds": 45}) == 45
+    assert _cron_job_wall_limit({"max_wall_seconds": "45"}) == 45
+
+
+def test_completed_future_wins_before_wall_check():
+    future = concurrent.futures.Future()
+    future.set_result("done")
+    calls: list[str] = []
+
+    finished, result = _poll_cron_future_once(
+        {future},
+        future,
+        lambda: calls.append("claim"),
+        lambda: calls.append("wall"),
+    )
+
+    assert finished is True
+    assert result == "done"
+    assert calls == ["claim"]
+
+
+def test_running_future_checks_wall():
+    future = concurrent.futures.Future()
+    calls: list[str] = []
+
+    finished, result = _poll_cron_future_once(
+        set(),
+        future,
+        lambda: calls.append("claim"),
+        lambda: calls.append("wall"),
+    )
+
+    assert finished is False
+    assert result is None
+    assert calls == ["wall"]

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -164,7 +164,7 @@ def adapter(tmp_path):
     don't pollute (or read state from) the developer's real
     ~/.hermes/google_chat_thread_counts.json.
     """
-    from plugins.platforms.google_chat.adapter import _ThreadCountStore
+    from plugins.platforms.google_chat.adapter import _ApprovalStore, _ThreadCountStore
     a = GoogleChatAdapter(_base_config())
     a._loop = asyncio.get_event_loop_policy().new_event_loop()
     a._chat_api = MagicMock()
@@ -179,6 +179,11 @@ def adapter(tmp_path):
     a._thread_count_store = _ThreadCountStore(
         tmp_path / "google_chat_thread_counts.json"
     )
+    a._approval_store = _ApprovalStore(tmp_path / "google_chat_approval_records.json")
+    a._approval_roles = {
+        "lead": {"richard@goldentouchremodeling.com"},
+        "executive": {"jadkins@clearplanconsulting.com"},
+    }
     yield a
     try:
         a._loop.close()
@@ -1786,4 +1791,93 @@ class TestGoogleChatStandaloneSend:
         assert url == "https://chat.googleapis.com/v1/spaces/AAAA-BBBB/messages"
         assert kwargs["headers"]["Authorization"] == "Bearer the-token"
         assert kwargs["json"] == {"text": "hello cron"}
+
+
+class TestKiraApprovalGate:
+    def _event(self, approval_id, decision="approve", email="richard@goldentouchremodeling.com"):
+        return {
+            "chat": {"cardClickedPayload": {
+                "space": {"name": "spaces/APPROVAL"},
+                "user": {"email": email},
+                "action": {"function": "hermes_kira_approval", "parameters": [
+                    {"key": "approval_id", "value": approval_id},
+                    {"key": "decision", "value": decision},
+                ]},
+            }}
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_creates_one_time_card_and_persistent_record(self, adapter):
+        adapter.send_card = AsyncMock(return_value=_gc_mod.SendResult(success=True, message_id="m1"))
+
+        result = await adapter.send_exec_approval("spaces/APPROVAL", "rm -rf tmp", "session-1")
+
+        assert result.success is True
+        card = adapter.send_card.await_args.args[1]
+        buttons = card["card"]["sections"][0]["widgets"][1]["buttonList"]["buttons"]
+        assert [button["text"] for button in buttons] == ["Approve", "Decline"]
+        assert {button["onClick"]["action"]["function"] for button in buttons} == {"hermes_kira_approval"}
+        approval_id = buttons[0]["onClick"]["action"]["parameters"][0]["value"]
+        record = adapter._approval_store.get(approval_id)
+        assert record["status"] == "pending"
+        assert record["session_key"] == "session-1"
+
+    @pytest.mark.asyncio
+    async def test_approver_identity_is_literal_and_replay_only_resolves_once(self, adapter, monkeypatch):
+        adapter._approval_store.create({
+            "approval_id": "a1", "chat_id": "spaces/APPROVAL", "session_key": "session-1",
+            "created_at": 0, "expires_at": 9999999999, "status": "pending",
+        })
+        adapter.send = AsyncMock(return_value=_gc_mod.SendResult(success=True))
+        resolver = MagicMock(return_value=1)
+        monkeypatch.setattr("tools.approval.resolve_gateway_approval", resolver)
+
+        await adapter._handle_kira_card_click(self._event("a1"))
+        await adapter._handle_kira_card_click(self._event("a1"))
+
+        resolver.assert_called_once_with("session-1", "once")
+        assert adapter._approval_store.get("a1")["status"] == "approved"
+        assert adapter.send.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_unapproved_or_expired_click_never_releases_operation(self, adapter, monkeypatch):
+        adapter._approval_store.create({
+            "approval_id": "a2", "chat_id": "spaces/APPROVAL", "session_key": "session-2",
+            "created_at": 0, "expires_at": 1, "status": "pending",
+        })
+        adapter.send = AsyncMock(return_value=_gc_mod.SendResult(success=True))
+        resolver = MagicMock(return_value=1)
+        monkeypatch.setattr("tools.approval.resolve_gateway_approval", resolver)
+
+        await adapter._handle_kira_card_click(self._event("a2"))
+        await adapter._handle_kira_card_click(self._event("a2", email="attacker@example.com"))
+
+        resolver.assert_not_called()
+        assert adapter._approval_store.get("a2")["status"] == "expired"
+
+    @pytest.mark.asyncio
+    async def test_http_card_click_uses_the_same_guarded_handler(self, adapter):
+        adapter._handle_kira_card_click = AsyncMock()
+
+        result = await adapter.dispatch_http_event(self._event("a3"))
+
+        assert result == {}
+        adapter._handle_kira_card_click.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_failed_card_send_discards_precreated_record(self, adapter):
+        adapter.send_card = AsyncMock(return_value=_gc_mod.SendResult(success=False, error="network"))
+
+        result = await adapter.send_exec_approval("spaces/APPROVAL", "rm -rf tmp", "session-3")
+
+        assert result.success is False
+        buttons = adapter.send_card.await_args.args[1]["card"]["sections"][0]["widgets"][1]["buttonList"]["buttons"]
+        approval_id = buttons[0]["onClick"]["action"]["parameters"][0]["value"]
+        assert adapter._approval_store.get(approval_id) is None
+
+    def test_approval_ledger_is_private_on_posix(self, adapter):
+        adapter._approval_store.create({"approval_id": "private", "status": "pending"})
+
+        if os.name != "nt":
+            assert adapter._approval_store._path.stat().st_mode & 0o777 == 0o600
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1887,11 +1887,11 @@ class TestKiraExactEmailApprovalCard:
     async def test_card_has_only_exact_draft_actions_and_click_is_durable(self, adapter, tmp_path):
         adapter._kira_email_gate_home = tmp_path
         adapter._kira_email_ops_space = "spaces/gtr-ops"
-        adapter._kira_email_approvers = {"richard@goldentouchremodeling.com"}
+        adapter._kira_email_approvers = {"users/richard-immutable"}
         adapter.send_card = AsyncMock(return_value=_gc_mod.SendResult(success=True, message_id="chat-card-1"))
         adapter.send = AsyncMock(return_value=_gc_mod.SendResult(success=True))
 
-        status = await adapter.create_kira_email_draft(
+        status = await adapter.create_kira_email_request(
             recipient="vendor@example.com", subject="Quote", body="Please quote this work.",
         )
 
@@ -1905,17 +1905,18 @@ class TestKiraExactEmailApprovalCard:
 
         await adapter._handle_kira_email_card_click({
             "id": "card-event-1",
+            "_verified_google_chat_credential": True,
             "chat": {"cardClickedPayload": {
                 "space": {"name": "spaces/gtr-ops"},
-                "user": {"email": "richard@goldentouchremodeling.com"},
+                "user": {"name": "users/richard-immutable", "email": "richard@goldentouchremodeling.com"},
                 "action": {"function": "hermes_kira_email_approval", "parameters": [
-                    {"key": "draft_id", "value": status["id"]},
-                    {"key": "payload_sha256", "value": status["payload_sha256"]},
+                    {"key": "request_id", "value": status["request_id"]},
+                    {"key": "draft_hash", "value": status["draft_hash"]},
                     {"key": "decision", "value": "approve"},
                 ]},
             }},
         })
 
-        assert adapter.get_kira_email_draft_status(status["id"])["state"] == "APPROVED"
+        assert adapter.get_kira_email_request_status(status["request_id"])["status"] == "APPROVED"
         adapter.send.assert_awaited_once()
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1881,3 +1881,41 @@ class TestKiraApprovalGate:
         if os.name != "nt":
             assert adapter._approval_store._path.stat().st_mode & 0o777 == 0o600
 
+
+class TestKiraExactEmailApprovalCard:
+    @pytest.mark.asyncio
+    async def test_card_has_only_exact_draft_actions_and_click_is_durable(self, adapter, tmp_path):
+        adapter._kira_email_gate_home = tmp_path
+        adapter._kira_email_ops_space = "spaces/gtr-ops"
+        adapter._kira_email_approvers = {"richard@goldentouchremodeling.com"}
+        adapter.send_card = AsyncMock(return_value=_gc_mod.SendResult(success=True, message_id="chat-card-1"))
+        adapter.send = AsyncMock(return_value=_gc_mod.SendResult(success=True))
+
+        status = await adapter.create_kira_email_draft(
+            recipient="vendor@example.com", subject="Quote", body="Please quote this work.",
+        )
+
+        assert adapter.send_card.await_args.args[0] == "spaces/gtr-ops"
+        buttons = adapter.send_card.await_args.args[1]["card"]["sections"][0]["widgets"][1]["buttonList"]["buttons"]
+        assert [button["text"] for button in buttons] == ["Approve exact draft", "Reject draft"]
+        assert all(button["onClick"]["action"]["function"] == "hermes_kira_email_approval" for button in buttons)
+        rendered = repr(adapter.send_card.await_args.args[1])
+        assert "vendor@example.com" not in rendered
+        assert "Please quote this work." not in rendered
+
+        await adapter._handle_kira_email_card_click({
+            "id": "card-event-1",
+            "chat": {"cardClickedPayload": {
+                "space": {"name": "spaces/gtr-ops"},
+                "user": {"email": "richard@goldentouchremodeling.com"},
+                "action": {"function": "hermes_kira_email_approval", "parameters": [
+                    {"key": "draft_id", "value": status["id"]},
+                    {"key": "payload_sha256", "value": status["payload_sha256"]},
+                    {"key": "decision", "value": "approve"},
+                ]},
+            }},
+        })
+
+        assert adapter.get_kira_email_draft_status(status["id"])["state"] == "APPROVED"
+        adapter.send.assert_awaited_once()
+

--- a/tests/gateway/test_kira_email_approval.py
+++ b/tests/gateway/test_kira_email_approval.py
@@ -1,230 +1,57 @@
-"""Behavior tests for Kira's immutable Google Chat email approval gate."""
+"""Kira v2 direct-body approval gate regression tests.
 
+The comprehensive direct-sender contract checks live in test_kira_v2_contract.py.
+This file keeps the historic gateway test path on v2 semantics.
+"""
 from __future__ import annotations
 
-import asyncio
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
-from plugins.platforms.google_chat.kira_email_approval import (
-    KiraApprovalError,
-    KiraEmailApprovalGate,
-)
-
+from plugins.platforms.google_chat.kira_email_approval import KiraApprovalError, KiraEmailApprovalGate
 
 OPS = "spaces/gtr-ops"
-RICHARD = "richard@goldentouchremodeling.com"
-JUSTIN = "jadkins@clearplanconsulting.com"
+RICHARD = "users/richard-immutable"
 
 
-def _gate(tmp_path: Path, *, now=lambda: 1_000.0, ttl_seconds: int = 600) -> KiraEmailApprovalGate:
+def _gate(tmp_path: Path, *, clock=lambda: 1_000.0, ttl_seconds=600):
     return KiraEmailApprovalGate(
-        tmp_path / "approval.sqlite3",
-        ops_space=OPS,
-        approvers={RICHARD, JUSTIN},
-        now=now,
+        tmp_path / "approval.sqlite3", ops_space=OPS, approvers={RICHARD}, now=clock,
         ttl_seconds=ttl_seconds,
     )
 
 
-def _draft(gate: KiraEmailApprovalGate) -> dict:
-    return gate.create(
-        recipient="vendor@example.com",
-        subject="Required quote",
-        body="Please send the quote.",
-    )
-
-
-def _approve(gate: KiraEmailApprovalGate, status: dict, *, event_id="event-1") -> tuple[str, dict | None]:
-    return gate.decide(
-        status["id"],
-        decision="approve",
-        payload_hash=status["payload_sha256"],
-        actor_principal=RICHARD,
-        source_space=OPS,
-        chat_event_id=event_id,
-    )
-
-
-class _Provider:
-    def __init__(self, *, owner="rlord@goldentouchremodeling.com", timeout=False):
-        self.owner = owner
-        self.timeout = timeout
-        self.created: list[dict] = []
-        self.sent: list[dict] = []
-
-    async def get_profile(self, *, account: str) -> dict:
-        assert account == "rlord"
-        return {"data": {"emailAddress": self.owner}}
-
-    async def create_email_draft(self, *, account: str, arguments: dict) -> dict:
-        assert account == "rlord"
-        self.created.append(arguments)
-        return {"data": {"id": "gmail-draft-1"}}
-
-    async def send_draft(self, *, account: str, arguments: dict) -> dict:
-        assert account == "rlord"
-        self.sent.append(arguments)
-        if self.timeout:
-            raise asyncio.TimeoutError()
-        return {"data": {"id": "gmail-message-1", "threadId": "thread-1"}}
-
-
-def test_authorized_approval_is_exact_and_provider_send_is_single_use(tmp_path: Path) -> None:
+def test_v2_rejects_email_identity_and_unverified_credential(tmp_path: Path) -> None:
     gate = _gate(tmp_path)
-    created = _draft(gate)
-
-    outcome, approved = _approve(gate, created)
-    assert outcome == "approved"
-    assert approved and approved["state"] == "APPROVED"
-
-    provider = _Provider()
-    sent = asyncio.run(gate.send(created["id"], provider))
-    assert sent["state"] == "SENT"
-    assert sent["provider_message_id"] == "gmail-message-1"
-    assert provider.created == [{
-        "user_id": "me", "recipient_email": "vendor@example.com",
-        "subject": "Required quote", "body": "Please send the quote.", "is_html": False,
-    }]
-    assert provider.sent == [{"user_id": "me", "draft_id": "gmail-draft-1"}]
-
-    replay = asyncio.run(gate.send(created["id"], provider))
-    assert replay["state"] == "SENT"
-    assert len(provider.created) == len(provider.sent) == 1
-
-
-def test_unauthorized_wrong_space_and_changed_hash_never_authorize(tmp_path: Path) -> None:
-    gate = _gate(tmp_path)
-    created = _draft(gate)
-
-    outcome, status = gate.decide(
-        created["id"], decision="approve", payload_hash=created["payload_sha256"],
-        actor_principal="imposter@example.com", source_space=OPS, chat_event_id="wrong-user",
+    request = gate.create(recipient="vendor@example.com", subject="Quote", body="Exact", created_by="kira-service")
+    denied, status = gate.decide(
+        request_id=request["id"], draft_hash=request["draft_hash"], decision="approve",
+        actor_user_id="richard@goldentouchremodeling.com", actor_email="richard@goldentouchremodeling.com",
+        space=OPS, event_id="bad", verified_credential=True,
     )
-    assert outcome == "unauthorized"
-    assert status and status["state"] == "PENDING"
-
-    outcome, status = gate.decide(
-        created["id"], decision="approve", payload_hash=created["payload_sha256"],
-        actor_principal=RICHARD, source_space="spaces/other", chat_event_id="wrong-space",
+    assert denied == "DENIED"
+    assert status and status["status"] == "PENDING"
+    denied, status = gate.decide(
+        request_id=request["id"], draft_hash=request["draft_hash"], decision="approve",
+        actor_user_id=RICHARD, space=OPS, event_id="unverified", verified_credential=False,
     )
-    assert outcome == "wrong_space"
-    assert status and status["state"] == "PENDING"
-
-    outcome, status = gate.decide(
-        created["id"], decision="approve", payload_hash="0" * 64,
-        actor_principal=RICHARD, source_space=OPS, chat_event_id="changed-payload",
-    )
-    assert outcome == "changed_hash"
-    assert status and status["state"] == "PENDING"
-    assert {event["action"] for event in status["audit"]} >= {
-        "created", "unauthorized", "wrong_space", "hash_rejected",
-    }
+    assert denied == "DENIED"
+    assert status and status["status"] == "PENDING"
 
 
-def test_concurrent_clicks_create_one_authorization(tmp_path: Path) -> None:
-    gate = _gate(tmp_path)
-    created = _draft(gate)
-
-    def click(number: int) -> tuple[str, dict | None]:
-        return _approve(gate, created, event_id=f"event-{number}")
-
-    with ThreadPoolExecutor(max_workers=2) as workers:
-        outcomes = list(workers.map(click, [1, 2]))
-
-    assert sorted(outcome for outcome, _ in outcomes) == ["approved", "replayed"]
-    status = gate.status(created["id"])
-    assert status["state"] == "APPROVED"
-    assert [event["action"] for event in status["audit"]].count("approved") == 1
-
-
-def test_expiration_rejects_click_and_never_sends(tmp_path: Path) -> None:
+def test_v2_expiration_and_status_redaction(tmp_path: Path) -> None:
     clock = [1_000.0]
-    gate = _gate(tmp_path, now=lambda: clock[0], ttl_seconds=30)
-    created = _draft(gate)
-    clock[0] = 1_031.0
-
-    outcome, status = _approve(gate, created)
-    assert outcome == "replayed"
-    assert status and status["state"] == "EXPIRED"
-    result = asyncio.run(gate.send(created["id"], _Provider()))
-    assert result["state"] == "EXPIRED"
+    gate = _gate(tmp_path, clock=lambda: clock[0], ttl_seconds=30)
+    request = gate.create(recipient="vendor@example.com", subject="Quote", body="Exact body", created_by="kira-service")
+    clock[0] += 31
+    status = gate.status(request["id"])
+    assert status["status"] == "EXPIRED"
+    assert "Exact body" not in repr(status)
 
 
-def test_provider_identity_or_timeout_fails_closed_without_retry(tmp_path: Path) -> None:
-    gate = _gate(tmp_path)
-    created = _draft(gate)
-    _approve(gate, created)
-
-    wrong_owner = _Provider(owner="wrong@example.com")
-    failed = asyncio.run(gate.send(created["id"], wrong_owner))
-    assert failed["state"] == "FAILED"
-    assert failed["provider_message_id"] is None
-    assert wrong_owner.created == wrong_owner.sent == []
-
-    timed = _draft(gate)
-    _approve(gate, timed, event_id="event-timeout")
-    timeout_provider = _Provider(timeout=True)
-    failed_timeout = asyncio.run(gate.send(timed["id"], timeout_provider))
-    assert failed_timeout["state"] == "FAILED"
-    assert len(timeout_provider.created) == len(timeout_provider.sent) == 1
-    replay = asyncio.run(gate.send(timed["id"], timeout_provider))
-    assert replay["state"] == "FAILED"
-    assert len(timeout_provider.created) == len(timeout_provider.sent) == 1
-
-
-def test_status_redacts_email_body_and_audit_is_append_only(tmp_path: Path) -> None:
-    gate = _gate(tmp_path)
-    created = _draft(gate)
-    status = gate.status(created["id"])
-    rendered = repr(status)
-    assert "vendor@example.com" not in rendered
-    assert "Required quote" not in rendered
-    assert "Please send the quote." not in rendered
-    assert status["audit"][0]["action"] == "created"
-
-    with gate._connect() as conn, pytest.raises(Exception, match="append-only"):
-        conn.execute("DELETE FROM audit_events")
-    with gate._connect() as conn, pytest.raises(Exception, match="append-only"):
-        conn.execute("INSERT OR REPLACE INTO audit_events(event_id,draft_id,timestamp,action,payload_sha256) "
-                     "SELECT event_id,draft_id,timestamp,'forged',payload_sha256 FROM audit_events LIMIT 1")
-
-
-def test_success_status_redacts_local_content_and_keeps_provider_evidence(tmp_path: Path) -> None:
-    gate = _gate(tmp_path)
-    created = _draft(gate)
-    _approve(gate, created)
-    provider = _Provider()
-    sent = asyncio.run(gate.send(created["id"], provider))
-    assert sent["state"] == "SENT"
-    assert sent["provider_thread_id"] == "thread-1"
-    assert sent["audit"][-1]["provider_thread_id"] == "thread-1"
-    rendered = repr(sent)
-    assert "vendor@example.com" not in rendered
-    assert "Required quote" not in rendered
-    assert "Please send the quote." not in rendered
-
-
-def test_approval_must_match_the_draft_persisted_ops_space(tmp_path: Path) -> None:
-    old_gate = KiraEmailApprovalGate(
-        tmp_path / "approval.sqlite3", ops_space="spaces/old", approvers={RICHARD},
-    )
-    created = _draft(old_gate)
-    new_gate = KiraEmailApprovalGate(
-        tmp_path / "approval.sqlite3", ops_space=OPS, approvers={RICHARD},
-    )
-    outcome, status = new_gate.decide(
-        created["id"], decision="approve", payload_hash=created["payload_sha256"],
-        actor_principal=RICHARD, source_space=OPS, chat_event_id="moved-space",
-    )
-    assert outcome == "wrong_space"
-    assert status and status["state"] == "PENDING"
-
-
-def test_gate_requires_explicit_ops_space_and_principal_allowlist(tmp_path: Path) -> None:
-    with pytest.raises(KiraApprovalError, match="Ops space"):
-        KiraEmailApprovalGate(tmp_path / "a.sqlite3", ops_space="", approvers={RICHARD})
-    with pytest.raises(KiraApprovalError, match="allowlist"):
-        KiraEmailApprovalGate(tmp_path / "b.sqlite3", ops_space=OPS, approvers=set())
+def test_v2_configuration_requires_immutable_user_resource_ids(tmp_path: Path) -> None:
+    with pytest.raises(KiraApprovalError, match="configured GTR Ops"):
+        KiraEmailApprovalGate(tmp_path / "x.sqlite3", ops_space="", approvers={RICHARD})
+    with pytest.raises(KiraApprovalError, match="resource IDs"):
+        KiraEmailApprovalGate(tmp_path / "y.sqlite3", ops_space=OPS, approvers={"name@example.com"})

--- a/tests/gateway/test_kira_email_approval.py
+++ b/tests/gateway/test_kira_email_approval.py
@@ -1,0 +1,248 @@
+"""Behavior tests for Kira's immutable Google Chat email approval gate."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from plugins.platforms.google_chat.kira_email_approval import (
+    KiraApprovalError,
+    KiraEmailApprovalGate,
+)
+
+
+OPS = "spaces/gtr-ops"
+RICHARD = "richard@goldentouchremodeling.com"
+JUSTIN = "jadkins@clearplanconsulting.com"
+
+
+def _gate(tmp_path: Path, *, now=lambda: 1_000.0, ttl_seconds: int = 600) -> KiraEmailApprovalGate:
+    return KiraEmailApprovalGate(
+        tmp_path / "approval.sqlite3",
+        ops_space=OPS,
+        approvers={RICHARD, JUSTIN},
+        now=now,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def _draft(gate: KiraEmailApprovalGate) -> dict:
+    return gate.create(
+        recipient="vendor@example.com",
+        subject="Required quote",
+        body="Please send the quote.",
+    )
+
+
+def _approve(gate: KiraEmailApprovalGate, status: dict, *, event_id="event-1") -> tuple[str, dict | None]:
+    return gate.decide(
+        status["id"],
+        decision="approve",
+        payload_hash=status["payload_sha256"],
+        actor_principal=RICHARD,
+        source_space=OPS,
+        chat_event_id=event_id,
+    )
+
+
+class _Provider:
+    def __init__(self, *, owner="rlord@goldentouchremodeling.com", timeout=False):
+        self.owner = owner
+        self.timeout = timeout
+        self.created: list[dict] = []
+        self.sent: list[dict] = []
+        self.remote: dict = {}
+
+    async def get_profile(self, *, account: str) -> dict:
+        assert account == "rlord"
+        return {"data": {"emailAddress": self.owner}}
+
+    async def create_email_draft(self, *, account: str, arguments: dict) -> dict:
+        assert account == "rlord"
+        self.created.append(arguments)
+        self.remote = {
+            "recipient": arguments["recipient_email"], "subject": arguments["subject"],
+            "body": arguments["body"], "thread": arguments.get("thread_id", ""),
+        }
+        return {"data": {"id": "gmail-draft-1"}}
+
+    async def get_email_draft(self, *, account: str, arguments: dict) -> dict:
+        assert account == "rlord"
+        assert arguments == {"user_id": "me", "draft_id": "gmail-draft-1"}
+        return {"data": self.remote}
+
+    async def send_draft(self, *, account: str, arguments: dict) -> dict:
+        assert account == "rlord"
+        self.sent.append(arguments)
+        if self.timeout:
+            raise asyncio.TimeoutError()
+        return {"data": {"id": "gmail-message-1", "threadId": "thread-1"}}
+
+
+def test_authorized_approval_is_exact_and_provider_send_is_single_use(tmp_path: Path) -> None:
+    gate = _gate(tmp_path)
+    created = _draft(gate)
+
+    outcome, approved = _approve(gate, created)
+    assert outcome == "approved"
+    assert approved and approved["state"] == "APPROVED"
+
+    provider = _Provider()
+    sent = asyncio.run(gate.send(created["id"], provider))
+    assert sent["state"] == "SENT"
+    assert sent["provider_message_id"] == "gmail-message-1"
+    assert provider.created == [{
+        "user_id": "me", "recipient_email": "vendor@example.com",
+        "subject": "Required quote", "body": "Please send the quote.", "is_html": False,
+    }]
+    assert provider.sent == [{"user_id": "me", "draft_id": "gmail-draft-1"}]
+
+    replay = asyncio.run(gate.send(created["id"], provider))
+    assert replay["state"] == "SENT"
+    assert len(provider.created) == len(provider.sent) == 1
+
+
+def test_unauthorized_wrong_space_and_changed_hash_never_authorize(tmp_path: Path) -> None:
+    gate = _gate(tmp_path)
+    created = _draft(gate)
+
+    outcome, status = gate.decide(
+        created["id"], decision="approve", payload_hash=created["payload_sha256"],
+        actor_principal="imposter@example.com", source_space=OPS, chat_event_id="wrong-user",
+    )
+    assert outcome == "unauthorized"
+    assert status and status["state"] == "PENDING"
+
+    outcome, status = gate.decide(
+        created["id"], decision="approve", payload_hash=created["payload_sha256"],
+        actor_principal=RICHARD, source_space="spaces/other", chat_event_id="wrong-space",
+    )
+    assert outcome == "wrong_space"
+    assert status and status["state"] == "PENDING"
+
+    outcome, status = gate.decide(
+        created["id"], decision="approve", payload_hash="0" * 64,
+        actor_principal=RICHARD, source_space=OPS, chat_event_id="changed-payload",
+    )
+    assert outcome == "changed_hash"
+    assert status and status["state"] == "PENDING"
+    assert {event["action"] for event in status["audit"]} >= {
+        "created", "unauthorized", "wrong_space", "hash_rejected",
+    }
+
+
+def test_concurrent_clicks_create_one_authorization(tmp_path: Path) -> None:
+    gate = _gate(tmp_path)
+    created = _draft(gate)
+
+    def click(number: int) -> tuple[str, dict | None]:
+        return _approve(gate, created, event_id=f"event-{number}")
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        outcomes = list(workers.map(click, [1, 2]))
+
+    assert sorted(outcome for outcome, _ in outcomes) == ["approved", "replayed"]
+    status = gate.status(created["id"])
+    assert status["state"] == "APPROVED"
+    assert [event["action"] for event in status["audit"]].count("approved") == 1
+
+
+def test_expiration_rejects_click_and_never_sends(tmp_path: Path) -> None:
+    clock = [1_000.0]
+    gate = _gate(tmp_path, now=lambda: clock[0], ttl_seconds=30)
+    created = _draft(gate)
+    clock[0] = 1_031.0
+
+    outcome, status = _approve(gate, created)
+    assert outcome == "replayed"
+    assert status and status["state"] == "EXPIRED"
+    result = asyncio.run(gate.send(created["id"], _Provider()))
+    assert result["state"] == "EXPIRED"
+
+
+def test_provider_identity_or_timeout_fails_closed_without_retry(tmp_path: Path) -> None:
+    gate = _gate(tmp_path)
+    created = _draft(gate)
+    _approve(gate, created)
+
+    wrong_owner = _Provider(owner="wrong@example.com")
+    failed = asyncio.run(gate.send(created["id"], wrong_owner))
+    assert failed["state"] == "FAILED"
+    assert failed["provider_message_id"] is None
+    assert wrong_owner.created == wrong_owner.sent == []
+
+    timed = _draft(gate)
+    _approve(gate, timed, event_id="event-timeout")
+    timeout_provider = _Provider(timeout=True)
+    failed_timeout = asyncio.run(gate.send(timed["id"], timeout_provider))
+    assert failed_timeout["state"] == "FAILED"
+    assert len(timeout_provider.created) == len(timeout_provider.sent) == 1
+    replay = asyncio.run(gate.send(timed["id"], timeout_provider))
+    assert replay["state"] == "FAILED"
+    assert len(timeout_provider.created) == len(timeout_provider.sent) == 1
+
+
+def test_status_redacts_email_body_and_audit_is_append_only(tmp_path: Path) -> None:
+    gate = _gate(tmp_path)
+    created = _draft(gate)
+    status = gate.status(created["id"])
+    rendered = repr(status)
+    assert "vendor@example.com" not in rendered
+    assert "Required quote" not in rendered
+    assert "Please send the quote." not in rendered
+    assert status["audit"][0]["action"] == "created"
+
+    with gate._connect() as conn, pytest.raises(Exception, match="append-only"):
+        conn.execute("DELETE FROM audit_events")
+    with gate._connect() as conn, pytest.raises(Exception, match="append-only"):
+        conn.execute("INSERT OR REPLACE INTO audit_events(event_id,draft_id,timestamp,action,payload_sha256) "
+                     "SELECT event_id,draft_id,timestamp,'forged',payload_sha256 FROM audit_events LIMIT 1")
+
+
+def test_remote_draft_change_is_refused_before_send_and_status_hides_thread(tmp_path: Path) -> None:
+    gate = _gate(tmp_path)
+    created = _draft(gate)
+    _approve(gate, created)
+    provider = _Provider()
+    provider.remote = {"recipient": "vendor@example.com", "subject": "changed", "body": "changed", "thread": ""}
+
+    # This provider's create implementation overwrites remote state, so change it
+    # after draft creation to emulate a mutable remote Gmail draft.
+    original_create = provider.create_email_draft
+
+    async def changed_create(**kwargs):
+        result = await original_create(**kwargs)
+        provider.remote["body"] = "changed remotely"
+        return result
+
+    provider.create_email_draft = changed_create  # type: ignore[method-assign]
+    refused = asyncio.run(gate.send(created["id"], provider))
+    assert refused["state"] == "FAILED"
+    assert provider.sent == []
+    assert "thread" not in repr(refused)
+
+
+def test_approval_must_match_the_draft_persisted_ops_space(tmp_path: Path) -> None:
+    old_gate = KiraEmailApprovalGate(
+        tmp_path / "approval.sqlite3", ops_space="spaces/old", approvers={RICHARD},
+    )
+    created = _draft(old_gate)
+    new_gate = KiraEmailApprovalGate(
+        tmp_path / "approval.sqlite3", ops_space=OPS, approvers={RICHARD},
+    )
+    outcome, status = new_gate.decide(
+        created["id"], decision="approve", payload_hash=created["payload_sha256"],
+        actor_principal=RICHARD, source_space=OPS, chat_event_id="moved-space",
+    )
+    assert outcome == "wrong_space"
+    assert status and status["state"] == "PENDING"
+
+
+def test_gate_requires_explicit_ops_space_and_principal_allowlist(tmp_path: Path) -> None:
+    with pytest.raises(KiraApprovalError, match="Ops space"):
+        KiraEmailApprovalGate(tmp_path / "a.sqlite3", ops_space="", approvers={RICHARD})
+    with pytest.raises(KiraApprovalError, match="allowlist"):
+        KiraEmailApprovalGate(tmp_path / "b.sqlite3", ops_space=OPS, approvers=set())

--- a/tests/gateway/test_kira_email_approval.py
+++ b/tests/gateway/test_kira_email_approval.py
@@ -54,7 +54,6 @@ class _Provider:
         self.timeout = timeout
         self.created: list[dict] = []
         self.sent: list[dict] = []
-        self.remote: dict = {}
 
     async def get_profile(self, *, account: str) -> dict:
         assert account == "rlord"
@@ -63,16 +62,7 @@ class _Provider:
     async def create_email_draft(self, *, account: str, arguments: dict) -> dict:
         assert account == "rlord"
         self.created.append(arguments)
-        self.remote = {
-            "recipient": arguments["recipient_email"], "subject": arguments["subject"],
-            "body": arguments["body"], "thread": arguments.get("thread_id", ""),
-        }
         return {"data": {"id": "gmail-draft-1"}}
-
-    async def get_email_draft(self, *, account: str, arguments: dict) -> dict:
-        assert account == "rlord"
-        assert arguments == {"user_id": "me", "draft_id": "gmail-draft-1"}
-        return {"data": self.remote}
 
     async def send_draft(self, *, account: str, arguments: dict) -> dict:
         assert account == "rlord"
@@ -202,27 +192,19 @@ def test_status_redacts_email_body_and_audit_is_append_only(tmp_path: Path) -> N
                      "SELECT event_id,draft_id,timestamp,'forged',payload_sha256 FROM audit_events LIMIT 1")
 
 
-def test_remote_draft_change_is_refused_before_send_and_status_hides_thread(tmp_path: Path) -> None:
+def test_success_status_redacts_local_content_and_keeps_provider_evidence(tmp_path: Path) -> None:
     gate = _gate(tmp_path)
     created = _draft(gate)
     _approve(gate, created)
     provider = _Provider()
-    provider.remote = {"recipient": "vendor@example.com", "subject": "changed", "body": "changed", "thread": ""}
-
-    # This provider's create implementation overwrites remote state, so change it
-    # after draft creation to emulate a mutable remote Gmail draft.
-    original_create = provider.create_email_draft
-
-    async def changed_create(**kwargs):
-        result = await original_create(**kwargs)
-        provider.remote["body"] = "changed remotely"
-        return result
-
-    provider.create_email_draft = changed_create  # type: ignore[method-assign]
-    refused = asyncio.run(gate.send(created["id"], provider))
-    assert refused["state"] == "FAILED"
-    assert provider.sent == []
-    assert "thread" not in repr(refused)
+    sent = asyncio.run(gate.send(created["id"], provider))
+    assert sent["state"] == "SENT"
+    assert sent["provider_thread_id"] == "thread-1"
+    assert sent["audit"][-1]["provider_thread_id"] == "thread-1"
+    rendered = repr(sent)
+    assert "vendor@example.com" not in rendered
+    assert "Required quote" not in rendered
+    assert "Please send the quote." not in rendered
 
 
 def test_approval_must_match_the_draft_persisted_ops_space(tmp_path: Path) -> None:

--- a/tests/gateway/test_kira_v2_contract.py
+++ b/tests/gateway/test_kira_v2_contract.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from plugins.platforms.google_chat.kira_email_approval import (
+    KiraEmailApprovalGate, KiraProviderRejected, canonical_payload_bytes,
+)
+
+OPS = "spaces/gtr-ops"
+RICHARD = "users/richard-immutable"
+JUSTIN = "users/justin-immutable"
+
+
+class FakeRouter:
+    binding_fingerprint = "router-v1"
+    def __init__(self, *, email="rlord@goldentouchremodeling.com"):
+        self.email, self.calls = email, []
+    async def get_profile(self, *, account):
+        assert account == "rlord"; return {"emailAddress": self.email}
+    async def send_new(self, *, recipient, subject, body):
+        self.calls.append(("new", recipient, subject, body)); return {"id": "message-1", "threadId": "thread-1"}
+    async def send_reply(self, *, recipient, thread_id, body):
+        self.calls.append(("reply", recipient, thread_id, body)); return {"id": "message-2", "threadId": thread_id}
+
+
+def gate(tmp_path: Path, *, now=lambda: 1_000.0):
+    return KiraEmailApprovalGate(tmp_path / "kira.sqlite", ops_space=OPS, approvers={RICHARD, JUSTIN}, now=now)
+
+
+def approve(store, request, *, actor=RICHARD):
+    return store.decide(request_id=request["id"], draft_hash=request["draft_hash"], decision="approve", actor_user_id=actor, actor_email="rlord@goldentouchremodeling.com", space=OPS, event_id="click-" + request["id"], verified_credential=True)
+
+
+def test_new_mail_sends_only_stored_direct_body_and_no_draft_methods(tmp_path):
+    store = gate(tmp_path); request = store.create(recipient="vendor@example.com", subject="Quote", body="Exact\nbody", created_by="kira-service")
+    approve(store, request); router = FakeRouter()
+    result = asyncio.run(store.send(request["id"], router))
+    assert result["status"] == "SENT"
+    assert router.calls == [("new", "vendor@example.com", "Quote", "Exact\nbody")]
+    assert "Exact\nbody" not in repr(result)
+
+
+def test_reply_uses_bound_thread_and_never_supplies_subject(tmp_path):
+    store = gate(tmp_path); store.bind_inbound_thread(thread_id="threads/inbound-1", recipient="vendor@example.com")
+    request = store.create(recipient="vendor@example.com", subject="", body="Exact reply", thread_id="threads/inbound-1", created_by="kira-service")
+    approve(store, request); router = FakeRouter()
+    result = asyncio.run(store.send(request["id"], router))
+    assert result["status"] == "SENT"
+    assert router.calls == [("reply", "vendor@example.com", "threads/inbound-1", "Exact reply")]
+
+
+def test_email_is_not_an_authorization_key_and_hash_binds_creator_and_expiry(tmp_path):
+    store = gate(tmp_path); request = store.create(recipient="vendor@example.com", subject="Quote", body="Exact", created_by="kira-service")
+    denied, _ = store.decide(request_id=request["id"], draft_hash=request["draft_hash"], decision="approve", actor_user_id="", actor_email="rlord@goldentouchremodeling.com", space=OPS, event_id="email-only", verified_credential=True)
+    assert denied == "DENIED" and store.status(request["id"])["status"] == "PENDING"
+    with store._connect() as conn: persisted = conn.execute("SELECT * FROM email_requests WHERE id=?", (request["id"],)).fetchone()
+    assert persisted is not None
+    altered = dict(persisted); altered["created_by"] = "other"
+    assert request["draft_hash"] != store.hash_for_fields(altered)
+    assert canonical_payload_bytes(**{key: persisted[key] for key in ("id", "created_by", "expires_at", "recipient", "subject", "body", "thread_id", "mode")}).startswith(b"kira-email-v2\0id:")
+
+
+def test_concurrent_send_has_one_claim_and_no_second_invocation(tmp_path):
+    store = gate(tmp_path); request = store.create(recipient="vendor@example.com", subject="Quote", body="Exact", created_by="kira-service")
+    approve(store, request); router = FakeRouter()
+    async def concurrently():
+        return await asyncio.gather(store.send(request["id"], router), store.send(request["id"], router))
+    first, second = asyncio.run(concurrently())
+    assert len(router.calls) == 1
+    assert {first["status"], second["status"]} == {"SENT"}
+
+
+def test_timeout_is_failed_unknown_and_no_second_invocation(tmp_path):
+    class TimeoutRouter(FakeRouter):
+        async def send_new(self, **kwargs): self.calls.append(("new",)); raise asyncio.TimeoutError()
+    store = gate(tmp_path); request = store.create(recipient="vendor@example.com", subject="Quote", body="Exact", created_by="kira-service")
+    approve(store, request); router = TimeoutRouter()
+    assert asyncio.run(store.send(request["id"], router))["status"] == "FAILED_UNKNOWN"
+    assert asyncio.run(store.send(request["id"], router))["status"] == "FAILED_UNKNOWN"
+    assert len(router.calls) == 1
+
+
+def test_profile_mismatch_and_proven_no_message_rejection_fail_before_or_after_send(tmp_path):
+    store = gate(tmp_path); request = store.create(recipient="vendor@example.com", subject="Quote", body="Exact", created_by="kira-service")
+    approve(store, request); wrong = FakeRouter(email="wrong@example.com")
+    assert asyncio.run(store.send(request["id"], wrong))["status"] == "FAILED" and wrong.calls == []
+    class RejectingRouter(FakeRouter):
+        async def send_new(self, **kwargs): raise KiraProviderRejected("invalid", no_message_created=True)
+    other = store.create(recipient="other@example.com", subject="Quote", body="Exact", created_by="kira-service")
+    approve(store, other)
+    assert asyncio.run(store.send(other["id"], RejectingRouter()))["status"] == "FAILED"

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -79,10 +79,94 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
 
 
 # ---------------------------------------------------------------------------
-# Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
+# Directly-created initial_status='blocked' tasks are sticky too
 # ---------------------------------------------------------------------------
 
 
+def test_direct_initial_block_is_not_auto_promoted(kanban_home: Path) -> None:
+    """A task created directly in ``blocked`` is an intentional human-ops
+    gate, not a dependency-only wait.  It must not silently become dispatchable
+    merely because it has no parent edges."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="awaiting human operational approval",
+            initial_status="blocked",
+        )
+
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_direct_initial_block_with_all_parents_done_requires_unblock(
+    kanban_home: Path,
+) -> None:
+    """Completed dependencies never override an initial human-ops block."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="finished upstream work")
+        assert kb.complete_task(conn, parent, summary="done")
+        child = kb.create_task(
+            conn,
+            title="human-gated child after dependency completion",
+            parents=[parent],
+            initial_status="blocked",
+        )
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child).status == "blocked"
+        assert kb.unblock_task(conn, child) is True
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_direct_initial_block_with_unfinished_parent_requires_unblock(
+    kanban_home: Path,
+) -> None:
+    """An initial human-ops block remains sticky after dispatcher ticks.
+
+    An explicit unblock re-gates the child to ``todo`` while its parent is
+    unfinished; the dispatcher must not make it ready until the dependency
+    completes.  This pins both halves of the API contract.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="upstream work")
+        child = kb.create_task(
+            conn,
+            title="human-gated child",
+            parents=[parent],
+            initial_status="blocked",
+        )
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child).status == "blocked"
+
+        assert kb.unblock_task(conn, child) is True
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child).status == "todo"
+
+
+# ---------------------------------------------------------------------------
+# Circuit-breaker blocks still auto-recover (mutation negative)
+# ---------------------------------------------------------------------------
+
+
+def test_circuit_breaker_block_without_block_event_still_recovers(
+    kanban_home: Path,
+) -> None:
+    """Kill the tempting but wrong mutation: treating every blocked state
+    as sticky would strand circuit-breaker blocks forever.
+
+    This reproduces the circuit-breaker shape: status is ``blocked`` but
+    lifecycle history has no operator ``blocked`` event.  It must promote.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="transient worker failure")
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (tid,))
+        conn.commit()
+
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, tid).status == "ready"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1277,6 +1277,19 @@ class TestPreToolCallModify:
         assert modified == {"path": "/real"}
 
 
+def test_pre_tool_hook_callback_error_propagates_to_fail_closed_dispatch():
+    """Only the enforcement hook must surface callback failure to its caller."""
+    manager = PluginManager()
+
+    def broken_hook(**kwargs):
+        del kwargs
+        raise RuntimeError("sensitive internal error")
+
+    manager._hooks["pre_tool_call"] = [broken_hook]
+    with pytest.raises(RuntimeError, match="sensitive internal error"):
+        manager.invoke_hook("pre_tool_call", tool_name="write_file", args={})
+
+
 class TestGetPreVerifyContinueMessage:
     """`pre_verify` directive aggregation — mirrors the pre_tool_call block path."""
 

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -1,6 +1,7 @@
 """Runtime tests for tool-call loop guardrails."""
 
 import json
+from pathlib import Path
 import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -293,7 +294,7 @@ def test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispat
     assert observed["start"] == expected
     assert observed["dispatch"] == expected
     assert observed["checkpoint"] == [
-        ("/approved/path", "before write_file")
+        (str(Path("/approved/path")), "before write_file")
     ]
 
 
@@ -342,6 +343,47 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     mock_hfc.assert_not_called()
     assert "plugin policy" in messages[0]["content"]
     assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
+
+
+def test_concurrent_executor_blocks_when_pre_tool_hook_dispatch_raises():
+    """The managed/concurrent executor cannot turn hook errors into execution."""
+    agent = _make_agent("web_search")
+    tc = _mock_tool_call("web_search", json.dumps({"query": "test"}), "c-hook-error")
+    messages = []
+
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            side_effect=RuntimeError("sensitive internal error"),
+        ),
+        patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as dispatch,
+    ):
+        agent._execute_tool_calls_concurrent(SimpleNamespace(content="", tool_calls=[tc]), messages, "task-1")
+
+    dispatch.assert_not_called()
+    assert "Tool blocked: pre-tool policy check failed" in messages[0]["content"]
+    assert "sensitive internal error" not in messages[0]["content"]
+
+
+def test_terminal_pre_tool_hook_fires_exactly_once_before_sequential_dispatch():
+    agent = _make_agent("terminal")
+    args = {"command": "git status"}
+    tc = _mock_tool_call("terminal", json.dumps(args), "c-terminal")
+    hook_calls = []
+
+    def observe_hook(name, payload, **kwargs):
+        del kwargs
+        hook_calls.append((name, dict(payload)))
+        return (None, None)
+
+    with (
+        patch("hermes_cli.plugins._dispatch_pre_tool_call_hooks", side_effect=observe_hook),
+        patch("run_agent.handle_function_call", return_value='{"ok":true}') as dispatch,
+    ):
+        agent._execute_tool_calls_sequential(SimpleNamespace(content="", tool_calls=[tc]), [], "task-1")
+
+    assert hook_calls == [("terminal", args)]
+    assert dispatch.call_args.kwargs["skip_pre_tool_call_hook"] is True
 
 
 def test_default_run_conversation_warns_without_guardrail_halt():

--- a/tests/test_dispatch_session_id.py
+++ b/tests/test_dispatch_session_id.py
@@ -73,3 +73,63 @@ class TestSessionIdForwarding:
                 skip_pre_tool_call_hook=True,
             )
         assert captured.get("task_id") == "task-999"
+
+
+def test_model_tools_blocks_when_pre_tool_hook_dispatch_raises():
+    """A hook failure is a policy failure, never a route around the hook."""
+    registry = MagicMock()
+    registry.dispatch.side_effect = AssertionError("underlying tool must not run")
+
+    with (
+        patch("model_tools.registry", registry),
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            side_effect=RuntimeError("sensitive internal error"),
+        ),
+    ):
+        from model_tools import handle_function_call
+        result = handle_function_call("web_search", {"query": "test"}, task_id="t1")
+
+    registry.dispatch.assert_not_called()
+    assert json.loads(result) == {"error": "Tool blocked: pre-tool policy check failed"}
+
+
+def test_agent_runtime_blocks_when_pre_tool_hook_dispatch_raises():
+    """The agent-owned tool path shares the same fail-closed boundary."""
+    from types import SimpleNamespace
+    from agent.agent_runtime_helpers import invoke_tool
+
+    agent = SimpleNamespace(
+        session_id="s1", _current_turn_id="turn-1", _current_api_request_id="request-1",
+        _todo_store=MagicMock(),
+    )
+    with (
+        patch(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            side_effect=RuntimeError("sensitive internal error"),
+        ),
+        patch("tools.todo_tool.todo_tool", side_effect=AssertionError("underlying tool must not run")) as todo,
+    ):
+        result = invoke_tool(agent, "todo", {"todos": []}, "t1")
+
+    todo.assert_not_called()
+    assert json.loads(result) == {"error": "Tool blocked: pre-tool policy check failed"}
+
+
+def test_delegated_child_tool_is_blocked_before_dispatch_when_hook_errors():
+    from types import SimpleNamespace
+    from agent.agent_runtime_helpers import invoke_tool
+
+    child_dispatch = MagicMock(side_effect=AssertionError("child must not run"))
+    agent = SimpleNamespace(
+        session_id="s1", _current_turn_id="turn-1", _current_api_request_id="request-1",
+        _dispatch_delegate_task=child_dispatch,
+    )
+    with patch(
+        "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+        side_effect=RuntimeError("sensitive internal error"),
+    ):
+        result = invoke_tool(agent, "delegate_task", {"goal": "child"}, "t1")
+
+    child_dispatch.assert_not_called()
+    assert json.loads(result) == {"error": "Tool blocked: pre-tool policy check failed"}

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -315,6 +315,9 @@ class TestSafeRestore:
     """
 
     def _checkpoint(self, mgr, work_dir):
+        # Safe restore records writes against a discovered project root. Keep
+        # this fixture rooted locally on every platform.
+        (work_dir / ".git").mkdir(exist_ok=True)
         assert mgr.ensure_checkpoint(str(work_dir), "initial") is True
         mgr.new_turn()
         cps = mgr.list_checkpoints(str(work_dir))
@@ -393,6 +396,166 @@ class TestSafeRestore:
         assert "README.md" in result["skipped_user_edits"]
         assert "agent.txt" in result["restored_files"]
 
+    def test_safe_restore_fails_loudly_when_created_file_cannot_be_removed(self, mgr, work_dir, monkeypatch):
+        """A deletion failure must never produce a successful rollback claim."""
+        base = self._checkpoint(mgr, work_dir)
+        created = work_dir / "agent.txt"
+        created.write_text("agent file\n")
+        mgr.record_agent_write(str(created))
+
+        from tools import checkpoint_manager
+
+        real_run_git = checkpoint_manager._run_git
+
+        def cat_file_reports_absent(command, *args, **kwargs):
+            if command[:2] == ["cat-file", "-e"]:
+                return False, "", ""
+            return real_run_git(command, *args, **kwargs)
+
+        monkeypatch.setattr(checkpoint_manager, "_run_git", cat_file_reports_absent)
+
+        real_unlink = Path.unlink
+        unlink_calls = []
+
+        def locked_unlink(path, *args, **kwargs):
+            if path.name == "agent.txt":
+                unlink_calls.append(str(path))
+                raise PermissionError("simulated Windows sharing violation")
+            return real_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", locked_unlink)
+
+        result = mgr.restore(str(work_dir), base, safe=True)
+
+        assert unlink_calls == [str(created)]
+        assert result["success"] is False
+        assert str(created) in result["error"]
+        assert created.exists()
+        assert "restored_to" not in result
+        assert "restored_files" not in result
+
+    def test_safe_restore_reports_partial_deletions_without_success_fields(
+        self, mgr, work_dir, monkeypatch,
+    ):
+        """A multi-target delete failure reports both completed and untouched paths."""
+        base = self._checkpoint(mgr, work_dir)
+        created = []
+        for name in ("a-agent.txt", "b-agent.txt", "c-agent.txt"):
+            path = work_dir / name
+            path.write_text(f"{name}\n")
+            mgr.record_agent_write(str(path))
+            created.append(path)
+
+        from tools import checkpoint_manager
+
+        real_run_git = checkpoint_manager._run_git
+
+        def cat_file_reports_absent(command, *args, **kwargs):
+            if command[:2] == ["cat-file", "-e"]:
+                return False, "", ""
+            return real_run_git(command, *args, **kwargs)
+
+        monkeypatch.setattr(checkpoint_manager, "_run_git", cat_file_reports_absent)
+        real_unlink = Path.unlink
+        unlink_calls = []
+
+        def fail_second_unlink(path, *args, **kwargs):
+            unlink_calls.append(path.name)
+            if path.name == "b-agent.txt":
+                raise PermissionError("internal sharing diagnostic")
+            return real_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", fail_second_unlink)
+
+        result = mgr.restore(str(work_dir), base, safe=True)
+
+        assert result == {
+            "success": False,
+            "error": f"Restore failed: could not remove '{created[1]}'",
+            "removed_targets": ["a-agent.txt"],
+            "not_attempted_targets": ["c-agent.txt"],
+        }
+        assert unlink_calls == ["a-agent.txt", "b-agent.txt"]
+        assert not created[0].exists()
+        assert created[1].exists()
+        assert created[2].exists()
+        assert "internal sharing diagnostic" not in result["error"]
+        assert len(mgr.list_checkpoints(str(work_dir))) == 2
+
+    def test_safe_restore_treats_unlink_race_as_already_removed(
+        self, mgr, work_dir, monkeypatch,
+    ):
+        """A file disappearing during unlink already satisfies the rollback."""
+        base = self._checkpoint(mgr, work_dir)
+        created = work_dir / "agent.txt"
+        created.write_text("agent file\n")
+        mgr.record_agent_write(str(created))
+
+        from tools import checkpoint_manager
+
+        real_run_git = checkpoint_manager._run_git
+
+        def cat_file_reports_absent(command, *args, **kwargs):
+            if command[:2] == ["cat-file", "-e"]:
+                return False, "", ""
+            return real_run_git(command, *args, **kwargs)
+
+        monkeypatch.setattr(checkpoint_manager, "_run_git", cat_file_reports_absent)
+        real_unlink = Path.unlink
+
+        def disappears_during_unlink(path, *args, **kwargs):
+            if path == created:
+                real_unlink(path, *args, **kwargs)
+                raise FileNotFoundError(path)
+            return real_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", disappears_during_unlink)
+
+        result = mgr.restore(str(work_dir), base, safe=True)
+
+        assert result["success"] is True
+        assert result["restored_files"] == ["agent.txt"]
+        assert not created.exists()
+
+    def test_safe_restore_discloses_nonempty_directory_replacing_agent_file(
+        self, mgr, work_dir,
+    ):
+        """A replacement directory with user content is preserved and disclosed."""
+        base = self._checkpoint(mgr, work_dir)
+        created = work_dir / "agent.txt"
+        created.write_text("agent file\n")
+        mgr.record_agent_write(str(created))
+        created.unlink()
+        created.mkdir()
+        user_file = created / "user-content.txt"
+        user_file.write_text("user content\n")
+
+        result = mgr.restore(str(work_dir), base, safe=True)
+
+        assert result["success"] is True
+        assert result["restored_files"] == []
+        assert result["skipped_user_edits"] == ["agent.txt/user-content.txt"]
+        assert user_file.read_text() == "user content\n"
+
+    def test_safe_restore_reports_empty_directory_replacing_agent_file(
+        self, mgr, work_dir,
+    ):
+        """An empty replacement dir is explicit benign leftover, never a restored file."""
+        base = self._checkpoint(mgr, work_dir)
+        created = work_dir / "agent.txt"
+        created.write_text("agent file\n")
+        mgr.record_agent_write(str(created))
+        created.unlink()
+        created.mkdir()
+
+        result = mgr.restore(str(work_dir), base, safe=True)
+
+        assert result["success"] is True
+        assert result["restored_files"] == []
+        assert result["benign_empty_directories"] == ["agent.txt"]
+        assert created.is_dir()
+        assert "agent.txt" not in result["restored_files"]
+
     def test_unsafe_restore_overwrites_everything(self, mgr, work_dir):
         base = self._checkpoint(mgr, work_dir)
         (work_dir / "main.py").write_text("agent version\n")
@@ -446,8 +609,8 @@ class TestWorkingDirResolution:
         _real_exists = _pl.Path.exists
 
         def _guarded_exists(self):
-            s = str(self)
-            stop = str(tmp_path)
+            s = self.as_posix()
+            stop = tmp_path.as_posix()
             if not s.startswith(stop) and any(
                 s.endswith("/" + m) or s == "/" + m
                 for m in (".git", "pyproject.toml", "package.json",
@@ -486,7 +649,7 @@ class TestGitEnvIsolation:
         env = _git_env(
             store, str(work), index_file=store / "indexes" / "abc",
         )
-        assert env["GIT_INDEX_FILE"].endswith("indexes/abc")
+        assert env["GIT_INDEX_FILE"].endswith(str(Path("indexes") / "abc"))
 
         # ~ in the work tree is expanded.
         tilde_work = fake_home / "work"
@@ -498,6 +661,31 @@ class TestGitEnvIsolation:
 # =========================================================================
 # Error resilience
 # =========================================================================
+
+class TestRetryRemoveReadonly:
+    def test_preserves_existing_permission_bits_when_adding_owner_write(
+        self, monkeypatch,
+    ):
+        from tools import checkpoint_manager
+
+        original_mode = 0o454
+        chmod_modes = []
+        retried = []
+        from types import SimpleNamespace
+
+        fake_os = SimpleNamespace(
+            stat=lambda _path: SimpleNamespace(st_mode=original_mode),
+            chmod=lambda _path, mode: chmod_modes.append(mode),
+        )
+        monkeypatch.setattr(checkpoint_manager, "os", fake_os)
+
+        checkpoint_manager._retry_remove_readonly(
+            lambda path: retried.append(path), "checkpoint-object", None,
+        )
+
+        assert chmod_modes == [original_mode | checkpoint_manager.stat.S_IWRITE]
+        assert retried == ["checkpoint-object"]
+
 
 class TestErrorResilience:
     def test_run_git_allows_expected_nonzero_without_error_log(

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -54,6 +54,7 @@ import logging
 import os
 import re
 import shutil
+import stat
 import subprocess
 import time
 from pathlib import Path
@@ -830,7 +831,7 @@ class CheckpointManager:
         """Classify files changed since ``commit_hash`` for a safe restore.
 
         Returns ``{"success", "restore": [rel...], "skipped": [rel...],
-        "error"?}`` where ``restore`` lists files whose current content
+        "benign_empty_directories": [rel...], "error"?}`` where ``restore`` lists files whose current content
         still matches what Hermes last wrote (per the agent-write ledger)
         and ``skipped`` lists files the user hand-edited after Hermes'
         last write or that Hermes never wrote at all.
@@ -891,7 +892,27 @@ class CheckpointManager:
                 restore.append(rel)
             else:
                 skipped.append(rel)
-        return {"success": True, "restore": restore, "skipped": skipped}
+        empty_directories: List[str] = []
+        root = Path(abs_dir)
+        for path_string in ledger:
+            path = Path(path_string)
+            try:
+                rel = path.relative_to(root).as_posix()
+            except ValueError:
+                continue
+            if path.is_dir() and not path.is_symlink():
+                try:
+                    next(path.iterdir())
+                except StopIteration:
+                    empty_directories.append(rel)
+                except OSError:
+                    continue
+        return {
+            "success": True,
+            "restore": restore,
+            "skipped": skipped,
+            "benign_empty_directories": empty_directories,
+        }
 
     def ensure_checkpoint(self, working_dir: str, reason: str = "auto") -> bool:
         """Take a checkpoint if enabled and not already done this turn.
@@ -1076,6 +1097,10 @@ class CheckpointManager:
         hand-edited after Hermes' last write — per the agent-write ledger —
         are left untouched, and only Hermes-authored changes are reverted.
         The result gains ``skipped_user_edits`` listing the preserved paths.
+        Empty directories replacing an agent-written file are benign untracked
+        leftovers and are listed as ``benign_empty_directories``; they are not
+        reported as restored files.  Unsafe restores use Git checkout and do
+        not remove post-checkpoint untracked files or empty directories.
         """
         hash_err = _validate_commit_hash(commit_hash)
         if hash_err:
@@ -1101,6 +1126,7 @@ class CheckpointManager:
                     "debug": err or None}
 
         skipped_user_edits: List[str] = []
+        benign_empty_directories: List[str] = []
         restore_paths: Optional[List[str]] = None
         if safe and not file_path:
             plan = self.safe_restore_plan(abs_dir, commit_hash)
@@ -1113,8 +1139,9 @@ class CheckpointManager:
             else:
                 restore_paths = plan["restore"]
                 skipped_user_edits = plan["skipped"]
+                benign_empty_directories = plan.get("benign_empty_directories", [])
                 if not restore_paths:
-                    return {
+                    result = {
                         "success": True,
                         "restored_to": commit_hash[:8],
                         "reason": "nothing to restore (all changed files were user-edited)",
@@ -1122,6 +1149,9 @@ class CheckpointManager:
                         "restored_files": [],
                         "skipped_user_edits": skipped_user_edits,
                     }
+                    if benign_empty_directories:
+                        result["benign_empty_directories"] = benign_empty_directories
+                    return result
 
         # Take a pre-rollback snapshot so you can undo the undo.
         self._take(abs_dir, f"pre-rollback snapshot (restoring to {commit_hash[:8]})")
@@ -1140,13 +1170,24 @@ class CheckpointManager:
                     store, abs_dir, allowed_returncodes={1, 128},
                 )
                 (checkout_targets if ok_in_commit else delete_targets).append(rel)
-            for rel in delete_targets:
+            removed_targets: List[str] = []
+            for index, rel in enumerate(delete_targets):
+                target = Path(abs_dir) / rel
                 try:
-                    target = Path(abs_dir) / rel
                     if target.is_file() or target.is_symlink():
                         target.unlink()
+                    removed_targets.append(rel)
+                except FileNotFoundError:
+                    # The desired rollback state is already absent.
+                    removed_targets.append(rel)
                 except OSError as exc:
                     logger.debug("Safe restore: could not remove %s: %s", rel, exc)
+                    return {
+                        "success": False,
+                        "error": f"Restore failed: could not remove '{target}'",
+                        "removed_targets": removed_targets,
+                        "not_attempted_targets": delete_targets[index + 1:],
+                    }
             if not checkout_targets:
                 ok, stdout, err = True, "", ""
             else:
@@ -1182,6 +1223,8 @@ class CheckpointManager:
         if restore_paths is not None:
             result["restored_files"] = restore_paths
             result["skipped_user_edits"] = skipped_user_edits
+            if benign_empty_directories:
+                result["benign_empty_directories"] = benign_empty_directories
         return result
 
     def get_working_dir_for_path(self, file_path: str) -> str:
@@ -2123,6 +2166,12 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
     return out
 
 
+def _retry_remove_readonly(func, path, exc_info) -> None:
+    """Retry a failed removal after adding Windows' owner-write permission."""
+    os.chmod(path, os.stat(path).st_mode | stat.S_IWRITE)
+    func(path)
+
+
 def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
     """Nuke the entire checkpoint base (store + legacy).  Irreversible.
 
@@ -2134,7 +2183,7 @@ def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
         return out
     size = _dir_size_bytes(base)
     try:
-        shutil.rmtree(base)
+        shutil.rmtree(base, onerror=_retry_remove_readonly)
         out["bytes_freed"] = size
         out["deleted"] = True
     except OSError as exc:


### PR DESCRIPTION
## Summary
- Replaces Kira v1 remote Gmail-draft paths with a default-off, local immutable direct-body request and sender boundary.
- Requires configured Ops-space, exact Google Chat `users/<id>` approver identity, verified credential, request/hash match, durable decision, and a local atomic claim before Router dispatch.
- Uses only direct Router provider calls with the `rlord` account alias; preserves reply-thread provenance, immutable hash validation, lease-scoped recovery, terminal/audit records, and fail-closed provider schema handling.

## Verification
- `HERMES_PYTHON='C:/Users/jat00/AppData/Local/hermes/venvs/kira-v2-20260828/Scripts/python.exe' scripts/run_tests.sh tests/gateway/test_kira_email_approval.py tests/gateway/test_kira_v2_contract.py tests/gateway/test_google_chat.py` — 83 passed
- `python -m ty check plugins/platforms/google_chat/kira_email_approval.py` — passed
- `python -m ruff check plugins/platforms/google_chat/adapter.py plugins/platforms/google_chat/kira_email_approval.py tests/gateway/test_kira_email_approval.py tests/gateway/test_kira_v2_contract.py tests/gateway/test_google_chat.py` — passed
- `git diff --check` — passed

## Independent review
`C:\Users\jat00\AppData\Local\hermes\kanban\workspaces\t_d17b04fd\review-kira-v2-direct-sender.verdict.md`

VERDICT: UNREVIEWED (codex: failed: TIMEOUT after 300s; claude: ran: no VERDICT line)

No live Gmail send, OAuth/scope change, deployment, restart, vendor contact, or permission change was performed.