### PR TITLE
fix(tools): handle multimodal and non-string content in tool result storage and turn budget

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -298,6 +298,41 @@ class TestEnforceTurnBudget:
         result = enforce_turn_budget([], env=None, config=BudgetConfig(turn_budget=200_000))
         assert result == []
 
+    def test_multimodal_list_content_in_turn_budget(self):
+        """Multimodal list messages must not crash turn budget enforcement and should have their text lengths counted."""
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        multimodal_msg = {
+            "role": "tool",
+            "tool_call_id": "img1",
+            "content": [
+                {"type": "text", "text": "a" * 150_000},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        }
+        string_msg = {
+            "role": "tool",
+            "tool_call_id": "txt1",
+            "content": "b" * 100_000,
+        }
+        msgs = [multimodal_msg, string_msg]
+        # Total text size is 250K > 200K budget. The string message must be persisted, and the multimodal message preserved.
+        result = enforce_turn_budget(msgs, env=env, config=BudgetConfig(turn_budget=200_000))
+        assert result[0] is multimodal_msg
+        assert isinstance(result[0]["content"], list)
+        assert PERSISTED_OUTPUT_TAG in result[1]["content"]
+
+    def test_maybe_persist_non_string_returns_unmodified(self):
+        """Non-string tool results (e.g. list/None) should be returned unmodified without raising TypeError."""
+        multimodal_content = [{"type": "text", "text": "hello"}]
+        res = maybe_persist_tool_result(
+            content=multimodal_content,
+            tool_name="view_image",
+            tool_use_id="use_123",
+            threshold=0,
+        )
+        assert res == multimodal_content
+
 
 # ── Per-tool threshold integration ────────────────────────────────────
 

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -336,6 +336,9 @@ def maybe_persist_tool_result(
     Returns:
         Original content if small, or <persisted-output> replacement.
     """
+    if not isinstance(content, str):
+        return content
+
     effective_threshold = threshold if threshold is not None else config.resolve_threshold(tool_name)
 
     if effective_threshold == float("inf"):
@@ -412,11 +415,18 @@ def enforce_turn_budget(
     candidates = []
     total_size = 0
     for i, msg in enumerate(tool_messages):
+        if not isinstance(msg, dict):
+            continue
         content = msg.get("content", "")
-        size = len(content)
-        total_size += size
-        if PERSISTED_OUTPUT_TAG not in content:
-            candidates.append((i, size))
+        if isinstance(content, str):
+            size = len(content)
+            total_size += size
+            if PERSISTED_OUTPUT_TAG not in content:
+                candidates.append((i, size))
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    total_size += len(part["text"])
 
     if total_size <= config.turn_budget:
         return tool_messages
@@ -427,7 +437,9 @@ def enforce_turn_budget(
         if total_size <= config.turn_budget:
             break
         msg = tool_messages[idx]
-        content = msg["content"]
+        content = msg.get("content")
+        if not isinstance(content, str):
+            continue
         tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
 
         replacement = maybe_persist_tool_result(


### PR DESCRIPTION
## What does this PR do?

Fixes a tool result storage crash and turn budget corruption bug in [`tools/tool_result_storage.py`](file:///c:/Users/EricM/Dev/hermes-agent/tools/tool_result_storage.py) where `maybe_persist_tool_result()` and `enforce_turn_budget()` fail to handle multimodal or list-structured tool results, causing `TypeError: data must be str, not list` when writing to host/sandbox files and calculating corrupted turn character sizes (`len(list)` instead of summing text part lengths).

In Hermes Agent:
1. Multimodal and structured tool outputs (e.g. browser screenshots, vision inspect, PDF renders) have `content` formatted as a list of parts: `[{"type": "text", "text": "..."}, {"type": "image_url", ...}]`.
2. `maybe_persist_tool_result()` assumed `content` was always `str`. When receiving a `list`, `len(content)` checked list length (e.g. 2 <= threshold) and if forced to persist, `host_path.write_text(content)` crashed with `TypeError: data must be str, not list`.
3. `enforce_turn_budget()` iterated over `tool_messages` without checking `isinstance(content, str)`. For list content:
   - `size = len(content)` computed the number of content parts (e.g. 2) rather than actual text character count.
   - `PERSISTED_OUTPUT_TAG not in content` evaluated to `True` (list item membership).
   - When turn budget was exceeded, it passed list content into `maybe_persist_tool_result()`, triggering the `TypeError` crash.

The fix:
- Adds an early return in `maybe_persist_tool_result()`: `if not isinstance(content, str): return content`.
- Updates `enforce_turn_budget()` to compute character length by summing `text` parts of list-structured messages and ensures only string-content messages are considered candidates for disk persistence.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tool_result_storage.py`: Guarded `maybe_persist_tool_result()` against non-string inputs and updated `enforce_turn_budget()` to accurately accumulate text part lengths for multimodal messages while candidate-filtering for strings.
- `tests/tools/test_tool_result_storage.py`: Added unit tests verifying `test_multimodal_list_content_in_turn_budget` and `test_maybe_persist_non_string_returns_unmodified`.

## How to Test

Run the tool result storage and dispatch tests:
```bash
uv run --with pytest pytest tests/agent/test_tool_dispatch_helpers.py tests/tools/test_tool_result_storage.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tools): handle multimodal and non-string content in tool result storage and turn budget`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 70 items

tests/agent/test_tool_dispatch_helpers.py .............................. [ 42%]
tests/tools/test_tool_result_storage.py ........................................ [100%]

============================= 70 passed in 5.54s ==============================
```
