### PR TITLE
fix(tui-gateway): keep the WebSocket open when a frame has a lone surrogate

### DIFF
--- a/tests/tui_gateway/test_ws_surrogate_send.py
+++ b/tests/tui_gateway/test_ws_surrogate_send.py
@@ -1,0 +1,63 @@
+"""Lone UTF-16 surrogates must not tear down the Desktop WebSocket (#97288)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from tui_gateway.ws import WSTransport, _sanitize_ws_text
+
+
+LONE_SURROGATE = "\ud83d"
+
+
+def test_sanitize_ws_text_makes_utf8_encodable() -> None:
+    dirty = f"gateway.ready {LONE_SURROGATE} payload"
+    out = _sanitize_ws_text(dirty)
+    out.encode("utf-8")
+    assert LONE_SURROGATE not in out
+
+
+def test_sanitize_ws_text_leaves_valid_text_unchanged() -> None:
+    clean = '{"type":"gateway.ready","ok":true}'
+    assert _sanitize_ws_text(clean) is clean or _sanitize_ws_text(clean) == clean
+
+
+class _FakeWS:
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.raise_on: str | None = None
+
+    async def send_text(self, line: str) -> None:
+        line.encode("utf-8")
+        if self.raise_on is not None and self.raise_on in line:
+            raise UnicodeEncodeError("utf-8", line, 0, 1, "surrogates not allowed")
+        self.sent.append(line)
+
+
+def test_safe_send_sanitizes_surrogate_and_keeps_connection() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _FakeWS()
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        dirty = f'{{"type":"gateway.ready","x":"{LONE_SURROGATE}"}}'
+        await transport._safe_send_many(["first", dirty, "third"])
+        assert transport.closed is False
+        assert ws.sent[0] == "first"
+        assert ws.sent[-1] == "third"
+        assert LONE_SURROGATE not in "".join(ws.sent)
+        assert len(ws.sent) == 3
+
+    asyncio.run(_run())
+
+
+def test_unicode_encode_error_does_not_close_socket() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _FakeWS()
+        ws.raise_on = "BOOM"
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        await transport._safe_send_many(["ok-a", "BOOM-frame", "ok-b"])
+        assert transport.closed is False
+        assert ws.sent == ["ok-a", "ok-b"]
+
+    asyncio.run(_run())

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -37,6 +37,24 @@ from tui_gateway.event_replay import replay_epoch
 
 _log = logging.getLogger(__name__)
 
+
+def _sanitize_ws_text(text: str) -> str:
+    """Return *text* that can be UTF-8 encoded for a WebSocket frame.
+
+    Python ``str`` may contain lone UTF-16 surrogates (``\\ud800``-``\\udfff``)
+    that ``json.dumps(..., ensure_ascii=False)`` will happily emit. Starlette
+    then encodes the frame as UTF-8 and raises ``UnicodeEncodeError``, which
+    used to latch the whole connection closed (#97288). Replace those
+    code points rather than dropping the connection.
+    """
+    if not text:
+        return text
+    try:
+        text.encode("utf-8")
+    except UnicodeEncodeError:
+        return text.encode("utf-8", "replace").decode("utf-8")
+    return text
+
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler
 # threads from a wedged socket.
@@ -253,20 +271,30 @@ class WSTransport:
         async with self._send_lock:
             if self._closed:
                 return
-            try:
-                for line in lines:
-                    if self._closed:
-                        return
-                    await self._ws.send_text(line)
-            except Exception as exc:
-                # Latch while still holding the writer lock so queued batches
-                # observe the failure before they get a chance to touch the
-                # socket.
-                self._closed = True
-                _log.warning(
-                    "ws send failed peer=%s error_type=%s error=%s",
-                    self._peer, type(exc).__name__, exc,
-                )
+            for line in lines:
+                if self._closed:
+                    return
+                payload = _sanitize_ws_text(line)
+                try:
+                    await self._ws.send_text(payload)
+                except UnicodeEncodeError as exc:
+                    # A single illegal UTF-8 frame (lone surrogate in a
+                    # status/ready payload) must not tear down the socket.
+                    # Fresh Desktop installs looped on this (#97288).
+                    _log.warning(
+                        "ws send skipped invalid utf-8 frame peer=%s error=%s",
+                        self._peer, exc,
+                    )
+                    continue
+                except Exception as exc:
+                    # Latch while still holding the writer lock so queued
+                    # batches observe the failure before they touch the socket.
+                    self._closed = True
+                    _log.warning(
+                        "ws send failed peer=%s error_type=%s error=%s",
+                        self._peer, type(exc).__name__, exc,
+                    )
+                    return
 
     def close(self) -> None:
         self._closed = True


### PR DESCRIPTION
## What does this PR do?

Desktop WebSocket send encodes frames as UTF-8. A lone UTF-16 surrogate (`\ud83d`) in an early gateway payload (fresh install, no user data) raised `UnicodeEncodeError` inside `_safe_send_many`, which latched `_closed = True` and tore the connection down. The client then looped on "Hermes gateway connection closed".

Sanitize each frame so it is UTF-8-encodable, and if `send_text` still raises `UnicodeEncodeError`, skip that frame instead of closing the socket. Real socket errors still latch the transport closed.

## Related Issue

Fixes #97288

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tui_gateway/ws.py`: `_sanitize_ws_text` + per-frame `UnicodeEncodeError` handling in `_safe_send_many`
- `tests/tui_gateway/test_ws_surrogate_send.py`: surrogate payload stays encodable; encode errors do not close the socket; later frames still send

## How to Test

```text
PYTHONPATH=. python -m pytest tests/tui_gateway/test_ws_surrogate_send.py tests/tui_gateway/test_ws_keepalive.py -q
# 6 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (unit tests; the original report is Desktop on macOS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
