### PR TITLE
fix(cli): a rate-limited kanban worker was recorded as a protocol violation (exit 75 only existed on the -Q path)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4006,6 +4006,47 @@ def _interrupt_agent_for_signal(agent, signum) -> None:
         pass  # never block signal handling
 
 
+# Classified failure reasons that mean "the provider walled us off", not "the
+# task is broken". Kept as the tuple the ``-Q`` worker path has always used;
+# ``upstream_rate_limit`` is deliberately NOT here — a per-model 429 from an
+# aggregator can be durable for that model, and requeueing on it would spin.
+_QUOTA_WALL_FAILURE_REASONS = ("rate_limit", "billing")
+
+
+def _kanban_quota_wall_exit_code(result):
+    """Exit status for a kanban worker that died on a provider quota wall.
+
+    Returns ``KANBAN_RATE_LIMIT_EXIT_CODE`` (EX_TEMPFAIL) for that case and
+    ``None`` for every other, which leaves the caller's own 0/1 contract alone.
+
+    A worker's exit status is the ONLY thing the dispatcher's reap classifier
+    can read — it holds a pid, not a transcript — so the quota wall has to be
+    spelled in that one byte. The classifier maps the sentinel to a
+    ``rate_limited`` exit and releases the task back to ``ready`` WITHOUT
+    incrementing the failure counter, so a long quota window cannot trip the
+    circuit breaker. Exit 0 instead and the dispatcher sees a clean exit while
+    the task is still ``running`` — a PROTOCOL VIOLATION — and counts a failure
+    against a worker that did nothing wrong.
+
+    Only kanban workers get this: ``HERMES_KANBAN_TASK`` is the dispatcher's own
+    marker, and other one-shot runs keep the plain contract automation wrappers
+    expect.
+    """
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return None
+    if not isinstance(result, dict) or not result.get("failed"):
+        return None
+    if result.get("failure_reason") not in _QUOTA_WALL_FAILURE_REASONS:
+        return None
+    try:
+        from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+    except Exception:
+        # Never let a missing import turn a throttle into a crash; the generic
+        # code still beats no exit at all.
+        return None
+    return KANBAN_RATE_LIMIT_EXIT_CODE
+
+
 def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     """Drive a kanban goal_mode worker through ``goals.run_kanban_goal_loop`` after its first turn.
 
@@ -4107,13 +4148,8 @@ def _run_quiet_single_query(cli, effective_query):
     # the task without counting a failure (a quota window must not trip the breaker).
     _exit_code = 0
     if isinstance(result, dict) and result.get("failed"):
-        _exit_code = 1
-        if os.environ.get("HERMES_KANBAN_TASK") and result.get("failure_reason") in ("rate_limit", "billing"):
-            try:
-                from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE
-                _exit_code = _RL_CODE
-            except Exception:
-                _exit_code = 1
+        _quota_wall = _kanban_quota_wall_exit_code(result)
+        _exit_code = 1 if _quota_wall is None else _quota_wall
     sys.exit(_exit_code)
 
 
@@ -4432,6 +4468,15 @@ def _run_single_query_mode(cli, query, image, quiet, oneshot):
         cli._show_security_advisories()
         cli.chat(query, images=single_query_images or None)
         cli._print_exit_summary(clear_screen=False)
+        # The same worker contract as the ``-Q`` branch above, on THIS path too.
+        # Workers are only spawned with ``-Q`` in goal mode, so an ordinary card
+        # runs right here — and exiting 0 made the dispatcher read a protocol
+        # violation and count a failure against a card whose provider had
+        # merely throttled it. ``chat()`` returns response text, so the turn's
+        # structured verdict is parked on the CLI (see the mixin's store).
+        _quota_wall = _kanban_quota_wall_exit_code(getattr(cli, "_last_turn_result", None))
+        if _quota_wall is not None:
+            sys.exit(_quota_wall)
     finally:
         _finalize_single_query(cli)
 

--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -458,6 +458,12 @@ class CLIChatTurnMixin:
         time.sleep(0.15)
         if turn.result:
             self.conversation_history = turn.result.get("messages", self.conversation_history)
+            # Keep the turn's structured verdict reachable after ``chat()``
+            # returns: it yields the response TEXT, and the one-shot caller in
+            # ``main()`` needs ``failure_reason`` to spell a kanban worker's
+            # quota wall in the process exit status. This is the only scope
+            # where the agent thread's result dict is in hand.
+            self._last_turn_result = turn.result
         # Mid-turn auto-compression continues in a child session: sync so /status, /resume,
         # titling and the exit summary target the live child, not the ended parent.
         if (self.agent and getattr(self.agent, "session_id", None)

--- a/tests/cli/test_kanban_worker_quota_wall_exit.py
+++ b/tests/cli/test_kanban_worker_quota_wall_exit.py
@@ -1,0 +1,166 @@
+"""A kanban worker that hits a provider quota wall must SAY so in its exit status.
+
+The dispatcher's reap classifier holds a pid, not a transcript: exit status is
+the only channel. ``KANBAN_RATE_LIMIT_EXIT_CODE`` (75, EX_TEMPFAIL) means "the
+provider walled me off" and releases the task back to ``ready`` without counting
+a failure. Exit 0 instead and the dispatcher sees a clean exit while the task is
+still ``running`` — a protocol violation — and counts a failure against a worker
+that did nothing wrong. Three cards on a live board were blocked exactly that
+way, nine runs burned, every log ending in ``API call failed after 3 retries:
+HTTP 429``.
+
+The producer existed but only on the ``-Q`` branch of the one-shot path, and
+workers are spawned with ``-Q`` only in goal mode — so an ordinary card never
+reached it. These tests pin the decision (one helper) and the wiring (both
+one-shot paths ask it).
+
+Port note: since the cli.py god-file split, the two one-shot exits live in
+``_run_quiet_single_query`` and ``_run_single_query_mode`` rather than inline in
+``main()``, and the interactive turn's verdict is parked on the CLI by
+``hermes_cli/cli_chat_turn_mixin.py``. The guards follow the code.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+import cli as cli_module
+from hermes_cli import cli_chat_turn_mixin
+from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+
+CLI_SOURCE = Path(cli_module.__file__).read_text(encoding="utf-8")
+MIXIN_SOURCE = Path(cli_chat_turn_mixin.__file__).read_text(encoding="utf-8")
+
+
+def _rate_limited_result() -> dict:
+    return {
+        "final_response": "API call failed after 3 retries: HTTP 429",
+        "failed": True,
+        "completed": False,
+        "error": "HTTP 429: The service may be temporarily overloaded",
+        "failure_reason": "rate_limit",
+    }
+
+
+@pytest.mark.parametrize("reason", ["rate_limit", "billing"])
+def test_a_quota_wall_reports_the_tempfail_sentinel(monkeypatch, reason):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_deadbeef")
+    result = {**_rate_limited_result(), "failure_reason": reason}
+    assert cli_module._kanban_quota_wall_exit_code(result) == KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+def test_only_a_kanban_worker_gets_the_sentinel(monkeypatch):
+    """Other one-shot runs keep the plain contract automation wrappers expect."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    assert cli_module._kanban_quota_wall_exit_code(_rate_limited_result()) is None
+
+
+def test_a_real_failure_is_not_laundered_into_a_throttle(monkeypatch):
+    """The breaker must still see failures the task itself caused.
+
+    This is the assertion that keeps the fix from becoming a way for every
+    failure to dodge the failure counter.
+    """
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_deadbeef")
+    for reason in ("server_error", "timeout", "auth_permanent", "upstream_rate_limit", None):
+        result = {**_rate_limited_result(), "failure_reason": reason}
+        assert cli_module._kanban_quota_wall_exit_code(result) is None, reason
+
+
+def test_a_successful_turn_is_not_a_quota_wall(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_deadbeef")
+    # `failure_reason` can be carried by a turn that did NOT fail (a retry that
+    # later succeeded); the `failed` flag is what makes it terminal.
+    for result in (
+        {"failed": False, "failure_reason": "rate_limit"},
+        {"completed": True, "failure_reason": "rate_limit"},
+        {},
+        None,
+        "not a dict",
+        42,
+    ):
+        assert cli_module._kanban_quota_wall_exit_code(result) is None, repr(result)
+
+
+def test_the_quota_wall_reasons_are_named_in_exactly_one_place():
+    """Two copies of this tuple is how the two paths drifted apart in the first place."""
+    definitions = re.findall(r"^_QUOTA_WALL_FAILURE_REASONS\s*=", CLI_SOURCE, re.M)
+    assert len(definitions) == 1
+    inline = re.findall(r'\(\s*"rate_limit"\s*,\s*"billing"\s*\)', CLI_SOURCE)
+    assert len(inline) == 1, (
+        "the quota-wall reasons appear inline somewhere besides "
+        "_QUOTA_WALL_FAILURE_REASONS — the decision has been copied again"
+    )
+
+
+def _module_functions(source: str):
+    return {
+        node.name: node
+        for node in ast.parse(source).body
+        if isinstance(node, ast.FunctionDef)
+    }
+
+
+def test_both_one_shot_paths_ask_the_helper():
+    """The defect was an asymmetry, so the guard is about BOTH one-shot paths.
+
+    This reads the source: the two exits live deep inside functions that build a
+    whole CLI before reaching them, so there is no honest way to exercise them
+    in-process. What IS worth pinning is that neither path decides this for
+    itself: exactly one call inside each of the two one-shot runners, and no
+    third copy anywhere else in the module.
+    """
+    functions = _module_functions(CLI_SOURCE)
+    for name in ("_run_quiet_single_query", "_run_single_query_mode"):
+        assert name in functions, f"one-shot runner {name} moved again — repin this guard"
+    calls = {
+        name: [
+            node
+            for node in ast.walk(func)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_kanban_quota_wall_exit_code"
+        ]
+        for name, func in functions.items()
+        if name in ("_run_quiet_single_query", "_run_single_query_mode")
+    }
+    for name, sites in calls.items():
+        assert len(sites) == 1, f"expected exactly one helper call in {name}, found {len(sites)}"
+    total = sum(
+        len(
+            [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "_kanban_quota_wall_exit_code"
+            ]
+        )
+        for tree in ast.parse(CLI_SOURCE).body
+    )
+    assert total == 2, f"the helper is called {total}x module-wide — a third path grew its own copy"
+
+
+def test_the_human_path_can_reach_the_turns_verdict():
+    """``chat()`` returns response TEXT, so the verdict has to be parked on the CLI.
+
+    Without the mixin's assignment the human path reads ``None``, the helper
+    answers "not a quota wall", and the worker exits 0 again — the original bug,
+    with the fix in place and inert. The one-shot caller reads it back through
+    ``getattr(cli, "_last_turn_result", None)``.
+    """
+    stores = [
+        node for node in ast.walk(ast.parse(MIXIN_SOURCE))
+        if isinstance(node, ast.Attribute)
+        and node.attr == "_last_turn_result"
+        and isinstance(node.ctx, ast.Store)
+    ]
+    assert stores, "the mixin no longer assigns cli._last_turn_result"
+    reads = [
+        node for node in ast.walk(ast.parse(CLI_SOURCE))
+        if isinstance(node, ast.Constant) and node.value == "_last_turn_result"
+    ]
+    assert reads, "nothing reads cli._last_turn_result on the one-shot path"


### PR DESCRIPTION
Three cards on a live board sat blocked with `worker exited cleanly (rc=0) without calling kanban_complete or kanban_block — protocol violation`. Nine runs between them, every worker log ending the same way:

```
❌ API failed after 3 retries — HTTP 429: The service may be temporarily overloaded, please try again later
```

The worker did nothing wrong. The provider walled it off, and the exit status said "clean exit" — so the dispatcher, which holds a pid and not a transcript, read the only channel it has and concluded the worker had skipped the protocol. Each one counted a failure until the card was blocked.

## The contract already existed, on one of two paths

`KANBAN_RATE_LIMIT_EXIT_CODE` (75, `EX_TEMPFAIL`) means "quota wall, not a task error"; the reap classifier maps it to a `rate_limited` exit and releases the task back to `ready` **without** incrementing the failure counter, so a long quota window cannot trip the circuit breaker. `run_conversation` already returns `failure_reason` (`agent/conversation_loop.py`) for exactly this purpose.

That consumer lives in the `-Q` branch of the one-shot path (`_run_quiet_single_query` in `cli.py`). Workers are spawned with `-Q` only in goal mode (`if task.goal_mode` in `_worker_argv`, used by `_default_spawn`), so an ordinary card — `goal_mode=0`, the common case — runs the human-facing branch of `_run_single_query_mode` instead: `cli.chat(...)`, `_print_exit_summary()`, return. No exit-code logic at all, so the process exits 0. All three blocked cards had `goal_mode=0`.

## What changes

- The decision moves into `_kanban_quota_wall_exit_code(result)` and **both** one-shot runners (`_run_quiet_single_query` and `_run_single_query_mode`) ask it. It returns the sentinel only for a kanban worker whose turn failed on a quota-wall reason, and `None` otherwise — leaving each caller's own 0/1 contract untouched, so non-kanban one-shot runs behave exactly as before.
- `chat()` (in `hermes_cli/cli_chat_turn_mixin.py`) parks the turn's result on the CLI as `_last_turn_result`. It returns the response *text*, and the human path needs `failure_reason`; the assignment sits where the agent thread's dict is already in hand, beside the existing `conversation_history` update.
- `upstream_rate_limit` is deliberately **not** a quota-wall reason. The tuple is the one the `-Q` path has always used, and a per-model 429 from an aggregator can be durable for that model — requeueing on it would spin. Widening it is a separate decision with its own risk.

## Relationship to #85083

Not a mechanism-level duplicate (no shared files; merges cleanly in either order), though both close the same user-visible bug. #85083 makes `_default_spawn` always pass `-Q`, so dispatcher-spawned workers land on the branch that already exits 75. This PR fixes the exit semantics where they are decided, so any kanban worker running under `HERMES_KANBAN_TASK` without `-Q` (manual run, other tooling, a future spawn path) also exits 75 instead of 0. Keeping both is harmless.

## Verification

8 new tests in `tests/cli/test_kanban_worker_quota_wall_exit.py` (all pass on the rebased branch; neighbours `tests/cli/test_chat_q_exit_clear.py`, `tests/cli/test_single_query_session_finalize.py`, `tests/hermes_cli/test_kanban_db.py`, `tests/hermes_cli/test_kanban_worker_spawn_toolsets.py` green; ruff clean on the changed files).

Mutation-verified: **5 mutants, 0 survivors** — dropping the human-path call; dropping the `_last_turn_result` assignment (which would leave the fix in place and inert); dropping the worker-only env guard; dropping the reason check; restoring the inline tuple in the `-Q` branch. Each is killed by a different assertion.

The negative assertion is the one that matters most: a `server_error`, `timeout`, `auth_permanent` or `upstream_rate_limit` failure must **not** be laundered into a throttle, or the breaker stops seeing failures the task itself caused.

Two tests read the source rather than run it. Since the `cli.py` split, the two one-shot exits live in `_run_quiet_single_query` and `_run_single_query_mode`, which still build a whole CLI before reaching them, so there is no honest way to exercise them in-process — and what is worth pinning is structural anyway: that the reasons are named in exactly one place, and that both runners ask the helper (exactly one call each, two module-wide). The producer side of this contract had **no test at all** before, which is how the asymmetry survived.
