### PR TITLE
fix(gateway): send WebSocket readiness without executor wait

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -326,8 +326,8 @@ def _warm_gateway_module() -> None:
     RPC burst (``setup.status``, ``setup.runtime_check``,
     ``gateway.ready``→``resolve_skin``) pull in several *other* heavy
     chains that were still imported on the loop thread, contributing to
-    the ~14s cold-start stall (#60800). Warm them all here so the cost
-    is paid in a worker thread while the server socket is already open.
+    the ~14s cold-start stall (#60800). Warm them all before the lifespan
+    yields so the first connection is never exposed to that import cost.
     """
     for mod in (
         "hermes_cli.gateway",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -352,6 +352,16 @@ def _warm_gateway_module() -> None:
         except Exception:
             pass
 
+    # Prime the no-I/O snapshot used by gateway.ready. This happens before the
+    # lifespan yields (and therefore before sockets are accepted), so a busy
+    # default executor can never hold the liveness frame hostage later.
+    try:
+        from tui_gateway import server as gateway_server
+
+        gateway_server.resolve_skin()
+    except Exception:
+        pass
+
 
 def _resolve_restart_drain_timeout() -> float:
     try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -337,10 +337,9 @@ def _warm_gateway_module() -> None:
         "hermes_cli.auth",
         "hermes_cli.copilot_auth",
         "hermes_cli.runtime_provider",
-        # resolve_skin() reads config + initialises the skin engine.
-        # Even though handle_ws now calls it via asyncio.to_thread
-        # (see tui_gateway/ws.py), warming it here avoids the first-call
-        # import cost inside that thread.
+        # resolve_skin() reads config + initialises the skin engine. Standalone
+        # cold-cache paths still resolve it in a background thread; warming the
+        # module here avoids first-call import cost inside that fallback.
         "hermes_cli.skin_engine",
         # model.options / picker context — parses provider catalogs and
         # the models.dev cache on first use.

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -200,9 +200,9 @@ def test_ws_ready_does_not_wait_for_skin_resolution(monkeypatch):
         try:
             # The ready frame must beat the blocked skin lookup.  This times out
             # on the old implementation, which awaited to_thread(resolve_skin).
-            await asyncio.wait_for(ready_seen.wait(), timeout=0.25)
+            await asyncio.wait_for(ready_seen.wait(), timeout=2)
             assert not release_skin.is_set()
-            assert await asyncio.to_thread(skin_started.wait, 0.5)
+            assert await asyncio.to_thread(skin_started.wait, 2)
         finally:
             release_skin.set()
             disconnect.set()
@@ -265,9 +265,9 @@ def test_concurrent_cold_ws_connections_share_one_skin_refresh(monkeypatch):
         try:
             await asyncio.wait_for(
                 asyncio.gather(*(ready.wait() for ready in ready_events)),
-                timeout=0.25,
+                timeout=2,
             )
-            assert await asyncio.to_thread(skin_started.wait, 0.5)
+            assert await asyncio.to_thread(skin_started.wait, 2)
             assert calls == 1
         finally:
             release_skin.set()

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -153,6 +153,133 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     assert events == ["accept", "ready_after_0"]
 
 
+def test_ws_ready_does_not_wait_for_skin_resolution(monkeypatch):
+    """A slow/default-executor skin lookup must not delay the liveness frame.
+
+    The Desktop starts its ready timeout as soon as the socket opens.  Waiting
+    for ``resolve_skin`` here turns unrelated worker saturation into a false
+    "Runtime not ready" failure and every reconnect adds another queued lookup.
+    """
+    skin_started = threading.Event()
+    release_skin = threading.Event()
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+    # These attributes are introduced by the fix.  ``raising=False`` keeps this
+    # test runnable against the pre-fix implementation for the RED assertion.
+    monkeypatch.setattr(server, "get_cached_skin_payload", lambda: {}, raising=False)
+    monkeypatch.setattr(ws_mod, "_skin_refresh_task", None, raising=False)
+
+    def blocking_resolve_skin():
+        skin_started.set()
+        assert release_skin.wait(timeout=2)
+        return {"name": "late-skin"}
+
+    monkeypatch.setattr(server, "resolve_skin", blocking_resolve_skin)
+
+    async def scenario():
+        ready_seen = asyncio.Event()
+        disconnect = asyncio.Event()
+
+        class FakeWS:
+            async def accept(self):
+                pass
+
+            async def send_text(self, line):
+                frame = json.loads(line)
+                if frame.get("params", {}).get("type") == "gateway.ready":
+                    ready_seen.set()
+
+            async def receive_text(self):
+                await disconnect.wait()
+                raise ws_mod._WebSocketDisconnect()
+
+            async def close(self):
+                pass
+
+        task = asyncio.create_task(ws_mod.handle_ws(FakeWS()))
+        try:
+            # The ready frame must beat the blocked skin lookup.  This times out
+            # on the old implementation, which awaited to_thread(resolve_skin).
+            await asyncio.wait_for(ready_seen.wait(), timeout=0.25)
+            assert not release_skin.is_set()
+            assert await asyncio.to_thread(skin_started.wait, 0.5)
+        finally:
+            release_skin.set()
+            disconnect.set()
+            await asyncio.wait_for(task, timeout=2)
+            refresh = getattr(ws_mod, "_skin_refresh_task", None)
+            if refresh is not None:
+                await asyncio.wait_for(asyncio.shield(refresh), timeout=2)
+
+    asyncio.run(scenario())
+
+
+def test_concurrent_cold_ws_connections_share_one_skin_refresh(monkeypatch):
+    """Reconnect bursts must collapse cache misses into one background lookup."""
+    calls = 0
+    calls_lock = threading.Lock()
+    skin_started = threading.Event()
+    release_skin = threading.Event()
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+    monkeypatch.setattr(server, "get_cached_skin_payload", lambda: {}, raising=False)
+    monkeypatch.setattr(ws_mod, "_skin_refresh_task", None, raising=False)
+
+    def blocking_resolve_skin():
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        skin_started.set()
+        assert release_skin.wait(timeout=2)
+        return {"name": "shared-skin"}
+
+    monkeypatch.setattr(server, "resolve_skin", blocking_resolve_skin)
+
+    async def scenario():
+        ready_events = [asyncio.Event(), asyncio.Event()]
+        disconnect = asyncio.Event()
+
+        class FakeWS:
+            def __init__(self, ready):
+                self.ready = ready
+
+            async def accept(self):
+                pass
+
+            async def send_text(self, line):
+                frame = json.loads(line)
+                if frame.get("params", {}).get("type") == "gateway.ready":
+                    self.ready.set()
+
+            async def receive_text(self):
+                await disconnect.wait()
+                raise ws_mod._WebSocketDisconnect()
+
+            async def close(self):
+                pass
+
+        tasks = [
+            asyncio.create_task(ws_mod.handle_ws(FakeWS(ready)))
+            for ready in ready_events
+        ]
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*(ready.wait() for ready in ready_events)),
+                timeout=0.25,
+            )
+            assert await asyncio.to_thread(skin_started.wait, 0.5)
+            assert calls == 1
+        finally:
+            release_skin.set()
+            disconnect.set()
+            await asyncio.wait_for(asyncio.gather(*tasks), timeout=2)
+            refresh = getattr(ws_mod, "_skin_refresh_task", None)
+            if refresh is not None:
+                await asyncio.wait_for(asyncio.shield(refresh), timeout=2)
+
+    asyncio.run(scenario())
+
+
 def test_ws_ready_advertises_heartbeat_and_ping_is_inline(monkeypatch):
     sent = []
     inbound = iter(

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import json
 import threading
 import time
+from types import SimpleNamespace
 
 from hermes_cli import mcp_startup
 from tui_gateway import server
@@ -168,13 +169,18 @@ def test_ws_ready_does_not_wait_for_skin_resolution(monkeypatch):
     # test runnable against the pre-fix implementation for the RED assertion.
     monkeypatch.setattr(server, "get_cached_skin_payload", lambda: {}, raising=False)
     monkeypatch.setattr(ws_mod, "_skin_refresh_task", None, raising=False)
+    monkeypatch.setattr(ws_mod, "_skin_refresh_loop", None, raising=False)
+    monkeypatch.setattr(server, "_note_cached_skin_broadcast", lambda _revision: True)
+    monkeypatch.setattr(server, "_broadcast_global_event", lambda *_args: None)
 
-    def blocking_resolve_skin():
+    def blocking_resolve_skin_snapshot():
         skin_started.set()
         assert release_skin.wait(timeout=2)
-        return {"name": "late-skin"}
+        return {"name": "late-skin"}, 1
 
-    monkeypatch.setattr(server, "resolve_skin", blocking_resolve_skin)
+    monkeypatch.setattr(
+        server, "resolve_skin_snapshot", blocking_resolve_skin_snapshot, raising=False
+    )
 
     async def scenario():
         ready_seen = asyncio.Event()
@@ -224,16 +230,26 @@ def test_concurrent_cold_ws_connections_share_one_skin_refresh(monkeypatch):
     monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
     monkeypatch.setattr(server, "get_cached_skin_payload", lambda: {}, raising=False)
     monkeypatch.setattr(ws_mod, "_skin_refresh_task", None, raising=False)
+    monkeypatch.setattr(ws_mod, "_skin_refresh_loop", None, raising=False)
+    broadcasts = []
+    monkeypatch.setattr(server, "_note_cached_skin_broadcast", lambda _revision: True)
+    monkeypatch.setattr(
+        server,
+        "_broadcast_global_event",
+        lambda event, payload: broadcasts.append((event, payload)),
+    )
 
-    def blocking_resolve_skin():
+    def blocking_resolve_skin_snapshot():
         nonlocal calls
         with calls_lock:
             calls += 1
         skin_started.set()
         assert release_skin.wait(timeout=2)
-        return {"name": "shared-skin"}
+        return {"name": "shared-skin"}, 1
 
-    monkeypatch.setattr(server, "resolve_skin", blocking_resolve_skin)
+    monkeypatch.setattr(
+        server, "resolve_skin_snapshot", blocking_resolve_skin_snapshot, raising=False
+    )
 
     async def scenario():
         ready_events = [asyncio.Event(), asyncio.Event()]
@@ -278,6 +294,121 @@ def test_concurrent_cold_ws_connections_share_one_skin_refresh(monkeypatch):
                 await asyncio.wait_for(asyncio.shield(refresh), timeout=2)
 
     asyncio.run(scenario())
+    assert broadcasts == [("skin.changed", {"name": "shared-skin"})]
+
+
+def test_resolve_skin_snapshot_replaces_cache_and_preserves_last_good_on_failure(
+    monkeypatch,
+):
+    """Only a complete skin resolution may replace the process snapshot."""
+    import hermes_cli.skin_engine as skin_engine
+
+    skin = SimpleNamespace(
+        name="fresh",
+        colors={"accent": "#123456"},
+        light_colors={},
+        dark_colors={},
+        branding={"help_header": "Fresh"},
+        banner_logo="logo",
+        banner_hero="hero",
+        tool_prefix="tool",
+    )
+    monkeypatch.setattr(server, "_skin_payload_cache", {"name": "old"})
+    monkeypatch.setattr(server, "_skin_payload_sig", ("old", 1.0))
+    monkeypatch.setattr(server, "_skin_payload_revision", 7)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"display": {"skin": "fresh"}})
+    monkeypatch.setattr(server, "_skin_sig_from_config", lambda _cfg: ("fresh", 2.0))
+    monkeypatch.setattr(skin_engine, "init_skin_from_config", lambda _cfg: None)
+    monkeypatch.setattr(skin_engine, "get_active_skin", lambda: skin)
+
+    payload, revision = server.resolve_skin_snapshot()
+
+    assert payload["name"] == "fresh"
+    assert payload["help_header"] == "Fresh"
+    assert revision == 8
+    assert server.get_cached_skin_payload() == payload
+    assert server._skin_payload_sig == ("fresh", 2.0)
+    monkeypatch.setattr(server, "_last_skin_sig", ("old", 1.0))
+    assert server._note_cached_skin_broadcast(7) is False
+    assert server._last_skin_sig == ("old", 1.0)
+    assert server._note_cached_skin_broadcast(8) is True
+    assert server._last_skin_sig == ("fresh", 2.0)
+
+    def fail_resolution():
+        raise RuntimeError("resolution failed")
+
+    monkeypatch.setattr(skin_engine, "get_active_skin", fail_resolution)
+    failed, failed_revision = server.resolve_skin_snapshot()
+
+    assert (failed, failed_revision) == ({}, -1)
+    assert server.get_cached_skin_payload() == payload
+    assert server._skin_payload_sig == ("fresh", 2.0)
+    assert server._skin_payload_revision == 8
+
+
+def test_skin_watcher_detects_config_changed_after_startup_prime(monkeypatch):
+    """Watcher baseline must describe the cache, not a newer unread config."""
+    broadcasts = []
+
+    class NoopThread:
+        def __init__(self, **_kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(server, "_skin_payload_cache", {"name": "old"})
+    monkeypatch.setattr(server, "_skin_payload_sig", ("old", 1.0))
+    monkeypatch.setattr(server, "_skin_payload_revision", 1)
+    monkeypatch.setattr(server, "_last_skin_sig", None)
+    monkeypatch.setattr(server, "_skin_watcher_started", False)
+    monkeypatch.setattr(server.threading, "Thread", NoopThread)
+    monkeypatch.setattr(server, "_skin_sig", lambda: ("new", 2.0))
+    monkeypatch.setattr(server, "resolve_skin", lambda: {"name": "new"})
+    monkeypatch.setattr(
+        server,
+        "_broadcast_global_event",
+        lambda event, payload: broadcasts.append((event, payload)),
+    )
+
+    server._ensure_skin_watcher()
+    assert server._last_skin_sig == ("old", 1.0)
+
+    server._broadcast_skin_if_changed()
+    assert broadcasts == [("skin.changed", {"name": "new"})]
+    assert server._last_skin_sig == ("new", 2.0)
+
+
+def test_skin_refresh_task_is_recreated_for_a_new_event_loop(monkeypatch):
+    """A process-global task must never be reused from a different loop."""
+    monkeypatch.setattr(server, "resolve_skin_snapshot", lambda: ({"name": "x"}, 1))
+    monkeypatch.setattr(server, "_note_cached_skin_broadcast", lambda _revision: True)
+    monkeypatch.setattr(server, "_broadcast_global_event", lambda *_args: None)
+    first_loop = asyncio.new_event_loop()
+
+    async def never_finishes():
+        await asyncio.Future()
+
+    first_task = first_loop.create_task(never_finishes())
+    monkeypatch.setattr(ws_mod, "_skin_refresh_task", first_task)
+    monkeypatch.setattr(ws_mod, "_skin_refresh_loop", first_loop)
+    try:
+        async def make_second_task():
+            task = ws_mod._ensure_skin_cache_refresh()
+            await task
+            return task
+
+        second_task = asyncio.run(make_second_task())
+
+        assert second_task is not first_task
+        assert second_task.get_loop() is not first_task.get_loop()
+        assert first_task.done() is False
+    finally:
+        first_task.cancel()
+        first_loop.run_until_complete(
+            asyncio.gather(first_task, return_exceptions=True)
+        )
+        first_loop.close()
 
 
 def test_ws_ready_advertises_heartbeat_and_ping_is_inline(monkeypatch):

--- a/tests/tui_gateway/test_cold_start_gil_stall.py
+++ b/tests/tui_gateway/test_cold_start_gil_stall.py
@@ -86,18 +86,28 @@ def test_cold_skin_refresh_runs_off_the_loop_thread():
 
     idents = {}
 
-    def _fake_resolve_skin():
+    def _fake_resolve_skin_snapshot():
         idents["skin_thread"] = threading.get_ident()
-        return {"palette": "test"}
+        return {"palette": "test"}, 1
 
     async def _scenario():
         idents["loop_thread"] = threading.get_ident()
         ws_mod._skin_refresh_task = None
+        ws_mod._skin_refresh_loop = None
         try:
-            with patch.object(server_mod, "resolve_skin", _fake_resolve_skin):
+            with (
+                patch.object(
+                    server_mod,
+                    "resolve_skin_snapshot",
+                    _fake_resolve_skin_snapshot,
+                ),
+                patch.object(server_mod, "_note_cached_skin_broadcast", return_value=True),
+                patch.object(server_mod, "_broadcast_global_event"),
+            ):
                 return await ws_mod._ensure_skin_cache_refresh()
         finally:
             ws_mod._skin_refresh_task = None
+            ws_mod._skin_refresh_loop = None
 
     payload = _asyncio.run(_scenario())
 
@@ -115,7 +125,7 @@ def test_handle_ws_ready_payload_uses_no_io_skin_snapshot(monkeypatch):
     frames = []
     resolver = MagicMock(side_effect=AssertionError("ready path resolved skin"))
     monkeypatch.setattr(server_mod, "get_cached_skin_payload", lambda: {"name": "cached"})
-    monkeypatch.setattr(server_mod, "resolve_skin", resolver)
+    monkeypatch.setattr(server_mod, "resolve_skin_snapshot", resolver)
     monkeypatch.setattr(server_mod, "_WS_ORPHAN_REAP_GRACE_S", 0)
 
     class FakeWS:

--- a/tests/tui_gateway/test_cold_start_gil_stall.py
+++ b/tests/tui_gateway/test_cold_start_gil_stall.py
@@ -6,15 +6,14 @@ between ``HERMES_BACKEND_READY`` and the first prompt. Three fixes:
 
 1. ``copilot_auth.resolve_copilot_token`` skips the ``gh auth token``
    subprocess when a Copilot env var is explicitly set (even if invalid).
-2. ``tui_gateway.ws.handle_ws`` runs ``resolve_skin()`` via
-   ``asyncio.to_thread`` so the loop is not blocked by config/skin init.
+2. ``gateway.ready`` reads a startup-primed skin snapshot and a rare cold
+   cache refreshes once in the background, never in the liveness path.
 3. ``web_server._warm_gateway_module`` pre-imports the heavy module
    chains that the first WS connection + RPC burst would otherwise
    import on the loop thread.
 """
 
 import asyncio
-import inspect
 import sys
 from unittest.mock import patch, MagicMock
 
@@ -74,20 +73,16 @@ class TestCopilotAuthSkipsGhCli:
         mock_cli.assert_called_once()
 
 
-# ─── Fix 2: resolve_skin runs via to_thread in handle_ws ───────────────
+# ─── Fix 2: gateway.ready never waits for skin resolution ─────────────
 
 
-def test_handle_ws_resolves_skin_off_the_loop_thread():
-    """resolve_skin must run on a worker thread, not the event loop (#60800).
-
-    Behavioral check (not source inspection): run the ready-payload path
-    with a resolve_skin stub that records its thread ident and assert it
-    differs from the loop thread's. Pattern from the #72720 salvage.
-    """
+def test_cold_skin_refresh_runs_off_the_loop_thread():
+    """The cache-miss fallback must resolve on a worker and remain awaitable."""
     import asyncio as _asyncio
     import threading
 
     import tui_gateway.server as server_mod
+    import tui_gateway.ws as ws_mod
 
     idents = {}
 
@@ -97,65 +92,50 @@ def test_handle_ws_resolves_skin_off_the_loop_thread():
 
     async def _scenario():
         idents["loop_thread"] = threading.get_ident()
-        with patch.object(server_mod, "resolve_skin", _fake_resolve_skin):
-            payload = await _asyncio.to_thread(server_mod.resolve_skin)
-        return payload
+        ws_mod._skin_refresh_task = None
+        try:
+            with patch.object(server_mod, "resolve_skin", _fake_resolve_skin):
+                return await ws_mod._ensure_skin_cache_refresh()
+        finally:
+            ws_mod._skin_refresh_task = None
 
     payload = _asyncio.run(_scenario())
 
     assert payload == {"palette": "test"}
-    assert idents["skin_thread"] != idents["loop_thread"], (
-        "resolve_skin ran on the event loop thread — the #60800 cold-start "
-        "stall would be back."
-    )
+    assert idents["skin_thread"] != idents["loop_thread"]
 
 
-def test_handle_ws_ready_payload_wires_skin_through_to_thread():
-    """The gateway.ready payload construction must route resolve_skin
-    through asyncio.to_thread with change_events preserved.
-
-    Exercises handle_ws's actual payload site by faking the transport
-    and asserting on the written frame.
-    """
-    import asyncio as _asyncio
-    import threading
+def test_handle_ws_ready_payload_uses_no_io_skin_snapshot(monkeypatch):
+    """A warm cache is serialized into ready without calling the resolver."""
+    import json
 
     import tui_gateway.server as server_mod
     import tui_gateway.ws as ws_mod
 
-    idents = {}
     frames = []
+    resolver = MagicMock(side_effect=AssertionError("ready path resolved skin"))
+    monkeypatch.setattr(server_mod, "get_cached_skin_payload", lambda: {"name": "cached"})
+    monkeypatch.setattr(server_mod, "resolve_skin", resolver)
+    monkeypatch.setattr(server_mod, "_WS_ORPHAN_REAP_GRACE_S", 0)
 
-    def _fake_resolve_skin():
-        idents["skin_thread"] = threading.get_ident()
-        return {"palette": "wired"}
+    class FakeWS:
+        async def accept(self):
+            pass
 
-    async def _scenario():
-        idents["loop_thread"] = threading.get_ident()
-        with patch.object(server_mod, "resolve_skin", _fake_resolve_skin):
-            # Reproduce handle_ws's ready-frame construction verbatim.
-            skin_payload = await _asyncio.to_thread(server_mod.resolve_skin)
-            frames.append(
-                {
-                    "jsonrpc": "2.0",
-                    "method": "event",
-                    "params": {
-                        "type": "gateway.ready",
-                        "payload": {"skin": skin_payload, "change_events": True},
-                    },
-                }
-            )
+        async def send_text(self, line):
+            frames.append(json.loads(line))
 
-    _asyncio.run(_scenario())
+        async def receive_text(self):
+            raise ws_mod._WebSocketDisconnect()
 
-    assert frames[0]["params"]["payload"]["skin"] == {"palette": "wired"}
-    assert frames[0]["params"]["payload"]["change_events"] is True
-    assert idents["skin_thread"] != idents["loop_thread"]
-    # Belt and braces: the production site must still route through
-    # to_thread — assert against the live source so a revert to inline
-    # resolve_skin() cannot slip past the behavioral stub above.
-    source = inspect.getsource(ws_mod.handle_ws)
-    assert "to_thread(server.resolve_skin)" in source
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+    assert frames[0]["params"]["type"] == "gateway.ready"
+    assert frames[0]["params"]["payload"]["skin"] == {"name": "cached"}
+    resolver.assert_not_called()
 
 
 # ─── Fix 3: _warm_gateway_module pre-imports heavy chains ──────────────
@@ -188,6 +168,10 @@ def test_warm_gateway_module_imports_cold_start_chains():
     }
 
     web_server_mod._warm_gateway_module()
+
+    from tui_gateway import server as gateway_server
+
+    assert gateway_server.get_cached_skin_payload().get("name")
 
     missing = required - set(sys.modules)
     assert not missing, (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4771,6 +4771,9 @@ def _clear_pending(sid: str | None = None) -> None:
 
 _skin_payload_cache: dict = {}
 _skin_payload_cache_lock = threading.Lock()
+_skin_resolution_lock = threading.Lock()
+_skin_payload_sig: tuple[str, float | None] | None = None
+_skin_payload_revision = 0
 
 
 def get_cached_skin_payload() -> dict:
@@ -4781,36 +4784,70 @@ def get_cached_skin_payload() -> dict:
     of seconds queued behind unrelated work. The dashboard primes this cache
     before accepting sockets and every real skin resolution refreshes it.
     """
+    # Nested palette/branding values are immutable snapshot data by contract.
+    # Callers serialize or inspect them; they must not mutate the returned tree.
+    # Keep this a shallow copy so the WebSocket liveness path stays allocation-
+    # light while still preventing top-level cache mutation.
     with _skin_payload_cache_lock:
         return dict(_skin_payload_cache)
 
 
-def resolve_skin() -> dict:
+def _skin_sig_from_config(cfg: dict) -> tuple[str, float | None]:
+    """Return the skin signature represented by one config snapshot."""
+    name = str((cfg.get("display") or {}).get("skin") or "default")
+    override = get_hermes_home_override()
+    home = override if isinstance(override, str) and override else _hermes_home
     try:
-        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin
+        mtime: float | None = (Path(home) / "skins" / f"{name}.yaml").stat().st_mtime
+    except OSError:
+        mtime = None
+    return name, mtime
 
-        init_skin_from_config(_load_cfg())
-        skin = get_active_skin()
-        payload = {
-            "name": skin.name,
-            "colors": skin.colors,
-            # Paired palettes: the TUI detects the terminal's polarity and
-            # prefers the matching hand-tuned block over adapting `colors`.
-            "light_colors": skin.light_colors,
-            "dark_colors": skin.dark_colors,
-            "branding": skin.branding,
-            "banner_logo": skin.banner_logo,
-            "banner_hero": skin.banner_hero,
-            "tool_prefix": skin.tool_prefix,
-            "help_header": (skin.branding or {}).get("help_header", ""),
-        }
-    except Exception:
-        return {}
 
-    with _skin_payload_cache_lock:
-        _skin_payload_cache.clear()
-        _skin_payload_cache.update(payload)
-    return dict(payload)
+def resolve_skin_snapshot() -> tuple[dict, int]:
+    """Resolve and cache one atomic skin-engine snapshot.
+
+    The skin engine stores process-global active state, so watcher, config RPC,
+    and cold-WebSocket refreshes must not interleave ``init`` and ``get``. The
+    revision lets an async refresher avoid broadcasting a result superseded by
+    a newer resolution before its worker completed.
+    """
+    global _skin_payload_revision, _skin_payload_sig
+    with _skin_resolution_lock:
+        try:
+            from hermes_cli.skin_engine import init_skin_from_config, get_active_skin
+
+            cfg = _load_cfg()
+            sig = _skin_sig_from_config(cfg)
+            init_skin_from_config(cfg)
+            skin = get_active_skin()
+            payload = {
+                "name": skin.name,
+                "colors": skin.colors,
+                # Paired palettes: the TUI detects the terminal's polarity and
+                # prefers the matching hand-tuned block over adapting `colors`.
+                "light_colors": skin.light_colors,
+                "dark_colors": skin.dark_colors,
+                "branding": skin.branding,
+                "banner_logo": skin.banner_logo,
+                "banner_hero": skin.banner_hero,
+                "tool_prefix": skin.tool_prefix,
+                "help_header": (skin.branding or {}).get("help_header", ""),
+            }
+        except Exception:
+            return {}, -1
+
+        with _skin_payload_cache_lock:
+            _skin_payload_cache.clear()
+            _skin_payload_cache.update(payload)
+            _skin_payload_sig = sig
+            _skin_payload_revision += 1
+            revision = _skin_payload_revision
+        return dict(payload), revision
+
+
+def resolve_skin() -> dict:
+    return resolve_skin_snapshot()[0]
 
 
 # Signature of the last skin broadcast: (name, active user-file mtime). Lets the
@@ -4822,14 +4859,24 @@ _last_skin_sig: tuple[str, float | None] | None = None
 def _skin_sig() -> tuple[str, float | None]:
     """(active skin name, its user-file mtime). Built-ins have no file, so only
     their name moves; a user skin's mtime lets an in-place color edit repaint too."""
-    name = str((_load_cfg().get("display") or {}).get("skin") or "default")
-    override = get_hermes_home_override()
-    home = override if isinstance(override, str) and override else _hermes_home
-    try:
-        mtime: float | None = (Path(home) / "skins" / f"{name}.yaml").stat().st_mtime
-    except OSError:
-        mtime = None
-    return name, mtime
+    return _skin_sig_from_config(_load_cfg())
+
+
+def _note_cached_skin_broadcast(revision: int | None = None) -> bool:
+    """Set the watcher baseline to the cached snapshot if it is still current."""
+    global _last_skin_sig
+    with _skin_payload_cache_lock:
+        if (
+            not _skin_payload_cache
+            or _skin_payload_sig is None
+            or (revision is not None and revision != _skin_payload_revision)
+        ):
+            return False
+        # Keep the revision check and baseline assignment in one critical
+        # section. Otherwise a newer resolution can land between them and an
+        # older worker can overwrite the watcher's baseline with a stale sig.
+        _last_skin_sig = _skin_payload_sig
+    return True
 
 
 def _note_skin_broadcast() -> None:
@@ -5090,7 +5137,11 @@ def _ensure_skin_watcher() -> None:
     if _skin_watcher_started:
         return
     _skin_watcher_started = True
-    _note_skin_broadcast()  # seed the baseline so only a real change repaints
+    # Prefer the signature that produced the cached payload. If config changed
+    # after startup priming, seeding from the current file would hide that
+    # transition and leave the first client on a stale skin indefinitely.
+    if _last_skin_sig is None and not _note_cached_skin_broadcast():
+        _note_skin_broadcast()
 
     def _loop() -> None:
         while True:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4769,13 +4769,29 @@ def _clear_pending(sid: str | None = None) -> None:
 # ── Agent factory ────────────────────────────────────────────────────
 
 
+_skin_payload_cache: dict = {}
+_skin_payload_cache_lock = threading.Lock()
+
+
+def get_cached_skin_payload() -> dict:
+    """Return the last successfully resolved skin without I/O or config reads.
+
+    WebSocket liveness must never depend on the default executor: under a busy
+    multi-agent workload even a normally-cheap ``resolve_skin`` can spend tens
+    of seconds queued behind unrelated work. The dashboard primes this cache
+    before accepting sockets and every real skin resolution refreshes it.
+    """
+    with _skin_payload_cache_lock:
+        return dict(_skin_payload_cache)
+
+
 def resolve_skin() -> dict:
     try:
         from hermes_cli.skin_engine import init_skin_from_config, get_active_skin
 
         init_skin_from_config(_load_cfg())
         skin = get_active_skin()
-        return {
+        payload = {
             "name": skin.name,
             "colors": skin.colors,
             # Paired palettes: the TUI detects the terminal's polarity and
@@ -4790,6 +4806,11 @@ def resolve_skin() -> dict:
         }
     except Exception:
         return {}
+
+    with _skin_payload_cache_lock:
+        _skin_payload_cache.clear()
+        _skin_payload_cache.update(payload)
+    return dict(payload)
 
 
 # Signature of the last skin broadcast: (name, active user-file mtime). Lets the

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -47,14 +47,32 @@ _WS_LOG_PAYLOAD_PREVIEW = 240
 # sockets. Keep one process-wide fallback refresh for standalone/test entry
 # paths so a reconnect burst cannot enqueue one resolve_skin job per peer.
 _skin_refresh_task: asyncio.Task[dict] | None = None
+_skin_refresh_loop: asyncio.AbstractEventLoop | None = None
+
+
+async def _refresh_skin_cache() -> dict:
+    payload, revision = await asyncio.to_thread(server.resolve_skin_snapshot)
+    if payload and server._note_cached_skin_broadcast(revision):
+        # The transport is registered before this fallback is scheduled, so
+        # every cold-cache peer receives the resolved skin after readiness.
+        # The revision guard suppresses a result superseded by config.set or
+        # the watcher while this worker was queued.
+        server._broadcast_global_event("skin.changed", payload)
+    return payload
 
 
 def _ensure_skin_cache_refresh() -> asyncio.Task[dict]:
     """Start (or reuse) one non-blocking skin-cache refresh on this loop."""
-    global _skin_refresh_task
-    if _skin_refresh_task is None or _skin_refresh_task.done():
+    global _skin_refresh_loop, _skin_refresh_task
+    loop = asyncio.get_running_loop()
+    if (
+        _skin_refresh_task is None
+        or _skin_refresh_task.done()
+        or _skin_refresh_loop is not loop
+    ):
+        _skin_refresh_loop = loop
         _skin_refresh_task = asyncio.create_task(
-            asyncio.to_thread(server.resolve_skin),
+            _refresh_skin_cache(),
             name="gateway-skin-cache-refresh",
         )
     return _skin_refresh_task

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -43,6 +43,22 @@ _log = logging.getLogger(__name__)
 _WS_WRITE_TIMEOUT_S = 10.0
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
+# A cold cache is exceptional because web_server primes it before accepting
+# sockets. Keep one process-wide fallback refresh for standalone/test entry
+# paths so a reconnect burst cannot enqueue one resolve_skin job per peer.
+_skin_refresh_task: asyncio.Task[dict] | None = None
+
+
+def _ensure_skin_cache_refresh() -> asyncio.Task[dict]:
+    """Start (or reuse) one non-blocking skin-cache refresh on this loop."""
+    global _skin_refresh_task
+    if _skin_refresh_task is None or _skin_refresh_task.done():
+        _skin_refresh_task = asyncio.create_task(
+            asyncio.to_thread(server.resolve_skin),
+            name="gateway-skin-cache-refresh",
+        )
+    return _skin_refresh_task
+
 # Per-token streaming frames are coalesced: buffered and flushed as a batch on
 # a short timer instead of waking the event loop once per token. A model reply
 # emits hundreds of these in a burst, and each one is a loop wakeup competing
@@ -358,14 +374,15 @@ async def handle_ws(
             auth_identity=auth_identity,
         )
 
-        # resolve_skin() reads config + initializes the skin engine —
-        # synchronous I/O + CPU work that should not block the event loop
-        # during the cold-start window. Run it in the thread pool so the
-        # WS read loop stays free to drain the frontend's initial RPC
-        # burst (setup.status, session.list, ...) without a stall
-        # (#60800). The skin payload is small (a dict of strings/arrays),
-        # so the to_thread overhead is negligible.
-        skin_payload = await asyncio.to_thread(server.resolve_skin)
+        # gateway.ready is a liveness contract, so it must not wait for config
+        # I/O or the shared default executor. During a busy multi-agent turn a
+        # normally-cheap to_thread(resolve_skin) can queue for >30s, causing the
+        # Desktop to time out and reconnect; every reconnect then queued another
+        # lookup and prolonged the outage. web_server primes this snapshot at
+        # startup. Standalone entry paths may see a cold cache: send ready with
+        # an empty skin (clients safely keep their persisted theme) and collapse
+        # all fallback work into one background refresh.
+        skin_payload = server.get_cached_skin_payload()
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",
@@ -393,6 +410,8 @@ async def handle_ws(
             # Track this peer for session-less global broadcasts (skin.changed
             # from the background watcher) — write_json can't route those.
             server.register_live_transport(transport)
+            if not skin_payload:
+                _ensure_skin_cache_refresh()
         # Cross-backend liveness (#94895): register a heartbeat row so
         # the startup orphan sweep can distinguish "row owned by a live
         # but idle backend" from "row truly orphaned". The stdio TUI's


### PR DESCRIPTION
## Summary

- send `gateway.ready` from a thread-safe, last-good skin snapshot instead of waiting on the shared executor
- prime the skin snapshot before the dashboard starts accepting WebSocket connections
- collapse cold-cache fallback work into one process-wide background refresh so reconnect bursts cannot queue one resolver per peer
- serialize process-global skin resolution and revision-guard late refreshes so stale workers cannot overwrite or broadcast newer state
- bind fallback refresh task reuse to its owning event loop and notify connected cold-cache clients with `skin.changed` when resolution completes

## Problem

Each WebSocket handshake currently awaits `asyncio.to_thread(server.resolve_skin)` before emitting `gateway.ready`. Under executor/GIL pressure, the resolver itself may be fast once scheduled, but the wait can exceed the Desktop readiness timeout. The client reconnects, each reconnect queues another resolver, and the resulting feedback loop can leave an otherwise healthy dashboard appearing unavailable while unrelated HTTP routes remain responsive.

This is not deployment-specific: any Desktop or other WebSocket client can hit it when the dashboard is busy.

## Compatibility

A normally started dashboard primes the cache synchronously during existing module warm-up. Standalone/test entry points that somehow connect with a cold cache receive readiness immediately with an empty skin payload, allowing clients to retain their persisted theme. One background refresh repopulates the cache and emits `skin.changed` to the already-registered clients when the resolved snapshot is still current. Failed refreshes preserve the last-good snapshot.

## Related work

- Follow-up to #60800 / #77814: that work moved skin resolution off the event loop; this PR removes it from the WebSocket readiness critical path when the shared executor is saturated.
- Related to #83134 and tracker #94724: those cover broader reconnect-storm and retry/backoff failures. This PR fixes one server-side amplification trigger and does not replace client-side reconnect/backoff work.
- Compatible with #73821 (client readiness handshake) and #84803 (custom YAML skin reaffirmation).

## Test plan

- `uv run --with pytest python -m pytest -q tests/test_tui_gateway_ws.py tests/tui_gateway/test_cold_start_gil_stall.py tests/tui_gateway/test_94895_backend_heartbeat.py tests/tui_gateway/test_entry_picker_prewarm.py tests/tui_gateway/test_startup_orphan_sweep.py tests/tui_gateway/test_protocol.py tests/test_cli_skin_integration.py tests/cli/test_cli_skin_integration.py tests/hermes_cli/test_skin_engine.py tests/hermes_cli/test_skin_palettes.py tests/hermes_cli/test_skin_cmd.py` — **156 passed**
- Ruff on all five changed files — passed
- `compileall` on all five changed files — passed
- `git diff --check` — passed

Behavioral coverage includes readiness beating blocked resolution, reconnect-burst deduplication, late cold-client notification, last-good preservation on resolver failure, stale startup snapshot correction, stale revision rejection, and cross-event-loop task ownership.

## Manual verification

On Windows, after restarting the dashboard with this patch:

- 20 simultaneous authenticated WebSocket connections all received `gateway.ready` with a populated skin
- ready latency: **79 ms minimum, 131 ms median, 251 ms maximum**
- an older 4,216-message session resumed with `defer_history=true` and `omit_messages=true` in **741 ms**, with no message history included in the response
