### PR TITLE
fix(state): skip archive_and_compact when the live transcript already matches

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11823,6 +11823,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         "commit; refusing to publish a stale compaction"
                     )
 
+            if self._active_messages_match_compacted(
+                conn, session_id, compacted_messages
+            ):
+                # A second compression path in the same cycle (preflight +
+                # tool-loop tail) can republish the identical summary.
+                # archive-then-insert would duplicate the row as compacted=1
+                # and session_search would return both (#97321).
+                count_row = conn.execute(
+                    "SELECT COUNT(*) AS n FROM messages "
+                    "WHERE session_id = ? AND active = 1",
+                    (session_id,),
+                ).fetchone()
+                return int(count_row["n"] if count_row is not None else 0)
+
             patched_model_config = None
             if model_config_patch is not None:
                 # on_missing="raise": a prune/compaction must not commit
@@ -11905,6 +11919,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return inserted
 
         return self._execute_write(_do)
+
+    def _active_messages_match_compacted(
+        self,
+        conn,
+        session_id: str,
+        compacted_messages: List[Dict[str, Any]],
+    ) -> bool:
+        """True when the live transcript is already *compacted_messages*."""
+        rows = conn.execute(
+            "SELECT role, content FROM messages "
+            "WHERE session_id = ? AND active = 1 ORDER BY id",
+            (session_id,),
+        ).fetchall()
+        if len(rows) != len(compacted_messages):
+            return False
+        for row, msg in zip(rows, compacted_messages):
+            if (row["role"] or "") != (msg.get("role") or ""):
+                return False
+            if row["content"] != self._encode_content(msg.get("content")):
+                return False
+        return True
 
     def _message_column_names(self, conn) -> List[str]:
         """Column names of the messages table, cached per-connection era."""

--- a/tests/test_compression_watermark_commit.py
+++ b/tests/test_compression_watermark_commit.py
@@ -41,6 +41,31 @@ SUMMARY = [
 
 
 class TestWatermarkCommit:
+    def test_identical_second_compact_does_not_duplicate_summary(
+        self, db: SessionDB
+    ) -> None:
+        """Preflight + tool-loop must not insert the same summary twice (#97321)."""
+        _seed(db)
+        db.archive_and_compact("sess1", SUMMARY)
+        live_after_first = db.get_messages("sess1")
+        first_ids = [row["id"] for row in live_after_first]
+        assert [row["content"] for row in live_after_first] == [
+            SUMMARY[0]["content"],
+            SUMMARY[1]["content"],
+        ]
+
+        count = db.archive_and_compact("sess1", SUMMARY)
+        live = db.get_messages("sess1")
+        assert [row["id"] for row in live] == first_ids
+        assert count == 2
+        compacted = db.get_messages("sess1", include_compacted=True)
+        summaries = [
+            row
+            for row in compacted
+            if row.get("content") == SUMMARY[0]["content"]
+        ]
+        assert len(summaries) == 1
+
     def test_concurrent_tail_survives_compaction(self, db: SessionDB) -> None:
         _seed(db)
         watermark = db.get_active_message_watermark("sess1")


### PR DESCRIPTION
## What does this PR do?

`archive_and_compact()` always soft-archived the live transcript and inserted the compacted set, even when that set was already the live transcript. A second compression path in the same cycle (turn preflight + tool-loop tail) therefore published a second identical `[CONTEXT COMPACTION — REFERENCE ONLY]` row. `session_search` includes compacted rows, so the duplicate was visible.

If the active messages already match the compacted set (same roles and contents, same order), the commit is now a no-op.

## Related Issue

Fixes #97321

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: `_active_messages_match_compacted` + early return in `archive_and_compact`
- `tests/test_compression_watermark_commit.py`: second compact keeps the same live ids and does not duplicate the summary among compacted rows

## How to Test

```text
python -m pytest tests/test_compression_watermark_commit.py -q
# 17 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted tests listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (unit tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
