### PR TITLE
fix(guard): evaluate trailing consecutive attempts in deterministic empty detection

### DIFF
--- a/agent/empty_response_guard.py
+++ b/agent/empty_response_guard.py
@@ -240,21 +240,22 @@ def record_empty_attempt(
 def deterministic_empty(agent: Any) -> bool:
     """True when the current streak looks deterministic.
 
-    Requires >= 2 consecutive attempts with an identical (model, provider,
-    finish_reason) signature. Usage-backed attempts must all prove zero output.
-    Usage-absent attempts must all have no observed content or reasoning. Mixed
-    evidence fails open so ambiguous transients keep their retries.
+    Requires >= 2 consecutive attempts, with the trailing attempts having an
+    identical (model, provider, finish_reason) signature. Usage-backed attempts
+    must all prove zero output. Usage-absent attempts must all have no observed
+    content or reasoning. Mixed evidence fails open so ambiguous transients
+    keep their retries.
     """
     if not guard_enabled(agent):
         return False
     attempts = getattr(agent, _ATTEMPTS_ATTR, None) or []
     if len(attempts) < 2:
         return False
-    first = attempts[0]
-    same_signature = all(a.signature == first.signature for a in attempts)
-    usage_proves_empty = all(a.usage_present and a.zero_output for a in attempts)
+    last_two = attempts[-2:]
+    same_signature = last_two[0].signature == last_two[1].signature
+    usage_proves_empty = all(a.usage_present and a.zero_output for a in last_two)
     response_proves_empty = all(
-        not a.usage_present and not a.observed_generation for a in attempts
+        not a.usage_present and not a.observed_generation for a in last_two
     )
     return same_signature and (usage_proves_empty or response_proves_empty)
 

--- a/tests/agent/test_empty_response_guard.py
+++ b/tests/agent/test_empty_response_guard.py
@@ -113,6 +113,32 @@ class TestDeterministicEmpty:
         )
         assert guard.deterministic_empty(agent) is False
 
+    def test_nonzero_then_two_zero_attempts_is_deterministic(self):
+        """A transient first attempt must not poison subsequent consecutive zero-output attempts."""
+        agent = _agent()
+        _record_streak(
+            agent,
+            [
+                _response(completion_tokens=7),
+                _response(completion_tokens=0),
+                _response(completion_tokens=0),
+            ],
+        )
+        assert guard.deterministic_empty(agent) is True
+
+    def test_missing_usage_then_two_zero_attempts_is_deterministic(self):
+        """A transient first attempt missing usage must not poison subsequent consecutive zero-output attempts."""
+        agent = _agent()
+        _record_streak(
+            agent,
+            [
+                _response(usage_present=False),
+                _response(completion_tokens=0),
+                _response(completion_tokens=0),
+            ],
+        )
+        assert guard.deterministic_empty(agent) is True
+
     def test_signature_change_resets_determinism(self):
         """Fallback switched model mid-streak — new model deserves retries."""
         agent = _agent()


### PR DESCRIPTION
## What does this PR do?

Fixes an empty response retry loop and cost-runaway bug in [`agent/empty_response_guard.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/empty_response_guard.py) where `deterministic_empty(agent)` evaluated all historical streak attempts (`all(a.usage_present ... for a in attempts)`) rather than inspecting the trailing consecutive attempts (`attempts[-2:]`).

In Hermes Agent:
1. When a model returns zero output tokens deterministically (e.g. portal-proxied silent refusals or prompt-triggered empty responses), `deterministic_empty(agent)` is designed to detect two consecutive zero-output attempts, skip further costly retries on that model, and immediately walk the fallback model chain.
2. Previously, `deterministic_empty(agent)` checked `all(a.usage_present and a.zero_output and a.signature == first.signature for a in attempts)`.
3. If a streak started with a transient attempt (such as missing usage headers or a single decoding token on attempt 0), and was followed by two consecutive deterministic zero-output completions on attempts 1 and 2, `all(...)` evaluated to `False` because `attempts[0]` failed the condition.
4. The transient first attempt permanently poisoned the entire streak, disabling deterministic empty detection. The agent was forced to execute all retries (with up to 60-second backoffs), re-sending full conversation context repeatedly at high cost while delaying fallback model activation.

The fix updates `deterministic_empty(agent)` to inspect the trailing two consecutive attempts (`attempts[-2:]`), ensuring that consecutive deterministic empties trigger immediately while transient attempts still fail open.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/empty_response_guard.py`: Updated `deterministic_empty()` to evaluate `last_two = attempts[-2:]` for usage presence, zero output, and matching `(model, provider, finish_reason)` signatures.
- `tests/agent/test_empty_response_guard.py`: Added `test_nonzero_then_two_zero_attempts_is_deterministic` and `test_missing_usage_then_two_zero_attempts_is_deterministic` asserting that transient initial attempts do not poison subsequent consecutive zero-output detections.

## How to Test

Run the empty response guard test suite:
```bash
uv run --with pytest pytest tests/agent/test_empty_response_guard.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(guard): evaluate trailing consecutive attempts in deterministic empty detection`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 35 items

tests/agent/test_empty_response_guard.py ................................... [100%]

============================= 35 passed in 4.58s ==============================
```
