### PR TITLE
fix(gateway): preserve provider context length on hot reload

### DIFF
--- a/tests/tui_gateway/test_compression_config_hot_reload.py
+++ b/tests/tui_gateway/test_compression_config_hot_reload.py
@@ -82,6 +82,31 @@ def test_unchanged_compression_config_is_noop(monkeypatch):
     assert compressor.threshold_tokens == 99_999
 
 
+def test_provider_model_context_change_invalidates_live_compression_signature():
+    def _cfg(context_length):
+        return {
+            "model": {
+                "default": "gpt-5.6-sol",
+                "provider": "relay",
+                "base_url": "https://relay.example.test/v1",
+            },
+            "providers": {
+                "relay": {
+                    "api": "https://relay.example.test/v1",
+                    "models": {
+                        "gpt-5.6-sol": {"context_length": context_length},
+                    },
+                },
+            },
+            "compression": {},
+        }
+
+    before = server._tui_compression_config_signature(_cfg(256_000))
+    after = server._tui_compression_config_signature(_cfg(192_000))
+
+    assert before != after
+
+
 def test_clearing_threshold_tokens_restores_ratio_trigger(monkeypatch):
     session, compressor = _session_with_compressor(threshold_tokens_cap=100_000)
     assert compressor.threshold_tokens == 100_000
@@ -219,6 +244,170 @@ def test_removing_context_length_reinfers_from_model_metadata(monkeypatch):
     assert compressor._config_context_length is None
     assert compressor.context_length == 1_000_000
     assert compressor.threshold_tokens == int(1_000_000 * 0.50)
+
+
+def test_removing_context_length_invalidates_summary_budget(monkeypatch):
+    import agent.context_compressor as cc_mod
+
+    session, compressor = _neutral_session()
+    assert compressor.max_summary_tokens == 10_000
+
+    monkeypatch.setattr(
+        cc_mod,
+        "get_model_context_length",
+        lambda *a, **k: 100_000,
+    )
+    _sync_with_cfg(monkeypatch, session, {"model": {}, "compression": {}})
+
+    assert compressor.context_length == 100_000
+    assert compressor.max_summary_tokens == 5_000
+
+
+def test_provider_model_context_length_survives_live_sync_without_global_pin(
+    monkeypatch,
+):
+    import agent.context_compressor as cc_mod
+
+    base_url = "https://relay.example.test/v1"
+    compressor = ContextCompressor(
+        model="gpt-5.6-sol",
+        config_context_length=256_000,
+        quiet_mode=True,
+    )
+    agent = SimpleNamespace(
+        model="gpt-5.6-sol",
+        provider="custom",
+        base_url=base_url,
+        context_compressor=compressor,
+        compression_enabled=True,
+        compression_idle_compact_after_seconds=0,
+        _config_context_length=256_000,
+    )
+    session = {"agent": agent, "session_key": "session-provider-context"}
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "relay",
+            "base_url": base_url,
+        },
+        "providers": {
+            "relay": {
+                "api": base_url,
+                "models": {
+                    "gpt-5.6-sol": {"context_length": 256_000},
+                },
+            },
+        },
+        "compression": {},
+    }
+    monkeypatch.setattr(
+        cc_mod,
+        "get_model_context_length",
+        lambda *a, **k: 1_050_000,
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+
+    server._sync_agent_compression_with_config("sid-provider-context", session)
+
+    assert compressor._config_context_length == 256_000
+    assert compressor.context_length == 256_000
+    assert agent._config_context_length == 256_000
+
+
+def test_global_context_pin_does_not_override_different_active_custom_route(
+    monkeypatch,
+):
+    default_url = "https://default.example.test/v1"
+    active_url = "https://active.example.test/v1"
+    compressor = ContextCompressor(
+        model="active-model",
+        config_context_length=100_000,
+        quiet_mode=True,
+    )
+    agent = SimpleNamespace(
+        model="active-model",
+        provider="custom",
+        base_url=active_url,
+        context_compressor=compressor,
+        compression_enabled=True,
+        compression_idle_compact_after_seconds=0,
+        _config_context_length=100_000,
+    )
+    session = {"agent": agent, "session_key": "session-active-route"}
+    cfg = {
+        "model": {
+            "default": "default-model",
+            "provider": "default-relay",
+            "base_url": default_url,
+            "context_length": 500_000,
+        },
+        "providers": {
+            "active-relay": {
+                "api": active_url,
+                "models": {
+                    "active-model": {"context_length": 100_000},
+                },
+            },
+            "default-relay": {
+                "api": default_url,
+                "models": {
+                    "default-model": {"context_length": 500_000},
+                },
+            },
+        },
+        "compression": {},
+    }
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+
+    server._sync_agent_compression_with_config("sid-active-route", session)
+
+    assert compressor._config_context_length == 100_000
+    assert compressor.context_length == 100_000
+    assert agent._config_context_length == 100_000
+
+
+def test_global_context_pin_wins_on_same_named_custom_route_without_model_url(
+    monkeypatch,
+):
+    base_url = "https://relay.example.test/v1"
+    compressor = ContextCompressor(
+        model="gpt-5.6-sol",
+        config_context_length=100_000,
+        quiet_mode=True,
+    )
+    agent = SimpleNamespace(
+        model="gpt-5.6-sol",
+        provider="custom",
+        base_url=base_url,
+        context_compressor=compressor,
+        compression_enabled=True,
+        compression_idle_compact_after_seconds=0,
+        _config_context_length=100_000,
+    )
+    session = {"agent": agent, "session_key": "session-same-named-route"}
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "relay",
+            "context_length": 500_000,
+        },
+        "providers": {
+            "relay": {
+                "api": base_url,
+                "models": {
+                    "gpt-5.6-sol": {"context_length": 100_000},
+                },
+            },
+        },
+        "compression": {},
+    }
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+
+    server._sync_agent_compression_with_config("sid-same-named-route", session)
+
+    assert compressor._config_context_length == 500_000
+    assert compressor.context_length == 500_000
+    assert agent._config_context_length == 500_000
 
 
 def test_removing_idle_compact_after_seconds_restores_zero(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6557,6 +6557,31 @@ def _tui_compression_config_signature(cfg: dict | None) -> tuple:
     compression = cfg.get("compression") if isinstance(cfg, dict) and isinstance(cfg.get("compression"), dict) else {}
     for extra in ("idle_compact_after_seconds", "tail_mode"):
         picked[f"compression.{extra}"] = compression.get(extra)
+    # Named custom providers can pin context per model instead of using the
+    # route-scoped model.context_length key. Include only that non-secret
+    # metadata in the signature so editing the active model's pin is adopted
+    # by an already-open Desktop/TUI session on its next turn.
+    provider_model_contexts: list[tuple[str, str, str, str]] = []
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+
+        for entry in get_compatible_custom_providers(cfg):
+            models = entry.get("models")
+            if not isinstance(models, dict):
+                continue
+            identity = str(entry.get("provider_key") or entry.get("name") or "")
+            base_url = str(entry.get("base_url") or "").rstrip("/").lower()
+            for model, metadata in models.items():
+                if not isinstance(metadata, dict) or "context_length" not in metadata:
+                    continue
+                provider_model_contexts.append(
+                    (identity, base_url, str(model), repr(metadata.get("context_length")))
+                )
+    except Exception:
+        pass
+    picked["providers.model_context_lengths"] = tuple(
+        sorted(provider_model_contexts)
+    )
     return tuple(sorted(picked.items()))
 
 
@@ -6646,7 +6671,8 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     """
     cfg = cfg if isinstance(cfg, dict) else {}
     compression = cfg.get("compression") if isinstance(cfg.get("compression"), dict) else {}
-    model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+    raw_model_cfg = cfg.get("model")
+    model_cfg = raw_model_cfg if isinstance(raw_model_cfg, dict) else {}
 
     enabled_raw = compression.get("enabled", True)
     if isinstance(enabled_raw, bool):
@@ -6763,13 +6789,87 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     except (TypeError, ValueError):
         pass
 
+    custom_providers: list[dict] = []
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+
+        custom_providers = get_compatible_custom_providers(cfg)
+        agent._custom_providers = custom_providers
+    except Exception:
+        existing_custom_providers = getattr(agent, "_custom_providers", None)
+        if isinstance(existing_custom_providers, list):
+            custom_providers = existing_custom_providers
+
+    configured_default = model_cfg.get("default") or model_cfg.get("model")
+    configured_provider = model_cfg.get("provider")
+    try:
+        from hermes_cli.config import split_model_config_default
+
+        configured_model, embedded_provider = split_model_config_default(
+            configured_default
+        )
+        configured_provider = embedded_provider or configured_provider
+    except Exception:
+        configured_model = configured_default
+
+    configured_base_url = model_cfg.get("base_url")
+    if not configured_base_url and configured_provider and custom_providers:
+        try:
+            from agent.agent_init import _custom_provider_runtime_ids
+
+            configured_ids = _custom_provider_runtime_ids(configured_provider)
+            for entry in custom_providers:
+                entry_ids = _custom_provider_runtime_ids(
+                    entry.get("provider_key")
+                ) | _custom_provider_runtime_ids(entry.get("name"))
+                if configured_ids & entry_ids:
+                    configured_base_url = entry.get("base_url")
+                    break
+        except Exception:
+            configured_base_url = model_cfg.get("base_url")
+
     raw_ctx = model_cfg.get("context_length")
+    if raw_ctx is not None:
+        try:
+            from hermes_cli.route_identity import should_clear_context_pin
+
+            if should_clear_context_pin(
+                configured_model,
+                getattr(agent, "model", "") or "",
+                configured_base_url,
+                getattr(agent, "base_url", "") or "",
+                configured_provider,
+                getattr(agent, "provider", "") or "",
+            ):
+                raw_ctx = None
+        except Exception:
+            # Fail closed toward the active route: a default-model pin whose
+            # identity cannot be proven must not inflate another model's
+            # compressor window.
+            raw_ctx = None
+    if raw_ctx is None:
+        # ``agent_init`` accepts either the route-scoped global pin above or a
+        # per-model pin declared on a named custom provider.  Preserve that
+        # same precedence during Desktop/TUI hot reload: treating the absence
+        # of model.context_length as "no override" used to erase a valid
+        # providers.<name>.models.<model>.context_length on the first turn.
+        try:
+            from hermes_cli.config import get_custom_provider_context_length
+
+            raw_ctx = get_custom_provider_context_length(
+                model=getattr(agent, "model", "") or "",
+                base_url=getattr(agent, "base_url", "") or "",
+                custom_providers=custom_providers,
+            )
+        except Exception:
+            raw_ctx = None
     if raw_ctx is not None:
         try:
             new_ctx = int(raw_ctx)
         except (TypeError, ValueError):
             new_ctx = 0
         if new_ctx > 0:
+            agent._config_context_length = new_ctx
             cc._config_context_length = new_ctx
             try:
                 cc.context_length = new_ctx
@@ -6781,8 +6881,10 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
         # deferred get_model_context_length resolution agent construction
         # uses (#32221). The re-resolve also re-applies the small-context
         # threshold floor for the genuinely re-inferred window.
+        agent._config_context_length = None
         cc._config_context_length = None
         cc._resolved_context_length = None
+        cc._max_summary_tokens = None
 
     coerce_cap = getattr(cc, "_coerce_threshold_tokens_cap", None)
     if callable(coerce_cap):


### PR DESCRIPTION
## Summary

- preserve provider/model-scoped `context_length` during Desktop/TUI live compression reloads
- include provider/model context pins in the live compression config signature so edits apply on the next turn
- keep top-level `model.context_length` precedence only when the active model and normalized route match
- support named custom providers, legacy `custom_providers`, omitted `model.base_url`, and dict-valued `model.default`
- invalidate all context-window-derived caches, including the summary token budget, when a pin is removed

## Problem

Agent initialization already resolves `providers.<provider>.models.<model>.context_length`, but the Desktop/TUI hot-reload path only considered top-level `model.context_length`.

With a provider-scoped pin such as:

```yaml
providers:
  example:
    models:
      gpt-5.6-sol:
        context_length: 256000
```

initialization correctly set the compressor to `256000`. On the next Desktop/TUI live sync, the provider pin was treated as absent and cleared. If endpoint metadata did not expose a context window, the compressor then fell back to the hardcoded model value (for the reproduced model, `1050000`). This affected both the displayed capacity and the actual compression threshold.

The fix makes the live path follow the same model/route scoping rules as initialization and covers sibling cases where a session is pinned to a different provider route.

## Verification

- `python -m pytest -q tests/tui_gateway/test_compression_config_hot_reload.py` — **19 passed**
- `python -m ruff check tui_gateway/server.py tests/tui_gateway/test_compression_config_hot_reload.py` — passed
- `python -m py_compile tui_gateway/server.py tests/tui_gateway/test_compression_config_hot_reload.py` — passed
- `python scripts/check-windows-footguns.py tui_gateway/server.py tests/tui_gateway/test_compression_config_hot_reload.py` — passed
- `git diff --check` — passed
- no-inference runtime probe with a provider-scoped `256000` pin — `before=256000`, `after=256000`

I also ran the broader `tests/tui_gateway` directory on Windows. Five unrelated failures appeared outside the changed files; four reproduce directly on a clean `origin/main`, and the remaining toolset assertion passes in isolation and is order-dependent. The focused regression file and all static gates above are clean.

## Platform

- Windows 11
- Python 3.11.16
