### PR TITLE
fix(lifecycle): enforce parent disabled_toolsets in subagent launch validation

### DIFF
--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -414,3 +414,6 @@ class SubagentLifecycleService:
         enabled = getattr(parent, "enabled_toolsets", None)
         if enabled is not None and not set(request.allowed_toolsets).issubset(set(enabled)):
             raise SubagentLifecycleError("Requested toolsets would broaden parent permissions.")
+        disabled = getattr(parent, "disabled_toolsets", None)
+        if disabled and (set(request.allowed_toolsets) & set(disabled)):
+            raise SubagentLifecycleError("Requested toolsets would broaden parent permissions.")

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -178,3 +178,52 @@ def test_agent_turn_binds_and_clears_lifecycle_parent(monkeypatch):
     assert agent.run_conversation("hello") == {"final_response": "ok"}
     assert observed == [agent]
     assert get_active_subagent_parent() is None
+
+
+def test_launch_rejects_toolsets_in_parent_disabled_toolsets(monkeypatch):
+    """Requesting toolsets disabled on the parent raises SubagentLifecycleError before child construction."""
+    parent = SimpleNamespace(
+        session_id="parent-sec",
+        enabled_toolsets=None,
+        disabled_toolsets=["terminal", "web"],
+    )
+    service = SubagentLifecycleService(lambda: parent)
+
+    captured_builds = []
+
+    def mock_build_child(**kwargs):
+        captured_builds.append(kwargs)
+        return FakeChild("sa-sec-test")
+
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_preserving_parent_tools",
+        mock_build_child,
+    )
+    monkeypatch.setattr(
+        "tools.delegate_tool._run_single_child",
+        lambda *_args, **_kwargs: {"status": "completed"},
+    )
+
+    # Denied: toolset in parent's disabled_toolsets -> fails fast before child builder
+    with pytest.raises(
+        SubagentLifecycleError, match="Requested toolsets would broaden parent permissions"
+    ):
+        service.launch(
+            SubagentLaunchRequest(
+                goal="do something",
+                allowed_toolsets=("terminal", "file"),
+            )
+        )
+    assert len(captured_builds) == 0, "Child builder must not be invoked when validation fails"
+
+    # Allowed: toolset disjoint from parent's disabled_toolsets -> reaches child builder
+    handle = service.launch(
+        SubagentLaunchRequest(
+            goal="do something safe",
+            allowed_toolsets=("file",),
+        )
+    )
+    assert len(captured_builds) == 1
+    assert captured_builds[0]["toolsets"] == ["file"]
+    assert captured_builds[0]["parent_agent"] is parent
+    assert handle.subagent_id == "sa-sec-test"


### PR DESCRIPTION
## What does this PR do?

Hardens `SubagentLifecycleService.launch()` validation (`agent/subagent_lifecycle.py`) to reject requested `allowed_toolsets` that intersect the parent agent's `disabled_toolsets` before child construction (fail-fast contract parity at the public service boundary).

While `model_tools._compute_tool_definitions()` already subtracts inherited disabled toolsets downstream during child assembly, enforcing this at `SubagentLifecycleService._validate_request()` provides deterministic, fail-fast rejection of requests that attempt to broaden parent permissions.

## Related Issue

N/A (public lifecycle service boundary hardening)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/subagent_lifecycle.py`:
  - In `_validate_request()`: check if `request.allowed_toolsets` intersects `parent.disabled_toolsets` and raise `SubagentLifecycleError` with clear diagnostic text before child construction.
- `tests/agent/test_subagent_lifecycle.py`:
  - Added `test_launch_rejects_toolsets_in_parent_disabled_toolsets` asserting that:
    1. A forbidden toolset request raises `SubagentLifecycleError` and the child builder is never invoked.
    2. A disjoint allowed request successfully reaches the child builder with the expected toolset and parent reference.

## How to Test

1. Run lifecycle test suite:
   ```bash
   pytest tests/agent/test_subagent_lifecycle.py -v
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
