### PR TITLE
fix(desktop): board switcher crashed on every render

### DIFF
--- a/apps/desktop/src/plugins/kanban/board-switcher.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.test.tsx
@@ -1,0 +1,39 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type * as KanbanApi from './api'
+import { $boardSlug } from './api'
+import { BoardSwitcher } from './board-switcher'
+
+vi.mock('./api', async importOriginal => ({
+  ...(await importOriginal<typeof KanbanApi>()),
+  fetchBoards: vi.fn(async () => ({
+    boards: [{ name: 'Shipping', project_id: null, slug: 'shipping', total: 3 }],
+    current: 'shipping'
+  }))
+}))
+
+afterEach(() => {
+  cleanup()
+  $boardSlug.set('')
+})
+
+const mount = () =>
+  render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <BoardSwitcher />
+    </QueryClientProvider>
+  )
+
+describe('board switcher', () => {
+  // The rename and settings dialogs stay mounted while closed, so they render
+  // with a null board on every pass. Reading the slug inside their mutation
+  // callback used to crash the whole contribution, because the React Compiler
+  // lifts a callback's property reads into its render-time dependency check.
+  it('renders while its dialogs are closed', async () => {
+    mount()
+
+    expect(await screen.findByText('Shipping')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/board-switcher.tsx
+++ b/apps/desktop/src/plugins/kanban/board-switcher.tsx
@@ -218,6 +218,11 @@ function NewBoardDialog({ onClose, open }: { onClose: () => void; open: boolean 
 function RenameBoardDialog({ board, onClose }: { board: BoardMeta | null; onClose: () => void }) {
   const k = useKanban()
   const [name, setName] = useState('')
+  // The dialog stays mounted while closed, so `board` is null most of the
+  // time. Resolve the slug here rather than inside the mutation: the React
+  // Compiler lifts a callback's property reads into its render-time
+  // dependency check, which would deref that null on every closed render.
+  const slug = board?.slug ?? ''
 
   useEffect(() => {
     if (board) {
@@ -225,7 +230,7 @@ function RenameBoardDialog({ board, onClose }: { board: BoardMeta | null; onClos
     }
   }, [board])
 
-  const save = useBoardWrite(() => updateBoard(board!.slug, { name: name.trim() }), onClose)
+  const save = useBoardWrite(() => updateBoard(slug, { name: name.trim() }), onClose)
   const disabled = !name.trim() || save.isPending
 
   return (
@@ -240,7 +245,7 @@ function RenameBoardDialog({ board, onClose }: { board: BoardMeta | null; onClos
       <BoardNameField
         onChange={setName}
         onEnter={() => !disabled && save.mutate()}
-        slug={board?.slug ?? ''}
+        slug={slug}
         value={name}
       />
     </BoardDialog>
@@ -250,6 +255,9 @@ function RenameBoardDialog({ board, onClose }: { board: BoardMeta | null; onClos
 function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onClose: () => void }) {
   const k = useKanban()
   const [project, setProject] = useState('')
+  // Null while closed — see RenameBoardDialog on why this can't live inside
+  // the mutation callback.
+  const slug = board?.slug ?? ''
 
   useEffect(() => {
     if (board) {
@@ -259,7 +267,7 @@ function BoardSettingsDialog({ board, onClose }: { board: BoardMeta | null; onCl
 
   // The name lives in the rename dialog; '' clears the scope, which also
   // drops the mirrored default_workdir on the backend.
-  const save = useBoardWrite(() => updateBoard(board!.slug, { project_id: project }), onClose)
+  const save = useBoardWrite(() => updateBoard(slug, { project_id: project }), onClose)
 
   return (
     <BoardDialog


### PR DESCRIPTION
The Kanban board switcher has been dead since [#97636](https://github.com/NousResearch/hermes-agent/pull/97636) merged — it throws `TypeError: Cannot read properties of null (reading 'slug')` on mount and the titlebar shows the contribution's error chip instead of the board menu.

The rename and settings dialogs stay mounted while closed, so they render with a null `board` on every pass. Their mutation callbacks read `board!.slug`, and the React Compiler lifts a callback's property reads into its render-time dependency check:

```js
if ($[4] !== board.slug || $[5] !== name) {          // ← render time
  t3 = () => updateBoard(board.slug, { name: name.trim() });
```

So the read escaped the closure and dereferenced null immediately. The `!` never guarded anything; it erases at compile time. Resolving the slug null-safely in the component body is both correct and the form the compiler can hoist.

This arrived with the `useBoardWrite` extraction in that PR's cleanup pass, not with the feature. The inline `useMutation({ mutationFn })` shape it replaced memoized on the whole `board` object and kept the read inside the closure — verified against the compiler output for both shapes. I swept the rest of the desktop app for non-null assertions inside callbacks; the other sites (`registryBridge!.list()`, `canvasRef.current!.…`) all stay inside their closures.

## Test plan

- [x] `board-switcher.test.tsx` mounts the switcher and asserts it renders. Confirmed it fails with the exact `TypeError` when the fix is reverted, and that the vitest `ui` project extends `vite.config.ts`, so the compiler is in the transform path.
- [x] `npx vitest run src/plugins/kanban/` — 38 passed
- [x] `npx tsc --noEmit`, `npx eslint` clean
- [x] Verified live: no further boundary crashes in `desktop.log` after the fix hot-reloaded