### PR TITLE
fix(anthropic): sanitize scalar whitespace tool results to non-empty placeholder

### DIFF
--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -690,10 +690,10 @@ def _convert_tool_message_to_result(
     if multimodal_blocks:
         result_content: Any = multimodal_blocks
     elif isinstance(content, str):
-        result_content = content
+        result_content = content if content.strip() else "(no output)"
     else:
         result_content = json.dumps(content) if content else "(no output)"
-    if not result_content:
+    if not result_content or (isinstance(result_content, str) and not result_content.strip()):
         result_content = "(no output)"
     tool_result = {
         "type": "tool_result",
@@ -1136,6 +1136,11 @@ def _scrub_blank_text_blocks(result: List[Dict[str, Any]]) -> None:
                     role=role,
                     location="tool_result",
                 )
+            elif isinstance(inner, str):
+                if not inner.strip():
+                    blk["content"] = "(no output)"
+            elif not inner:
+                blk["content"] = "(no output)"
         msg["content"] = new_content
 
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1740,14 +1740,17 @@ def _find_blank_text_blocks(messages):
                 isinstance(blk.get("text"), str) and blk["text"].strip()
             ):
                 violations.append((m_idx, msg.get("role"), "content", b_idx))
-            if blk.get("type") == "tool_result" and isinstance(blk.get("content"), list):
-                for ib_idx, iblk in enumerate(blk["content"]):
-                    if (
-                        isinstance(iblk, dict)
-                        and iblk.get("type") == "text"
-                        and not (isinstance(iblk.get("text"), str) and iblk["text"].strip())
-                    ):
-                        violations.append((m_idx, msg.get("role"), "tool_result", ib_idx))
+            if blk.get("type") == "tool_result":
+                if isinstance(blk.get("content"), list):
+                    for ib_idx, iblk in enumerate(blk["content"]):
+                        if (
+                            isinstance(iblk, dict)
+                            and iblk.get("type") == "text"
+                            and not (isinstance(iblk.get("text"), str) and iblk["text"].strip())
+                        ):
+                            violations.append((m_idx, msg.get("role"), "tool_result", ib_idx))
+                elif isinstance(blk.get("content"), str) and not blk["content"].strip():
+                    violations.append((m_idx, msg.get("role"), "tool_result_scalar", b_idx))
     return violations
 
 
@@ -1907,3 +1910,38 @@ class TestFinalPayloadHasNoBlankTextBlocks:
         )
         image_blocks = [b for b in tool_result_block["content"] if b.get("type") == "image"]
         assert len(image_blocks) == 1
+
+    def test_blank_scalar_text_in_tool_result_is_coerced_to_placeholder(self):
+        """A whitespace-only scalar tool result (e.g. from empty terminal output)
+        must be coerced to '(no output)' to prevent HTTP 400 rejection."""
+        messages = [
+            {"role": "user", "content": "run command"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_4",
+                        "function": {"name": "terminal", "arguments": '{"command": "true"}'},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_4",
+                "content": "   \n\t  ",
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assert _find_blank_text_blocks(result) == []
+        tool_result_msg = next(
+            m
+            for m in result
+            if m["role"] == "user"
+            and isinstance(m["content"], list)
+            and any(b.get("type") == "tool_result" for b in m["content"])
+        )
+        tool_result_block = next(
+            b for b in tool_result_msg["content"] if b.get("type") == "tool_result"
+        )
+        assert tool_result_block["content"] == "(no output)"


### PR DESCRIPTION
## What does this PR do?

Fixes a protocol rejection and session-wedging bug in [`agent/anthropic_adapter.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/anthropic_adapter.py) where scalar tool results containing whitespace-only strings (e.g. `"   "`, `"\n"` from shell tools or empty outputs) were passed unsanitized into `tool_result` content, resulting in immediate `HTTP 400 Bad Request: text content blocks must contain non-whitespace text` on Anthropic and Bedrock endpoints and permanently crashing subsequent turns upon SQLite history replay.

In Hermes Agent:
1. The Anthropic Messages API strictly enforces that all text content blocks and `tool_result` text content must contain non-whitespace text.
2. In `_convert_tool_message_to_result()`, scalar string outputs were passed directly as `result_content = content`. For whitespace strings like `"   "`, `"   "` is truthy in Python, so `if not result_content:` evaluated to `False`, emitting `{"type": "tool_result", "content": "   "}`.
3. In `_scrub_blank_text_blocks()` (the final provider boundary pass), it iterated over `tool_result` blocks but only inspected `if isinstance(inner, list)`, completely skipping scalar strings.
4. Consequently, whitespace-only scalar tool outputs reached the wire, causing `HTTP 400 Bad Request` API rejections from Anthropic and Bedrock.

The fix updates `_convert_tool_message_to_result()` and `_scrub_blank_text_blocks()` to ensure that scalar string tool results are verified with `.strip()`, falling back to `"(no output)"` if whitespace-only or empty.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py`:
  - Updated `_convert_tool_message_to_result()` to fall back to `"(no output)"` when `content` is a whitespace-only scalar string.
  - Updated `_scrub_blank_text_blocks()` to sanitize scalar string `inner` content on `tool_result` blocks.
- `tests/agent/test_anthropic_adapter.py`:
  - Updated `_find_blank_text_blocks` helper to inspect scalar strings in `tool_result` blocks.
  - Added `test_blank_scalar_text_in_tool_result_is_coerced_to_placeholder` asserting that whitespace-only scalar tool outputs are coerced to `"(no output)"`.

## How to Test

Run the Anthropic adapter test suite:
```bash
uv run --with pytest tests/agent/test_anthropic_adapter.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(anthropic): sanitize scalar whitespace tool results to non-empty placeholder`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 104 items

tests/agent/test_anthropic_adapter.py ................................... [100%]

============================= 104 passed in 9.12s ==============================
```
