### PR TITLE
fix(discord): align clarify button lifetime

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -986,6 +986,8 @@ def _clarify_send_then_wait(fut, *, clarify_id: str, session_key: str, clarify_m
     response = clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))
     if response is None or response == "":
         # Timeout or session-boundary cancellation
+        if timeout <= 0:
+            return "[clarify wait cancelled before user response]"
         return f"[user did not respond within {int(timeout / 60)}m]"
     return response
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1031,6 +1031,24 @@ def _read_discord_prompt_timeout() -> int:
     return seconds
 
 
+def _read_discord_clarify_timeout() -> Optional[float]:
+    """Return the canonical clarify lifetime for Discord choice buttons.
+
+    Clarify prompts are not execution approvals: their button view must remain
+    usable for exactly as long as the gateway is waiting for the user's answer.
+    A non-positive canonical timeout means unlimited and maps to discord.py's
+    ``View(timeout=None)``. Security-sensitive approval views continue using
+    the separately bounded ``approvals.discord_prompt_timeout`` setting.
+    """
+    try:
+        from tools.clarify_gateway import get_clarify_timeout
+
+        seconds = float(get_clarify_timeout())
+    except Exception:
+        seconds = 3600.0
+    return None if seconds <= 0 else seconds
+
+
 class DiscordAdapter(BasePlatformAdapter):
     """
     Discord bot adapter.
@@ -9636,7 +9654,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=_read_discord_prompt_timeout())
+            super().__init__(timeout=_read_discord_clarify_timeout())
             self.choices = list(choices)[:24]
             self.clarify_id = clarify_id
             self.allowed_user_ids = allowed_user_ids

--- a/tests/gateway/test_clarify_send_timeout_ambiguity.py
+++ b/tests/gateway/test_clarify_send_timeout_ambiguity.py
@@ -154,6 +154,21 @@ def test_no_response_returns_timeout_sentinel():
     )
 
 
+def test_unlimited_wait_cancellation_does_not_claim_zero_minute_timeout():
+    fut = MagicMock()
+    fut.result.return_value = _Result(True)
+    clarify_mod = MagicMock()
+    clarify_mod.get_clarify_timeout.return_value = 0
+    clarify_mod.wait_for_response.return_value = None
+
+    assert (
+        _clarify_send_then_wait(
+            fut, clarify_id="cid123", session_key="sk", clarify_mod=clarify_mod
+        )
+        == "[clarify wait cancelled before user response]"
+    )
+
+
 # --- Definitive failures keep their diagnostic detail in the log ----------
 
 

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -86,6 +86,25 @@ class TestClarifyChoiceViewConstruction:
     """The view should build numeric buttons plus an Other button."""
 
 
+    def test_unlimited_clarify_keeps_discord_buttons_live(self, monkeypatch):
+        """Discord's button view must share the canonical clarify lifetime.
+
+        A separate five-minute view timeout made the card look expired while
+        the gateway was still waiting for the user's answer.
+        """
+        monkeypatch.setattr(
+            "tools.clarify_gateway.get_clarify_timeout", lambda: 0
+        )
+
+        view = ClarifyChoiceView(
+            choices=["approve", "reject"],
+            clarify_id="cid-unlimited",
+            allowed_user_ids=set(),
+        )
+
+        assert view.timeout is None
+
+
     def test_truncates_long_choice_label(self):
         long_choice = "x" * 200
         view = ClarifyChoiceView(


### PR DESCRIPTION
## What does this PR do?

Discord native-choice `clarify` prompts currently have two independent lifetimes:

- `ClarifyChoiceView` uses `approvals.discord_prompt_timeout` (300 seconds by default, capped at 900 seconds).
- The gateway waiter uses `agent.clarify_timeout` (3600 seconds by default; `<= 0` means unlimited).

After five minutes, Discord disables the buttons and says the prompt expired even though Hermes may still be waiting for up to another 55 minutes—or forever when clarify is configured as unlimited.

This PR makes the Discord clarify view use the same canonical clarify timeout as the gateway waiter:

- positive timeout: the buttons and waiter share the same lifetime;
- non-positive timeout: `discord.ui.View(timeout=None)`, matching the documented unlimited wait;
- execution approvals and other security-sensitive Discord views continue using the separately bounded `approvals.discord_prompt_timeout`.

It also fixes the cancellation sentinel for an unlimited wait. A session interruption previously produced `[user did not respond within 0m]`; it now reports `[clarify wait cancelled before user response]`.

## Related work

Related but intentionally different from #72742.

#72742 keeps the five-minute Discord view deadline, then introduces a second typed-answer grace timer and eventually resolves the waiter with an empty response. This PR instead removes the deadline split at its source. That preserves the documented `agent.clarify_timeout <= 0` unlimited contract and avoids another timer/task/race lifecycle.

## Type of change

- [x] Bug fix

## Changes

- Add `_read_discord_clarify_timeout()` using the canonical clarify resolver.
- Use it only for `ClarifyChoiceView`; approval/confirmation views stay bounded.
- Distinguish unlimited-wait cancellation from a finite timeout.
- Add regressions for unlimited Discord view lifetime and the false `0m` sentinel.

## Test plan

The new tests were first run against the old behavior and failed as expected:

- Discord view timeout was `300`, not `None`.
- unlimited-wait cancellation returned `[user did not respond within 0m]`.

After the fix:

```bash
scripts/run_tests.sh tests/gateway/test_discord_clarify_buttons.py -q -k 'TestClarifyChoiceViewConstruction'
# 3 passed

scripts/run_tests.sh \
  tests/gateway/test_discord_prompt_timeout_config.py \
  tests/tools/test_clarify_gateway.py \
  tests/gateway/test_clarify_send_timeout_ambiguity.py -q
# 47 passed
```

Live verification on Discord/Linux:

- `agent.clarify_timeout: 0`
- resolved clarify view timeout: `None`
- resolved execution-approval view timeout: `300`
- gateway restarted onto the patched checkout successfully.

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] Searched open and closed issues/PRs
- [x] Cross-referenced the overlapping open PR instead of claiming no prior work
- [x] Branch contains only the four scoped code/test files
- [x] Added red-capable regression tests
- [x] Ran focused canonical test commands
- [x] Preserved bounded execution-approval behavior
