### PR TITLE
fix(honcho): omit reasoning-contaminated session summaries

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -652,7 +652,9 @@ class HonchoMemoryProvider(MemoryProvider):
         parts = []
 
         # Session summary — session-scoped context, placed first for relevance
-        summary = ctx.get("summary", "")
+        from plugins.memory.honcho.session import usable_honcho_summary
+
+        summary = usable_honcho_summary(ctx.get("summary", ""))
         if summary:
             parts.append(f"## Session Summary\n{summary}")
 
@@ -832,7 +834,11 @@ class HonchoMemoryProvider(MemoryProvider):
                         base_context = formatted
 
             if base_context:
-                parts.append(base_context)
+                from plugins.memory.honcho.session import scrub_formatted_honcho_context
+
+                base_context = scrub_formatted_honcho_context(base_context)
+                if base_context:
+                    parts.append(base_context)
 
         # ----- Layer 2: Dialectic supplement -----
         # Turn 1 may briefly wait for dialectic; unfinished work remains async.
@@ -1617,7 +1623,11 @@ class HonchoMemoryProvider(MemoryProvider):
                     return json.dumps({"result": "No context available yet."})
                 parts = []
                 if ctx.get("summary"):
-                    parts.append(f"## Summary\n{ctx['summary']}")
+                    from plugins.memory.honcho.session import usable_honcho_summary
+
+                    summary = usable_honcho_summary(ctx["summary"])
+                    if summary:
+                        parts.append(f"## Summary\n{summary}")
                 if ctx.get("representation"):
                     parts.append(f"## Representation\n{ctx['representation']}")
                 if ctx.get("card"):

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -43,6 +43,65 @@ _AUTH_ERROR_MARKERS = (
 # A 401 in text counts only with HTTP context ("HTTP 401", "status 401"), never as a bare number.
 _HTTP_401_RE = re.compile(r"\b(?:http|status(?:[ _]code)?\s*[:=]?)\s*401\b")
 
+_THINK_BLOCK_RE = re.compile(
+    r"<\s*(?:think|thinking|reasoning|thought|reasoning_scratchpad)\s*>"
+    r".*?"
+    r"<\s*/\s*(?:think|thinking|reasoning|thought|reasoning_scratchpad)\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+_THINK_CLOSE_RE = re.compile(r"</\s*think\s*>", re.IGNORECASE)
+_PLANNING_HEAD_RE = re.compile(
+    r"^(?:i need to create a thorough|"
+    r"the instruction says to focus on capturing key facts|"
+    r"first, let me review)",
+    re.IGNORECASE,
+)
+
+
+def usable_honcho_summary(text: object) -> str | None:
+    """Return a session summary safe to inject, or None to omit it.
+
+    Honcho summarizers can persist the model's planning/`</think>` preamble
+    as the summary body (#97639). That text must not become trusted memory.
+    """
+    raw = "" if text is None else str(text)
+    if not raw.strip():
+        return None
+    # Observed payload starts inside a think block (no opening tag) then
+    # closes with ``</think>`` before the ordinary summary.
+    close = _THINK_CLOSE_RE.search(raw)
+    if close:
+        raw = raw[close.end() :]
+    cleaned = _THINK_BLOCK_RE.sub("", raw).strip()
+    if not cleaned:
+        return None
+    if "<think" in cleaned.lower() or "</think" in cleaned.lower():
+        return None
+    if _PLANNING_HEAD_RE.search(cleaned.lstrip()):
+        return None
+    return cleaned
+
+
+def scrub_formatted_honcho_context(formatted: str) -> str:
+    """Drop a cached ``## Session Summary`` section that is still contaminated."""
+    if not formatted:
+        return formatted
+    if "## Session Summary\n" not in formatted:
+        return formatted
+    chunks = re.split(r"(?=\n## )", "\n" + formatted.lstrip("\n"))
+    kept: list[str] = []
+    for chunk in chunks:
+        body = chunk.lstrip("\n")
+        if not body.strip():
+            continue
+        if body.startswith("## Session Summary\n"):
+            usable = usable_honcho_summary(body.split("\n", 1)[1])
+            if usable:
+                kept.append(f"## Session Summary\n{usable}")
+            continue
+        kept.append(body)
+    return "\n\n".join(kept)
+
 
 def _is_auth_error(exc: BaseException) -> bool:
     status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
@@ -1019,7 +1078,9 @@ class HonchoSessionManager:
                     lambda: self._sdk_session(session.honcho_session_id).context(summary=True),
                 )
                 if ctx.summary and getattr(ctx.summary, "content", None):
-                    result["summary"] = ctx.summary.content
+                    summary = usable_honcho_summary(ctx.summary.content)
+                    if summary:
+                        result["summary"] = summary
         except HonchoAuthError:
             # Auth is dead; the pop_auth_notice path tells the model why context is missing.
             return result
@@ -1377,7 +1438,9 @@ class HonchoSessionManager:
 
             # Summary
             if ctx.summary:
-                result["summary"] = ctx.summary.content
+                summary = usable_honcho_summary(getattr(ctx.summary, "content", ctx.summary))
+                if summary:
+                    result["summary"] = summary
 
             # Peer representation and card
             if ctx.peer_representation:

--- a/tests/test_honcho_summary_sanitize.py
+++ b/tests/test_honcho_summary_sanitize.py
@@ -1,0 +1,150 @@
+"""Honcho session summaries must not inject model reasoning (#97639)."""
+
+from types import SimpleNamespace
+
+from plugins.memory.honcho.session import (
+    HonchoSession,
+    HonchoSessionManager,
+    scrub_formatted_honcho_context,
+    usable_honcho_summary,
+)
+
+
+CONTAMINATED = """I need to create a thorough, comprehensive summary of this conversation.
+The instruction says to focus on capturing key facts...
+First, let me review what I have in the previous summary...
+</think>
+Alice prefers dark roast coffee.
+"""
+
+PLANNING_ONLY = """I need to create a thorough, comprehensive summary of this conversation.
+The instruction says to focus on capturing key facts...
+First, let me review what I have in the previous summary...
+"""
+
+
+def test_usable_summary_keeps_text_after_think_close() -> None:
+    out = usable_honcho_summary(CONTAMINATED)
+    assert out is not None
+    assert "Alice prefers dark roast coffee." in out
+    assert "</think>" not in out.lower()
+    assert "I need to create a thorough" not in out
+
+
+def test_usable_summary_drops_planning_preamble_without_body() -> None:
+    assert usable_honcho_summary(PLANNING_ONLY) is None
+
+
+def test_usable_summary_drops_closed_think_block() -> None:
+    raw = "<think>plan the summary</think>\nBob uses vim."
+    out = usable_honcho_summary(raw)
+    assert out == "Bob uses vim."
+
+
+def test_usable_summary_keeps_clean_text() -> None:
+    assert usable_honcho_summary("Uses Python 3.11.") == "Uses Python 3.11."
+
+
+def test_scrub_formatted_cache_drops_contaminated_summary_keeps_card() -> None:
+    formatted = (
+        "## Session Summary\n"
+        + CONTAMINATED
+        + "\n\n## User Peer Card\nLikes espresso."
+    )
+    out = scrub_formatted_honcho_context(formatted)
+    assert "Likes espresso." in out
+    assert "I need to create a thorough" not in out
+    assert "Alice prefers dark roast coffee." in out
+
+
+class _FakeSummary:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeContext:
+    def __init__(self, content: str) -> None:
+        self.summary = _FakeSummary(content)
+        self.peer_representation = "representation"
+        self.peer_card = ["fact"]
+        self.messages = []
+
+
+class _RecordingHonchoSession:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+    def context(self, **kwargs):
+        return _FakeContext(self.content)
+
+
+def _manager_with_summary(content: str):
+    cfg = SimpleNamespace(
+        write_frequency="turn",
+        dialectic_reasoning_level="low",
+        dialectic_dynamic=True,
+        dialectic_max_chars=600,
+        observation_mode="directional",
+        user_observe_me=True,
+        user_observe_others=True,
+        ai_observe_me=True,
+        ai_observe_others=True,
+        message_max_chars=25000,
+        dialectic_max_input_chars=10000,
+    )
+    mgr = HonchoSessionManager(honcho=SimpleNamespace(), config=cfg)
+    session = HonchoSession(
+        key="test-session",
+        user_peer_id="chris",
+        assistant_peer_id="hermes",
+        honcho_session_id="test-session",
+    )
+    fake = _RecordingHonchoSession(content)
+    mgr._cache[session.key] = session
+    mgr._sessions_cache[session.honcho_session_id] = fake
+    return mgr
+
+
+def test_prefetch_omits_planning_only_summary() -> None:
+    mgr = _manager_with_summary(PLANNING_ONLY)
+    mgr._fetch_peer_context = lambda *a, **k: {
+        "representation": "representation",
+        "card": ["fact"],
+    }
+    mgr._resolve_observer_target = lambda *a, **k: ("hermes", "chris")
+    result = mgr.get_prefetch_context("test-session")
+    assert "summary" not in result
+    assert result.get("representation") == "representation"
+
+
+def test_prefetch_keeps_body_after_think_close() -> None:
+    mgr = _manager_with_summary(CONTAMINATED)
+    mgr._fetch_peer_context = lambda *a, **k: {
+        "representation": "representation",
+        "card": ["fact"],
+    }
+    mgr._resolve_observer_target = lambda *a, **k: ("hermes", "chris")
+    result = mgr.get_prefetch_context("test-session")
+    assert result["summary"] == "Alice prefers dark roast coffee."
+
+
+def test_session_context_omits_planning_only_summary() -> None:
+    mgr = _manager_with_summary(PLANNING_ONLY)
+    result = mgr.get_session_context("test-session")
+    assert "summary" not in result
+    assert result.get("representation") == "representation"
+
+
+def test_format_first_turn_omits_contaminated_summary() -> None:
+    from plugins.memory.honcho import HonchoMemoryProvider
+
+    plugin = HonchoMemoryProvider.__new__(HonchoMemoryProvider)
+    out = plugin._format_first_turn_context(
+        {
+            "summary": PLANNING_ONLY,
+            "card": "Likes espresso.",
+        }
+    )
+    assert "Likes espresso." in out
+    assert "Session Summary" not in out
+    assert "I need to create a thorough" not in out


### PR DESCRIPTION
## What does this PR do?

Honcho session summaries can persist the summarizer model's planning/`</think>` preamble. Hermes then injects that text under `## Session Summary` as trusted memory.

`usable_honcho_summary` keeps the ordinary body after a think close-tag, and omits planning-only or still-tagged text. Fetch (`get_prefetch_context` / `get_session_context`), format, `honcho_context`, and the formatted cache all go through that guard so a stale contaminated cache cannot be re-emitted.

Producer-side Honcho coordination is out of scope here.

## Related Issue

Fixes #97639

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/session.py`: `usable_honcho_summary` + `scrub_formatted_honcho_context`; apply on summary fetch
- `plugins/memory/honcho/__init__.py`: format, cache read, and `honcho_context` use the same guard
- `tests/test_honcho_summary_sanitize.py`: think-close keeps the body; planning-only omitted; cache keeps the peer card

## How to Test

```text
python -m pytest tests/test_honcho_summary_sanitize.py tests/test_honcho_session_context.py -q
# 12 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted tests listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (unit tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
