### PR TITLE
feat(auxiliary): share local model preset and add hermes memory add

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8401,6 +8401,11 @@ def _resolve_task_provider_model(
             return cfg_provider, resolved_model, cfg_base_url, None, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
+        if cfg_base_url:
+            # Local / OpenAI-compatible servers often have a base_url and no
+            # API key (Ollama, llama.cpp, LM Studio). Do not drop the endpoint
+            # just because provider is still the default "auto".
+            return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
 
         return "auto", resolved_model, None, None, resolved_api_mode
 
@@ -8419,6 +8424,45 @@ _DEFAULT_AUX_TIMEOUT = 30.0
 # (they finish before the deadline) and is a minimum, so a higher config value
 # is kept unchanged.
 _COMPRESSION_TIMEOUT_FLOOR_SECONDS = 300.0
+
+
+_LOCAL_PRESET_KEYS = ("base_url", "model", "api_key", "provider", "api_mode", "key_env")
+
+
+def _apply_auxiliary_local_preset(
+    task: str,
+    task_config: Dict[str, Any],
+    aux: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Inherit empty fields from ``auxiliary.local`` when ``task`` is listed.
+
+    ``auxiliary.local.tasks`` is required and explicit — an empty list means
+    the preset is inert so a leftover base_url cannot silently reroute every
+    side task. Per-task non-empty keys are never overwritten.
+    """
+    if not isinstance(aux, dict):
+        return task_config
+    local = aux.get("local")
+    if not isinstance(local, dict):
+        return task_config
+    raw_tasks = local.get("tasks")
+    if not isinstance(raw_tasks, list) or not raw_tasks:
+        return task_config
+    wanted = {str(name).strip() for name in raw_tasks if str(name).strip()}
+    if task not in wanted:
+        return task_config
+    merged = dict(task_config)
+    for key in _LOCAL_PRESET_KEYS:
+        existing = str(merged.get(key) or "").strip()
+        if existing:
+            continue
+        incoming = local.get(key)
+        if incoming is None:
+            continue
+        text = str(incoming).strip()
+        if text:
+            merged[key] = text
+    return merged
 
 
 def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
@@ -8444,6 +8488,12 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     task_config = aux.get(task, {}) if isinstance(aux, dict) else {}
     if not isinstance(task_config, dict):
         task_config = {}
+
+    # Shared auxiliary.local preset fills empty per-task fields only.
+    # Explicit auxiliary.<task>.* values always win. ``local`` itself is
+    # not a task slot.
+    if task != "local":
+        task_config = _apply_auxiliary_local_preset(task, task_config, aux)
 
     # Layer plugin-declared defaults underneath user config so
     # ctx.register_auxiliary_task(defaults={...}) takes effect without

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1093,6 +1093,18 @@ DEFAULT_CONFIG = {
     # Each aux task is independent — main-agent provider_routing and
     # openrouter.min_coding_score do NOT propagate to aux calls by design.
     "auxiliary": {
+        # Shared local/OpenAI-compatible preset for side tasks. Empty by
+        # default (no routing change). When base_url + tasks are set, listed
+        # auxiliary.<task> slots inherit these fields unless the slot already
+        # has its own non-empty value. This is not a bundled in-process model
+        # — point it at Ollama, llama.cpp, LM Studio, or any /v1 endpoint.
+        "local": {
+            "base_url": "",
+            "model": "",
+            "api_key": "",
+            "provider": "",
+            "tasks": [],
+        },
         # Same-provider retries for a transient transport blip (connection
         # reset / timeout / 5xx / 408) on ANY auxiliary call before falling
         # back. Default 2 (→ 3 total attempts), clamped [0,6]. Matters most for

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12858,6 +12858,19 @@ def cmd_memory(args):
             "\n  Memory reset complete. New sessions will start with a blank slate."
         )
         print(f"  Files were in: {display_hermes_home()}/memories/\n")
+    elif sub == "add":
+        from hermes_cli.memory_write import add_builtin_memory
+        from hermes_constants import display_hermes_home
+
+        target = getattr(args, "target", "memory") or "memory"
+        result = add_builtin_memory(content=getattr(args, "content", ""), target=target)
+        if not result.get("success"):
+            print(f"\n  Memory add failed: {result.get('error', 'unknown error')}\n")
+            return 1
+        filename = "USER.md" if target == "user" else "MEMORY.md"
+        print(f"\n  {result.get('message', 'Entry added.')}")
+        print(f"  Wrote {display_hermes_home()}/memories/{filename}")
+        print("  Open sessions keep their current snapshot until the next session.\n")
     else:
         from hermes_cli.memory_setup import memory_command
 

--- a/hermes_cli/memory_write.py
+++ b/hermes_cli/memory_write.py
@@ -1,0 +1,36 @@
+"""CLI writes to built-in MEMORY.md / USER.md without an agent turn."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def add_builtin_memory(content: str, target: str = "memory") -> Dict[str, Any]:
+    """Append one built-in memory entry using the same store as the memory tool.
+
+    This is a housekeeping path: no LLM call, no conversation loop. The write
+    is live on disk immediately; an already-open session keeps its frozen
+    system-prompt snapshot until the next session (prompt-cache invariant).
+    """
+    from hermes_cli.config import load_config
+    from tools.memory_tool import MemoryStore
+
+    store_name = (target or "memory").strip().lower()
+    if store_name not in {"memory", "user"}:
+        return {"success": False, "error": "target must be 'memory' or 'user'."}
+
+    text = (content or "").strip()
+    if not text:
+        return {"success": False, "error": "Content cannot be empty."}
+
+    config = load_config()
+    mem = config.get("memory") if isinstance(config, dict) else {}
+    if not isinstance(mem, dict):
+        mem = {}
+
+    store = MemoryStore(
+        memory_char_limit=int(mem.get("memory_char_limit") or 2200),
+        user_char_limit=int(mem.get("user_char_limit") or 1375),
+    )
+    store.load_from_disk()
+    return store.add(store_name, text)

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -15,7 +15,8 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         "memory",
         help="Configure external memory provider",
         description=(
-            "Set up and manage external memory provider plugins.\n\n"
+            "Set up and manage external memory provider plugins, and write\n"
+            "built-in MEMORY.md / USER.md entries without an agent turn.\n\n"
             "Available providers: honcho, openviking, mem0, hindsight,\n"
             "holographic, retaindb, byterover.\n\n"
             "Only one external provider can be active at a time.\n"
@@ -49,5 +50,19 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         choices=["all", "memory", "user"],
         default="all",
         help="Which store to reset: 'all' (default), 'memory', or 'user'",
+    )
+    _add_parser = memory_sub.add_parser(
+        "add",
+        help="Append a built-in memory entry without calling a model",
+    )
+    _add_parser.add_argument(
+        "content",
+        help="Entry text to store in MEMORY.md or USER.md",
+    )
+    _add_parser.add_argument(
+        "--target",
+        choices=["memory", "user"],
+        default="memory",
+        help="Which store to write: memory (MEMORY.md) or user (USER.md)",
     )
     memory_parser.set_defaults(func=cmd_memory)

--- a/tests/agent/test_auxiliary_local.py
+++ b/tests/agent/test_auxiliary_local.py
@@ -1,0 +1,95 @@
+"""Shared auxiliary.local preset fills empty per-task fields only."""
+
+from unittest.mock import patch
+
+from agent.auxiliary_client import _get_auxiliary_task_config, _resolve_task_provider_model
+
+
+def test_local_preset_fills_empty_listed_task():
+    config = {
+        "auxiliary": {
+            "local": {
+                "base_url": "http://127.0.0.1:11434/v1",
+                "model": "qwen3.5:2b",
+                "tasks": ["compression", "memory_query_rewrite"],
+            },
+            "compression": {"provider": "auto", "model": "", "base_url": ""},
+        }
+    }
+    with patch("hermes_cli.config.load_config_readonly", return_value=config):
+        task = _get_auxiliary_task_config("compression")
+        assert task["base_url"] == "http://127.0.0.1:11434/v1"
+        assert task["model"] == "qwen3.5:2b"
+        provider, model, base_url, _api_key, _mode = _resolve_task_provider_model(
+            task="compression"
+        )
+        assert provider == "custom"
+        assert model == "qwen3.5:2b"
+        assert base_url == "http://127.0.0.1:11434/v1"
+
+
+def test_per_task_values_win_over_local_preset():
+    config = {
+        "auxiliary": {
+            "local": {
+                "base_url": "http://127.0.0.1:11434/v1",
+                "model": "qwen3.5:2b",
+                "tasks": ["compression"],
+            },
+            "compression": {
+                "provider": "auto",
+                "model": "kept-model",
+                "base_url": "http://127.0.0.1:8080/v1",
+            },
+        }
+    }
+    with patch("hermes_cli.config.load_config_readonly", return_value=config):
+        provider, model, base_url, _api_key, _mode = _resolve_task_provider_model(
+            task="compression"
+        )
+        assert provider == "custom"
+        assert model == "kept-model"
+        assert base_url == "http://127.0.0.1:8080/v1"
+
+
+def test_unlisted_or_empty_tasks_leave_slot_unchanged():
+    config = {
+        "auxiliary": {
+            "local": {
+                "base_url": "http://127.0.0.1:11434/v1",
+                "model": "qwen3.5:2b",
+                "tasks": [],
+            },
+            "compression": {"provider": "auto", "model": "", "base_url": ""},
+            "title_generation": {"provider": "auto", "model": "", "base_url": ""},
+        }
+    }
+    with patch("hermes_cli.config.load_config_readonly", return_value=config):
+        compression = _get_auxiliary_task_config("compression")
+        assert not str(compression.get("base_url") or "").strip()
+        config["auxiliary"]["local"]["tasks"] = ["title_generation"]
+        title = _get_auxiliary_task_config("title_generation")
+        other = _get_auxiliary_task_config("compression")
+        assert title["base_url"] == "http://127.0.0.1:11434/v1"
+        assert not str(other.get("base_url") or "").strip()
+
+
+def test_task_base_url_without_api_key_resolves_custom():
+    """Per-task local endpoints must not require a dummy API key."""
+    config = {
+        "auxiliary": {
+            "compression": {
+                "provider": "auto",
+                "model": "qwen3:8b",
+                "base_url": "http://localhost:11434/v1",
+            },
+        }
+    }
+    with patch("hermes_cli.config.load_config_readonly", return_value=config):
+        provider, model, base_url, api_key, _mode = _resolve_task_provider_model(
+            task="compression"
+        )
+        assert provider == "custom"
+        assert model == "qwen3:8b"
+        assert base_url == "http://localhost:11434/v1"
+        assert not api_key

--- a/tests/hermes_cli/test_memory_add.py
+++ b/tests/hermes_cli/test_memory_add.py
@@ -1,0 +1,45 @@
+"""Tests for `hermes memory add` — no-LLM built-in memory writes."""
+
+from hermes_cli.memory_write import add_builtin_memory
+
+
+def test_memory_add_writes_memory_md(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    memories = hermes_home / "memories"
+    memories.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"memory_char_limit": 2200, "user_char_limit": 1375}},
+    )
+
+    result = add_builtin_memory("Prefer dark themes", target="memory")
+    assert result.get("success") is True
+    text = (memories / "MEMORY.md").read_text(encoding="utf-8")
+    assert "Prefer dark themes" in text
+
+
+def test_memory_add_user_target(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    (hermes_home / "memories").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"memory_char_limit": 2200, "user_char_limit": 1375}},
+    )
+
+    result = add_builtin_memory("Timezone: US Pacific", target="user")
+    assert result.get("success") is True
+    text = (hermes_home / "memories" / "USER.md").read_text(encoding="utf-8")
+    assert "Timezone: US Pacific" in text
+
+
+def test_memory_add_rejects_empty(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    (hermes_home / "memories").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"memory": {}})
+
+    result = add_builtin_memory("   ", target="memory")
+    assert result.get("success") is False
+    assert "empty" in str(result.get("error", "")).lower()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1296,6 +1296,23 @@ auxiliary:
 
 When `base_url` is set, Hermes ignores the provider and calls that endpoint directly (using `api_key` or `OPENAI_API_KEY` for auth). When only `provider` is set, Hermes uses that provider's built-in auth and base URL.
 
+To share one local endpoint across several side tasks (without repeating `base_url` on each slot), set `auxiliary.local`. Listed tasks inherit empty fields from the preset; a non-empty `auxiliary.<task>` value always wins. An empty `tasks` list leaves every slot unchanged.
+
+```yaml
+auxiliary:
+  local:
+    base_url: "http://127.0.0.1:11434/v1"
+    model: "qwen3.5:2b"
+    tasks:
+      - compression
+      - title_generation
+      - memory_query_rewrite
+      - skills_hub
+      - approval
+```
+
+This is still your local server — Hermes does not bundle model weights. Saving a memory fact without an agent turn is `hermes memory add "…"`. Installing a skill without a chat loop is `hermes skills install …`.
+
 Available providers for auxiliary tasks: `auto`, `main`, plus any provider in the [provider registry](/reference/environment-variables) — `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `alibaba`, `bedrock`, `huggingface`, `arcee`, `xiaomi`, `kilocode`, `opencode-zen`, `opencode-go`, `opencode-free`, `commandcode`, `commandcode-anthropic`, `ai-gateway`, `azure-foundry` — or any named custom provider from your `providers:` dict (e.g. `provider: "beans"`).
 
 :::tip MiniMax OAuth

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -75,6 +75,8 @@ Click **Show auxiliary** to reveal the 11 task slots:
 
 Every auxiliary task defaults to `auto` — meaning Hermes tries your main model for that job too. If that route is unavailable or hits a capacity-style failure, `auto` follows any task-specific `auxiliary.<task>.fallback_chain`, then the main `fallback_providers` / `fallback_model` chain, then Hermes' built-in auxiliary discovery chain. Override a specific task when you want a cheaper or faster model for a side-job.
 
+Hermes does **not** ship an in-process LLM. Local models stay on your endpoint (Ollama, llama.cpp, LM Studio, or any OpenAI-compatible `/v1` server). To point several side tasks at one local model without repeating `base_url` on every slot, set `auxiliary.local` and list the tasks that should inherit it. Per-task values still win. Housekeeping that should not wait on any model at all — appending MEMORY.md / USER.md, installing a skill — uses the CLI (`hermes memory add`, `hermes skills install`) instead of a chat turn. Obsidian notes are ordinary vault files; write them with file tools or the `obsidian` skill rather than a second model.
+
 ### Common override patterns
 
 | Task | When to override |


### PR DESCRIPTION
## What does this PR do?

Housekeeping (save a memory fact, pin a cheap local model for side tasks) still goes through the main agent loop today, so even Gemini Flash or a local 2B/4B feels slow. Hermes already talks to local OpenAI-compatible servers and already has per-task `auxiliary.<task>.base_url`, but users have to repeat the endpoint on every slot, and a slot with `provider: auto` plus `base_url` and no API key dropped the endpoint entirely (Ollama / llama.cpp / LM Studio typically have no key).

This PR adds a shared `auxiliary.local` preset that listed side tasks inherit when their own fields are empty, keeps a configured `base_url` as `custom` without a dummy key, and adds `hermes memory add` so MEMORY.md / USER.md can be appended through the same `MemoryStore` as the memory tool — no chat turn. Skill install stays `hermes skills install`. Obsidian stays filesystem writes via the existing skill. Hermes still does not ship model weights.

## Related Issue

Fixes #79415

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config_defaults.py` — default `auxiliary.local` (`base_url`, `model`, `api_key`, `provider`, `tasks`; empty `tasks` is inert)
- `agent/auxiliary_client.py` — `_apply_auxiliary_local_preset`; resolve `base_url` + `provider: auto` as `custom` without requiring `api_key`
- `hermes_cli/memory_write.py` — `add_builtin_memory()` writes via `MemoryStore.add`
- `hermes_cli/subcommands/memory.py`, `hermes_cli/main.py` — `hermes memory add "…" [--target memory|user]`
- `tests/agent/test_auxiliary_local.py`, `tests/hermes_cli/test_memory_add.py`
- `website/docs/user-guide/configuration.md`, `website/docs/user-guide/configuring-models.md` — preset example and CLI paths

## How to Test

1. Point several aux slots at one local server without repeating `base_url`:

```yaml
auxiliary:
  local:
    base_url: "http://127.0.0.1:11434/v1"
    model: "qwen3.5:2b"
    tasks:
      - compression
      - title_generation
      - memory_query_rewrite
```

2. Confirm a listed empty slot inherits the endpoint, and a slot with its own `base_url` / `model` keeps those values.
3. Append built-in memory without starting a chat:

```text
hermes memory add "Prefer dark themes"
```

Expect `MEMORY.md` under `$HERMES_HOME/memories/` to contain the entry. Open sessions keep their frozen snapshot until the next session.

```text
scripts/run_tests.sh tests/agent/test_auxiliary_local.py tests/hermes_cli/test_memory_add.py tests/agent/test_auxiliary_client.py -q
```

```text
=== Summary: 3 files, 192 tests passed, 0 failed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/agent/test_auxiliary_local.py tests/hermes_cli/test_memory_add.py tests/agent/test_auxiliary_client.py -q

=== Summary: 3 files, 192 tests passed, 0 failed
```

```text
add_builtin_memory('Issue 79415 local chore write', target='memory')
result_success True
file_exists True
contains True
```
