### PR TITLE
fix(desktop): deliver /background results to the originating conversation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/background-complete-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/background-complete-event.test.tsx
@@ -1,0 +1,67 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RpcEvent } from '@/types/hermes'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const SID = 'session-1'
+const OTHER_SID = 'session-2'
+
+let stream: MessageStreamHarness
+
+function mountStream() {
+  stream = renderMessageStream(SID)
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}, sessionId = SID) {
+  act(() => stream.handleEvent({ payload, session_id: sessionId, type }))
+}
+
+function lastMessage(id = SID) {
+  return stream.state(id).messages.at(-1)
+}
+
+describe('background.complete event', () => {
+  beforeEach(() => {
+    mountStream()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  // #97635: the finished background turn's response has to land in the
+  // conversation that started it — the event carries the originating session
+  // id, so the result is appended there instead of surfacing in an unlinked
+  // bg_* session.
+  it('appends the result to the originating session as a system message', () => {
+    emit('background.complete', { task_id: 'bg_104613_385db3', text: 'the answer' })
+
+    const message = lastMessage()
+
+    expect(message?.role).toBe('system')
+    expect(message?.id).toBe('background-complete-bg_104613_385db3')
+    expect(stream.text()).toBe('[bg bg_104613_385db3]\nthe answer')
+  })
+
+  it('keeps another session untouched when the event targets this one', () => {
+    emit('background.complete', { task_id: 'bg_1', text: 'for the other chat' }, OTHER_SID)
+
+    expect(lastMessage()).toBeUndefined()
+    expect(stream.text(OTHER_SID)).toBe('[bg bg_1]\nfor the other chat')
+  })
+
+  it('appends without a task-id header when the backend omits the id', () => {
+    emit('background.complete', { text: 'the answer' })
+
+    expect(stream.text()).toBe('the answer')
+  })
+
+  it('drops an empty completion instead of appending a blank line', () => {
+    emit('background.complete', { task_id: 'bg_1', text: '   ' })
+
+    expect(lastMessage()).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -78,6 +78,36 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
     return true
   }
 
+  if (event.type === 'background.complete') {
+    // prompt.background RPC (the TUI's /background path) reports the finished
+    // background turn here; the event carries the originating session id, so
+    // the result lands in the conversation that started the task. Persistent
+    // transcript line (not a toast), mirroring the TUI's `[bg <task_id>]`
+    // system line — without it the completion was indistinguishable from a
+    // lost task (#97635).
+    const text = coerceGatewayText(payload?.text).trim()
+
+    if (text && sessionId) {
+      const taskId = String(payload?.task_id ?? '').trim()
+
+      flushQueuedDeltas(sessionId)
+      updateSessionState(sessionId, state => ({
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            id: `background-complete-${taskId || Date.now()}`,
+            role: 'system',
+            parts: [textPart(taskId ? `[bg ${taskId}]\n${text}` : text, occurredAt)],
+            timestamp: occurredAt
+          }
+        ]
+      }))
+    }
+
+    return true
+  }
+
   if (event.type === 'notification.show') {
     // Driver-agnostic agent notice (credits usage/grant/depleted/restored
     // from `agent/credits_tracker.py`). The Ink TUI renders these in its

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1002,6 +1002,82 @@ describe('usePromptActions /compress', () => {
   })
 })
 
+describe('usePromptActions /background', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  // #97635: the slash-worker route prints the completion from a
+  // fire-and-forget thread after process_command already returned — past the
+  // worker's stdout capture window — so the result never reached the desktop
+  // conversation that started the task. The dedicated prompt.background RPC
+  // is the TUI's path; the response arrives later as a background.complete
+  // gateway event.
+  it('routes through prompt.background (not slash.exec) and renders the start notice', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.background') {
+        return { task_id: 'bg_104613_385db3' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/background summarize the top HN stories')
+
+    expect(requestGateway).toHaveBeenCalledWith('prompt.background', {
+      session_id: RUNTIME_SESSION_ID,
+      text: 'summarize the top HN stories'
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+    expect(renderedSeedTexts(seeds).some(text => text.includes('bg_104613_385db3'))).toBe(true)
+  })
+
+  it('falls back to the slash worker when an older gateway lacks prompt.background', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.background') {
+        throw new Error('method not found: prompt.background')
+      }
+
+      if (method === 'slash.exec') {
+        return { output: 'Background task started by legacy gateway' } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/background anything')
+
+    expect(requestGateway).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'background anything' }))
+    expect(renderedSeedTexts(seeds).some(text => text.includes('legacy gateway'))).toBe(true)
+  })
+})
+
 describe('usePromptActions exec fallback error reporting', () => {
   beforeEach(() => {
     setSessions(() => [sessionInfo()])

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -497,6 +497,58 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         branch: async () => {
           await branchCurrentSession()
         },
+        // /background (aliases /bg, /btw) starts a detached background turn via
+        // the gateway's prompt.background RPC — the TUI's path
+        // (ui-tui/src/app/slash/commands/session.ts). It must NOT go through
+        // runExec: the slash worker's HermesCLI prints the completion header
+        // from a fire-and-forget thread after process_command already
+        // returned, past the worker's stdout capture window, so the result
+        // never reached the conversation that started the task (#97635). The
+        // RPC replies immediately with the task id; the response itself
+        // arrives later as a background.complete gateway event, which the
+        // gateway-event dispatcher appends to this session.
+        background: async ctx => {
+          const text = ctx.arg.trim()
+
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render: renderSlashOutput, sessionId } = resolved
+
+          if (!text) {
+            renderSlashOutput(
+              'Usage: /background <prompt> — the task runs in a separate session and the result appears here when done.'
+            )
+
+            return
+          }
+
+          try {
+            const result = await requestGateway<{ task_id?: string }>('prompt.background', {
+              session_id: sessionId,
+              text
+            })
+
+            renderSlashOutput(
+              result.task_id
+                ? `Background task ${result.task_id} started — you can continue chatting; the result will appear here when done.`
+                : 'Background task started — you can continue chatting; the result will appear here when done.'
+            )
+          } catch (err) {
+            // Older gateways without the dedicated RPC still have the
+            // slash-worker route — same compatibility fallback as runRpc.
+            if (isMissingRpcMethod(err)) {
+              await runExec(ctx)
+
+              return
+            }
+
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
+        },
         // /compress (alias /compact) runs the gateway's dedicated
         // session.compress RPC — the TUI's path
         // (ui-tui/src/app/slash/commands/session.ts). It must NOT go through

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -93,6 +93,8 @@ export type GatewayEventPayload = {
   // clarify.request
   request_id?: string
   question?: string
+  // background.complete — id of the prompt.background task that finished
+  task_id?: string
   choices?: string[] | null
   multi_select?: boolean
   // clarify.request batch form: questions replaces question/choices, and

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -229,8 +229,11 @@ describe('desktop slash command curation', () => {
   })
 
   it('still routes commands without dedicated RPCs through exec()', () => {
+    // /background deliberately NOT here — it has the dedicated
+    // prompt.background RPC since #97635 (the slash worker's completion
+    // print lands after the capture window closes, so the result never
+    // reached the originating conversation).
     const execNames = [
-      '/background',
       '/debug',
       '/goal',
       '/personality',
@@ -251,6 +254,7 @@ describe('desktop slash command curation', () => {
     expect(desktopSlashCommandArgumentMode('/goal')).toBe('mixed')
     expect(desktopSlashCommandArgumentMode('/steer')).toBe('text')
     expect(desktopSlashCommandArgumentMode('/queue')).toBe('text')
+    expect(desktopSlashCommandArgumentMode('/background')).toBe('text')
     expect(desktopSlashCommandArgumentMode('/personality')).toBe('options')
     expect(desktopSlashCommandArgumentMode('/handoff')).toBe('options')
     expect(desktopSlashCommandArgumentMode('/version')).toBeNull()

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -53,6 +53,7 @@ export interface DesktopThemeCommandOption {
  * keyed by the id.
  */
 export type DesktopActionId =
+  | 'background'
   | 'branch'
   | 'browser'
   | 'compress'
@@ -238,6 +239,18 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     description: 'Compress this conversation context',
     aliases: ['/compact'],
     surface: action('compress'),
+    argumentMode: 'text'
+  },
+  // /background must be an action (prompt.background RPC — the TUI's path),
+  // not exec: the slash worker's HermesCLI prints the completion from a
+  // fire-and-forget thread after process_command already returned, past the
+  // worker's stdout capture window, so the result never reached the desktop
+  // conversation that started the task (#97635).
+  {
+    name: '/background',
+    description: 'Run a prompt in a background session',
+    aliases: ['/bg', '/btw'],
+    surface: action('background'),
     argumentMode: 'text'
   },
   {


### PR DESCRIPTION
## What does this PR do?

On the desktop app, `/background <prompt>` (aliases `/bg`, `/btw`) showed the "task started" notice, ran the task successfully, persisted the response in the `bg_*` session — and never delivered the result back to the conversation that started it (#97635).

Root cause: the desktop routed the command through the slash worker. The worker's `HermesCLI` prints the `✅ Background task complete` block from a fire-and-forget thread **after `process_command` has already returned** — past the worker's stdout capture window (`tui_gateway/slash_worker.py` restores `_cprint` and exits `redirect_stdout` in its `finally`) — so the completion print can never travel back over the JSON-lines pipe. This is why the reporter saw no delivery, no error, and no `delivery_obligations` row: the CLI path's "delivery" *is* that print.

Fix, mirroring how the TUI already runs this command (`ui-tui/src/app/slash/commands/session.ts` → the `prompt.background` RPC):

- Route `/background` to a dedicated desktop action that calls `prompt.background` (immediate reply with the task id) and renders a start notice — the same pattern `/compress` uses to avoid the slash-worker route (#44456).
- Handle the `background.complete` gateway event in the event dispatcher: append the result to the **originating** session's transcript as a persistent system message (`[bg <task_id>] …`), keyed by the session id the event already carries. Previously this event type was declared in the shared gateway types but never consumed by the desktop.
- Older gateways without the RPC surface fall back to the legacy slash-worker route via the same `isMissingRpcMethod` compatibility path `runRpc` uses.

## Related Issue

Fixes #97635

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/desktop-slash-commands.ts` — register `/background` (aliases `/bg`, `/btw`) as the `background` action instead of the default `exec` route; `argumentMode: 'text'`.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts` — add the `background` action handler: usage hint on empty arg, `prompt.background` RPC with the runtime session id, start-notice rendering, `isMissingRpcMethod` → `runExec` fallback.
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts` — consume `background.complete`, appending the response to the event's session as a system message (stable message id from the task id).
- `apps/desktop/src/lib/chat-messages/types.ts` — add `task_id?: string` to `GatewayEventPayload`.
- `apps/desktop/src/lib/desktop-slash-commands.test.ts` — move `/background` out of the exec-routed list; pin its `text` argument mode.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx` — new cases: routes through `prompt.background` (not `slash.exec`/`command.dispatch`) and renders the start notice; falls back to the slash worker when the RPC is missing.
- `apps/desktop/src/app/session/hooks/use-message-stream/background-complete-event.test.tsx` — new suite: result appended to the originating session as a system message with the `[bg <id>]` header, other sessions untouched, missing task id tolerated, empty completion dropped.

## How to Test

1. `cd apps/desktop && npx vitest run src/lib/desktop-slash-commands.test.ts src/app/session/hooks/use-prompt-actions/ src/app/session/hooks/use-message-stream/` — Observed result: 30 files, 399 tests passed.
2. `cd apps/desktop && npx tsc --build tsconfig.json` — Observed result: clean (no type errors).
3. Manual (desktop app, any platform): send `/background summarize this repo` in a conversation, keep chatting, and wait — Observed result (expected): the start notice renders immediately, and when the task finishes a `✅ [bg <task_id>] <response>` system message is appended to that same conversation instead of the result surfacing only in the unlinked `bg_*` session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — TS-only diff (desktop renderer), so the desktop suites above were run in lieu of pytest; no Python files changed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.4.0, arm64) — desktop vitest suites + `tsc --build`

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the bug was reported on Windows; the fix is renderer-side and platform-neutral (event routing + RPC), verified by unit tests that mock the gateway surface
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill.
