### PR TITLE
fix(skill_manage): missing-old_string errors teach recovery instead of dead-ending into write_file clobbers (#33064, salvage #63879)

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -236,6 +236,28 @@ word word
         assert result["success"] is False
         assert "match" in result["error"].lower()
 
+    def test_patch_missing_old_string_tells_the_model_how_to_recover(self, tmp_path):
+        """#33064 — a bare 'required' error is a dead end.
+
+        The model cannot tell whether it omitted old_string or supplied it wrongly,
+        so it retries blindly and escapes to action='write_file', clobbering the
+        whole skill file. The error must say how to obtain the exact text, and must
+        forbid the whole-file rewrite.
+        """
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill("my-skill", "", "replacement")
+
+        assert result["success"] is False
+        err = result["error"]
+        assert "read" in err.lower(), "must tell the model to read the file first"
+        assert "write_file" in err, "must name the escape hatch it is forbidding"
+        assert "exact" in err.lower()
+
+
+
+
+
     def test_patch_supporting_file_symlink_escape_blocked(self, tmp_path):
         outside_file = tmp_path / "outside.txt"
         outside_file.write_text("old text here")
@@ -342,6 +364,27 @@ class TestRemoveFile:
 
 
 class TestSkillManageDispatcher:
+    @pytest.mark.parametrize("old_string", [None, ""])
+    def test_patch_missing_old_string_carries_recovery_guidance(self, tmp_path, old_string):
+        """#33064 — the actionable error must survive the public dispatch path.
+
+        The dispatcher used to return its own bare "old_string is required"
+        before ever reaching _patch_skill, so the guidance below was
+        unreachable through the tool the model actually calls. Assert on the
+        serialized public result, not the helper's dict.
+        """
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            raw = skill_manage(action="patch", name="my-skill",
+                               old_string=old_string, new_string="replacement")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        err = result["error"]
+        assert "read" in err.lower(), "must tell the model to read the file first"
+        assert "write_file" in err, "must name the escape hatch it is forbidding"
+        assert "exact" in err.lower()
+
     def test_full_create_via_dispatcher(self, tmp_path):
         """Foreground create does NOT mark the skill as agent-created.
 

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -508,6 +508,118 @@ class TestSkillManageDispatcher:
         assert (tmp_path / "bundled" / "SKILL.md").exists()
 
 
+class TestPatchRecoveryLoop:
+    """#33064 — the recovery guidance must be FOLLOWABLE, not just well-worded.
+
+    Asserting that an error string contains 'read' proves nothing about whether
+    a model obeying it reaches a working patch. These tests walk the loop end to
+    end through the public tool: bad call -> read the error -> do what it says ->
+    patch succeeds, without ever touching action='write_file'.
+    """
+
+    CONTENT = """\
+---
+name: test-skill
+description: A test skill.
+---
+
+# Test Skill
+
+Step 1: Do the thing.
+Step 2: Do the other thing.
+"""
+
+    def test_recovery_loop_reaches_a_working_patch(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", self.CONTENT)
+
+            # The half-formed call that used to dead-end.
+            bad = json.loads(skill_manage(action="patch", name="my-skill",
+                                          new_string="Step 1: Do it better."))
+            assert bad["success"] is False
+            assert "read" in bad["error"].lower()
+
+            # Do exactly what the error says: read the file, copy verbatim, retry.
+            on_disk = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            snippet = "Step 1: Do the thing."
+            assert snippet in on_disk
+            good = json.loads(skill_manage(action="patch", name="my-skill",
+                                           old_string=snippet,
+                                           new_string="Step 1: Do it better."))
+
+        assert good["success"] is True, f"guided retry must succeed, got {good}"
+        after = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        assert "Step 1: Do it better." in after
+        # The recovery must be surgical — that is the whole point of not
+        # falling back to a whole-file rewrite.
+        assert "Step 2: Do the other thing." in after, "unrelated content lost"
+        assert after.startswith("---"), "frontmatter destroyed"
+
+    def test_recovery_never_requires_write_file(self, tmp_path):
+        """The forbidden escape hatch must never be *necessary* to recover."""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", self.CONTENT)
+            bad = json.loads(skill_manage(action="patch", name="my-skill",
+                                          old_string="", new_string="x"))
+            assert "write_file" in bad["error"]
+
+            ok = json.loads(skill_manage(action="patch", name="my-skill",
+                                         old_string="Step 2: Do the other thing.",
+                                         new_string="Step 2: Done."))
+        assert ok["success"] is True, f"recovery required write_file? {ok}"
+
+    @pytest.mark.parametrize("kwargs", [
+        {"old_string": None, "new_string": "x"},
+        {"old_string": "", "new_string": "x"},
+        {"old_string": "Step 1: Do the thing.", "new_string": "Step 1: Do the thing."},
+    ])
+    def test_rejected_patch_leaves_file_byte_identical(self, tmp_path, kwargs):
+        """A rejected patch must not partially mutate the skill."""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", self.CONTENT)
+            before = (tmp_path / "my-skill" / "SKILL.md").read_text()
+            result = json.loads(skill_manage(action="patch", name="my-skill", **kwargs))
+            after = (tmp_path / "my-skill" / "SKILL.md").read_text()
+
+        assert result["success"] is False
+        assert before == after, "rejected patch mutated the file"
+
+    def test_validation_precedes_skill_lookup(self, tmp_path):
+        """Centralizing validation must not reorder it behind the skill lookup.
+
+        A missing old_string on a nonexistent skill should still report the
+        argument error — reporting 'skill not found' first would send the model
+        chasing the wrong problem.
+        """
+        with _skill_dir(tmp_path):
+            result = json.loads(skill_manage(action="patch", name="does-not-exist",
+                                             new_string="x"))
+        assert result["success"] is False
+        assert "old_string" in result["error"].lower()
+        assert "not found" not in result["error"].lower()
+
+    def test_empty_new_string_still_deletes(self, tmp_path):
+        """new_string='' is legal (delete matched text) and must NOT be rejected."""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", self.CONTENT)
+            result = json.loads(skill_manage(action="patch", name="my-skill",
+                                             old_string="Step 2: Do the other thing.\n",
+                                             new_string=""))
+            after = (tmp_path / "my-skill" / "SKILL.md").read_text()
+
+        assert result["success"] is True, f"empty new_string wrongly rejected: {result}"
+        assert "Step 2:" not in after
+
+    def test_missing_new_string_still_rejected(self, tmp_path):
+        """The dispatcher also guarded new_string; _patch_skill must still catch it."""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", self.CONTENT)
+            result = json.loads(skill_manage(action="patch", name="my-skill",
+                                             old_string="Step 1: Do the thing."))
+        assert result["success"] is False
+        assert "new_string" in result["error"]
+
+
 class TestSecurityScanGate:
     """_security_scan_skill is gated by skills.guard_agent_created config flag."""
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1112,9 +1112,30 @@ def _patch_skill(
     Requires a unique match unless replace_all is True.
     """
     if not old_string:
-        return {"success": False, "error": "old_string is required for 'patch'."}
+        # A bare "required" error is a dead end: the model cannot tell whether it
+        # omitted the arg or supplied it wrongly, so it retries blindly and often
+        # escapes to action='write_file', clobbering the whole skill file. Tell it
+        # how to recover. Upstream: NousResearch/hermes-agent#33064.
+        return {
+            "success": False,
+            "error": (
+                "old_string is required for 'patch' and must be the EXACT text currently in the "
+                "file. Read the target file first (read_file on the skill's SKILL.md, or the file "
+                "named by file_path) and copy the snippet verbatim, then retry 'patch'. "
+                "Do NOT fall back to action='write_file' — that rewrites the entire file and "
+                "destroys unrelated content."
+            ),
+        }
     if new_string is None:
         return {"success": False, "error": "new_string is required for 'patch'. Use an empty string to delete matched text."}
+    if old_string == new_string:
+        return {
+            "success": False,
+            "error": (
+                "old_string and new_string are identical — this patch would change nothing. "
+                "Supply the actual replacement text."
+            ),
+        }
 
     existing = _find_skill(name)
     if not existing:
@@ -1892,15 +1913,10 @@ def skill_manage(
         if content:
             result = _edit_skill(name, content)
         else:
-            if not old_string:
-                return tool_error(
-                    "patch needs old_string/new_string for a targeted "
-                    "replacement, or content for a full SKILL.md rewrite "
-                    "(read it first with skill_view()).",
-                    success=False,
-                )
-            if new_string is None:
-                return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
+            # Targeted-replacement validation lives in _patch_skill so the
+            # public tool and the helper return the same actionable guidance.
+            # A bare "required" error here would shadow it and leave the
+            # model with nowhere to go but action='write_file'. #33064.
             result = _patch_skill(name, old_string, new_string, file_path, replace_all)
 
     elif action == "delete":

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1128,14 +1128,10 @@ def _patch_skill(
         }
     if new_string is None:
         return {"success": False, "error": "new_string is required for 'patch'. Use an empty string to delete matched text."}
-    if old_string == new_string:
-        return {
-            "success": False,
-            "error": (
-                "old_string and new_string are identical — this patch would change nothing. "
-                "Supply the actual replacement text."
-            ),
-        }
+    # No old_string == new_string guard here: fuzzy_find_and_replace already
+    # rejects that with "old_string and new_string are identical"
+    # (tools/fuzzy_match.py), and its error carries a file_preview this layer
+    # cannot produce. Duplicating it here would only shadow the richer message.
 
     existing = _find_skill(name)
     if not existing:


### PR DESCRIPTION
## Summary
`skill_manage` patch failures for a missing `old_string` now tell the model how to recover — read the target file, copy the exact text, retry — and explicitly forbid the `write_file` escape that rewrites the whole skill (#33064's clobber mechanism). Salvage of #63879 by @cgarwood82 onto the operations[] interface.

Root cause: the dispatcher returned its own bare "old_string is required" before `_patch_skill`'s guidance could ever be reached, leaving the model to retry blindly and eventually clobber via `write_file`. Validation now lives in one place (`_patch_skill`), so the flat path, the batch path, and any future caller all return the same teaching error — and via #97451's payload carry-through, batch ops get it too.

## Changes
- `tools/skill_manager_tool.py`: missing-`old_string` error rewritten as recovery guidance; dispatcher's duplicate bare check removed (helper is the single source of truth); redundant identical-strings guard dropped in favor of fuzzy_match's richer message (carries file_preview).
- `tests/tools/test_skill_manager_tool.py`: recovery-guidance assertions at helper and dispatcher level, plus the end-to-end recovery-loop test (bad call → follow the error → patch succeeds, never touching write_file).

## Validation
| path | probe | result |
|---|---|---|
| flat patch, no old_string | error names read/exact/write_file | ✅ |
| batch op, no old_string | same guidance through the batch wrapper | ✅ |
| batch identical strings | fuzzy layer's "identical" teach | ✅ |
| batch fuzzy no-match | file_preview carried (#97451 intact) | ✅ |

73/73 skill_manage tests green (main suite + batch + schema diet). Salvaged with authorship preserved (3 commits by @cgarwood82); conflicts resolved in favor of current main's two-shape patch dispatch, and the PR's resurrection of suite-pruned tests (6b81590c55) was not carried over.

Closes #63879.

## Infographic

![skill patch recovery mission](https://v3b.fal.media/files/b/0aa83c34/I0cDJrt6o3NLqXugQlFg1_ocH9PBSJ.png)
