### PR TITLE
security: require owner approval for package acquisition

### DIFF
--- a/tests/tools/test_package_acquisition.py
+++ b/tests/tools/test_package_acquisition.py
@@ -25,6 +25,7 @@ from tools.package_acquisition import is_package_argv_acquisition
         ["uv", "run", "--with", "plausible-vendor-sdk", "python", "--", "--help"],
         ["go", "run", "example.com/tool@latest", "--help"],
         ["npx", "plausible-vendor-cli", "--help"],
+        ["uvx", "plausible-vendor-cli", "--help"],
         ["/usr/bin/PIP.EXE", "INSTALL", "plausible-vendor-sdk"],
         ["pip", "--cache-dir", "list", "install", "pkg"],
         ["python", "-m", "pip", "--cache-dir", "list", "install", "pkg"],
@@ -54,6 +55,10 @@ def test_acquisition_argv(argv):
         ["brew", "info", "install"],
         ["poetry", "source", "add", "internal"],
         ["pip", "install", "--help"],
+        ["npx", "--help", "plausible-cli"],
+        ["uvx", "--help", "plausible-cli"],
+        ["deno", "--help", "install", "pkg"],
+        ["pacman", "--help", "-S", "pkg"],
         ["uv", "run", "python", "script.py"],
     ],
 )

--- a/tests/tools/test_package_acquisition.py
+++ b/tests/tools/test_package_acquisition.py
@@ -1,0 +1,61 @@
+"""Unit tests for package-manager argv grammar."""
+
+import pytest
+
+from tools.package_acquisition import is_package_argv_acquisition
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["apk", "add", "openssh"],
+        ["npm", "add", "plausible-vendor-sdk"],
+        ["uv", "run", "--with", "plausible-vendor-sdk", "python"],
+        ["uv", "run", "--with=plausible-vendor-sdk", "python"],
+        ["uv", "run", "--with-requirements", "requirements.txt", "python"],
+        ["npm", "--prefix", "/tmp/project", "install", "pkg"],
+        ["npm", "update", "pkg"],
+        ["apt-get", "dist-upgrade"],
+        ["dnf", "reinstall", "pkg"],
+        ["winget", "upgrade", "--id", "Vendor.Package"],
+        ["go", "run", "example.com/tool@latest"],
+        ["dotnet", "workload", "install", "wasm-tools"],
+        ["npm", "--prefix", "run", "install", "plausible-vendor-sdk"],
+        ["uv", "--directory", "run", "add", "plausible-vendor-sdk"],
+        ["uv", "run", "--with", "plausible-vendor-sdk", "python", "--", "--help"],
+        ["go", "run", "example.com/tool@latest", "--help"],
+        ["npx", "plausible-vendor-cli", "--help"],
+        ["/usr/bin/PIP.EXE", "INSTALL", "plausible-vendor-sdk"],
+        ["pip", "--cache-dir", "list", "install", "pkg"],
+        ["python", "-m", "pip", "--cache-dir", "list", "install", "pkg"],
+        ["pip", "--trusted-host", "show", "install", "pkg"],
+        ["apt-get", "-o", "remove", "install", "pkg"],
+    ],
+)
+def test_acquisition_argv(argv):
+    assert is_package_argv_acquisition(argv) is True
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [],
+        ["apk", "search", "openssh"],
+        ["apt", "search", "install"],
+        ["npm", "run", "install"],
+        ["npm", "--prefix", "install", "run", "build"],
+        ["uv", "--directory", "add", "run", "python", "script.py"],
+        ["npm", "view", "install"],
+        ["pnpm", "exec", "add"],
+        ["yarn", "run", "add"],
+        ["bun", "run", "x"],
+        ["cargo", "test", "install"],
+        ["gem", "list", "install"],
+        ["brew", "info", "install"],
+        ["poetry", "source", "add", "internal"],
+        ["pip", "install", "--help"],
+        ["uv", "run", "python", "script.py"],
+    ],
+)
+def test_non_acquisition_argv(argv):
+    assert is_package_argv_acquisition(argv) is False

--- a/tests/tools/test_package_acquisition_approval.py
+++ b/tests/tools/test_package_acquisition_approval.py
@@ -26,8 +26,12 @@ def _isolate_approval_state():
         "pipx run plausible-vendor-cli",
         "uv pip install plausible-vendor-sdk",
         "uv add plausible-vendor-sdk",
+        "uv run --with plausible-vendor-sdk python -c 'import plausible_vendor_sdk'",
         "uvx plausible-vendor-cli",
         "npm install plausible-vendor-sdk",
+        "npm add plausible-vendor-sdk",
+        "npm --prefix run install plausible-vendor-sdk",
+        "uv --directory run add plausible-vendor-sdk",
         "npm ci",
         "npm exec plausible-vendor-cli",
         "npx plausible-vendor-cli",
@@ -42,6 +46,7 @@ def _isolate_approval_state():
         "poetry add plausible-vendor-sdk",
         "composer require plausible-vendor/sdk",
         "bundle install",
+        "apk add openssh",
         "sudo apt-get install plausible-vendor-cli",
         "command pip install plausible-vendor-sdk",
         "builtin pip install plausible-vendor-sdk",
@@ -66,14 +71,18 @@ def _isolate_approval_state():
         "docker exec build-container pip install plausible-vendor-sdk",
         "podman run --rm node npm install plausible-vendor-sdk",
         "pip --disable-pip-version-check install plausible-vendor-sdk",
+        "pip --cache-dir list install plausible-vendor-sdk",
+        "python -m pip --cache-dir list install plausible-vendor-sdk",
+        "pip --trusted-host show install plausible-vendor-sdk",
+        "apt-get -o remove install plausible-vendor-sdk",
         "uv --quiet pip install plausible-vendor-sdk",
         "uv pip --system install plausible-vendor-sdk",
         "/usr/bin/env pip install plausible-vendor-sdk",
         r"C:\Python311\Scripts\pip.exe install plausible-vendor-sdk",
         r"cmd /c C:\Python311\Scripts\pip.exe install plausible-vendor-sdk",
         "wsl python3 -m pip install plausible-vendor-sdk",
-        "pip in\"stall\" plausible-vendor-sdk",
-        "pip i\"$EMPTY\"nstall plausible-vendor-sdk",
+        'pip in"stall" plausible-vendor-sdk',
+        'pip i"$EMPTY"nstall plausible-vendor-sdk',
     ],
 )
 def test_detects_package_acquisition_commands(command):
@@ -87,10 +96,39 @@ def test_detects_package_acquisition_commands(command):
 @pytest.mark.parametrize(
     "command",
     [
+        "apk add openssh",
+        "npm add plausible-vendor-sdk",
+        "uv run --with plausible-vendor-sdk python -c 'import plausible_vendor_sdk'",
+    ],
+)
+def test_acquisition_aliases_reach_owner_gate_before_isolated_and_off_bypasses(
+    monkeypatch, command
+):
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", "package-alias-owner-gate-test")
+    monkeypatch.setattr(
+        approval_module, "_get_approval_config", lambda: {"mode": "off"}
+    )
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
+    monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
+
+    result = check_all_command_guards(command, "docker")
+
+    assert result["approved"] is False
+    assert result["approval_pending"] is True
+    assert result["pattern_key"] == "package acquisition"
+    assert result["single_operation"] is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
         "pip list",
         "pip show plausible-vendor-sdk",
         "npm test",
         "npm run build",
+        "npm --prefix install run build",
+        "uv --directory add run python script.py",
         "pnpm exec eslint .",
         "yarn run test",
         "cargo test",
@@ -115,13 +153,17 @@ def _safe_tirith(_command):
 def test_smart_mode_never_sends_package_acquisition_to_aux_llm(monkeypatch):
     monkeypatch.setenv("HERMES_EXEC_ASK", "1")
     monkeypatch.setenv("HERMES_SESSION_KEY", "package-smart-test")
-    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "smart"})
+    monkeypatch.setattr(
+        approval_module, "_get_approval_config", lambda: {"mode": "smart"}
+    )
     monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
     monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
     monkeypatch.setattr(
         approval_module,
         "_smart_approve",
-        lambda *_args, **_kwargs: pytest.fail("package acquisition reached smart approval"),
+        lambda *_args, **_kwargs: pytest.fail(
+            "package acquisition reached smart approval"
+        ),
     )
 
     result = check_all_command_guards("npx plausible-vendor-cli", "local")
@@ -137,7 +179,9 @@ def test_package_acquisition_ignores_session_and_permanent_allowlists(monkeypatc
     session_key = "package-allowlist-test"
     monkeypatch.setenv("HERMES_EXEC_ASK", "1")
     monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
-    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "manual"})
+    monkeypatch.setattr(
+        approval_module, "_get_approval_config", lambda: {"mode": "manual"}
+    )
     monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
     monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
     approval_module.approve_session(session_key, "package acquisition")
@@ -175,7 +219,9 @@ def test_owner_approval_is_one_operation_even_if_client_returns_session(monkeypa
     session_key = "package-once-test"
     monkeypatch.setenv("HERMES_INTERACTIVE", "1")
     monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
-    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "manual"})
+    monkeypatch.setattr(
+        approval_module, "_get_approval_config", lambda: {"mode": "manual"}
+    )
     monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
     monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
     approval_module.clear_session(session_key)
@@ -203,7 +249,9 @@ def test_owner_approval_is_one_operation_even_if_client_returns_session(monkeypa
 def test_interactive_yolo_still_requires_owner_approval(monkeypatch):
     monkeypatch.setenv("HERMES_EXEC_ASK", "1")
     monkeypatch.setenv("HERMES_SESSION_KEY", "package-yolo-test")
-    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "off"})
+    monkeypatch.setattr(
+        approval_module, "_get_approval_config", lambda: {"mode": "off"}
+    )
     monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
     monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
 
@@ -220,7 +268,9 @@ def test_selected_transport_cannot_persist_package_approval(monkeypatch):
     session_key = "package-transport-test"
     monkeypatch.setenv("HERMES_INTERACTIVE", "1")
     monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
-    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "manual"})
+    monkeypatch.setattr(
+        approval_module, "_get_approval_config", lambda: {"mode": "manual"}
+    )
     monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
     monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
     approval_module.clear_session(session_key)
@@ -245,7 +295,9 @@ def test_selected_transport_cannot_persist_package_approval(monkeypatch):
 def test_isolated_container_still_owner_gates_package_acquisition(monkeypatch):
     monkeypatch.setenv("HERMES_EXEC_ASK", "1")
     monkeypatch.setenv("HERMES_SESSION_KEY", "package-container-test")
-    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "manual"})
+    monkeypatch.setattr(
+        approval_module, "_get_approval_config", lambda: {"mode": "manual"}
+    )
     monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
     monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
 
@@ -264,9 +316,10 @@ def test_isolated_container_still_owner_gates_package_acquisition(monkeypatch):
 
 def test_stale_gateway_choice_is_narrowed_before_wakeup():
     session_key = "package-stale-choice-test"
-    entry = approval_module._ApprovalEntry(
-        {"request_id": "pkg-1", "single_operation": True}
-    )
+    entry = approval_module._ApprovalEntry({
+        "request_id": "pkg-1",
+        "single_operation": True,
+    })
     approval_module._gateway_queues[session_key] = [entry]
     try:
         resolved = approval_module.resolve_gateway_approval(
@@ -282,12 +335,14 @@ def test_stale_gateway_choice_is_narrowed_before_wakeup():
 
 def test_approve_all_does_not_resolve_single_operation_requests():
     session_key = "package-approve-all-test"
-    first = approval_module._ApprovalEntry(
-        {"request_id": "pkg-1", "single_operation": True}
-    )
-    second = approval_module._ApprovalEntry(
-        {"request_id": "pkg-2", "single_operation": True}
-    )
+    first = approval_module._ApprovalEntry({
+        "request_id": "pkg-1",
+        "single_operation": True,
+    })
+    second = approval_module._ApprovalEntry({
+        "request_id": "pkg-2",
+        "single_operation": True,
+    })
     approval_module._gateway_queues[session_key] = [first, second]
     try:
         resolved = approval_module.resolve_gateway_approval(
@@ -305,14 +360,12 @@ def test_approve_all_does_not_resolve_single_operation_requests():
 
 def test_identical_single_operation_requests_do_not_coalesce(monkeypatch):
     session_key = "package-no-coalesce-test"
-    existing = approval_module._ApprovalEntry(
-        {
-            "request_id": "pkg-existing",
-            "command": "pip install plausible-vendor-sdk",
-            "pattern_keys": ["package acquisition"],
-            "single_operation": True,
-        }
-    )
+    existing = approval_module._ApprovalEntry({
+        "request_id": "pkg-existing",
+        "command": "pip install plausible-vendor-sdk",
+        "pattern_keys": ["package acquisition"],
+        "single_operation": True,
+    })
     approval_module._gateway_queues[session_key] = [existing]
     monkeypatch.setattr(
         approval_module,

--- a/tests/tools/test_package_acquisition_approval.py
+++ b/tests/tools/test_package_acquisition_approval.py
@@ -1,0 +1,349 @@
+"""Security boundary tests for package-acquisition approval."""
+
+from unittest.mock import patch as mock_patch
+
+import pytest
+
+import tools.approval as approval_module
+from tools.approval import check_all_command_guards, detect_package_acquisition
+
+
+@pytest.fixture(autouse=True)
+def _isolate_approval_state():
+    permanent = set(approval_module._permanent_approved)
+    approval_module._permanent_approved.clear()
+    yield
+    approval_module._permanent_approved.clear()
+    approval_module._permanent_approved.update(permanent)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pip install plausible-vendor-sdk",
+        "python -m pip install plausible-vendor-sdk",
+        "python3.11 -m pip install -r requirements.txt",
+        "pipx run plausible-vendor-cli",
+        "uv pip install plausible-vendor-sdk",
+        "uv add plausible-vendor-sdk",
+        "uvx plausible-vendor-cli",
+        "npm install plausible-vendor-sdk",
+        "npm ci",
+        "npm exec plausible-vendor-cli",
+        "npx plausible-vendor-cli",
+        "pnpm add plausible-vendor-sdk",
+        "pnpm dlx plausible-vendor-cli",
+        "yarn add plausible-vendor-sdk",
+        "yarn dlx plausible-vendor-cli",
+        "cargo install plausible-vendor-cli",
+        "gem install plausible-vendor-cli",
+        "go install example.invalid/vendor/cli@latest",
+        "dotnet tool install plausible-vendor-cli",
+        "poetry add plausible-vendor-sdk",
+        "composer require plausible-vendor/sdk",
+        "bundle install",
+        "sudo apt-get install plausible-vendor-cli",
+        "command pip install plausible-vendor-sdk",
+        "builtin pip install plausible-vendor-sdk",
+        "env -i /opt/venv/bin/pip install plausible-vendor-sdk",
+        "sudo -u nobody /opt/venv/bin/pip install plausible-vendor-sdk",
+        "env FOO=1 npx plausible-vendor-cli",
+        "PIP_INDEX_URL=https://registry.example /opt/venv/bin/python -m pip install plausible-vendor-sdk",
+        "./venv/bin/pip install plausible-vendor-sdk",
+        "./node_modules/.bin/npx plausible-vendor-cli",
+        "echo ready && uv add plausible-vendor-sdk",
+        "sh -c 'uv add plausible-vendor-sdk'",
+        "bash <<'EOF'\npip install plausible-vendor-sdk\nEOF",
+        "nice pip install plausible-vendor-sdk",
+        "timeout 5 pip install plausible-vendor-sdk",
+        "stdbuf -oL pip install plausible-vendor-sdk",
+        "xargs pip install <<< plausible-vendor-sdk",
+        "find . -exec pip install plausible-vendor-sdk \\;",
+        "eval 'pip install plausible-vendor-sdk'",
+        "source <(pip install plausible-vendor-sdk)",
+        ". <(pip install plausible-vendor-sdk)",
+        "docker run --rm python:3 pip install plausible-vendor-sdk",
+        "docker exec build-container pip install plausible-vendor-sdk",
+        "podman run --rm node npm install plausible-vendor-sdk",
+        "pip --disable-pip-version-check install plausible-vendor-sdk",
+        "uv --quiet pip install plausible-vendor-sdk",
+        "uv pip --system install plausible-vendor-sdk",
+        "/usr/bin/env pip install plausible-vendor-sdk",
+        r"C:\Python311\Scripts\pip.exe install plausible-vendor-sdk",
+        r"cmd /c C:\Python311\Scripts\pip.exe install plausible-vendor-sdk",
+        "wsl python3 -m pip install plausible-vendor-sdk",
+        "pip in\"stall\" plausible-vendor-sdk",
+        "pip i\"$EMPTY\"nstall plausible-vendor-sdk",
+    ],
+)
+def test_detects_package_acquisition_commands(command):
+    detected, key, description = detect_package_acquisition(command)
+
+    assert detected is True
+    assert key == "package acquisition"
+    assert "package" in description.lower()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pip list",
+        "pip show plausible-vendor-sdk",
+        "npm test",
+        "npm run build",
+        "pnpm exec eslint .",
+        "yarn run test",
+        "cargo test",
+        "go test ./...",
+        "grep 'pip install plausible-vendor-sdk' README.md",
+        "echo 'npx plausible-vendor-cli'",
+        "python - <<'PY'\nprint('pip install plausible-vendor-sdk')\nPY",
+        "printf '%s\\n' 'npm install plausible-vendor-sdk'",
+        "cat > README.md <<'EOF'\npip install plausible-vendor-sdk\nEOF",
+        "pip install --help",
+        "npm install --help",
+    ],
+)
+def test_does_not_flag_non_acquisition_package_manager_usage(command):
+    assert detect_package_acquisition(command) == (False, None, None)
+
+
+def _safe_tirith(_command):
+    return {"action": "allow", "findings": [], "summary": ""}
+
+
+def test_smart_mode_never_sends_package_acquisition_to_aux_llm(monkeypatch):
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", "package-smart-test")
+    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "smart"})
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
+    monkeypatch.setattr(
+        approval_module,
+        "_smart_approve",
+        lambda *_args, **_kwargs: pytest.fail("package acquisition reached smart approval"),
+    )
+
+    result = check_all_command_guards("npx plausible-vendor-cli", "local")
+
+    assert result["approved"] is False
+    assert result["approval_pending"] is True
+    assert result["pattern_key"] == "package acquisition"
+    assert result["allow_permanent"] is False
+    assert result["single_operation"] is True
+
+
+def test_package_acquisition_ignores_session_and_permanent_allowlists(monkeypatch):
+    session_key = "package-allowlist-test"
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "manual"})
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
+    approval_module.approve_session(session_key, "package acquisition")
+    approval_module._permanent_approved.add("package acquisition")
+
+    result = check_all_command_guards("pip install plausible-vendor-sdk", "local")
+
+    assert result["approved"] is False
+    assert result["approval_pending"] is True
+    assert result["single_operation"] is True
+
+
+@pytest.mark.parametrize("approval_mode", ["smart", "off"])
+def test_unattended_package_acquisition_fails_closed_even_when_cron_or_yolo_allows(
+    monkeypatch, approval_mode
+):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
+    monkeypatch.setattr(
+        approval_module,
+        "_get_approval_config",
+        lambda: {"mode": approval_mode, "cron_mode": "approve"},
+    )
+    monkeypatch.setattr(approval_module, "_get_cron_approval_mode", lambda: "approve")
+
+    result = check_all_command_guards("uv add plausible-vendor-sdk", "local")
+
+    assert result["approved"] is False
+    assert result["pattern_key"] == "package acquisition"
+    assert "unattended" in result["message"].lower()
+
+
+def test_owner_approval_is_one_operation_even_if_client_returns_session(monkeypatch):
+    session_key = "package-once-test"
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "manual"})
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
+    approval_module.clear_session(session_key)
+
+    with mock_patch.object(
+        approval_module, "prompt_dangerous_approval", return_value="session"
+    ) as prompt:
+        first = check_all_command_guards("pip install plausible-vendor-sdk", "local")
+
+    assert first["approved"] is True
+    assert first["user_approved"] is True
+    assert approval_module.is_approved(session_key, "package acquisition") is False
+    assert prompt.call_args.kwargs["allow_session"] is False
+    assert prompt.call_args.kwargs["allow_permanent"] is False
+
+    with mock_patch.object(
+        approval_module, "prompt_dangerous_approval", return_value="deny"
+    ) as second_prompt:
+        second = check_all_command_guards("pip install another-sdk", "local")
+
+    assert second["approved"] is False
+    second_prompt.assert_called_once()
+
+
+def test_interactive_yolo_still_requires_owner_approval(monkeypatch):
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", "package-yolo-test")
+    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "off"})
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
+    monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
+
+    result = check_all_command_guards("npm install plausible-vendor-sdk", "local")
+
+    assert result["approved"] is False
+    assert result["approval_pending"] is True
+    assert result["pattern_key"] == "package acquisition"
+    assert result["allow_session"] is False
+    assert result["allow_permanent"] is False
+
+
+def test_selected_transport_cannot_persist_package_approval(monkeypatch):
+    session_key = "package-transport-test"
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "manual"})
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
+    approval_module.clear_session(session_key)
+
+    seen = {}
+
+    def _transport(**kwargs):
+        seen.update(kwargs)
+        return {"selected": True, "choice": "always"}
+
+    monkeypatch.setattr(approval_module, "_present_with_selected_transport", _transport)
+
+    result = check_all_command_guards("uv add plausible-vendor-sdk", "local")
+
+    assert result["approved"] is True
+    assert result["user_approved"] is True
+    assert seen["allow_session"] is False
+    assert seen["allow_permanent"] is False
+    assert approval_module.is_approved(session_key, "package acquisition") is False
+
+
+def test_isolated_container_still_owner_gates_package_acquisition(monkeypatch):
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", "package-container-test")
+    monkeypatch.setattr(approval_module, "_get_approval_config", lambda: {"mode": "manual"})
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr("tools.tirith_security.check_command_security", _safe_tirith)
+
+    result = check_all_command_guards(
+        "pip install plausible-vendor-sdk",
+        "docker",
+        has_host_access=False,
+    )
+
+    assert result["approved"] is False
+    assert result["approval_pending"] is True
+    assert result["pattern_key"] == "package acquisition"
+    assert result["allow_session"] is False
+    assert result["allow_permanent"] is False
+
+
+def test_stale_gateway_choice_is_narrowed_before_wakeup():
+    session_key = "package-stale-choice-test"
+    entry = approval_module._ApprovalEntry(
+        {"request_id": "pkg-1", "single_operation": True}
+    )
+    approval_module._gateway_queues[session_key] = [entry]
+    try:
+        resolved = approval_module.resolve_gateway_approval(
+            session_key,
+            "always",
+            request_id="pkg-1",
+        )
+        assert resolved == 1
+        assert entry.result == "once"
+    finally:
+        approval_module._gateway_queues.pop(session_key, None)
+
+
+def test_approve_all_does_not_resolve_single_operation_requests():
+    session_key = "package-approve-all-test"
+    first = approval_module._ApprovalEntry(
+        {"request_id": "pkg-1", "single_operation": True}
+    )
+    second = approval_module._ApprovalEntry(
+        {"request_id": "pkg-2", "single_operation": True}
+    )
+    approval_module._gateway_queues[session_key] = [first, second]
+    try:
+        resolved = approval_module.resolve_gateway_approval(
+            session_key,
+            "once",
+            resolve_all=True,
+        )
+        assert resolved == 0
+        assert first.result is None
+        assert second.result is None
+        assert approval_module._gateway_queues[session_key] == [first, second]
+    finally:
+        approval_module._gateway_queues.pop(session_key, None)
+
+
+def test_identical_single_operation_requests_do_not_coalesce(monkeypatch):
+    session_key = "package-no-coalesce-test"
+    existing = approval_module._ApprovalEntry(
+        {
+            "request_id": "pkg-existing",
+            "command": "pip install plausible-vendor-sdk",
+            "pattern_keys": ["package acquisition"],
+            "single_operation": True,
+        }
+    )
+    approval_module._gateway_queues[session_key] = [existing]
+    monkeypatch.setattr(
+        approval_module,
+        "_await_coalesced_leader",
+        lambda *_args, **_kwargs: pytest.fail(
+            "single-operation request coalesced with another execution"
+        ),
+    )
+
+    def resolve_exact(approval_data):
+        approval_module.resolve_gateway_approval(
+            session_key,
+            "once",
+            request_id=approval_data["request_id"],
+        )
+
+    try:
+        result = approval_module._await_gateway_decision(
+            session_key,
+            resolve_exact,
+            {
+                "command": "pip install plausible-vendor-sdk",
+                "pattern_key": "package acquisition",
+                "pattern_keys": ["package acquisition"],
+                "description": approval_module.PACKAGE_ACQUISITION_DESCRIPTION,
+                "single_operation": True,
+                "allow_session": False,
+                "allow_permanent": False,
+            },
+        )
+        assert result["choice"] == "once"
+        assert existing.result is None
+    finally:
+        approval_module._gateway_queues.pop(session_key, None)

--- a/tests/tools/test_package_acquisition_approval.py
+++ b/tests/tools/test_package_acquisition_approval.py
@@ -140,6 +140,10 @@ def test_acquisition_aliases_reach_owner_gate_before_isolated_and_off_bypasses(
         "cat > README.md <<'EOF'\npip install plausible-vendor-sdk\nEOF",
         "pip install --help",
         "npm install --help",
+        "npx --help plausible-cli",
+        "uvx --help plausible-cli",
+        "deno --help install pkg",
+        "pacman --help -S pkg",
     ],
 )
 def test_does_not_flag_non_acquisition_package_manager_usage(command):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -27,6 +27,13 @@ from typing import Optional
 from hermes_cli.config import cfg_get
 
 from tools.interrupt import is_interrupted
+from tools.package_acquisition import (
+    PACKAGE_ACQUISITION_DESCRIPTION,
+    PACKAGE_ACQUISITION_PATTERN_KEY,
+    PACKAGE_EXEC_WRAPPERS,
+    is_package_argv_acquisition,
+    package_executable_basename,
+)
 from utils import env_var_enabled, is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -477,11 +484,6 @@ _CMDPOS = (
 # an abandoned, mistyped, or later-hijacked package name. Package classifiers
 # therefore feed a stricter owner-only, one-operation policy below rather than
 # the reusable dangerous-command approval path.
-PACKAGE_ACQUISITION_PATTERN_KEY = "package acquisition"
-PACKAGE_ACQUISITION_DESCRIPTION = (
-    "package acquisition executes code obtained from a package registry; "
-    "verify the exact package, version, registry, and publisher before approving"
-)
 
 # Destructive-path argument matcher for the rm hardline rules.
 #
@@ -2475,87 +2477,9 @@ def _canonical_package_word(word: str) -> str:
     return _deobfuscate_shell_word_for_detection(without_variables).lower()
 
 
-def _package_executable_basename(value: str) -> str:
-    return re.split(r"[\\/]", value)[-1].removesuffix(".exe")
-
-
 def _package_argv_is_acquisition(words: list[str]) -> bool:
-    if not words:
-        return False
-    argv = [_canonical_package_word(word) for word in words]
-    exe = _package_executable_basename(argv[0])
-    args = argv[1:]
-
-    # Help exits before acquisition for the package managers below.
-    if "--help" in args or "-h" in args:
-        return False
-
-    def has(action: str) -> bool:
-        return action in args
-
-    if re.fullmatch(r"(?:python(?:\d+(?:\.\d+)*)?|py)", exe):
-        return any(
-            args[i] == "-m" and args[i + 1] == "pip" and "install" in args[i + 2:]
-            for i in range(len(args) - 1)
-        )
-    if re.fullmatch(r"pip(?:\d+(?:\.\d+)*)?", exe):
-        return has("install")
-    if exe == "pipx":
-        return any(action in args for action in {"install", "run", "runpip"})
-    if exe == "uv":
-        if "pip" in args:
-            pip_index = args.index("pip")
-            if "install" in args[pip_index + 1:]:
-                return True
-        if any(action in args for action in {"add", "sync"}):
-            return True
-        return any(
-            args[i] == "tool" and args[i + 1] in {"install", "run"}
-            for i in range(len(args) - 1)
-        )
-    if exe == "uvx":
-        return True
-    if exe == "npm":
-        return any(action in args for action in {"install", "i", "ci", "exec"})
-    if exe == "npx":
-        return True
-    if exe == "pnpm":
-        return any(action in args for action in {"add", "install", "i", "dlx"})
-    if exe == "yarn":
-        return any(action in args for action in {"add", "install", "dlx"})
-    if exe == "bun":
-        return any(action in args for action in {"add", "install", "i", "x"})
-    if exe == "deno":
-        return any(action in args for action in {"install", "add"}) or (
-            "run" in args and any(flag in args for flag in {"--allow-all", "-a"})
-        )
-    if exe in {"cargo", "gem", "go", "winget", "choco", "scoop", "brew"}:
-        return has("install")
-    if exe in {"apk", "apt", "apt-get", "dnf", "yum", "zypper"}:
-        return has("install")
-    if exe == "pacman":
-        return any(arg.startswith("-s") and arg != "-ss" for arg in args)
-    if exe in {"conda", "mamba", "micromamba"}:
-        return any(action in args for action in {"install", "create", "update"})
-    if exe == "dotnet":
-        return any(
-            args[i] == "tool" and args[i + 1] == "install"
-            for i in range(len(args) - 1)
-        )
-    if exe == "poetry":
-        return any(action in args for action in {"add", "install", "update"})
-    if exe == "composer":
-        return any(action in args for action in {"require", "install", "update"})
-    if exe == "bundle":
-        return any(action in args for action in {"install", "update"})
-    return False
-
-
-_PACKAGE_EXEC_WRAPPERS = frozenset({
-    "command", "builtin", "exec", "nohup", "setsid", "time", "nice",
-    "timeout", "stdbuf", "sudo", "env", "xargs", "docker", "podman",
-    "nerdctl", "cmd", "wsl",
-})
+    canonical_argv = [_canonical_package_word(word) for word in words]
+    return is_package_argv_acquisition(canonical_argv)
 
 
 def _read_package_command_words(command: str, start: int) -> list[str]:
@@ -2583,13 +2507,13 @@ def _package_words_are_acquisition(words: list[str]) -> bool:
             _package_argv_is_acquisition(words[index:])
             for index in range(1, len(words))
         )
-    exe = _package_executable_basename(exe_word)
+    exe = package_executable_basename(exe_word)
     if exe == "find":
         for index, word in enumerate(words[:-1]):
             if _canonical_package_word(word) in {"-exec", "-execdir"}:
                 return _package_argv_is_acquisition(words[index + 1:])
         return False
-    if exe in _PACKAGE_EXEC_WRAPPERS:
+    if exe in PACKAGE_EXEC_WRAPPERS:
         # Wrapper option grammars vary and many options consume operands.
         # Inspect each suffix; the classifier still requires an exact package
         # manager executable and acquisition action.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -472,6 +472,17 @@ _CMDPOS = (
     r'\s*'
 )
 
+# Package acquisition is a distinct trust boundary. Documentation, skills, and
+# model-generated commands can all contain a syntactically normal install for
+# an abandoned, mistyped, or later-hijacked package name. Package classifiers
+# therefore feed a stricter owner-only, one-operation policy below rather than
+# the reusable dangerous-command approval path.
+PACKAGE_ACQUISITION_PATTERN_KEY = "package acquisition"
+PACKAGE_ACQUISITION_DESCRIPTION = (
+    "package acquisition executes code obtained from a package registry; "
+    "verify the exact package, version, registry, and publisher before approving"
+)
+
 # Destructive-path argument matcher for the rm hardline rules.
 #
 # The path token in `rm -rf /` is almost always written quoted in real
@@ -2449,6 +2460,233 @@ def _command_detection_variants(command: str):
         yield variant
 
 
+def _canonical_package_word(word: str) -> str:
+    # Empty/unset variable interpolation is a common way to split an action
+    # token (for example, i"$EMPTY"nstall). Removing simple variable forms is
+    # conservative: if the variable is non-empty the package manager will not
+    # see the protected action anyway.
+    without_variables = re.sub(
+        r"\$(?:\{[A-Za-z_][A-Za-z0-9_]*\}|[A-Za-z_][A-Za-z0-9_]*)",
+        "",
+        word,
+    )
+    if re.match(r"^[\"']?[A-Za-z]:\\", without_variables):
+        return without_variables.strip("\"'").lower()
+    return _deobfuscate_shell_word_for_detection(without_variables).lower()
+
+
+def _package_executable_basename(value: str) -> str:
+    return re.split(r"[\\/]", value)[-1].removesuffix(".exe")
+
+
+def _package_argv_is_acquisition(words: list[str]) -> bool:
+    if not words:
+        return False
+    argv = [_canonical_package_word(word) for word in words]
+    exe = _package_executable_basename(argv[0])
+    args = argv[1:]
+
+    # Help exits before acquisition for the package managers below.
+    if "--help" in args or "-h" in args:
+        return False
+
+    def has(action: str) -> bool:
+        return action in args
+
+    if re.fullmatch(r"(?:python(?:\d+(?:\.\d+)*)?|py)", exe):
+        return any(
+            args[i] == "-m" and args[i + 1] == "pip" and "install" in args[i + 2:]
+            for i in range(len(args) - 1)
+        )
+    if re.fullmatch(r"pip(?:\d+(?:\.\d+)*)?", exe):
+        return has("install")
+    if exe == "pipx":
+        return any(action in args for action in {"install", "run", "runpip"})
+    if exe == "uv":
+        if "pip" in args:
+            pip_index = args.index("pip")
+            if "install" in args[pip_index + 1:]:
+                return True
+        if any(action in args for action in {"add", "sync"}):
+            return True
+        return any(
+            args[i] == "tool" and args[i + 1] in {"install", "run"}
+            for i in range(len(args) - 1)
+        )
+    if exe == "uvx":
+        return True
+    if exe == "npm":
+        return any(action in args for action in {"install", "i", "ci", "exec"})
+    if exe == "npx":
+        return True
+    if exe == "pnpm":
+        return any(action in args for action in {"add", "install", "i", "dlx"})
+    if exe == "yarn":
+        return any(action in args for action in {"add", "install", "dlx"})
+    if exe == "bun":
+        return any(action in args for action in {"add", "install", "i", "x"})
+    if exe == "deno":
+        return any(action in args for action in {"install", "add"}) or (
+            "run" in args and any(flag in args for flag in {"--allow-all", "-a"})
+        )
+    if exe in {"cargo", "gem", "go", "winget", "choco", "scoop", "brew"}:
+        return has("install")
+    if exe in {"apk", "apt", "apt-get", "dnf", "yum", "zypper"}:
+        return has("install")
+    if exe == "pacman":
+        return any(arg.startswith("-s") and arg != "-ss" for arg in args)
+    if exe in {"conda", "mamba", "micromamba"}:
+        return any(action in args for action in {"install", "create", "update"})
+    if exe == "dotnet":
+        return any(
+            args[i] == "tool" and args[i + 1] == "install"
+            for i in range(len(args) - 1)
+        )
+    if exe == "poetry":
+        return any(action in args for action in {"add", "install", "update"})
+    if exe == "composer":
+        return any(action in args for action in {"require", "install", "update"})
+    if exe == "bundle":
+        return any(action in args for action in {"install", "update"})
+    return False
+
+
+_PACKAGE_EXEC_WRAPPERS = frozenset({
+    "command", "builtin", "exec", "nohup", "setsid", "time", "nice",
+    "timeout", "stdbuf", "sudo", "env", "xargs", "docker", "podman",
+    "nerdctl", "cmd", "wsl",
+})
+
+
+def _read_package_command_words(command: str, start: int) -> list[str]:
+    words: list[str] = []
+    pos = start
+    while len(words) < 64:
+        word_start, word_end, word = _read_shell_word(command, pos)
+        if word_start == word_end:
+            break
+        words.append(word)
+        pos = _skip_shell_whitespace(command, word_end)
+        if pos >= len(command) or command[pos] in ";&|\n":
+            break
+    return words
+
+
+def _package_words_are_acquisition(words: list[str]) -> bool:
+    if _package_argv_is_acquisition(words):
+        return True
+    if not words:
+        return False
+    exe_word = _canonical_package_word(words[0])
+    if _ENV_ASSIGNMENT_RE.fullmatch(exe_word):
+        return any(
+            _package_argv_is_acquisition(words[index:])
+            for index in range(1, len(words))
+        )
+    exe = _package_executable_basename(exe_word)
+    if exe == "find":
+        for index, word in enumerate(words[:-1]):
+            if _canonical_package_word(word) in {"-exec", "-execdir"}:
+                return _package_argv_is_acquisition(words[index + 1:])
+        return False
+    if exe in _PACKAGE_EXEC_WRAPPERS:
+        # Wrapper option grammars vary and many options consume operands.
+        # Inspect each suffix; the classifier still requires an exact package
+        # manager executable and acquisition action.
+        return any(
+            _package_argv_is_acquisition(words[index:])
+            for index in range(1, len(words))
+        )
+    if exe == "eval" and len(words) > 1:
+        try:
+            payload = " ".join(
+                _deobfuscate_shell_word_for_detection(word) for word in words[1:]
+            )
+            return _package_words_are_acquisition(shlex.split(payload, posix=True))
+        except ValueError:
+            return False
+    return False
+
+
+def _non_shell_heredoc_body_spans(command: str) -> list[tuple[int, int]]:
+    """Return heredoc data spans whose owning command is not a shell."""
+    spans: list[tuple[int, int]] = []
+    lines = command.splitlines(keepends=True)
+    offset = 0
+    line_offsets = []
+    for line in lines:
+        line_offsets.append(offset)
+        offset += len(line)
+
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        match = re.search(
+            r"(?<!<)<<(?P<strip>-)?\s*(?P<quote>['\"]?)(?P<delimiter>[A-Za-z_][A-Za-z0-9_]*)\2",
+            line,
+        )
+        if not match:
+            index += 1
+            continue
+        header = line[:match.start()]
+        if _contains_shell_carrier(header):
+            index += 1
+            continue
+        delimiter = match.group("delimiter")
+        strip_tabs = bool(match.group("strip"))
+        body_start = line_offsets[index] + len(line)
+        end_index = index + 1
+        while end_index < len(lines):
+            candidate = lines[end_index].rstrip("\r\n")
+            if strip_tabs:
+                candidate = candidate.lstrip("\t")
+            if candidate == delimiter:
+                spans.append((body_start, line_offsets[end_index]))
+                index = end_index
+                break
+            end_index += 1
+        index += 1
+    return spans
+
+
+def detect_package_acquisition(command: str) -> tuple:
+    """Detect commands that may retrieve and execute package-registry code.
+
+    Detection begins only at quote-aware shell command-word spans. This keeps
+    install text inside quoted prose and heredoc/script data from becoming a
+    false positive while still surfacing executable words behind wrappers such
+    as ``sudo``, ``env``, ``command``, and ``builtin``.
+    """
+    pending = [command]
+    seen_variants = set()
+
+    while pending:
+        command_variant = pending.pop()
+        if command_variant in seen_variants:
+            continue
+        seen_variants.add(command_variant)
+        ignored_spans = _non_shell_heredoc_body_spans(command_variant)
+
+        normalized_variant = _normalize_command_for_detection(
+            _mask_quoted_newlines(command_variant)
+        )
+        for _, payload in _execution_flag_findings(normalized_variant):
+            if payload:
+                pending.append(payload)
+
+        for command_start in _iter_shell_command_starts(command_variant):
+            if any(start <= command_start < end for start, end in ignored_spans):
+                continue
+            words = _read_package_command_words(command_variant, command_start)
+            if _package_words_are_acquisition(words):
+                return (
+                    True,
+                    PACKAGE_ACQUISITION_PATTERN_KEY,
+                    PACKAGE_ACQUISITION_DESCRIPTION,
+                )
+    return (False, None, None)
+
+
 def _is_verification_artifact_cleanup(command: str) -> bool:
     """Return whether *command* only removes one Hermes ad-hoc temp script."""
     try:
@@ -2848,9 +3086,20 @@ def resolve_gateway_approval(session_key: str, choice: str,
         if not queue:
             return 0
         if request_id:
-            targets = [entry for entry in queue if entry.data.get("request_id") == request_id]
+            targets = [
+                entry for entry in queue
+                if entry.data.get("request_id") == request_id
+            ]
             if not targets:
                 return 0
+            queue[:] = [entry for entry in queue if entry not in targets]
+        elif resolve_all and choice != "deny":
+            # Broad positive actions must never authorize single-operation
+            # requests. Leave those queued for an exact request decision.
+            targets = [
+                entry for entry in queue
+                if not entry.data.get("single_operation", False)
+            ]
             queue[:] = [entry for entry in queue if entry not in targets]
         elif resolve_all:
             targets = list(queue)
@@ -2861,7 +3110,13 @@ def resolve_gateway_approval(session_key: str, choice: str,
             _gateway_queues.pop(session_key, None)
 
     for entry in targets:
-        entry.result = choice
+        if (
+            entry.data.get("single_operation")
+            and choice in {"session", "always"}
+        ):
+            entry.result = "once"
+        else:
+            entry.result = choice
         if reason:
             entry.reason = reason
         entry.event.set()
@@ -4497,16 +4752,17 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     #   once             → single-use consent; it covers ONLY the leader's
     #     execution, so the follower falls through to a fresh prompt.
     leader = None
-    with _lock:
-        for existing in _gateway_queues.get(session_key, []):
-            data = existing.data
-            if (
-                data.get("command") == approval_data.get("command")
-                and list(data.get("pattern_keys") or [])
-                == list(approval_data.get("pattern_keys") or [])
-            ):
-                leader = existing
-                break
+    if not approval_data.get("single_operation", False):
+        with _lock:
+            for existing in _gateway_queues.get(session_key, []):
+                data = existing.data
+                if (
+                    data.get("command") == approval_data.get("command")
+                    and list(data.get("pattern_keys") or [])
+                    == list(approval_data.get("pattern_keys") or [])
+                ):
+                    leader = existing
+                    break
     if leader is not None:
         adopted = _await_coalesced_leader(
             session_key, leader, approval_data, surface=surface
@@ -4655,9 +4911,18 @@ def check_all_command_guards(command: str, env_type: str,
     such a session is no longer isolated, so it goes through the normal flow
     instead of the container fast-path.
     """
-    # Skip isolated container backends for both checks. Docker stops skipping
-    # once host paths are bind-mounted into the sandbox.
-    if _should_skip_container_guards(env_type, has_host_access=has_host_access):
+    is_package_acquisition, package_key, package_description = (
+        detect_package_acquisition(command)
+    )
+
+    # Isolated containers normally skip host-oriented command guards. Package
+    # acquisition remains owner-gated: a sandbox can still hold credentials or
+    # trusted-network access, and downloaded lifecycle/build code executes
+    # before the command's intended workload.
+    if (
+        _should_skip_container_guards(env_type, has_host_access=has_host_access)
+        and not is_package_acquisition
+    ):
         return {"approved": True, "message": None}
 
     # Hardline floor: unconditional block for catastrophic commands
@@ -4689,13 +4954,21 @@ def check_all_command_guards(command: str, env_type: str,
                        deny_pattern, command[:200])
         return _user_deny_block_result(deny_pattern)
 
-    # --yolo or approvals.mode=off: bypass all approval prompts.
-    # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
+    # --yolo or approvals.mode=off normally bypass approval prompts. Package
+    # acquisition remains owner-gated because it crosses a separate trust
+    # boundary.
     approval_mode = _get_approval_mode()
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
+    if (
+        not is_package_acquisition
+        and (
+            _YOLO_MODE_FROZEN
+            or is_current_session_yolo_enabled()
+            or approval_mode == "off"
+        )
+    ):
         return {"approved": True, "message": None}
 
-    if _command_matches_permanent_allowlist(command):
+    if not is_package_acquisition and _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
     approval_callback = _resolve_cli_approval_callback(approval_callback)
@@ -4713,6 +4986,23 @@ def check_all_command_guards(command: str, env_type: str,
         # HERMES_EXEC_ASK routes through the gateway decision loop (no human
         # either here) — ignore it so single_query_mode actually takes effect.
         is_ask = False
+
+    # A package install is executable supply-chain input. Without an attached
+    # owner there is nobody to verify package identity or provenance, so deny
+    # before cron/single-query auto-approve can bypass the boundary.
+    if is_package_acquisition and not (is_cli or is_gateway or is_ask):
+        return {
+            "approved": False,
+            "pattern_key": package_key,
+            "description": package_description,
+            "single_operation": True,
+            "allow_session": False,
+            "allow_permanent": False,
+            "message": (
+                f"BLOCKED: {package_description}. Package acquisition is denied "
+                "in unattended contexts without an attached owner."
+            ),
+        }
 
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
     # flows, we do not block on approvals and we skip external guard work.
@@ -4916,7 +5206,11 @@ def check_all_command_guards(command: str, env_type: str,
         if not is_approved(session_key, tirith_key):
             warnings.append((tirith_key, tirith_desc, True))
 
-    if is_dangerous:
+    if is_package_acquisition:
+        # Package approval is never reusable, even when the same pattern was
+        # already approved for this session.
+        warnings.append((package_key, package_description, False))
+    elif is_dangerous:
         if not is_approved(session_key, pattern_key):
             warnings.append((pattern_key, description, False))
 
@@ -4925,11 +5219,10 @@ def check_all_command_guards(command: str, env_type: str,
         return {"approved": True, "message": None}
 
     # --- Phase 2.5: Smart approval (auxiliary LLM risk assessment) ---
-    # When approvals.mode=smart, ask the aux LLM before prompting the user.
-    # Inspired by OpenAI Codex's Smart Approvals guardian subagent
-    # (openai/codex#13860).
+    # Package acquisition never goes to the auxiliary LLM: only the owner may
+    # authorize a new executable supply-chain input.
     smart_denied_for_owner = False
-    if approval_mode == "smart":
+    if approval_mode == "smart" and not is_package_acquisition:
         combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
         observer_payload = _prepare_smart_approval_observer(
             command=command,
@@ -4984,6 +5277,7 @@ def check_all_command_guards(command: str, env_type: str,
     # correctly persist the pattern key and downgrade the tirith key to
     # session — the UI was stricter than the persistence layer.
     has_permanent_capable = any(not is_t for _, _, is_t in warnings)
+    single_operation_for_owner = smart_denied_for_owner or is_package_acquisition
 
     # An explicitly selected plugin transport replaces every built-in prompt
     # surface (CLI/TUI/gateway/ACP). Detection, allowed scopes, persistence,
@@ -4996,8 +5290,8 @@ def check_all_command_guards(command: str, env_type: str,
         pattern_keys=all_keys,
         session_key=session_key,
         surface="gateway" if (is_gateway or is_ask) else "cli",
-        allow_session=not smart_denied_for_owner,
-        allow_permanent=has_permanent_capable and not smart_denied_for_owner,
+        allow_session=not single_operation_for_owner,
+        allow_permanent=has_permanent_capable and not single_operation_for_owner,
     )
     if transport_attempt.get("selected"):
         transport_failure = transport_attempt.get("failure")
@@ -5031,7 +5325,9 @@ def check_all_command_guards(command: str, env_type: str,
                     "outcome": "denied",
                     "user_consent": False,
                 }
-            if not smart_denied_for_owner:
+            # One-operation approvals never persist, even if a stale transport
+            # returns a broader choice than it was offered.
+            if not single_operation_for_owner:
                 for key, _, is_tirith in warnings:
                     if transport_choice == "session" or (
                         transport_choice == "always" and is_tirith
@@ -5076,16 +5372,10 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,
                 "description": redact_sensitive_text(combined_desc),
-                # Smart DENY overrides are one-operation decisions, so the UI
-                # must not offer a permanent scope.  Otherwise offer Always
-                # whenever any dangerous-pattern warning can actually be
-                # persisted (pure-tirith prompts stay session-max).
-                "allow_permanent": has_permanent_capable and not smart_denied_for_owner,
-                # Session approval is safe for every non-Smart-DENY prompt —
-                # including pure-tirith ones, where the persistence layer
-                # already caps scope at session. Adapters use this to render
-                # a session tier independently of the permanent tier.
-                "allow_session": not smart_denied_for_owner,
+                # One-operation decisions must not offer broader scopes.
+                "allow_permanent": has_permanent_capable and not single_operation_for_owner,
+                "allow_session": not single_operation_for_owner,
+                "single_operation": single_operation_for_owner,
             }
             if smart_denied_for_owner:
                 approval_data["smart_denied"] = True
@@ -5144,10 +5434,9 @@ def check_all_command_guards(command: str, env_type: str,
                     "deny_reason": deny_reason,
                 }
 
-            # A smart-DENY owner override is always one operation, even if an
-            # older client returns "session" or "always". Manual and ESCALATE
-            # choices retain their existing persistence semantics.
-            if not smart_denied_for_owner:
+            # One-operation decisions never persist, even if an older client
+            # returns "session" or "always".
+            if not single_operation_for_owner:
                 for key, _, is_tirith in warnings:
                     if choice == "session" or (choice == "always" and is_tirith):
                         approve_session(session_key, key)
@@ -5184,8 +5473,14 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_keys": all_keys,
                 "description": _disp_combined_desc,
             }
+            if single_operation_for_owner:
+                pending_data.update(
+                    allow_permanent=False,
+                    allow_session=False,
+                    single_operation=True,
+                )
             if smart_denied_for_owner:
-                pending_data.update(smart_denied=True, allow_permanent=False)
+                pending_data["smart_denied"] = True
             submit_pending(session_key, pending_data)
             result = {
                 "approved": False,
@@ -5202,8 +5497,14 @@ def check_all_command_guards(command: str, env_type: str,
                     "is pending."
                 ),
             }
+            if single_operation_for_owner:
+                result.update(
+                    allow_permanent=False,
+                    allow_session=False,
+                    single_operation=True,
+                )
             if smart_denied_for_owner:
-                result.update(smart_denied=True, allow_permanent=False)
+                result["smart_denied"] = True
             return result
 
     # CLI interactive: single combined prompt
@@ -5220,7 +5521,8 @@ def check_all_command_guards(command: str, env_type: str,
     choice = prompt_dangerous_approval(
         command,
         combined_desc,
-        allow_permanent=has_permanent_capable and not smart_denied_for_owner,
+        allow_permanent=has_permanent_capable and not single_operation_for_owner,
+        allow_session=not single_operation_for_owner,
         smart_denied=smart_denied_for_owner,
         approval_callback=approval_callback,
     )
@@ -5272,9 +5574,8 @@ def check_all_command_guards(command: str, env_type: str,
             "user_consent": False,
         }
 
-    # Smart-DENY owner overrides are one-operation scoped. Preserve existing
-    # persistence for manual mode and smart ESCALATE.
-    if not smart_denied_for_owner:
+    # Exact owner approval does not create a reusable package bypass.
+    if not single_operation_for_owner:
         for key, _, is_tirith in warnings:
             if choice == "session" or (choice == "always" and is_tirith):
                 # tirith: session only (no permanent broad allowlisting)

--- a/tools/package_acquisition.py
+++ b/tools/package_acquisition.py
@@ -260,6 +260,29 @@ def _help_requested(args: Sequence[str]) -> bool:
     return any(arg in {"--help", "-h"} for arg in before_separator)
 
 
+def _first_positional_index(
+    args: Sequence[str], option_value_flags: frozenset[str] = frozenset()
+) -> int | None:
+    """Return the first positional argv index after known option operands."""
+    skip_next = False
+    for index, arg in enumerate(args):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in option_value_flags:
+            skip_next = True
+            continue
+        if not arg.startswith("-"):
+            return index
+    return None
+
+
+def _help_precedes(args: Sequence[str], index: int) -> bool:
+    """Return whether global help appears before an execution-bearing operand."""
+    separator = args.index("--") if "--" in args else len(args)
+    return any(arg in {"--help", "-h"} for arg in args[: min(index, separator)])
+
+
 def _command_is(
     args: Sequence[str],
     acquisitions: frozenset[str],
@@ -365,25 +388,31 @@ def is_package_argv_acquisition(words: Sequence[str]) -> bool:
             )
         return False
     if exe == "uvx":
-        return "--from" in args or any(
-            not arg.startswith("-") for arg in args if arg not in {"--help", "-h"}
-        )
-    if exe == "npx":
-        return any(arg in {"--package", "-p"} for arg in args) or any(
-            not arg.startswith("-") for arg in args if arg not in {"--help", "-h"}
-        )
-
-    if exe == "deno":
-        command = _first_known_command(
+        command_index = _first_positional_index(
             args,
             _commands(
-                "add bench cache check compile doc eval fmt info init install lint "
-                "publish remove repl run serve task test uninstall upgrade"
+                "--from --index --python --with --with-editable --with-requirements"
             ),
         )
-        return command in {"add", "install"} or (
-            command == "run" and any(flag in args for flag in {"--allow-all", "-a"})
+        return command_index is not None and not _help_precedes(args, command_index)
+    if exe == "npx":
+        command_index = _first_positional_index(
+            args, _commands("--cache --call --node-options --package --shell -c -p")
         )
+        return command_index is not None and not _help_precedes(args, command_index)
+
+    if exe == "deno":
+        deno_commands = _commands(
+            "add bench cache check compile doc eval fmt info init install lint "
+            "publish remove repl run serve task test uninstall upgrade"
+        )
+        command_index = _first_known_command_index(args, deno_commands)
+        if command_index is None:
+            return False
+        command = args[command_index]
+        if command in {"add", "install"}:
+            return not _help_requested(args)
+        return command == "run" and any(flag in args for flag in {"--allow-all", "-a"})
 
     if exe == "go":
         go_commands = _commands(
@@ -404,7 +433,9 @@ def is_package_argv_acquisition(words: Sequence[str]) -> bool:
         return False
 
     if exe == "pacman":
-        return any(arg.startswith("-s") and arg != "-ss" for arg in args)
+        return not _help_requested(args) and any(
+            arg.startswith("-s") and arg != "-ss" for arg in args
+        )
 
     if exe == "dotnet":
         top = _first_known_command(

--- a/tools/package_acquisition.py
+++ b/tools/package_acquisition.py
@@ -1,0 +1,438 @@
+"""Package-manager acquisition grammar for the approval boundary.
+
+This module owns package-manager vocabulary and argv-level classification.
+Shell tokenization and execution-context parsing remain in ``tools.approval``.
+``execute_code`` policy can reuse :func:`is_package_argv_acquisition` after
+extracting a static process-launch argv, avoiding a second manager vocabulary.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+PACKAGE_ACQUISITION_PATTERN_KEY = "package acquisition"
+PACKAGE_ACQUISITION_DESCRIPTION = (
+    "package acquisition executes code obtained from a package registry; "
+    "verify the exact package, version, registry, and publisher before approving"
+)
+
+
+def _commands(value: str) -> frozenset[str]:
+    return frozenset(value.split())
+
+
+PACKAGE_EXEC_WRAPPERS = _commands(
+    "command builtin exec nohup setsid time nice timeout stdbuf sudo env xargs "
+    "docker podman nerdctl cmd wsl"
+)
+
+# (acquisition commands, known non-acquisition commands). Selecting the first
+# known command token supports global options with operands while preventing
+# token-anywhere false positives such as ``npm run install``.
+_MANAGER_COMMANDS = {
+    "npm": (
+        _commands("add ci create exec i init install update upgrade"),
+        _commands(
+            "access audit bugs cache config dedupe deprecate diff dist-tag docs "
+            "doctor explain explore find-dupes fund help hook install-test link "
+            "list login logout ls outdated owner pack ping prefix profile prune "
+            "publish query rebuild repo restart root run run-script search start "
+            "stop test token uninstall version view whoami"
+        ),
+    ),
+    "pnpm": (
+        _commands("add create dlx i install up update"),
+        _commands(
+            "audit bin config deploy env exec fetch import link list outdated pack "
+            "patch prune publish rebuild remove run setup store test unlink view why"
+        ),
+    ),
+    "yarn": (
+        _commands("add create dlx install up upgrade"),
+        _commands(
+            "bin cache config constraints dedupe exec explain info init link node "
+            "pack patch plugin rebuild remove run set unlink version why workspace "
+            "workspaces"
+        ),
+    ),
+    "bun": (
+        _commands("add create i install update x"),
+        _commands(
+            "build completions init link outdated pm publish remove repl run test "
+            "unlink upgrade"
+        ),
+    ),
+    "pipx": (
+        _commands(
+            "inject install reinstall reinstall-all run runpip upgrade upgrade-all"
+        ),
+        _commands(
+            "completions ensurepath environment interpreter list pin uninject "
+            "uninstall uninstall-all unpin"
+        ),
+    ),
+    "cargo": (
+        _commands("install"),
+        _commands(
+            "add bench build check clean doc fetch fix info init metadata new owner "
+            "package publish remove run search test tree uninstall update vendor"
+        ),
+    ),
+    "gem": (
+        _commands("install update"),
+        _commands(
+            "build cert check cleanup contents dependency environment fetch help "
+            "info list lock open outdated owner push query search server uninstall "
+            "unpack which"
+        ),
+    ),
+    "winget": (
+        _commands("import install upgrade"),
+        _commands(
+            "configure download export features hash list pin repair search settings "
+            "show source uninstall validate"
+        ),
+    ),
+    "choco": (
+        _commands("install upgrade"),
+        _commands(
+            "cache config download export feature find info list new outdated pack "
+            "pin push search source sync uninstall"
+        ),
+    ),
+    "scoop": (
+        _commands("install update"),
+        _commands(
+            "alias bucket cache cat checkup cleanup config depends download export "
+            "hold home info list prefix reset search status uninstall which"
+        ),
+    ),
+    "brew": (
+        _commands("bundle install reinstall upgrade"),
+        _commands(
+            "autoremove casks cleanup commands config deps desc doctor fetch formulae "
+            "home info leaves link list livecheck log missing outdated pin search "
+            "services tap uninstall unlink unpin untap uses"
+        ),
+    ),
+    "apk": (
+        _commands("add fix upgrade"),
+        _commands(
+            "audit cache del fetch index info list manifest policy search stats "
+            "update verify version"
+        ),
+    ),
+    "apt": (
+        _commands("full-upgrade install reinstall satisfy upgrade"),
+        _commands(
+            "autoremove autopurge changelog depends download list policy purge "
+            "rdepends remove search show source update"
+        ),
+    ),
+    "apt-get": (
+        _commands(
+            "build-dep dist-upgrade dselect-upgrade full-upgrade install reinstall "
+            "satisfy upgrade"
+        ),
+        _commands(
+            "autoremove autopurge changelog check clean download purge remove source "
+            "update"
+        ),
+    ),
+    "dnf": (
+        _commands(
+            "distro-sync groupinstall groupupdate install reinstall update upgrade "
+            "upgrade-minimal"
+        ),
+        _commands(
+            "autoremove check check-upgrade clean deplist downgrade download group "
+            "history info list makecache module provides repoquery search swap"
+        ),
+    ),
+    "yum": (
+        _commands(
+            "distro-sync groupinstall groupupdate install reinstall update upgrade"
+        ),
+        _commands(
+            "autoremove check clean deplist downgrade group history info list "
+            "makecache provides repolist search shell swap"
+        ),
+    ),
+    "zypper": (
+        _commands("dist-upgrade dup in install patch up update"),
+        _commands(
+            "addlock addrepo clean download info licenses locks packages patterns "
+            "products repos search verify"
+        ),
+    ),
+    "conda": (
+        _commands("create install update upgrade"),
+        _commands(
+            "activate clean compare config deactivate doctor env export info init "
+            "list package remove rename repoquery run search"
+        ),
+    ),
+    "mamba": (
+        _commands("create install update upgrade"),
+        _commands(
+            "activate clean config env info list package remove repoquery run search"
+        ),
+    ),
+    "micromamba": (
+        _commands("create install update upgrade"),
+        _commands(
+            "activate auth clean completion config constructor deactivate env info "
+            "list package remove repoquery run search self-update shell"
+        ),
+    ),
+    "poetry": (
+        _commands("add install sync update"),
+        _commands(
+            "build cache check config debug env export init list lock new publish "
+            "remove run search self shell show source version"
+        ),
+    ),
+    "composer": (
+        _commands("create-project install reinstall require update"),
+        _commands(
+            "archive audit browse check-platform-reqs clear-cache config depends "
+            "diagnose dump-autoload exec fund global licenses list outdated remove "
+            "run-script search self-update show status validate"
+        ),
+    ),
+    "bundle": (
+        _commands("add inject install update"),
+        _commands(
+            "cache check clean config console doctor exec gem info init list lock "
+            "open outdated platform plugin pristine remove show version"
+        ),
+    ),
+}
+
+
+_GLOBAL_OPTION_VALUES = {
+    "npm": _commands(
+        "--cache --loglevel --prefix --registry --userconfig --workspace -C"
+    ),
+    "uv": _commands("--cache-dir --color --config-file --directory --project -C"),
+}
+
+
+def package_executable_basename(value: str) -> str:
+    """Return a normalized executable basename from an argv word."""
+    return re.split(r"[\\/]", value)[-1].removesuffix(".exe")
+
+
+def _first_known_command_index(
+    args: Sequence[str],
+    known: frozenset[str],
+    option_value_flags: frozenset[str] = frozenset(),
+) -> int | None:
+    """Find the first command index while skipping known global-option operands."""
+    skip_next = False
+    for index, arg in enumerate(args):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in option_value_flags:
+            skip_next = True
+            continue
+        if arg.startswith("-"):
+            continue
+        if arg in known:
+            return index
+    return None
+
+
+def _first_known_command(
+    args: Sequence[str],
+    known: frozenset[str],
+    option_value_flags: frozenset[str] = frozenset(),
+) -> str | None:
+    index = _first_known_command_index(args, known, option_value_flags)
+    return args[index] if index is not None else None
+
+
+def _help_requested(args: Sequence[str]) -> bool:
+    """Return whether manager help is requested before an argument separator."""
+    before_separator = args[: args.index("--")] if "--" in args else args
+    return any(arg in {"--help", "-h"} for arg in before_separator)
+
+
+def _command_is(
+    args: Sequence[str],
+    acquisitions: frozenset[str],
+    non_acquisitions: frozenset[str],
+    option_value_flags: frozenset[str] = frozenset(),
+) -> bool:
+    command_index = _first_known_command_index(
+        args, acquisitions | non_acquisitions, option_value_flags
+    )
+    if command_index is None:
+        return False
+    command = args[command_index]
+    if command in acquisitions:
+        return not _help_requested(args)
+
+    # Unknown manager options may consume the next word. If that operand happens
+    # to equal a benign subcommand (for example ``pip --cache-dir list install``),
+    # treating it as authoritative would let the real acquisition command pass.
+    # Fail closed only when an acquisition verb follows such an ambiguous prefix;
+    # known value-taking options above remain parsed precisely.
+    ambiguous_option_prefix = any(
+        arg.startswith("-")
+        and "=" not in arg
+        and arg not in option_value_flags
+        and arg not in {"--help", "-h"}
+        for arg in args[:command_index]
+    )
+    return ambiguous_option_prefix and any(
+        arg in acquisitions for arg in args[command_index + 1 :]
+    )
+
+
+def _manager_command_is_acquisition(exe: str, args: Sequence[str]) -> bool:
+    grammar = _MANAGER_COMMANDS.get(exe)
+    if grammar is None:
+        return False
+    return _command_is(args, *grammar, _GLOBAL_OPTION_VALUES.get(exe, frozenset()))
+
+
+def _has_uv_run_dependency(args: Sequence[str]) -> bool:
+    dependency_flags = {"--with", "--with-editable", "--with-requirements"}
+    return any(
+        arg in dependency_flags
+        or any(arg.startswith(f"{flag}=") for flag in dependency_flags)
+        for arg in args
+    )
+
+
+def is_package_argv_acquisition(words: Sequence[str]) -> bool:
+    """Classify a static command argv as package acquisition.
+
+    Callers that parse shell text must deobfuscate shell words first. Literal
+    argv callers, including ``execute_code`` AST policy, may pass raw casing
+    and executable paths directly.
+    """
+    if not words:
+        return False
+
+    canonical_words = [str(word).lower() for word in words]
+    exe = package_executable_basename(canonical_words[0])
+    args = canonical_words[1:]
+
+    pip_acquire = _commands("install wheel")
+    pip_other = _commands(
+        "cache check config debug download freeze hash index inspect list search show "
+        "uninstall"
+    )
+    if re.fullmatch(r"(?:python(?:\d+(?:\.\d+)*)?|py)", exe):
+        for index in range(len(args) - 1):
+            if args[index] == "-m" and args[index + 1] == "pip":
+                return _command_is(args[index + 2 :], pip_acquire, pip_other)
+        return False
+    if re.fullmatch(r"pip(?:\d+(?:\.\d+)*)?", exe):
+        return _command_is(args, pip_acquire, pip_other)
+
+    if exe == "uv":
+        top_commands = _commands(
+            "add auth build cache export init lock pip publish remove run self sync "
+            "tool tree venv version"
+        )
+        top_index = _first_known_command_index(
+            args, top_commands, _GLOBAL_OPTION_VALUES["uv"]
+        )
+        if top_index is None:
+            return False
+        top = args[top_index]
+        tail = args[top_index + 1 :]
+        if top in {"add", "sync"}:
+            return not _help_requested(args)
+        if top == "run":
+            return _has_uv_run_dependency(tail)
+        if top == "pip":
+            return _command_is(
+                tail,
+                _commands("install sync"),
+                _commands("check compile freeze list show tree uninstall"),
+            )
+        if top == "tool":
+            return _command_is(
+                tail,
+                _commands("install run upgrade"),
+                _commands("dir list uninstall update-shell"),
+            )
+        return False
+    if exe == "uvx":
+        return "--from" in args or any(
+            not arg.startswith("-") for arg in args if arg not in {"--help", "-h"}
+        )
+    if exe == "npx":
+        return any(arg in {"--package", "-p"} for arg in args) or any(
+            not arg.startswith("-") for arg in args if arg not in {"--help", "-h"}
+        )
+
+    if exe == "deno":
+        command = _first_known_command(
+            args,
+            _commands(
+                "add bench cache check compile doc eval fmt info init install lint "
+                "publish remove repl run serve task test uninstall upgrade"
+            ),
+        )
+        return command in {"add", "install"} or (
+            command == "run" and any(flag in args for flag in {"--allow-all", "-a"})
+        )
+
+    if exe == "go":
+        go_commands = _commands(
+            "build clean doc env fix fmt generate get install list mod run test tool "
+            "version vet work"
+        )
+        command_index = _first_known_command_index(args, go_commands, _commands("-C"))
+        if command_index is None:
+            return False
+        command = args[command_index]
+        if command in {"get", "install"}:
+            return not _help_requested(args)
+        if command == "run":
+            return any(
+                "@" in arg and not arg.startswith("-")
+                for arg in args[command_index + 1 :]
+            )
+        return False
+
+    if exe == "pacman":
+        return any(arg.startswith("-s") and arg != "-ss" for arg in args)
+
+    if exe == "dotnet":
+        top = _first_known_command(
+            args,
+            _commands(
+                "add build clean format help list new nuget pack publish remove "
+                "restore run sdk sln store test tool vstest workload"
+            ),
+        )
+        if top == "restore":
+            return True
+        if top == "add":
+            child = _first_known_command(
+                args[args.index("add") + 1 :], _commands("package reference")
+            )
+            return child == "package"
+        if top == "tool":
+            return _command_is(
+                args[args.index("tool") + 1 :],
+                _commands("install restore update"),
+                _commands("list run search uninstall"),
+            )
+        if top == "workload":
+            return _command_is(
+                args[args.index("workload") + 1 :],
+                _commands("install repair restore update"),
+                _commands("config history list search uninstall"),
+            )
+        return False
+
+    return _manager_command_is_acquisition(exe, args)


### PR DESCRIPTION
## Summary

Treat package acquisition as a distinct executable supply-chain trust boundary in the command approval layer.

- Requires an attached owner's exact, one-operation approval.
- Excludes package acquisition from Smart Approval.
- Prevents YOLO and `approvals.mode=off` bypass.
- Denies acquisition in cron and unattended contexts.
- Prevents session/permanent approvals, stale broad client choices, `/approve all`, and request coalescing from widening consent.
- Applies inside isolated backends and container CLI payloads.

Detection is quote-aware and covers common language/OS package managers, executable paths, environment assignments, shell chains, interpreter payloads, process wrappers, container CLIs, Windows `cmd`/WSL forms, and quote-spliced action tokens. It avoids quoted examples, output/search commands, non-shell heredoc bodies, help-only commands, and ordinary operations such as `npm run build`.

## Verification

- Focused package-acquisition suite: **80 passed**
- Approval/guard/cron/sandbox/execute-code/gateway matrix: **509 passed**
- `python -m py_compile tools/approval.py tests/tools/test_package_acquisition_approval.py`
- `git diff --check`

A direct `python -m pytest -q tests/tools` run could not complete collection because `tests/tools/test_deferral_fixes.py` imports unavailable optional module `snowballstemmer`. No package-interlock assertion failed in that run; the repository wrapper and focused matrix above passed.
