### PR TITLE
fix(cli): warn on model slugs missing from the provider catalog

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5567,6 +5567,109 @@ def _coerce_float(value: str):
     return f
 
 
+def _resolve_catalog_check_provider(key: str, user_config: dict) -> str:
+    """Best-effort static provider for a model-routing key's catalog check.
+
+    Mirrors the runtime resolution shapes (``_resolve_delegation_credentials``
+    in tools/delegate_tool.py, ``agent/auxiliary_client.py``) closely enough
+    for a typo warning, and returns "" whenever the provider cannot be
+    determined statically — direct endpoints (``base_url``), the auxiliary
+    ``auto`` chain (a runtime 6-level fallback), bare/legacy scalar sections,
+    and unknown shapes all bail out so the caller fails open.
+    """
+    k = key.strip().lower()
+    model_cfg = user_config.get("model")
+    model_provider = (
+        str(model_cfg.get("provider") or "").strip()
+        if isinstance(model_cfg, dict)
+        else ""
+    )
+    if k == "model.default":
+        if isinstance(model_cfg, dict) and str(model_cfg.get("base_url") or "").strip():
+            return ""
+        return model_provider
+    if k == "delegation.model":
+        dele = user_config.get("delegation")
+        if not isinstance(dele, dict):
+            # No delegation section yet (first write): fall through to the
+            # global provider — the runtime inherits the parent's provider.
+            dele = {}
+        if str(dele.get("base_url") or "").strip():
+            return ""
+        return str(dele.get("provider") or "").strip() or model_provider
+    m = re.fullmatch(r"auxiliary\.([a-z0-9_-]+)\.model", k)
+    if m:
+        aux_cfg = user_config.get("auxiliary")
+        task_cfg = aux_cfg.get(m.group(1)) if isinstance(aux_cfg, dict) else None
+        if not isinstance(task_cfg, dict):
+            return ""
+        p = str(task_cfg.get("provider") or "").strip()
+        if not p or p.lower() == "auto":
+            # "auto" resolves through a runtime fallback chain; a static
+            # catalog guess would misfire on legitimately-routed models.
+            return ""
+        return p
+    return ""
+
+
+def _maybe_warn_unknown_model_slug(
+    key: str, value: Any, user_config: dict, force: bool
+) -> None:
+    """Write-time typo guard for model-routing keys (#97656).
+
+    Warn (and confirm on an interactive TTY) when the value is absent from
+    the resolved provider's cached model catalog. Fail-open by design:
+    unknown/custom providers, catalog fetch errors, and empty catalogs never
+    block the write — the guard only fires when a non-empty catalog exists
+    and the slug (in full or first-segment-stripped form) is absent from it.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return
+    provider = _resolve_catalog_check_provider(key, user_config)
+    if not provider:
+        return
+    try:
+        from hermes_cli.providers import get_provider, normalize_provider
+
+        canonical = normalize_provider(provider)
+        if not canonical or get_provider(canonical, allow_network=False) is None:
+            # Custom/user-defined providers keep their own model namespaces.
+            return
+        from hermes_cli.models import cached_provider_model_ids
+
+        catalog_ids = cached_provider_model_ids(canonical)
+    except Exception:
+        return
+    if not catalog_ids:
+        return
+    slug = value.strip()
+    candidates = [slug]
+    if "/" in slug:
+        stripped = slug.split("/", 1)[1].strip()
+        if stripped:
+            candidates.append(stripped)
+    if any(c in catalog_ids for c in candidates):
+        return
+    print(
+        f'⚠ "{slug}" is not in provider "{canonical}"\'s model catalog '
+        f"({len(catalog_ids)} known models).",
+        file=sys.stderr,
+    )
+    if force or not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return
+    try:
+        answer = input(f"  Set {key} = {slug!r} anyway? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt, OSError):
+        answer = ""
+    if answer not in ("y", "yes"):
+        print(
+            "✗ Skipped — value is not in the provider catalog "
+            "(use --force to write it anyway).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def set_config_value(key: str, value: str, force: bool = False):
     """Set a configuration value.
 
@@ -5772,6 +5875,11 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
+    # Write-time typo guard for model-routing keys (#97656): warn + confirm
+    # when the slug is absent from the resolved provider's catalog. Runs after
+    # the bare-model redirect so ``config set model <slug>`` is covered too,
+    # and before _set_nested so a declined confirmation skips the write.
+    _maybe_warn_unknown_model_slug(key, value, user_config, force)
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5638,7 +5638,10 @@ def _maybe_warn_unknown_model_slug(
         from hermes_cli.models import cached_provider_model_ids
 
         catalog_ids = cached_provider_model_ids(canonical)
-    except Exception:
+    except Exception as e:
+        # Fail-open by design; debug-level so a broken catalog path stays
+        # distinguishable from the expected unknown-provider bail-outs.
+        logger.debug("model catalog guard skipped for %s/%s: %s", key, provider, e)
         return
     if not catalog_ids:
         return

--- a/tests/hermes_cli/test_config_set_model_catalog_guard.py
+++ b/tests/hermes_cli/test_config_set_model_catalog_guard.py
@@ -1,0 +1,309 @@
+"""Regression tests for the write-time model-slug catalog guard (#97656).
+
+`hermes config set` accepted any string for model-routing keys; a one-character
+typo was written silently and only surfaced as HTTP 400s at subagent dispatch
+time. The guard warns (and confirms on an interactive TTY) when the value is
+absent from the resolved provider's cached catalog — fail-open everywhere else.
+
+These tests pin:
+- the warning fires only with a non-empty catalog and an absent slug;
+- fail-open on empty catalogs, fetch errors, and unknown providers;
+- direct endpoints (base_url) and the auxiliary "auto" chain are never checked
+  (their runtime provider is not statically predictable);
+- provider-prefixed values are checked in stripped form too;
+- --force and non-TTY runs never block; a declined TTY confirmation aborts.
+"""
+
+import pytest
+import yaml
+
+from hermes_cli import config as cfg
+
+
+class _FakeTTY:
+    def isatty(self):
+        return True
+
+    def write(self, s):
+        return len(s)
+
+    def flush(self):
+        pass
+
+
+def _seed_config(tmp_path, config: dict) -> None:
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(config))
+
+
+def _read(tmp_path, *path):
+    data = yaml.safe_load((tmp_path / "config.yaml").read_text()) or {}
+    node = data
+    for seg in path:
+        node = node[seg]
+    return node
+
+
+def _mock_catalog(monkeypatch, ids, calls=None):
+    def fake(provider, **kwargs):
+        if calls is not None:
+            calls.append(provider)
+        return list(ids)
+
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", fake)
+
+
+_CATALOG = ["upstage/solar-pro4", "deepseek/deepseek-v4-flash", "zai/glm-5.3"]
+
+
+class TestWarningFires:
+    def test_typo_slug_warns_but_writes_non_tty(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        _mock_catalog(monkeypatch, _CATALOG)
+
+        cfg.set_config_value("delegation.model", "upstage/solar-pro-4")
+
+        assert "not in provider" in capsys.readouterr().err
+        assert _read(tmp_path, "delegation", "model") == "upstage/solar-pro-4"
+
+    def test_model_default_checked_against_global_provider(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        _mock_catalog(monkeypatch, _CATALOG)
+
+        cfg.set_config_value("model.default", "totally-fake-model-xyz")
+
+        assert "not in provider" in capsys.readouterr().err
+        assert _read(tmp_path, "model", "default") == "totally-fake-model-xyz"
+
+    def test_provider_prefixed_value_checked_stripped(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        _mock_catalog(monkeypatch, _CATALOG)
+
+        cfg.set_config_value("delegation.model", "openrouter/upstage/solar-pro4")
+
+        assert "not in provider" not in capsys.readouterr().err
+        assert _read(tmp_path, "delegation", "model") == "openrouter/upstage/solar-pro4"
+
+    def test_valid_slug_no_warning(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        _mock_catalog(monkeypatch, _CATALOG)
+
+        cfg.set_config_value("delegation.model", "upstage/solar-pro4")
+
+        assert "not in provider" not in capsys.readouterr().err
+
+
+class TestFailOpen:
+    def test_empty_catalog_never_warns(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        _mock_catalog(monkeypatch, [])
+
+        cfg.set_config_value("delegation.model", "upstage/solar-pro-4")
+
+        assert "not in provider" not in capsys.readouterr().err
+        assert _read(tmp_path, "delegation", "model") == "upstage/solar-pro-4"
+
+    def test_catalog_exception_never_blocks(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+
+        def boom(provider, **kwargs):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", boom)
+
+        cfg.set_config_value("delegation.model", "upstage/solar-pro-4")
+
+        assert _read(tmp_path, "delegation", "model") == "upstage/solar-pro-4"
+
+    def test_unknown_provider_skipped(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path,
+            {"model": {"default": "x", "provider": "my-own-endpoint-thing"}},
+        )
+        calls = []
+        _mock_catalog(monkeypatch, _CATALOG, calls)
+
+        cfg.set_config_value("delegation.model", "whatever")
+
+        assert calls == []
+        assert _read(tmp_path, "delegation", "model") == "whatever"
+
+    def test_non_model_key_never_touched(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        calls = []
+        _mock_catalog(monkeypatch, _CATALOG, calls)
+
+        cfg.set_config_value("agent.max_turns", "10")
+
+        assert calls == []
+
+
+class TestScopeBoundaries:
+    def test_delegation_base_url_direct_endpoint_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path,
+            {
+                "model": {"default": "zai/glm-5.3", "provider": "openrouter"},
+                "delegation": {
+                    "base_url": "https://litellm.internal/v1",
+                    "provider": "",
+                },
+            },
+        )
+        calls = []
+        _mock_catalog(monkeypatch, _CATALOG, calls)
+
+        cfg.set_config_value("delegation.model", "internal-model")
+
+        assert calls == []
+        assert _read(tmp_path, "delegation", "model") == "internal-model"
+
+    def test_auxiliary_auto_provider_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path,
+            {
+                "model": {"default": "zai/glm-5.3", "provider": "openrouter"},
+                "auxiliary": {"goal_judge": {"provider": "auto"}},
+            },
+        )
+        calls = []
+        _mock_catalog(monkeypatch, _CATALOG, calls)
+
+        cfg.set_config_value("auxiliary.goal_judge.model", "some-auto-chain-model")
+
+        assert calls == []
+        assert (
+            _read(tmp_path, "auxiliary", "goal_judge", "model")
+            == "some-auto-chain-model"
+        )
+
+    def test_auxiliary_explicit_provider_checked(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path,
+            {
+                "model": {"default": "zai/glm-5.3", "provider": "openrouter"},
+                "auxiliary": {"goal_judge": {"provider": "zai"}},
+            },
+        )
+        calls = []
+        _mock_catalog(monkeypatch, ["glm-5.3", "glm-5.3-air"], calls)
+
+        cfg.set_config_value("auxiliary.goal_judge.model", "glm-5.3")
+
+        assert calls == ["zai"]
+        assert "not in provider" not in capsys.readouterr().err
+
+    def test_delegation_provider_pinned_overrides_global(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path,
+            {
+                "model": {"default": "zai/glm-5.3", "provider": "openrouter"},
+                "delegation": {"provider": "zai"},
+            },
+        )
+        calls = []
+        _mock_catalog(monkeypatch, ["glm-5.3"], calls)
+
+        cfg.set_config_value("delegation.model", "glm-5.3")
+
+        assert calls == ["zai"]
+        assert "not in provider" not in capsys.readouterr().err
+
+
+class TestConfirmationFlow:
+    def test_tty_decline_aborts_write(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        _mock_catalog(monkeypatch, _CATALOG)
+        monkeypatch.setattr("sys.stdin", _FakeTTY())
+        monkeypatch.setattr("sys.stdout", _FakeTTY())
+        monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+
+        with pytest.raises(SystemExit) as exc:
+            cfg.set_config_value("delegation.model", "upstage/solar-pro-4")
+
+        assert exc.value.code == 1
+        data = yaml.safe_load((tmp_path / "config.yaml").read_text()) or {}
+        assert "delegation" not in data
+
+    def test_tty_accept_writes(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        _mock_catalog(monkeypatch, _CATALOG)
+        monkeypatch.setattr("sys.stdin", _FakeTTY())
+        monkeypatch.setattr("sys.stdout", _FakeTTY())
+        monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+        cfg.set_config_value("delegation.model", "upstage/solar-pro-4")
+
+        assert _read(tmp_path, "delegation", "model") == "upstage/solar-pro-4"
+
+    def test_force_skips_confirmation_on_tty(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        _mock_catalog(monkeypatch, _CATALOG)
+        monkeypatch.setattr("sys.stdin", _FakeTTY())
+        monkeypatch.setattr("sys.stdout", _FakeTTY())
+
+        def no_input(prompt=""):
+            raise AssertionError("input() must not be called with --force")
+
+        monkeypatch.setattr("builtins.input", no_input)
+
+        cfg.set_config_value("delegation.model", "upstage/solar-pro-4", force=True)
+
+        assert _read(tmp_path, "delegation", "model") == "upstage/solar-pro-4"
+
+    def test_tty_eof_declines(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_config(
+            tmp_path, {"model": {"default": "zai/glm-5.3", "provider": "openrouter"}}
+        )
+        _mock_catalog(monkeypatch, _CATALOG)
+        monkeypatch.setattr("sys.stdin", _FakeTTY())
+        monkeypatch.setattr("sys.stdout", _FakeTTY())
+
+        def eof_input(prompt=""):
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", eof_input)
+
+        with pytest.raises(SystemExit):
+            cfg.set_config_value("delegation.model", "upstage/solar-pro-4")


### PR DESCRIPTION
## What does this PR do?

`hermes config set` accepted any string for model-routing keys — a one-character typo (e.g. `delegation.model: upstage/solar-pro-4` instead of the real OpenRouter slug `upstage/solar-pro4`) was written silently and only surfaced as per-task `HTTP 400: not a valid model ID` failures at subagent dispatch time, often days later.

This adds a write-time typo guard to `set_config_value` for `model.default`, `delegation.model`, and `auxiliary.<task>.model`: when the resolved provider is a known built-in and its cached model catalog (the same `cached_provider_model_ids` disk cache the model picker uses) is non-empty, and the value is absent from it (checked in full form and with the first `provider/` segment stripped, so `openrouter/vendor/model` values match), print a warning and — on an interactive TTY — ask for confirmation. `--force` and non-TTY runs (scripts, agent-driven writes) still write the value, keeping the warning only.

The guard is fail-open everywhere the provider cannot be determined statically, mirroring the runtime resolution shapes (`_resolve_delegation_credentials` in `tools/delegate_tool.py`, the `auto` chain in `agent/auxiliary_client.py`):

- `delegation.base_url` / `model.base_url` direct endpoints are skipped — their model ids are endpoint-local.
- `auxiliary.<task>.provider` empty or `auto` is skipped — `auto` resolves through a runtime 6-level fallback chain a static check would misfire on.
- Unknown/custom providers (`get_provider(...) is None`) are skipped — they keep their own model namespaces.
- Catalog fetch exceptions and empty catalogs are skipped — "no catalog data" is never treated as "slug doesn't exist".

## Related Issue

Fixes #97656

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — new `_resolve_catalog_check_provider()` helper: static best-effort provider resolution for the three model-routing key shapes (global `model.provider`, `delegation.provider` → global fallback, explicit `auxiliary.<task>.provider` only).
- `hermes_cli/config.py` — new `_maybe_warn_unknown_model_slug()` guard: catalog membership check (full + first-segment-stripped candidates), stderr warning, TTY-only confirmation with `y/N`, abort on decline, `--force`/non-TTY fail-open. Called from `set_config_value` after the bare-`model` → `model.default` redirect and before `_set_nested`, so a declined confirmation skips the write entirely.
- `tests/hermes_cli/test_config_set_model_catalog_guard.py` — 16 regression tests pinning: warning fires only with a non-empty catalog + absent slug; fail-open on empty catalog / fetch exception / unknown provider / non-model keys; direct-endpoint and `auto`-chain scope boundaries; prefix-stripped matching; TTY decline aborts (exit 1, nothing written), accept writes, `--force` never prompts, EOF declines.

## How to Test

1. `uv run pytest tests/hermes_cli/test_config_set_model_catalog_guard.py -q` → 16 passed.
2. `uv run pytest tests/hermes_cli/test_config_set_coercion.py tests/hermes_cli/test_config_set_list_values.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_aux_config.py -q` → 43 passed (existing `config set` suites unaffected).
3. Manual shape (non-interactive, e.g. piping stdin): with `model.provider: openrouter` in config and a warm catalog, `hermes config set delegation.model upstage/solar-pro-4 </dev/null` should print the `⚠ ... not in provider "openrouter"'s model catalog` warning to stderr and still write the value; `hermes config set delegation.model upstage/solar-pro4 </dev/null` should write with no warning. Observed result: covered by `test_typo_slug_warns_but_writes_non_tty` and `test_valid_slug_no_warning`.
4. `uv run ruff check hermes_cli/config.py tests/hermes_cli/test_config_set_model_catalog_guard.py` → All checks passed; `ty check hermes_cli/config.py` error count identical to clean `upstream/main` (27 before / 27 after, no new diagnostics).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ hermes config set delegation.model upstage/solar-pro-4
⚠ "upstage/solar-pro-4" is not in provider "openrouter"'s model catalog (437 known models).
  Set delegation.model = 'upstage/solar-pro-4' anyway? [y/N]: n
✗ Skipped — value is not in the provider catalog (use --force to write it anyway).
```
