### PR TITLE
fix(bedrock): support multimodal tool results, normalize toolUse input, and guarantee non-empty messages

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -989,11 +989,15 @@ def convert_messages_to_converse(
         if role == "tool":
             # Tool result messages → merge into the preceding user turn
             tool_call_id = msg.get("tool_call_id", "")
-            result_content = content if isinstance(content, str) else json.dumps(content)
+            if isinstance(content, list):
+                result_blocks = _convert_content_to_converse(content)
+            else:
+                result_content = content if isinstance(content, str) else json.dumps(content)
+                result_blocks = [{"text": _safe_text(result_content)}]
             tool_result_block = {
                 "toolResult": {
                     "toolUseId": tool_call_id,
-                    "content": [{"text": _safe_text(result_content)}],
+                    "content": result_blocks,
                 }
             }
             # In Converse, tool results go in a "user" role message
@@ -1035,10 +1039,13 @@ def convert_messages_to_converse(
                             content_blocks.append({"reasoningContent": replay})
                     elif "toolUse" in block and isinstance(block["toolUse"], dict):
                         tu = block["toolUse"]
+                        tu_input = tu.get("input", {})
+                        if not isinstance(tu_input, dict):
+                            tu_input = {"_value": tu_input}
                         content_blocks.append({"toolUse": {
                             "toolUseId": tu.get("toolUseId", ""),
                             "name": tu.get("name", ""),
-                            "input": tu.get("input", {}),
+                            "input": tu_input,
                         }})
 
                 if not content_blocks:
@@ -1079,6 +1086,8 @@ def convert_messages_to_converse(
                         args_dict = json.loads(args_str) if isinstance(args_str, str) else args_str
                     except (json.JSONDecodeError, TypeError):
                         args_dict = {}
+                    if not isinstance(args_dict, dict):
+                        args_dict = {"_value": args_dict}
                     content_blocks.append({
                         "toolUse": {
                             "toolUseId": tc.get("id", ""),
@@ -1112,12 +1121,13 @@ def convert_messages_to_converse(
                 })
             continue
 
-    # Converse requires the first message to be from the user
-    if converse_msgs and converse_msgs[0]["role"] != "user":
+    # Converse requires non-empty messages and leading/trailing user messages
+    if not converse_msgs:
+        converse_msgs.append({"role": "user", "content": [{"text": _EMPTY_TEXT_PLACEHOLDER}]})
+    elif converse_msgs[0]["role"] != "user":
         converse_msgs.insert(0, {"role": "user", "content": [{"text": _EMPTY_TEXT_PLACEHOLDER}]})
 
-    # Converse requires the last message to be from the user
-    if converse_msgs and converse_msgs[-1]["role"] != "user":
+    if converse_msgs[-1]["role"] != "user":
         converse_msgs.append({"role": "user", "content": [{"text": _EMPTY_TEXT_PLACEHOLDER}]})
 
     return (system_blocks if system_blocks else None, converse_msgs)

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -265,6 +265,60 @@ class TestConvertMessagesToConverse:
         # Empty string should get a space placeholder
         assert msgs[0]["content"][0]["text"].strip() != "" or msgs[0]["content"][0]["text"] == " "
 
+    def test_multimodal_tool_result_preserves_image_blocks(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "take screenshot"},
+            {"role": "assistant", "content": "", "tool_calls": [{
+                "id": "call_img", "type": "function",
+                "function": {"name": "screenshot", "arguments": "{}"},
+            }]},
+            {
+                "role": "tool",
+                "tool_call_id": "call_img",
+                "content": [
+                    {"type": "text", "text": "captured"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                ],
+            },
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        tool_result_msg = [m for m in msgs if m["role"] == "user" and any(
+            "toolResult" in b for b in m["content"]
+        )]
+        assert len(tool_result_msg) == 1
+        tr = [b for b in tool_result_msg[0]["content"] if "toolResult" in b][0]
+        blocks = tr["toolResult"]["content"]
+        assert len(blocks) == 2
+        assert blocks[0]["text"] == "captured"
+        assert "image" in blocks[1]
+        assert blocks[1]["image"]["format"] == "png"
+
+    def test_non_dict_tool_use_arguments_normalized_to_dict(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [
+            {"role": "user", "content": "calc"},
+            {"role": "assistant", "content": "", "tool_calls": [{
+                "id": "call_raw", "type": "function",
+                "function": {"name": "eval", "arguments": "[1, 2, 3]"},
+            }]},
+            {"role": "tool", "tool_call_id": "call_raw", "content": "6"},
+        ]
+        system, msgs = convert_messages_to_converse(messages)
+        assistant_msg = next(m for m in msgs if m["role"] == "assistant")
+        tu = next(b for b in assistant_msg["content"] if "toolUse" in b)
+        assert isinstance(tu["toolUse"]["input"], dict)
+        assert tu["toolUse"]["input"] == {"_value": [1, 2, 3]}
+
+    def test_system_only_messages_produces_non_empty_converse_messages(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+        messages = [{"role": "system", "content": "You are Hermes"}]
+        system, msgs = convert_messages_to_converse(messages)
+        assert system == [{"text": "You are Hermes"}]
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"][0]["text"] != ""
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes protocol schema and API rejection bugs in [`agent/bedrock_adapter.py`](file:///c:/Users/EricM/Dev/hermes-agent/agent/bedrock_adapter.py) where:
1. `convert_messages_to_converse()` returned `converse_messages = []` when `messages` only contained system prompts, causing AWS Bedrock to reject the request with `ValidationException: Invalid parameter messages: Expected a non-empty list of messages`.
2. Multimodal tool results (e.g. `[{"type": "text", ...}, {"type": "image_url", ...}]` from screenshot tools or visual outputs) were serialized with `json.dumps(content)` into raw text strings instead of being converted into `_convert_content_to_converse(content)` blocks, dropping image blocks and breaking Bedrock vision.
3. Tool call arguments that parsed to non-dict values (e.g. strings, lists, numbers) were passed directly into `toolUse.input`, causing AWS Bedrock to reject with `ValidationException: Invalid parameter toolUse.input: Expected a document or object map`.

In Hermes Agent:
1. In the AWS Bedrock Converse API specification:
   - `messages` must be a non-empty array of message objects.
   - `toolUse.input` must be a JSON document object (`dict`), not a primitive or list.
   - `toolResult.content` accepts a list of content blocks (including image and text blocks).
2. The fix ensures:
   - `converse_messages` is always non-empty by inserting a user placeholder turn if empty.
   - List-type tool results are converted via `_convert_content_to_converse(content)` to preserve image blocks and text parts in `toolResult.content`.
   - `toolUse.input` wraps non-dict parsed arguments into `{"_value": ...}`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/bedrock_adapter.py`:
  - Converted list-type tool message `content` via `_convert_content_to_converse(content)`.
  - Coerced non-dict parsed `args_dict` to `{"_value": args_dict}` for `toolUse.input`.
  - Guaranteed `converse_msgs` is non-empty before returning.
- `tests/agent/test_bedrock_adapter.py`:
  - Added `test_multimodal_tool_result_preserves_image_blocks` verifying image blocks are preserved in `toolResult.content`.
  - Added `test_non_dict_tool_use_arguments_normalized_to_dict` verifying non-dict toolUse inputs are normalized to dicts.
  - Added `test_system_only_messages_produces_non_empty_converse_messages` verifying system-only input produces non-empty `converse_messages`.

## How to Test

Run the Bedrock adapter test suite:
```bash
uv run --with pytest tests/agent/test_bedrock_adapter.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(bedrock): support multimodal tool results, normalize toolUse input, and guarantee non-empty messages`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 55 items

tests/agent/test_bedrock_adapter.py ................................... [100%]

============================== 55 passed in 6.18s ==============================
```
