### PR TITLE
fix(tui): default inline mode on Windows ConPTY

### DIFF
--- a/contributors/emails/islamimad66@gmail.com
+++ b/contributors/emails/islamimad66@gmail.com
@@ -1,0 +1,1 @@
+Elshayib

--- a/ui-tui/src/__tests__/windows-conpty.test.ts
+++ b/ui-tui/src/__tests__/windows-conpty.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { isWindowsConptyTuiMode } from '../lib/windows-conpty.js'
+
+describe('isWindowsConptyTuiMode', () => {
+  it('is false on non-Windows hosts', () => {
+    expect(isWindowsConptyTuiMode({} as NodeJS.ProcessEnv, 'linux')).toBe(false)
+    expect(isWindowsConptyTuiMode({ WT_SESSION: '1' } as NodeJS.ProcessEnv, 'darwin')).toBe(false)
+  })
+
+  it('defaults to true on native Windows ConPTY (cmd/powershell/conhost)', () => {
+    expect(isWindowsConptyTuiMode({} as NodeJS.ProcessEnv, 'win32')).toBe(true)
+  })
+
+  it('is true inside Windows Terminal even with MSYSTEM set', () => {
+    expect(isWindowsConptyTuiMode({ MSYSTEM: 'MINGW64', WT_SESSION: 'abc' } as NodeJS.ProcessEnv, 'win32')).toBe(true)
+  })
+
+  it('is false for Git Bash/MSYS mintty outside Windows Terminal', () => {
+    expect(isWindowsConptyTuiMode({ MSYSTEM: 'MINGW64' } as NodeJS.ProcessEnv, 'win32')).toBe(false)
+  })
+})

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -1,6 +1,7 @@
 import type { MouseTrackingMode } from '@hermes/ink'
 
 import { isTermuxTuiMode } from '../lib/termux.js'
+import { isWindowsConptyTuiMode } from '../lib/windows-conpty.js'
 
 const truthy = (v?: string) => /^(?:1|true|yes|on)$/i.test((v ?? '').trim())
 const falsy = (v?: string) => /^(?:0|false|no|off)$/i.test((v ?? '').trim())
@@ -24,6 +25,7 @@ const parseToggle = (v?: string): boolean | null => {
 }
 
 export const TERMUX_TUI_MODE = isTermuxTuiMode()
+export const WINDOWS_CONPTY_TUI_MODE = isWindowsConptyTuiMode()
 
 export const STARTUP_RESUME_ID = (process.env.HERMES_TUI_RESUME ?? '').trim()
 export const STARTUP_QUERY = (process.env.HERMES_TUI_QUERY ?? '').trim()
@@ -40,12 +42,14 @@ export const STARTUP_IMAGE = (process.env.HERMES_TUI_IMAGE ?? '').trim()
 //   kill-switch and the Termux default.
 // - HERMES_TUI_DISABLE_MOUSE=1 forces mouse off — the legacy kill switch.
 // - On Termux the default is mouse off so touch selection isn't intercepted
-//   by terminal mouse protocols. Desktop defaults to 'all' to preserve prior
-//   behavior.
+//   by terminal mouse protocols. Native Windows ConPTY does the same: DEC
+//   mouse sequences never arrive, so tracking only blocks native selection.
+//   Other desktops default to 'all' to preserve prior behavior.
 const mouseTrackingOverride = parseToggle(process.env.HERMES_TUI_MOUSE_TRACKING)
 const mouseTrackingDisabledLegacy = truthy(process.env.HERMES_TUI_DISABLE_MOUSE)
 
-const resolvedBootMouseEnabled = mouseTrackingOverride ?? (TERMUX_TUI_MODE ? false : !mouseTrackingDisabledLegacy)
+const resolvedBootMouseEnabled =
+  mouseTrackingOverride ?? (TERMUX_TUI_MODE || WINDOWS_CONPTY_TUI_MODE ? false : !mouseTrackingDisabledLegacy)
 
 export const MOUSE_TRACKING: MouseTrackingMode = resolvedBootMouseEnabled ? 'all' : 'off'
 
@@ -67,8 +71,11 @@ const inlineOverride = parseToggle(process.env.HERMES_TUI_INLINE)
 //
 // On Termux we default this on: users often background/foreground the app,
 // and primary-buffer rendering makes long-thread review and copy/paste much
-// less fragile. Override explicitly with HERMES_TUI_INLINE=0/1.
-export const INLINE_MODE = inlineOverride ?? TERMUX_TUI_MODE
+// less fragile. Native Windows ConPTY (Windows Terminal, conhost) never
+// delivers DEC mouse sequences, so AlternateScreen + mouse tracking swallows
+// wheel and native selection (#86571). Override explicitly with
+// HERMES_TUI_INLINE=0/1.
+export const INLINE_MODE = inlineOverride ?? (TERMUX_TUI_MODE || WINDOWS_CONPTY_TUI_MODE)
 
 // Live FPS counter overlay, fed by ink's onFrame (real render rate, not a
 // synthetic timer).

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -5,7 +5,7 @@ import './lib/forceTruecolor.js'
 
 import type { FrameEvent } from '@hermes/ink'
 
-import { DASHBOARD_TUI_MODE, TERMUX_TUI_MODE } from './config/env.js'
+import { DASHBOARD_TUI_MODE, INLINE_MODE } from './config/env.js'
 import { GatewayClient } from './gatewayClient.js'
 import { setupGracefulExit } from './lib/gracefulExit.js'
 import { formatBytes, type HeapDumpResult, performHeapDump } from './lib/memory.js'
@@ -40,9 +40,9 @@ process.on('exit', () => {
 })
 
 // Desktop terminals benefit from a clean startup slate because the TUI usually
-// runs in AlternateScreen. On Termux we keep prior output intact so users can
-// review/copy earlier assistant replies after reopening the app.
-if (TERMUX_TUI_MODE) {
+// runs in AlternateScreen. Inline mode (Termux, Windows ConPTY) keeps prior
+// output intact so the host terminal's native scrollback/selection work.
+if (INLINE_MODE) {
   process.stdout.write('\n')
 } else {
   process.stdout.write('\x1b[2J\x1b[H\x1b[3J')

--- a/ui-tui/src/lib/windows-conpty.ts
+++ b/ui-tui/src/lib/windows-conpty.ts
@@ -1,0 +1,25 @@
+/**
+ * Detect native Windows ConPTY hosts where DEC mouse tracking never
+ * arrives and AlternateScreen therefore swallows wheel + native selection.
+ *
+ * Git Bash/MSYS mintty outside Windows Terminal has a real PTY and keeps
+ * the existing AlternateScreen default. A WT tab (including git-bash inside
+ * WT) sets WT_SESSION and still goes through ConPTY.
+ */
+export const isWindowsConptyTuiMode = (
+  env: NodeJS.ProcessEnv = process.env,
+  platform: string = process.platform
+): boolean => {
+  if (platform !== 'win32') {
+    return false
+  }
+
+  const msystem = String(env.MSYSTEM ?? '').trim()
+  const wtSession = String(env.WT_SESSION ?? '').trim()
+
+  if (msystem && !wtSession) {
+    return false
+  }
+
+  return true
+}

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -243,6 +243,8 @@ display:
                              #             link mouseenter, etc.)
 ```
 
+On **Windows Terminal / ConPTY**, DEC mouse sequences never reach the TUI, so AlternateScreen + mouse tracking swallows the wheel and native text selection. `hermes --tui` therefore defaults to **inline mode** (primary buffer) on native Windows ConPTY — the same fallback Termux uses — so the host terminal's wheel and copy/select work. Opt out with `HERMES_TUI_INLINE=0` (then `/mouse off` if you still want native selection). Git Bash/MSYS outside Windows Terminal keeps the AlternateScreen default.
+
 Runtime toggles:
 
 - `/details [hidden|collapsed|expanded|cycle]` — set the global mode

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -89,7 +89,7 @@ Everything except the dashboard's embedded terminal pane runs natively on Window
 | Feature | Native Windows | WSL2 |
 |---|---|---|
 | CLI (`hermes chat`, `hermes setup`, `hermes gateway`, …) | ✓ | ✓ |
-| Interactive TUI (`hermes --tui`) | ✓ | ✓ |
+| Interactive TUI (`hermes --tui`) | ✓ (inline by default; see below) | ✓ |
 | Messaging gateway (Telegram, Discord, Slack, WhatsApp, 15+ platforms) | ✓ | ✓ |
 | Cron scheduler | ✓ | ✓ |
 | Browser tool (Chromium via Node) | ✓ | ✓ |
@@ -100,6 +100,8 @@ Everything except the dashboard's embedded terminal pane runs natively on Window
 | Auto-start at login | ✓ (schtasks) | ✓ (systemd) |
 
 The dashboard's `/chat` tab embeds a real terminal via a POSIX PTY (`ptyprocess`). Native Windows has no equivalent primitive; Python's `pywinpty` / Windows ConPTY would work but is a separate implementation — treat as future work. **The rest of the dashboard works natively** — only that one tab shows a "use WSL2 for this" banner.
+
+**TUI on Windows Terminal / ConPTY:** DEC mouse sequences never reach `hermes --tui`, so the AlternateScreen + mouse-tracking default would swallow the wheel and native text selection. Native Windows ConPTY therefore defaults to inline mode (primary buffer), matching Termux. Wheel scroll and copy/select then use Windows Terminal's own behavior. Restore AlternateScreen with `HERMES_TUI_INLINE=0`. Git Bash/MSYS mintty outside Windows Terminal is unchanged.
 
 ## How Hermes runs shell commands on Windows
 


### PR DESCRIPTION
## What does this PR do?

Windows Terminal/ConPTY never delivers DEC mouse sequences, so AlternateScreen + mouse tracking swallows the wheel and native text selection. `hermes --tui` now defaults to inline mode (primary buffer) on native Windows ConPTY — the same fallback Termux already uses. Opt out with `HERMES_TUI_INLINE=0`. Git Bash/MSYS mintty outside WT is unchanged.

## Related Issue

Fixes #86571

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `ui-tui/src/lib/windows-conpty.ts` — `isWindowsConptyTuiMode(env, platform)` (platform as data, not a faked host OS)
- `ui-tui/src/config/env.ts` — default `INLINE_MODE` and boot mouse-off on that path; existing `HERMES_TUI_INLINE=0/1` still wins
- `ui-tui/src/entry.tsx` — skip the alt-screen wipe whenever inline
- `website/docs/user-guide/tui.md` and `windows-native.md` — document the ConPTY limitation and opt-out
- `contributors/emails/islamimad66@gmail.com` → Elshayib

## How to Test

1. On Windows Terminal, run `hermes --tui` with no `HERMES_TUI_INLINE` override.
2. Produce enough transcript to scroll. Mouse wheel and drag-to-select should use the host terminal.
3. `HERMES_TUI_INLINE=0 hermes --tui` restores AlternateScreen.
4. Unit tests: `npx vitest run src/__tests__/windows-conpty.test.ts src/__tests__/termux.test.ts` from `ui-tui/`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, TUI TypeScript only
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (unit tests; did not re-run a live TUI mouse session)

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — Linux/macOS and MSYS mintty outside WT keep AlternateScreen
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Verified

- `npx vitest run src/__tests__/windows-conpty.test.ts src/__tests__/termux.test.ts` — 2 files, 10 passed
- Source: `AppLayout` already skips mouse tracking when `INLINE_MODE` is set; issue #86571 stdin probe showed zero mouse sequences under WT 1.24 ConPTY; reporter's working workaround was `HERMES_TUI_INLINE=1`

## NOT verified

- Did not re-run a live `hermes --tui` mouse-wheel session in Windows Terminal (this session is the desktop app, not a WT tab)
- Did not build the docs site
- `scripts/run_tests.sh` is POSIX-only; no Python files changed

## Screenshots / Logs

N/A