### PR TITLE
fix(delegate): stop provider failures looking like iteration exhaustion

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -667,6 +667,39 @@ class TestDelegateObservability(unittest.TestCase):
             result = json.loads(delegate_task(goal="Test empty sentinel", parent_agent=parent))
             self.assertEqual(result["results"][0]["status"], "failed")
 
+    def test_provider_failure_is_not_reported_as_iteration_exhaustion(self):
+        """A structured provider failure must outrank its error-text summary."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "upstage/solar-pro-4"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "HTTP 400: model is not a valid model ID",
+                "completed": False,
+                "failed": True,
+                "error": "HTTP 400: model is not a valid model ID",
+                "failure_reason": "model_not_found",
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Test rejected provider model", parent_agent=parent)
+            )
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "failed")
+            self.assertEqual(entry["exit_reason"], "model_not_found")
+            self.assertFalse(entry["truncated"])
+            self.assertEqual(
+                entry["error"], "HTTP 400: model is not a valid model ID"
+            )
+
 
 class TestSubagentCostRollup(unittest.TestCase):
     """Port of Kilo-Org/kilocode#9448 — parent's session_estimated_cost_usd

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -313,8 +313,34 @@ class TestRunSingleChildSchemaValidation:
         assert entry["exit_reason"] == "model_not_found"
         assert entry["truncated"] is False
         assert entry["error"] == "HTTP 400: model rejected"
+        assert entry["summary"] == "HTTP 400: model rejected"
         assert entry["schema_valid"] is False
         assert entry["schema_retries"] == 1
+
+    def test_provider_failure_on_retry_clears_stale_summary(self):
+        child = _StubChild(
+            [
+                "not json at all",
+                {
+                    "completed": False,
+                    "failed": True,
+                    "error": "HTTP 400: model rejected",
+                    "failure_reason": "model_not_found",
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                },
+            ]
+        )
+        child._delegate_output_schema = ADDRESS_SCHEMA
+
+        entry = _run(child)
+
+        assert entry["status"] == "failed"
+        assert entry["summary"] == ""
+        assert entry["exit_reason"] == "model_not_found"
+        assert entry["truncated"] is False
+        assert entry["error"] == "HTTP 400: model rejected"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -169,9 +169,11 @@ class _StubChild:
 
     def run_conversation(self, user_message, task_id=None, **_kwargs):
         self.calls.append(user_message)
-        text = self.responses.pop(0)
+        response = self.responses.pop(0)
+        if isinstance(response, dict):
+            return response
         return {
-            "final_response": text,
+            "final_response": response,
             "completed": True,
             "api_calls": 1,
             "messages": [],
@@ -258,6 +260,61 @@ class TestRunSingleChildSchemaValidation:
         assert entry["status"] == "failed"
         assert len(child.calls) == 1
         assert entry.get("schema_valid") is False
+
+    def test_provider_failure_with_output_skips_retry(self):
+        child = _StubChild(
+            [
+                {
+                    "final_response": "HTTP 400: model rejected",
+                    "completed": False,
+                    "failed": True,
+                    "error": "HTTP 400: model rejected",
+                    "failure_reason": "model_not_found",
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+            ]
+        )
+        child._delegate_output_schema = ADDRESS_SCHEMA
+
+        entry = _run(child)
+
+        assert len(child.calls) == 1
+        assert entry["status"] == "failed"
+        assert entry["exit_reason"] == "model_not_found"
+        assert entry["truncated"] is False
+        assert entry["error"] == "HTTP 400: model rejected"
+        assert entry["schema_valid"] is False
+        assert "schema_retries" not in entry
+
+    def test_provider_failure_on_retry_preserves_terminal_outcome(self):
+        child = _StubChild(
+            [
+                "not json at all",
+                {
+                    "final_response": "HTTP 400: model rejected",
+                    "completed": False,
+                    "failed": True,
+                    "error": "HTTP 400: model rejected",
+                    "failure_reason": "model_not_found",
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                },
+            ]
+        )
+        child._delegate_output_schema = ADDRESS_SCHEMA
+
+        entry = _run(child)
+
+        assert len(child.calls) == 2
+        assert entry["status"] == "failed"
+        assert entry["exit_reason"] == "model_not_found"
+        assert entry["truncated"] is False
+        assert entry["error"] == "HTTP 400: model rejected"
+        assert entry["schema_valid"] is False
+        assert entry["schema_retries"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3040,6 +3040,14 @@ def _run_single_child(
         interrupted = result.get("interrupted", False)
         api_calls = result.get("api_calls", 0)
 
+        # A terminal child result is authoritative even when its user-facing
+        # error text is carried in final_response.  Some older result builders
+        # only stamped ``error``; an explicit failed=False remains a soft
+        # outcome (for example compression_deferred), not a terminal failure.
+        terminal_failure = result.get("failed") is True or (
+            bool(result.get("error")) and result.get("failed") is not False
+        )
+
         # The child emits the literal "(empty)" sentinel (see run_agent.py) when
         # it gives up after repeated empty-LLM-response retries — typically a
         # transport bug (misrouted provider, adapter returning empty
@@ -3049,6 +3057,8 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
+        elif terminal_failure:
+            status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -3098,6 +3108,13 @@ def _run_single_child(
         # Determine exit reason
         if interrupted:
             exit_reason = "interrupted"
+        elif terminal_failure:
+            failure_reason = result.get("failure_reason")
+            exit_reason = (
+                failure_reason
+                if isinstance(failure_reason, str) and failure_reason
+                else "error"
+            )
         elif completed:
             exit_reason = "completed"
         else:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3004,7 +3004,8 @@ def _run_single_child(
                     )
                 if isinstance(_retry_result, dict):
                     _retry_text = _retry_result.get("final_response") or ""
-                    if _retry_text.strip():
+                    _retry_is_terminal = _is_terminal_child_result(_retry_result)
+                    if _retry_text.strip() or _retry_is_terminal:
                         result["final_response"] = _retry_text
                     try:
                         result["api_calls"] = int(
@@ -3017,7 +3018,7 @@ def _run_single_child(
                         result.get("messages"), list
                     ):
                         result["messages"] = result["messages"] + _retry_messages
-                    if _is_terminal_child_result(_retry_result):
+                    if _retry_is_terminal:
                         for _outcome_key in (
                             "completed",
                             "failed",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2451,6 +2451,15 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
         )
 
 
+def _is_terminal_child_result(result: Dict[str, Any]) -> bool:
+    """Return whether a child result must not be treated as usable output."""
+    return (
+        result.get("interrupted") is True
+        or result.get("failed") is True
+        or (bool(result.get("error")) and result.get("failed") is not False)
+    )
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -2957,6 +2966,7 @@ def _run_single_child(
         # Pattern from: github/copilot-cli ctx.agent(prompt, {schema}) —
         # PATTERN ONLY, no code copied.
         _output_schema = getattr(child, "_delegate_output_schema", None)
+        _terminal_result = _is_terminal_child_result(result)
         _schema_valid: Optional[bool] = None
         _schema_errors: List[str] = []
         _schema_retries = 0
@@ -2973,7 +2983,7 @@ def _run_single_child(
             if (
                 not _schema_valid
                 and _first_text.strip()
-                and not result.get("interrupted", False)
+                and not _terminal_result
             ):
                 # Exactly one retry turn, carrying the validation errors
                 # verbatim (no schema re-paste — the child already holds
@@ -3007,6 +3017,16 @@ def _run_single_child(
                         result.get("messages"), list
                     ):
                         result["messages"] = result["messages"] + _retry_messages
+                    if _is_terminal_child_result(_retry_result):
+                        for _outcome_key in (
+                            "completed",
+                            "failed",
+                            "error",
+                            "failure_reason",
+                            "interrupted",
+                        ):
+                            if _outcome_key in _retry_result:
+                                result[_outcome_key] = _retry_result[_outcome_key]
                     _schema_valid, _schema_errors = validate_output(
                         _retry_text, _output_schema
                     )
@@ -3044,9 +3064,7 @@ def _run_single_child(
         # error text is carried in final_response.  Some older result builders
         # only stamped ``error``; an explicit failed=False remains a soft
         # outcome (for example compression_deferred), not a terminal failure.
-        terminal_failure = result.get("failed") is True or (
-            bool(result.get("error")) and result.get("failed") is not False
-        )
+        terminal_failure = _is_terminal_child_result(result)
 
         # The child emits the literal "(empty)" sentinel (see run_agent.py) when
         # it gives up after repeated empty-LLM-response retries — typically a


### PR DESCRIPTION
## What does this PR do?

Provider-rejected subagents are now reported as failed instead of completed and truncated by a nonexistent iteration limit. The delegate result classifier now gives structured terminal failures precedence over a non-empty error-text summary, preserves a machine-readable failure reason when available, and leaves explicit soft outcomes alone.

### Symptom

A child rejected by the provider on its first API call could be rendered as `status=completed`, `exit_reason=max_iterations`, and `TRUNCATED`, even though it produced no work and never exhausted its iteration budget.

### Impact

The parent agent and operator receive the wrong diagnosis and may retry with a larger budget instead of correcting the provider or model configuration.

### Bug Cause

**Trigger:** `tools/delegate_tool.py` / `_run_single_child` status and exit-reason derivation

**Causal chain:**
1. A provider failure returns a structured child result with `failed=True`, an `error`, `completed=False`, and the error text in `final_response`.
2. `_run_single_child` treats any non-empty `final_response` as usable output and labels the child completed without checking the structured failure fields.
3. The same code maps every `completed=False` result to `max_iterations`, causing the async renderer to add a false truncation warning.

**Why it is wrong:** The summary-presence heuristic and completed flag were allowed to override the child's authoritative terminal failure metadata.

**Working sibling / contrast:** Genuine budget exhaustion has no terminal failure flag and still follows the existing summarized-but-truncated path.

**Ruled out:** The async renderer is not inventing the failure classification; it renders the `status`, `exit_reason`, and `truncated` fields produced by `_run_single_child`.

### Fix

Classify explicit `failed=True` results, plus legacy error-only terminal results, before considering summary text. Use the child's machine-readable `failure_reason` when present, otherwise `error`, so provider failures no longer become `max_iterations`. An explicit `failed=False` still protects soft outcomes such as compression deferral. Structured-output delegations now skip schema retries for an already-terminal result and preserve authoritative failure metadata when the bounded schema retry itself fails.

## Related Issue

Closes #97655

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py` - prioritize structured child failures when deriving delegation status, exit reason, and truncation.
- `tests/tools/test_delegate.py` - reproduce a one-call provider rejection and assert its honest failed classification.
- `tests/tools/test_delegate_output_schema.py` - cover terminal failures before and during the bounded structured-output retry.

## How to Test

1. Run the focused delegation test suite.
2. Confirm the provider-failure regression reports `status=failed`, `exit_reason=model_not_found`, and `truncated=false`.

```bash
scripts/run_tests.sh tests/tools/test_delegate_output_schema.py tests/tools/test_delegate.py tests/tools/test_async_delegation.py -q
```

Result: 119 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A; no user-facing documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact per the compatibility guide; the fix is platform-independent Python logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the schema is unchanged

## Screenshots / Logs

N/A; the focused regression test covers the structured result consumed by the renderer.
