### PR TITLE
fix(tools): surface config-level model_not_found notices in delegation batch reports

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -881,3 +881,86 @@ def test_batch_truncation_banner_marks_only_truncated_task():
     # The header banner for task 2 appears after task 1's summary.
     assert banner_pos > clean_pos
 
+
+def test_batch_model_rejection_notice_prepended():
+    """A rejected delegation model must surface ONE config-level notice above
+    the per-task blocks instead of staying buried in each summary (#97654)."""
+    rejection = "HTTP 400: upstage/solar-pro-4 is not a valid model ID"
+    evt = _make_async_evt(
+        is_batch=True,
+        model="upstage/solar-pro-4",
+        goals=["task a", "task b"],
+        results=[
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": rejection,
+                "api_calls": 1,
+                "duration_seconds": 0.74,
+                "exit_reason": "max_iterations",
+                "truncated": True,
+            },
+            {
+                "task_index": 1,
+                "status": "completed",
+                "summary": rejection,
+                "api_calls": 1,
+                "duration_seconds": 0.71,
+                "exit_reason": "max_iterations",
+                "truncated": True,
+            },
+        ],
+    )
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "SUBAGENT MODEL REJECTED" in text
+    assert "upstage/solar-pro-4" in text
+    assert "2/2" in text
+    assert "delegation.model" in text
+    # The notice precedes the per-task blocks, not just trails them.
+    assert text.index("SUBAGENT MODEL REJECTED") < text.index("TASK 1/2")
+
+
+def test_batch_model_rejection_notice_absent_when_clean():
+    """Ordinary summaries must not grow a model-rejection notice."""
+    evt = _make_async_evt(
+        is_batch=True,
+        model="upstage/solar-pro4",
+        goals=["task a"],
+        results=[
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "did the work",
+                "api_calls": 3,
+                "exit_reason": "completed",
+                "truncated": False,
+            },
+        ],
+    )
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "SUBAGENT MODEL REJECTED" not in text
+
+
+def test_batch_model_rejection_notice_requires_configured_model_in_text():
+    """A model_not_found pattern naming a DIFFERENT model than the configured
+    delegation model is task-level noise, not a config-level rejection."""
+    evt = _make_async_evt(
+        is_batch=True,
+        model="upstage/solar-pro4",
+        goals=["task a"],
+        results=[
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "HTTP 400: other/model-x is not a valid model ID",
+                "api_calls": 1,
+                "exit_reason": "max_iterations",
+                "truncated": True,
+            },
+        ],
+    )
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "SUBAGENT MODEL REJECTED" not in text

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2960,6 +2960,48 @@ def _format_age(seconds: float) -> str:
     return f"{h}h" if m == 0 else f"{h}h{m}m"
 
 
+def _batch_model_rejection_notice(results, model):
+    """Config-level notice lines when a batch died on a rejected model id.
+
+    A typo'd ``delegation.model`` slug makes every subagent abort within a
+    second with the provider's rejection text as its summary, while the
+    per-task blocks keep labelling it ``status=completed`` + TRUNCATED — the
+    config-level cause stays buried in the batch dump (#97654). A task counts
+    as a rejection hit only when its summary/error text both names the
+    configured delegation model id and matches a ``model_not_found`` pattern
+    from ``agent.error_classifier`` (the same classification the failover
+    path consumes), so incidental prose about other models never triggers it.
+    """
+    if not results or not isinstance(model, str):
+        return None
+    model_l = model.strip().lower()
+    if not model_l or model_l == "?":
+        return None
+    from agent.error_classifier import _MODEL_NOT_FOUND_PATTERNS
+
+    hits = 0
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        text = " ".join(
+            str(r.get(k) or "") for k in ("summary", "error")
+        ).lower()
+        if text and model_l in text and any(p in text for p in _MODEL_NOT_FOUND_PATTERNS):
+            hits += 1
+    if not hits:
+        return None
+    return [
+        "",
+        f"⚠ SUBAGENT MODEL REJECTED: the configured Subagent Model \"{model}\" "
+        "was rejected by the provider (model_not_found). "
+        f"{hits}/{len(results)} task(s) in this batch failed for this "
+        "reason before doing any work — the per-task blocks below repeat "
+        "the same rejection once per task. Check the Subagent Model setting "
+        "(Settings → Advanced, or `hermes config get delegation.model`) and "
+        "re-dispatch.",
+    ]
+
+
 def _format_async_delegation(evt: dict) -> str:
     """Format an async-delegation completion into a self-contained re-injection.
 
@@ -3018,6 +3060,10 @@ def _format_async_delegation(evt: dict) -> str:
             lines.append("--- ERROR ---")
             lines.append(f"The batch did not complete successfully: {error}")
             return "\n".join(lines)
+        # Config-level rejection notice BEFORE the per-task wall — a rejected
+        # delegation model fails every task identically before doing any
+        # work, and that signal must not stay buried in the task blocks.
+        lines.extend(_batch_model_rejection_notice(results, model) or [])
         for r in sorted(results, key=lambda x: x.get("task_index", 0)):
             idx = r.get("task_index", 0)
             r_status = r.get("status", "?")

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2971,6 +2971,10 @@ def _batch_model_rejection_notice(results, model):
     configured delegation model id and matches a ``model_not_found`` pattern
     from ``agent.error_classifier`` (the same classification the failover
     path consumes), so incidental prose about other models never triggers it.
+    The containment check is best-effort: a provider that wraps or escapes
+    the model id (so it no longer appears verbatim in the task text) is
+    missed, and the ``model_not_found`` pattern gate is what keeps a model
+    id that is a substring of unrelated text from firing.
     """
     if not results or not isinstance(model, str):
         return None
@@ -2994,8 +2998,8 @@ def _batch_model_rejection_notice(results, model):
         "",
         f"⚠ SUBAGENT MODEL REJECTED: the configured Subagent Model \"{model}\" "
         "was rejected by the provider (model_not_found). "
-        f"{hits}/{len(results)} task(s) in this batch failed for this "
-        "reason before doing any work — the per-task blocks below repeat "
+        f"{hits}/{len(results)} task(s) in this batch failed with this "
+        "rejection — the per-task blocks below repeat "
         "the same rejection once per task. Check the Subagent Model setting "
         "(Settings → Advanced, or `hermes config get delegation.model`) and "
         "re-dispatch.",


### PR DESCRIPTION
## What does this PR do?

When the configured `delegation.model` slug is rejected by the provider (e.g. a typo'd `upstage/solar-pro-4` where the valid slug is `upstage/solar-pro4`), every subagent in a `delegate_task` batch dies within ~1 second carrying the provider's rejection text as its summary, while the per-task blocks keep labelling the run `status=completed` + `TRUNCATED: hit max_iterations`. The config-level root cause stays buried inside the per-task summaries — nothing tells the user "your Subagent Model is invalid" (#97654).

This adds a single config-level notice to the batch completion report. A task counts as a rejection hit only when its summary/error text both matches a `model_not_found` pattern (reused from `agent.error_classifier._MODEL_NOT_FOUND_PATTERNS` — the same classification the failover path consumes, kept as the single source of truth) and names the configured delegation model id, so incidental prose about other models never triggers it. The notice is rendered once above the per-task blocks with the model id, the hit count, and the setting to fix.

## Related Issue

Fixes #97654

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py` — added `_batch_model_rejection_notice()`: scans a batch's per-task summary/error text for `model_not_found` patterns naming the configured delegation model, returns the config-level notice lines (or `None`).
- `tools/process_registry.py` (`_format_async_delegation`, batch branch) — insert the notice after the `Role:/Model:` header line and before the per-task blocks, only when the batch has results.
- `tests/tools/test_async_delegation.py` — three regression tests: notice prepended before the task blocks (issue's exact scenario), no notice for clean summaries, and no notice when the pattern names a different model than the configured one.

## How to Test

1. `uv run --extra dev pytest tests/tools/test_async_delegation.py -q`
   Observed result: `29 passed` (26 pre-existing + 3 new).
2. Focused: `uv run --extra dev pytest tests/tools/test_async_delegation.py -q -k model_rejection`
   Observed result: `3 passed`.
3. `test_batch_model_rejection_notice_prepended` reproduces the issue's exact payload (two tasks, `status=completed`, `exit_reason=max_iterations`, summary `HTTP 400: upstage/solar-pro-4 is not a valid model ID`) and asserts the rendered block now contains `SUBAGENT MODEL REJECTED`, the model id, `2/2`, the `delegation.model` hint, and that the notice precedes `TASK 1/2`.
4. Lint: `ruff check tools/process_registry.py tests/tools/test_async_delegation.py` — all checks pass; `ty check tools/process_registry.py` shows no new diagnostics vs. the pre-change tree (57 = 57).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure string rendering, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
