### PR TITLE
fix(agent): normalize relative MEDIA paths against the session cwd at finalize

### DIFF
--- a/agent/media_path_normalizer.py
+++ b/agent/media_path_normalizer.py
@@ -1,0 +1,137 @@
+"""Normalize relative ``MEDIA:`` paths in the final response.
+
+The system prompt asks the model to deliver files as ``MEDIA:/absolute/path``,
+but a model working inside a project directory routinely emits relative paths
+(``MEDIA: final_video.mp4``) instead. Every consumer downstream assumes
+absolute: the messaging gateways' MEDIA regexes only match absolute paths (the
+file silently isn't delivered), and the desktop renders a player that resolves
+the path against the app's own cwd — a black, unplayable card (observed on a
+Windows deployment; reproduced identically on macOS).
+
+This module rewrites such lines at turn-finalize time, joining the relative
+path onto the session's working directory. Three deliberate fences keep it
+strictly no-worse-than-before:
+
+1. Only the line form is touched — ``MEDIA: <path>`` alone on a line
+   (leading whitespace allowed, quoted paths supported). Inline mentions in
+   prose are left alone to keep the false-positive surface minimal.
+2. Fenced code blocks (``` / ~~~) are never rewritten — those are examples,
+   not deliveries.
+3. A rewrite happens ONLY when the joined absolute path actually exists on
+   disk. A wrong base-directory guess therefore degrades to "leave the text
+   unchanged", never to a broken rewrite.
+
+Base directories, in order: the session's live terminal cwd
+(``tools.terminal_tool.get_session_cwd`` — tracks ``cd`` during the turn),
+then the configured session cwd (``agent.runtime_cwd.resolve_agent_cwd``).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import List, Optional
+
+_MEDIA_LINE_RE = re.compile(
+    r"(?m)^(?P<lead>[\t ]*)MEDIA:[\t ]*"
+    r"(?P<path>`[^`\n]+`|\"[^\"\n]+\"|'[^'\n]+'|\S+)"
+    r"(?P<tail>[\t ]*)$"
+)
+
+_FENCE_LINE_RE = re.compile(r"^[\t ]*(?:```|~~~)")
+
+_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+_DRIVE_RE = re.compile(r"^[A-Za-z]:[/\\]")
+
+
+def _unquote(value: str) -> str:
+    v = value.strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in "`\"'":
+        return v[1:-1].strip()
+    return v
+
+
+def _is_relative_candidate(path: str) -> bool:
+    """Only plain relative paths qualify; absolute/home/drive/URL forms never."""
+    if not path or path.startswith(("/", "~", "\\")):
+        return False
+    if _DRIVE_RE.match(path):
+        return False
+    if _SCHEME_RE.match(path):
+        return False
+    return True
+
+
+def _base_dirs(session_key: Optional[str]) -> List[str]:
+    bases: List[str] = []
+    try:
+        from tools.terminal_tool import get_session_cwd
+
+        live = get_session_cwd(session_key)
+        if isinstance(live, str) and live.strip():
+            bases.append(live)
+    except Exception:
+        pass
+    try:
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        bases.append(str(resolve_agent_cwd()))
+    except Exception:
+        pass
+    seen = set()
+    out: List[str] = []
+    for b in bases:
+        if b not in seen:
+            seen.add(b)
+            out.append(b)
+    return out
+
+
+def normalize_relative_media_paths(text: str, session_key: Optional[str] = None) -> str:
+    """Rewrite line-form relative MEDIA paths to existing absolute paths.
+
+    Never raises — on any surprise the original text is returned unchanged
+    (delivering the response beats normalizing it).
+    """
+    try:
+        if not isinstance(text, str) or "MEDIA:" not in text:
+            return text
+
+        bases = _base_dirs(session_key)
+        if not bases:
+            return text
+
+        def rewrite_segment(segment: str) -> str:
+            def repl(m: "re.Match[str]") -> str:
+                raw = m.group("path")
+                p = _unquote(raw)
+                if not _is_relative_candidate(p):
+                    return m.group(0)
+                for base in bases:
+                    candidate = os.path.normpath(os.path.join(base, p))
+                    if os.path.isfile(candidate):
+                        return f"{m.group('lead')}MEDIA: {candidate}{m.group('tail')}"
+                return m.group(0)
+
+            return _MEDIA_LINE_RE.sub(repl, segment)
+
+        lines = text.split("\n")
+        out_lines: List[str] = []
+        buffer: List[str] = []
+        in_fence = False
+        for line in lines:
+            if _FENCE_LINE_RE.match(line):
+                if buffer:
+                    joined = "\n".join(buffer)
+                    out_lines.append(joined if in_fence else rewrite_segment(joined))
+                    buffer = []
+                out_lines.append(line)
+                in_fence = not in_fence
+                continue
+            buffer.append(line)
+        if buffer:
+            joined = "\n".join(buffer)
+            out_lines.append(joined if in_fence else rewrite_segment(joined))
+        return "\n".join(out_lines)
+    except Exception:
+        return text

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -223,6 +223,38 @@ def finalize_turn(
                 _kanban_task, api_call_count, agent.max_iterations, logger,
             )
 
+    # Normalize relative MEDIA paths against the session cwd before the
+    # response is persisted/delivered. Models routinely violate the
+    # "MEDIA:/absolute/path" instruction while working inside a project
+    # directory; downstream consumers all assume absolute (gateways skip
+    # delivery, the desktop renders an unplayable card). Rewrites happen only
+    # when the joined path exists on disk — see agent/media_path_normalizer.py.
+    # The matching assistant message in the histories is updated too so the
+    # stored transcript and the returned response stay consistent.
+    if isinstance(final_response, str) and "MEDIA:" in final_response:
+        try:
+            from agent.media_path_normalizer import normalize_relative_media_paths
+
+            _normalized_media = normalize_relative_media_paths(
+                final_response, session_key=effective_task_id
+            )
+            if _normalized_media != final_response:
+                for _hist in (messages, conversation_history):
+                    try:
+                        for _m in reversed(_hist or []):
+                            if (
+                                isinstance(_m, dict)
+                                and _m.get("role") == "assistant"
+                                and _m.get("content") == final_response
+                            ):
+                                _m["content"] = _normalized_media
+                                break
+                    except Exception:
+                        pass
+                final_response = _normalized_media
+        except Exception:
+            logger.debug("media path normalization skipped", exc_info=True)
+
     # Determine if conversation completed successfully
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")
     completed = (

--- a/tests/agent/test_media_path_normalizer.py
+++ b/tests/agent/test_media_path_normalizer.py
@@ -1,0 +1,97 @@
+"""Behavior contract for relative MEDIA path normalization.
+
+The central fence: a rewrite happens only when the joined absolute path
+actually exists — so "making things worse" is impossible by construction.
+These tests pin the three design fences (line-form only / fenced blocks
+untouched / missing files untouched).
+"""
+
+import os
+
+import pytest
+
+from agent.media_path_normalizer import normalize_relative_media_paths
+
+
+@pytest.fixture
+def workdir(tmp_path, monkeypatch):
+    """A session workdir holding real media files, registered as the live cwd. CJK filenames double as a unicode-path test."""
+    (tmp_path / "成片.mp4").write_bytes(b"x")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "clip.mp4").write_bytes(b"x")
+
+    from tools import terminal_tool
+
+    monkeypatch.setattr(terminal_tool, "get_session_cwd", lambda key: str(tmp_path))
+    return tmp_path
+
+
+class TestRewrites:
+    def test_relative_file_becomes_absolute(self, workdir):
+        out = normalize_relative_media_paths("done\nMEDIA: 成片.mp4\n", session_key="t1")
+        assert f"MEDIA: {workdir / '成片.mp4'}" in out
+        assert "MEDIA: 成片.mp4" not in out
+
+    def test_subdir_and_dot_slash(self, workdir):
+        out = normalize_relative_media_paths("MEDIA: ./sub/clip.mp4", session_key="t1")
+        assert f"MEDIA: {workdir / 'sub' / 'clip.mp4'}" in out
+
+    def test_quoted_path_with_spaces(self, workdir):
+        (workdir / "my clip.mp4").write_bytes(b"x")
+        out = normalize_relative_media_paths('MEDIA: "my clip.mp4"', session_key="t1")
+        assert f"MEDIA: {workdir / 'my clip.mp4'}" in out
+
+    def test_leading_indent_preserved(self, workdir):
+        out = normalize_relative_media_paths("  MEDIA: 成片.mp4", session_key="t1")
+        assert out.startswith("  MEDIA: ")
+
+
+class TestFuses:
+    def test_missing_file_left_untouched(self, workdir):
+        src = "MEDIA: 不存在.mp4"
+        assert normalize_relative_media_paths(src, session_key="t1") == src
+
+    def test_absolute_path_never_touched(self, workdir):
+        src = f"MEDIA: {workdir / '成片.mp4'}"
+        assert normalize_relative_media_paths(src, session_key="t1") == src
+
+    def test_home_url_and_drive_paths_never_touched(self, workdir):
+        for src in (
+            "MEDIA: ~/videos/a.mp4",
+            "MEDIA: https://example.com/a.mp4",
+            "MEDIA: C:\\Users\\a\\b.mp4",
+        ):
+            assert normalize_relative_media_paths(src, session_key="t1") == src
+
+    def test_code_fence_left_untouched(self, workdir):
+        src = "example:\n```\nMEDIA: 成片.mp4\n```\nthat was a syntax example"
+        assert normalize_relative_media_paths(src, session_key="t1") == src
+
+    def test_inline_media_not_line_form_untouched(self, workdir):
+        src = "inline MEDIA: 成片.mp4 inside prose stays untouched"
+        assert normalize_relative_media_paths(src, session_key="t1") == src
+
+    def test_no_cwd_available_untouched(self, monkeypatch):
+        from tools import terminal_tool
+
+        monkeypatch.setattr(terminal_tool, "get_session_cwd", lambda key: None)
+        monkeypatch.setenv("TERMINAL_CWD", "")
+        src = "MEDIA: 成片.mp4"
+        out = normalize_relative_media_paths(src, session_key="t1")
+        # resolve_agent_cwd falls back to the process cwd — no such file there, the existence fence holds
+        assert out == src
+
+    def test_non_string_and_no_media_fast_path(self):
+        assert normalize_relative_media_paths("no media line here") == "no media line here"
+        assert normalize_relative_media_paths(None) is None  # type: ignore[arg-type]
+
+
+class TestFenceStateMachine:
+    def test_media_after_closed_fence_rewritten(self, workdir):
+        src = "```\ncode\n```\nMEDIA: 成片.mp4"
+        out = normalize_relative_media_paths(src, session_key="t1")
+        assert f"MEDIA: {workdir / '成片.mp4'}" in out
+
+    def test_unclosed_fence_tail_untouched(self, workdir):
+        src = "```\nMEDIA: 成片.mp4"
+        assert normalize_relative_media_paths(src, session_key="t1") == src


### PR DESCRIPTION
## Problem

The system prompt asks for `MEDIA:/absolute/path`, but a model working inside a project directory routinely emits relative paths (`MEDIA: final_video.mp4`). Every consumer downstream assumes absolute:

- the messaging gateways' MEDIA regexes only match absolute paths → the file silently isn't delivered;
- the desktop resolves the path against the app's own cwd → a black, unplayable card (observed on a Windows deployment, reproduced identically on macOS).

## Fix

At turn finalize, rewrite **line-form** relative MEDIA paths by joining them onto the session's working directory — live terminal cwd first (`get_session_cwd`, tracks `cd` during the turn), then the configured session cwd. The matching assistant message in the histories is updated too, so the stored transcript stays consistent.

Three fences make this strictly no-worse-than-before:
1. **Line form only** (`MEDIA: <path>` alone on a line; quoted paths supported) — inline prose mentions untouched.
2. **Fenced code blocks untouched** — examples aren't deliveries.
3. **A rewrite only happens when the joined path exists on disk** — a wrong base-directory guess degrades to leaving the text unchanged, never to a broken rewrite.

Never raises: any surprise returns the original text.

## Tests

`tests/agent/test_media_path_normalizer.py` — 13 cases pinning the fences (relative/subdir/quoted-with-spaces rewrites; missing-file / absolute / home / drive / URL / fenced / inline / no-cwd all untouched; unclosed-fence state machine). Existing `test_turn_finalizer` suite passes unchanged. Verified end-to-end: a turn whose response contains a relative MEDIA line finalizes with the absolute path.

Companion desktop PR (resolves relative paths in already-stored transcripts): see cross-link comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)