### PR TITLE
fix(desktop): resolve relative MEDIA paths against the owning session's cwd

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -8,8 +8,9 @@ import {
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
 import type { code as streamdownCode } from '@streamdown/code'
-import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
+import { type ComponentProps, memo, useContext, useEffect, useMemo, useState } from 'react'
 
+import { MediaCwdContext } from '@/components/assistant-ui/media-cwd-context'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
@@ -31,6 +32,7 @@ import {
   mediaName,
   mediaPathFromMarkdownHref,
   resolveMediaDisplaySrc,
+  absolutizeMediaPath,
   resolveMediaPlaybackSrc
 } from '@/lib/media'
 import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
@@ -143,7 +145,13 @@ function OpenMediaButton({ kind, path }: { kind: 'audio' | 'video'; path: string
   )
 }
 
-function MediaAttachment({ path }: { path: string }) {
+function MediaAttachment({ path: rawPath }: { path: string }) {
+  // Resolve relative MEDIA paths against the owning session's cwd — including
+  // relative paths already stored in old transcripts, which start playing
+  // without the agent having to resend. Absolute/URL forms pass through
+  // untouched (absolutizeMediaPath guards itself).
+  const mediaCwd = useContext(MediaCwdContext)
+  const path = useMemo(() => absolutizeMediaPath(rawPath, mediaCwd), [rawPath, mediaCwd])
   const [src, setSrc] = useState('')
   const [failed, setFailed] = useState(false)
   const { open, openFailed } = useOpenMediaFile(path)

--- a/apps/desktop/src/components/assistant-ui/media-cwd-context.ts
+++ b/apps/desktop/src/components/assistant-ui/media-cwd-context.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+/** The owning session's working directory — MediaAttachment uses it to resolve
+ *  relative MEDIA paths (provided by Thread, so split panes stay independent). */
+export const MediaCwdContext = createContext<null | string>(null)

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -2,6 +2,7 @@ import { createContext, memo, useCallback, useContext, useMemo, useRef, useState
 
 import { ChatEmptySlot } from '@/components/assistant-ui/chat-empty-slot'
 import { AssistantMessage } from '@/components/assistant-ui/thread/assistant-message'
+import { MediaCwdContext } from '@/components/assistant-ui/media-cwd-context'
 import { ThreadMessageList } from '@/components/assistant-ui/thread/list'
 import { BackgroundResumeNotice, CenteredThreadSpinner } from '@/components/assistant-ui/thread/status'
 import { SystemMessage } from '@/components/assistant-ui/thread/system-message'
@@ -169,6 +170,7 @@ export const Thread = memo(function Thread({
 
   return (
     <ThreadEditContext.Provider value={editContext}>
+      <MediaCwdContext.Provider value={cwd}>
       <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]">
         <ThreadMessageList
           clampToComposer={clampToComposer}
@@ -189,6 +191,7 @@ export const Thread = memo(function Thread({
           title={copy.restoreTitle}
         />
       </div>
+      </MediaCwdContext.Provider>
     </ThreadEditContext.Provider>
   )
 })

--- a/apps/desktop/src/lib/media-absolutize.test.ts
+++ b/apps/desktop/src/lib/media-absolutize.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { absolutizeMediaPath } from '@/lib/media'
+
+describe('absolutizeMediaPath', () => {
+  it('joins a relative path onto the session cwd', () => {
+    expect(absolutizeMediaPath('final.mp4', '/home/u/work')).toBe('/home/u/work/final.mp4')
+    expect(absolutizeMediaPath('./sub/a.mp4', '/home/u/work/')).toBe('/home/u/work/./sub/a.mp4')
+  })
+
+  it('uses backslash join for pure-Windows cwds', () => {
+    expect(absolutizeMediaPath('final.mp4', 'C:\\Users\\u\\workdir')).toBe('C:\\Users\\u\\workdir\\final.mp4')
+  })
+
+  it('never touches absolute, home, drive or scheme paths', () => {
+    for (const p of [
+      '/a/b.mp4',
+      '~/v/b.mp4',
+      'C:\\a\\b.mp4',
+      'C:/a/b.mp4',
+      'https://x/y.mp4',
+      'data:video/mp4;base64,AAA',
+      'hermes-media://stream/x'
+    ]) {
+      expect(absolutizeMediaPath(p, '/home/u')).toBe(p)
+    }
+  })
+
+  it('returns the path unchanged without a cwd', () => {
+    expect(absolutizeMediaPath('final.mp4', null)).toBe('final.mp4')
+    expect(absolutizeMediaPath('final.mp4', '')).toBe('final.mp4')
+  })
+})

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -65,6 +65,30 @@ export function mediaName(path: string): string {
   }
 }
 
+// A relative path in a MEDIA tag (the model violating the MEDIA:/absolute/path
+// instruction) must be resolved against the SESSION's cwd — otherwise the main
+// process resolves it against the app's own cwd, which 404s and renders an
+// unplayable black card. Absolute, home, drive-letter and scheme'd forms
+// (data:, blob:, https:, the media stream scheme) are always left untouched.
+const MEDIA_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/
+const WINDOWS_DRIVE_RE = /^[A-Za-z]:[/\\]/
+
+export function absolutizeMediaPath(path: string, baseCwd?: string | null): string {
+  const p = path.trim()
+
+  if (!baseCwd || !p) {
+    return path
+  }
+
+  if (p.startsWith('/') || p.startsWith('~') || p.startsWith('\\') || WINDOWS_DRIVE_RE.test(p) || MEDIA_SCHEME_RE.test(p)) {
+    return path
+  }
+
+  const sep = baseCwd.includes('\\') && !baseCwd.includes('/') ? '\\' : '/'
+
+  return `${baseCwd.replace(/[/\\]+$/, '')}${sep}${p}`
+}
+
 export function mediaMarkdownHref(path: string): string {
   return `#media:${encodeURIComponent(path)}`
 }


### PR DESCRIPTION
## Problem

When the model emits a relative MEDIA path (`MEDIA: final_video.mp4` — routine while it works inside a project directory, despite the absolute-path instruction), the desktop renders a player card whose URL the main process resolves against the **app's own cwd**. The file is never found and the user sees a black, unplayable 0:00 card (`MediaError` code 4, `networkState` NO_SOURCE). Observed on a Windows deployment; reproduced identically on macOS.

## Fix

`Thread` already receives the session's live `cwd` — provide it through a new `MediaCwdContext` (per-thread, so split panes stay independent), and have `MediaAttachment` join relative paths onto it before resolving playback/open sources. `absolutizeMediaPath` guards itself: absolute, `~`, drive-letter and scheme'd forms (`data:`, `blob:`, `https:`, the media stream scheme) pass through untouched, as does everything when no cwd is available.

**This also heals transcripts that already contain relative MEDIA paths** — they start playing after the update without the agent resending anything.

## Tests

- `src/lib/media-absolutize.test.ts`: join for POSIX and pure-Windows cwds; absolute/home/drive/scheme/no-cwd pass-through.
- Renderer `tsc` clean; full desktop suite passes on a deployment carrying this exact change (4400+ tests).
- Live verification: a session whose stored message contains a relative MEDIA path rendered a dead card (readyState 0, error 4) before, and plays (readyState 4, correct duration) after.

Companion engine PR normalizes the paths at turn-finalize so messaging gateways (absolute-only delivery) benefit too: see cross-link comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)