### PR TITLE
fix(kanban): let block --kind consume a trailing reason

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -213,6 +213,47 @@ def _check_dispatcher_presence(
 # Argparse builder
 # ---------------------------------------------------------------------------
 
+def _hoist_kind_token(argv: list[str]) -> list[str]:
+    """Move a ``--kind <val>`` / ``--kind=<val>`` token to the front of the
+    token list so argparse can still consume a trailing ``nargs='*'`` reason.
+
+    argparse's ``nargs='*'`` positional cannot consume tokens that follow an
+    option once positional consumption has started: ``block t_X --kind
+    needs_input some reason`` fails with ``unrecognized arguments: some
+    reason`` because ``--kind`` sits mid-stream after the positional has
+    begun consuming. Hoisting the option to the head of the token list —
+    before every positional — lets the reason positional take everything
+    that follows. Stops at ``--`` (everything after it is literal) and never
+    rewrites a ``--kind`` that is missing its value (argparse reports the
+    real error instead). Only ``block`` uses ``--kind`` in the kanban tree.
+    """
+    argv = list(argv)
+    for i, tok in enumerate(argv):
+        if tok == "--":
+            break
+        if tok == "--kind":
+            if i + 1 < len(argv) and not argv[i + 1].startswith("-"):
+                return [tok, argv[i + 1]] + argv[:i] + argv[i + 2:]
+            break
+        if tok.startswith("--kind="):
+            return [tok] + argv[:i] + argv[i + 1:]
+    return argv
+
+
+class _KanbanParser(argparse.ArgumentParser):
+    """Argparse subclass that hoists ``--kind`` ahead of positionals.
+
+    Used as ``parser_class`` for the kanban subcommand tree so every
+    subparser (including ``block``) parses with the hoist applied. The
+    hoist is a no-op for every subcommand that does not use ``--kind``.
+    """
+
+    def parse_known_args(self, args=None, namespace=None):  # type: ignore[override]
+        if args is None:
+            args = sys.argv[1:]
+        return super().parse_known_args(_hoist_kind_token(args), namespace)
+
+
 def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
     """Attach the ``kanban`` subcommand tree under an existing subparsers.
 
@@ -245,7 +286,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
             "to see all boards."
         ),
     )
-    sub = kanban_parser.add_subparsers(dest="kanban_action")
+    sub = kanban_parser.add_subparsers(dest="kanban_action", parser_class=_KanbanParser)
 
     # --- init ---
     sub.add_parser("init", help="Create kanban.db if missing (idempotent)")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -116,6 +116,80 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
     assert beta_titles == ["beta-task"]
 
 
+def _kanban_parser():
+    """Build the real kanban parser tree (same shape the CLI and slash
+    surfaces use) and return it for parse assertions."""
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    return parser
+
+
+def test_block_kind_parses_with_trailing_reason():
+    """Regression for #88135: `block <id> --kind <kind> <reason>` must not
+    fail with `unrecognized arguments: <reason>`.
+
+    The block subparser's `reason` positional is `nargs='*'`; argparse
+    cannot consume tokens after an option once positional consumption has
+    started, so the trailing reason was rejected as an extra argument. The
+    parser now hoists `--kind <val>` ahead of the positionals before
+    parsing, letting the trailing reason bind to the positional.
+    """
+    parser = _kanban_parser()
+
+    args = parser.parse_args(
+        ["kanban", "block", "t_1", "--kind", "needs_input", "some reason"]
+    )
+    assert args.task_id == "t_1"
+    assert args.kind == "needs_input"
+    assert args.reason == ["some reason"]
+
+    # Multi-word reason after the kind.
+    args = parser.parse_args(
+        ["kanban", "block", "t_1", "--kind", "dependency", "multi", "word", "reason"]
+    )
+    assert args.kind == "dependency"
+    assert args.reason == ["multi", "word", "reason"]
+
+    # `--kind=<val>` equals form.
+    args = parser.parse_args(["kanban", "block", "t_1", "--kind=capability", "eq form"])
+    assert args.kind == "capability"
+    assert args.reason == ["eq form"]
+
+    # Kind-only (no reason) still parses.
+    args = parser.parse_args(["kanban", "block", "t_1", "--kind", "transient"])
+    assert args.kind == "transient"
+    assert args.reason == []
+
+    # The no-kind form must keep working (backward compat).
+    args = parser.parse_args(["kanban", "block", "t_1", "some reason"])
+    assert args.kind is None
+    assert args.reason == ["some reason"]
+
+
+def test_block_kind_end_to_end_sets_kind_on_task(kanban_home):
+    """`block <id> --kind needs_input <reason>` actually persists the kind
+    on the task (not just parses), and the reason is recorded as a comment.
+    """
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="kind test", assignee="alice")
+
+    rc = kc.kanban_command(
+        _kanban_parser().parse_args(
+            ["kanban", "block", tid, "--kind", "needs_input", "human input needed"]
+        )
+    )
+    assert rc == 0
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.block_kind == "needs_input"
+
+
 # ---------------------------------------------------------------------------
 # Integration with the COMMAND_REGISTRY
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`hermes kanban block <id> --kind <kind> <reason>` always failed with `unrecognized arguments: <reason>` (exit 2), in every form tried (`--kind <val> <reason>`, `--kind=<val> <reason>`, single-word reason, with `--`). `block <id> <reason>` without `--kind` works. Result: every typed block kind (`needs_input` / `capability` / `dependency` / `transient`) was unreachable from the CLI. Fixes #88135.

## Root cause

The `block` subparser declares the `reason` positional as `nargs='*'` plus a `--kind` option. argparse cannot consume tokens that follow an option once positional consumption has started, so the trailing reason was rejected as an extra argument.

## Fix

Hoist a `--kind <val>` / `--kind=<val>` token to the head of the token list (`_hoist_kind_token`) before parsing, so the `nargs='*'` reason positional consumes everything after it. Applied via a `_KanbanParser` argparse subclass (`parser_class=` on the kanban subparsers action) so every surface that builds through `build_parser()` gets it: the `hermes kanban` CLI, the gateway `/kanban` slash command, and `run_slash`.

Details:
- No-op for subcommands that don't use `--kind`.
- Stops at `--` (everything after it is literal).
- Leaves a `--kind` missing its value untouched so argparse reports the real error.
- The no-kind form (`block <id> <reason>`) parses unchanged (`kind=None`).
- `unblock --reason` was never affected.

## Tests

`tests/hermes_cli/test_kanban_cli.py`:
- `test_block_kind_parses_with_trailing_reason` — parse-level regression: `--kind <val>` + single/multi-word reason, `--kind=<val>` equals form, kind-only, and the no-kind backward-compat form.
- `test_block_kind_end_to_end_sets_kind_on_task` — `kanban_command` with `--kind needs_input` persists `block_kind='needs_input'` on the task.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py -q` → 6/6 pass.
- Broader kanban set (48 files: all `tests/hermes_cli/test_kanban_*.py`, `test_subparser_routing_fallback.py`, `tests/tools/test_delegate_kanban_isolation.py`) → 301 passed, 0 failed, 2 skipped.
- `ruff check` clean; the two touched files carry pre-existing `ruff format` drift also present on `main` (not touched to keep the diff minimal).
- Live CLI E2E on a temp `HERMES_HOME`: `hermes kanban block t_X --kind needs_input "human input needed"` → exit 0, task `status=blocked`, `block_kind=needs_input`; no-kind form → exit 0, `block_kind` stays NULL.

Environment: macOS 26.3.1, Python 3.11 venv, hermes-agent 0.20.5 editable install.