### PR TITLE
fix(compression): stop superseded lean attempts from multiplying provider calls

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4813,9 +4813,9 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         Splits the region into ``_LEAN_DIGEST_CHUNK_CHARS`` chunks (capped at
         ``_LEAN_DIGEST_MAX_CHUNKS`` — beyond that, earliest chunks are merged
         coarser) and digests each with the compression LLM. Any chunk failure
-        degrades to a placeholder naming the message range; the whole call
-        never raises. Chunks run sequentially on the same transport as the
-        main summary.
+        degrades to a placeholder naming the message range. Explicit attempt
+        cancellation still propagates to the host. Chunks run sequentially on
+        the same transport as the main summary.
         """
         text = _serialize_turns_for_digest(
             turns, getattr(self, "_lean_pristine_tools", None),
@@ -4842,7 +4842,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             if not _start_compression_provider_call():
                 logger.info(
                     "Stopping lean chunk digests after %d/%d segment(s): "
-                    "compression attempt provider budget cancelled or exhausted",
+                    "compression attempt provider budget exhausted",
                     ci,
                     n_chunks,
                 )

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1102,7 +1102,6 @@ class _CompressionAttemptProviderBudget:
     def __init__(self, max_calls: int, cancel_check=None) -> None:
         self.max_calls = max(1, int(max_calls))
         self.started_calls = 0
-        self.completed_calls = 0
         self._cancel_check = cancel_check
 
     @property
@@ -1124,10 +1123,6 @@ class _CompressionAttemptProviderBudget:
             return False
         self.started_calls += 1
         return True
-
-    def finish_call(self) -> None:
-        self.completed_calls += 1
-
 
 _COMPRESSION_ATTEMPT_PROVIDER_BUDGET: contextvars.ContextVar[
     Optional[_CompressionAttemptProviderBudget]
@@ -1154,14 +1149,9 @@ class _CompressionAttemptBudgetExhausted(RuntimeError):
 
 
 def _start_compression_provider_call() -> bool:
+    """Admit a call, preserving legacy unbounded behavior outside ``compress``."""
     budget = _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.get()
     return budget is None or budget.try_start_call()
-
-
-def _finish_compression_provider_call() -> None:
-    budget = _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.get()
-    if budget is not None:
-        budget.finish_call()
 
 _LEAN_DIGEST_PROMPT = """You are writing one segment of a detailed session log for an AI agent's context checkpoint. Digest the transcript segment below.
 
@@ -4867,8 +4857,6 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             except Exception as exc:
                 logger.warning("lean chunk digest %d/%d failed: %s", ci + 1, n_chunks, exc)
                 body = f"[digest unavailable for segment {ci + 1}/{n_chunks} — recover via session_search]"
-            finally:
-                _finish_compression_provider_call()
             digests.append(f"### Segment {ci + 1}/{n_chunks}\n{body}")
         if not digests:
             return ""
@@ -5333,7 +5321,6 @@ This compaction should PRIORITISE preserving all information related to the focu
                 with aux_interrupt_protection():
                     response = call_llm(**call_kwargs)
             finally:
-                _finish_compression_provider_call()
                 route_known = bool(_aux_route.get("provider") and _aux_route.get("model"))
                 _aux_provider = _aux_route.get("provider") or self.provider or ""
                 _aux_model = _aux_route.get("model") or self.summary_model or self.model or ""

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1148,10 +1148,24 @@ class _CompressionAttemptBudgetExhausted(RuntimeError):
     pass
 
 
+def _raise_if_compression_attempt_cancelled() -> None:
+    budget = _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.get()
+    if budget is not None and budget.is_cancelled:
+        raise AuxiliaryExplicitCancellation()
+
+
 def _start_compression_provider_call() -> bool:
     """Admit a call, preserving legacy unbounded behavior outside ``compress``."""
     budget = _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.get()
-    return budget is None or budget.try_start_call()
+    if budget is None:
+        return True
+    _raise_if_compression_attempt_cancelled()
+    admitted = budget.try_start_call()
+    if not admitted:
+        # ``try_start_call`` also checks cancellation. Re-check so a cancel
+        # racing admission is never mistaken for ordinary budget exhaustion.
+        _raise_if_compression_attempt_cancelled()
+    return admitted
 
 _LEAN_DIGEST_PROMPT = """You are writing one segment of a detailed session log for an AI agent's context checkpoint. Digest the transcript segment below.
 
@@ -4813,8 +4827,9 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         budget = _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.get()
         digest_call_limit = _LEAN_DIGEST_MAX_CHUNKS
         if budget is not None:
+            _raise_if_compression_attempt_cancelled()
             digest_call_limit = min(digest_call_limit, budget.remaining_calls)
-            if digest_call_limit <= 0 or budget.is_cancelled:
+            if digest_call_limit <= 0:
                 return ""
         if n_chunks > digest_call_limit:
             chunk_size = (len(text) + digest_call_limit - 1) // digest_call_limit
@@ -4858,6 +4873,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
                 logger.warning("lean chunk digest %d/%d failed: %s", ci + 1, n_chunks, exc)
                 body = f"[digest unavailable for segment {ci + 1}/{n_chunks} — recover via session_search]"
             digests.append(f"### Segment {ci + 1}/{n_chunks}\n{body}")
+        _raise_if_compression_attempt_cancelled()
         if not digests:
             return ""
         return (
@@ -5391,6 +5407,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             summary = _reinject_pruned_skill_markers(summary, _pruned_skill_names)
             summary = self._ground_historical_task_snapshot(summary, turns_to_summarize)
             summary = self._augment_summary_lean(summary, turns_to_summarize)
+            _raise_if_compression_attempt_cancelled()
             self._validate_summary_user_provenance(summary, has_user_turn)
             # Store for iterative updates on next compaction
             self._previous_summary = summary
@@ -7588,13 +7605,15 @@ This compaction should PRIORITISE preserving all information related to the focu
     ) -> List[Dict[str, Any]]:
         """Run one compression attempt under a total provider-call budget."""
         with _compression_attempt_provider_budget(cancel_check=_cancel_check):
-            return self._compress_impl(
+            result = self._compress_impl(
                 messages,
                 current_tokens=current_tokens,
                 focus_topic=focus_topic,
                 force=force,
                 memory_context=memory_context,
             )
+            _raise_if_compression_attempt_cancelled()
+            return result
 
     def _compress_impl(
         self,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1092,7 +1092,76 @@ def _build_recovery_footer(session_id: str, region_len: int) -> str:
 _LEAN_DIGEST_CHUNK_CHARS = 72_000      # ~18K tokens of region per chunk
 _LEAN_DIGEST_MAX_CHUNKS = 28
 _LEAN_DIGEST_MAX_TOKENS = 1_400        # per-chunk digest cap (~13:1 ratio)
+_LEAN_ATTEMPT_MAX_PROVIDER_CALLS = 8   # summary/fallback + all chunk digests
 _LEAN_DIGESTS_HEADING = "## Detailed Session Log (chunked digests, oldest first)"
+
+
+class _CompressionAttemptProviderBudget:
+    """Attempt-local provider-call admission shared by summary and digests."""
+
+    def __init__(self, max_calls: int, cancel_check=None) -> None:
+        self.max_calls = max(1, int(max_calls))
+        self.started_calls = 0
+        self.completed_calls = 0
+        self._cancel_check = cancel_check
+
+    @property
+    def remaining_calls(self) -> int:
+        return max(0, self.max_calls - self.started_calls)
+
+    @property
+    def is_cancelled(self) -> bool:
+        if not callable(self._cancel_check):
+            return False
+        try:
+            return bool(self._cancel_check())
+        except Exception:
+            logger.debug("compression provider-work cancellation check failed", exc_info=True)
+            return False
+
+    def try_start_call(self) -> bool:
+        if self.is_cancelled or self.started_calls >= self.max_calls:
+            return False
+        self.started_calls += 1
+        return True
+
+    def finish_call(self) -> None:
+        self.completed_calls += 1
+
+
+_COMPRESSION_ATTEMPT_PROVIDER_BUDGET: contextvars.ContextVar[
+    Optional[_CompressionAttemptProviderBudget]
+] = contextvars.ContextVar("hermes_compression_attempt_provider_budget", default=None)
+
+
+@contextlib.contextmanager
+def _compression_attempt_provider_budget(
+    *,
+    cancel_check=None,
+    max_calls: int = _LEAN_ATTEMPT_MAX_PROVIDER_CALLS,
+):
+    """Bound one synchronous compressor attempt without cross-worker state."""
+    budget = _CompressionAttemptProviderBudget(max_calls, cancel_check)
+    token = _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.set(budget)
+    try:
+        yield budget
+    finally:
+        _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.reset(token)
+
+
+class _CompressionAttemptBudgetExhausted(RuntimeError):
+    pass
+
+
+def _start_compression_provider_call() -> bool:
+    budget = _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.get()
+    return budget is None or budget.try_start_call()
+
+
+def _finish_compression_provider_call() -> None:
+    budget = _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.get()
+    if budget is not None:
+        budget.finish_call()
 
 _LEAN_DIGEST_PROMPT = """You are writing one segment of a detailed session log for an AI agent's context checkpoint. Digest the transcript segment below.
 
@@ -4751,14 +4820,28 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             return ""
         chunk_size = _LEAN_DIGEST_CHUNK_CHARS
         n_chunks = max(1, (len(text) + chunk_size - 1) // chunk_size)
-        if n_chunks > _LEAN_DIGEST_MAX_CHUNKS:
-            chunk_size = (len(text) + _LEAN_DIGEST_MAX_CHUNKS - 1) // _LEAN_DIGEST_MAX_CHUNKS
-            n_chunks = _LEAN_DIGEST_MAX_CHUNKS
+        budget = _COMPRESSION_ATTEMPT_PROVIDER_BUDGET.get()
+        digest_call_limit = _LEAN_DIGEST_MAX_CHUNKS
+        if budget is not None:
+            digest_call_limit = min(digest_call_limit, budget.remaining_calls)
+            if digest_call_limit <= 0 or budget.is_cancelled:
+                return ""
+        if n_chunks > digest_call_limit:
+            chunk_size = (len(text) + digest_call_limit - 1) // digest_call_limit
+            n_chunks = digest_call_limit
         digests: list[str] = []
         for ci in range(n_chunks):
             segment = text[ci * chunk_size:(ci + 1) * chunk_size]
             if not segment.strip():
                 continue
+            if not _start_compression_provider_call():
+                logger.info(
+                    "Stopping lean chunk digests after %d/%d segment(s): "
+                    "compression attempt provider budget cancelled or exhausted",
+                    ci,
+                    n_chunks,
+                )
+                break
             try:
                 from agent.auxiliary_client import call_llm
 
@@ -4784,6 +4867,8 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             except Exception as exc:
                 logger.warning("lean chunk digest %d/%d failed: %s", ci + 1, n_chunks, exc)
                 body = f"[digest unavailable for segment {ci + 1}/{n_chunks} — recover via session_search]"
+            finally:
+                _finish_compression_provider_call()
             digests.append(f"### Segment {ci + 1}/{n_chunks}\n{body}")
         if not digests:
             return ""
@@ -5240,10 +5325,15 @@ This compaction should PRIORITISE preserving all information related to the focu
                 "prompt_build_ms": max(0, int((_aux_call_start - prompt_started_at) * 1000))
             }
             call_kwargs["latency_info"] = _latency_info
+            if not _start_compression_provider_call():
+                raise _CompressionAttemptBudgetExhausted(
+                    "compression attempt provider-call budget exhausted"
+                )
             try:
                 with aux_interrupt_protection():
                     response = call_llm(**call_kwargs)
             finally:
+                _finish_compression_provider_call()
                 route_known = bool(_aux_route.get("provider") and _aux_route.get("model"))
                 _aux_provider = _aux_route.get("provider") or self.provider or ""
                 _aux_model = _aux_route.get("model") or self.summary_model or self.model or ""
@@ -5324,6 +5414,12 @@ This compaction should PRIORITISE preserving all information related to the focu
             self._last_summary_network_failure = False
             self._last_summary_empty_content_failure = False
             return self._with_summary_prefix(summary)
+        except _CompressionAttemptBudgetExhausted:
+            logger.warning(
+                "Context compression stopped before summary dispatch: attempt "
+                "provider-call budget exhausted"
+            )
+            return None
         except Exception as e:
             # ``call_llm`` raises ``RuntimeError`` for two very different cases:
             #   1. No provider configured ("No LLM provider configured ...") —
@@ -7495,6 +7591,25 @@ This compaction should PRIORITISE preserving all information related to the focu
         return merged
 
     def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+        focus_topic: Optional[str] = None,
+        force: bool = False,
+        memory_context: str = "",
+        _cancel_check=None,
+    ) -> List[Dict[str, Any]]:
+        """Run one compression attempt under a total provider-call budget."""
+        with _compression_attempt_provider_budget(cancel_check=_cancel_check):
+            return self._compress_impl(
+                messages,
+                current_tokens=current_tokens,
+                focus_topic=focus_topic,
+                force=force,
+                memory_context=memory_context,
+            )
+
+    def _compress_impl(
         self,
         messages: List[Dict[str, Any]],
         current_tokens: Optional[int] = None,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1790,6 +1790,7 @@ def _supported_compression_kwargs(
     focus_topic: Optional[str],
     force: bool,
     memory_context: str,
+    cancel_check: Any = None,
 ) -> dict:
     """Return only compression kwargs accepted by an engine callable.
 
@@ -1812,6 +1813,11 @@ def _supported_compression_kwargs(
         # introduction. Keep the oldest documented call shape when a C-backed
         # or otherwise opaque callable has no inspectable signature.
         return {"current_tokens": current_tokens}
+
+    # Private built-in extension: do not forward host cancellation into plugin
+    # engines merely because they accept arbitrary **kwargs.
+    if "_cancel_check" in parameters:
+        candidates["_cancel_check"] = cancel_check
 
     accepts_kwargs = any(
         parameter.kind is inspect.Parameter.VAR_KEYWORD
@@ -3490,12 +3496,18 @@ def compress_context(
                 pass
 
         compress_fn = agent.context_compressor.compress
+        _fence_cancel_check = (
+            (lambda: commit_fence.is_cancelled)
+            if commit_fence is not None
+            else None
+        )
         compress_kwargs = _supported_compression_kwargs(
             compress_fn,
             current_tokens=approx_tokens,
             focus_topic=focus_topic,
             force=force,
             memory_context=memory_context,
+            cancel_check=_fence_cancel_check,
         )
         if memory_context.strip() and "memory_context" not in compress_kwargs:
             engine_name = getattr(
@@ -3572,7 +3584,8 @@ def compress_context(
                 compressed = messages
             else:
                 with aux_progress_hook(_progress_hook), aux_interrupt_protection(
-                    cancel_event=_hard_cancel_event
+                    cancel_check=_fence_cancel_check,
+                    cancel_event=_hard_cancel_event,
                 ):
                     compressed = compress_fn(messages, **compress_kwargs)
                     # Freeze a hard stop that arrived after the final provider

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1783,6 +1783,22 @@ def _compression_lock_holder(agent: Any) -> str:
     )
 
 
+def _compression_attempt_cancel_check(
+    commit_fence: Optional[CompressionCommitFence], hard_cancel_event: Any
+) -> Optional[Callable[[], bool]]:
+    """Combine every explicit cancellation source for one provider attempt."""
+    if commit_fence is None and hard_cancel_event is None:
+        return None
+
+    def _cancelled() -> bool:
+        return bool(
+            (hard_cancel_event is not None and hard_cancel_event.is_set())
+            or (commit_fence is not None and commit_fence.is_cancelled)
+        )
+
+    return _cancelled
+
+
 def _supported_compression_kwargs(
     compress_fn: Any,
     *,
@@ -3496,10 +3512,9 @@ def compress_context(
                 pass
 
         compress_fn = agent.context_compressor.compress
-        _fence_cancel_check = (
-            (lambda: commit_fence.is_cancelled)
-            if commit_fence is not None
-            else None
+        _hard_cancel_event = getattr(agent, "_hard_interrupt_requested", None)
+        _attempt_cancel_check = _compression_attempt_cancel_check(
+            commit_fence, _hard_cancel_event
         )
         compress_kwargs = _supported_compression_kwargs(
             compress_fn,
@@ -3507,7 +3522,7 @@ def compress_context(
             focus_topic=focus_topic,
             force=force,
             memory_context=memory_context,
-            cancel_check=_fence_cancel_check,
+            cancel_check=_attempt_cancel_check,
         )
         if memory_context.strip() and "memory_context" not in compress_kwargs:
             engine_name = getattr(
@@ -3571,7 +3586,6 @@ def compress_context(
         # Incoming-message interrupts and active-turn redirects must not tear an
         # atomic summary in half (#23975). Explicit stop surfaces set a separate
         # Event atomically; never infer cause from the racy message fields.
-        _hard_cancel_event = getattr(agent, "_hard_interrupt_requested", None)
         try:
             # F6: never start expensive summary work for an already-cancelled
             # fence (a stale queued job admitted after host departure).
@@ -3584,8 +3598,7 @@ def compress_context(
                 compressed = messages
             else:
                 with aux_progress_hook(_progress_hook), aux_interrupt_protection(
-                    cancel_check=_fence_cancel_check,
-                    cancel_event=_hard_cancel_event,
+                    cancel_check=_attempt_cancel_check,
                 ):
                     compressed = compress_fn(messages, **compress_kwargs)
                     # Freeze a hard stop that arrived after the final provider

--- a/tests/agent/test_auxiliary_explicit_cancellation.py
+++ b/tests/agent/test_auxiliary_explicit_cancellation.py
@@ -176,6 +176,51 @@ def test_protected_silent_provider_is_isolated_and_raises_frozen_explicit_cancel
     stream.close()  # release the bounded daemon provider worker
 
 
+def test_compression_fence_cancel_is_not_masked_by_unset_hard_cancel_event() -> None:
+    from agent.conversation_compression import (
+        CompressionCommitFence,
+        _compression_attempt_cancel_check,
+    )
+
+    started = threading.Event()
+    hard_cancel_event = threading.Event()
+    fence = CompressionCommitFence()
+    stream = _BlockingStream(started)
+    client = _GenericClient(stream)
+    dispatches = 0
+    outcome: dict[str, BaseException] = {}
+
+    def _worker() -> None:
+        nonlocal dispatches
+        try:
+            cancel_check = _compression_attempt_cancel_check(
+                fence, hard_cancel_event
+            )
+            with aux.aux_interrupt_protection(cancel_check=cancel_check):
+                dispatches += 1
+                _invoke_generic(client)
+                dispatches += 1
+                _invoke_generic(client)
+        except BaseException as exc:
+            outcome["exc"] = exc
+
+    worker = threading.Thread(target=_worker, daemon=True)
+    worker.start()
+    assert started.wait(timeout=1), "request never entered its silent transport"
+    cancelled_at = time.monotonic()
+    assert not hard_cancel_event.is_set()
+    assert fence.cancel_before_commit() is True
+    worker.join(timeout=1)
+    elapsed = time.monotonic() - cancelled_at
+
+    assert not worker.is_alive(), "fence cancellation did not wake the request"
+    assert isinstance(outcome["exc"], aux.AuxiliaryExplicitCancellation)
+    assert dispatches == 1
+    assert not client.closed.is_set()
+    assert elapsed < 0.75
+    stream.close()
+
+
 def test_codex_silent_stream_is_isolated_without_closing_shared_client() -> None:
     started = threading.Event()
     stream = _BlockingStream(started)

--- a/tests/agent/test_compression_attempt_ownership.py
+++ b/tests/agent/test_compression_attempt_ownership.py
@@ -30,6 +30,11 @@ from agent.conversation_compression import (
     _install_compression_cancelled_check,
     _restore_compressor_attempt_state,
     _snapshot_compressor_attempt_state,
+    _supported_compression_kwargs,
+)
+from agent.context_compressor import (
+    ContextCompressor,
+    _compression_attempt_provider_budget,
 )
 
 
@@ -224,6 +229,97 @@ class TestDigestCallsFollowThePinnedRoute:
         from agent.context_compressor import attempt_summary_route_kwargs
 
         assert attempt_summary_route_kwargs() == {}
+
+
+class TestLeanAttemptProviderBudget:
+    """One lean attempt must bound and promptly cancel digest provider work."""
+
+    @staticmethod
+    def _compressor() -> ContextCompressor:
+        compressor = object.__new__(ContextCompressor)
+        compressor._lean_pristine_tools = None
+        return compressor
+
+    @staticmethod
+    def _response(content: str = "digest") -> SimpleNamespace:
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+        )
+
+    def test_remaining_attempt_budget_coarsens_all_digest_input(
+        self, monkeypatch
+    ):
+        import agent.auxiliary_client as auxiliary_client
+        import agent.context_compressor as context_compressor
+
+        prompts = []
+
+        def call_llm(**kwargs):
+            prompts.append(kwargs["messages"][0]["content"])
+            return self._response()
+
+        monkeypatch.setattr(auxiliary_client, "call_llm", call_llm)
+        monkeypatch.setattr(context_compressor, "_LEAN_DIGEST_CHUNK_CHARS", 40)
+        turns = [{"role": "user", "content": "start " + "x" * 300 + " END-MARKER"}]
+
+        with _compression_attempt_provider_budget(max_calls=3) as budget:
+            assert budget.try_start_call()  # reserve the main-summary request
+            budget.finish_call()
+            result = self._compressor()._build_chunk_digests(turns)
+
+        assert len(prompts) == 2
+        assert "END-MARKER" in prompts[-1]
+        assert "Segment 2/2" in result
+
+    def test_cancelled_attempt_stops_before_the_next_digest_call(
+        self, monkeypatch
+    ):
+        import agent.auxiliary_client as auxiliary_client
+        import agent.context_compressor as context_compressor
+
+        calls = 0
+        cancelled = False
+
+        def call_llm(**_kwargs):
+            nonlocal calls, cancelled
+            calls += 1
+            cancelled = True
+            return self._response()
+
+        monkeypatch.setattr(auxiliary_client, "call_llm", call_llm)
+        monkeypatch.setattr(context_compressor, "_LEAN_DIGEST_CHUNK_CHARS", 40)
+        turns = [{"role": "user", "content": "x" * 400}]
+
+        with _compression_attempt_provider_budget(
+            cancel_check=lambda: cancelled,
+            max_calls=8,
+        ):
+            self._compressor()._build_chunk_digests(turns)
+
+        assert calls == 1
+
+    def test_host_cancel_check_only_flows_to_opted_in_builtin_signature(self):
+        cancel_check = lambda: True  # noqa: E731
+
+        def builtin(messages, current_tokens=None, _cancel_check=None):
+            return messages
+
+        def plugin(messages, current_tokens=None, **kwargs):
+            return messages
+
+        common = {
+            "current_tokens": 100,
+            "focus_topic": None,
+            "force": False,
+            "memory_context": "",
+            "cancel_check": cancel_check,
+        }
+
+        builtin_kwargs = _supported_compression_kwargs(builtin, **common)
+        plugin_kwargs = _supported_compression_kwargs(plugin, **common)
+
+        assert builtin_kwargs["_cancel_check"] is cancel_check
+        assert "_cancel_check" not in plugin_kwargs
 
 
 class TestMidRestoreClaimRace:

--- a/tests/agent/test_compression_attempt_ownership.py
+++ b/tests/agent/test_compression_attempt_ownership.py
@@ -23,6 +23,9 @@ no timing, no threads.
 
 from types import SimpleNamespace
 
+import pytest
+
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
 from agent.conversation_compression import (
     _claim_compressor_attempt,
     _clear_compression_cancelled_check_if_owner,
@@ -289,11 +292,12 @@ class TestLeanAttemptProviderBudget:
         monkeypatch.setattr(context_compressor, "_LEAN_DIGEST_CHUNK_CHARS", 40)
         turns = [{"role": "user", "content": "x" * 400}]
 
-        with _compression_attempt_provider_budget(
-            cancel_check=lambda: cancelled,
-            max_calls=8,
-        ):
-            self._compressor()._build_chunk_digests(turns)
+        with pytest.raises(AuxiliaryExplicitCancellation):
+            with _compression_attempt_provider_budget(
+                cancel_check=lambda: cancelled,
+                max_calls=8,
+            ):
+                self._compressor()._build_chunk_digests(turns)
 
         assert calls == 1
 

--- a/tests/agent/test_compression_attempt_ownership.py
+++ b/tests/agent/test_compression_attempt_ownership.py
@@ -264,7 +264,6 @@ class TestLeanAttemptProviderBudget:
 
         with _compression_attempt_provider_budget(max_calls=3) as budget:
             assert budget.try_start_call()  # reserve the main-summary request
-            budget.finish_call()
             result = self._compressor()._build_chunk_digests(turns)
 
         assert len(prompts) == 2


### PR DESCRIPTION
## What does this PR do?

Lean compression can currently issue up to 29 auxiliary model requests in one logical attempt, and a worker that loses its commit fence can continue issuing chunk-digest requests after its result becomes unpublishable. This change gives each attempt one context-local eight-call budget, coarsens digest segmentation to cover the whole source within the remaining slots, and propagates commit-fence cancellation into both queued and in-flight auxiliary work.

### Symptom

An oversized lean-mode session can repeatedly time out without committing progress while detached attempts continue consuming compression requests.

### Impact

Affected sessions can accumulate substantial auxiliary-model usage and latency without producing a usable compressed summary. The reported session recorded 877 cumulative compression calls while repeated attempts could each plan up to 29 more calls.

### Bug Cause

**Trigger:** `agent/context_compressor.py:_build_chunk_digests` after a large lean-mode summary, combined with host timeout cancellation in `agent/conversation_compression.py:compress_context`.

**Causal chain:**
1. Lean mode issues one summary request and then plans as many as 28 sequential digest requests.
2. The host can cancel the commit fence and detach the worker after the progress ceiling, but the digest loop does not consult that fence before another provider request.
3. A fallback or later attempt starts against unchanged state while the old worker continues consuming auxiliary requests whose commit will be rejected.

**Why it is wrong:** The commit fence protects session mutation but did not bound or revoke provider work, so resource consumption outlived attempt ownership.

**Working sibling / contrast:** Legacy mode uses one summary request and therefore does not have the lean digest fan-out. The same reported session completed with one legacy compression request.

**Ruled out:** The 877-call figure is not treated as one attempt. The deterministic live constants still show the per-attempt amplification: one summary plus up to 28 digest requests.

### Fix

Each built-in compression call now establishes an attempt-local provider budget using a `ContextVar`, so overlapping detached and fallback workers cannot share counters. Summary retries and digest calls reserve from the same eight-call cap. Digest chunks are made coarser when fewer slots remain, preserving coverage of the full compacted region instead of dropping its newest tail. Commit-fence cancellation is also passed to the auxiliary transport and checked before each digest dispatch, stopping both in-flight and subsequent provider work once ownership is lost. Plugin context engines do not receive the private cancellation argument unless they explicitly opt into that signature.

## Related Issue

Closes #97648

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` - add the attempt-local call budget, budget-aware digest coarsening, and pre-dispatch cancellation checks.
- `agent/conversation_compression.py` - propagate commit-fence cancellation through the built-in compressor and auxiliary request scope without changing plugin kwargs.
- `tests/agent/test_compression_attempt_ownership.py` - cover total digest admission, full-region coarsening, cancellation, and plugin signature isolation.

## How to Test

1. Run the deterministic attempt-budget and ownership tests.
2. Run the compressor, concurrent timeout/fence, and worker-isolation suites.

```bash
scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_compression_worker_isolation_76354.py tests/agent/test_compression_attempt_ownership.py -q
```

Result: 211 tests passed before the final focused test addition; the updated focused file then passed all 14 tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant repository test entry and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A; behavior and internal contract are documented in code and tests
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no contributor workflow changed
- [x] I've considered cross-platform impact; the implementation uses Python `ContextVar` and existing cancellation primitives
- [x] Tool description/schema updates are N/A; no model tool changed

## Screenshots / Logs

N/A - verified with deterministic automated tests.
