### PR TITLE
feat(config): confirm agent model routing changes

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2512,6 +2512,11 @@ DEFAULT_CONFIG = {
         # modal; HERMES_TUI_NO_CONFIRM=1 force-skips that modal regardless of
         # the configured value.
         "destructive_slash_confirm": True,
+        # Agent-tool calls that change model routing require confirmation even
+        # when approvals.mode is off. Direct human CLI writes do not traverse
+        # the agent-tool approval boundary; an explicitly user-directed agent
+        # write marks that intent with ``hermes config set --yes``.
+        "model_config_confirm": True,
     },
 
     # Permanently allowed dangerous command patterns (added via "always" approval)

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -46,12 +46,22 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
         help="Skip the unknown-key notice printed after writing a key the "
         "running version doesn't recognize (the value is saved either way).",
     )
+    config_set.add_argument(
+        "--yes",
+        action="store_true",
+        help="Mark an agent-run model-routing change as explicitly user-directed",
+    )
 
     # config unset
     config_unset = config_subparsers.add_parser(
         "unset", help="Remove a configuration value"
     )
     config_unset.add_argument("key", nargs="?", help="Configuration key to remove")
+    config_unset.add_argument(
+        "--yes",
+        action="store_true",
+        help="Mark an agent-run model-routing change as explicitly user-directed",
+    )
 
     # config path
     config_subparsers.add_parser("path", help="Print config file path")

--- a/tests/tools/test_model_config_approval.py
+++ b/tests/tools/test_model_config_approval.py
@@ -1,0 +1,241 @@
+"""Agent-originated model-routing config writes require explicit consent."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+import time
+from unittest.mock import MagicMock
+
+import tools.approval as approval
+import tools.terminal_tool as terminal_tool
+from hermes_cli.config import DEFAULT_CONFIG
+from hermes_cli.subcommands.config import build_config_parser
+
+
+def _allow_tirith(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "tools.tirith_security.check_command_security",
+        lambda _command: {"action": "allow", "findings": [], "summary": ""},
+    )
+
+
+def test_model_config_confirm_defaults_on() -> None:
+    assert DEFAULT_CONFIG["approvals"]["model_config_confirm"] is True
+
+
+def test_detects_only_model_routing_config_set_commands() -> None:
+    protected = {
+        "hermes config set model.default gpt-5": "model.default",
+        "hermes config set --force model.provider openrouter": "model.provider",
+        "hermes -p coder config set delegation.model sonnet": "delegation.model",
+        "hermes config set delegation.provider anthropic": "delegation.provider",
+        "env hermes config set model.default gpt-5": "model.default",
+        "echo ready && hermes config set model.provider openai": "model.provider",
+        "hermes config unset delegation.model": "delegation.model",
+        "hermes config set auxiliary.title_generation.model fast":
+            "auxiliary.title_generation.model",
+        "hermes config set auxiliary.vision.base_url https://example.test":
+            "auxiliary.vision.base_url",
+    }
+    for command, key in protected.items():
+        change = approval.detect_model_config_change(command)
+        assert change is not None, command
+        assert change.key == key
+        assert change.user_directed is False
+
+    for command in (
+        "hermes config get delegation.model",
+        "hermes config set display.skin mono",
+        "echo hermes config set model.default gpt-5",
+        "printf 'hermes config set model.default gpt-5'",
+        "hermes config set auxiliary.vision.timeout 30",
+    ):
+        assert approval.detect_model_config_change(command) is None, command
+
+
+def test_yes_marks_explicit_user_direction() -> None:
+    change = approval.detect_model_config_change(
+        "hermes config set --yes delegation.model sonnet"
+    )
+    assert change is not None
+    assert change.user_directed is True
+
+
+def test_model_config_gate_survives_approvals_off(monkeypatch) -> None:
+    _allow_tirith(monkeypatch)
+    monkeypatch.setattr(
+        approval,
+        "_get_approval_config",
+        lambda: {"mode": "off", "model_config_confirm": True},
+    )
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False)
+    token = approval.set_hermes_interactive_context(True)
+    seen = []
+    try:
+        result = approval.check_all_command_guards(
+            "hermes config set delegation.model sonnet",
+            "local",
+            approval_callback=lambda command, description, **kwargs: (
+                seen.append((command, description, kwargs)) or "once"
+            ),
+        )
+    finally:
+        approval.reset_hermes_interactive_context(token)
+
+    assert result["approved"] is True
+    assert result["user_approved"] is True
+    assert seen
+    assert "delegation.model" in seen[0][1]
+
+
+def test_user_directed_or_opted_out_writes_skip_model_gate(monkeypatch) -> None:
+    _allow_tirith(monkeypatch)
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False)
+    token = approval.set_hermes_interactive_context(True)
+    try:
+        for command, config in (
+            (
+                "hermes config set --yes delegation.model sonnet",
+                {"mode": "off", "model_config_confirm": True},
+            ),
+            (
+                "hermes config set delegation.model sonnet",
+                {"mode": "off", "model_config_confirm": False},
+            ),
+        ):
+            monkeypatch.setattr(approval, "_get_approval_config", lambda config=config: config)
+            result = approval.check_all_command_guards(
+                command,
+                "local",
+                approval_callback=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("approval callback should not run")
+                ),
+            )
+            assert result == {"approved": True, "message": None}
+    finally:
+        approval.reset_hermes_interactive_context(token)
+
+
+def test_always_approve_disables_future_model_config_confirmation(monkeypatch) -> None:
+    _allow_tirith(monkeypatch)
+    monkeypatch.setattr(
+        approval,
+        "_get_approval_config",
+        lambda: {"mode": "manual", "model_config_confirm": True},
+    )
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False)
+    saved = []
+    monkeypatch.setattr(
+        "hermes_cli.config.set_config_value",
+        lambda key, value: saved.append((key, value)),
+    )
+    token = approval.set_hermes_interactive_context(True)
+    try:
+        result = approval.check_all_command_guards(
+            "hermes config set delegation.provider anthropic",
+            "local",
+            approval_callback=lambda *_args, **_kwargs: "always",
+        )
+    finally:
+        approval.reset_hermes_interactive_context(token)
+
+    assert result["approved"] is True
+    assert saved == [("approvals.model_config_confirm", "false")]
+
+
+def test_gateway_receives_model_config_confirmation_when_mode_is_off(monkeypatch) -> None:
+    _allow_tirith(monkeypatch)
+    session_key = "model-config-gateway"
+    approval.clear_session(session_key)
+    approval._gateway_queues.clear()
+    approval._gateway_notify_cbs.clear()
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.setattr(
+        approval,
+        "_get_approval_config",
+        lambda: {"mode": "off", "model_config_confirm": True, "timeout": 5},
+    )
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False)
+    notified = []
+    approval.register_gateway_notify(session_key, notified.append)
+    result_holder = {}
+
+    thread = threading.Thread(
+        target=lambda: result_holder.setdefault(
+            "result",
+            approval.check_all_command_guards(
+                "hermes config set model.default gpt-5", "local"
+            ),
+        )
+    )
+    thread.start()
+    for _ in range(200):
+        if approval._gateway_queues.get(session_key):
+            break
+        time.sleep(0.005)
+    approval.resolve_gateway_approval(session_key, "once")
+    thread.join(timeout=5)
+
+    assert result_holder["result"]["approved"] is True
+    assert notified
+    assert "model.default" in notified[0]["description"]
+
+
+def test_config_set_parser_accepts_user_directed_yes_flag() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_config_parser(subparsers, cmd_config=lambda _args: None)
+
+    args = parser.parse_args(
+        ["config", "set", "--yes", "delegation.model", "sonnet"]
+    )
+    assert args.yes is True
+    assert args.key == "delegation.model"
+
+    args = parser.parse_args(
+        ["config", "unset", "--yes", "delegation.model"]
+    )
+    assert args.yes is True
+    assert args.key == "delegation.model"
+
+
+def test_terminal_result_keeps_model_config_change_visible(monkeypatch, tmp_path) -> None:
+    mock_env = MagicMock()
+    mock_env.execute.return_value = {"output": "saved", "returncode": 0}
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "local",
+            "timeout": 30,
+            "cwd": str(tmp_path),
+            "host_cwd": None,
+            "modal_mode": "auto",
+            "docker_image": "",
+            "singularity_image": "",
+            "modal_image": "",
+            "daytona_image": "",
+        },
+    )
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool, "_check_all_guards", lambda *_args, **_kwargs: {"approved": True}
+    )
+    monkeypatch.setitem(terminal_tool._active_environments, "default", mock_env)
+    monkeypatch.setitem(terminal_tool._last_activity, "default", 0.0)
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            command="hermes config set --yes delegation.model sonnet"
+        )
+    )
+
+    assert result["exit_code"] == 0
+    assert result["notice"] == (
+        "⚠ Agent changed model-routing config: delegation.model."
+    )
+    assert result["output"].startswith(result["notice"])

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -23,13 +23,83 @@ import threading
 import time
 import unicodedata
 import uuid
-from typing import Optional
+from typing import NamedTuple, Optional
 from hermes_cli.config import cfg_get
 
 from tools.interrupt import is_interrupted
 from utils import env_var_enabled, is_truthy_value
 
 logger = logging.getLogger(__name__)
+
+
+class ModelConfigChange(NamedTuple):
+    """A direct ``hermes config set`` targeting model routing."""
+
+    key: str
+    user_directed: bool
+
+
+_MODEL_CONFIG_PATTERN_KEY = "agent:model-routing-config"
+_MODEL_CONFIG_LEAF_KEYS = {"model", "provider", "base_url"}
+
+
+def _is_model_routing_key(key: str) -> bool:
+    normalized = key.strip().lower()
+    if normalized == "model" or normalized.startswith("model."):
+        return True
+    if normalized in {"delegation.model", "delegation.provider"}:
+        return True
+    parts = normalized.split(".")
+    return (
+        len(parts) >= 3
+        and parts[0] == "auxiliary"
+        and parts[-1] in _MODEL_CONFIG_LEAF_KEYS
+    )
+
+
+def detect_model_config_change(command: str) -> ModelConfigChange | None:
+    """Recognize direct agent invocations that alter model routing.
+
+    Human terminal invocations never pass through this agent-tool guard.
+    ``--yes`` marks a change explicitly directed by the user in the current
+    conversation.
+    """
+    if not isinstance(command, str) or not command.strip():
+        return None
+    for word_start, _, raw_word in _iter_shell_command_word_spans(command):
+        executable = os.path.basename(
+            _deobfuscate_shell_word_for_detection(raw_word)
+        ).lower()
+        if executable not in {"hermes", "hermes.exe"}:
+            continue
+        try:
+            words = shlex.split(command[word_start:], posix=os.name != "nt")
+        except ValueError:
+            continue
+        try:
+            config_index = words.index("config", 1)
+        except ValueError:
+            continue
+        if config_index + 1 >= len(words):
+            continue
+        action = words[config_index + 1]
+        if action not in {"set", "unset"}:
+            continue
+
+        set_args = words[config_index + 2 :]
+        user_directed = "--yes" in set_args
+        positionals = [
+            word for word in set_args if word not in {"--force", "--yes"}
+        ]
+        required_positionals = 2 if action == "set" else 1
+        if (
+            len(positionals) >= required_positionals
+            and _is_model_routing_key(positionals[0])
+        ):
+            return ModelConfigChange(
+                positionals[0].strip().lower(), user_directed
+            )
+    return None
 
 # Freeze YOLO mode at module import time. Reading os.environ on every call
 # would allow any skill running inside the process to set this variable and
@@ -3400,6 +3470,38 @@ def _get_approval_mode() -> str:
     return _normalize_approval_mode(mode)
 
 
+def _model_config_confirmation_enabled() -> bool:
+    """Return the independent model-routing confirmation policy."""
+    return is_truthy_value(
+        _get_approval_config().get("model_config_confirm", True)
+    )
+
+
+def _apply_warning_approval_choice(
+    choice: str,
+    warnings: list[tuple[str, str, bool]],
+    session_key: str,
+) -> None:
+    """Persist the scope selected for a combined command warning."""
+    for key, _, is_tirith in warnings:
+        if choice == "session" or (choice == "always" and is_tirith):
+            approve_session(session_key, key)
+        elif choice == "always" and key == _MODEL_CONFIG_PATTERN_KEY:
+            approve_session(session_key, key)
+            try:
+                from hermes_cli.config import set_config_value
+
+                set_config_value("approvals.model_config_confirm", "false")
+            except (Exception, SystemExit) as exc:
+                logger.warning(
+                    "Failed to persist model-config confirmation opt-out: %s", exc
+                )
+        elif choice == "always":
+            approve_session(session_key, key)
+            approve_permanent(key)
+            save_permanent_allowlist(_permanent_approved)
+
+
 def is_approval_bypass_active_for_session(session_key: str) -> bool:
     """Return whether one exact session bypasses Hermes approval prompts.
 
@@ -4672,13 +4774,25 @@ def check_all_command_guards(command: str, env_type: str,
                        deny_pattern, command[:200])
         return _user_deny_block_result(deny_pattern)
 
-    # --yolo or approvals.mode=off: bypass all approval prompts.
+    model_config_change = detect_model_config_change(command)
+    model_config_guard = bool(
+        model_config_change
+        and not model_config_change.user_directed
+        and _model_config_confirmation_enabled()
+    )
+
+    # --yolo or approvals.mode=off: bypass ordinary approval prompts. The
+    # model-routing gate is independent because these writes affect every
+    # subsequent agent/subagent request and its billing route.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
+    if (
+        not model_config_guard
+        and (_YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off")
+    ):
         return {"approved": True, "message": None}
 
-    if _command_matches_permanent_allowlist(command):
+    if not model_config_guard and _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
     approval_callback = _resolve_cli_approval_callback(approval_callback)
@@ -4700,6 +4814,21 @@ def check_all_command_guards(command: str, env_type: str,
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
+        if model_config_guard:
+            return {
+                "approved": False,
+                "message": (
+                    "BLOCKED: An agent-originated model-routing config change "
+                    "requires user confirmation, but no interactive approval "
+                    "surface is available. If the user explicitly requested this "
+                    "exact change, retry with `hermes config set --yes ...`."
+                ),
+                "pattern_key": _MODEL_CONFIG_PATTERN_KEY,
+                "description": (
+                    f"Agent requested a model-routing config change to "
+                    f"{model_config_change.key}"
+                ),
+            }
         # Single-query (-q) sessions: respect single_query_mode config
         if _is_single_query_approval_context():
             if _get_single_query_approval_mode() == "deny":
@@ -4879,6 +5008,13 @@ def check_all_command_guards(command: str, env_type: str,
 
     # Dangerous command check (detection only, no approval)
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    if model_config_guard:
+        is_dangerous = True
+        pattern_key = _MODEL_CONFIG_PATTERN_KEY
+        description = (
+            f"Agent requested a model-routing config change to "
+            f"{model_config_change.key}"
+        )
 
     # --- Phase 2: Decide ---
 
@@ -4912,7 +5048,7 @@ def check_all_command_guards(command: str, env_type: str,
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
     # (openai/codex#13860).
     smart_denied_for_owner = False
-    if approval_mode == "smart":
+    if approval_mode == "smart" and not model_config_guard:
         combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
         observer_payload = _prepare_smart_approval_observer(
             command=command,
@@ -5015,15 +5151,9 @@ def check_all_command_guards(command: str, env_type: str,
                     "user_consent": False,
                 }
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
-                    if transport_choice == "session" or (
-                        transport_choice == "always" and is_tirith
-                    ):
-                        approve_session(session_key, key)
-                    elif transport_choice == "always":
-                        approve_session(session_key, key)
-                        approve_permanent(key)
-                        save_permanent_allowlist(_permanent_approved)
+                _apply_warning_approval_choice(
+                    transport_choice, warnings, session_key
+                )
             _reset_denials(session_key)
             return {
                 "approved": True,
@@ -5131,13 +5261,7 @@ def check_all_command_guards(command: str, env_type: str,
             # older client returns "session" or "always". Manual and ESCALATE
             # choices retain their existing persistence semantics.
             if not smart_denied_for_owner:
-                for key, _, is_tirith in warnings:
-                    if choice == "session" or (choice == "always" and is_tirith):
-                        approve_session(session_key, key)
-                    elif choice == "always":
-                        approve_session(session_key, key)
-                        approve_permanent(key)
-                        save_permanent_allowlist(_permanent_approved)
+                _apply_warning_approval_choice(choice, warnings, session_key)
 
             # A human approval (including an ESCALATE-then-approve or a
             # smart-DENY owner override) resets the consecutive-denial tally.
@@ -5258,15 +5382,7 @@ def check_all_command_guards(command: str, env_type: str,
     # Smart-DENY owner overrides are one-operation scoped. Preserve existing
     # persistence for manual mode and smart ESCALATE.
     if not smart_denied_for_owner:
-        for key, _, is_tirith in warnings:
-            if choice == "session" or (choice == "always" and is_tirith):
-                # tirith: session only (no permanent broad allowlisting)
-                approve_session(session_key, key)
-            elif choice == "always":
-                # dangerous patterns: permanent allowed
-                approve_session(session_key, key)
-                approve_permanent(key)
-                save_permanent_allowlist(_permanent_approved)
+        _apply_warning_approval_choice(choice, warnings, session_key)
 
     # A human approval resets the consecutive-denial tally.
     _reset_denials(session_key)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -357,6 +357,7 @@ def _reset_cached_sudo_passwords() -> None:
 # Dangerous command detection + approval now consolidated in tools/approval.py
 from tools.approval import (
     check_all_command_guards as _check_all_guards_impl,
+    detect_model_config_change,
 )
 
 
@@ -1134,6 +1135,8 @@ TERMINAL_TOOL_DESCRIPTION = """Execute shell commands. The host OS, shell, and t
 
 Do NOT use cat/head/tail (use read_file), grep/rg/find/ls (use search_files), sed/awk (use patch), or echo/heredoc file creation (use write_file). Reserve terminal for: builds, installs, git, processes, scripts, network, package managers — anything that needs a shell. Output is auto-truncated with the full text saved to a file — never pipe through tail/head to shorten it.
 Environment state persists: activate a virtualenv or export variables once per session, not before every command.
+
+Never silently rewrite model-routing config. For `model.*`, `delegation.model`, `delegation.provider`, or auxiliary model/provider/base-URL changes, use `hermes config set --yes ...` / `config unset --yes ...` only when the user explicitly directed that exact change; otherwise omit `--yes` so Hermes asks for confirmation. Always report the persisted change.
 
 Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.
 Background: set background=true (returns a session_id); add notify=true for bounded tasks, leave silent only for servers/daemons that never exit. After starting a server, verify readiness with a health check in a separate call (no blind sleep loops); manage with process(action="poll"/"wait").
@@ -3227,6 +3230,7 @@ def terminal_tool(
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)
         approval_note = None
+        model_config_change = detect_model_config_change(command)
         # True when the user explicitly approved this run (or pre-confirmed via
         # force).  Drives the clean-interrupt-slate clear before env.execute so
         # an approved command can't be SIGINT-killed by a bit that landed during
@@ -3329,6 +3333,11 @@ def terminal_tool(
                 # cannot occur here and this note never co-occurs with rc=130.
                 if approval_note:
                     result_data["approval"] = approval_note
+                if model_config_change:
+                    result_data["notice"] = (
+                        "⚠ Agent started a model-routing config change: "
+                        f"{model_config_change.key}."
+                    )
                 if pty_disabled_reason:
                     result_data["pty_note"] = pty_disabled_reason
 
@@ -3834,6 +3843,17 @@ def terminal_tool(
                     result_dict["approval"] = approval_note.rstrip(".") + ", then interrupted."
                 else:
                     result_dict["approval"] = approval_note
+            if model_config_change and returncode == 0:
+                notice = (
+                    "⚠ Agent changed model-routing config: "
+                    f"{model_config_change.key}."
+                )
+                result_dict["notice"] = notice
+                result_dict["output"] = (
+                    f"{notice}\n{result_dict['output']}"
+                    if result_dict["output"]
+                    else notice
+                )
             if exit_note:
                 result_dict["exit_code_meaning"] = exit_note
             if failure_hint:


### PR DESCRIPTION
## What does this PR do?

Adds a default-on confirmation gate for agent-originated model-routing configuration changes. The gate remains active when `approvals.mode` is `off`, while direct human CLI commands remain unchanged and explicitly user-directed agent changes can use the inline `--yes` marker.

### Motivation

Model-routing keys control the models and providers used by future agent and subagent requests. Agent sessions could previously change those persistent billing-relevant routes through `hermes config set` without a dedicated confirmation or durable user-visible notice.

### Behavior

- Agent terminal calls that set or unset `model.*`, `delegation.model`, `delegation.provider`, or auxiliary model/provider/base-URL keys request confirmation by default.
- The independent `approvals.model_config_confirm` setting defaults to `true`, including when ordinary command approvals are disabled.
- Direct human CLI invocations do not cross the agent-tool guard.
- An agent may use `config set --yes` or `config unset --yes` only when the user explicitly requested that exact change.
- Successful writes add a persistent warning line to the terminal tool result. Headless agent contexts fail closed when no approval surface is available.

### Implementation

The terminal approval layer recognizes direct and shell-wrapped Hermes config invocations at real command positions, routes them through the existing CLI/gateway/plugin approval transports, and persists an Always Approve choice through the dedicated config key. The terminal tool schema documents the user-direction contract, and focused tests cover CLI and gateway surfaces, `approvals.mode: off`, opt-out persistence, shell wrappers, false-positive prose, parser flags, and result notices.

## Related Issue

Closes #97652

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/approval.py` - detect model-routing config changes and enforce the independent confirmation policy across approval transports.
- `tools/terminal_tool.py` - document explicit user direction and keep successful changes visible in tool output.
- `hermes_cli/config_defaults.py` - add the default-on `approvals.model_config_confirm` setting.
- `hermes_cli/subcommands/config.py` - accept the explicit `--yes` marker for set and unset.
- `tests/tools/test_model_config_approval.py` - cover protected keys, bypass boundaries, CLI/gateway approvals, persistence, parser behavior, and notices.

## How to Test

1. With `approvals.mode: off`, invoke an agent terminal call that runs `hermes config set delegation.model <value>` and verify an approval request appears.
2. Run the same command with `--yes` after explicitly directing the exact change and verify it proceeds while the result still contains the warning notice.
3. Run the automated coverage:

```bash
scripts/run_tests.sh tests/tools/test_model_config_approval.py -q
scripts/run_tests.sh tests/tools/test_approval.py -k 'not TestDetectDangerousRm' -q
scripts/run_tests.sh tests/tools/test_terminal_output_transform_hook.py -k 'not large_process_output' -q
scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_destructive_slash_confirm_gate.py -q
```

The focused and neighboring selections pass on Windows 11. The unfiltered neighboring run also exposed three existing host-assumption failures: two POSIX `/tmp` expectations in `TestDetectDangerousRm` and one test command that requires unavailable `python3`; none execute the changed model-config path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant test entry points and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant behavior is documented in the terminal tool schema and config default comments
- [x] `cli-config.yaml.example` is N/A; it does not enumerate approval defaults
- [x] Architecture/workflow documentation changes are N/A
- [x] I've considered cross-platform impact; detection uses the existing quote-aware shell command-position parser
- [x] I've updated the terminal tool description for the new behavior
