### PR TITLE
fix(mcp): make reconnect retries safe for write tools

### DIFF
--- a/tests/tools/test_mcp_reconnect_bounded_wait.py
+++ b/tests/tools/test_mcp_reconnect_bounded_wait.py
@@ -1,0 +1,132 @@
+"""Tests for bounded readiness waits on MCP read-path handlers.
+
+When a call lands while an MCP server is still completing its initial
+connection or a reconnect, ``server.session`` is briefly ``None``. The
+``tools/call`` handler (``_make_tool_handler``) already waits briefly for a
+fresh session instead of failing immediately (see #26892). The four
+protocol-level read handlers -- ``list_resources``, ``read_resource``,
+``list_prompts``, ``get_prompt`` -- did not share that wait: they returned
+"not connected" the instant ``session`` was ``None``, even though a
+reconnect might complete a fraction of a second later. This file locks in
+the fix: all read-path handlers wait up to a bounded timeout for a live
+session before giving up, and still fail (rather than hang) when the
+session never comes back.
+"""
+import json
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _install_connecting_server(name: str):
+    """Register a real MCPServerTask with no session yet (mid-connect)."""
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    mcp_tool._ensure_mcp_loop()
+    server = MCPServerTask(name)
+    server.session = None
+    mcp_tool._servers[name] = server
+    return server
+
+
+def _make_ready_result(session_method: str):
+    """Return a MagicMock session whose *session_method* succeeds cleanly."""
+    session = MagicMock()
+
+    if session_method == "list_resources":
+        result = MagicMock(resources=[], nextCursor=None)
+    elif session_method == "read_resource":
+        result = MagicMock(contents=[])
+    elif session_method == "list_prompts":
+        result = MagicMock(prompts=[], nextCursor=None)
+    else:  # get_prompt
+        result = MagicMock(messages=[], description=None)
+
+    async def _call(*a, **kw):
+        return result
+
+    setattr(session, session_method, _call)
+    return session
+
+
+@pytest.mark.parametrize(
+    "handler_factory, handler_kwargs, session_method, call_args",
+    [
+        ("_make_list_resources_handler", {"tool_timeout": 2.0}, "list_resources", {}),
+        ("_make_read_resource_handler", {"tool_timeout": 2.0}, "read_resource", {"uri": "file://x"}),
+        ("_make_list_prompts_handler", {"tool_timeout": 2.0}, "list_prompts", {}),
+        ("_make_get_prompt_handler", {"tool_timeout": 2.0}, "get_prompt", {"name": "p1"}),
+    ],
+)
+def test_read_handler_waits_for_session_instead_of_failing_immediately(
+    monkeypatch, tmp_path, handler_factory, handler_kwargs, session_method, call_args,
+):
+    """A call arriving mid-connect must wait for the session, not fail
+    on the spot -- a reconnect that completes 150ms later should still
+    let the call through."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    server_name = f"connecting-{session_method}"
+    server = _install_connecting_server(server_name)
+
+    def _finish_connecting():
+        time.sleep(0.15)
+        server.session = _make_ready_result(session_method)
+        server._ready.set()
+
+    threading.Thread(target=_finish_connecting, daemon=True).start()
+
+    try:
+        factory = getattr(mcp_tool, handler_factory)
+        handler = factory(server_name, **handler_kwargs)
+        out = handler(call_args)
+        parsed = json.loads(out)
+        assert "error" not in parsed, (
+            f"{handler_factory}: expected the handler to wait for the "
+            f"in-flight (re)connect and succeed, got {parsed}"
+        )
+    finally:
+        mcp_tool._servers.pop(server_name, None)
+
+
+@pytest.mark.parametrize(
+    "handler_factory, handler_kwargs, call_args",
+    [
+        ("_make_list_resources_handler", {"tool_timeout": 0.6}, {}),
+        ("_make_read_resource_handler", {"tool_timeout": 0.6}, {"uri": "file://x"}),
+        ("_make_list_prompts_handler", {"tool_timeout": 0.6}, {}),
+        ("_make_get_prompt_handler", {"tool_timeout": 0.6}, {"name": "p1"}),
+    ],
+)
+def test_read_handler_bounded_wait_times_out_cleanly(
+    monkeypatch, tmp_path, handler_factory, handler_kwargs, call_args,
+):
+    """If the session never comes back, the handler must still return an
+    error (not hang forever) -- and it must have actually waited some of
+    the bounded window rather than failing on the very first check."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    server_name = f"never-ready-{handler_factory}"
+    _install_connecting_server(server_name)
+
+    try:
+        factory = getattr(mcp_tool, handler_factory)
+        handler = factory(server_name, **handler_kwargs)
+        started = time.monotonic()
+        out = handler(call_args)
+        elapsed = time.monotonic() - started
+        parsed = json.loads(out)
+        assert "error" in parsed
+        assert elapsed >= 0.2, (
+            f"{handler_factory}: expected a bounded wait of a real fraction "
+            f"of the timeout budget before giving up, only waited {elapsed:.3f}s"
+        )
+    finally:
+        mcp_tool._servers.pop(server_name, None)

--- a/tests/tools/test_mcp_session_expired_write_no_replay.py
+++ b/tests/tools/test_mcp_session_expired_write_no_replay.py
@@ -1,0 +1,191 @@
+"""Tests for the write-safety carve-out in session-expired retry (gcal-mcp
+stabilization, 2026-08-28).
+
+``_handle_session_expired_and_retry`` reconnects the transport and replays
+the failed call once. That is safe for read-only tools (idempotent), but a
+session-expired error (broken pipe / closed stream / EOF) can also fire
+*after* a write already reached the remote server, just before its response
+made it back over the wire. Blindly replaying a ``create_event``-style call
+in that window could duplicate the write. Tools without a discovery-time
+``readOnlyHint: true`` annotation (fail-closed default: unknown metadata is
+write-capable, matching ``_annotation_read_only_hint``) must therefore never
+be transparently replayed — only the transport gets reconnected, and the
+caller is told the outcome is unknown.
+"""
+import json
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _install_stub_server(name: str):
+    """Minimal server stub: reconnect swaps in a fresh session + fires ready."""
+    from tools import mcp_tool
+
+    mcp_tool._ensure_mcp_loop()
+
+    server = MagicMock()
+    server.name = name
+
+    ready_flag = threading.Event()
+    ready_flag.set()
+
+    class _ReadyAdapter:
+        def is_set(self):
+            return ready_flag.is_set()
+
+        def clear(self):
+            ready_flag.clear()
+
+        def set(self):
+            ready_flag.set()
+
+    server._ready = _ReadyAdapter()
+
+    class _EventAdapter:
+        def set(self):
+            old_session = server.session
+            new_session = MagicMock()
+            if hasattr(old_session, "call_tool"):
+                new_session.call_tool = old_session.call_tool
+            server.session = new_session
+            ready_flag.set()
+
+    server._reconnect_event = _EventAdapter()
+    server.session = MagicMock()
+    mcp_tool._servers[name] = server
+    return server
+
+
+# ---------------------------------------------------------------------------
+# _handle_session_expired_and_retry(retryable=...) — unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_non_retryable_reconnects_but_does_not_replay(monkeypatch, tmp_path):
+    """retryable=False must still heal the transport, but must NOT call
+    retry_call — and the returned error must flag the outcome as unknown."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _handle_session_expired_and_retry
+
+    server = _install_stub_server("gcal-write")
+    call_count = {"n": 0}
+
+    def _retry_call():
+        call_count["n"] += 1
+        return '{"result": "created"}'
+
+    try:
+        out = _handle_session_expired_and_retry(
+            "gcal-write",
+            RuntimeError("Session terminated"),
+            _retry_call,
+            "tools/call create_event",
+            retryable=False,
+        )
+        assert call_count["n"] == 0, (
+            "a non-read-only tool must never have its call replayed after "
+            "a session-expired transport error"
+        )
+        assert out is not None
+        parsed = json.loads(out)
+        assert parsed.get("error"), parsed
+        assert parsed.get("uncertain_outcome") is True, parsed
+        # Transport must still have been reconnected so the *next* call works.
+        assert server._ready.is_set()
+    finally:
+        mcp_tool._servers.pop("gcal-write", None)
+
+
+def test_retryable_default_still_replays(monkeypatch, tmp_path):
+    """Sanity guard: the default (retryable=True, existing read-path
+    behavior) is unchanged by the new parameter."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _handle_session_expired_and_retry
+
+    server = _install_stub_server("gcal-read")
+    call_count = {"n": 0}
+
+    def _retry_call():
+        call_count["n"] += 1
+        return '{"result": "ok"}'
+
+    try:
+        out = _handle_session_expired_and_retry(
+            "gcal-read",
+            RuntimeError("Session terminated"),
+            _retry_call,
+            "resources/list",
+        )
+        assert call_count["n"] == 1
+        assert json.loads(out) == {"result": "ok"}
+    finally:
+        mcp_tool._servers.pop("gcal-read", None)
+
+
+# ---------------------------------------------------------------------------
+# _make_tool_handler wiring — readOnlyHint drives retryable end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "read_only_hint, expect_replay",
+    [
+        (True, True),
+        (False, False),
+        (None, False),  # missing hint fails closed to write-capable
+    ],
+)
+def test_tool_handler_replay_gated_by_read_only_hint(
+    monkeypatch, tmp_path, read_only_hint, expect_replay,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    server_name = f"gcal-hint-{read_only_hint}"
+    server = _install_stub_server(server_name)
+    mcp_tool._server_error_counts.pop(server_name, None)
+    mcp_tool._server_breaker_opened_at.pop(server_name, None)
+
+    if read_only_hint is None:
+        mcp_tool._tool_read_only_hints.pop(server_name, None)
+    else:
+        mcp_tool._tool_read_only_hints[server_name] = {
+            "create_event": read_only_hint,
+        }
+
+    call_count = {"n": 0}
+
+    async def _call_tool(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("Broken pipe")
+        result = MagicMock()
+        result.is_error = False
+        result.content = [MagicMock(type="text", text="second-call-result")]
+        result.structured_content = None
+        return result
+
+    server.session.call_tool = _call_tool
+
+    try:
+        handler = _make_tool_handler(server_name, "create_event", 10.0)
+        out = json.loads(handler({}))
+        if expect_replay:
+            assert call_count["n"] == 2, "read-only tool should be replayed once"
+            assert out == {"result": "second-call-result"}
+        else:
+            assert call_count["n"] == 1, (
+                "write-capable tool must not be replayed after a "
+                "session-expired transport error"
+            )
+            assert out.get("uncertain_outcome") is True, out
+    finally:
+        mcp_tool._servers.pop(server_name, None)
+        mcp_tool._tool_read_only_hints.pop(server_name, None)
+        mcp_tool._server_error_counts.pop(server_name, None)
+        mcp_tool._server_breaker_opened_at.pop(server_name, None)

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -182,6 +182,11 @@ def test_call_tool_handler_rebuilds_configured_server_transport(
     mcp_tool._servers["resumed"] = server
     mcp_tool._server_error_counts.pop("resumed", None)
     mcp_tool._server_breaker_opened_at.pop("resumed", None)
+    # This test exercises the transport-rebuild plumbing itself, not the
+    # write-replay safety gate — mark the probe tool read-only so the
+    # session-expired retry is allowed to fire (see the write-tool
+    # non-replay coverage below for the opposite case).
+    mcp_tool._tool_read_only_hints["resumed"] = {"health": True}
     loop = mcp_tool._mcp_loop
     assert loop is not None
     run_future = asyncio.run_coroutine_threadsafe(
@@ -205,6 +210,7 @@ def test_call_tool_handler_rebuilds_configured_server_transport(
         mcp_tool._servers.pop("resumed", None)
         mcp_tool._server_error_counts.pop("resumed", None)
         mcp_tool._server_breaker_opened_at.pop("resumed", None)
+        mcp_tool._tool_read_only_hints.pop("resumed", None)
 
 
 def test_session_expired_retry_waits_for_new_session(monkeypatch, tmp_path):
@@ -272,6 +278,10 @@ def test_session_expired_retry_waits_for_new_session(monkeypatch, tmp_path):
     mcp_tool._server_breaker_opened_at["hindsight"] = (
         time.monotonic() - mcp_tool._CIRCUIT_BREAKER_COOLDOWN_SEC - 1.0
     )
+    # This test covers the reconnect-then-retry mechanics, not the write
+    # replay gate — "get_bank" is a read, so mark it read-only to allow
+    # the retry through (write-tool non-replay is covered separately).
+    mcp_tool._tool_read_only_hints["hindsight"] = {"get_bank": True}
 
     try:
         handler = _make_tool_handler("hindsight", "get_bank", 10.0)
@@ -283,6 +293,85 @@ def test_session_expired_retry_waits_for_new_session(monkeypatch, tmp_path):
         mcp_tool._servers.pop("hindsight", None)
         mcp_tool._server_error_counts.pop("hindsight", None)
         mcp_tool._server_breaker_opened_at.pop("hindsight", None)
+        mcp_tool._tool_read_only_hints.pop("hindsight", None)
+
+
+def test_session_expired_write_tool_does_not_retry(monkeypatch, tmp_path):
+    """A write-capable tool (no readOnlyHint=true) must NOT be replayed
+    after a session-expired transport drop — the original call may have
+    already reached the remote server. The handler should reconnect the
+    transport but surface an "outcome unknown" error instead of guessing.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    mcp_tool._ensure_mcp_loop()
+    server = MagicMock()
+    server.name = "hindsight"
+    ready_flag = threading.Event()
+    ready_flag.set()
+
+    class _ReadyAdapter:
+        def is_set(self):
+            return ready_flag.is_set()
+
+        def clear(self):
+            ready_flag.clear()
+
+        def set(self):
+            ready_flag.set()
+
+    old_session = MagicMock()
+
+    async def _old_call(*a, **kw):
+        raise RuntimeError("Session terminated")
+
+    old_session.call_tool = _old_call
+    new_session = MagicMock()
+    new_call_count = {"n": 0}
+
+    async def _new_call(*a, **kw):
+        new_call_count["n"] += 1
+        result = MagicMock()
+        result.is_error = False
+        result.content = [MagicMock(type="text", text="should not be reached")]
+        result.structured_content = None
+        return result
+
+    new_session.call_tool = _new_call
+    server.session = old_session
+    server._ready = _ReadyAdapter()
+
+    class _ReconnectAdapter:
+        def set(self):
+            server.session = new_session
+            ready_flag.set()
+
+    server._reconnect_event = _ReconnectAdapter()
+    mcp_tool._servers["hindsight"] = server
+    mcp_tool._server_error_counts.pop("hindsight", None)
+    mcp_tool._server_breaker_opened_at.pop("hindsight", None)
+    # No readOnlyHint registered for "create_event" — fail-closed means
+    # write-capable, so the retry must be skipped.
+    mcp_tool._tool_read_only_hints["hindsight"] = {}
+
+    try:
+        handler = _make_tool_handler("hindsight", "create_event", 10.0)
+        parsed = json.loads(handler({}))
+        assert parsed.get("uncertain_outcome") is True, parsed
+        assert "error" in parsed, parsed
+        assert new_call_count["n"] == 0, (
+            "write-capable tool must not be replayed after session expiry"
+        )
+        # Transport was still reconnected even though the call wasn't replayed.
+        assert server.session is new_session
+    finally:
+        mcp_tool._servers.pop("hindsight", None)
+        mcp_tool._server_error_counts.pop("hindsight", None)
+        mcp_tool._server_breaker_opened_at.pop("hindsight", None)
+        mcp_tool._tool_read_only_hints.pop("hindsight", None)
 
 
 def test_session_expired_handler_returns_none_without_loop(monkeypatch):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5159,6 +5159,8 @@ def _handle_session_expired_and_retry(
     exc: BaseException,
     retry_call,
     op_description: str,
+    *,
+    retryable: bool = True,
 ):
     """Trigger a transport reconnect and retry once on session expiry.
 
@@ -5170,18 +5172,33 @@ def _handle_session_expired_and_retry(
     and rebuild them, reusing the existing OAuth provider instance.
     See #13383.
 
+    ``retryable=False`` (callers pass this for non-read-only tools, per
+    each tool's discovery-time ``readOnlyHint``) skips the retry: a
+    session-expired error covers transport drops like a broken pipe or
+    closed stream, which can happen *after* a write already reached the
+    remote server but *before* its response made it back. Blindly
+    replaying ``retry_call`` in that window could duplicate the write
+    (e.g. a second calendar event). Reads are idempotent, so they keep
+    retrying automatically; writes instead surface an "outcome unknown"
+    error once the transport is reconnected, so the caller verifies
+    state before deciding whether to redo the operation.
+
     Args:
         server_name: Name of the MCP server that raised.
         exc: The exception from the failed call.
         retry_call: Zero-arg callable that re-runs the operation,
             returning the same JSON string format as the handler.
         op_description: Human-readable name of the operation (logs).
+        retryable: Whether replaying ``retry_call`` after reconnect is
+            safe. Defaults to True (read-path callers); non-read-only
+            ``tools/call`` invocations must pass False.
 
     Returns:
-        A JSON string if reconnect + retry was attempted and produced
-        a response, or ``None`` to fall through to the caller's
-        generic error path (not a session-expired error, no server
-        record, reconnect didn't ready in time, or retry also failed).
+        A JSON string if reconnect (+ retry, when retryable) was
+        attempted and produced a response, or ``None`` to fall through
+        to the caller's generic error path (not a session-expired
+        error, no server record, reconnect didn't ready in time, or
+        retry also failed).
     """
     if not _is_session_expired_error(exc):
         return None
@@ -5197,8 +5214,9 @@ def _handle_session_expired_and_retry(
 
     logger.info(
         "MCP server '%s': %s failed with session-expired error (%s); "
-        "signalling transport reconnect and retrying once.",
+        "signalling transport reconnect%s.",
         server_name, op_description, exc,
+        " and retrying once" if retryable else " (no replay — not read-only)",
     )
 
     # Trigger the same reconnect mechanism the OAuth recovery path
@@ -5215,6 +5233,23 @@ def _handle_session_expired_and_retry(
             server_name,
         )
         return None
+
+    if not retryable:
+        # The transport is healthy again, but we do not know whether the
+        # original write reached the remote server before the connection
+        # dropped. Replaying it here could duplicate a create/update/delete;
+        # surface that uncertainty instead of guessing.
+        _bump_server_error(server_name)
+        return tool_error(
+            f"MCP server '{server_name}': transport session expired during "
+            f"'{op_description}'. The outcome of that call is unknown — it "
+            f"may have completed on the remote server before the connection "
+            f"dropped. The transport has been reconnected, but this write "
+            f"was NOT retried. Verify current state (e.g. a read/list call) "
+            f"before deciding whether to redo it.",
+            uncertain_outcome=True,
+            server=server_name,
+        )
 
     try:
         result = retry_call()
@@ -6398,9 +6433,19 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # Transport session expiry (#13383): same reconnect flow
             # but skips OAuth recovery because the access token is
             # still valid — only the server-side session is stale.
+            #
+            # Replay is only safe for tools the server declared
+            # readOnlyHint=True at discovery (fail-closed: unknown/missing
+            # hint means write-capable, per _annotation_read_only_hint) —
+            # a session-expired error can mean the write already reached
+            # the remote server before the connection dropped.
+            is_read_only_tool = (
+                _tool_read_only_hints.get(server_name, {}).get(tool_name) is True
+            )
             recovered = _handle_session_expired_and_retry(
                 server_name, exc, _call_once,
                 f"tools/call {tool_name}",
+                retryable=is_read_only_tool,
             )
             if recovered is not None:
                 return recovered
@@ -6417,12 +6462,32 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     return _handler
 
 
+def _get_ready_server_for_read(server_name: str, tool_timeout: float):
+    """Resolve a connected server for a read-path call (resources/prompts).
+
+    Mirrors ``_make_tool_handler``'s session-readiness wait (#26892): a
+    call landing mid-reconnect saw ``server.session`` as ``None`` and the
+    protocol-level read handlers failed instantly instead of giving the
+    in-flight (re)connect a bounded chance to complete. Returns the server
+    once a live session is available, or ``None`` if it never arrives
+    within the bounded window.
+    """
+    server = _get_connected_server_for_call(server_name)
+    if not server:
+        return None
+    if not server.session:
+        _wait_for_server_session_ready(
+            server, timeout=min(5.0, float(tool_timeout or 5.0)),
+        )
+    return server if server.session else None
+
+
 def _make_list_resources_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that lists resources from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
-        if not server or not server.session:
+        server = _get_ready_server_for_read(server_name, tool_timeout)
+        if not server:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
         async def _call():
@@ -6480,8 +6545,8 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that reads a resource by URI from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
-        if not server or not server.session:
+        server = _get_ready_server_for_read(server_name, tool_timeout)
+        if not server:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
         uri = args.get("uri")
@@ -6541,8 +6606,8 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that lists prompts from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
-        if not server or not server.session:
+        server = _get_ready_server_for_read(server_name, tool_timeout)
+        if not server:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
         async def _call():
@@ -6602,8 +6667,8 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that gets a prompt by name from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        server = _get_connected_server_for_call(server_name)
-        if not server or not server.session:
+        server = _get_ready_server_for_read(server_name, tool_timeout)
+        if not server:
             return tool_error(f"MCP server '{server_name}' is not connected")
 
         name = args.get("name")


### PR DESCRIPTION
## Summary
- Read paths (`list_resources`, `read_resource`, `list_prompts`, `get_prompt`) now do a bounded wait for a fresh session on `session expired`/`session not found` instead of failing immediately, then retry once.
- Only tool calls that are known reads (discovery-time `readOnlyHint is True`) are transparently replayed after a reconnect.
- Write or unknown-hint tool calls do not get silently replayed after a session-expiry reconnect — they return an `uncertain_outcome` result instead, so the caller can decide how to proceed rather than risking a duplicate side effect.
- This does not claim exactly-once semantics for the underlying third-party MCP server; it only avoids the agent itself blindly replaying a call whose original outcome is unknown.

## Test plan
- [x] `tests/tools/test_mcp_tool_session_expired.py`
- [x] `tests/tools/test_mcp_reconnect_bounded_wait.py`
- [x] `tests/tools/test_mcp_session_expired_write_no_replay.py`
- 27 passed, 0 failed (run via `uv run python -m pytest` on the three files above)

Originally surfaced against a Google Calendar MCP server (session expiry mid-tool-call), but the fix is a general MCP reconnect/replay-safety change, not calendar-specific.