### PR TITLE
fix(teams): authenticate Bot Framework connector attachment downloads (pasted images 401)

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -898,29 +898,75 @@ class TeamsAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
 
+    async def _get_botframework_token(self) -> str:
+        """Acquire a Bot Framework bearer token via client credentials.
+
+        Needed to download connector attachments (smba.trafficmanager.net
+        /v3/attachments/...), which -- unlike SharePoint file downloadUrls --
+        are NOT pre-authenticated and return 401 without the bot's own
+        token. Token is cached until ~5 minutes before expiry.
+        """
+        import time
+        import httpx
+
+        cached = getattr(self, "_bf_token_cache", None)
+        if cached and cached[1] > time.time() + 300:
+            return cached[0]
+
+        client_id = self._client_id
+        client_secret = self._client_secret
+        tenant_id = self._tenant_id
+        if not (client_id and client_secret and tenant_id):
+            raise ValueError("Missing TEAMS_CLIENT_ID/SECRET/TENANT_ID for attachment auth")
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "scope": "https://api.botframework.com/.default",
+                },
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        token = payload["access_token"]
+        self._bf_token_cache = (token, time.time() + int(payload.get("expires_in", 3600)))
+        return token
+
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
         """Download attachment bytes with SSRF protection.
 
         Teams file attachments carry pre-authenticated SharePoint download
-        URLs (no extra auth header needed). Validates the URL against the
-        SSRF guard and follows redirects through the shared redirect guard,
+        URLs (no extra auth header needed). Bot Framework connector
+        attachment URLs (pasted/inline images on smba.trafficmanager.net /
+        botframework.com hosts) require the bot's bearer token -- detected
+        below and fetched with auth. Validates the URL against the SSRF
+        guard and follows redirects through the shared redirect guard,
         matching the cache_*_from_url helpers in gateway.platforms.base.
         """
+        from urllib.parse import urlparse
         from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
         from gateway.platforms.base import _ssrf_redirect_guard
 
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
 
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
+        host = (urlparse(url).hostname or "").lower()
+        if host.endswith("trafficmanager.net") or host.endswith("botframework.com"):
+            try:
+                headers["Authorization"] = f"Bearer {await self._get_botframework_token()}"
+            except Exception as e:
+                logger.warning("[teams] Could not acquire Bot Framework token for attachment: %s", e)
+
         async with create_ssrf_safe_async_client(
             timeout=timeout,
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
+            response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.content
 
@@ -1024,11 +1070,28 @@ class TeamsAdapter(BasePlatformAdapter):
 
             if content_url and content_type.startswith("image/"):
                 try:
-                    cached = await cache_image_from_url(content_url)
-                    if cached:
-                        media_urls.append(cached)
-                        media_types.append(content_type)
-                        media_kinds.append("image")
+                    from urllib.parse import urlparse as _urlparse
+                    _host = (_urlparse(content_url).hostname or "").lower()
+                    if _host.endswith("trafficmanager.net") or _host.endswith("botframework.com"):
+                        # Bot Framework connector URL: needs the bot's own
+                        # bearer token; the generic cache helper sends none.
+                        data = await self._fetch_attachment_bytes(content_url)
+                        ext = content_type.split("/")[-1].split(";")[0] or "png"
+                        cached_m = cache_media_bytes(
+                            data,
+                            filename=att_name or f"image.{ext}",
+                            mime_type=content_type,
+                        )
+                        if cached_m:
+                            media_urls.append(cached_m.path)
+                            media_types.append(content_type)
+                            media_kinds.append("image")
+                    else:
+                        cached = await cache_image_from_url(content_url)
+                        if cached:
+                            media_urls.append(cached)
+                            media_types.append(content_type)
+                            media_kinds.append("image")
                 except Exception as e:
                     logger.warning("[teams] Failed to cache image attachment: %s", e)
                 continue

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -513,6 +513,22 @@ _ALLOWED_TEAMS_SERVICE_HOSTS = frozenset({
     "smba.infra.gov.teams.microsoft.us",
 })
 
+
+def _is_botframework_attachment_host(host: str) -> bool:
+    """True if ``host`` (lowercased) is a Bot Framework connector host.
+
+    Dot-anchored suffix match so attacker hosts like
+    ``evil-trafficmanager.net`` / ``notbotframework.com`` never receive the
+    bot's bearer token (same threat model as _ALLOWED_TEAMS_SERVICE_HOSTS:
+    the token must only ever be sent to Bot Framework infrastructure).
+    """
+    return (
+        host == "trafficmanager.net"
+        or host.endswith(".trafficmanager.net")
+        or host == "botframework.com"
+        or host.endswith(".botframework.com")
+    )
+
 # Conservative pattern for Bot Framework conversation IDs.  Real values
 # combine digits, colons, hyphens, dots, '@', and the ``thread.skype`` /
 # ``thread.tacv2`` suffixes; reject anything outside this set so a hostile
@@ -780,6 +796,8 @@ class TeamsAdapter(BasePlatformAdapter):
         self._client_id = extra.get("client_id") or os.getenv("TEAMS_CLIENT_ID", "")
         self._client_secret = extra.get("client_secret") or _get_scoped_secret("TEAMS_CLIENT_SECRET", "")
         self._tenant_id = extra.get("tenant_id") or os.getenv("TEAMS_TENANT_ID", "")
+        # (token, expiry unix ts) for Bot Framework connector attachment auth
+        self._bf_token_cache: Optional[tuple] = None
         self._port = _coerce_port(
             extra.get("port") or os.getenv("TEAMS_PORT", str(_DEFAULT_PORT))
         )
@@ -909,7 +927,7 @@ class TeamsAdapter(BasePlatformAdapter):
         import time
         import httpx
 
-        cached = getattr(self, "_bf_token_cache", None)
+        cached = self._bf_token_cache
         if cached and cached[1] > time.time() + 300:
             return cached[0]
 
@@ -955,7 +973,7 @@ class TeamsAdapter(BasePlatformAdapter):
 
         headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
         host = (urlparse(url).hostname or "").lower()
-        if host.endswith("trafficmanager.net") or host.endswith("botframework.com"):
+        if _is_botframework_attachment_host(host):
             try:
                 headers["Authorization"] = f"Bearer {await self._get_botframework_token()}"
             except Exception as e:
@@ -1072,7 +1090,7 @@ class TeamsAdapter(BasePlatformAdapter):
                 try:
                     from urllib.parse import urlparse as _urlparse
                     _host = (_urlparse(content_url).hostname or "").lower()
-                    if _host.endswith("trafficmanager.net") or _host.endswith("botframework.com"):
+                    if _is_botframework_attachment_host(_host):
                         # Bot Framework connector URL: needs the bot's own
                         # bearer token; the generic cache helper sends none.
                         data = await self._fetch_attachment_bytes(content_url)
@@ -1084,8 +1102,13 @@ class TeamsAdapter(BasePlatformAdapter):
                         )
                         if cached_m:
                             media_urls.append(cached_m.path)
-                            media_types.append(content_type)
+                            media_types.append(cached_m.media_type)
                             media_kinds.append("image")
+                        else:
+                            logger.warning(
+                                "[teams] Bot Framework attachment '%s' returned data that failed image validation, skipping",
+                                att_name or content_url,
+                            )
                     else:
                         cached = await cache_image_from_url(content_url)
                         if cached:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -514,20 +514,28 @@ _ALLOWED_TEAMS_SERVICE_HOSTS = frozenset({
 })
 
 
-def _is_botframework_attachment_host(host: str) -> bool:
-    """True if ``host`` (lowercased) is a Bot Framework connector host.
+def _is_botframework_attachment_url(url: str) -> bool:
+    """True if ``url`` points at a Bot Framework connector attachment host.
 
-    Dot-anchored suffix match so attacker hosts like
-    ``evil-trafficmanager.net`` / ``notbotframework.com`` never receive the
-    bot's bearer token (same threat model as _ALLOWED_TEAMS_SERVICE_HOSTS:
-    the token must only ever be sent to Bot Framework infrastructure).
+    Exact-match against ``_ALLOWED_TEAMS_SERVICE_HOSTS`` — the same allowlist
+    that gates where outbound sends may carry a freshly minted bearer token —
+    plus scheme/port sanity: only https on the default port qualifies. A
+    lookalike host must never receive the bot's bearer token: note that any
+    Azure customer can register ``<name>.trafficmanager.net`` Traffic Manager
+    profiles, so a suffix match would not be safe either. New Bot Framework
+    regions are allowlist additions, not predicate changes.
     """
-    return (
-        host == "trafficmanager.net"
-        or host.endswith(".trafficmanager.net")
-        or host == "botframework.com"
-        or host.endswith(".botframework.com")
-    )
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        if parsed.scheme != "https":
+            return False
+        if parsed.port not in (None, 443):
+            return False
+        return parsed.hostname in _ALLOWED_TEAMS_SERVICE_HOSTS
+    except Exception:
+        return False
 
 # Conservative pattern for Bot Framework conversation IDs.  Real values
 # combine digits, colons, hyphens, dots, '@', and the ``thread.skype`` /
@@ -796,8 +804,11 @@ class TeamsAdapter(BasePlatformAdapter):
         self._client_id = extra.get("client_id") or os.getenv("TEAMS_CLIENT_ID", "")
         self._client_secret = extra.get("client_secret") or _get_scoped_secret("TEAMS_CLIENT_SECRET", "")
         self._tenant_id = extra.get("tenant_id") or os.getenv("TEAMS_TENANT_ID", "")
-        # (token, expiry unix ts) for Bot Framework connector attachment auth
+        # (token, expiry monotonic ts) for Bot Framework connector attachment
+        # auth; refreshed under _bf_token_lock so concurrent attachments
+        # can't stampede the token endpoint.
         self._bf_token_cache: Optional[tuple] = None
+        self._bf_token_lock: Optional[asyncio.Lock] = None
         self._port = _coerce_port(
             extra.get("port") or os.getenv("TEAMS_PORT", str(_DEFAULT_PORT))
         )
@@ -922,58 +933,67 @@ class TeamsAdapter(BasePlatformAdapter):
         Needed to download connector attachments (smba.trafficmanager.net
         /v3/attachments/...), which -- unlike SharePoint file downloadUrls --
         are NOT pre-authenticated and return 401 without the bot's own
-        token. Token is cached until ~5 minutes before expiry.
+        token. Token is cached until ~5 minutes before expiry. The refresh
+        is serialized by an asyncio lock (lazily created on first use —
+        ``asyncio.Lock()`` at __init__ time would bind to the wrong event
+        loop on Python < 3.10) so concurrent attachments share one POST.
         """
         import time
         import httpx
 
-        cached = self._bf_token_cache
-        if cached and cached[1] > time.time() + 300:
-            return cached[0]
+        # The gateway may run adapters on a loop created after __init__;
+        # bind the lock on first use instead of at construction.
+        lock = self._bf_token_lock
+        if lock is None:
+            lock = self._bf_token_lock = asyncio.Lock()
+        async with lock:
+            cached = self._bf_token_cache
+            if cached and cached[1] > time.monotonic() + 300:
+                return cached[0]
 
-        client_id = self._client_id
-        client_secret = self._client_secret
-        tenant_id = self._tenant_id
-        if not (client_id and client_secret and tenant_id):
-            raise ValueError("Missing TEAMS_CLIENT_ID/SECRET/TENANT_ID for attachment auth")
+            client_id = self._client_id
+            client_secret = self._client_secret
+            tenant_id = self._tenant_id
+            if not (client_id and client_secret and tenant_id):
+                raise ValueError("Missing TEAMS_CLIENT_ID/SECRET/TENANT_ID for attachment auth")
 
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.post(
-                f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
-                data={
-                    "grant_type": "client_credentials",
-                    "client_id": client_id,
-                    "client_secret": client_secret,
-                    "scope": "https://api.botframework.com/.default",
-                },
-            )
-            resp.raise_for_status()
-            payload = resp.json()
-        token = payload["access_token"]
-        self._bf_token_cache = (token, time.time() + int(payload.get("expires_in", 3600)))
-        return token
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.post(
+                    f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                        "scope": "https://api.botframework.com/.default",
+                    },
+                )
+                resp.raise_for_status()
+                payload = resp.json()
+            token = payload["access_token"]
+            expires_in = float(payload.get("expires_in", 3600) or 3600)
+            self._bf_token_cache = (token, time.monotonic() + expires_in)
+            return token
 
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
         """Download attachment bytes with SSRF protection.
 
         Teams file attachments carry pre-authenticated SharePoint download
         URLs (no extra auth header needed). Bot Framework connector
-        attachment URLs (pasted/inline images on smba.trafficmanager.net /
-        botframework.com hosts) require the bot's bearer token -- detected
-        below and fetched with auth. Validates the URL against the SSRF
-        guard and follows redirects through the shared redirect guard,
-        matching the cache_*_from_url helpers in gateway.platforms.base.
+        attachment URLs (pasted/inline images on _ALLOWED_TEAMS_SERVICE_HOSTS
+        hosts) require the bot's bearer token -- detected below and fetched
+        with auth. Validates the URL against the SSRF guard, streams the
+        body through the shared inbound media cap, and follows redirects
+        through the shared redirect guard, matching the cache_*_from_url
+        helpers in gateway.platforms.base.
         """
-        from urllib.parse import urlparse
         from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
-        from gateway.platforms.base import _ssrf_redirect_guard
+        from gateway.platforms.base import _ssrf_redirect_guard, _read_httpx_body_with_limit
 
         if not is_safe_url(url):
             raise ValueError("Blocked unsafe attachment URL (SSRF protection)")
 
         headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
-        host = (urlparse(url).hostname or "").lower()
-        if _is_botframework_attachment_host(host):
+        if _is_botframework_attachment_url(url):
             try:
                 headers["Authorization"] = f"Bearer {await self._get_botframework_token()}"
             except Exception as e:
@@ -984,9 +1004,12 @@ class TeamsAdapter(BasePlatformAdapter):
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            return response.content
+            async with client.stream("GET", url, headers=headers) as response:
+                response.raise_for_status()
+                # Stream through the shared inbound media cap (matches
+                # cache_image_from_url) instead of buffering .content — a
+                # lying Content-Length must not OOM the gateway.
+                return await _read_httpx_body_with_limit(response, media_type="attachment")
 
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
         """Process an incoming Teams message and dispatch to the gateway."""
@@ -1088,9 +1111,7 @@ class TeamsAdapter(BasePlatformAdapter):
 
             if content_url and content_type.startswith("image/"):
                 try:
-                    from urllib.parse import urlparse as _urlparse
-                    _host = (_urlparse(content_url).hostname or "").lower()
-                    if _is_botframework_attachment_host(_host):
+                    if _is_botframework_attachment_url(content_url):
                         # Bot Framework connector URL: needs the bot's own
                         # bearer token; the generic cache helper sends none.
                         data = await self._fetch_attachment_bytes(content_url)

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -631,6 +631,251 @@ class TestTeamsAttachmentClassification:
         assert len(event.media_urls) == 2
 
 
+# ── Bot Framework connector attachments (pasted images) ──────────────────
+
+
+class TestTeamsBotFrameworkAttachments:
+    """Pasted/inline images arrive on smba.trafficmanager.net hosts and need
+    the bot's own bearer token (unlike SharePoint downloadUrls). These tests
+    pin the auth routing, the token cache, the attacker-host block, and the
+    failure fallbacks of that path."""
+
+    def _make_adapter(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    def _make_activity(self, attachments):
+        activity = MagicMock()
+        activity.text = "see attached"
+        activity.id = "activity-att-001"
+        activity.from_ = MagicMock()
+        activity.from_.id = "user-123"
+        activity.from_.aad_object_id = "aad-456"
+        activity.from_.name = "Test User"
+        activity.conversation = MagicMock()
+        activity.conversation.id = "19:abc@thread.v2"
+        activity.conversation.conversation_type = "personal"
+        activity.conversation.name = "Test Chat"
+        activity.conversation.tenant_id = "tenant-789"
+        activity.attachments = attachments
+        return activity
+
+    def _make_ctx(self, activity):
+        ctx = MagicMock()
+        ctx.activity = activity
+        return ctx
+
+    def _bf_image_attachment(self, url=None):
+        att = MagicMock()
+        att.content_type = "image/png"
+        att.content_url = url or "https://smba.trafficmanager.net/emea/b1/v3/attachments/0-abc/views/original"
+        att.name = "pasted.png"
+        return att
+
+    @pytest.mark.anyio
+    async def test_bf_host_predicate_dot_anchored(self):
+        """The host check must be dot-anchored: attacker lookalike hosts must
+        NOT receive the bot's bearer token."""
+        f = _teams_mod._is_botframework_attachment_host
+        assert f("smba.trafficmanager.net")
+        assert f("emea.smba.trafficmanager.net")
+        assert f("smba.trafficmanager.net")  # exact apex
+        assert f("api.botframework.com")
+        assert f("botframework.com")
+        # Attacker lookalikes — the pre-followup suffix check matched these
+        assert not f("evil-trafficmanager.net")
+        assert not f("notbotframework.com")
+        assert not f("trafficmanager.net.evil.com")
+        assert not f("")
+        assert not f("sharepoint.com")
+
+    @pytest.mark.anyio
+    async def test_bf_image_routes_through_authenticated_fetch(self):
+        adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"\x89PNG fake")
+        adapter._get_botframework_token = AsyncMock(return_value="tok")
+
+        def fake_cache_media_bytes(data, **kwargs):
+            return SimpleNamespace(
+                path="/tmp/img.png", media_type="image/png", kind="image"
+            )
+
+        with patch.object(_teams_mod, "cache_media_bytes", fake_cache_media_bytes):
+            activity = self._make_activity([self._bf_image_attachment()])
+            await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert len(event.media_urls) == 1
+        assert event.media_types == ["image/png"]
+        # URL was fetched with auth (via _fetch_attachment_bytes, which the
+        # token routing test below exercises end-to-end)
+        adapter._fetch_attachment_bytes.assert_awaited_once_with(
+            "https://smba.trafficmanager.net/emea/b1/v3/attachments/0-abc/views/original"
+        )
+
+    @pytest.mark.anyio
+    async def test_non_bf_image_uses_generic_cache_helper(self):
+        adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(side_effect=AssertionError("must not be called"))
+
+        async def fake_cache_image(url, *a, **kw):
+            return "/tmp/img.jpg"
+
+        with patch.object(_teams_mod, "cache_image_from_url", fake_cache_image):
+            activity = self._make_activity(
+                [self._bf_image_attachment(url="https://contoso.sharepoint.com/img.png")]
+            )
+            await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert len(event.media_urls) == 1
+        assert event.media_urls[0] == "/tmp/img.jpg"
+
+    @pytest.mark.anyio
+    async def test_fetch_attachment_bytes_sends_bearer_for_bf_host(self):
+        """End-to-end over _fetch_attachment_bytes: BF host → token acquired
+        and Authorization attached; non-BF host → no token call."""
+        adapter = self._make_adapter()
+        adapter._get_botframework_token = AsyncMock(return_value="the-token")
+
+        captured = {}
+
+        class _FakeClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def get(self, url, headers=None):
+                captured["headers"] = headers or {}
+                return SimpleNamespace(
+                    status_code=200,
+                    content=b"\x89PNG fake",
+                    raise_for_status=lambda: None,
+                )
+
+        with patch("tools.url_safety.create_ssrf_safe_async_client", lambda **kw: _FakeClient()), \
+             patch("tools.url_safety.is_safe_url", lambda url: True):
+            # BF host: bearer attached
+            await adapter._fetch_attachment_bytes("https://smba.trafficmanager.net/emea/v3/attachments/x")
+        assert captured["headers"].get("Authorization") == "Bearer the-token"
+
+        adapter._get_botframework_token = AsyncMock(return_value="the-token")
+        with patch("tools.url_safety.create_ssrf_safe_async_client", lambda **kw: _FakeClient()), \
+             patch("tools.url_safety.is_safe_url", lambda url: True):
+            # Attacker lookalike host: NO bearer (dot-anchored check)
+            await adapter._fetch_attachment_bytes("https://evil-trafficmanager.net/steal")
+        assert "Authorization" not in captured["headers"], (
+            "bearer token must not be sent to attacker lookalike hosts"
+        )
+        adapter._get_botframework_token.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_token_acquisition_and_cache_reuse(self):
+        adapter = self._make_adapter()
+
+        posts = []
+
+        class _TokenResp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"access_token": "tok-1", "expires_in": 3600}
+
+        class _TokenClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def post(self, url, data=None):
+                posts.append((url, dict(data or {})))
+                return _TokenResp()
+
+        with patch("httpx.AsyncClient", _TokenClient):
+            tok1 = await adapter._get_botframework_token()
+            tok2 = await adapter._get_botframework_token()
+        assert tok1 == "tok-1" and tok2 == "tok-1"
+        assert len(posts) == 1, "second call must hit the cache"
+        assert posts[0][0] == "https://login.microsoftonline.com/tenant/oauth2/v2.0/token"
+        assert posts[0][1]["scope"] == "https://api.botframework.com/.default"
+        assert posts[0][1]["client_id"] == "bot-id"
+        assert posts[0][1]["client_secret"] == "secret"
+
+    @pytest.mark.anyio
+    async def test_token_acquisition_failure_degrades_to_unauthenticated_fetch(self):
+        """Token failure must not break the fetch: warning + fetch without
+        Authorization (same net behavior as the pre-fix path)."""
+        import httpx as _httpx
+
+        adapter = self._make_adapter()
+        adapter._get_botframework_token = AsyncMock(side_effect=ValueError("no creds"))
+
+        captured = {}
+
+        class _FakeClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def get(self, url, headers=None):
+                captured["headers"] = headers or {}
+                return SimpleNamespace(
+                    status_code=401,
+                    content=b"",
+                    raise_for_status=lambda: (_ for _ in ()).throw(
+                        _httpx.HTTPStatusError(
+                            "401", request=MagicMock(), response=SimpleNamespace(status_code=401)
+                        )
+                    ),
+                )
+
+        with patch("tools.url_safety.create_ssrf_safe_async_client", lambda **kw: _FakeClient()), \
+             patch("tools.url_safety.is_safe_url", lambda url: True):
+            with pytest.raises(_httpx.HTTPStatusError):
+                await adapter._fetch_attachment_bytes("https://smba.trafficmanager.net/v3/attachments/x")
+        assert "Authorization" not in captured["headers"]
+
+    @pytest.mark.anyio
+    async def test_bf_image_invalid_bytes_logs_warning(self):
+        """Non-image bytes from the BF endpoint must not be silently dropped
+        — the else branch warns (regression guard for the silent-drop)."""
+        adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"<html>error page</html>")
+
+        with patch.object(_teams_mod, "cache_media_bytes", lambda *a, **kw: None):
+            with patch.object(_teams_mod.logger, "warning") as warn:
+                activity = self._make_activity([self._bf_image_attachment()])
+                await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls == []
+        assert warn.called, "silent drop of invalid BF image bytes must log a warning"
+        logged = " ".join(str(c) for c in warn.call_args_list)
+        assert "image validation" in logged or "failed image validation" in logged
+
+
 # ── _standalone_send (out-of-process cron delivery) ──────────────────────
 
 

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -678,21 +678,23 @@ class TestTeamsBotFrameworkAttachments:
         return att
 
     @pytest.mark.anyio
-    async def test_bf_host_predicate_dot_anchored(self):
-        """The host check must be dot-anchored: attacker lookalike hosts must
-        NOT receive the bot's bearer token."""
-        f = _teams_mod._is_botframework_attachment_host
-        assert f("smba.trafficmanager.net")
-        assert f("emea.smba.trafficmanager.net")
-        assert f("smba.trafficmanager.net")  # exact apex
-        assert f("api.botframework.com")
-        assert f("botframework.com")
-        # Attacker lookalikes — the pre-followup suffix check matched these
-        assert not f("evil-trafficmanager.net")
-        assert not f("notbotframework.com")
-        assert not f("trafficmanager.net.evil.com")
+    async def test_bf_url_predicate_exact_match_allowlist(self):
+        """Only exact allowlisted hosts on https default port may receive the
+        bot's bearer token — lookalikes, other schemes, and non-443 ports must
+        NOT (any Azure customer can register <name>.trafficmanager.net)."""
+        f = _teams_mod._is_botframework_attachment_url
+        assert f("https://smba.trafficmanager.net/emea/v3/attachments/x")
+        assert f("https://smba.infra.gov.teams.microsoft.us/amer/v3/attachments/x")
+        assert f("https://smba.trafficmanager.net:443/emea/v3/attachments/x")
+        # Attacker lookalikes / non-allowlisted / wrong scheme / wrong port
+        assert not f("https://evil-trafficmanager.net/steal")
+        assert not f("https://emea.smba.trafficmanager.net/v3/attachments/x")
+        assert not f("https://notbotframework.com/steal")
+        assert not f("https://trafficmanager.net.evil.com/steal")
+        assert not f("http://smba.trafficmanager.net/v3/attachments/x")
+        assert not f("https://smba.trafficmanager.net:444/v3/attachments/x")
         assert not f("")
-        assert not f("sharepoint.com")
+        assert not f("https://sharepoint.com/x")
 
     @pytest.mark.anyio
     async def test_bf_image_routes_through_authenticated_fetch(self):
@@ -745,6 +747,26 @@ class TestTeamsBotFrameworkAttachments:
 
         captured = {}
 
+        class _FakeStreamResponse:
+            def __init__(self):
+                self.headers = {}
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_bytes(self):
+                yield b"\x89PNG fake"
+
+        class _FakeStreamCtx:
+            def __init__(self, response):
+                self._response = response
+
+            async def __aenter__(self):
+                return self._response
+
+            async def __aexit__(self, *a):
+                return None
+
         class _FakeClient:
             def __init__(self, **kw):
                 pass
@@ -755,29 +777,72 @@ class TestTeamsBotFrameworkAttachments:
             async def __aexit__(self, *a):
                 return None
 
-            async def get(self, url, headers=None):
+            def stream(self, method, url, headers=None):
                 captured["headers"] = headers or {}
-                return SimpleNamespace(
-                    status_code=200,
-                    content=b"\x89PNG fake",
-                    raise_for_status=lambda: None,
-                )
+                return _FakeStreamCtx(_FakeStreamResponse())
 
         with patch("tools.url_safety.create_ssrf_safe_async_client", lambda **kw: _FakeClient()), \
              patch("tools.url_safety.is_safe_url", lambda url: True):
             # BF host: bearer attached
-            await adapter._fetch_attachment_bytes("https://smba.trafficmanager.net/emea/v3/attachments/x")
+            data = await adapter._fetch_attachment_bytes("https://smba.trafficmanager.net/emea/v3/attachments/x")
         assert captured["headers"].get("Authorization") == "Bearer the-token"
+        assert data == b"\x89PNG fake"
 
         adapter._get_botframework_token = AsyncMock(return_value="the-token")
         with patch("tools.url_safety.create_ssrf_safe_async_client", lambda **kw: _FakeClient()), \
              patch("tools.url_safety.is_safe_url", lambda url: True):
-            # Attacker lookalike host: NO bearer (dot-anchored check)
+            # Attacker lookalike host: NO bearer (exact-match allowlist)
             await adapter._fetch_attachment_bytes("https://evil-trafficmanager.net/steal")
         assert "Authorization" not in captured["headers"], (
             "bearer token must not be sent to attacker lookalike hosts"
         )
         adapter._get_botframework_token.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_token_refresh_is_serialized_under_lock(self):
+        """Two concurrent token fetches on a cold cache share ONE POST —
+        the lock prevents a token-endpoint stampede."""
+        import asyncio as _asyncio
+
+        adapter = self._make_adapter()
+        posts = []
+        release = _asyncio.Event()
+
+        class _TokenResp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"access_token": "tok-1", "expires_in": 3600}
+
+        class _SlowTokenClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return None
+
+            async def post(self, url, data=None):
+                posts.append((url, dict(data or {})))
+                await release.wait()  # hold both callers at the STS door
+                return _TokenResp()
+
+        async def release_later():
+            await _asyncio.sleep(0.05)
+            release.set()
+
+        with patch("httpx.AsyncClient", _SlowTokenClient):
+            t1 = _asyncio.create_task(adapter._get_botframework_token())
+            t2 = _asyncio.create_task(adapter._get_botframework_token())
+            await release_later()
+            tok1, tok2 = await t1, await t2
+        assert tok1 == "tok-1" and tok2 == "tok-1"
+        assert len(posts) == 1, f"concurrent cold-cache fetches must share one POST, got {len(posts)}"
 
     @pytest.mark.anyio
     async def test_token_acquisition_and_cache_reuse(self):
@@ -829,6 +894,28 @@ class TestTeamsBotFrameworkAttachments:
 
         captured = {}
 
+        class _FakeStreamResponse:
+            def __init__(self):
+                self.headers = {}
+
+            def raise_for_status(self):
+                raise _httpx.HTTPStatusError(
+                    "401", request=MagicMock(), response=MagicMock(status_code=401)
+                )
+
+            async def aiter_bytes(self):
+                yield b""
+
+        class _FakeStreamCtx:
+            def __init__(self, response):
+                self._response = response
+
+            async def __aenter__(self):
+                return self._response
+
+            async def __aexit__(self, *a):
+                return None
+
         class _FakeClient:
             def __init__(self, **kw):
                 pass
@@ -839,17 +926,9 @@ class TestTeamsBotFrameworkAttachments:
             async def __aexit__(self, *a):
                 return None
 
-            async def get(self, url, headers=None):
+            def stream(self, method, url, headers=None):
                 captured["headers"] = headers or {}
-                return SimpleNamespace(
-                    status_code=401,
-                    content=b"",
-                    raise_for_status=lambda: (_ for _ in ()).throw(
-                        _httpx.HTTPStatusError(
-                            "401", request=MagicMock(), response=SimpleNamespace(status_code=401)
-                        )
-                    ),
-                )
+                return _FakeStreamCtx(_FakeStreamResponse())
 
         with patch("tools.url_safety.create_ssrf_safe_async_client", lambda **kw: _FakeClient()), \
              patch("tools.url_safety.is_safe_url", lambda url: True):


### PR DESCRIPTION
## Summary

Pasted/inline images in Microsoft Teams now reach the agent instead of being silently dropped with a 401.

Teams delivers two kinds of inbound attachments: file uploads (paperclip) carry pre-authenticated SharePoint downloadUrls, while pasted/inline images carry a contentUrl on `smba.trafficmanager.net` (Bot Framework connector), which requires the bot's own bearer token. The adapter fetched all attachments unauthenticated, so every pasted image failed with `401 Unauthorized` and was dropped with only a log warning.

Root cause: no Bot Framework token acquisition for connector-hosted attachment downloads.

This is a consolidation of a five-way duplicate-PR cluster (#47015, #55054, #58476, #72977, #73685 all fix the same 401); the surviving implementation is based on #94547 with hardening folded in from review findings across the cluster.

## Changes

- `plugins/platforms/teams/adapter.py`:
  - `TeamsAdapter._get_botframework_token()` — client-credentials token for scope `https://api.botframework.com/.default`, cached until ~5 min before expiry (`time.monotonic()`), refresh serialized by an `asyncio.Lock` so concurrent attachments share one token POST (based on #94547 by @Sibbern; lock + monotonic clock from review of #94547/#55054)
  - `_fetch_attachment_bytes()` — attaches the bearer token only when the URL is an exact-match allowlisted Bot Framework host (`_ALLOWED_TEAMS_SERVICE_HOSTS`, https, default port); downloads stream through `_read_httpx_body_with_limit` so the shared inbound media cap applies (streaming + port from the sweeper review of #73685)
  - `_is_botframework_attachment_url()` — single predicate replacing the duplicated inline host checks. Exact-match allowlist, not suffix matching: any Azure customer can register `<name>.trafficmanager.net`, so `evil-trafficmanager.net` must not match. Also gates gov-cloud (`smba.infra.gov.teams.microsoft.us`)
  - Inbound `image/*` attachments with Bot Framework contentUrls route through the authenticated path + `cache_media_bytes()` instead of the unauthenticated `cache_image_from_url()`; images whose bytes fail validation are logged, not silently dropped; `media_types` records the computed MIME
  - Token-acquisition failure degrades to the pre-fix behavior (warning + unauthenticated fetch) — no new failure mode
- `tests/gateway/test_teams.py`: 8 new tests — exact-allowlist predicate (lookalike/subdomain/port/scheme negatives), BF routing vs generic helper, bearer attach + attacker-host block end-to-end, token acquire + cache reuse, concurrent cold-cache lock serialization, token-failure degradation, and the silent-drop regression guard

## Validation

| | Before | After |
|---|---|---|
| Pasted image (BF host) | 401 → dropped, only a log warning | cached + delivered to agent |
| Attacker host `evil-trafficmanager.net` / `emea.smba.…` / `:444` | n/a (would receive bearer in naive suffix match) | no token sent, no token acquired |
| Oversized / lying Content-Length | unbounded `.content` buffer | streamed, capped by shared media limit |
| Concurrent attachments, cold token cache | one STS POST per racing task | one shared POST (lock) |
| BF endpoint returns non-image bytes | silent drop, no log | warning logged |
| Token acquisition failure | warning + unauthenticated fetch (401) | same — no new failure mode |
| SharePoint paperclip uploads | work | unchanged (non-BF host → no token attached) |
| `tests/gateway/test_teams.py` | 24 passed | 32 passed (24 + 8 new) |
| Mutation checks | — | suffix match, silent drop, no-lock, unbounded buffer each fail a test |
| ruff / ty | — | clean / 0 new diagnostics |

E2E (real adapter code, isolated HERMES_HOME, mocked HTTP seam): 2 BF pasted images cached and delivered, token POSTed once and reused, `Authorization: Bearer` attached, file present on disk; lookalike/port/subdomain variants receive no bearer; 5 concurrent token fetches → 1 POST.

## Credit

Based on #94547 by @Sibbern (verified end-to-end on a live EMEA tenant by the author); his commit is cherry-picked with authorship preserved. Hardening folded in from the duplicate-PR cluster: exact-match allowlist approach of #73685 (@zenplace-system) and #55054 (@rodnavarro), `time.monotonic()` from #55054, streaming + port restriction from the automated review of #73685, token-refresh lock from the review of #94547.

Closes #94547
