### PR TITLE
fix(cron): NO_WORK wake-gate parity with OpenClaw precheck (#68809) (salvage of #68824)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4540,19 +4540,42 @@ def _run_job_script_with_claim_heartbeat(
         heartbeat_thread.join(timeout=1.0)
 
 
-def _parse_wake_gate(script_output: str) -> bool:
-    """Parse the last non-empty stdout line of a cron job's pre-check script
-    as a wake gate.
+def _stdout_signals_no_work(script_output: str) -> bool:
+    """True when stdout begin-line is an OpenClaw-compatible ``NO_WORK`` gate.
 
-    The convention (ported from nanoclaw #1232): if the last stdout line is
-    JSON like ``{"wakeAgent": false}``, the agent is skipped entirely — no
-    LLM run, no delivery. Any other output (non-JSON, missing flag, gate
-    absent, or ``wakeAgent: true``) means wake the agent normally.
+    Shared wake-gate convention with OpenClaw ``job.precheck`` (openclaw#112371
+    / hermes#68809) so the same check script can gate a cron job on either
+    runtime.
+
+    The token boundary is exact: the (leading-whitespace-stripped) begin-line
+    must be exactly ``NO_WORK`` or start ``NO_WORK:`` (an optional
+    ``NO_WORK: reason`` form). Longer identifiers such as ``NO_WORKING`` or
+    ``NO_WORK_TODAY`` are NOT treated as the gate token.
+    """
+    if not script_output:
+        return False
+    begin_line = script_output.lstrip().split("\n", 1)[0].rstrip()
+    return begin_line == "NO_WORK" or begin_line.startswith("NO_WORK:")
+
+
+def _parse_wake_gate(script_output: str) -> bool:
+    """Parse a cron pre-check script's stdout as a wake gate.
+
+    Skip the agent (return False) when either:
+
+    * the stdout begin-line is an OpenClaw-compatible ``NO_WORK`` token
+      (hermes#68809), or
+    * the last non-empty line is JSON ``{"wakeAgent": false}`` (nanoclaw #1232).
+
+    Any other output (non-JSON, missing flag, gate absent, or
+    ``wakeAgent: true``) means wake the agent normally.
 
     Returns True if the agent should wake, False to skip.
     """
     if not script_output:
         return True
+    if _stdout_signals_no_work(script_output):
+        return False
     stripped_lines = [line for line in script_output.splitlines() if line.strip()]
     if not stripped_lines:
         return True
@@ -5466,6 +5489,14 @@ def run_job(
     #   - wakeAgent=false gate    → treated like empty stdout (silent), since
     #                               the whole point of no_agent is that there
     #                               is no agent to wake
+    #   - NO_WORK begin-line gate → same as wakeAgent=false: silent run. A
+    #                               no_agent watchdog with nothing to report
+    #                               emits the shared NO_WORK token
+    #                               (openclaw#112371 / hermes#68809) instead
+    #                               of empty stdout, so it is suppressed here
+    #                               too. This intentionally means a no_agent
+    #                               job whose begin-line is the NO_WORK gate
+    #                               is NOT delivered verbatim.
     if job.get("no_agent"):
         # Load .env before the script runs so auto-delivery can resolve home
         # channels. A standalone cron tick process typically starts WITHOUT
@@ -5539,11 +5570,12 @@ def run_job(
             )
             return False, doc, alert, output
 
-        # Honour the wakeAgent gate as a silent signal — `wakeAgent: false`
-        # means "nothing to report this tick", same as empty stdout.
+        # Honour the wake gate as a silent signal — either `wakeAgent: false`
+        # JSON or a leading `NO_WORK` token means "nothing to report this
+        # tick", same as empty stdout.
         if not _parse_wake_gate(output):
             logger.info(
-                "Job '%s' (no_agent): wakeAgent=false gate — silent run", job_id
+                "Job '%s' (no_agent): wake gate not set — silent run", job_id
             )
             silent_doc = (
                 f"# Cron Job: {job_name}\n\n"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1629,6 +1629,86 @@ class TestParseWakeGate:
         from cron.scheduler import _parse_wake_gate
         assert _parse_wake_gate('{"wakeAgent": false}') is False
 
+    def test_wake_gate_true_wakes(self):
+        from cron.scheduler import _parse_wake_gate
+        assert _parse_wake_gate('{"wakeAgent": true}') is True
+
+    def test_wake_gate_missing_wakes(self):
+        """A JSON dict without a wakeAgent key defaults to waking."""
+        from cron.scheduler import _parse_wake_gate
+        assert _parse_wake_gate('{"data": {"foo": "bar"}}') is True
+
+    def test_non_boolean_false_still_wakes(self):
+        """Only strict ``False`` skips — truthy/falsy shortcuts are too risky."""
+        from cron.scheduler import _parse_wake_gate
+        assert _parse_wake_gate('{"wakeAgent": 0}') is True
+        assert _parse_wake_gate('{"wakeAgent": null}') is True
+        assert _parse_wake_gate('{"wakeAgent": ""}') is True
+
+    def test_only_last_non_empty_line_parsed(self):
+        from cron.scheduler import _parse_wake_gate
+        multi = 'some log output\nmore output\n{"wakeAgent": false}'
+        assert _parse_wake_gate(multi) is False
+
+    def test_trailing_blank_lines_ignored(self):
+        from cron.scheduler import _parse_wake_gate
+        multi = '{"wakeAgent": false}\n\n\n'
+        assert _parse_wake_gate(multi) is False
+
+    def test_non_last_json_line_does_not_gate(self):
+        """A JSON gate on an earlier line with plain text after it does NOT trigger."""
+        from cron.scheduler import _parse_wake_gate
+        multi = '{"wakeAgent": false}\nactually this is the real output'
+        assert _parse_wake_gate(multi) is True
+
+    def test_no_work_begin_line_gates(self):
+        """OpenClaw-compatible NO_WORK begin-line skips the agent (hermes#68809)."""
+        from cron.scheduler import _parse_wake_gate
+        assert _parse_wake_gate("NO_WORK") is False
+        assert _parse_wake_gate("NO_WORK: inbox empty") is False
+        assert _parse_wake_gate("   NO_WORK\n") is False
+
+    def test_no_work_only_at_begin_line(self):
+        """NO_WORK later in the output does not gate; only the begin-line counts."""
+        from cron.scheduler import _parse_wake_gate
+        assert _parse_wake_gate("work found\nNO_WORK") is True
+
+    def test_work_needed_prefix_wakes(self):
+        """WORK_NEEDED begin-line wakes normally (not a NO_WORK token)."""
+        from cron.scheduler import _parse_wake_gate
+        assert _parse_wake_gate("WORK_NEEDED: 3 dirty PRs") is True
+
+    def test_no_work_negative_prefixes_wake(self):
+        """NO_WORKING / NO_WORK_TODAY are not the gate token and wake normally."""
+        from cron.scheduler import _parse_wake_gate
+        assert _parse_wake_gate("NO_WORKING") is True
+        assert _parse_wake_gate("NO_WORK_TODAY") is True
+
+
+class TestStdoutSignalsNoWork:
+    """Unit tests for the shared NO_WORK begin-line detector."""
+
+    def test_detects_exact_no_work_token(self):
+        from cron.scheduler import _stdout_signals_no_work
+        assert _stdout_signals_no_work("NO_WORK") is True
+        assert _stdout_signals_no_work("  NO_WORK\n") is True
+        # Optional `NO_WORK: reason` form.
+        assert _stdout_signals_no_work("NO_WORK: inbox empty") is True
+        assert _stdout_signals_no_work("   NO_WORK: nothing to do\nextra") is True
+
+    def test_rejects_negative_prefixes(self):
+        """Longer identifiers sharing the NO_WORK prefix must NOT gate."""
+        from cron.scheduler import _stdout_signals_no_work
+        assert _stdout_signals_no_work("NO_WORKING") is False
+        assert _stdout_signals_no_work("NO_WORK_TODAY") is False
+        assert _stdout_signals_no_work("NO_WORK trailing") is False
+
+    def test_empty_and_other_output(self):
+        from cron.scheduler import _stdout_signals_no_work
+        assert _stdout_signals_no_work("") is False
+        assert _stdout_signals_no_work("all good") is False
+        assert _stdout_signals_no_work("WORK_NEEDED") is False
+
 
 class TestRunJobWakeGate:
     """Integration tests for run_job wake-gate short-circuit."""
@@ -1708,6 +1788,41 @@ class TestRunJobWakeGate:
         assert script_output in prompt_arg
         assert success is True
         assert err is None
+
+    def test_no_agent_no_work_token_is_silent_and_skips_agent(self):
+        """A no_agent job emitting NO_WORK is silent and never constructs AIAgent."""
+        from cron.scheduler import SILENT_MARKER
+        import cron.scheduler as scheduler
+
+        job = self._make_job(name="no-agent-nowork")
+        job["no_agent"] = True
+
+        with patch.object(scheduler, "_run_job_script_with_claim_heartbeat",
+                          return_value=(True, "NO_WORK: nothing to report")), \
+             patch("run_agent.AIAgent") as agent_cls:
+            success, doc, final, err = scheduler.run_job(job)
+
+        assert success is True
+        assert err is None
+        assert final == SILENT_MARKER
+        agent_cls.assert_not_called()
+
+    def test_no_agent_negative_prefix_delivered_verbatim(self):
+        """NO_WORKING is not the gate token, so a no_agent job delivers it."""
+        import cron.scheduler as scheduler
+
+        job = self._make_job(name="no-agent-noworking")
+        job["no_agent"] = True
+
+        with patch.object(scheduler, "_run_job_script_with_claim_heartbeat",
+                          return_value=(True, "NO_WORKING today")), \
+             patch("run_agent.AIAgent") as agent_cls:
+            success, doc, final, err = scheduler.run_job(job)
+
+        assert success is True
+        assert err is None
+        assert "NO_WORKING today" in final
+        agent_cls.assert_not_called()
 
 
 class TestBuildJobPromptMissingSkill:

--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -245,3 +245,40 @@ For critical system-health watchdogs that must fire *even when the gateway is do
 - [Scheduled Tasks (Cron) reference](/user-guide/features/cron) — full schedule syntax, lifecycle, delivery routing.
 - [Webhook Subscriptions](/user-guide/messaging/webhooks) — fire-and-forget HTTP entry points for external schedulers.
 - [Gateway Internals](/developer-guide/gateway-internals) — delivery-router internals.
+
+
+## Wake gate: skip the agent when there is no work
+
+Script-only jobs are already zero-token. For **LLM** cron jobs that attach a `script`, the script can act as a **wake gate** so the model only runs when there is real work. The agent is skipped (silent tick, no tokens) when either of these is true:
+
+- The **last non-empty stdout line** is JSON `{"wakeAgent": false}`.
+- The **stdout begin-line** is `NO_WORK` (optionally `NO_WORK: reason`).
+
+The `NO_WORK` begin-line token is intentionally identical to OpenClaw's `job.precheck` gate, so the **same check script runs on both runtimes** (hermes#68809 / openclaw#112371).
+
+> **Dual-fleet:** the matching OpenClaw feature is [`job.precheck`](https://github.com/openclaw/openclaw/issues/112371), which uses the same `WORK_NEEDED` / `NO_WORK` convention — so one check script gates a cron job identically on Hermes or OpenClaw.
+
+```bash
+#!/usr/bin/env bash
+# ~/.hermes/scripts/inbox-gate.sh
+count=$(curl -s "$INBOX_URL" | jq 'length')
+if [ "$count" -gt 0 ]; then
+  echo "WORK_NEEDED: $count unread"   # any non-gate output → wake agent
+else
+  echo "NO_WORK"                       # skip the agent entirely
+fi
+```
+
+Attach it to an LLM job (omit `no_agent`) so the gate decides per tick:
+
+```python
+cronjob(
+    action="create",
+    schedule="every 15m",
+    script="inbox-gate.sh",
+    prompt="Triage unread inbox items and draft replies.",
+    deliver="telegram",
+)
+```
+
+On a `NO_WORK` / `wakeAgent: false` tick the run is silent and no model call is made; any other output wakes the agent and (as before) is injected as `## Script Output` context.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -639,6 +639,7 @@ Semantics:
 - **Empty stdout → silent tick**, no delivery. This is the watchdog pattern: "only say something when something is wrong".
 - Non-zero exit or timeout → an error alert is delivered, so a broken watchdog can't fail silently.
 - `{"wakeAgent": false}` on the last line → silent tick (same gate LLM jobs use).
+- A begin-line of exactly `NO_WORK` (or `NO_WORK: <reason>`) → silent tick. This is the OpenClaw-compatible wake-gate token, so the same check script gates a job on either runtime. The boundary is exact: `NO_WORKING`, `NO_WORK_TODAY`, or `NO_WORK` mid-output are **not** the token and are delivered normally.
 - No tokens, no model, no provider fallback — the job never touches the inference layer.
 
 `.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash` (important on Windows Git Bash). Anything else runs under the current Python interpreter (`sys.executable`). Scripts must resolve inside `$HERMES_HOME/scripts/` — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; paths that escape it are rejected. Subprocess env is sanitized (`_sanitize_subprocess_env`): provider API credentials and other Hermes-managed secrets are **not** inherited by cron scripts.
@@ -909,6 +910,23 @@ print(json.dumps({"wakeAgent": True, "context": {"new_issues": latest - prev}}))
 ```
 
 When `wakeAgent` is omitted, the default is `true` (wake the agent as usual).
+
+#### OpenClaw-compatible `NO_WORK` token
+
+Instead of JSON, a pre-check script can emit a begin-line of exactly `NO_WORK`
+(optionally `NO_WORK: <reason>`) to skip the tick. This is the same wake-gate
+convention OpenClaw's `job.precheck` uses (openclaw#112371 / hermes#68809), so a
+single check script can gate a cron job on either runtime:
+
+```text
+NO_WORK: issue count unchanged
+```
+
+The token boundary is exact — the stripped begin-line must be `NO_WORK` or start
+`NO_WORK:`. Longer identifiers such as `NO_WORKING` or `NO_WORK_TODAY`, or a
+`NO_WORK` appearing later in the output, do **not** gate and wake the agent as
+usual. For `no_agent` jobs the token behaves like empty stdout / `wakeAgent:
+false`: the tick is silent and the token line is not delivered.
 
 #### Recipes: cheap pre-run gates
 


### PR DESCRIPTION
## Summary

Salvage of #68824 onto current `main`.

Adds an OpenClaw-compatible **`NO_WORK`** stdout begin-line token to the cron **wake gate**, so the *same* pre-check script can skip the agent on **both** Hermes and OpenClaw (hermes#68809 / openclaw#112371).

Hermes already skips the agent when the last non-empty stdout line is `{"wakeAgent": false}`. This PR adds a second, cross-runtime-friendly form:

- **stdout begin-line `NO_WORK`** (optionally `NO_WORK: reason`) → skip the agent (silent tick, zero tokens).
- Existing `{"wakeAgent": false}` behavior unchanged.
- Exact token boundary (`NO_WORKING` / `NO_WORK_TODAY` do **not** match).

## Why salvage

#68824 still needed (no `NO_WORK` on main as of 9f90cd438c; issue #68809 OPEN) and was MERGEABLE but BLOCKED on stale CI (unrelated vercel lazy-install + gateway-help timeout flakes from 2026-07-30). Clean 3-way re-apply on fresh main.

## Credit

Original PR #68824 by @Bartok9.

## Test

```bash
python3 -m pytest tests/cron/test_scheduler.py -k "wake_gate or StdoutSignals or no_work or NoWork or parse_wake" -q
# 10 passed locally
```

## Docs

`website/docs/guides/cron-script-only.md` + cron feature guide wake-gate section.