### PR TITLE
fix(desktop): isolate local backend from public dashboard auth

### DIFF
--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -206,6 +206,11 @@ def _load_dashboard_section() -> dict:
 def resolve_public_url() -> str:
     """Resolve the operator-declared dashboard public URL.
 
+    A Desktop-managed loopback backend is not the public dashboard, even when
+    this Hermes installation also hosts one behind a reverse proxy. It must
+    retain its private per-process session-token auth, so ignore the public URL
+    declaration for that child only.
+
     Precedence (mirrors ``dashboard.oauth.client_id``):
 
       1. ``HERMES_DASHBOARD_PUBLIC_URL`` env var (when non-empty after
@@ -220,6 +225,13 @@ def resolve_public_url() -> str:
     malformed config entry falls through to ``""``. This means a typo
     in one surface doesn't prevent the other from working.
     """
+    # Desktop launches a private loopback backend and authenticates it with a
+    # per-process token. A public dashboard URL belongs to a separate hosted
+    # dashboard and would incorrectly switch this local child to cookie/OAuth
+    # auth, causing its WebSocket token to be rejected.
+    if os.environ.get("HERMES_DESKTOP") == "1":
+        return ""
+
     env_raw = os.environ.get("HERMES_DASHBOARD_PUBLIC_URL", "")
     env_clean = _normalise_public_url(env_raw)
     if env_clean:

--- a/tests/hermes_cli/test_dashboard_auth_prefix.py
+++ b/tests/hermes_cli/test_dashboard_auth_prefix.py
@@ -326,6 +326,19 @@ class TestPublicUrlOverride:
             "depends on this precedence"
         )
 
+    def test_desktop_backend_ignores_public_dashboard_url(
+        self, patch_config, monkeypatch
+    ):
+        """Desktop's private loopback backend keeps token auth even when this
+        Hermes home also has a reverse-proxied public dashboard."""
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_PUBLIC_URL", "https://from-env.example",
+        )
+        patch_config("https://from-config.example")
+
+        assert prefix_mod.resolve_public_url() == ""
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents a Desktop-managed loopback backend from inheriting a configured public dashboard URL. Without the isolation, the public URL engages the cookie/OAuth auth gate while Electron expects the private per-process session-token flow, causing `/api/ws` to reject the token after an update.

## Related Issue

Fixes the Desktop startup failure: `Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws) rejected the session token`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/dashboard_auth/prefix.py`: return no public URL for `HERMES_DESKTOP=1` private backends.
- `tests/hermes_cli/test_dashboard_auth_prefix.py`: cover both env and config public-URL sources under Desktop mode.

## How to Test

1. Configure a public dashboard URL in `.env` or config.
2. Launch Hermes Desktop.
3. Confirm the local backend accepts the Desktop session token and reaches normal startup.

Validated locally on macOS 27:
- Targeted auth-prefix suite: 14 passed
- Desktop TypeScript typecheck: passed
- Force-built the packaged app and verified the Desktop log reached `Hermes backend is ready. Finalizing desktop startup`.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] My PR contains only related changes
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted suite run; full suite not run)
- [x] I've added a regression test
- [x] I've tested on macOS
- [x] Documentation/config/architecture changes: N/A
- [x] Cross-platform impact considered: Python environment-scoped behavior
- [x] Tool schemas: N/A