### PR TITLE
fix(desktop): annotate canonical relay targets for remote @mentions

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -253,11 +253,15 @@ describe('the mention middleware', () => {
     expect(hostMock.requestProfile).not.toHaveBeenCalled()
   })
 
-  it('hands the agent the connection-qualified message_agent target', async () => {
+  it('hands the agent a relay-resolvable canonical target', async () => {
     const { handler } = await contributions()
     const result = await handler({ text: 'ping @default-vera' })
 
-    expect(result.text).toMatch(/message_agent target: "default-vera@vera"/)
+    // The UI alias ('default-vera') is not a relay identity: resolve_remote_target()
+    // accepts only a roster row's handle/profile, optionally @connection-qualified.
+    // The annotation must carry the canonical profile@connection form (#97678).
+    expect(result.text).toMatch(/message_agent target: "default@vera"/)
+    expect(result.text).not.toMatch(/message_agent target: "default-vera/)
     expect(result.text).toMatch(/on Vera/)
   })
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -730,7 +730,13 @@ export default {
               botRosterMeta(bot, $botMeta.get())?.title || bot.ui_meta?.['hermes-bots']?.title || bot.title || ''
             ).trim()
 
-            const target = bot.remoteSource && bot.connectionId ? `${handle}@${bot.connectionId}` : handle
+            // message_agent only resolves canonical identities: the relay
+            // matches a roster row's handle/profile (± @connection-id), the
+            // local path a bare profile name or 'hermes'. botHandle() prefers
+            // the row's source-qualified UI alias ('default-vera'), which
+            // neither resolver accepts — annotate the canonical form instead.
+            const target =
+              bot.remoteSource && bot.connectionId ? `${bot.name}@${bot.connectionId}` : botHandle(bot.name)
 
             const where = bot.remoteSource
               ? ` — on ${bot.connectionLabel || bot.connectionId} (message_agent target: "${target}")`

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -84,6 +84,9 @@ def test_resolve_remote_target_forms(root):
     assert bot_relay.resolve_remote_target("default", roster)["connection_id"] == "cloud-1"
     # exact connection-qualified form
     assert bot_relay.resolve_remote_target("hermes@cloud-1", roster)["profile"] == "default"
+    # profile@connection — the form Desktop's mention middleware annotates
+    # for remote bots (#97678); the UI alias form must not be required
+    assert bot_relay.resolve_remote_target("default@cloud-1", roster)["profile"] == "default"
     assert bot_relay.resolve_remote_target("hermes@nope", roster) is None
     assert bot_relay.resolve_remote_target("ghost", roster) is None
 


### PR DESCRIPTION
## What does this PR do?

Desktop Bot Mode's mention middleware annotated `message_agent` targets from `botHandle()`, which prefers a roster row's **source-qualified UI alias** (`default-vera`). Neither resolver accepts that form: the relay's `resolve_remote_target()` matches only a canonical roster `handle`/`profile` (optionally `@connection-id`-qualified), and the local path resolves only a bare profile name or `hermes`. A remote handoff selected through `@mention` autocomplete therefore died with `No teammate named ...` before the message was ever enqueued, even though the agent followed Desktop's own hidden instruction verbatim.

The middleware now annotates the canonical identity instead: `profile@connection-id` for remote rows, and the canonical bare handle (`default` → `hermes`) for local rows. The UI alias still appears in the human-readable identification line — only the machine-resolved target changes. The relay side gains a contract pin for the `profile@connection-id` form, so the emitted target stays inside the documented resolver contract in both directions.

## Related Issue

Fixes #97678

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.tsx` — the mention middleware builds its `message_agent target:` annotation from the canonical identity (`${bot.name}@${bot.connectionId}` for remote rows, `botHandle(bot.name)` for local rows) instead of the UI alias `botHandle(bot.name, bot)`.
- `apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts` — the target assertion now pins the canonical `default@vera` form and asserts the alias-qualified form is gone.
- `tests/tools/test_bot_relay.py` — `test_resolve_remote_target_forms` pins `resolve_remote_target("default@cloud-1", ...)` so the `profile@connection-id` form the middleware emits stays resolvable.

## How to Test

1. `cd apps/desktop && npx vitest run src/plugins/hermes-bots/plugin.mentions.test.ts` — Observed result: 15 passed, including `hands the agent a relay-resolvable canonical target` (`message_agent target: "default@vera"`).
2. `npx vitest run src/contrib/plugin.test.ts` (the other suite importing the plugin) — Observed result: 6 passed.
3. `npx tsc -p . --noEmit` — Observed result: exit 0.
4. `pytest tests/tools/test_bot_relay.py -q` — Observed result: 26 passed, including the new `default@cloud-1` pin.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — the change is inside a hidden annotation string; the visible `@handle` identification line is unchanged.
