### PR TITLE
fix(desktop): emit resolvable remote mention targets

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -253,11 +253,12 @@ describe('the mention middleware', () => {
     expect(hostMock.requestProfile).not.toHaveBeenCalled()
   })
 
-  it('hands the agent the connection-qualified message_agent target', async () => {
+  it('hands the agent a relay-resolvable connection-qualified message_agent target', async () => {
     const { handler } = await contributions()
     const result = await handler({ text: 'ping @default-vera' })
 
-    expect(result.text).toMatch(/message_agent target: "default-vera@vera"/)
+    expect(result.text).toMatch(/message_agent target: "default@vera"/)
+    expect(result.text).not.toMatch(/message_agent target: "default-vera@vera"/)
     expect(result.text).toMatch(/on Vera/)
   })
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -730,7 +730,9 @@ export default {
               botRosterMeta(bot, $botMeta.get())?.title || bot.ui_meta?.['hermes-bots']?.title || bot.title || ''
             ).trim()
 
-            const target = bot.remoteSource && bot.connectionId ? `${handle}@${bot.connectionId}` : handle
+            // A multi-source handle is a UI disambiguation alias. The relay
+            // resolves only the registered profile or relay handle.
+            const target = bot.remoteSource && bot.connectionId ? `${bot.name}@${bot.connectionId}` : handle
 
             const where = bot.remoteSource
               ? ` — on ${bot.connectionLabel || bot.connectionId} (message_agent target: "${target}")`


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop Bot Mode remote @mentions that supply a UI-only multi-source alias as the `message_agent` target. The middleware now preserves that alias for display but emits the stable remote profile plus connection ID for the relay.

## Related Issue

Fixes #97678

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.tsx`: derive remote `message_agent` targets from `bot.name`, not the source-qualified UI handle.
- `apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts`: prove `@default-vera` emits `default@vera` and never the unresolvable alias target.

## How to Test

1. On base `9f90cd438cb59524f0197f6b64b1a78f11be0c10`, the production mention middleware emits `default-vera@vera`; the new regression fails 1/15.
2. On candidate `405b376952595796ca8d6273aa9f19c9130812af`, run `npm --prefix apps/desktop exec vitest run src/plugins/hermes-bots/plugin.mentions.test.ts` (15/15 pass).
3. The actual relay resolver accepts `default@vera` for `{profile: default, handle: hermes, connection_id: vera}` and rejects `default-vera@vera`.

## Checklist

### Code

- [x] Ive read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and merged PRs and issues for the issue number, title, alias, resolver, and owner symbol.
- [x] My PR contains only this fix and its regression.
- [ ] I ran `pytest tests/ -q`: the clean isolated clone has no pytest venv, so the repository wrapper correctly refused to run.
- [x] I added a regression test.
- [x] I tested on macOS 26.6 with Node v22.22.0.

### Documentation & Housekeeping

- [x] Documentation N/A; the behavior is internal target selection.
- [x] `cli-config.yaml.example` N/A; no configuration changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: the resolver target is platform-independent.
- [x] Tool descriptions/schemas N/A; the existing `message_agent` contract is preserved.

## Screenshots / Logs

- `npm --prefix apps/desktop run typecheck` passed all three Desktop TypeScript projects.
- ESLint, Prettier, `git diff --check`, and exact-diff TruffleHog passed with zero findings.
- The full Python suite was not available in this clean clone because its required pytest virtual environment is absent.