### PR TITLE
fix(plugin-guard): exclude tests/ from plugin scan (closes #93927)

### DIFF
--- a/tools/plugin_guard.py
+++ b/tools/plugin_guard.py
@@ -59,9 +59,14 @@ from tools.skills_guard import (
 PLUGIN_SCANNER_VERSION = "plugin-guard-v1"
 
 # Directories that are never scanned (VCS internals, caches, vendored envs).
+# "tests" is excluded because test fixtures deliberately contain destructive
+# strings (rm -rf /, secret decoys, /etc/passwd) to prove the code under test
+# REJECTS them — scoring them as production threats yields DANGEROUS verdicts
+# for self-authored plugin repos (see hermes-agent#93927).
 EXCLUDED_DIRS = {
     ".git", "__pycache__", "node_modules", ".venv", "venv",
     ".mypy_cache", ".pytest_cache", ".ruff_cache", ".tox",
+    "tests",
 }
 
 # Code file extensions where "reads an env secret" / "HTTP call with a key


### PR DESCRIPTION
Fixes #93927.

## Problem
scan_plugin rates plugin repos DANGEROUS (always-blocked) when their test suites contain scanner-bait fixtures — destructive-looking strings, decoy secrets, or system-file paths that exist precisely to prove the plugin's own defenses REJECT them.

Live repro from the issue: paivot-hermes scored DANGEROUS (126 findings, 4 critical) — all 4 criticals inside tests/ (shell-quoting regression fixtures, decoy-token secret-scrub test, traversal-rejection tests). None executed at runtime.

## Fix
Add `tests` to `EXCLUDED_DIRS` in `tools/plugin_guard.py`. Test code never ships in the runtime path; fixtures exercise defensive rejection, not destructive behavior.

## Verification (live, post-fix)
```
verdict=caution  findings=34  severities={'medium': 27, 'high': 7}
```
Exactly matches the minus-tests/ projection from the issue triage (0 critical, 7 high). Remaining highs are vendored gitignored README install lines and negative doc statements — caution is the correct human-confirmable posture for self-authored source.
