### PR TITLE
fix(agent): make Codex TTFB max-seconds cap opt-in

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1566,7 +1566,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     _ttfb_disable_above,
                 )
                 _ttfb_timeout = _large_request_ttfb_timeout
-        _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 120.0)
+        # Independent hard cap on the TTFB cutoff. Opt-in: default 0 means no
+        # cap, so the size-based ladder above (e.g. 180s for >100K-token
+        # requests) survives. A previous default of 120s silently reverted the
+        # large-request scale-up on every call, cancelling the safety margin.
+        _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 0.0)
         if _ttfb_cap > 0 and _ttfb_timeout > _ttfb_cap:
             logger.info(
                 "Capping openai-codex no-byte TTFB timeout from %.0fs to %.0fs "

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -16,6 +16,7 @@ stall.
 
 from __future__ import annotations
 
+import logging
 import sys
 import time
 import types
@@ -345,6 +346,73 @@ def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkey
         assert "with no response" in str(excinfo.value)
     finally:
         stop["flag"] = True
+
+
+def _run_large_request_and_capture(agent, monkeypatch, caplog):
+    """Drive one healthy >100k-token Codex request and return captured logs."""
+    sentinel = SimpleNamespace(ok=True)
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        # Bytes flow immediately so the TTFB watchdog never fires; we only care
+        # about the timeout computation logged before the stream starts.
+        agent._codex_stream_last_event_ts = time.time()
+        if on_first_delta:
+            on_first_delta()
+        return sentinel
+
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: SimpleNamespace())
+    monkeypatch.setattr(agent, "_abort_request_openai_client", lambda c, reason=None: None)
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda c, reason=None: None)
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    from agent import chat_completion_helpers as h
+
+    large_input = "x" * 480_000  # >100k estimated tokens → size ladder default 180s
+    with caplog.at_level(logging.INFO):
+        resp = h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": large_input})
+    assert resp is sentinel
+    return caplog.text
+
+
+def test_large_request_ttfb_scaling_survives_without_explicit_cap(tmp_path, monkeypatch, caplog):
+    """#97682 regression: with no HERMES_CODEX_TTFB_* overrides, the >100k-token
+    scale-up to 180s must NOT be silently reverted by the (now opt-in) cap."""
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    for var in (
+        "HERMES_CODEX_TTFB_MAX_SECONDS",
+        "HERMES_CODEX_TTFB_TIMEOUT_SECONDS",
+        "HERMES_CODEX_TTFB_STRICT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    text = _run_large_request_and_capture(agent, monkeypatch, caplog)
+    assert "Scaling openai-codex no-byte TTFB watchdog from 120s to 180s" in text
+    assert "Capping openai-codex no-byte TTFB timeout" not in text
+
+
+def test_explicit_ttfb_max_seconds_still_caps(tmp_path, monkeypatch, caplog):
+    """An operator-provided HERMES_CODEX_TTFB_MAX_SECONDS still caps the
+    size-based allowance — the opt-in cap is honored when explicitly set."""
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.delenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_CODEX_TTFB_STRICT", raising=False)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_MAX_SECONDS", "120")
+
+    text = _run_large_request_and_capture(agent, monkeypatch, caplog)
+    assert "Scaling openai-codex no-byte TTFB watchdog from 120s to 180s" in text
+    assert "Capping openai-codex no-byte TTFB timeout from 180s to 120s" in text
+
+
+def test_ttfb_strict_prevents_scale_up(tmp_path, monkeypatch, caplog):
+    """HERMES_CODEX_TTFB_STRICT=1 keeps the smaller cutoff — no scale-up log."""
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.delenv("HERMES_CODEX_TTFB_MAX_SECONDS", raising=False)
+    monkeypatch.delenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_STRICT", "1")
+
+    text = _run_large_request_and_capture(agent, monkeypatch, caplog)
+    assert "Scaling openai-codex no-byte TTFB watchdog" not in text
+    assert "Capping openai-codex no-byte TTFB timeout" not in text
 
 
 


### PR DESCRIPTION
## What does this PR do?

For a >100K-token Codex request, the size-based TTFB ladder raised the no-byte
watchdog from 120s to 180s — and the very next line applied an independent cap
that defaulted to 120s (`HERMES_CODEX_TTFB_MAX_SECONDS`), immediately reverting
the scale-up. Every large request logged the contradictory pair:

    Scaling openai-codex no-byte TTFB watchdog from 120s to 180s
    Capping openai-codex no-byte TTFB timeout from 180s to 120s

so the large-context safety margin never took effect.

Fix: default the cap to `0` (opt-in). With no `HERMES_CODEX_TTFB_MAX_SECONDS`
override the size-based ladder survives; an explicitly configured positive value
still caps the computed allowance.

Credit to @jangwonpark74 for the root-cause diagnosis and proposed fix in #97682.

## Related Issue

Fixes #97682

## Type of Change

- [√] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — default `HERMES_CODEX_TTFB_MAX_SECONDS`
  to `0.0` (opt-in cap) so the >10K/>100K-token TTFB ladder is not reverted.
- `tests/agent/test_codex_ttfb_watchdog.py` — regression tests for the
  no-override, explicit-cap, and `HERMES_CODEX_TTFB_STRICT=1` cases.

## How to Test

    pytest tests/agent/test_codex_ttfb_watchdog.py -q

All 11 pass. New tests assert that with no overrides "Scaling ... 120s to 180s"
is logged while "Capping ..." is not; that an explicit `=120` still caps; and
that `TTFB_STRICT=1` suppresses the scale-up.

## Checklist

- [√] I've read the Contributing Guide
- [√] My commit messages follow Conventional Commits
- [√] I searched for existing PRs / issues
- [√] My PR contains only changes related to this fix
- [√] I've run `pytest tests/ -q` and all tests pass
- [√] I've added tests for my changes
- [√] I've tested on my platform: Windows 11