### PR TITLE
fix(gateway): fail closed when a secondary profile handoff cannot load its config

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14187,14 +14187,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # The watcher already entered _profile_runtime_scope for this
             # profile, so a fresh load resolves that profile's config.yaml
             # and .env (home channel, tokens) rather than the primary's.
+            # Fail closed on a load error: self.config is the primary's, so
+            # falling back would deliver through the right bot to the
+            # WRONG chat and report completed. A failed row the CLI can
+            # retry beats a wrong delivery.
             try:
                 handoff_config = load_gateway_config()
-            except Exception:
-                logger.warning(
+            except Exception as exc:
+                logger.error(
                     "Handoff: could not load config for profile %s; "
-                    "falling back to the primary's config",
+                    "failing the handoff instead of delivering via the "
+                    "primary's config",
                     profile_name, exc_info=True,
                 )
+                raise RuntimeError(
+                    f"could not load config for profile '{profile_name}': {exc}"
+                ) from exc
 
         # Adapter must be live. A relay-fronted gateway registers ONE adapter
         # under Platform.RELAY that fronts N logical platforms — so a literal

--- a/tests/gateway/test_handoff_secondary_profile_adapter.py
+++ b/tests/gateway/test_handoff_secondary_profile_adapter.py
@@ -168,6 +168,34 @@ async def test_default_profile_handoff_keeps_primary_adapter(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_secondary_profile_config_load_failure_fails_closed(monkeypatch):
+    """A secondary profile whose config cannot load must fail the handoff.
+
+    Falling back to the primary's config delivers through the right bot to
+    the WRONG chat (the primary's home channel) and reports completed.
+    """
+    runner, _ = _make_multiplex_runner()
+    used = {}
+
+    def _boom():
+        raise RuntimeError("config.yaml exploded")
+
+    monkeypatch.setattr(
+        "gateway.run.resolve_delivery_transport", _spy_transport_factory(used),
+    )
+    monkeypatch.setattr("gateway.run.load_gateway_config", _boom)
+
+    with pytest.raises(RuntimeError, match="could not load config"):
+        await runner._process_handoff(
+            {"id": "cli-session", "title": "work", "handoff_platform": "telegram"},
+            profile_name="medicina",
+        )
+    assert used == {}, (
+        "nothing may be delivered when the profile config fails to load"
+    )
+
+
+@pytest.mark.asyncio
 async def test_secondary_profile_without_live_adapters_fails_loudly(monkeypatch):
     """Never silently fall back to the primary's bot — that ships to the wrong chat.
 


### PR DESCRIPTION
## What does this PR do?

On a multiplexed gateway, `_process_handoff` reloads the config for a secondary profile so delivery goes to that profile's own home channel. When that load failed, the code logged a warning and kept going with `self.config`, the primary's config. The handoff then went out through the secondary's bot to the primary's chat and the row was recorded completed.

This PR makes the config branch fail closed, mirroring the no-live-adapters branch right above it: log at error level and raise, which marks the row failed so the CLI can report and retry. A failed row the user can retry beats a delivery to the wrong chat that reports success.

## Related Issue

Fixes #97693

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `gateway/run.py`: the secondary-profile `load_gateway_config()` failure path in `_process_handoff` now logs at error level and raises RuntimeError instead of falling back to the primary's config.
- `tests/gateway/test_handoff_secondary_profile_adapter.py`: new test that makes the config load raise, asserts the handoff raises and nothing is delivered.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/gateway/test_handoff_secondary_profile_adapter.py -q`
2. New test `test_secondary_profile_config_load_failure_fails_closed` fails on current main (DID NOT RAISE, the spy records a delivery with the primary's home channel). With the fix it raises and the spy records nothing.
3. Regression check across the whole handoff suite: `scripts/run_tests.sh tests/gateway/ -q -k handoff`

Ran on Windows 11 with Python 3.11: 21 tests passed across all five handoff test files.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
On current main: DID NOT RAISE RuntimeError, spy records delivery via 'medicina' to home '1111' (the primary's chat)
With this PR:   RuntimeError: could not load config for profile 'medicina': config.yaml exploded
                 spy records nothing delivered
```

```
=== Summary: 5 files, 21 tests passed, 0 failed ===
```