### PR TITLE
fix: fall back to legacy com.hermes.gateway launchd service name

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3489,10 +3489,20 @@ def get_launchd_plist_path() -> Path:
 
     Default ``~/.hermes`` → ``ai.hermes.gateway.plist`` (backward compatible).
     Profile ``~/.hermes/profiles/coder`` → ``ai.hermes.gateway-coder.plist``.
+    Legacy pre-rename installs wrote ``com.hermes.gateway.plist`` — fall back
+    to it when the canonical name is absent so status/start/stop keep working
+    on upgraded machines.
     """
     suffix = _profile_suffix()
     name = f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
-    return _launchd_user_home() / "Library" / "LaunchAgents" / f"{name}.plist"
+    path = _launchd_user_home() / "Library" / "LaunchAgents" / f"{name}.plist"
+    if not suffix and not path.exists():
+        legacy = (
+            _launchd_user_home() / "Library" / "LaunchAgents" / "com.hermes.gateway.plist"
+        )
+        if legacy.exists():
+            return legacy
+    return path
 
 
 def launchd_gateway_labels_for_install() -> list[str]:
@@ -4762,8 +4772,19 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
 
 
 def get_launchd_label() -> str:
-    """Return the launchd service label, scoped per profile."""
+    """Return the launchd service label, scoped per profile.
+
+    Mirrors ``get_launchd_plist_path``'s legacy-name fallback so the label
+    always matches the resolved plist on machines that still run the
+    pre-rename ``com.hermes.gateway`` service.
+    """
     suffix = _profile_suffix()
+    if not suffix:
+        launch_agents = _launchd_user_home() / "Library" / "LaunchAgents"
+        legacy_plist = launch_agents / "com.hermes.gateway.plist"
+        canonical_plist = launch_agents / "ai.hermes.gateway.plist"
+        if legacy_plist.exists() and not canonical_plist.exists():
+            return "com.hermes.gateway"
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2587,3 +2587,60 @@ class TestTimeoutStopSecCoversCronFloor:
             env={"HERMES_CRON_DRAIN_TIMEOUT": "200"},
         )
         assert "TimeoutStopSec=240" in unit
+
+class TestLaunchdLegacyNameFallback:
+    """Legacy pre-rename ``com.hermes.gateway`` service resolution.
+
+    Older install.sh revisions wrote the launchd service under the label
+    ``com.hermes.gateway``; the CLI only looked for ``ai.hermes.gateway``, so
+    ``hermes gateway status`` reported "not running" on upgraded machines whose
+    service kept the legacy name (every PID source missed it: label lookup,
+    missing PID file, and the process-table scan excluding the gateway as an
+    ancestor of the invoking CLI).  ``get_launchd_plist_path`` /
+    ``get_launchd_label`` now fall back to the legacy name when the canonical
+    plist is absent.
+    """
+
+    @staticmethod
+    def _make_launch_agents(tmp_path) -> Path:
+        la = tmp_path / "Library" / "LaunchAgents"
+        la.mkdir(parents=True)
+        return la
+
+    def test_legacy_plist_only_falls_back_to_legacy_name(self, tmp_path, monkeypatch):
+        la = self._make_launch_agents(tmp_path)
+        legacy = la / "com.hermes.gateway.plist"
+        legacy.write_text("{}")
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+
+        assert gateway_cli.get_launchd_plist_path() == legacy
+        assert gateway_cli.get_launchd_label() == "com.hermes.gateway"
+
+    def test_canonical_plist_wins_when_present(self, tmp_path, monkeypatch):
+        la = self._make_launch_agents(tmp_path)
+        canonical = la / "ai.hermes.gateway.plist"
+        canonical.write_text("{}")
+        (la / "com.hermes.gateway.plist").write_text("{}")
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+
+        assert gateway_cli.get_launchd_plist_path() == canonical
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway"
+
+    def test_no_plist_returns_canonical_for_install(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+
+        assert gateway_cli.get_launchd_plist_path() == (
+            tmp_path / "Library" / "LaunchAgents" / "ai.hermes.gateway.plist"
+        )
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway"
+
+    def test_profiled_profile_never_uses_legacy_name(self, tmp_path, monkeypatch):
+        la = self._make_launch_agents(tmp_path)
+        (la / "com.hermes.gateway.plist").write_text("{}")
+        monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "coder")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway-coder"


### PR DESCRIPTION
## Problem

On macOS, `hermes gateway status` incorrectly reports `✗ Gateway is not running` even when the gateway is healthy and supervised by launchd.

## Root cause

`get_launchd_plist_path()` and `get_launchd_label()` only look for the canonical service name `ai.hermes.gateway`. However, older revisions of `install.sh` registered the launchd service as `com.hermes.gateway`. On machines upgraded from those revisions the plist lookup comes back empty, and the remaining PID sources also miss the live gateway: the pidfile is absent, and the process-table scan deliberately excludes ancestors of the invoking CLI — which includes the gateway itself when the CLI is spawned by the gateway. All three signal sources are empty, so status reports "not running".

## Fix

Fall back to the legacy `com.hermes.gateway` plist/label whenever the canonical `ai.hermes.gateway` plist is absent (default profile only). Since `start` / `stop` / `install` / `cron` all resolve through these two functions, the one change fixes the whole command family, not just `status`.

## Tests

Added `TestLaunchdLegacyNameFallback` (4 cases): legacy fallback, canonical-wins, install-default, profiled-profile.

```
pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdLegacyNameFallback -q
# 4 passed
```
