### PR TITLE
fix(vertex): pick up rotated service-account files — signature-keyed creds cache

### DIFF
--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -19,7 +19,7 @@ under the ``vertex:`` section; env vars take precedence over config.yaml.
 import logging
 import os
 import time
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from agent.secret_scope import get_secret as _get_secret, is_multiplex_active
 
@@ -108,6 +108,30 @@ def _refresh_credentials(creds) -> None:
     creds.refresh(auth_req)
 
 
+def _creds_cache_key(resolved_path: Optional[str]) -> Tuple[Any, ...]:
+    """Cache key for the Credentials object backing *resolved_path*.
+
+    Keyed on the service-account file's (path, mtime_ns, size) signature —
+    the house idiom (agent/skill_utils.py, hermes_cli/config.py,
+    agent/models_dev.py) — so rotating the file on disk (new key, re-issued
+    service account) is picked up on the next call instead of serving
+    tokens minted from the old identity for the life of the process
+    (Pattern D: stale cache after out-of-band change). ADC has no file to
+    fingerprint; it keeps a plain sentinel key and its existing
+    refresh/expiry handling.
+
+    A stat failure falls back to the bare path: worst case we serve the
+    cached credentials exactly as the pre-signature code did.
+    """
+    if not resolved_path:
+        return ("__adc__",)
+    try:
+        st = os.stat(resolved_path)
+        return (resolved_path, st.st_mtime_ns, st.st_size)
+    except OSError:
+        return (resolved_path,)
+
+
 def get_vertex_credentials(credentials_path: Optional[str] = None) -> Tuple[Optional[str], Optional[str]]:
     """Return a (fresh access_token, project_id) pair or (None, None) on failure.
 
@@ -119,7 +143,7 @@ def get_vertex_credentials(credentials_path: Optional[str] = None) -> Tuple[Opti
         return None, None
 
     resolved_path = _resolve_credentials_path(credentials_path)
-    cache_key = resolved_path or "__adc__"
+    cache_key = _creds_cache_key(resolved_path)
 
     try:
         cached = _creds_cache.get(cache_key)
@@ -153,6 +177,15 @@ def get_vertex_credentials(credentials_path: Optional[str] = None) -> Tuple[Opti
                     scopes=["https://www.googleapis.com/auth/cloud-platform"]
                 )
             _creds_cache[cache_key] = (creds, project_id)
+            # A rotation leaves the old signature's entry behind; drop any
+            # other entries for the same path so the cache holds at most one
+            # Credentials per file (bounded, and stale identities don't
+            # linger for surprise reuse via an old key).
+            for k in [
+                k for k in _creds_cache
+                if k is not cache_key and k != cache_key and k[0] == cache_key[0]
+            ]:
+                _creds_cache.pop(k, None)
         else:
             creds, project_id = cached
 

--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -211,7 +211,11 @@ def get_vertex_credentials(credentials_path: Optional[str] = None) -> Tuple[Opti
 
         # If ADC failed (e.g. expired refresh token), try the SA file
         # before giving up — it may have been added after initial startup.
-        if cache_key == "__adc__":
+        # Keyed on the RESOLVED PATH being absent (i.e. this attempt was
+        # ADC), not on the cache-key literal: the signature-keyed cache
+        # made keys tuples, and a tuple never equals the old "__adc__"
+        # string (that comparison silently killed this retry path).
+        if not resolved_path:
             sa_path = _resolve_credentials_path(credentials_path)
             if sa_path:
                 logger.info("ADC failed, retrying with service account: %s", sa_path)

--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -16,6 +16,8 @@ Non-secret routing settings (project_id, region) also live in config.yaml
 under the ``vertex:`` section; env vars take precedence over config.yaml.
 """
 
+import hashlib
+import json
 import logging
 import os
 import time
@@ -108,26 +110,44 @@ def _refresh_credentials(creds) -> None:
     creds.refresh(auth_req)
 
 
+def _read_sa_file(resolved_path: str) -> Tuple[bytes, Tuple[Any, ...]]:
+    """Read the service-account file once, returning (bytes, cache key).
+
+    The cache key fingerprints the file CONTENT (sha256), not stat
+    metadata. A (path, mtime_ns, size) signature — the idiom used for
+    config caches — is not sufficient here: metadata-preserving atomic
+    replacement (deployment tools that restore mtime; equal-length JSON)
+    produces a different private key under an identical stat signature,
+    and this cache guards an identity, not a parse (review finding on
+    #97701, reproduced: inode/content changed, stat key equal). Reading
+    the bytes also lets the caller construct credentials from the SAME
+    snapshot the key was computed from, closing the stat->read TOCTOU.
+
+    The file is a few KB of JSON; one read + sha256 per cache PROBE is
+    noise next to the OAuth token mint the cache exists to avoid.
+    """
+    with open(resolved_path, "rb") as fh:
+        raw = fh.read()
+    digest = hashlib.sha256(raw).hexdigest()
+    return raw, (resolved_path, digest)
+
+
 def _creds_cache_key(resolved_path: Optional[str]) -> Tuple[Any, ...]:
     """Cache key for the Credentials object backing *resolved_path*.
 
-    Keyed on the service-account file's (path, mtime_ns, size) signature —
-    the house idiom (agent/skill_utils.py, hermes_cli/config.py,
-    agent/models_dev.py) — so rotating the file on disk (new key, re-issued
-    service account) is picked up on the next call instead of serving
-    tokens minted from the old identity for the life of the process
-    (Pattern D: stale cache after out-of-band change). ADC has no file to
-    fingerprint; it keeps a plain sentinel key and its existing
+    Content-digest keyed via _read_sa_file (see there for why stat
+    signatures are not enough for credential identity). ADC has no file
+    to fingerprint; it keeps a plain sentinel key and its existing
     refresh/expiry handling.
 
-    A stat failure falls back to the bare path: worst case we serve the
+    A read failure falls back to the bare path: worst case we serve the
     cached credentials exactly as the pre-signature code did.
     """
     if not resolved_path:
         return ("__adc__",)
     try:
-        st = os.stat(resolved_path)
-        return (resolved_path, st.st_mtime_ns, st.st_size)
+        _, key = _read_sa_file(resolved_path)
+        return key
     except OSError:
         return (resolved_path,)
 
@@ -143,16 +163,34 @@ def get_vertex_credentials(credentials_path: Optional[str] = None) -> Tuple[Opti
         return None, None
 
     resolved_path = _resolve_credentials_path(credentials_path)
-    cache_key = _creds_cache_key(resolved_path)
+    sa_raw: Optional[bytes] = None
+    if resolved_path:
+        try:
+            # One read serves both the cache key and (on a miss) credential
+            # construction, so the credentials always match the bytes the
+            # key fingerprints — no stat/read or read/read TOCTOU.
+            sa_raw, cache_key = _read_sa_file(resolved_path)
+        except OSError:
+            cache_key = (resolved_path,)
+    else:
+        cache_key = ("__adc__",)
 
     try:
         cached = _creds_cache.get(cache_key)
         if cached is None:
             if resolved_path:
-                creds = service_account.Credentials.from_service_account_file(
-                    resolved_path,
-                    scopes=["https://www.googleapis.com/auth/cloud-platform"],
-                )
+                if sa_raw is not None:
+                    creds = service_account.Credentials.from_service_account_info(
+                        json.loads(sa_raw),
+                        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                    )
+                else:
+                    # Unreadable at key time (bare-path key): let the SDK
+                    # try the file directly — pre-signature behavior.
+                    creds = service_account.Credentials.from_service_account_file(
+                        resolved_path,
+                        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                    )
                 project_id = creds.project_id
             else:
                 # google.auth.default() reads GOOGLE_APPLICATION_CREDENTIALS

--- a/tests/agent/test_vertex_adapter.py
+++ b/tests/agent/test_vertex_adapter.py
@@ -52,6 +52,12 @@ def _install_fake_google_auth(monkeypatch, *, adc_ok=True, adc_project="adc-proj
             c.project_id = sa_project
             return c
 
+        @staticmethod
+        def from_service_account_info(info, scopes=None):
+            c = _Creds()
+            c.project_id = sa_project
+            return c
+
     gsa.Credentials = _SA
     go.service_account = gsa
     gp.auth = ga
@@ -242,3 +248,36 @@ def test_adc_failure_retries_with_late_added_sa_file(vertex_adapter, monkeypatch
     assert token == "ya29.FAKE"
     assert project == "sa-project"
     assert calls["n"] >= 2
+
+
+def test_metadata_preserving_rotation_invalidates_creds_cache(vertex_adapter, monkeypatch, tmp_path):
+    """Atomic replacement that keeps SIZE and MTIME identical (deployment
+    tools that restore metadata; equal-length JSON) must still be picked up.
+    Review finding on #97701: a (path, mtime_ns, size) stat signature keyed
+    the cache, so this replacement served the old private key; the key is
+    now a content digest."""
+    import os as _os
+
+    sa_file = tmp_path / "sa.json"
+    sa_file.write_text('{"project_id": "AAAA-identity"}')
+    monkeypatch.setattr(
+        vertex_adapter, "_resolve_credentials_path", lambda explicit=None: str(sa_file)
+    )
+
+    vertex_adapter.get_vertex_credentials()
+    (key1,) = vertex_adapter._creds_cache
+    creds_obj_1 = vertex_adapter._creds_cache[key1][0]
+
+    # Same-length content, mtime restored, atomic replace.
+    st = _os.stat(sa_file)
+    new = tmp_path / "sa.json.new"
+    new.write_text('{"project_id": "BBBB-identity"}')  # equal length
+    _os.utime(new, ns=(st.st_atime_ns, st.st_mtime_ns))
+    _os.replace(new, sa_file)
+    st2 = _os.stat(sa_file)
+    assert st2.st_size == st.st_size and st2.st_mtime_ns == st.st_mtime_ns
+
+    vertex_adapter.get_vertex_credentials()
+    (key2,) = vertex_adapter._creds_cache
+    assert key2 != key1, "content change must produce a new cache key"
+    assert vertex_adapter._creds_cache[key2][0] is not creds_obj_1

--- a/tests/agent/test_vertex_adapter.py
+++ b/tests/agent/test_vertex_adapter.py
@@ -213,3 +213,32 @@ def test_adc_cache_key_is_stable_sentinel(vertex_adapter):
     same sentinel so repeated ADC calls share one cache entry."""
     assert vertex_adapter._creds_cache_key(None) == ("__adc__",)
     assert vertex_adapter._creds_cache_key("") == ("__adc__",)
+
+
+def test_adc_failure_retries_with_late_added_sa_file(vertex_adapter, monkeypatch, tmp_path):
+    """ADC failure must fall back to a service-account file that appeared
+    after startup. The signature-keyed cache turned keys into tuples and the
+    old `cache_key == "__adc__"` string comparison silently disabled this
+    retry (caught in review); the guard is now `not resolved_path`."""
+    sa_file = tmp_path / "late_sa.json"
+    sa_file.write_text('{"project_id": "late-identity"}')
+
+    calls = {"n": 0}
+
+    def _resolve(explicit=None):
+        # First resolution (entry): nothing configured -> ADC attempt.
+        # Second resolution (retry after ADC failure): the file has appeared.
+        calls["n"] += 1
+        return None if calls["n"] == 1 else str(sa_file)
+
+    monkeypatch.setattr(vertex_adapter, "_resolve_credentials_path", _resolve)
+    # Make the ADC attempt itself raise.
+    monkeypatch.setattr(
+        vertex_adapter.google.auth, "default",
+        lambda scopes=None: (_ for _ in ()).throw(RuntimeError("ADC expired")),
+    )
+
+    token, project = vertex_adapter.get_vertex_credentials()
+    assert token == "ya29.FAKE"
+    assert project == "sa-project"
+    assert calls["n"] >= 2

--- a/tests/agent/test_vertex_adapter.py
+++ b/tests/agent/test_vertex_adapter.py
@@ -159,3 +159,57 @@ def test_adc_refuses_foreign_profile_google_application_credentials(
 
 
 
+
+
+# --- Pattern D: credential-file rotation invalidates the cache ---
+
+
+def test_sa_file_rotation_invalidates_creds_cache(vertex_adapter, monkeypatch, tmp_path):
+    """Rotating the service-account file on disk must be picked up on the
+    next call — the pre-signature cache served tokens minted from the OLD
+    identity for the life of the process (Pattern D: stale cache after an
+    out-of-band change)."""
+    import os as _os
+
+    sa_file = tmp_path / "sa.json"
+    sa_file.write_text('{"project_id": "first-identity"}')
+    monkeypatch.setattr(
+        vertex_adapter, "_resolve_credentials_path", lambda explicit=None: str(sa_file)
+    )
+
+    token1, project1 = vertex_adapter.get_vertex_credentials()
+    assert token1 == "ya29.FAKE"
+    assert len(vertex_adapter._creds_cache) == 1
+
+    # Same file untouched: cache hit (same Credentials object).
+    (key1,) = vertex_adapter._creds_cache
+    creds_obj_1 = vertex_adapter._creds_cache[key1][0]
+    vertex_adapter.get_vertex_credentials()
+    (key1b,) = vertex_adapter._creds_cache
+    assert key1b == key1
+    assert vertex_adapter._creds_cache[key1b][0] is creds_obj_1
+
+    # Rotate: rewrite the file with different content and a bumped mtime.
+    sa_file.write_text('{"project_id": "second-identity", "rotated": true}')
+    st = _os.stat(sa_file)
+    _os.utime(sa_file, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+    vertex_adapter.get_vertex_credentials()
+    # New signature key replaced the old entry — not appended beside it.
+    (key2,) = vertex_adapter._creds_cache
+    assert key2 != key1
+    assert vertex_adapter._creds_cache[key2][0] is not creds_obj_1
+
+
+def test_creds_cache_stat_failure_falls_back_to_path_key(vertex_adapter, monkeypatch):
+    """If the credentials file cannot be stat'ed the key degrades to the bare
+    path — same behavior as the pre-signature cache, never an exception."""
+    key = vertex_adapter._creds_cache_key("/nonexistent/sa.json")
+    assert key == ("/nonexistent/sa.json",)
+
+
+def test_adc_cache_key_is_stable_sentinel(vertex_adapter):
+    """ADC has no file to fingerprint; both None and empty resolve to the
+    same sentinel so repeated ADC calls share one cache entry."""
+    assert vertex_adapter._creds_cache_key(None) == ("__adc__",)
+    assert vertex_adapter._creds_cache_key("") == ("__adc__",)


### PR DESCRIPTION
## Summary

Pattern-D fix (stale cache/state after out-of-band changes) — the remaining core gap found by a systematic audit of every file-backed in-memory cache in `agent/`, `hermes_cli/`, `gateway/`, `tools/`.

**The bug:** the Vertex credentials cache (`agent/vertex_adapter.py:_creds_cache`) is keyed on the service-account file **path alone**. Rotate the file on disk — revoke a compromised key, re-issue the service account — and the process keeps minting tokens from the OLD `Credentials` object until restart. Operators rotate keys precisely when they most need the new identity to take effect.

## Real-world impact

**WHO/WHEN:** anyone running Vertex with a service-account file who rotates it while a gateway/agent process is alive. Before: the old identity is served for the life of the process (silently — tokens still mint fine until the old SA is disabled server-side, at which point every call 401s with no local explanation). After: the next call stats the file, sees the new signature, and rebuilds credentials from the rotated file.

## The fix

Cache key: path → `(path, mtime_ns, size)` — the established house idiom (`agent/skill_utils.py:414`, `hermes_cli/config.py:3343`, and the exact shape #89792 applies to model overrides). Superseded same-path entries are evicted on insert (bounded: one Credentials per file). ADC keeps a stable `("__adc__",)` sentinel and its existing expiry/refresh handling. Stat failure degrades to the bare-path key — byte-for-byte the old behavior.

## Verification

- New tests: rotation invalidates (rewrite + mtime bump → new key, new Credentials, old entry evicted); stat-failure fallback; ADC sentinel stability
- **Mutation check:** prod file reverted to origin/main → 3 tests fail (rotation test fails exactly at the stale-key assertion); restored → 8/8 green
- ruff green; rebased on fresh main

## Pattern-D context (the audit)

Every other file-backed cache checked already carries invalidation: `skill_utils` raw-config (sig-keyed), `config.py` (sig-keyed), `skill_bundles` (max-mtime over dir+files), `moa_loop` preset (config-stamp keyed + 300s TTL runtimes), `model_metadata`/`models_dev` (TTL + ETag). The cluster's remaining fixes live in three open PRs doing the same idiom at their sites — #89792 (model overrides memo), #92253 (non-blocking pricing prewarm), #96099 (disk-persisted catalog) — each independently tested green in isolated worktrees this pass (69/69, 91/91, 83/83) and endorsed on-thread. Unlike Patterns A/C, D has no mechanical/AST-detectable signature, so there is no CI gate to ship — the deliverable is closing the gaps and the three endorsed PRs.