### PR TITLE
fix(relaunch): invoke resolved Python entry points via sys.executable

### DIFF
--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -139,7 +139,26 @@ def build_relaunch_argv(
     bin_path = resolve_hermes_bin()
 
     if bin_path:
-        argv = [bin_path]
+        # If the resolved entry point is itself a Python script (detected
+        # via its shebang, since it may have no file extension -- e.g. the
+        # "hermes" console entry point), invoke it explicitly via
+        # sys.executable rather than relying on its shebang line.
+        # A generic shebang (e.g. #!/usr/bin/env python3) can silently
+        # resolve to a different interpreter than the one currently
+        # running (e.g. system Python instead of a project venv),
+        # dropping dependencies installed only in the venv.
+        is_python_script = False
+        try:
+            with open(bin_path, "rb") as bf:
+                first_line = bf.readline(256)
+            if first_line.startswith(b"#!") and b"python" in first_line:
+                is_python_script = True
+        except OSError:
+            pass
+        if is_python_script:
+            argv = [sys.executable, bin_path]
+        else:
+            argv = [bin_path]
     else:
         argv = [sys.executable, "-m", "hermes_cli.main"]
 


### PR DESCRIPTION
resolve_hermes_bin() can resolve to the raw hermes entry script (e.g. via sys.argv[0]). Executing that script directly relies on its shebang line, which may point to a different Python interpreter than the one currently running (e.g. system python3 instead of the project's venv). This silently drops venv-only dependencies (such as python-dotenv) on relaunch, causing:
  ModuleNotFoundError: No module named 'dotenv'
when using 'hermes sessions browse' to resume a session.
The entry script has no .py extension, so this detects a Python script by inspecting its shebang line instead of the file extension, then invokes it explicitly with sys.executable.

## What does this PR do?

Fixes a bug in `relaunch()` where resuming a session (`hermes sessions browse` → pick a session) can silently switch to a different Python interpreter than the one actually running, causing `ModuleNotFoundError: No module named 'dotenv'`.

`resolve_hermes_bin()` can return the raw `hermes` entry script path (resolved via `sys.argv[0]`). When `build_relaunch_argv()` execs that path directly, it relies on the script's shebang line (`#!/usr/bin/env python3`) to pick the interpreter — which may not be the same Python that was actually running hermes (e.g. a project venv). This drops venv-only dependencies like `python-dotenv` on relaunch.

I hit this directly using a venv-based install: launching `hermes` correctly used the venv Python, but resuming a session via `sessions browse` re-executed the entry script under system Python instead, which didn't have `dotenv` installed.

## Related Issue

No existing issue — happy to open one if preferred.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/relaunch.py`: in `build_relaunch_argv()`, when the resolved bin path is a Python script (detected by checking its shebang line, since the entry script has no `.py` extension), invoke it explicitly via `[sys.executable, bin_path]` instead of executing it directly and relying on its shebang.

## How to Test

1. Install hermes-agent into a dedicated venv (not system Python), with `python-dotenv` present only in that venv.
2. Run `hermes sessions browse`, select a session to resume.
3. Before the fix: the relaunch crashes with `ModuleNotFoundError: No module named 'dotenv'` because it silently drops to system Python.
4. After the fix: the relaunch correctly reuses `sys.executable` (the venv Python) and resumes the session normally.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(relaunch):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: EndeavourOS (Arch-based, x86_64)

### Documentation & Housekeeping
- [x] N/A — no config keys, docs, or architecture changes involved
- [x] N/A — no tool schema/behavior changes