### PR TITLE
fix: P0 batch — five prompt-cache fixes + two desktop persistence fixes (salvage of #97618 #96755 #97327 #96768 #96608 #95886)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -645,6 +645,162 @@ def _model_supports_prompt_cache(model_id: str) -> bool:
     return any(pattern in model_lower for pattern in _CACHE_POINT_PATTERNS)
 
 
+# ---------------------------------------------------------------------------
+# Server-verdict cachePoint suppression
+# ---------------------------------------------------------------------------
+# The allowlist above is a static guess about *placement*, and Bedrock's real
+# rule is per-model-family AND per-field: Amazon Nova accepts cachePoint in
+# ``system``/``messages`` but rejects it inside ``toolConfig.tools`` with a
+# hard ValidationException that fails the whole request (#97281). Any static
+# table drifts the moment AWS ships a family whose placement rules differ, and
+# the failure mode is 100% of turns with no recovery and no user workaround.
+#
+# So the table is not the only authority: when Bedrock names a placement as
+# unpermitted, that verdict is recorded and the marker is dropped from that
+# placement for the rest of the process, and the rejected request is retried
+# once without it. Mirrors the existing self-heal idiom in this module
+# (is_streaming_access_denied_error → non-streaming converse()).
+
+CACHE_POINT_PLACEMENTS = ("tools", "system", "messages")
+
+# model_id (lowercased) → placements Bedrock has rejected this process.
+_CACHE_POINT_REJECTIONS: Dict[str, set] = {}
+
+# "#/toolConfig/tools/18: extraneous key [cachePoint] is not permitted"
+_CACHE_POINT_PATH_PATTERN = re.compile(
+    r"#/(?P<path>[A-Za-z0-9_./\[\]-]*)", re.IGNORECASE
+)
+
+
+def cache_point_rejection_placement(exc: BaseException) -> Optional[str]:
+    """Return the Converse section whose cachePoint block Bedrock refused.
+
+    Returns one of ``CACHE_POINT_PLACEMENTS``, or None when the error is not a
+    cachePoint rejection. Bedrock reports it as a ValidationException naming
+    the offending JSON pointer, e.g.::
+
+        Malformed input request: #/toolConfig/tools/18: extraneous key
+        [cachePoint] is not permitted, please reformat your input and try again.
+
+    Detection is message-based on purpose: the pointer is the only part of the
+    response that says *which* section was rejected, and the same wording
+    reaches us both as a raw botocore ``ClientError`` and wrapped by SDKs.
+    """
+    msg = str(exc)
+    lowered = msg.lower()
+    if "cachepoint" not in lowered:
+        return None
+    if "not permitted" not in lowered and "extraneous" not in lowered:
+        return None
+    match = _CACHE_POINT_PATH_PATTERN.search(msg)
+    path = (match.group("path") if match else "").lower()
+    if "toolconfig" in path or "tools" in path:
+        return "tools"
+    if "system" in path:
+        return "system"
+    if "messages" in path:
+        return "messages"
+    # A rejection we cannot localise: suppress the tool marker first, since
+    # toolConfig.tools is the only placement any supported family is known to
+    # refuse while still accepting the others.
+    return "tools"
+
+
+def note_cache_point_rejection(model_id: str, placement: str) -> None:
+    """Record that ``model_id`` refuses cachePoint blocks in ``placement``."""
+    if placement not in CACHE_POINT_PLACEMENTS:
+        return
+    _CACHE_POINT_REJECTIONS.setdefault(model_id.lower(), set()).add(placement)
+
+
+def cache_point_allowed(model_id: str, placement: str) -> bool:
+    """Return False once Bedrock has refused this placement for this model."""
+    return placement not in _CACHE_POINT_REJECTIONS.get(model_id.lower(), ())
+
+
+def reset_cache_point_rejections() -> None:
+    """Clear recorded cachePoint rejections. Used in tests."""
+    _CACHE_POINT_REJECTIONS.clear()
+
+
+def _is_cache_point_block(block: Any) -> bool:
+    return isinstance(block, dict) and set(block.keys()) == {"cachePoint"}
+
+
+def strip_cache_points(kwargs: Dict[str, Any], placement: str) -> Dict[str, Any]:
+    """Return a copy of Converse kwargs with ``placement``'s cachePoint removed.
+
+    Returns the input unchanged (same object) when there was nothing to strip,
+    which is what callers use to decide a retry cannot help.
+    """
+    if placement == "system":
+        system = kwargs.get("system")
+        if not isinstance(system, list):
+            return kwargs
+        cleaned = [b for b in system if not _is_cache_point_block(b)]
+        if len(cleaned) == len(system):
+            return kwargs
+        return {**kwargs, "system": cleaned}
+
+    if placement == "tools":
+        tool_config = kwargs.get("toolConfig")
+        tools = (tool_config or {}).get("tools")
+        if not isinstance(tools, list):
+            return kwargs
+        cleaned = [t for t in tools if not _is_cache_point_block(t)]
+        if len(cleaned) == len(tools):
+            return kwargs
+        return {**kwargs, "toolConfig": {**tool_config, "tools": cleaned}}
+
+    if placement == "messages":
+        messages = kwargs.get("messages")
+        if not isinstance(messages, list):
+            return kwargs
+        changed = False
+        cleaned_messages = []
+        for msg in messages:
+            content = msg.get("content") if isinstance(msg, dict) else None
+            if isinstance(content, list) and any(_is_cache_point_block(b) for b in content):
+                changed = True
+                cleaned_messages.append({
+                    **msg,
+                    "content": [b for b in content if not _is_cache_point_block(b)],
+                })
+            else:
+                cleaned_messages.append(msg)
+        if not changed:
+            return kwargs
+        return {**kwargs, "messages": cleaned_messages}
+
+    return kwargs
+
+
+def recover_from_cache_point_rejection(
+    exc: BaseException, kwargs: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Record Bedrock's cachePoint verdict and return retry kwargs, or None.
+
+    None means the error was not a cachePoint rejection, or the marker was
+    already absent — in which case retrying cannot change the outcome and the
+    caller must re-raise.
+    """
+    placement = cache_point_rejection_placement(exc)
+    if placement is None:
+        return None
+    retry_kwargs = strip_cache_points(kwargs, placement)
+    if retry_kwargs is kwargs:
+        return None
+    model_id = str(kwargs.get("modelId", ""))
+    note_cache_point_rejection(model_id, placement)
+    logger.warning(
+        "bedrock: %s rejected a cachePoint block in %s — dropping that cache "
+        "marker for this model and retrying. Prompt caching stays active for "
+        "the remaining sections.",
+        model_id or "model", placement,
+    )
+    return retry_kwargs
+
+
 def is_anthropic_bedrock_model(model_id: str) -> bool:
     """Return True if the model is an Anthropic Claude model on Bedrock.
 
@@ -1238,7 +1394,7 @@ def build_converse_kwargs(
     }
 
     if system_prompt:
-        if cache_enabled:
+        if cache_enabled and cache_point_allowed(model, "system"):
             system_prompt = system_prompt + [{"cachePoint": {"type": "default"}}]
         kwargs["system"] = system_prompt
 
@@ -1263,7 +1419,7 @@ def build_converse_kwargs(
             # Strip tools for known non-tool-calling models and warn the user.
             # Ref: PR #7920 feedback from @ptlally, pattern from PR #4346.
             if _model_supports_tool_use(model):
-                if cache_enabled:
+                if cache_enabled and cache_point_allowed(model, "tools"):
                     converse_tools = converse_tools + [{"cachePoint": {"type": "default"}}]
                 kwargs["toolConfig"] = {"tools": converse_tools}
             else:
@@ -1272,7 +1428,11 @@ def build_converse_kwargs(
                     "The agent will operate in text-only mode.", model
                 )
 
-    if cache_enabled and len(converse_messages) >= 2:
+    if (
+        cache_enabled
+        and cache_point_allowed(model, "messages")
+        and len(converse_messages) >= 2
+    ):
         # Checkpoint everything up to (not including) the newest turn, so the
         # marker survives unchanged across requests as only the tail grows —
         # mirroring the Anthropic system_and_3 strategy in prompt_caching.py.
@@ -1320,6 +1480,9 @@ def call_converse(
     try:
         response = client.converse(**kwargs)
     except Exception as exc:
+        retry_kwargs = recover_from_cache_point_rejection(exc, kwargs)
+        if retry_kwargs is not None:
+            return normalize_converse_response(client.converse(**retry_kwargs))
         if is_stale_connection_error(exc):
             logger.warning(
                 "bedrock: stale-connection error on converse(region=%s, model=%s): "
@@ -1362,6 +1525,11 @@ def call_converse_stream(
     try:
         response = client.converse_stream(**kwargs)
     except Exception as exc:
+        retry_kwargs = recover_from_cache_point_rejection(exc, kwargs)
+        if retry_kwargs is not None:
+            return normalize_converse_stream_events(
+                client.converse_stream(**retry_kwargs)
+            )
         if is_streaming_access_denied_error(exc):
             # IAM allows bedrock:InvokeModel but not
             # InvokeModelWithResponseStream — permanent for this session.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -958,6 +958,7 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
             invalidate_runtime_client,
             is_stale_connection_error,
             normalize_converse_response,
+            recover_from_cache_point_rejection,
         )
         region = api_kwargs.pop("__bedrock_region__", "us-east-1")
         api_kwargs.pop("__bedrock_converse__", None)
@@ -965,6 +966,15 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
         try:
             raw_response = client.converse(**api_kwargs)
         except Exception as _bedrock_exc:
+            # A model that refuses cachePoint in one section (Nova rejects it
+            # inside toolConfig.tools, #97281) fails every turn otherwise —
+            # drop that marker and resend before surfacing the error.
+            _retry_kwargs = recover_from_cache_point_rejection(
+                _bedrock_exc, api_kwargs
+            )
+            if _retry_kwargs is not None:
+                raw_response = client.converse(**_retry_kwargs)
+                return normalize_converse_response(raw_response)
             # Evict the cached client on stale-connection failures
             # so the outer retry loop builds a fresh client/pool.
             if is_stale_connection_error(_bedrock_exc):
@@ -3438,6 +3448,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     is_stale_connection_error,
                     is_streaming_access_denied_error,
                     normalize_converse_response,
+                    recover_from_cache_point_rejection,
                     stream_converse_with_callbacks,
                 )
                 intercepted_events = []
@@ -3451,6 +3462,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     try:
                         raw_response = client.converse_stream(**final_kwargs)
                     except Exception as _bedrock_exc:
+                        # Bedrock refuses a cachePoint block in one section for
+                        # some families (Nova: toolConfig.tools, #97281) and
+                        # fails the whole request. Drop that marker and reopen
+                        # the stream inside the same Relay attempt.
+                        _retry_kwargs = recover_from_cache_point_rejection(
+                            _bedrock_exc, final_kwargs
+                        )
+                        if _retry_kwargs is not None:
+                            return client.converse_stream(**_retry_kwargs).get(
+                                "stream", []
+                            )
                         # InvokeModel-only policies cannot open a stream. Keep
                         # the fallback inside the same managed Relay attempt so
                         # the real provider request and terminal response still

--- a/agent/prompt_cache_boundary.py
+++ b/agent/prompt_cache_boundary.py
@@ -67,10 +67,11 @@ def register_stable_prefix(prefix: str) -> None:
 
 
 def find_stable_prefix(content: str) -> Optional[str]:
-    """Longest registered prefix that is a *proper* prefix of ``content``.
+    """Longest registered prefix that is a *proper* prefix of ``content`` with non-whitespace tail.
 
-    Proper (``len(content) > len(prefix)``) so the split never produces an
-    empty volatile text block, which Anthropic rejects on the wire.
+    Proper with non-whitespace tail (``bool(content[len(prefix):].strip())``) so the
+    split never produces an empty or whitespace-only volatile text block, which
+    Anthropic rejects on the wire (HTTP 400).
 
     A hit refreshes the entry's LRU position: a scaffold fired every minute
     by cron must not be evicted by a burst of one-off skill invocations,
@@ -79,7 +80,7 @@ def find_stable_prefix(content: str) -> Optional[str]:
     with _lock:
         best: Optional[str] = None
         for prefix in _prefixes:
-            if len(content) > len(prefix) and content.startswith(prefix):
+            if content.startswith(prefix) and bool(content[len(prefix):].strip()):
                 if best is None or len(prefix) > len(best):
                     best = prefix
         if best is not None:

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -63,20 +63,22 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
         if role == "user":
             stable_prefix = find_stable_prefix(content)
             if stable_prefix is not None:
-                # Builder-declared boundary (#81867): the scaffold carries the
-                # breakpoint, the volatile invocation tail rides unmarked so a
-                # changed ticket ID or timestamp no longer invalidates the
-                # whole skill body. Request-local only — the canonical session
-                # message stays a plain string.
-                msg["content"] = [
-                    {
-                        "type": "text",
-                        "text": stable_prefix,
-                        "cache_control": cache_marker,
-                    },
-                    {"type": "text", "text": content[len(stable_prefix):]},
-                ]
-                return
+                suffix = content[len(stable_prefix):]
+                if suffix.strip():
+                    # Builder-declared boundary (#81867): the scaffold carries the
+                    # breakpoint, the volatile invocation tail rides unmarked so a
+                    # changed ticket ID or timestamp no longer invalidates the
+                    # whole skill body. Request-local only — the canonical session
+                    # message stays a plain string.
+                    msg["content"] = [
+                        {
+                            "type": "text",
+                            "text": stable_prefix,
+                            "cache_control": cache_marker,
+                        },
+                        {"type": "text", "text": suffix},
+                    ]
+                    return
         msg["content"] = [
             {"type": "text", "text": content, "cache_control": cache_marker}
         ]
@@ -204,7 +206,7 @@ def _apply_system_cache_markers(
         and content.startswith(static_system_prefix)
     ):
         suffix = content[len(static_system_prefix):]
-        if suffix:
+        if suffix.strip():
             suffix_part: dict = {"type": "text", "text": suffix}
             if mark_suffix:
                 suffix_part["cache_control"] = cache_marker
@@ -217,7 +219,7 @@ def _apply_system_cache_markers(
                 suffix_part,
             ]
             return 2 if mark_suffix else 1
-        # Empty suffix: the stored prompt IS the static prefix. Mark it as
+        # Empty/whitespace-only suffix: the stored prompt IS the static prefix. Mark it as
         # one whole block — a [marked-prefix, ""] split would put an empty
         # text block on the wire (HTTP 400 on native Anthropic).
         _apply_cache_marker(message, cache_marker, native_anthropic=native_anthropic)

--- a/agent/transcript_repair.py
+++ b/agent/transcript_repair.py
@@ -1,0 +1,112 @@
+"""Transcript repair and in-place row reconciliation helpers for SessionDB and run_agent.
+
+Extracted from hermes_state.py and run_agent.py to keep the godfiles narrow and bounded
+under the 2K invariant (#95514 / PR #95886). Provides focused helpers to:
+1. Resolve active assistant rows and watermark compaction clones in SQLite during batch appends.
+2. In-place update blank assistant rows or adopt concurrent non-blank winner content without overwrite.
+3. Synchronize in-memory message dicts with canonical committed content and row IDs after commit.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Callable, Dict, List, Optional
+
+from agent.context_compressor import _DB_PERSISTED_MARKER
+
+
+def is_content_blank(content: Any) -> bool:
+    """True when decoded message content is None, whitespace-only, or has no visible text parts."""
+    if content is None:
+        return True
+    if isinstance(content, str):
+        return not content.strip()
+    if isinstance(content, list):
+        if not content:
+            return True
+        texts = [
+            p.get("text", "")
+            for p in content
+            if isinstance(p, dict) and p.get("type") == "text"
+        ]
+        return not "".join(texts).strip()
+    return False
+
+
+def resolve_and_repair_transcript_batch(
+    conn: sqlite3.Connection,
+    session_id: str,
+    messages: List[Dict[str, Any]],
+    encode_content_fn: Callable[[Any], Any],
+    decode_content_fn: Callable[[Any], Any],
+) -> List[Dict[str, Any]]:
+    """Partition a message batch within an active write transaction.
+
+    For assistant messages carrying an existing integer `_row_id`:
+    - Checks for an active target row or watermark compaction clone in SQLite.
+    - If blank, updates the row in-place with new content.
+    - If already non-blank (concurrent winner), adopts canonical content without overwrite.
+    - Returns the list of messages that must be inserted as fresh rows.
+    """
+    inserted_rows: List[Dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role", "unknown") if isinstance(msg, dict) else "unknown"
+        existing_row_id = msg.get("_row_id") if isinstance(msg, dict) else None
+        repaired = False
+        if role == "assistant" and isinstance(existing_row_id, int):
+            row = conn.execute(
+                "SELECT id, role, active, timestamp, content FROM messages "
+                "WHERE id = ? AND session_id = ?",
+                (existing_row_id, session_id),
+            ).fetchone()
+            target_row = None
+            if row is not None and row["role"] == "assistant":
+                if int(row["active"] or 0) == 1:
+                    target_row = row
+                else:
+                    # Watermark compaction soft-archived the concurrent tail
+                    # and cloned it. Find the active clone.
+                    clone = conn.execute(
+                        "SELECT id, role, active, timestamp, content FROM messages "
+                        "WHERE session_id = ? AND active = 1 AND role = 'assistant' "
+                        "AND timestamp IS ? AND id != ? "
+                        "ORDER BY id DESC LIMIT 1",
+                        (session_id, row["timestamp"], row["id"]),
+                    ).fetchone()
+                    if clone is not None:
+                        target_row = clone
+            if target_row is not None:
+                target_id = int(target_row["id"])
+                raw_content = target_row["content"]
+                decoded = decode_content_fn(raw_content)
+                if is_content_blank(decoded):
+                    encoded = encode_content_fn(msg.get("content"))
+                    conn.execute(
+                        "UPDATE messages SET content = ? "
+                        "WHERE id = ? AND session_id = ? AND active = 1",
+                        (encoded, target_id, session_id),
+                    )
+                    if isinstance(msg, dict):
+                        msg["_row_id"] = target_id
+                else:
+                    # Concurrent winner: adopt canonical content without overwrite
+                    if isinstance(msg, dict):
+                        msg["_row_id"] = target_id
+                        msg["_canonical_content"] = decoded
+                repaired = True
+        if not repaired:
+            inserted_rows.append(msg)
+    return inserted_rows
+
+
+def sync_flushed_message_markers(
+    batch_msgs: List[Dict[str, Any]],
+    batch_rows: List[Dict[str, Any]],
+) -> None:
+    """Stamp _DB_PERSISTED_MARKER and sync canonical row ID / content onto live dicts after commit."""
+    for written, row in zip(batch_msgs, batch_rows):
+        written[_DB_PERSISTED_MARKER] = True
+        if isinstance(row.get("_row_id"), int):
+            written["_row_id"] = row["_row_id"]
+        if "_canonical_content" in row:
+            written["content"] = row["_canonical_content"]

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -66,15 +66,36 @@ def _add_prompt_cache_key(
     precedence over the physical ``session_id`` so the key survives
     context-compression session rotation (#79017).
     """
-    if not supports_prompt_cache_key:
+    # An explicit caller body field is authoritative — do not add a duplicate
+    # top-level field whose SDK merge precedence could overwrite it.  But it
+    # must still respect the wire constraint: OpenAI caps ``prompt_cache_key``
+    # at 64 chars (DeepSeek and Zai inherit the same limit via their
+    # OpenAI-compatible APIs) and rejects longer values with HTTP 400.  Bound
+    # caller keys in place with the same hash shape the Responses transport
+    # uses (``_bounded_prompt_cache_key`` in agent/transports/codex.py), so
+    # both transports behave identically for over-length keys.
+    from agent.transports.codex import _bounded_prompt_cache_key
+
+    extra_body = api_kwargs.get("extra_body")
+    caller_supplied = "prompt_cache_key" in api_kwargs or (
+        isinstance(extra_body, dict) and "prompt_cache_key" in extra_body
+    )
+    if caller_supplied:
+        if "prompt_cache_key" in api_kwargs:
+            bounded = _bounded_prompt_cache_key(api_kwargs["prompt_cache_key"])
+            if bounded:
+                api_kwargs["prompt_cache_key"] = bounded
+            else:
+                api_kwargs.pop("prompt_cache_key", None)
+        if isinstance(extra_body, dict) and "prompt_cache_key" in extra_body:
+            bounded = _bounded_prompt_cache_key(extra_body["prompt_cache_key"])
+            if bounded:
+                extra_body["prompt_cache_key"] = bounded
+            else:
+                extra_body.pop("prompt_cache_key", None)
         return
 
-    # An explicit caller body field is authoritative too.  Do not add a
-    # duplicate top-level field whose SDK merge precedence could overwrite it.
-    extra_body = api_kwargs.get("extra_body")
-    if "prompt_cache_key" in api_kwargs or (
-        isinstance(extra_body, dict) and "prompt_cache_key" in extra_body
-    ):
+    if not supports_prompt_cache_key:
         return
 
     # Reuse the Responses transport's single authoritative hash algorithm and

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -32,18 +32,26 @@ from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import _sanitize_surrogates
 
 
-def _is_pure_tool_call_tail(msg: dict) -> bool:
-    """An assistant row with ``tool_calls`` but no visible text content of its own.
-
-    Such a row satisfies the role check (``tail role == "assistant"``) while
-    carrying none of the delivered answer — see the #43849/#44100 invariant
-    block in :func:`finalize_turn`. Uses :func:`flatten_message_text` so that
-    multimodal (list-type) content is evaluated by its text parts, not just
-    its type.
-    """
-    if not msg.get("tool_calls"):
+def _assistant_row_missing_visible_text(msg: dict) -> bool:
+    """True when an assistant row has no visible text (blank final or tool-only)."""
+    if not isinstance(msg, dict) or msg.get("role") != "assistant":
         return False
     return not flatten_message_text(msg.get("content")).strip()
+
+
+def _is_pure_tool_call_tail(msg: dict) -> bool:
+    """Assistant row with ``tool_calls`` but no visible text of its own."""
+    if not isinstance(msg, dict) or not msg.get("tool_calls"):
+        return False
+    return _assistant_row_missing_visible_text(msg)
+
+
+def _fill_assistant_tail_content(agent, tail: dict, final_response) -> None:
+    """Write delivered text onto an already-persisted blank assistant row."""
+    tail["content"] = final_response
+    stamp_message_timestamp(tail)
+    tail.pop(_DB_PERSISTED_MARKER, None)
+    agent._db_flush_scan_prefix = None
 
 
 # Verification continuation scaffolding flags: verify-on-stop / pre_verify
@@ -305,6 +313,21 @@ def finalize_turn(
         # state.db. (#65919 §7)
         _drop_verification_continuation_scaffolding(messages)
 
+        # #95514: an empty terminal completion is not authoritative when the
+        # stream already delivered text. Recover before persist so a blank
+        # assistant tail is filled instead of frozen as content=''.
+        _recovered_from_stream = False
+        if not interrupted and not failed:
+            _streamed = getattr(agent, "_current_streamed_assistant_text", "") or ""
+            if isinstance(_streamed, str):
+                _streamed = _streamed.strip()
+            else:
+                _streamed = ""
+            _final_visible = flatten_message_text(final_response).strip() if final_response else ""
+            if not _final_visible and _streamed:
+                final_response = _streamed
+                _recovered_from_stream = True
+
         # When the turn was interrupted and the last message is a tool
         # result, append a synthetic assistant message to close the
         # tool-call sequence. Without this, the session persists a
@@ -351,40 +374,23 @@ def finalize_turn(
                     messages,
                     {"role": "assistant", "content": final_response},
                 )
-            elif isinstance(_tail, dict) and _tail.get("content") != final_response and _is_pure_tool_call_tail(_tail):
-                # The tail IS an assistant row, but a *pure tool-call turn*:
-                # tool_calls with no text of its own. The role check alone
-                # leaves the #43849/#44100 invariant unmet — the user saw a
-                # response that never reached the transcript, and the next turn
-                # replays the user backlog and re-answers it (the very symptom
-                # this block was added for). Fill that row's empty content
-                # instead of appending, so the durable turn ends with the answer
-                # without disturbing the tool-call structure or creating an
-                # assistant→assistant pair.
-                #
-                # The ``content != final_response`` guard prevents filling when
-                # the tail already carries the final response text (verification
-                # candidate collapse — the provisional answer was persisted and
-                # reused as the terminal response, #65919 §7).
-                _tail["content"] = final_response
-                # The normal assistant builder already stamps this row. Cover
-                # legacy/exceptional pure-tool tails before they become a
-                # delivered final response.
-                stamp_message_timestamp(_tail)
-                # The row may have already been flushed to SQLite by the
-                # incremental tool-call persist (conversation_loop.py:4990),
-                # which stamps ``_DB_PERSISTED_MARKER`` so subsequent flushes
-                # skip it. Pop the marker so the next ``_persist_session``
-                # re-writes the filled content to the durable store —
-                # otherwise ``/resume`` reloads ``content=""`` and the bug
-                # resurfaces cross-session.
-                _tail.pop(_DB_PERSISTED_MARKER, None)
-                # The bounded flush-scan cursor (run_agent.py) skips the
-                # identity-matched prefix of its previous snapshot on the
-                # assumption that no live dict loses the marker in place —
-                # this pop is the one place that does. Invalidate it so the
-                # filled row is re-examined instead of skipped.
-                agent._db_flush_scan_prefix = None
+            elif (
+                isinstance(_tail, dict)
+                and _tail.get("content") != final_response
+                and (
+                    _is_pure_tool_call_tail(_tail)
+                    or (
+                        _recovered_from_stream
+                        and _assistant_row_missing_visible_text(_tail)
+                    )
+                )
+            ):
+                # The tail IS an assistant row, but a *pure tool-call turn* or
+                # a blank assistant tail whose content was recovered from the
+                # stream buffer (#95514). Fill that row's content instead of
+                # appending, so the durable turn ends with the answer without
+                # creating an assistant→assistant pair.
+                _fill_assistant_tail_content(agent, _tail, final_response)
 
         # The model has completed its request, so replace API-local
         # voice/model/skill guidance with the clean user input before writing the

--- a/apps/desktop/electron/gateway-file-download-transport.test.ts
+++ b/apps/desktop/electron/gateway-file-download-transport.test.ts
@@ -51,6 +51,21 @@ test('finalizeGatewayDownload prompts a save dialog then streams the response', 
 
   assert.match(fn, /dialog\.showSaveDialog/)
   assert.match(fn, /pumpStreamToFile\(/)
+  // Production deps come from one place so the streaming save and the data-URL
+  // fallback share the exclusive-create + rename contract (#96597).
+  assert.match(fn, /fsPumpDeps\(\)/)
+  assert.doesNotMatch(fn, /fs\.createWriteStream/)
   // HTTP errors carry their status so a 404 can trigger the fallback.
   assert.match(fn, /error\.statusCode = statusCode/)
+})
+
+test('data-URL fallback writes through the same failure-atomic primitive, never writeFile in place', () => {
+  const fn = extract('async function saveGatewayFileViaDataUrl', '\n// Mint a single-use WS ticket')
+
+  assert.match(fn, /dialog\.showSaveDialog/)
+  assert.match(fn, /writeBufferToFile\(/)
+  assert.match(fn, /fsPumpDeps\(\)/)
+  // A direct writeFile truncates an existing destination before the write
+  // completes; a mid-write failure would destroy it (#96597).
+  assert.doesNotMatch(fn, /fs\.promises\.writeFile/)
 })

--- a/apps/desktop/electron/gateway-file-download.fs.test.ts
+++ b/apps/desktop/electron/gateway-file-download.fs.test.ts
@@ -1,0 +1,152 @@
+// Real-filesystem witnesses for the failure-atomic save contract (#96597).
+//
+// The unit tests in gateway-file-download.test.ts prove the pump's control flow
+// against fakes. These run the exact production deps (`fsPumpDeps()`) against
+// node:fs in a scratch directory and assert the user-visible invariants
+// byte-for-byte: a pre-existing destination survives every failure mode this
+// harness can force, a pre-existing file at the temp name survives a pre-open
+// collision, and no owned `.part` file is ever left behind.
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { Readable } from 'node:stream'
+
+import { afterEach, beforeEach, test } from 'vitest'
+
+import { fsPumpDeps, pumpStreamToFile, writeBufferToFile } from './gateway-file-download'
+
+let dir = ''
+
+beforeEach(async () => {
+  dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'hermes-download-fs-'))
+})
+
+afterEach(async () => {
+  await fs.promises.rm(dir, { force: true, recursive: true })
+})
+
+// A body that delivers `chunks` then fails with `error` (or ends cleanly when
+// `error` is omitted). Readable satisfies the pump's ReadableLike shape.
+function body(chunks: string[], error?: Error): Readable {
+  let i = 0
+
+  return new Readable({
+    read() {
+      if (i < chunks.length) {
+        this.push(Buffer.from(chunks[i++]))
+
+        return
+      }
+
+      if (error) {
+        this.destroy(error)
+
+        return
+      }
+
+      this.push(null)
+    }
+  })
+}
+
+async function listing(): Promise<string[]> {
+  return (await fs.promises.readdir(dir)).sort()
+}
+
+test('a completed download replaces the destination and leaves no temp file', async () => {
+  const dest = path.join(dir, 'report.bin')
+
+  await fs.promises.writeFile(dest, 'OLD CONTENT')
+
+  await pumpStreamToFile(body(['new ', 'content']), dest, fsPumpDeps())
+
+  assert.equal(await fs.promises.readFile(dest, 'utf8'), 'new content')
+  assert.deepEqual(await listing(), ['report.bin'])
+})
+
+test('a download that fails mid-stream leaves the pre-existing destination byte-for-byte and no temp file', async () => {
+  const dest = path.join(dir, 'report.bin')
+  const original = Buffer.from('OLD CONTENT THAT MUST SURVIVE')
+
+  await fs.promises.writeFile(dest, original)
+
+  await assert.rejects(
+    pumpStreamToFile(body(['partial'], new Error('socket hang up')), dest, fsPumpDeps()),
+    /socket hang up/
+  )
+
+  assert.ok(original.equals(await fs.promises.readFile(dest)), 'destination bytes must be unchanged')
+  assert.deepEqual(await listing(), ['report.bin'], 'no .part file may remain')
+})
+
+test('a download into a name with no existing file that fails leaves nothing behind', async () => {
+  const dest = path.join(dir, 'fresh.bin')
+
+  await assert.rejects(pumpStreamToFile(body(['partial'], new Error('reset')), dest, fsPumpDeps()), /reset/)
+
+  assert.deepEqual(await listing(), [])
+})
+
+// The reviewer-requested regression: seed the candidate temp path with known
+// bytes, force the exclusive open to fail with EEXIST, and prove those bytes
+// remain untouched and no rename occurred.
+test('a pre-open EEXIST collision leaves the seeded temp file and the destination untouched', async () => {
+  const dest = path.join(dir, 'report.bin')
+  const pinnedTemp = path.join(dir, '.hermes-download-pinned.part')
+  const seeded = Buffer.from('SOMEONE ELSES BYTES')
+  const original = Buffer.from('OLD CONTENT')
+
+  await fs.promises.writeFile(dest, original)
+  await fs.promises.writeFile(pinnedTemp, seeded)
+
+  const deps = { ...fsPumpDeps(), tempPathFor: () => pinnedTemp }
+
+  await assert.rejects(pumpStreamToFile(body(['new content']), dest, deps), (err: NodeJS.ErrnoException) => {
+    assert.equal(err.code, 'EEXIST')
+
+    return true
+  })
+
+  assert.ok(seeded.equals(await fs.promises.readFile(pinnedTemp)), 'the colliding file must not be unlinked')
+  assert.ok(original.equals(await fs.promises.readFile(dest)), 'destination must not be renamed over')
+  assert.deepEqual(await listing(), ['.hermes-download-pinned.part', 'report.bin'])
+})
+
+test('a failed final rename removes the owned temp file and leaves the destination as it was', async () => {
+  // A directory at the destination makes rename(2) fail on every platform.
+  const dest = path.join(dir, 'report.bin')
+
+  await fs.promises.mkdir(dest)
+  await fs.promises.writeFile(path.join(dest, 'keep.txt'), 'inside')
+
+  await assert.rejects(pumpStreamToFile(body(['new content']), dest, fsPumpDeps()))
+
+  assert.ok((await fs.promises.stat(dest)).isDirectory(), 'destination directory must survive')
+  assert.equal(await fs.promises.readFile(path.join(dest, 'keep.txt'), 'utf8'), 'inside')
+  assert.deepEqual(await listing(), ['report.bin'], 'the owned temp file must be cleaned up')
+})
+
+test('writeBufferToFile replaces the destination atomically and leaves no temp file', async () => {
+  const dest = path.join(dir, 'fallback.bin')
+
+  await fs.promises.writeFile(dest, 'OLD CONTENT')
+
+  await writeBufferToFile(Buffer.from('data-url payload'), dest, fsPumpDeps())
+
+  assert.equal(await fs.promises.readFile(dest, 'utf8'), 'data-url payload')
+  assert.deepEqual(await listing(), ['fallback.bin'])
+})
+
+test('writeBufferToFile into a missing directory fails without creating anything', async () => {
+  const dest = path.join(dir, 'missing-subdir', 'fallback.bin')
+
+  await assert.rejects(writeBufferToFile(Buffer.from('payload'), dest, fsPumpDeps()), (err: NodeJS.ErrnoException) => {
+    assert.equal(err.code, 'ENOENT')
+
+    return true
+  })
+
+  assert.deepEqual(await listing(), [])
+})

--- a/apps/desktop/electron/gateway-file-download.test.ts
+++ b/apps/desktop/electron/gateway-file-download.test.ts
@@ -1,17 +1,21 @@
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
+import path from 'node:path'
 
 import { test } from 'vitest'
 
 import { pathForRegistryBackendRequest } from './connection-config'
+import type { PumpDeps } from './gateway-file-download'
 import {
+  downloadTempPath,
   filenameFromContentDisposition,
   gatewayFilePath,
   gatewayFileRequestPaths,
   isNotFoundError,
   parseDataUrlToBuffer,
   pumpStreamToFile,
-  resolveGatewayFileBackend
+  resolveGatewayFileBackend,
+  writeBufferToFile
 } from './gateway-file-download'
 
 // A Readable-like response driven manually in tests.
@@ -40,9 +44,15 @@ class FakeWriteStream extends EventEmitter {
   destroyed = false
   private writeReturns: boolean[]
 
-  constructor(writeReturns: boolean[] = []) {
+  constructor(writeReturns: boolean[] = [], { opens = true }: { opens?: boolean } = {}) {
     super()
     this.writeReturns = writeReturns
+
+    // Like fs.WriteStream: 'open' fires once the exclusive create succeeded.
+    // `opens: false` models a create that fails before any file exists.
+    if (opens) {
+      queueMicrotask(() => this.emit('open'))
+    }
   }
 
   write(chunk: Buffer): boolean {
@@ -56,22 +66,81 @@ class FakeWriteStream extends EventEmitter {
     cb()
   }
 
+  // Like fs.WriteStream: the descriptor is released asynchronously and 'close'
+  // fires afterwards.
   destroy() {
     this.destroyed = true
+    queueMicrotask(() => this.emit('close'))
   }
 }
 
-test('pumpStreamToFile streams chunks to the destination without buffering the whole body', async () => {
-  const res = new FakeResponse()
-  const ws = new FakeWriteStream()
+// Deps recorder shared by the pumpStreamToFile tests: captures every path the
+// pump opens, renames, or unlinks so each test can assert the destination itself
+// was never touched before the body finished.
+function recordingDeps(ws: FakeWriteStream, { renameError }: { renameError?: Error } = {}) {
+  const opened: string[] = []
+  const renamed: Array<[string, string]> = []
   const unlinked: string[] = []
 
-  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', {
-    createWriteStream: () => ws as never,
-    unlink: async p => {
+  const deps: PumpDeps = {
+    createWriteStream: (p: string) => {
+      opened.push(p)
+
+      return ws as never
+    },
+    rename: async (from: string, to: string) => {
+      if (renameError) {
+        throw renameError
+      }
+
+      renamed.push([from, to])
+    },
+    unlink: async (p: string) => {
       unlinked.push(p)
     }
-  })
+  }
+
+  return { deps, opened, renamed, unlinked }
+}
+
+// Separator-agnostic: path.join emits backslashes on Windows, so the expectation
+// is "short hidden .part name, same directory as the destination", not a
+// literal POSIX string.
+const TEMP_BASENAME = /^\.hermes-download-[0-9a-f]{8}\.part$/
+
+// path.join normalizes separators (``/tmp`` -> ``\\tmp`` on Windows) while the
+// literal destination strings in these tests do not, so compare normalized forms.
+function assertTempPathBeside(tempPath: string, destPath: string) {
+  assert.equal(
+    path.normalize(path.dirname(tempPath)),
+    path.normalize(path.dirname(destPath)),
+    'temp file must sit beside the destination'
+  )
+  assert.match(path.basename(tempPath), TEMP_BASENAME)
+}
+
+test('downloadTempPath stays beside the destination with a short, random per-call name', () => {
+  const a = downloadTempPath('/tmp/out.bin')
+  const b = downloadTempPath('/tmp/out.bin')
+
+  assertTempPathBeside(a, '/tmp/out.bin')
+  assertTempPathBeside(b, '/tmp/out.bin')
+  assert.notEqual(a, b, 'two concurrent saves into the same directory must not share a temp file')
+
+  // The temp name must not grow with the user's filename: a destination near the
+  // filesystem's name limit still gets a temp file that fits beside it.
+  const longName = `/downloads/${'x'.repeat(250)}.bin`
+
+  assert.equal(path.normalize(path.dirname(downloadTempPath(longName))), path.normalize(path.dirname(longName)))
+  assert.ok(path.basename(downloadTempPath(longName)).length < 40)
+})
+
+test('pumpStreamToFile streams chunks into a sibling temp file, then renames it onto the destination', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream()
+  const { deps, opened, renamed, unlinked } = recordingDeps(ws)
+
+  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', deps)
 
   res.emit('data', Buffer.from('abc'))
   res.emit('data', Buffer.from('def'))
@@ -81,17 +150,51 @@ test('pumpStreamToFile streams chunks to the destination without buffering the w
 
   assert.equal(Buffer.concat(ws.chunks).toString('utf8'), 'abcdef')
   assert.equal(ws.ended, true)
+  assert.equal(opened.length, 1)
+  assertTempPathBeside(opened[0], '/tmp/out.bin')
+  assert.deepEqual(renamed, [[opened[0], '/tmp/out.bin']])
   assert.deepEqual(unlinked, []) // success -> no cleanup
+})
+
+test('pumpStreamToFile waits for the descriptor to close before renaming when the stream supports close()', async () => {
+  const res = new FakeResponse()
+  const order: string[] = []
+
+  class ClosingWriteStream extends FakeWriteStream {
+    close(cb: (err?: Error | null) => void) {
+      order.push('close')
+      // Like fs.WriteStream: end the stream, release the fd, then call back.
+      this.ended = true
+      setTimeout(() => cb(), 0)
+    }
+  }
+
+  const ws = new ClosingWriteStream()
+  const { deps, renamed } = recordingDeps(ws)
+
+  deps.rename = async (from, to) => {
+    order.push('rename')
+    renamed.push([from, to])
+  }
+
+  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', deps)
+
+  res.emit('data', Buffer.from('abc'))
+  res.emit('end')
+
+  await promise
+
+  assert.deepEqual(order, ['close', 'rename'])
+  assert.equal(renamed.length, 1)
+  assert.equal(renamed[0][1], '/tmp/out.bin')
 })
 
 test('pumpStreamToFile applies backpressure: pauses on a full buffer and resumes on drain', async () => {
   const res = new FakeResponse()
   const ws = new FakeWriteStream([false]) // first write signals "buffer full"
+  const { deps } = recordingDeps(ws)
 
-  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', {
-    createWriteStream: () => ws as never,
-    unlink: async () => {}
-  })
+  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', deps)
 
   res.emit('data', Buffer.from('big-chunk'))
   assert.equal(res.paused, true, 'source should be paused when write() returns false')
@@ -104,43 +207,166 @@ test('pumpStreamToFile applies backpressure: pauses on a full buffer and resumes
   await promise
 })
 
-test('pumpStreamToFile unlinks the partial file and rejects on a write error', async () => {
+test('pumpStreamToFile removes only the temp file and rejects on a write error', async () => {
   const res = new FakeResponse()
   const ws = new FakeWriteStream()
-  const unlinked: string[] = []
+  const { deps, opened, renamed, unlinked } = recordingDeps(ws)
 
-  const promise = pumpStreamToFile(res as never, '/tmp/partial.bin', {
-    createWriteStream: () => ws as never,
-    unlink: async p => {
-      unlinked.push(p)
-    }
-  })
+  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', deps)
 
   res.emit('data', Buffer.from('abc'))
   ws.emit('error', new Error('ENOSPC: disk full'))
 
   await assert.rejects(promise, /disk full/)
-  assert.deepEqual(unlinked, ['/tmp/partial.bin'])
+  assert.deepEqual(unlinked, [opened[0]])
+  assertTempPathBeside(unlinked[0], '/tmp/out.bin')
+  assert.deepEqual(renamed, [], 'a failed body must never be moved onto the destination')
   assert.equal(res.destroyed, true, 'source should be torn down on write failure')
 })
 
-test('pumpStreamToFile unlinks the partial file and rejects on a response error', async () => {
+test('pumpStreamToFile waits for the write stream to close before unlinking the temp file', async () => {
   const res = new FakeResponse()
-  const ws = new FakeWriteStream()
-  const unlinked: string[] = []
+  const order: string[] = []
 
-  const promise = pumpStreamToFile(res as never, '/tmp/partial.bin', {
-    createWriteStream: () => ws as never,
-    unlink: async p => {
-      unlinked.push(p)
+  class SlowCloseWriteStream extends FakeWriteStream {
+    destroy() {
+      this.destroyed = true
+      order.push('destroy')
+      // Release the fd later than a microtask: cleanup must still wait for it.
+      setTimeout(() => {
+        order.push('close')
+        this.emit('close')
+      }, 5)
     }
-  })
+  }
+
+  const ws = new SlowCloseWriteStream()
+  const { deps, opened, unlinked } = recordingDeps(ws)
+
+  deps.unlink = async (p: string) => {
+    order.push('unlink')
+    unlinked.push(p)
+  }
+
+  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', deps)
 
   res.emit('data', Buffer.from('abc'))
   res.emit('error', new Error('socket hang up'))
 
   await assert.rejects(promise, /socket hang up/)
-  assert.deepEqual(unlinked, ['/tmp/partial.bin'])
+  assert.deepEqual(order, ['destroy', 'close', 'unlink'])
+  assert.deepEqual(unlinked, [opened[0]])
+})
+
+// Ownership gate: an exclusive create can fail BEFORE this pump owns anything at
+// the temp path (EEXIST on a collision). Cleanup must not unlink a file it did
+// not create, or the destructive class moves from the destination to the temp
+// name.
+test('pumpStreamToFile never unlinks a temp path it did not create when the exclusive open fails', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream([], { opens: false })
+  const { deps, opened, renamed, unlinked } = recordingDeps(ws)
+
+  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', deps)
+
+  const eexist: any = new Error("EEXIST: file already exists, open '/tmp/.hermes-download-deadbeef.part'")
+
+  eexist.code = 'EEXIST'
+  ws.emit('error', eexist)
+
+  await assert.rejects(promise, /EEXIST/)
+  assert.equal(opened.length, 1, 'one create attempt')
+  assert.deepEqual(unlinked, [], 'the colliding file belongs to someone else and must survive')
+  assert.deepEqual(renamed, [])
+  assert.equal(res.destroyed, true)
+})
+
+test('pumpStreamToFile honours tempPathFor so a regression can pin the temp path', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream()
+  const { deps, opened, renamed } = recordingDeps(ws)
+
+  deps.tempPathFor = () => '/tmp/pinned.part'
+
+  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', deps)
+
+  res.emit('data', Buffer.from('abc'))
+  res.emit('end')
+
+  await promise
+
+  assert.deepEqual(opened, ['/tmp/pinned.part'])
+  assert.deepEqual(renamed, [['/tmp/pinned.part', '/tmp/out.bin']])
+})
+
+test('writeBufferToFile streams the buffer through the same temp-then-rename contract', async () => {
+  const ws = new FakeWriteStream()
+  const { deps, opened, renamed, unlinked } = recordingDeps(ws)
+
+  await writeBufferToFile(Buffer.from('whole body'), '/tmp/out.bin', deps)
+
+  assert.equal(Buffer.concat(ws.chunks).toString('utf8'), 'whole body')
+  assert.equal(opened.length, 1)
+  assertTempPathBeside(opened[0], '/tmp/out.bin')
+  assert.deepEqual(renamed, [[opened[0], '/tmp/out.bin']])
+  assert.deepEqual(unlinked, [])
+})
+
+test('writeBufferToFile leaves the destination untouched when the write fails after open', async () => {
+  // fs.WriteStream surfaces a write failure before 'finish', never after, so
+  // the fake errors from write() itself.
+  class FailingWriteStream extends FakeWriteStream {
+    write(chunk: Buffer): boolean {
+      super.write(chunk)
+      this.emit('error', new Error('ENOSPC: disk full'))
+
+      return true
+    }
+  }
+
+  const ws = new FailingWriteStream()
+  const { deps, opened, renamed, unlinked } = recordingDeps(ws)
+
+  await assert.rejects(writeBufferToFile(Buffer.from('whole body'), '/tmp/out.bin', deps), /disk full/)
+  assert.ok(!opened.includes('/tmp/out.bin'))
+  assert.deepEqual(unlinked, [opened[0]], 'only the owned temp file is removed')
+  assert.deepEqual(renamed, [])
+})
+
+// Regression for #96597: opening the destination directly truncated it as soon
+// as the stream opened, and the error path then unlinked it — so a gateway
+// hiccup mid-download destroyed a pre-existing file the user had chosen to
+// overwrite. The destination must be neither opened nor removed on failure.
+test('pumpStreamToFile leaves a pre-existing destination untouched when the response fails mid-stream', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream()
+  const { deps, opened, renamed, unlinked } = recordingDeps(ws)
+
+  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', deps)
+
+  res.emit('data', Buffer.from('abc'))
+  res.emit('error', new Error('socket hang up'))
+
+  await assert.rejects(promise, /socket hang up/)
+  assert.ok(!opened.includes('/tmp/out.bin'), 'destination must not be opened (and truncated) before the body lands')
+  assert.ok(!unlinked.includes('/tmp/out.bin'), 'destination must not be removed on failure')
+  assert.deepEqual(unlinked, [opened[0]])
+  assert.deepEqual(renamed, [])
+})
+
+test('pumpStreamToFile removes the temp file and rejects when the final rename fails', async () => {
+  const res = new FakeResponse()
+  const ws = new FakeWriteStream()
+  const { deps, opened, unlinked } = recordingDeps(ws, { renameError: new Error('EPERM: destination locked') })
+
+  const promise = pumpStreamToFile(res as never, '/tmp/out.bin', deps)
+
+  res.emit('data', Buffer.from('abc'))
+  res.emit('end')
+
+  await assert.rejects(promise, /destination locked/)
+  assert.deepEqual(unlinked, [opened[0]], 'the temp file must not be left behind after a failed rename')
+  assert.ok(!unlinked.includes('/tmp/out.bin'))
 })
 
 test('parseDataUrlToBuffer decodes base64 payloads', () => {

--- a/apps/desktop/electron/gateway-file-download.ts
+++ b/apps/desktop/electron/gateway-file-download.ts
@@ -5,11 +5,15 @@
 // The transport wrappers (token / OAuth) live in main.ts because they need
 // main-process singletons (https/http, electronNet, the OAuth session). They
 // delegate the byte-moving to `pumpStreamToFile` here, which streams the
-// response to a user-selected destination with backpressure and cleans up a
-// partial file on error — so a large download never has to be buffered whole in
-// the native process.
+// response into a sibling temp file with backpressure and renames it onto the
+// user-selected destination only once the body has landed in full — so a large
+// download never has to be buffered whole in the native process, and a failed
+// one never touches a file that was already at the destination.
 
+import crypto from 'node:crypto'
+import fs from 'node:fs'
 import path from 'node:path'
+import { Readable } from 'node:stream'
 
 // Minimal shape of the response objects we consume. Both Node's
 // http.IncomingMessage and Electron net's IncomingMessage satisfy it.
@@ -25,14 +29,58 @@ export interface ReadableLike {
 export interface WriteStreamLike {
   write(chunk: Buffer): boolean
   end(cb: () => void): void
+  // fs.WriteStream's close() ends the stream and calls back only after the
+  // descriptor is released. end()'s callback fires on 'finish', while the fd can
+  // still be open — and Windows refuses to rename a file with an open handle.
+  close?(cb: (err?: Error | null) => void): void
   destroy(err?: Error): void
   on(event: 'error', listener: (err: Error) => void): unknown
-  once(event: 'drain', listener: () => void): unknown
+  // 'open' is the ownership signal: only after it fires did THIS pump create
+  // the temp file, and only then may cleanup unlink it.
+  once(event: 'close' | 'drain' | 'open', listener: () => void): unknown
 }
 
 export interface PumpDeps {
-  createWriteStream: (destPath: string) => WriteStreamLike
-  unlink: (destPath: string) => Promise<unknown>
+  // Must open the temp path exclusively (`flags: 'wx'`): the pump relies on
+  // creating a brand-new file, never on truncating or following something that
+  // already sits at that name.
+  createWriteStream: (tempPath: string) => WriteStreamLike
+  rename: (fromPath: string, toPath: string) => Promise<unknown>
+  unlink: (tempPath: string) => Promise<unknown>
+  // Test seam: pick the temp path deterministically so a regression can seed
+  // it and prove a pre-open collision leaves the seeded file untouched.
+  tempPathFor?: (destPath: string) => string
+}
+
+// Production deps: exclusive create on the real filesystem. Shared by the
+// streaming save and the data-URL fallback in main.ts, and exercised directly
+// by the real-filesystem tests so the guarantees are proven against node:fs,
+// not only against fakes.
+export function fsPumpDeps(): PumpDeps {
+  return {
+    createWriteStream: tempPath => fs.createWriteStream(tempPath, { flags: 'wx' }),
+    rename: (fromPath, toPath) => fs.promises.rename(fromPath, toPath),
+    unlink: tempPath => fs.promises.unlink(tempPath)
+  }
+}
+
+// How long to wait for a destroyed write stream to emit 'close' before giving
+// up and unlinking anyway. fs.WriteStream always emits it; the grace period only
+// protects against a stream shape that never does.
+const CLOSE_GRACE_MS = 2000
+
+// Resolve once `ws` has released its descriptor. destroy() closes the fd
+// asynchronously, and Windows rejects unlink/rename on a path whose handle is
+// still open, so cleanup must not run until 'close' has fired.
+function awaitClosed(ws: WriteStreamLike): Promise<void> {
+  return new Promise(resolve => {
+    const timer = setTimeout(resolve, CLOSE_GRACE_MS)
+
+    ws.once('close', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
 }
 
 export interface GatewayFileBackendDeps<T> {
@@ -79,14 +127,56 @@ export async function resolveGatewayFileBackend<T>(
   return { connection, connectionId, profile }
 }
 
-// Stream `res` into `destPath`, honoring backpressure. On any read/write error
-// the write stream is torn down and the (partial) destination file is removed
-// before the returned promise rejects, so a failed download never leaves a
-// truncated file behind.
+// Sibling temp name for an in-flight download. It lives in the destination's own
+// directory so the final step is a same-volume rename (and stays inside whatever
+// directory the save dialog approved). The name is short and fixed rather than
+// derived from the destination's basename so a long user-chosen filename cannot
+// push the temp name past the filesystem limit, and the random suffix keeps two
+// concurrent saves into the same directory from sharing a temp file. The leading
+// dot hides the in-flight file in Finder/ls while it exists.
+export function downloadTempPath(destPath: string): string {
+  return path.join(path.dirname(destPath), `.hermes-download-${crypto.randomBytes(4).toString('hex')}.part`)
+}
+
+// Stream `res` to `destPath`, honoring backpressure. Bytes land in a sibling
+// temp file first and are renamed onto `destPath` only after the whole body has
+// been written and the descriptor released. The destination itself is never
+// opened before that point, so a download that fails part-way leaves any file
+// already at `destPath` exactly as it was — only the temp file is removed before
+// the returned promise rejects. (Opening `destPath` directly truncated it on the
+// spot and the error path then unlinked it, destroying a pre-existing file the
+// user had chosen to overwrite; #96597.)
 export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: PumpDeps): Promise<void> {
   return new Promise((resolve, reject) => {
-    const ws = deps.createWriteStream(destPath)
+    const tempPath = (deps.tempPathFor ?? downloadTempPath)(destPath)
+    const ws = deps.createWriteStream(tempPath)
     let failed = false
+
+    // Ownership gate. An exclusive open can fail BEFORE this pump has created
+    // anything at `tempPath` (EEXIST on a collision, EACCES, a missing parent);
+    // in that case the path belongs to someone else and cleanup must not touch
+    // it. fs.WriteStream emits 'open' exactly when the create succeeded.
+    let owned = false
+
+    ws.once('open', () => {
+      owned = true
+    })
+
+    // `.then(() => dep())` rather than `Promise.resolve(dep())` so a dep that
+    // throws synchronously still lands on the rejection path instead of escaping
+    // the stream callback it was invoked from.
+    const discardTemp = (): Promise<void> => {
+      if (!owned) {
+        return Promise.resolve()
+      }
+
+      return Promise.resolve()
+        .then(() => deps.unlink(tempPath))
+        .then(
+          () => {},
+          () => {} // best effort
+        )
+    }
 
     const fail = (err: Error) => {
       if (failed) {
@@ -101,15 +191,60 @@ export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: Pump
         // best effort — the socket may already be closed
       }
 
+      // Register the 'close' listener BEFORE destroy(): on a stream that is
+      // already tearing down after its own 'error', 'close' can follow on the
+      // next tick.
+      const closed = awaitClosed(ws)
+
       try {
         ws.destroy()
       } catch {
         // best effort
       }
 
-      Promise.resolve(deps.unlink(destPath))
-        .catch(() => {})
-        .then(() => reject(err))
+      closed.then(discardTemp).then(() => reject(err))
+    }
+
+    // Flush and release the temp file, then move it into place. A rename failure
+    // (destination locked, permissions) must not leave the temp file behind.
+    const finish = () => {
+      const onClosed = (err?: Error | null) => {
+        if (failed) {
+          return
+        }
+
+        if (err) {
+          fail(err)
+
+          return
+        }
+
+        Promise.resolve()
+          .then(() => deps.rename(tempPath, destPath))
+          .then(
+            () => {
+              // A failure that raced the rename has already taken the reject
+              // path; never report success on top of it.
+              if (!failed) {
+                resolve()
+              }
+            },
+            (renameErr: Error) => {
+              if (failed) {
+                return
+              }
+
+              failed = true
+              discardTemp().then(() => reject(renameErr))
+            }
+          )
+      }
+
+      if (typeof ws.close === 'function') {
+        ws.close(onClosed)
+      } else {
+        ws.end(() => onClosed())
+      }
     }
 
     ws.on('error', fail)
@@ -140,9 +275,18 @@ export function pumpStreamToFile(res: ReadableLike, destPath: string, deps: Pump
         return
       }
 
-      ws.end(() => resolve())
+      finish()
     })
   })
+}
+
+// Write an in-memory body to `destPath` with the same failure-atomic contract as
+// `pumpStreamToFile` (temp file, exclusive create, close, rename). Used by the
+// data-URL compatibility fallback, which has the whole body up front; a plain
+// `fs.promises.writeFile(destPath, buffer)` would truncate an existing file
+// before the write completes and so could destroy it on a mid-write failure.
+export function writeBufferToFile(buffer: Buffer, destPath: string, deps: PumpDeps): Promise<void> {
+  return pumpStreamToFile(Readable.from([buffer]), destPath, deps)
 }
 
 // Decode a `data:[<mime>][;base64],<payload>` URL into a Buffer. Used by the

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -187,12 +187,14 @@ import { createFirstRunSetupGate } from './first-run-setup-gate'
 import { registerFsIpc } from './fs-ipc'
 import {
   filenameFromContentDisposition,
+  fsPumpDeps,
   gatewayFilePath,
   gatewayFileRequestPaths,
   isNotFoundError,
   parseDataUrlToBuffer,
   pumpStreamToFile,
-  resolveGatewayFileBackend
+  resolveGatewayFileBackend,
+  writeBufferToFile
 } from './gateway-file-download'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { registerGitIpc } from './git-ipc'
@@ -7709,10 +7711,9 @@ async function finalizeGatewayDownload(res, statusCode, headers, ctx: any = {}) 
   }
 
   try {
-    await pumpStreamToFile(res, result.filePath, {
-      createWriteStream: (destPath: string) => fs.createWriteStream(destPath),
-      unlink: (destPath: string) => fs.promises.unlink(destPath)
-    })
+    // Failure-atomic: exclusive temp create beside the destination, rename into
+    // place only once the body is complete (#96597).
+    await pumpStreamToFile(res, result.filePath, fsPumpDeps())
   } catch (error) {
     ctx.abort?.()
     throw error
@@ -7864,7 +7865,9 @@ async function saveGatewayFileViaDataUrl(
     return { canceled: true, saved: false }
   }
 
-  await fs.promises.writeFile(result.filePath, buffer)
+  // Same failure-atomic contract as the streaming path: a direct writeFile
+  // truncates an existing destination before the write completes (#96597).
+  await writeBufferToFile(buffer, result.filePath, fsPumpDeps())
 
   return { path: result.filePath, saved: true }
 }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -725,15 +725,25 @@ export function useMessageStream({
         const hasInlineError = nextMessages.some(m => m.role === 'assistant' && m.error && !m.hidden)
         const lastVisible = [...nextMessages].reverse().find(m => !m.hidden)
         const unresolvedUserTail = lastVisible?.role === 'user'
+        const sameTurnAssistant = streamId
+          ? nextMessages.find(m => m.id === streamId)
+          : [...nextMessages].reverse().find(m => m.role === 'assistant' && !m.hidden)
+        const localVisibleText = sameTurnAssistant ? chatMessageText(sameTurnAssistant).trim() : ''
         // Having streamed the reply normally means this window owns the whole
         // turn and re-reading stored history would be wasted work. That only
         // holds for a turn it STARTED: an adopted one (resumed onto a session
         // already running elsewhere) arrives reply-first, with no prompt row,
         // so it has to hydrate or the user's own message never shows up.
+        // Adopted turns still hydrate so a resume-onto-running session can
+        // pick up the user's prompt row — unless this window already has
+        // visible assistant text and the terminal frame is empty. In that
+        // case hydrate would replace the live bubble with a stored empty
+        // row (#95514; adoptedRunningTurn must not short-circuit).
         shouldHydrate =
           !completionError &&
           !hasInlineError &&
           !unresolvedUserTail &&
+          !(localVisibleText && !finalText) &&
           (state.adoptedRunningTurn || !state.sawAssistantPayload || !finalText)
 
         return {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -264,6 +264,88 @@ describe('session.info settles a turn that produced no assistant payload', () =>
   })
 })
 
+describe('empty message.complete after streamed text (#95514)', () => {
+  it('keeps streamed text and does not hydrate over it', () => {
+    mountStream()
+
+    act(() => stream.handleEvent({ payload: {}, session_id: ACTIVE_SID, type: 'message.start' }))
+    act(() =>
+      stream.handleEvent({
+        payload: { text: 'Already rendered answer.' },
+        session_id: ACTIVE_SID,
+        type: 'message.delta'
+      })
+    )
+    act(() => stream.handleEvent({ payload: { text: '' }, session_id: ACTIVE_SID, type: 'message.complete' }))
+
+    const assistant = stream.state(ACTIVE_SID).messages.find(message => message.role === 'assistant')
+    expect(assistant?.parts.filter(part => part.type === 'text').map(part => part.text)).toEqual([
+      'Already rendered answer.'
+    ])
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+  })
+
+  it('does not hydrate over interim-sealed text when streamId is already cleared', () => {
+    mountStream()
+
+    act(() => stream.handleEvent({ payload: {}, session_id: ACTIVE_SID, type: 'message.start' }))
+    act(() =>
+      stream.handleEvent({
+        payload: { text: 'Let me check the files.' },
+        session_id: ACTIVE_SID,
+        type: 'message.delta'
+      })
+    )
+    act(() =>
+      stream.handleEvent({
+        payload: { already_streamed: true, text: 'Let me check the files.' },
+        session_id: ACTIVE_SID,
+        type: 'message.interim'
+      })
+    )
+    act(() => stream.handleEvent({ payload: { text: '' }, session_id: ACTIVE_SID, type: 'message.complete' }))
+
+    const assistant = stream.state(ACTIVE_SID).messages.find(message => message.role === 'assistant')
+    expect(assistant?.parts.filter(part => part.type === 'text').map(part => part.text)).toEqual([
+      'Let me check the files.'
+    ])
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+  })
+
+  it('does not hydrate an adopted turn over streamed text on empty complete', () => {
+    mountStream()
+    act(() => {
+      const current = stream.states.get(ACTIVE_SID) ?? createClientSessionState()
+      stream.states.set(ACTIVE_SID, { ...current, adoptedRunningTurn: true })
+    })
+
+    act(() => stream.handleEvent({ payload: {}, session_id: ACTIVE_SID, type: 'message.start' }))
+    act(() =>
+      stream.handleEvent({
+        payload: { text: 'Already rendered answer.' },
+        session_id: ACTIVE_SID,
+        type: 'message.delta'
+      })
+    )
+    act(() => stream.handleEvent({ payload: { text: '' }, session_id: ACTIVE_SID, type: 'message.complete' }))
+
+    const assistant = stream.state(ACTIVE_SID).messages.find(message => message.role === 'assistant')
+    expect(assistant?.parts.filter(part => part.type === 'text').map(part => part.text)).toEqual([
+      'Already rendered answer.'
+    ])
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+  })
+
+  it('still hydrates an empty complete when this turn streamed no text', () => {
+    mountStream()
+
+    act(() => stream.handleEvent({ payload: {}, session_id: ACTIVE_SID, type: 'message.start' }))
+    act(() => stream.handleEvent({ payload: { text: '' }, session_id: ACTIVE_SID, type: 'message.complete' }))
+
+    expect(hydrateFromStoredSession).toHaveBeenCalled()
+  })
+})
+
 describe('message.complete sidebar refresh coalescing', () => {
   it('collapses near-simultaneous completions into one refresh', async () => {
     mountStream()

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -1248,13 +1248,23 @@ describe('mergeFinalAssistantText', () => {
     expect(result.filter(p => p.type === 'text')).toHaveLength(1)
   })
 
-  it('handles empty final text', () => {
+  it('does not erase streamed text when the final completion is empty (#95514)', () => {
     const parts = [{ type: 'text' as const, text: 'streamed' }, reasoningPart('some reasoning')]
 
     const result = mergeFinalAssistantText(parts, '')
 
-    expect(result.filter(p => p.type === 'text')).toHaveLength(0)
+    expect(result.filter(p => p.type === 'text')).toHaveLength(1)
+    expect(result.filter(p => p.type === 'text')[0]).toMatchObject({ text: 'streamed' })
     expect(result.filter(p => p.type === 'reasoning')).toHaveLength(1)
+  })
+
+  it('treats whitespace-only final text as non-authoritative (#95514)', () => {
+    const parts = [{ type: 'text' as const, text: 'already on screen' }]
+
+    const result = mergeFinalAssistantText(parts, '   \n\t')
+
+    expect(result.filter(p => p.type === 'text')).toHaveLength(1)
+    expect(result.filter(p => p.type === 'text')[0]).toMatchObject({ text: 'already on screen' })
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -155,6 +155,12 @@ export function mergeFinalAssistantText(
   finalText: string,
   fallbackTimestamp?: number
 ): ChatMessagePart[] {
+  // Empty / whitespace-only completion is not authoritative — keep streamed
+  // text, reasoning, and tool parts (#95514).
+  if (!finalText.trim()) {
+    return parts
+  }
+
   const dedupeReference = normalizeWs(finalText)
 
   const streamedText = normalizeWs(

--- a/contributors/emails/amansk@gmail.com
+++ b/contributors/emails/amansk@gmail.com
@@ -1,0 +1,2 @@
+amansk
+# PR #96608 (desktop: failure-atomic gateway downloads, #96597)

--- a/contributors/emails/eric.maddox@outlook.com
+++ b/contributors/emails/eric.maddox@outlook.com
@@ -1,0 +1,1 @@
+ericmaddox

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11261,17 +11261,30 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 turn_lease_holder=turn_lease_holder,
                 turn_lease_ttl_seconds=turn_lease_ttl_seconds,
             )
-            inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, messages
+            from agent.transcript_repair import resolve_and_repair_transcript_batch
+
+            inserted_rows = resolve_and_repair_transcript_batch(
+                conn,
+                session_id,
+                messages,
+                encode_content_fn=self._encode_content,
+                decode_content_fn=self._decode_content,
             )
-            # One aggregated counter update for the whole batch.
+            inserted = 0
+            tool_calls_total = 0
+            if inserted_rows:
+                inserted, tool_calls_total = self._insert_message_rows(
+                    conn, session_id, inserted_rows
+                )
+
+            # One aggregated counter update for the newly inserted rows.
             if tool_calls_total > 0:
                 conn.execute(
                     """UPDATE sessions SET message_count = message_count + ?,
                        tool_call_count = tool_call_count + ? WHERE id = ?""",
                     (inserted, tool_calls_total, session_id),
                 )
-            else:
+            elif inserted > 0:
                 conn.execute(
                     "UPDATE sessions SET message_count = message_count + ? WHERE id = ?",
                     (inserted, session_id),

--- a/run_agent.py
+++ b/run_agent.py
@@ -2229,6 +2229,7 @@ class AIAgent:
                 while (
                     _scan_start < _limit
                     and messages[_scan_start] is _prev_prefix[_scan_start]
+                    and bool(messages[_scan_start].get(_DB_PERSISTED_MARKER))
                 ):
                     _scan_start += 1
 
@@ -2354,7 +2355,7 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
-                _batch_rows.append({
+                _row = {
                     "role": role,
                     "content": content,
                     "tool_name": msg.get("tool_name"),
@@ -2395,7 +2396,10 @@ class AIAgent:
                         else msg.get("display_kind")
                     ),
                     "display_metadata": msg.get("display_metadata"),
-                })
+                }
+                if isinstance(msg.get("_row_id"), int):
+                    _row["_row_id"] = msg["_row_id"]
+                _batch_rows.append(_row)
                 _batch_msgs.append(msg)
             # One transaction for the whole turn's new rows (typically 3-8
             # messages): one BEGIN IMMEDIATE / commit — and, off WAL, one
@@ -2419,8 +2423,9 @@ class AIAgent:
                     )
                     or 300.0,
                 )
-                for _written in _batch_msgs:
-                    _written[_DB_PERSISTED_MARKER] = True
+                from agent.transcript_repair import sync_flushed_message_markers
+
+                sync_flushed_message_markers(_batch_msgs, _batch_rows)
             # The intrinsic markers are now the sole source of truth. Reset the
             # one-shot seed so no id() outlives this flush to alias a message
             # allocated next turn at a recycled address.

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -544,6 +544,176 @@ class TestBuildConverseKwargs:
 
 
 # ---------------------------------------------------------------------------
+# cachePoint rejection self-heal (#97281)
+# ---------------------------------------------------------------------------
+
+CACHE_POINT = {"cachePoint": {"type": "default"}}
+
+NOVA_TOOLS_REJECTION = (
+    "An error occurred (ValidationException) when calling the ConverseStream "
+    "operation: The model returned the following errors: Malformed input "
+    "request: #/toolConfig/tools/18: extraneous key [cachePoint] is not "
+    "permitted, please reformat your input and try again."
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache_point_rejections():
+    """Rejections are process-wide; keep them from leaking between tests."""
+    from agent.bedrock_adapter import reset_cache_point_rejections
+    reset_cache_point_rejections()
+    yield
+    reset_cache_point_rejections()
+
+
+class TestCachePointRejectionRecovery:
+    """Bedrock placement rules are per-family and per-field: Nova accepts
+    cachePoint in system/messages but rejects it inside toolConfig.tools,
+    failing 100% of tool-enabled turns (#97281). The server verdict is the
+    authority - record it, drop that one marker, and retry."""
+
+    def _nova_kwargs(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        return build_converse_kwargs(
+            model="us.amazon.nova-pro-v1:0",
+            messages=[
+                {"role": "system", "content": "Be helpful."},
+                {"role": "user", "content": "First"},
+                {"role": "assistant", "content": "Reply"},
+                {"role": "user", "content": "Second"},
+            ],
+            tools=[{"type": "function", "function": {
+                "name": "test", "description": "Test", "parameters": {},
+            }}],
+        )
+
+    def test_classifies_tools_rejection(self):
+        from agent.bedrock_adapter import cache_point_rejection_placement
+        assert cache_point_rejection_placement(
+            Exception(NOVA_TOOLS_REJECTION)
+        ) == "tools"
+
+    def test_classifies_system_and_messages_rejections(self):
+        from agent.bedrock_adapter import cache_point_rejection_placement
+        assert cache_point_rejection_placement(Exception(
+            "Malformed input request: #/system/1: extraneous key [cachePoint] "
+            "is not permitted"
+        )) == "system"
+        assert cache_point_rejection_placement(Exception(
+            "Malformed input request: #/messages/2/content/3: extraneous key "
+            "[cachePoint] is not permitted"
+        )) == "messages"
+
+    def test_ignores_unrelated_errors(self):
+        from agent.bedrock_adapter import cache_point_rejection_placement
+        assert cache_point_rejection_placement(
+            Exception("ThrottlingException: Too many requests")
+        ) is None
+        assert cache_point_rejection_placement(Exception(
+            "Malformed input request: #/toolConfig/tools/0: extraneous key "
+            "[toolChoice] is not permitted"
+        )) is None
+
+    def test_strip_removes_only_the_rejected_placement(self):
+        from agent.bedrock_adapter import strip_cache_points
+        kwargs = self._nova_kwargs()
+        assert CACHE_POINT in kwargs["toolConfig"]["tools"]
+        stripped = strip_cache_points(kwargs, "tools")
+        assert CACHE_POINT not in stripped["toolConfig"]["tools"]
+        # system and messages markers survive - Nova accepts those.
+        assert stripped["system"][-1] == CACHE_POINT
+        assert stripped["messages"][-2]["content"][-1] == CACHE_POINT
+        # Original kwargs are untouched (no in-place mutation).
+        assert CACHE_POINT in kwargs["toolConfig"]["tools"]
+
+    def test_strip_is_identity_when_marker_absent(self):
+        """No marker to remove -> same object, so callers know a retry is futile."""
+        from agent.bedrock_adapter import strip_cache_points
+        kwargs = {"modelId": "x", "toolConfig": {"tools": [{"toolSpec": {}}]}}
+        assert strip_cache_points(kwargs, "tools") is kwargs
+
+    def test_recovery_records_verdict_so_later_turns_omit_the_marker(self):
+        from agent.bedrock_adapter import recover_from_cache_point_rejection
+        kwargs = self._nova_kwargs()
+        retry = recover_from_cache_point_rejection(
+            Exception(NOVA_TOOLS_REJECTION), kwargs
+        )
+        assert retry is not None
+        assert CACHE_POINT not in retry["toolConfig"]["tools"]
+        # Next turn is built clean without another round-trip failure.
+        rebuilt = self._nova_kwargs()
+        assert CACHE_POINT not in rebuilt["toolConfig"]["tools"]
+        assert rebuilt["system"][-1] == CACHE_POINT
+        assert rebuilt["messages"][-2]["content"][-1] == CACHE_POINT
+
+    def test_verdict_is_scoped_to_the_rejecting_model(self):
+        from agent.bedrock_adapter import (
+            build_converse_kwargs,
+            recover_from_cache_point_rejection,
+        )
+        recover_from_cache_point_rejection(
+            Exception(NOVA_TOOLS_REJECTION), self._nova_kwargs()
+        )
+        claude = build_converse_kwargs(
+            model="anthropic.claude-sonnet-4-6-20250514-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {
+                "name": "test", "description": "Test", "parameters": {},
+            }}],
+        )
+        assert claude["toolConfig"]["tools"][-1] == CACHE_POINT
+
+    def test_recovery_declines_when_nothing_can_be_stripped(self):
+        """A cachePoint rejection with no marker present must re-raise, not loop."""
+        from agent.bedrock_adapter import recover_from_cache_point_rejection
+        kwargs = {"modelId": "us.amazon.nova-pro-v1:0",
+                  "toolConfig": {"tools": [{"toolSpec": {}}]}}
+        assert recover_from_cache_point_rejection(
+            Exception(NOVA_TOOLS_REJECTION), kwargs
+        ) is None
+
+    def test_call_converse_retries_without_the_marker(self):
+        from agent.bedrock_adapter import call_converse
+        client = MagicMock()
+        client.converse.side_effect = [
+            Exception(NOVA_TOOLS_REJECTION),
+            {"output": {"message": {"role": "assistant",
+                                    "content": [{"text": "ok"}]}},
+             "stopReason": "end_turn",
+             "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2}},
+        ]
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client",
+                   return_value=client):
+            response = call_converse(
+                region="us-east-1",
+                model="us.amazon.nova-pro-v1:0",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {
+                    "name": "test", "description": "Test", "parameters": {},
+                }}],
+            )
+        assert response.choices[0].message.content == "ok"
+        assert client.converse.call_count == 2
+        first, second = client.converse.call_args_list
+        assert CACHE_POINT in first.kwargs["toolConfig"]["tools"]
+        assert CACHE_POINT not in second.kwargs["toolConfig"]["tools"]
+
+    def test_call_converse_reraises_unrelated_errors(self):
+        from agent.bedrock_adapter import call_converse
+        client = MagicMock()
+        client.converse.side_effect = Exception("ThrottlingException")
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client",
+                   return_value=client):
+            with pytest.raises(Exception, match="ThrottlingException"):
+                call_converse(
+                    region="us-east-1",
+                    model="us.amazon.nova-pro-v1:0",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+        assert client.converse.call_count == 1
+
+
+# ---------------------------------------------------------------------------
 # Model discovery
 # ---------------------------------------------------------------------------
 

--- a/tests/agent/test_prompt_cache_boundary.py
+++ b/tests/agent/test_prompt_cache_boundary.py
@@ -80,8 +80,10 @@ class TestRegistry:
     def test_requires_proper_prefix(self):
         register_stable_prefix("scaffold")
         assert find_stable_prefix("scaffold volatile") == "scaffold"
-        # Exact match would leave an empty volatile block — never split.
+        # Exact match or whitespace-only tail would leave an empty/whitespace volatile block — never split.
         assert find_stable_prefix("scaffold") is None
+        assert find_stable_prefix("scaffold   ") is None
+        assert find_stable_prefix("scaffold\n\n\t") is None
         assert find_stable_prefix("other") is None
 
     def test_longest_registered_prefix_wins(self):

--- a/tests/agent/test_prompt_cache_scope.py
+++ b/tests/agent/test_prompt_cache_scope.py
@@ -384,3 +384,188 @@ class TestAuxiliaryRuntimeThreading:
             assert aux._runtime_main_value("cache_scope") == ""
         finally:
             aux.reset_runtime_main(token)
+
+
+class TestPerResponseRunNonceIsolation:
+    """Issue #96570 — hosts that mint one physical session per RESPONSE.
+
+    Hermes Studio group chat builds ``gc_run_<room>_<profile>_<name>_<uuid4hex>``
+    for every reply and destroys it when the reply completes
+    (``groupRuntimeSessionId``), so every conversation-affinity hint Hermes
+    derives from that id is re-keyed on every reply. What is demonstrated here
+    is the routing/affinity mechanism moving per response; no provider cache
+    telemetry or billing outcome is measured or claimed.
+
+    The normalizer cannot repair that from the id alone: a physical session id
+    is an identity, and Hermes' public session API lets a client choose one
+    freely (``POST /v1/sessions`` honors ``body["id"]``/``body["session_id"]``).
+    These tests pin the isolation invariant that any future scope rule has to
+    keep — collapsing a trailing token because it *looks* like per-run noise
+    merges independent conversations, which is the failure class already
+    recorded on #79017.
+    """
+
+    RUN = "gc_run_room42_default_Worker"
+    RESPONSE_1 = f"{RUN}_5f2c1ab9d4e34f7a8b0c6d1e2f3a4b5c"
+    RESPONSE_2 = f"{RUN}_9a7e3b1c05d24e6fb83a1c7d9e0f2a4b"
+
+    SYS = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
+
+    @staticmethod
+    def _prompt_cache_key(session_id: str) -> str:
+        from agent.transports.codex import ResponsesApiTransport
+
+        return ResponsesApiTransport().build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "system", "content": "same"}],
+            tools=[],
+            session_id=session_id,
+        )["prompt_cache_key"]
+
+    def test_external_uuid_identity_remains_isolated(self):
+        """Two independent API-supplied ids may differ only in a trailing hex.
+
+        ``POST /v1/sessions`` preserves a client-provided id verbatim, so a
+        whole trailing 32-hex token is not per-run noise by construction.
+        """
+        first = "customer_chat_11111111111141118111111111111111"
+        second = "customer_chat_22222222222242228222222222222222"
+
+        assert _cache_scope_from_session_id(first) != _cache_scope_from_session_id(
+            second
+        )
+        assert self._prompt_cache_key(first) != self._prompt_cache_key(second)
+
+    def test_studio_truncation_does_not_merge_members(self):
+        """Studio truncates the semantic prefix BEFORE appending the nonce.
+
+        ``groupRuntimeSessionId`` slices its ``gc_run_<room>_<profile>_<name>``
+        prefix to 96 characters and only then appends the per-response token,
+        so two members of one room whose names diverge past that boundary are
+        distinguished *only* by that token. Any rule that drops it merges two
+        distinct agents onto one affinity key.
+        """
+        room = "mabc1234qwerty"
+        profile = "default"
+        common_name = "A" * 70
+
+        first = (
+            f"gc_run_{room}_{profile}_{common_name}Worker"[:96]
+            + "_11111111111141118111111111111111"
+        )
+        second = (
+            f"gc_run_{room}_{profile}_{common_name}Reviewer"[:96]
+            + "_22222222222242228222222222222222"
+        )
+
+        assert first != second
+        assert _cache_scope_from_session_id(first) != _cache_scope_from_session_id(
+            second
+        )
+
+    def test_cron_normalization_stays_the_only_carve_out(self):
+        """The one accepted exception: cron's per-fire timestamp (#51395)."""
+        assert (
+            _cache_scope_from_session_id("cron_backup_20260814_120000")
+            == "cron_backup"
+        )
+        assert (
+            _cache_scope_from_session_id(self.RESPONSE_1) == self.RESPONSE_1
+        )
+
+    def test_parentless_rows_resolve_to_their_own_scope(self, db):
+        """A row with no lineage is its own scope — permanently.
+
+        The Studio bridge creates the row with ``create_session(id, source,
+        model)`` — no ``parent_session_id`` — so ``resolve_prompt_cache_scope``
+        returns the physical id. This is the invariant, not a defect record:
+        an owner Hermes was never told about must never be guessed. #96811
+        closes the gap by having the host declare the logical conversation (a
+        stable session id, or an explicit key); rows that still declare
+        nothing keep resolving exactly like this.
+        """
+        db.create_session(self.RESPONSE_1, source="studio")
+        db.create_session(self.RESPONSE_2, source="studio")
+
+        assert resolve_prompt_cache_scope(_agent(self.RESPONSE_1, db)) == self.RESPONSE_1
+        assert resolve_prompt_cache_scope(_agent(self.RESPONSE_2, db)) == self.RESPONSE_2
+
+    def test_distinct_ids_keep_distinct_affinity_keys(self):
+        """Every affinity surface isolates two distinct physical ids.
+
+        This is the isolation invariant restated at the wire layer, and it is
+        also the reported symptom: Studio hands these two ids to the same
+        logical conversation, so the routing/affinity key moves per response.
+
+        It stays true after #96811. The logical identity is supplied one layer
+        up — ``cache_scope_id`` here, the ambient conversation context for the
+        provider profiles — and these call sites pass neither, exactly as an
+        undeclared conversation would.
+        """
+        from agent.transports.chat_completions import _add_prompt_cache_key
+        from agent.transports.codex import ResponsesApiTransport
+
+        transport = ResponsesApiTransport()
+        base = dict(model="gpt-5.5", messages=self.SYS, tools=[])
+        assert (
+            transport.build_kwargs(**base, session_id=self.RESPONSE_1)[
+                "prompt_cache_key"
+            ]
+            != transport.build_kwargs(**base, session_id=self.RESPONSE_2)[
+                "prompt_cache_key"
+            ]
+        )
+
+        xai = dict(model="grok-4", messages=self.SYS, tools=[], is_xai_responses=True)
+        assert (
+            transport.build_kwargs(**xai, session_id=self.RESPONSE_1)["extra_headers"][
+                "x-grok-conv-id"
+            ]
+            != transport.build_kwargs(**xai, session_id=self.RESPONSE_2)[
+                "extra_headers"
+            ]["x-grok-conv-id"]
+        )
+
+        def chat_key(session_id):
+            kwargs: dict = {}
+            _add_prompt_cache_key(
+                kwargs,
+                messages=[{"role": "system", "content": "sys"}],
+                tools=None,
+                supports_prompt_cache_key=True,
+                session_id=session_id,
+            )
+            return kwargs.get("prompt_cache_key")
+
+        assert chat_key(self.RESPONSE_1) != chat_key(self.RESPONSE_2)
+
+    @pytest.mark.parametrize("profile_name", ["openrouter", "nous"])
+    def test_distinct_ids_keep_distinct_provider_sticky_keys(self, profile_name):
+        """OpenRouter/Nous route by this key, and it isolates distinct ids.
+
+        Same invariant as above on the sticky-routing surface: two ids of one
+        Studio conversation re-key it on every reply, and a declared logical
+        identity would arrive through the conversation contextvar, not from
+        re-reading this id.
+        """
+        from agent.portal_tags import (
+            reset_conversation_context,
+            set_conversation_context,
+        )
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(profile_name)
+        keys = []
+        for session_id in (self.RESPONSE_1, self.RESPONSE_2):
+            token = set_conversation_context(session_id)
+            try:
+                keys.append(
+                    profile.build_extra_body(session_id=session_id)["session_id"]
+                )
+            finally:
+                reset_conversation_context(token)
+
+        assert keys[0] != keys[1]

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -379,5 +379,73 @@ class TestReconstructStaticPrefixMemoization:
         assert getattr(agent, "_static_rebuild_failed_for", None) is None
 
 
+class TestPerResponseSessionWritePath:
+    """The write path under an embedding host's per-response session (#96570).
+
+    Hermes Studio group chat pre-creates the SQLite row and pre-persists the
+    user message BEFORE ``run_conversation()``, then runs one turn under a
+    session id it destroys afterwards. The row therefore starts with a null
+    system prompt and a non-empty history on its own genuine FIRST turn, which
+    is what trips the "stored system prompt is null" warning — the warning is
+    a first-turn artifact of that lifecycle, not evidence of a lost write.
+
+    This pins the write path against that exact lifecycle: the freshly built
+    prompt must land in the pre-created row within the same run.
+    """
+
+    def _agent(self, db, session_id):
+        agent = _make_agent(session_db=db, prebuilt_prompt="GROUP_PROMPT")
+        agent.session_id = session_id
+        return agent
+
+    def test_prepersisted_row_stores_the_freshly_built_prompt(self, tmp_path):
+        from hermes_state import SessionDB
+
+        session_id = "gc_run_room42_default_Worker_5f2c1ab9d4e34f7a8b0c6d1e2f3a4b5c"
+        with SessionDB(db_path=tmp_path / "state.db") as db:
+            # What the bridge does before the turn starts.
+            db.create_session(session_id, source="studio")
+            db.append_message(session_id=session_id, role="user", content="hi")
+
+            _restore_or_build_system_prompt(
+                self._agent(db, session_id),
+                None,
+                [{"role": "user", "content": "hi"}],
+            )
+
+            assert db.get_session(session_id)["system_prompt"] == "GROUP_PROMPT"
+
+    def test_warning_is_a_first_turn_artifact_not_a_lost_write(
+        self, tmp_path, caplog
+    ):
+        """Second turn of the SAME id restores — so nothing was dropped."""
+        from hermes_state import SessionDB
+
+        session_id = "gc_run_room42_default_Worker_9a7e3b1c05d24e6fb83a1c7d9e0f2a4b"
+        history = [{"role": "user", "content": "hi"}]
+        with SessionDB(db_path=tmp_path / "state.db") as db:
+            db.create_session(session_id, source="studio")
+            db.append_message(session_id=session_id, role="user", content="hi")
+
+            with caplog.at_level(
+                logging.WARNING, logger="agent.conversation_loop"
+            ):
+                _restore_or_build_system_prompt(
+                    self._agent(db, session_id), None, history
+                )
+            assert "is null" in caplog.text
+
+            caplog.clear()
+            second = self._agent(db, session_id)
+            with caplog.at_level(
+                logging.WARNING, logger="agent.conversation_loop"
+            ):
+                _restore_or_build_system_prompt(second, None, history)
+
+            assert second._cached_system_prompt == "GROUP_PROMPT"
+            second._build_system_prompt.assert_not_called()
+            assert "is null" not in caplog.text
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -271,3 +271,141 @@ def test_final_response_fill_invalidates_flush_scan_cursor():
     )
 
     assert agent._db_flush_scan_prefix is None
+
+
+def test_empty_final_response_recovers_stream_buffer_into_blank_assistant_row(
+    monkeypatch, tmp_path
+):
+    """#95514: empty terminal completion must not persist content='' over a live stream.
+
+    After a tool result the incremental flush can leave a blank assistant tail.
+    If finalize_turn then receives final_response='' while the stream buffer
+    still holds the delivered text, that blank row is the durable transcript —
+    Desktop reload shows nothing even though the user already saw the answer.
+    """
+    from hermes_state import SessionDB
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("sess-test", source="cli")
+    agent = FakeAgent()
+    agent._current_streamed_assistant_text = "Already streamed to the user."
+
+    def persist_to_sqlite(messages, _conversation_history):
+        db.replace_messages(agent.session_id, messages)
+        agent.persisted_messages = db.get_messages_as_conversation(agent.session_id)
+
+    agent._persist_session = persist_to_sqlite
+    messages = [
+        {"role": "user", "content": "summarize"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "t1", "name": "terminal", "content": "ok"},
+        {"role": "assistant", "content": "", "_db_persisted": True},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="",
+        api_call_count=2,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="summarize",
+        original_user_message="summarize",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    assert result["final_response"] == "Already streamed to the user."
+    assistants = [m for m in agent.persisted_messages if m.get("role") == "assistant"]
+    assert assistants[-1]["content"] == "Already streamed to the user."
+    assert assistants[0].get("tool_calls")
+    assert sum(1 for m in assistants) == 2
+
+    reopened = SessionDB(db_path=tmp_path / "state.db")
+    reloaded = reopened.get_messages_as_conversation("sess-test")
+    assert reloaded[-1]["role"] == "assistant"
+    assert reloaded[-1]["content"] == "Already streamed to the user."
+    assert sum(1 for m in reloaded if m.get("role") == "assistant") == 2
+
+
+def test_failed_turn_does_not_recover_stream_buffer_as_final_response(monkeypatch):
+    """A failed turn must not invent a successful answer from the stream buffer."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    agent._current_streamed_assistant_text = "partial tokens"
+
+    result = finalize_turn(
+        agent,
+        final_response="",
+        api_call_count=1,
+        interrupted=False,
+        failed=True,
+        messages=[{"role": "user", "content": "q"}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="q",
+        original_user_message="q",
+        _should_review_memory=False,
+        _turn_exit_reason="error",
+    )
+
+    assert result["final_response"] in ("", None)
+    assert result["failed"] is True
+
+
+def test_delivery_only_reasoning_excerpt_does_not_fill_blank_assistant(monkeypatch):
+    """Labeled empty-terminal excerpt is delivery-only, not durable content.
+
+    ``empty_response_exhausted`` sets final_response to a labeled reasoning
+    excerpt while the transcript tail is a blank/sentinel assistant without
+    tool_calls. Filling that tail would persist the excerpt and break replay
+    (test_empty_terminal_reasoning_surface).
+    """
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    excerpt = (
+        "⚠️ The model produced only internal reasoning and no final answer, "
+        "despite retries. Its last reasoning, which may contain the answer:\n\n"
+        "The answer is 42"
+    )
+    messages = [
+        {"role": "user", "content": "what is the answer?"},
+        {"role": "assistant", "content": ""},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=excerpt,
+        api_call_count=6,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="what is the answer?",
+        original_user_message="what is the answer?",
+        _should_review_memory=False,
+        _turn_exit_reason="empty_response_exhausted",
+    )
+
+    assert result["final_response"] == excerpt
+    assert not any(
+        m.get("role") == "assistant"
+        and "only internal reasoning" in (m.get("content") or "")
+        for m in result["messages"]
+    )
+

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -875,3 +875,78 @@ class TestPromptCacheKeyCapability:
             provider_profile=profile,
         )
         assert "prompt_cache_key" not in kwargs
+
+    def test_overlong_caller_top_level_key_is_bounded(self, transport):
+        """OpenAI caps prompt_cache_key at 64 chars and 400s longer values.
+
+        A caller-supplied over-length key (request_overrides) must be hashed
+        to the same pck_<sha256[:24]> shape the Responses transport uses
+        (opencode#44571 parity — clamp on every chat protocol).
+        """
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="cache-capable", supports_prompt_cache_key=True)
+        long_key = "sess-" + "x" * 200
+
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            provider_profile=profile,
+            request_overrides={"prompt_cache_key": long_key},
+        )
+
+        assert kwargs["prompt_cache_key"].startswith("pck_")
+        assert len(kwargs["prompt_cache_key"]) <= 64
+        body = self._request_body(kwargs)
+        assert body["prompt_cache_key"] == kwargs["prompt_cache_key"]
+
+    def test_overlong_caller_extra_body_key_is_bounded(self, transport):
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="cache-capable", supports_prompt_cache_key=True)
+        long_key = "sess-" + "y" * 200
+
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            provider_profile=profile,
+            request_overrides={"extra_body": {"prompt_cache_key": long_key}},
+        )
+
+        eb_key = kwargs["extra_body"]["prompt_cache_key"]
+        assert eb_key.startswith("pck_")
+        assert len(eb_key) <= 64
+        # No duplicate top-level field competing with the caller's extra_body.
+        assert "prompt_cache_key" not in kwargs
+
+    def test_short_caller_key_passes_through_unchanged(self, transport):
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="cache-capable", supports_prompt_cache_key=True)
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            provider_profile=profile,
+            request_overrides={"prompt_cache_key": "caller-top-level"},
+        )
+        assert kwargs["prompt_cache_key"] == "caller-top-level"
+
+    def test_overlong_caller_key_bounded_on_legacy_path(self, transport):
+        long_key = "sess-" + "z" * 200
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            supports_prompt_cache_key=True,
+            request_overrides={"prompt_cache_key": long_key},
+        )
+        assert kwargs["prompt_cache_key"].startswith("pck_")
+        assert len(kwargs["prompt_cache_key"]) <= 64
+
+    def test_whitespace_only_caller_key_is_dropped(self, transport):
+        """_bounded_prompt_cache_key returns None for blank keys — the field
+        must be removed rather than sent empty."""
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="cache-capable", supports_prompt_cache_key=True)
+        kwargs = transport.build_kwargs(
+            model="cache-model", messages=self._messages(), tools=self._tools(),
+            provider_profile=profile,
+            request_overrides={"prompt_cache_key": "   "},
+        )
+        assert "prompt_cache_key" not in kwargs

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -614,3 +614,288 @@ def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
     # production flush call breaks one of these assertions.
     assert flushed_tool_ids == ["c1", "c2"]
     assert flush_lengths == [1, 2]
+
+
+def test_empty_final_response_updates_already_flushed_blank_assistant_row(tmp_path):
+    """#95514: popping _db_persisted must UPDATE the flushed row, not INSERT.
+
+    Incremental persist already wrote assistant(content=''). finalize_turn
+    recovers the stream buffer onto that live dict. Production flush is
+    append-only, so a re-insert would leave the empty row and add a second
+    assistant (assistant→assistant on reload).
+    """
+    from agent.turn_finalizer import finalize_turn
+
+    agent = _make_agent()
+    db_path = tmp_path / "state.db"
+    session_id = "sess-empty-final-flush"
+    _attach_real_session_db(agent, db_path, session_id)
+    agent._current_streamed_assistant_text = "Already streamed to the user."
+
+    messages = [
+        {"role": "user", "content": "summarize"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "t1", "name": "terminal", "content": "ok"},
+        {"role": "assistant", "content": ""},
+    ]
+    agent._flush_messages_to_session_db(messages)
+    pre = _durable_messages(db_path, session_id)
+    assert pre[-1]["role"] == "assistant"
+    assert (pre[-1].get("content") or "") == ""
+
+    finalize_turn(
+        agent,
+        final_response="",
+        api_call_count=2,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="summarize",
+        original_user_message="summarize",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    reloaded = _durable_messages(db_path, session_id)
+    assistants = [m for m in reloaded if m.get("role") == "assistant"]
+    assert assistants[-1]["content"] == "Already streamed to the user."
+    assert len(assistants) == 2
+    assert assistants[0].get("tool_calls")
+    assert sum(
+        1 for m in assistants
+        if not (m.get("content") or "").strip() and not m.get("tool_calls")
+    ) == 0
+
+
+def test_flush_stale_row_id_from_other_session_still_inserts(tmp_path):
+    """Copied dicts that keep a parent _row_id must still INSERT in a child session."""
+    parent = _make_agent()
+    child = _make_agent()
+    db_path = tmp_path / "state.db"
+    _attach_real_session_db(parent, db_path, "sess-parent")
+    _attach_real_session_db(child, db_path, "sess-child")
+    parent_msgs = [
+        {"role": "user", "content": "p-user"},
+        {"role": "assistant", "content": "p-answer"},
+    ]
+    parent._flush_messages_to_session_db(parent_msgs)
+    copies = [{k: v for k, v in m.items() if k != "_db_persisted"} for m in parent_msgs]
+    copies.extend(
+        [
+            {"role": "user", "content": "c-user"},
+            {"role": "assistant", "content": "c-answer"},
+        ]
+    )
+    child._flush_messages_to_session_db(copies)
+    reloaded = _durable_messages(db_path, "sess-child")
+    assert [m.get("content") for m in reloaded] == [
+        "p-user",
+        "p-answer",
+        "c-user",
+        "c-answer",
+    ]
+
+
+def test_flush_stale_row_id_from_other_session_does_not_fill_child_blank(tmp_path):
+    """A parent `_row_id` must INSERT in the child, not steal a blank tail."""
+    parent = _make_agent()
+    child = _make_agent()
+    db_path = tmp_path / "state.db"
+    _attach_real_session_db(parent, db_path, "sess-parent")
+    _attach_real_session_db(child, db_path, "sess-child")
+    parent_msgs = [
+        {"role": "user", "content": "p-user"},
+        {"role": "assistant", "content": "p-answer"},
+    ]
+    parent._flush_messages_to_session_db(parent_msgs)
+    child_msgs = [
+        {"role": "user", "content": "c-keep"},
+        {"role": "assistant", "content": ""},
+    ]
+    child._flush_messages_to_session_db(child_msgs)
+    copies = [{k: v for k, v in m.items() if k != "_db_persisted"} for m in parent_msgs]
+    copies.extend(
+        [
+            {"role": "user", "content": "c-user"},
+            {"role": "assistant", "content": "c-answer"},
+        ]
+    )
+    child._flush_messages_to_session_db(copies)
+    reloaded = _durable_messages(db_path, "sess-child")
+    assert [m.get("content") for m in reloaded] == [
+        "c-keep",
+        "",
+        "p-user",
+        "p-answer",
+        "c-user",
+        "c-answer",
+    ]
+
+
+def test_flush_archived_same_session_row_id_fills_active_clone(tmp_path):
+    """Watermark compaction clones the tail; stale `_row_id` must not win.
+
+    ``archive_and_compact(..., watermark=...)`` archives the original
+    concurrent-tail row and inserts a fresh active clone with a new id.
+    The live dict still holds the archived id. A rewrite keyed only on
+    ``id + session_id`` updates the inactive row, stamps persistence, and
+    skips INSERT — reload then still sees the blank clone (#95514 P0).
+    """
+    from agent.turn_finalizer import finalize_turn
+
+    agent = _make_agent()
+    db_path = tmp_path / "state.db"
+    session_id = "sess-archived-row-id"
+    db = _attach_real_session_db(agent, db_path, session_id)
+    recovered = "Already streamed to the user."
+    agent._current_streamed_assistant_text = recovered
+    messages = [
+        {"role": "user", "content": "summarize"},
+        {"role": "assistant", "content": ""},
+    ]
+    agent._flush_messages_to_session_db(messages)
+    stale_id = messages[-1]["_row_id"]
+    user_id = messages[0]["_row_id"]
+    assert isinstance(stale_id, int)
+    assert stale_id > user_id
+
+    db.archive_and_compact(
+        session_id,
+        compacted_messages=[{"role": "user", "content": "prior turns summarized"}],
+        watermark=user_id,
+    )
+
+    finalize_turn(
+        agent,
+        final_response="",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="summarize",
+        original_user_message="summarize",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    reloaded = _durable_messages(db_path, session_id)
+    active_assistants = [m for m in reloaded if m.get("role") == "assistant"]
+    assert active_assistants, "compaction clone should keep an active assistant"
+    assert any(
+        (m.get("content") or "").strip() == recovered for m in active_assistants
+    )
+    assert not any(
+        not (m.get("content") or "").strip() for m in active_assistants
+    )
+    inactive = db.get_messages(session_id, include_inactive=True)
+    archived = next(m for m in inactive if m.get("id") == stale_id)
+    assert archived.get("active") in (0, False)
+    assert messages[-1].get("_row_id") != stale_id
+
+
+def test_flush_atomic_mixed_repair_and_append_rollback_on_failure(tmp_path, monkeypatch):
+    """Mixed rewrite + append must be atomic: failure rolls back repair and stamps no markers.
+
+    If a turn contains both a blank assistant repair and a subsequent new message,
+    failure during the batch insert must roll back the assistant update and stamp
+    no in-memory markers.
+    """
+    from hermes_state import SessionDB
+
+    agent = _make_agent()
+    db_path = tmp_path / "state.db"
+    session_id = "sess-atomic-rollback"
+    db = _attach_real_session_db(agent, db_path, session_id)
+
+    messages = [
+        {"role": "user", "content": "summarize"},
+        {"role": "assistant", "content": ""},
+    ]
+    agent._flush_messages_to_session_db(messages)
+    orig_row_id = messages[-1]["_row_id"]
+    assert isinstance(orig_row_id, int)
+
+    # Now modify assistant message in memory and add a new message to the batch
+    messages[-1]["content"] = "Recovered stream answer"
+    messages[-1].pop("_db_persisted", None)
+    new_tool_msg = {"role": "tool", "tool_call_id": "t1", "name": "terminal", "content": "ok"}
+    messages.append(new_tool_msg)
+
+    # Force a failure inside the batch write transaction on the second message
+    orig_insert = SessionDB._insert_message_rows
+
+    def _failing_insert(self_db, conn, sid, msgs):
+        for msg in msgs:
+            if msg.get("role") == "tool":
+                raise RuntimeError("Simulated mid-batch persistence crash")
+        return orig_insert(self_db, conn, sid, msgs)
+
+    monkeypatch.setattr(SessionDB, "_insert_message_rows", _failing_insert)
+
+    success = agent._flush_messages_to_session_db(messages)
+    assert success is False or getattr(agent, "_incremental_persistence_failed", False) is True
+
+    # Check that in-memory markers were NOT stamped
+    assert messages[-1].get("_db_persisted") is not True
+    assert new_tool_msg.get("_db_persisted") is not True
+
+    # Check that the durable SQLite row was NOT updated (rolled back)
+    durable = _durable_messages(db_path, session_id)
+    assert len(durable) == 2
+    assert durable[-1]["role"] == "assistant"
+    assert (durable[-1].get("content") or "") == ""
+
+
+def test_flush_concurrent_nonblank_winner_adopts_canonical_content(tmp_path):
+    """A concurrent non-blank winner must be adopted without overwrite and synced to live dict."""
+    agent = _make_agent()
+    db_path = tmp_path / "state.db"
+    session_id = "sess-concurrent-winner"
+    db = _attach_real_session_db(agent, db_path, session_id)
+
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": ""},
+    ]
+    agent._flush_messages_to_session_db(messages)
+    row_id = messages[-1]["_row_id"]
+    assert isinstance(row_id, int)
+
+    # Concurrent writer updates the row in SQLite to non-blank canonical content
+    def _concurrent_write(conn):
+        conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?",
+            (db._encode_content("Canonical winner answer from sibling"), row_id),
+        )
+
+    db._execute_write(_concurrent_write)
+
+    # Live agent attempts to flush divergent content
+    messages[-1]["content"] = "Divergent live agent answer"
+    messages[-1].pop("_db_persisted", None)
+
+    success = agent._flush_messages_to_session_db(messages)
+    assert success is True
+
+    # SQLite must still have canonical winner content
+    durable = _durable_messages(db_path, session_id)
+    assert durable[-1]["content"] == "Canonical winner answer from sibling"
+
+    # Live dict must have adopted the canonical content and be marked persisted
+    assert messages[-1]["content"] == "Canonical winner answer from sibling"
+    assert messages[-1]["_db_persisted"] is True
+    assert messages[-1]["_row_id"] == row_id
+


### PR DESCRIPTION
## Summary

Batch salvage of the six merge-ready P0 PRs onto current `main` — five cache-layer fixes and two desktop persistence fixes, each cherry-picked with contributor authorship preserved (one commit per original PR).

## Included PRs

| Original | Author | Commit here | What it fixes |
|---|---|---|---|
| #97618 | @ericmaddox | `fix(caching): prevent whitespace-only text blocks…` | Anthropic HTTP 400 when a prefix split produced a whitespace-only secondary text block; split now requires a non-whitespace tail, falls back to whole-message caching |
| #96755 | @teknium1 | `fix(cache): over-length caller prompt_cache_key…` | Caller-supplied `prompt_cache_key` >64 chars 400'd every Chat Completions request on OpenAI/DeepSeek/Zai; now bounded to the same `pck_<sha256[:24]>` shape the Responses transport uses (opencode#44571 port) |
| #97327 | @JoaoMarcos44 | `fix(bedrock): recover from server-side cachePoint rejections…` | Amazon Nova rejects `cachePoint` inside `toolConfig.tools`, failing 100% of tool-enabled turns; server verdict is now classified from the JSON pointer, that one marker dropped, request retried once, verdict remembered for the process |
| #96768 | @JoaoMarcos44 | `test(cache): pin the prompt-cache scope isolation invariant…` | Tests-only. The PR's three commits net to a tests-only diff (its mid-series production hunk was reverted in-PR after review), squashed to that net with authorship preserved |
| #96608 | @amansk | `fix(desktop): make gateway file saves failure-atomic…` | `createWriteStream`/`writeFile` truncated the user's chosen destination on open, and the error path unlinked it — a gateway drop mid-download destroyed the pre-existing file; both save paths now stream into an exclusive sibling `.part` temp and rename into place only after the full body lands |
| #95886 | @StanleyStetson | `fix(desktop): preserve streamed assistant text and unify atomic persistence` | Empty terminal completion erased already-streamed assistant text in the Desktop UI and froze `content=''` rows in SQLite (#95514); recovery from the stream buffer + blank-row repair inside the single `append_messages_batch` transaction |

Commit 1 is the attribution mapping for @ericmaddox (first-time contributor).

## Review evidence

Every PR went through the full review battery before batching:

- Diffs read line-by-line; premises verified against `origin/main` (Nova IS in `_CACHE_POINT_PATTERNS` today, the caller-key early-return does skip bounding, etc.)
- Each cherry-picked individually onto current main: targeted suites green (97618: 52, 96755: 56, 97327: 76, 96768: 49, 95886: 26 pytest + 88 vitest, 96608: 32 vitest incl. a real-filesystem tier)
- Mutation checks: with production files reverted to main and PR tests kept, the new guards fail (97618: 1F, 96755: 4F, 95886: 5F, 97582-style source checks n/a for tests-only 96768)
- 3-agent deep review (reuse / quality / efficiency / hermes-specific) — no critical findings on any of the six; cache-integrity specifically verified (97618's new condition is strictly more restrictive, so existing valid splits keep byte-identical cached prefixes; 96755 only changes keys that previously 400'd)
- #95886's four persistence risk points traced with line-level proof: stream buffer resets per API attempt (`conversation_loop.py` while-loop → `_reset_stream_delivery_tracking`), batch_rows/batch_msgs zip alignment holds (repair mutates in place, never removes), the new marker-gate correctly degrades the bounded flush scan after `turn_finalizer` pops a marker, rollback atomicity is test-covered
- Combined stack: 308 pytest + 12 cross-process lease guards + 120 vitest, all green

## Validation (this branch)

| Suite | Result |
|---|---|
| cache/bedrock/transport/persistence pytest targets | 308 passed |
| tests/run_agent/test_cross_process_turn_lease.py | 12 passed |
| desktop gateway-file-download (unit + real-fs + transport) | 32 passed |
| desktop chat-messages + session-info side effects | 88 passed |

Closes #97618. Closes #96755. Closes #97327. Closes #96768. Closes #96608. Closes #95886.
