### PR TITLE
fix(desktop): HUD clicks, links, and right-click on Linux X11

### DIFF
--- a/apps/desktop/electron/hud-windowing.test.ts
+++ b/apps/desktop/electron/hud-windowing.test.ts
@@ -111,12 +111,14 @@ test('the renderer view is a boolean slice of the profile', () => {
     clientPlacement: false,
     controlDrag: false,
     nativeDrag: true,
+    solid: false,
     workspaceTransfer: false
   })
   assert.deepEqual(x11, {
     clientPlacement: true,
     controlDrag: true,
     nativeDrag: false,
+    solid: true,
     workspaceTransfer: true
   })
 })

--- a/apps/desktop/electron/hud-windowing.ts
+++ b/apps/desktop/electron/hud-windowing.ts
@@ -37,6 +37,8 @@ export interface HudWindowingView {
   clientPlacement: boolean
   controlDrag: boolean
   nativeDrag: boolean
+  /** The OS window cannot punch click-through holes (Linux X11). */
+  solid: boolean
   workspaceTransfer: boolean
 }
 
@@ -128,6 +130,7 @@ export function hudWindowingView(windowing: HudWindowing): HudWindowingView {
     clientPlacement: windowing.clientPlacement,
     controlDrag: windowing.controlDrag,
     nativeDrag: windowing.move === 'native-drag',
+    solid: windowing.input === 'solid',
     workspaceTransfer: windowing.workspaceTransfer
   }
 }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -84,6 +84,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       clientPlacement: hudWindowing?.clientPlacement !== false,
       controlDrag: hudWindowing?.controlDrag === true,
       nativeDrag: hudNativeDrag,
+      solid: hudWindowing?.solid === true,
       workspaceTransfer: hudWindowing?.workspaceTransfer === true
     },
     open: request => ipcRenderer.invoke('hermes:hud:open', request),

--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -118,6 +118,28 @@ describe('AppContextMenu', () => {
     await waitFor(() => expect($previewTabs.get().at(-1)?.target.url).toBe('https://example.com/docs'))
   })
 
+  it('skips Open in in-app browser on the HUD — that window has no browser pane', async () => {
+    const originalLocation = window.location
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, search: '?win=hud' }
+    })
+
+    try {
+      installBridge()
+      mountMenu()
+      const host = attach('<a href="https://accounts.google.com/o/oauth2/auth">Sign in</a>')
+
+      fireEvent.contextMenu(host.querySelector('a')!)
+
+      expect(await screen.findByText('Open in external browser')).toBeTruthy()
+      expect(screen.queryByText('Open in in-app browser')).toBeNull()
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+    }
+  })
+
   it('offers the resolved copy only for loopback links on a remote gateway', async () => {
     $connection.set({ mode: 'remote' } as never)
     const reachPreviewUrl = vi.fn(async () => 'http://127.0.0.1:45173/')

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { type Translations, useI18n } from '@/i18n'
-import { hostPathLabel, normalizeExternalUrl, openExternalLink } from '@/lib/external-link'
+import { hostPathLabel, hudForcesNativeLinks, normalizeExternalUrl, openExternalLink } from '@/lib/external-link'
 import { formatCombo } from '@/lib/keybinds/combo'
 import { isRemoteGateway } from '@/lib/media'
 import { reachablePreviewUrl } from '@/lib/preview-reach'
@@ -137,6 +137,7 @@ function domSections(open: Extract<OpenContextMenu, { kind: 'dom' }>, t: Transla
   const linkUrl = target.linkUrl ? normalizeExternalUrl(target.linkUrl) : ''
   const linkIsWeb = isWebUrl(linkUrl)
   const imageIsWeb = isWebUrl(target.imageUrl)
+  const openInApp = !hudForcesNativeLinks()
   const showResolvedCopy = linkIsWeb && isRemoteGateway() && isLoopbackUrl(linkUrl)
 
   // The edit verbs and spell-check actions act on the sender's FOCUSED
@@ -194,7 +195,7 @@ function domSections(open: Extract<OpenContextMenu, { kind: 'dom' }>, t: Transla
   if (linkUrl) {
     sections.push(
       [
-        linkIsWeb ? (
+        linkIsWeb && openInApp ? (
           <Item
             icon="globe"
             key="link-open-app"
@@ -234,7 +235,7 @@ function domSections(open: Extract<OpenContextMenu, { kind: 'dom' }>, t: Transla
   if (target.onImage) {
     sections.push(
       [
-        imageIsWeb ? (
+        imageIsWeb && openInApp ? (
           <Item
             icon="globe"
             key="image-open-app"
@@ -382,6 +383,7 @@ function guestSections(open: Extract<OpenContextMenu, { kind: 'guest' }>, t: Tra
   const sections: ReactNode[][] = []
   const linkUrl = params.linkURL
   const imageUrl = params.srcURL
+  const openInApp = !hudForcesNativeLinks()
 
   // Same trap-timing rule as the dom side: dispatch AFTER the menu closes,
   // so the webview's focus() is not stolen back by the radix content.
@@ -393,7 +395,7 @@ function guestSections(open: Extract<OpenContextMenu, { kind: 'guest' }>, t: Tra
   if (linkUrl) {
     sections.push(
       [
-        isWebUrl(linkUrl) ? (
+        isWebUrl(linkUrl) && openInApp ? (
           <Item
             icon="globe"
             key="guest-link-open-app"

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -451,10 +451,11 @@ discoverBundledPlugins()
 watchContributedPanes()
 
 // Session + route (page) tiles: persisted splits register panes docked beside
-// main. A popped-out Browser has no layout tree — registering tiles there
-// would still run, and preview-tile watching would try to dock into a tree
-// this window never renders.
-if (!isBrowserWindow()) {
+// main. A popped-out Browser and the HUD have no layout tree — registering
+// tiles there would still run, and preview-tile watching would try to dock
+// into a tree this window never renders (and, in the HUD, paint a webview
+// into the transparent overlay).
+if (!isBrowserWindow() && !isHudWindow()) {
   watchSessionTiles()
   watchRouteTiles()
   watchPreviewTiles()
@@ -819,6 +820,7 @@ export function ContribController() {
   if (isHudWindow()) {
     return (
       <ContribWiring>
+        <AppContextMenu />
         <HudShell />
       </ContribWiring>
     )

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -377,7 +377,11 @@ export function HudShell() {
   // growth bug); the handle is the one sanctioned way to change size, driving
   // the same flip-resizable-for-the-call pattern the pet overlay uses.
   const { resizing: hudResizing, onPointerDown: onHudResizePointerDown } = useHudResizeHandle()
-  const resizeDirections = hudResizeDirections(window.hermesDesktop?.hud?.windowing?.clientPlacement !== false)
+  const hudWindowing = window.hermesDesktop?.hud?.windowing
+  const resizeDirections = hudResizeDirections(hudWindowing?.clientPlacement !== false)
+  // Linux X11 cannot ignore-mouse; a visible band that also ignores the
+  // pointer just eats the click. The stylesheet keys off this.
+  const hudInput = hudWindowing?.solid ? 'solid' : 'click-through'
 
   // Force the HOST layers transparent. index.html's pre-paint script writes an
   // opaque themed background onto <html> as an INLINE style (the anti-white-
@@ -399,6 +403,8 @@ export function HudShell() {
       className="relative flex h-screen w-screen flex-col overflow-hidden"
       data-hud-edge={edge}
       data-hud-game={gameUnder ? '' : undefined}
+      data-hud-held={held ? '' : undefined}
+      data-hud-input={hudInput}
       data-hud-recent={recent || held ? '' : undefined}
       data-hud-shell
       // Letting go of the composer re-arms the hold, so the transcript steps

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -101,6 +101,7 @@ declare global {
           clientPlacement: boolean
           controlDrag: boolean
           nativeDrag: boolean
+          solid: boolean
           workspaceTransfer: boolean
         }
         open: (request?: { sessionId?: null | string; profile?: null | string }) => Promise<{ ok: boolean }>

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -9,6 +9,7 @@ import {
   ExternalLink,
   fetchLinkTitle,
   hostPathLabel,
+  hudForcesNativeLinks,
   isTitleFetchable,
   LinkifiedText,
   MarkdownLinkText,
@@ -133,6 +134,39 @@ describe('external link helpers', () => {
 
     expect(openExternal).toHaveBeenCalledWith('https://example.com/path/to/resource')
     expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('treats only the HUD renderer as a native-link surface', () => {
+    expect(hudForcesNativeLinks('')).toBe(false)
+    expect(hudForcesNativeLinks('?win=secondary')).toBe(false)
+    expect(hudForcesNativeLinks('?win=browser&tab=1')).toBe(false)
+    expect(hudForcesNativeLinks('?win=hud')).toBe(true)
+    expect(hudForcesNativeLinks('?profile=work&win=hud')).toBe(true)
+  })
+
+  // The HUD has no in-app browser. A click that opened a preview tile would
+  // try to paint a webview into the transparent overlay (OAuth, consoles).
+  it('sends every HUD web link to the OS browser', () => {
+    const originalLocation = window.location
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, search: '?win=hud' }
+    })
+
+    try {
+      const openExternal = vi.fn().mockResolvedValue(undefined)
+      installDesktopBridge({ openExternal: openExternal as unknown as Window['hermesDesktop']['openExternal'] })
+
+      render(<ExternalLink href="https://accounts.google.com/o/oauth2/auth">Sign in</ExternalLink>)
+
+      fireEvent.click(screen.getByRole('link', { name: 'Sign in' }))
+
+      expect(openExternal).toHaveBeenCalledWith('https://accounts.google.com/o/oauth2/auth')
+      expect($previewTabs.get()).toHaveLength(0)
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+    }
   })
 
   // A setup step sends you to a console you are signed into in your own

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -212,6 +212,21 @@ export function wantsNativeBrowser(event: Pick<MouseEvent, 'button' | 'ctrlKey' 
 }
 
 /**
+ * The HUD is a chrome-free bar with no in-app browser. A preview tile there
+ * either no-ops or tries to paint a webview into the transparent overlay —
+ * the OAuth-in-the-HUD case. Always hand off to the OS browser.
+ */
+export function hudForcesNativeLinks(
+  search = typeof window === 'undefined' ? '' : window.location.search
+): boolean {
+  try {
+    return new URLSearchParams(search).get('win') === 'hud'
+  } catch {
+    return false
+  }
+}
+
+/**
  * Where a link the user clicked should open.
  *
  * A web page opens in the in-app browser — that pane exists so reading a doc
@@ -220,7 +235,8 @@ export function wantsNativeBrowser(event: Pick<MouseEvent, 'button' | 'ctrlKey' 
  * where you go for anything needing your logged-in session or a password.
  *
  * Everything that ISN'T a web page — `mailto:`, `file:`, a custom scheme — has
- * no business in the webview and always hands off to the OS.
+ * no business in the webview and always hands off to the OS. The HUD has no
+ * browser pane, so it always takes the OS path.
  */
 export function openLink(href: string, options: { native?: boolean } = {}): void {
   const target = normalizeExternalUrl(href)
@@ -229,7 +245,11 @@ export function openLink(href: string, options: { native?: boolean } = {}): void
     return
   }
 
-  if (options.native || !/^https?:$/i.test(parseUrl(target)?.protocol ?? '')) {
+  if (
+    options.native ||
+    hudForcesNativeLinks() ||
+    !/^https?:$/i.test(parseUrl(target)?.protocol ?? '')
+  ) {
     openExternalLink(target)
 
     return

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2846,6 +2846,37 @@ button[data-slot='aui_msg-reactions'] svg {
   pointer-events: auto;
 }
 
+/* A held band is the interface — clarify / approval / a live turn. It must
+   take clicks even if the composer never received focus. On click-through
+   hosts that is a deliberate dead zone over the game; on a prompt it is a
+   surface you cannot use. */
+[data-hud-shell][data-hud-held] [data-slot='composer-bounds'] {
+  pointer-events: auto;
+}
+
+/* Linux X11 is a solid window: ignore-mouse cannot restore, so a visible
+   band that still has pointer-events:none swallows the click and does
+   nothing. Once the band is up it is the surface. */
+[data-hud-shell][data-hud-input='solid'][data-hud-recent] [data-slot='composer-bounds'] {
+  pointer-events: auto;
+}
+
+/* Widgets and links opt in even when the band is a ghost, so a click-through
+   HUD can still answer a clarify option or open an OAuth URL without sitting
+   in the composer first. Children inherit auto from these roots. */
+[data-hud-shell]
+  :is(
+    [data-slot='clarify-inline'],
+    [data-clarify-choices],
+    [data-clarify-batch],
+    [data-slot='tool-approval-inline'],
+    [data-slot='tool-approval-fallback'],
+    [data-slot='tool-approval-actions'],
+    a[href]
+  ) {
+  pointer-events: auto;
+}
+
 /* Three states, not two. A turn landing brings the transcript up, but only part
    way — it is there to be glanced at over whatever you are actually doing, and
    full-strength text over another app reads as the HUD demanding attention it
@@ -3466,11 +3497,14 @@ html:has([data-hud-shell]) [data-slot='popover-content'] [class*='max-h-'] {
   max-height: max(5rem, calc(100dvh - 9rem)) !important;
 }
 
-/* The menu panels themselves: never taller than the window minus the bar. */
+/* The menu panels themselves: never taller than the window minus the bar.
+   Portalled out of the shell, they must still take the pointer — the HUD
+   defaults to none and a right-click menu that cannot be clicked is dead. */
 html:has([data-hud-shell]) [data-slot='dropdown-menu-content'],
 html:has([data-hud-shell]) [data-slot='popover-content'] {
   max-height: calc(100dvh - 4.5rem) !important;
   overflow-y: auto;
+  pointer-events: auto;
 }
 
 /* Hide the scrollbar — a HUD with a visible track stops reading as an overlay. */


### PR DESCRIPTION
## Summary

On Linux X11 the HUD is a solid window that cannot punch click-through holes. The transcript still ignored the pointer unless the composer was focused, so clarify options, links, and right-click did nothing. A link that did fire opened the in-app browser (a webview) inside the transparent overlay, which is how an OAuth URL tried to load in the HUD itself.

Held prompts and solid-window bands now take clicks. HUD links go to the system browser. The context menu is mounted and no longer offers "Open in in-app browser" there.

## Test plan

- [ ] Linux X11: open HUD, raise a batch clarify, click A–E without focusing the composer first
- [ ] Click an OAuth / https link in the HUD — it opens in the OS browser, not inside the overlay
- [ ] Right-click a link in the HUD — Copy URL / Open in external browser; no "Open in in-app browser"
- [ ] macOS/Windows HUD: glanceable band still click-throughs; focusing the composer (or a held prompt) still lets you click