### PR TITLE
feat(plugins): dispatch busy-safe controls during active turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2750,6 +2750,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    _mark_notify_metadata,
     _prefix_within_utf16_limit,
     _reply_anchor_for_event,
     build_auto_tts_output_path,
@@ -10414,6 +10415,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return text
         return (enriched_text or text).strip()
 
+    async def _dispatch_busy_plugin_command(
+        self,
+        *,
+        plugin_name: str,
+        plugin_entry: dict,
+        event: MessageEvent,
+    ) -> Optional[str]:
+        """Authorize, validate, and dispatch one opted-in busy plugin command."""
+        denied = self._check_slash_access(event.source, plugin_name)
+        if denied is not None:
+            return denied
+
+        plugin_args = (event.get_command_args() or "").strip()
+        plugin_verb = plugin_args.split(None, 1)[0].lower() if plugin_args else ""
+        busy_safe = set(plugin_entry.get("busy_safe_subcommands") or ())
+        if plugin_verb not in busy_safe:
+            return (
+                f"⏳ Agent is running — `/{plugin_name}` can't run mid-turn. "
+                "Wait for the current response or `/stop` first."
+            )
+
+        handler = plugin_entry.get("handler")
+        if not callable(handler):
+            logger.warning("Plugin command /%s has no callable handler", plugin_name)
+            return "Plugin command failed."
+        try:
+            result = handler(plugin_args)
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception:
+            logger.warning(
+                "Busy-safe plugin command dispatch failed for /%s",
+                plugin_name,
+                exc_info=True,
+            )
+            return "Plugin command failed."
+        return str(result) if result else None
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -10557,6 +10596,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return True
         if getattr(event, "internal", False):
             return False
+
+        # Plugin commands opt into mid-turn dispatch one first-token verb at a
+        # time. Once opted in, unlisted verbs reject here instead of reaching
+        # the generic queue/steer/interrupt path. Legacy plugin commands omit
+        # busy_safe_subcommands and keep their existing behavior.
+        plugin_name = (event.get_command() or "").replace("_", "-")
+        plugin_entry = None
+        if plugin_name:
+            try:
+                from hermes_cli.plugins import get_plugin_command_entry
+
+                plugin_entry = get_plugin_command_entry(plugin_name)
+            except Exception:
+                logger.warning(
+                    "Plugin command metadata lookup failed for /%s",
+                    plugin_name,
+                    exc_info=True,
+                )
+        if plugin_entry and plugin_entry.get("busy_safe_subcommands"):
+            response = await self._dispatch_busy_plugin_command(
+                plugin_name=plugin_name,
+                plugin_entry=plugin_entry,
+                event=event,
+            )
+            if response:
+                text, ephemeral_ttl = adapter._unwrap_ephemeral(response)
+                if text:
+                    anchor = self._reply_anchor_for_event(event)
+                    sent = await adapter._send_with_retry(
+                        chat_id=event.source.chat_id,
+                        content=text,
+                        reply_to=anchor,
+                        metadata=_mark_notify_metadata(
+                            self._thread_metadata_for_source(event.source, anchor)
+                        ),
+                    )
+                    if ephemeral_ttl > 0 and sent.success and sent.message_id:
+                        adapter._schedule_ephemeral_delete(
+                            chat_id=event.source.chat_id,
+                            message_id=sent.message_id,
+                            ttl_seconds=ephemeral_ttl,
+                        )
+            return True
 
         _busy_state = self._peek_session_state(session_key)
         running_agent = _busy_state.turn.agent if _busy_state else None
@@ -17970,6 +18052,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
 
+            # Plugin commands are outside the built-in CommandDef registry.
+            # Resolve their explicit busy-safe policy before generic busy input
+            # can interrupt or queue the active turn.
+            _plugin_name_inner = (_evt_cmd or "").replace("_", "-")
+            _plugin_entry_inner = None
+            if _plugin_name_inner:
+                try:
+                    from hermes_cli.plugins import get_plugin_command_entry
+
+                    _plugin_entry_inner = get_plugin_command_entry(
+                        _plugin_name_inner
+                    )
+                except Exception:
+                    logger.warning(
+                        "Plugin command metadata lookup failed for /%s",
+                        _plugin_name_inner,
+                        exc_info=True,
+                    )
+            if (
+                _plugin_entry_inner
+                and _plugin_entry_inner.get("busy_safe_subcommands")
+            ):
+                return await self._dispatch_busy_plugin_command(
+                    plugin_name=_plugin_name_inner,
+                    plugin_entry=_plugin_entry_inner,
+                    event=event,
+                )
+
             # /status and /context are intentionally pre-gate so users
             # always see session state.
             if _cmd_def_inner and _cmd_def_inner.name == "status":
@@ -18721,11 +18831,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Normalize underscores to hyphens so Telegram's underscored
                 # autocomplete form matches plugin commands registered with
                 # hyphens. See hermes_cli/commands.py:_build_telegram_menu.
-                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
+                plugin_name = command.replace("_", "-")
+                plugin_handler = get_plugin_command_handler(plugin_name)
                 if plugin_handler:
+                    # Plugin commands are slash capabilities too. Keep their
+                    # cold-path authorization identical to busy-safe dispatch.
+                    denied = self._check_slash_access(source, plugin_name)
+                    if denied is not None:
+                        return denied
                     user_args = event.get_command_args().strip()
                     result = plugin_handler(user_args)
-                    if asyncio.iscoroutine(result):
+                    if inspect.isawaitable(result):
                         result = await result
                     return str(result) if result else None
             except Exception as e:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2199,6 +2199,7 @@ class PluginContext:
         description: str = "",
         args_hint: str = "",
         argument_mode: str | None = None,
+        *,
         busy_safe_subcommands: Iterable[str] = (),
     ) -> Optional[PluginRegistration]:
         """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2175,6 +2175,22 @@ class PluginContext:
 
     # -- slash command registration -------------------------------------------
 
+    @staticmethod
+    def _normalize_busy_safe_subcommands(values: Iterable[str]) -> Tuple[str, ...]:
+        """Normalize the public busy-safe verb list once for every registrar."""
+        normalized: List[str] = []
+        for raw_subcommand in values or ():
+            if not isinstance(raw_subcommand, str):
+                raise TypeError("busy_safe_subcommands entries must be strings")
+            subcommand = raw_subcommand.strip().lower()
+            if any(char.isspace() for char in subcommand):
+                raise ValueError(
+                    "busy_safe_subcommands entries must be single tokens"
+                )
+            if subcommand not in normalized:
+                normalized.append(subcommand)
+        return tuple(normalized)
+
     @_serialized_replacement
     def register_command(
         self,
@@ -2183,6 +2199,7 @@ class PluginContext:
         description: str = "",
         args_hint: str = "",
         argument_mode: str | None = None,
+        busy_safe_subcommands: Iterable[str] = (),
     ) -> Optional[PluginRegistration]:
         """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.
 
@@ -2203,6 +2220,12 @@ class PluginContext:
         ``argument_mode`` tells the desktop composer how text after the command
         name behaves (``options``, ``text``, or ``mixed``). Omit it to infer
         ``text`` whenever ``args_hint`` is set, so ``/myplugin `` stays typeable.
+
+        ``busy_safe_subcommands`` opts specific first argument tokens into
+        authorization-aware dispatch while an agent is already running. The
+        empty string represents the bare command. Once a command opts in, any
+        unlisted first token is rejected mid-turn rather than interrupting or
+        queueing the active agent. Omit it to preserve the legacy busy behavior.
 
         Names conflicting with built-in commands are rejected with a warning.
         """
@@ -2239,6 +2262,9 @@ class PluginContext:
             "plugin_key": self.manifest.key or self.manifest.name,
             "args_hint": hint,
             "argument_mode": mode,
+            "busy_safe_subcommands": self._normalize_busy_safe_subcommands(
+                busy_safe_subcommands
+            ),
         }
         self._manager._plugin_commands[clean] = entry
         handle = self._track_replacement(
@@ -7046,6 +7072,14 @@ def get_plugin_command_handler(name: str) -> Optional[Callable]:
     """Return the handler for a plugin-registered slash command, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry else None
+
+
+def get_plugin_command_entry(name: str) -> Optional[dict]:
+    """Return normalized metadata for a plugin slash command, if registered."""
+    clean = (name or "").lower().strip().lstrip("/").replace("_", "-")
+    if not clean:
+        return None
+    return _ensure_plugins_discovered()._plugin_commands.get(clean)
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -220,6 +220,7 @@ class _EngineCollector:
         description: str = "",
         args_hint: str = "",
         argument_mode: str | None = None,
+        *,
         busy_safe_subcommands=(),
     ) -> None:
         """Forward to the global plugin command registry."""

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -219,6 +219,8 @@ class _EngineCollector:
         handler,
         description: str = "",
         args_hint: str = "",
+        argument_mode: str | None = None,
+        busy_safe_subcommands=(),
     ) -> None:
         """Forward to the global plugin command registry."""
         clean = (name or "").lower().strip().lstrip("/").replace(" ", "-")
@@ -243,7 +245,7 @@ class _EngineCollector:
             pass
 
         try:
-            from hermes_cli.plugins import get_plugin_manager
+            from hermes_cli.plugins import PluginContext, get_plugin_manager
             manager = get_plugin_manager()
             if clean in manager._plugin_commands:
                 # Don't clobber a regular plugin's command — same conflict
@@ -254,11 +256,24 @@ class _EngineCollector:
                     self._engine_name, clean,
                 )
                 return
+            hint = (args_hint or "").strip()
+            mode = (
+                argument_mode
+                if argument_mode in {"options", "text", "mixed"}
+                else ("text" if hint else None)
+            )
             manager._plugin_commands[clean] = {
                 "handler": handler,
                 "description": description or "Context engine command",
                 "plugin": f"context-engine:{self._engine_name}",
-                "args_hint": (args_hint or "").strip(),
+                "plugin_key": f"context-engine:{self._engine_name}",
+                "args_hint": hint,
+                "argument_mode": mode,
+                "busy_safe_subcommands": (
+                    PluginContext._normalize_busy_safe_subcommands(
+                        busy_safe_subcommands
+                    )
+                ),
             }
             self._registered_commands.append(clean)
             logger.debug(

--- a/tests/gateway/test_plugin_busy_safe_commands.py
+++ b/tests/gateway/test_plugin_busy_safe_commands.py
@@ -1,0 +1,386 @@
+import asyncio
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+from plugins.context_engine import _EngineCollector
+from tests.gateway.test_run_cleanup_progress import CleanupCaptureAdapter, _make_runner
+from tests.gateway.test_slash_access_dispatch import (
+    _make_event as _make_access_event,
+    _make_runner as _make_access_runner,
+    _make_source as _make_access_source,
+)
+
+
+def _plugin_manager() -> PluginManager:
+    manager = PluginManager()
+    manager._discovered = True
+    return manager
+
+
+def _active_adapter(runner, adapter, source):
+    session_key = runner._session_key_for_source(source)
+    runner._is_user_authorized = lambda _source: True
+    runner._check_slash_access = lambda _source, _command: None
+    runner._effective_busy_input_mode = lambda _source: "interrupt"
+    runner._draining = False
+    adapter.set_message_handler(AsyncMock(return_value=None))
+    adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._session_tasks[session_key] = asyncio.current_task()
+    return session_key
+
+
+def test_plugin_command_records_normalized_busy_safe_subcommands():
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+
+    context.register_command(
+        "control",
+        lambda _raw: "ok",
+        busy_safe_subcommands=("", " STATUS ", "status", "Pause"),
+    )
+
+    assert manager._plugin_commands["control"]["busy_safe_subcommands"] == (
+        "",
+        "status",
+        "pause",
+    )
+
+
+def test_plugin_command_rejects_multitoken_busy_safe_entry():
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+
+    with pytest.raises(ValueError, match="single tokens"):
+        context.register_command(
+            "control",
+            lambda _raw: "ok",
+            busy_safe_subcommands=("not safe",),
+        )
+
+
+def test_busy_safe_subcommands_is_keyword_only():
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+
+    with pytest.raises(TypeError):
+        context.register_command(
+            "control",
+            lambda _raw: "ok",
+            "",
+            "",
+            None,
+            ("",),
+        )
+
+
+def test_context_engine_collector_forwards_busy_safe_metadata():
+    manager = _plugin_manager()
+    collector = _EngineCollector("memory-engine")
+
+    with patch("hermes_cli.plugins._plugin_manager", manager):
+        collector.register_command(
+            "memory-control",
+            lambda _raw: "ok",
+            args_hint="[status]",
+            argument_mode="mixed",
+            busy_safe_subcommands=("", "STATUS"),
+        )
+
+    assert manager._plugin_commands["memory-control"] == {
+        "handler": manager._plugin_commands["memory-control"]["handler"],
+        "description": "Context engine command",
+        "plugin": "context-engine:memory-engine",
+        "plugin_key": "context-engine:memory-engine",
+        "args_hint": "[status]",
+        "argument_mode": "mixed",
+        "busy_safe_subcommands": ("", "status"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_cold_plugin_command_applies_slash_access_control():
+    runner = _make_access_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [],
+        }
+    )
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+    called = []
+    context.register_command(
+        "control",
+        lambda raw: called.append(raw) or "secret",
+    )
+
+    with patch("hermes_cli.plugins._plugin_manager", manager):
+        result = await runner._handle_message(
+            _make_access_event(
+                "/control status",
+                _make_access_source(user_id="999"),
+            )
+        )
+
+    assert called == []
+    assert result is not None
+    assert "⛔" in result
+    assert "/control is admin-only here" in result
+
+
+@pytest.mark.asyncio
+async def test_cold_plugin_command_keeps_unrestricted_back_compat():
+    runner = _make_access_runner()
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+
+    async def handler(raw_args):
+        await asyncio.sleep(0)
+        return f"cold:{raw_args}"
+
+    context.register_command("control", handler)
+
+    with patch("hermes_cli.plugins._plugin_manager", manager):
+        result = await runner._handle_message(
+            _make_access_event(
+                "/control status",
+                _make_access_source(user_id="999"),
+            )
+        )
+
+    assert result == "cold:status"
+
+
+@pytest.mark.asyncio
+async def test_active_adapter_dispatches_bare_busy_safe_plugin_command():
+    gateway_run = importlib.import_module("gateway.run")
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        user_id="111",
+        chat_type="dm",
+    )
+    session_key = _active_adapter(runner, adapter, source)
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+    seen = []
+    context.register_command(
+        "control",
+        lambda raw: seen.append(raw) or "healthy",
+        busy_safe_subcommands=("",),
+    )
+
+    with patch("hermes_cli.plugins._plugin_manager", manager):
+        await adapter.handle_message(
+            gateway_run.MessageEvent(
+                text="/control",
+                message_type=gateway_run.MessageType.TEXT,
+                source=source,
+            )
+        )
+
+    assert seen == [""]
+    assert [item["content"] for item in adapter.sent] == ["healthy"]
+    assert adapter.sent[0]["metadata"]["notify"] is True
+    assert adapter._pending_messages == {}
+    assert session_key in adapter._active_sessions
+
+
+@pytest.mark.asyncio
+async def test_active_adapter_awaits_busy_safe_plugin_command():
+    gateway_run = importlib.import_module("gateway.run")
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        user_id="111",
+        chat_type="dm",
+    )
+    _active_adapter(runner, adapter, source)
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+
+    async def handler(raw_args):
+        await asyncio.sleep(0)
+        return f"paused:{raw_args}"
+
+    context.register_command(
+        "control",
+        handler,
+        busy_safe_subcommands=("pause",),
+    )
+
+    with patch("hermes_cli.plugins._plugin_manager", manager):
+        await adapter.handle_message(
+            gateway_run.MessageEvent(
+                text="/control pause",
+                message_type=gateway_run.MessageType.TEXT,
+                source=source,
+            )
+        )
+
+    assert [item["content"] for item in adapter.sent] == ["paused:pause"]
+    assert adapter.sent[0]["metadata"]["notify"] is True
+    assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_active_adapter_rejects_unsafe_plugin_verb_without_queueing():
+    gateway_run = importlib.import_module("gateway.run")
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        user_id="111",
+        chat_type="dm",
+    )
+    session_key = _active_adapter(runner, adapter, source)
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+    called = []
+    context.register_command(
+        "control",
+        lambda raw: called.append(raw) or "started",
+        busy_safe_subcommands=("status", "pause"),
+    )
+
+    with patch("hermes_cli.plugins._plugin_manager", manager):
+        await adapter.handle_message(
+            gateway_run.MessageEvent(
+                text="/control start new mission",
+                message_type=gateway_run.MessageType.TEXT,
+                source=source,
+            )
+        )
+
+    assert called == []
+    assert len(adapter.sent) == 1
+    assert "can't run mid-turn" in adapter.sent[0]["content"]
+    assert adapter.sent[0]["metadata"]["notify"] is True
+    assert adapter._pending_messages == {}
+    assert session_key in adapter._active_sessions
+
+
+@pytest.mark.asyncio
+async def test_legacy_plugin_command_keeps_existing_busy_path():
+    gateway_run = importlib.import_module("gateway.run")
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        user_id="111",
+        chat_type="dm",
+    )
+    _active_adapter(runner, adapter, source)
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+    called = []
+    context.register_command(
+        "control",
+        lambda raw: called.append(raw) or "legacy",
+    )
+
+    with patch("hermes_cli.plugins._plugin_manager", manager):
+        await adapter.handle_message(
+            gateway_run.MessageEvent(
+                text="/control status",
+                message_type=gateway_run.MessageType.TEXT,
+                source=source,
+            )
+        )
+
+    assert called == []
+    adapter._message_handler.assert_not_awaited()
+    assert len(adapter.sent) == 1
+    assert "Interrupting current task" in adapter.sent[0]["content"]
+    assert list(adapter._pending_messages) == [runner._session_key_for_source(source)]
+
+
+@pytest.mark.asyncio
+async def test_active_adapter_rejects_unsafe_verb_after_runner_cleanup():
+    gateway_run = importlib.import_module("gateway.run")
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        user_id="111",
+        chat_type="dm",
+    )
+    _active_adapter(runner, adapter, source)
+    runner._running_agents.clear()
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+    called = []
+    context.register_command(
+        "control",
+        lambda raw: called.append(raw) or "deleted",
+        busy_safe_subcommands=("status",),
+    )
+
+    with patch("hermes_cli.plugins._plugin_manager", manager):
+        await adapter.handle_message(
+            gateway_run.MessageEvent(
+                text="/control delete",
+                message_type=gateway_run.MessageType.TEXT,
+                source=source,
+            )
+        )
+
+    assert called == []
+    assert len(adapter.sent) == 1
+    assert "can't run mid-turn" in adapter.sent[0]["content"]
+    assert adapter.sent[0]["metadata"]["notify"] is True
+    assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_active_adapter_applies_slash_access_before_busy_dispatch():
+    gateway_run = importlib.import_module("gateway.run")
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        user_id="999",
+        chat_type="dm",
+    )
+    _active_adapter(runner, adapter, source)
+    runner._check_slash_access = lambda _source, command: (
+        f"⛔ /{command} is admin-only here."
+    )
+    manager = _plugin_manager()
+    context = PluginContext(PluginManifest(name="plug"), manager)
+    called = []
+    context.register_command(
+        "control",
+        lambda raw: called.append(raw) or "status",
+        busy_safe_subcommands=("",),
+    )
+
+    with patch("hermes_cli.plugins._plugin_manager", manager):
+        await adapter.handle_message(
+            gateway_run.MessageEvent(
+                text="/control",
+                message_type=gateway_run.MessageType.TEXT,
+                source=source,
+            )
+        )
+
+    assert called == []
+    assert [item["content"] for item in adapter.sent] == [
+        "⛔ /control is admin-only here."
+    ]
+    assert adapter.sent[0]["metadata"]["notify"] is True
+    assert adapter._pending_messages == {}

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -1157,13 +1157,50 @@ def register(ctx):
 
 After registration, users can type `/mystatus` in any session. The command appears in autocomplete, `/help` output, and the Telegram bot menu.
 
-**Signature:** `ctx.register_command(name: str, handler: Callable, description: str = "", args_hint: str = "")`
+**Signature:**
+
+```python
+ctx.register_command(
+    name: str,
+    handler: Callable,
+    description: str = "",
+    args_hint: str = "",
+    argument_mode: str | None = None,
+    busy_safe_subcommands: Iterable[str] = (),
+)
+```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | `str` | Command name without the leading slash (e.g. `"lcm"`, `"mystatus"`) |
 | `handler` | `Callable[[str], str \| None]` | Called with the raw argument string. May also be `async`. |
 | `description` | `str` | Shown in `/help`, autocomplete, and Telegram bot menu |
+| `args_hint` | `str` | Optional argument hint shown by native command pickers |
+| `argument_mode` | `str \| None` | Desktop composer behavior: `options`, `text`, or `mixed` |
+| `busy_safe_subcommands` | `Iterable[str]` | First argument tokens allowed while an agent is running; `""` means the bare command |
+
+#### Busy-safe control commands
+
+Plugin commands keep their legacy busy behavior unless they explicitly opt in.
+Use `busy_safe_subcommands` only for deterministic control-plane operations that
+are safe to run without interrupting the active agent:
+
+```python
+def register(ctx):
+    ctx.register_command(
+        "worker",
+        handler=handle_worker,
+        description="Inspect or control the worker",
+        busy_safe_subcommands=("status", "pause", "stop"),
+    )
+```
+
+Hermes compares only the lower-cased first argument token. The bare command is
+represented by `""`. Once a plugin opts in, listed tokens dispatch inline and
+unlisted tokens reject without invoking the handler, interrupting the agent, or
+queueing the command as user text. Normal slash-command authorization still
+applies, and inline gateway responses are delivered as notify-worthy control
+messages. Sync and async legacy `handler(raw_args)` callables are both supported.
 
 **Key differences from `register_cli_command()`:**
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -1166,6 +1166,7 @@ ctx.register_command(
     description: str = "",
     args_hint: str = "",
     argument_mode: str | None = None,
+    *,
     busy_safe_subcommands: Iterable[str] = (),
 )
 ```


### PR DESCRIPTION
## Summary

This is a focused current-main successor for the busy-safe command subset of #63208. It deliberately leaves the broader command-context and turn-controller ABI to a separate follow-up.

- lets plugin commands declare exact `busy_safe_subcommands` (including `""` for the bare command)
- routes opted-in controls through the real active-adapter busy callback
- preserves slash access control on both cold and busy paths
- rejects undeclared verbs mid-turn without queueing or interrupting the active run
- supports sync and awaitable handlers and marks inline replies notify-worthy
- forwards the metadata through the context-engine collector
- documents the public registration and runtime contract

The first commit preserves the original contributor as author; the gateway completion commit retains co-authorship.

## Why a focused successor

The original ABI branch is now conflicting with current `main`, and its broader session-identity/controller surface overlaps other open work. The concrete downstream blocker only requires the generic busy-safe plugin command contract. Keeping this PR to that contract avoids rebasing unrelated turn-controller APIs and makes the production-path fix independently reviewable.

## Verification

- `99 passed` across the new regression suite plus adjacent plugin, context-engine, cleanup, and slash-access suites
- Ruff: PASS
- Python compile checks: PASS
- regression sabotage: representative tests fail on unchanged upstream `main` with `unexpected keyword argument 'busy_safe_subcommands'`
- external acceptance consumer: `cortadito-ops-control` passes `hermes plugins doctor --ci`
- external active-adapter probe: `/cortadito_status` dispatches inline while active, produces one notify-worthy response, and creates no queued follow-up

- broader affected suite: `6,668 passed`, `34 skipped`, `2 xfailed`; seven order-dependent failures all passed when rerun in isolation on both this branch and the exact upstream base
- independent read-only audit bound to `415ee6974c15b193658f363510b924a0296a59c4`: PASS, no BLOCK/HIGH/MEDIUM findings

## Behavior and compatibility

- Existing plugin commands that omit `busy_safe_subcommands` keep the prior busy queue/interrupt path.
- An empty declaration opts into nothing.
- The first argument token is matched case-insensitively; `""` matches a bare command.
- Once a command opts in, undeclared verbs are rejected while a turn is active.
- Current open work in #78016 owns `pre_gateway_dispatch` parity for the generic busy path; this PR does not duplicate that unrelated fix.

## Scope exclusions

- no `CommandContext` or `TurnControlContext`
- no post-turn controllers or follow-up scheduling
- no session-identity ABI changes
- no consumer-specific logic in Hermes core

Related: #63208
