### PR TITLE
feat(desktop): surface Bot Mode handoffs in Agents

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-activity.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-activity.test.ts
@@ -15,6 +15,7 @@ import type { GroupMember } from './types'
 // The transcript stays the only durable record — activity is never persisted.
 
 const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+const agentActivity = vi.hoisted(() => ({ clear: vi.fn(), update: vi.fn() }))
 
 vi.mock('@hermes/plugin-sdk', async () => {
   const { pluginSdkMock } = await import('./group-test-utils')
@@ -49,6 +50,7 @@ async function loadRoom(options: GatewayOptions = {}): Promise<Room> {
   }
 
   Object.assign(host, gateway.host)
+  host.agentActivity = agentActivity
 
   const [activity, chat, data, rounds, shared] = await Promise.all([
     import('./group-activity'),
@@ -69,9 +71,77 @@ function feed(room: Room, group: string): ActivityRow[] {
 
 beforeEach(() => {
   runTimersInline()
+  agentActivity.clear.mockReset()
+  agentActivity.update.mockReset()
 })
 
 describe('turn arc', () => {
+  it('mirrors a bot-to-bot handoff into the shared Agents activity tree', async () => {
+    const room = await loadRoom()
+    room.chat.updateGroupChat('Leadership', current => {
+      current.epoch = 1
+      current.log = []
+      current.roomId = 'leadership-room'
+      current.running = true
+
+      return current
+    })
+
+    room.activity.recordGroupActivity('Leadership', {
+      kind: 'queued',
+      member: 'You',
+      thread: 'thread-1'
+    })
+    room.activity.recordGroupActivity('Leadership', {
+      kind: 'working',
+      member: 'cto',
+      source: 'ceo',
+      thread: 'thread-1'
+    })
+
+    expect(agentActivity.clear).toHaveBeenCalledWith('bot-group:leadership-room')
+    expect(agentActivity.update).toHaveBeenLastCalledWith(
+      'bot-group:leadership-room',
+      expect.objectContaining({ goal: 'ceo → cto · Leadership', status: 'running' })
+    )
+
+    room.activity.recordGroupActivity('Leadership', {
+      kind: 'replied',
+      member: 'cto',
+      source: 'ceo',
+      thread: 'thread-1'
+    })
+
+    expect(agentActivity.update).toHaveBeenLastCalledWith(
+      'bot-group:leadership-room',
+      expect.objectContaining({ status: 'completed', summary: 'Replied in Leadership' })
+    )
+  })
+
+  it('keeps a timed-out room turn active until its late reply is delivered', async () => {
+    const room = await loadRoom()
+    room.chat.updateGroupChat('Slow', current => {
+      current.log = []
+      current.running = true
+
+      return current
+    })
+    room.activity.recordGroupActivity('Slow', { kind: 'working', member: 'cto', source: 'ceo', thread: 't' })
+    room.activity.recordGroupActivity('Slow', { kind: 'timed-out', member: 'cto', source: 'ceo', thread: 't' })
+
+    expect(agentActivity.update).toHaveBeenLastCalledWith(
+      'bot-group:Slow',
+      expect.objectContaining({ status: 'running', text: expect.stringContaining('still working') })
+    )
+
+    room.activity.recordGroupActivity('Slow', { kind: 'delivered', member: 'cto', source: 'ceo', thread: 't' })
+
+    expect(agentActivity.update).toHaveBeenLastCalledWith(
+      'bot-group:Slow',
+      expect.objectContaining({ status: 'completed', summary: 'Delivered a late reply in Slow' })
+    )
+  })
+
   it('a settled turn records the full truthful arc: queued, working, replies and passes, settled', async () => {
     const room = await loadRoom({
       turn: ({ profile, prompt }) =>

--- a/apps/desktop/src/plugins/hermes-bots/group-activity.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-activity.ts
@@ -2,12 +2,12 @@
  * The per-room activity feed: a bounded, runtime-only record of turn events
  * for the room view's collapsible Activity list.
  *
- * Depends on the room store (for the epoch it tags events with and the
- * speaker label it renders) and on nothing else, so the coordination engine
- * can record into it without a cycle.
+ * Depends on the room store for epoch/speaker truth and mirrors live member
+ * turns into the shared Agents store. The transcript remains authoritative;
+ * this module only projects its already-recorded activity lifecycle.
  */
 
-import { atom } from '@hermes/plugin-sdk'
+import { atom, host } from '@hermes/plugin-sdk'
 
 import { $groupChats, groupSpeakerLabel } from './group-chat'
 import type { GroupActivityEvent, GroupActivityKind } from './types'
@@ -31,6 +31,157 @@ export interface GroupActivityEntry extends Omit<GroupActivityEvent, 'group' | '
   thread?: null | string
 }
 export const $groupActivity = atom<Record<string, { events: GroupActivityEntry[] }>>({})
+
+const groupAgentTurns = new Map<string, { id: string; source?: string }>()
+let groupAgentTurnSequence = 0
+
+const groupAgentScope = (group: string, roomId?: null | string) => {
+  const room = $groupChats.get()[group]
+
+  return `bot-group:${roomId || room?.roomId || group}`
+}
+
+const groupAgentTurnKey = (scope: string, thread: null | string | undefined, member: string) =>
+  `${scope}:${thread || 'room'}:${member}`
+
+/** Remove the Agents-panel projection for a room without touching native
+ * subagents or another room. Used on a new room run and on disband. */
+export function clearGroupAgentActivity(group: string, roomId?: null | string) {
+  const scope = groupAgentScope(group, roomId)
+  host.agentActivity?.clear(scope)
+
+  for (const key of groupAgentTurns.keys()) {
+    if (key.startsWith(`${scope}:`)) {
+      groupAgentTurns.delete(key)
+    }
+  }
+}
+
+function mirrorGroupActivityToAgents(group: string, entry: GroupActivityEntry) {
+  const scope = groupAgentScope(group)
+
+  if (entry.kind === 'queued' && entry.member === 'You') {
+    clearGroupAgentActivity(group)
+
+    return
+  }
+
+  const member = entry.member && entry.member !== 'You' ? entry.member : null
+
+  if (!member) {
+    if (entry.kind === 'stopped') {
+      for (const [key, turn] of groupAgentTurns) {
+        if (!key.startsWith(`${scope}:`)) {
+          continue
+        }
+
+        host.agentActivity?.update(
+          scope,
+          {
+            createIfMissing: false,
+            id: turn.id,
+            status: 'interrupted',
+            summary: `Stopped in ${group}`
+          }
+        )
+        groupAgentTurns.delete(key)
+      }
+    }
+
+    return
+  }
+
+  const turnKey = groupAgentTurnKey(scope, entry.thread, member)
+  let turn = groupAgentTurns.get(turnKey)
+
+  if (entry.kind === 'working') {
+    // Manual/history-only activity rows are presentation data; only an actual
+    // live room drive belongs in the global Agents activity panel.
+    if (!$groupChats.get()[group]?.running) {
+      return
+    }
+
+    const source = entry.source || undefined
+    turn = {
+      id: `${turnKey}:${++groupAgentTurnSequence}`,
+      source
+    }
+    groupAgentTurns.set(turnKey, turn)
+    host.agentActivity?.update(
+      scope,
+      {
+        goal: `${source ? `${source} → ` : ''}${member} · ${group}`,
+        id: turn.id,
+        status: 'running',
+        text: `${member} started work in ${group}`
+      }
+    )
+
+    return
+  }
+
+  if (!turn) {
+    return
+  }
+
+  if (entry.kind === 'timed-out') {
+    host.agentActivity?.update(
+      scope,
+      {
+        createIfMissing: false,
+        id: turn.id,
+        status: 'running',
+        text: `${member} is still working; the reply will be delivered when ready`
+      }
+    )
+
+    return
+  }
+
+  let terminal: { status: 'cancelled' | 'completed' | 'failed'; summary: string } | undefined
+
+  switch (entry.kind) {
+    case 'cancelled':
+      terminal = { status: 'cancelled', summary: `Turn superseded in ${group}` }
+
+      break
+
+    case 'delivered':
+      terminal = { status: 'completed', summary: `Delivered a late reply in ${group}` }
+
+      break
+
+    case 'failed':
+      terminal = { status: 'failed', summary: `Failed in ${group}` }
+
+      break
+
+    case 'passed':
+      terminal = { status: 'completed', summary: `Reviewed ${group}; no reply needed` }
+
+      break
+
+    case 'replied':
+      terminal = { status: 'completed', summary: `Replied in ${group}` }
+
+      break
+  }
+
+  if (!terminal) {
+    return
+  }
+
+  host.agentActivity?.update(
+    scope,
+    {
+      createIfMissing: false,
+      id: turn.id,
+      status: terminal.status === 'cancelled' ? 'interrupted' : terminal.status,
+      summary: terminal.summary
+    }
+  )
+  groupAgentTurns.delete(turnKey)
+}
 
 export function recordGroupActivity(group: string, event: Omit<GroupActivityEntry, 'at' | 'epoch'>) {
   const room = $groupChats.get()[group]
@@ -57,6 +208,7 @@ export function recordGroupActivity(group: string, event: Omit<GroupActivityEntr
       events
     }
   })
+  mirrorGroupActivityToAgents(group, entry)
 
   return entry
 }

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
@@ -61,6 +61,18 @@ beforeEach(() => {
 })
 
 describe('opening a room', () => {
+  it('gives member replies a bordered assistant flashcard distinct from user prompts', async () => {
+    const room = await loadRoom()
+    const agent = room.view.groupMessageCardPresentation(false)
+    const user = room.view.groupMessageCardPresentation(true)
+
+    expect(agent.slot).toBe('bot-group-agent-card')
+    expect(agent.className).toContain('border-l-4')
+    expect(agent.className).toContain('ui-chat-bubble-opaque-background')
+    expect(user.slot).toBe('bot-group-user-card')
+    expect(user.className).not.toContain('border-l-4')
+  })
+
   it('follows the main-window tab open and close', async () => {
     const room = await loadRoom()
     let onClose: () => void = () => undefined

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -51,6 +51,7 @@ import {
 } from './data'
 import {
   $groupActivity,
+  clearGroupAgentActivity,
   currentGroupActivity,
   GROUP_ACTIVITY_GLYPHS,
   groupActivityLabel,
@@ -101,6 +102,19 @@ import { bumpBotOpenGeneration, getPluginCtx, ID } from './shared'
 import type { Attachment, BotMeta, GroupChat, GroupMember, GroupMessage, RosterRow } from './types'
 
 const Streamdown = typeof sdk === 'undefined' ? undefined : sdk.Streamdown
+
+export function groupMessageCardPresentation(isUser: boolean) {
+  return isUser
+    ? {
+        className: 'border-(--ui-stroke-secondary) bg-(--chrome-action-hover)',
+        slot: 'bot-group-user-card'
+      }
+    : {
+        className:
+          'border-(--ui-stroke-tertiary) border-l-4 border-l-(--ui-stroke-secondary) bg-(--ui-chat-bubble-opaque-background) hover:shadow-[0_0_18px_color-mix(in_srgb,var(--ui-accent,#6e9fc5)_14%,transparent)]',
+        slot: 'bot-group-agent-card'
+      }
+}
 
 /** Soft-disband a group chat: remove only this group from every local member's
  *  membership list (the metadata syncs cross-machine via ui_meta), drop the
@@ -176,6 +190,7 @@ export async function disbandGroupChat(group: string, members: RosterRow[]) {
   delete needs[group]
   $groupNeedsYou.set(needs)
   clearGroupClarify(group)
+  clearGroupAgentActivity(group, prior.roomId)
 
   // Persist the room map WITHOUT the disbanded room so it can't come back
   // on the next window load.
@@ -934,7 +949,9 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
     </Button>
   )
 
-  // One log entry, rendered exactly as before conversation folding existed.
+  // One room entry. Member replies use the same quiet, bordered flashcard
+  // language as the main assistant transcript so a long group conversation
+  // remains scannable; user prompts keep their stronger selected tint.
   const renderEntry = (entry: GroupMessage, index: number) => {
     const isUser = entry.from.kind === 'user'
     const meta = isUser || entry.from.source ? null : allMeta[entry.from.name]
@@ -979,13 +996,15 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
     const appearance = isUser ? null : botAppearance(entry.from.name, meta)
     const image = appearance?.image ?? null
     const photo = Boolean(image && !isBackfilledFacePng(image))
+    const card = groupMessageCardPresentation(isUser)
 
     return (
       <div
         className={cn(
-          'group flex items-start gap-2',
-          isUser ? 'rounded-md bg-(--chrome-action-hover) px-2 py-1.5' : 'px-2 py-1'
+          'group flex items-start gap-2 rounded-xl border px-2.5 py-2 shadow-sm transition-shadow',
+          card.className
         )}
+        data-slot={card.slot}
         key={entryKey}
       >
         {appearance ? (

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -628,6 +628,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
         // into the member's session so the model sees the pixels, not just
         // the transcript's [attached image: …] marker.
         const deltaImages = delta.flatMap((e: GroupMessage) => (Array.isArray(e.images) ? e.images : []))
+        const source = delta[delta.length - 1]?.from?.name
 
         // Surface WHO is on turn (runtime-only, like running/epoch) so the
         // room shows "Radar is thinking…" instead of a generic working line —
@@ -640,7 +641,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
         let reply: null | string = null
 
         try {
-          reply = await runGroupChatMemberTurn(group, member, prompt, thread, deltaImages)
+          reply = await runGroupChatMemberTurn(group, member, prompt, thread, deltaImages, source)
 
           // Needs-attention hook (#93091 item 3): a turn that produced a real
           // reply (or an explicit pass) is a good turn — clear the badge.
@@ -654,6 +655,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
           recordGroupActivity(group, {
             kind: 'failed',
             member: member.name,
+            source,
             thread,
             ...(reason
               ? {
@@ -695,6 +697,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
           recordGroupActivity(group, {
             kind: 'cancelled',
             member: member.name,
+            source,
             thread
           })
 
@@ -799,6 +802,8 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                   .map((e: GroupMessage) => formatGroupChatLine(e, member.name))
               })
 
+              const source = delta[delta.length - 1]?.from?.name
+
               updateGroupChat(group, (r: GroupChatRoom) => {
                 r.turn = member.name
 
@@ -807,7 +812,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
               let continuationReply: null | string = null
 
               try {
-                continuationReply = await runGroupChatMemberTurn(group, member, prompt, thread)
+                continuationReply = await runGroupChatMemberTurn(group, member, prompt, thread, undefined, source)
 
                 if (continuationReply !== null) {
                   clearBotAttention(memberKey)
@@ -816,6 +821,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
                 recordGroupActivity(group, {
                   kind: 'failed',
                   member: member.name,
+                  source,
                   thread
                 })
                 noteBotAttention(memberKey, error?.message || error)

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -520,7 +520,8 @@ export async function runGroupChatMemberTurn(
   member: GroupMember,
   prompt: string,
   thread: string,
-  images?: Attachment[]
+  images?: Attachment[],
+  source?: string
 ): Promise<null | string> {
   // #93602: hold the member's route socket for the whole turn. Without the
   // lease, every RPC below rides its own request-scoped socket lease; the
@@ -529,7 +530,7 @@ export async function runGroupChatMemberTurn(
   const releaseTurnLease = await retainGroupTurnRoute(member)
 
   try {
-    return await runGroupChatMemberTurnLeased(group, member, prompt, thread, images)
+    return await runGroupChatMemberTurnLeased(group, member, prompt, thread, images, source)
   } finally {
     releaseTurnLease()
   }
@@ -540,7 +541,8 @@ async function runGroupChatMemberTurnLeased(
   member: GroupMember,
   prompt: string,
   thread: string,
-  images?: Attachment[]
+  images?: Attachment[],
+  source?: string
 ): Promise<null | string> {
   const { runtime, stored } = await ensureGroupChatSession(group, member)
 
@@ -555,6 +557,7 @@ async function runGroupChatMemberTurnLeased(
   recordGroupActivity(group, {
     kind: 'working',
     member: member.name,
+    source,
     thread
   })
 
@@ -669,6 +672,7 @@ async function runGroupChatMemberTurnLeased(
         recordGroupActivity(group, {
           kind: isGroupPassText(replyText) ? 'passed' : 'replied',
           member: member.name,
+          source,
           thread
         })
 
@@ -678,6 +682,7 @@ async function runGroupChatMemberTurnLeased(
       recordGroupActivity(group, {
         kind: 'passed',
         member: member.name,
+        source,
         thread
       })
 
@@ -699,6 +704,7 @@ async function runGroupChatMemberTurnLeased(
   recordGroupActivity(group, {
     kind: 'timed-out',
     member: member.name,
+    source,
     thread
   })
   syncGroupClarify(group, member, null)
@@ -707,6 +713,7 @@ async function runGroupChatMemberTurnLeased(
       ...(r.stranded || {}),
       [groupMemberKey(member)]: {
         before,
+        source,
         thread
       }
     }
@@ -727,6 +734,7 @@ export async function harvestStrandedGroupReply(group: string, member: GroupMemb
   // Markers were a bare number before threads; normalize both shapes.
   const strandedBefore = typeof marker === 'number' ? marker : marker?.before
   const strandedThread = (typeof marker === 'object' && marker?.thread) || 'legacy'
+  const strandedSource = typeof marker === 'object' ? marker?.source : undefined
 
   if (typeof strandedBefore !== 'number') {
     return
@@ -777,6 +785,7 @@ export async function harvestStrandedGroupReply(group: string, member: GroupMemb
     recordGroupActivity(group, {
       kind: 'delivered',
       member: member.name,
+      source: strandedSource,
       thread: strandedThread
     })
     appendGroupChatEntry(

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -166,7 +166,7 @@ export interface GroupChat {
    *  `{ name }`, and the sweep re-validates the route before trusting one. */
   sessionOwners?: Record<string, Partial<RosterRow>>
   sessions?: Record<string, string | true>
-  stranded?: Record<string, number | { before: number; thread?: string }>
+  stranded?: Record<string, number | { before: number; source?: string; thread?: string }>
   syncRevision?: number
   /** Left behind when a room is disbanded, so sync can't resurrect it. */
   tombstone?: boolean
@@ -230,6 +230,8 @@ export interface GroupActivityEvent {
   kind: GroupActivityKind
   member?: string
   preview?: string
+  /** The room speaker whose message caused this member turn, when known. */
+  source?: string
 }
 
 /**

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -4,6 +4,44 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import { host } from '@/sdk'
 import { setActiveSessionId, setAwaitingResponse, setBusy } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
+
+describe('host.agentActivity', () => {
+  afterEach(() => $subagentsBySession.set({}))
+
+  it('namespaces plugin work in the shared Agents store and clears only that scope', () => {
+    upsertSubagent('native-session', {
+      goal: 'native work',
+      status: 'running',
+      subagent_id: 'native-1'
+    })
+
+    host.agentActivity.update('bot-group:leadership', {
+      goal: 'ceo → cto · Leadership',
+      id: 'handoff-1',
+      status: 'running',
+      text: 'cto started work'
+    })
+
+    const scope = 'plugin:bot-group:leadership'
+    expect($subagentsBySession.get()[scope]?.[0]).toMatchObject({
+      goal: 'ceo → cto · Leadership',
+      status: 'running'
+    })
+
+    host.agentActivity.update('bot-group:leadership', {
+      createIfMissing: false,
+      id: 'handoff-1',
+      status: 'completed',
+      summary: 'Replied in Leadership'
+    })
+    expect($subagentsBySession.get()[scope]?.[0]?.status).toBe('completed')
+
+    host.agentActivity.clear('bot-group:leadership')
+    expect($subagentsBySession.get()[scope]).toBeUndefined()
+    expect($subagentsBySession.get()['native-session']).toHaveLength(1)
+  })
+})
 
 describe('host.state turn flags', () => {
   afterEach(() => {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -95,6 +95,7 @@ import {
   focusWorkspaceOwnerSessionTile,
   sessionTileDelegate
 } from '@/store/session-states'
+import { clearSessionSubagents, upsertSubagent } from '@/store/subagents'
 import { runGatewayRestart } from '@/store/system-actions'
 import type { PaginatedSessions, UsageStats } from '@/types/hermes'
 
@@ -131,6 +132,18 @@ const $focusedAwaitingResponse = focusedTurnFlag(
 export interface PluginFocusedSessionOwner {
   connectionId: string
   profile: string
+}
+
+export type PluginAgentActivityStatus = 'completed' | 'failed' | 'interrupted' | 'queued' | 'running'
+
+export interface PluginAgentActivityUpdate {
+  createIfMissing?: boolean
+  goal?: string
+  id: string
+  parentId?: null | string
+  status: PluginAgentActivityStatus
+  summary?: string
+  text?: string
 }
 
 /**
@@ -620,6 +633,44 @@ export const host = {
   /** Toast into the app's notification stack. */
   notify,
   notifyError,
+
+  /** Project plugin-owned work into the shared Agents panel without exposing
+   * the core subagent store. Scopes are namespaced by the host, so a plugin
+   * cannot collide with backend session ids or another plugin's native rows. */
+  agentActivity: {
+    clear: (scope: string): void => {
+      const key = String(scope || '').trim()
+
+      if (key) {
+        clearSessionSubagents(`plugin:${key}`)
+      }
+    },
+    update: (scope: string, activity: PluginAgentActivityUpdate): void => {
+      const key = String(scope || '').trim()
+      const id = String(activity?.id || '').trim()
+
+      if (!key || !id) {
+        return
+      }
+
+      const terminal =
+        activity.status === 'completed' || activity.status === 'failed' || activity.status === 'interrupted'
+
+      upsertSubagent(
+        `plugin:${key}`,
+        {
+          goal: activity.goal,
+          parent_id: activity.parentId,
+          status: activity.status,
+          subagent_id: id,
+          summary: activity.summary,
+          text: activity.text
+        },
+        activity.createIfMissing ?? true,
+        terminal ? 'subagent.complete' : 'subagent.progress'
+      )
+    }
+  },
 
   // NOTE: every host door is async-safe — wrapped so a sync throw from an
   // internal helper (e.g. no desktop bridge in a plain browser) becomes a


### PR DESCRIPTION
## Summary
- mirror live Bot Mode group-member work into the shared Agents panel through a namespaced plugin SDK capability
- preserve source and target labels for bot-to-bot handoffs and keep late/timed-out work active until delivery
- render Group Chat member replies as bordered assistant flashcards while retaining distinct user cards
- clear projected room activity on a new run or disband without touching native subagents

## Verification
- `npm run test:ui --workspace apps/desktop -- src/sdk/index.test.ts src/plugins/hermes-bots/group-activity.test.ts src/plugins/hermes-bots/group-chat-view.test.ts src/plugins/hermes-bots/group-rounds.test.ts src/plugins/hermes-bots/group-turns.test.ts` (107 tests passed)
- `npm run typecheck --workspace apps/desktop`
- focused ESLint on all changed TypeScript files
- `git diff --check`