### PR TITLE
fix(skills): keep the skill and snapshots when a batch rollback restore fails

### DIFF
--- a/tests/tools/test_skill_manage_batch.py
+++ b/tests/tools/test_skill_manage_batch.py
@@ -176,6 +176,42 @@ class TestSkillManageBatch(unittest.TestCase):
         self.assertNotIn("Step A.", content)
         self.assertFalse(os.path.exists(os.path.join(self.home, "skills", "beta")))
 
+    def test_failed_restore_never_destroys_the_skill(self):
+        """Rollback used to rmtree the live skill directory BEFORE
+        copytree restored the snapshot. When copytree failed (disk full,
+        locked file) the except only appended a note and the finally then
+        deleted the snapshot too: nothing survived. The broken state must
+        be moved aside and only deleted once the restore succeeded."""
+        from unittest.mock import patch as _patch
+
+        import shutil as _shutil
+
+        self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
+        state = {"n": 0}
+        real_copytree = _shutil.copytree
+
+        def flaky_copytree(src, dst, *a, **k):
+            state["n"] += 1
+            if state["n"] == 2:  # call 1 snapshots, call 2 is the restore
+                raise OSError("disk full")
+            return real_copytree(src, dst, *a, **k)
+
+        with _patch("shutil.copytree", side_effect=flaky_copytree):
+            r = self._call("probe", [
+                {"action": "patch",
+                 "old_string": "Step 1.", "new_string": "Step ONE."},
+                {"action": "write_file",
+                 "file_path": "bad/nope.md", "file_content": "x"},
+            ])
+        self.assertFalse(r["success"], r)
+        self.assertIn("ROLLBACK FAILED", r["error"])
+        # The skill directory was NOT destroyed by the failed rollback:
+        # the half applied state survives instead of nothing at all.
+        skill_md = os.path.join(self.home, "skills", "probe", "SKILL.md")
+        self.assertTrue(os.path.exists(skill_md))
+        content = open(skill_md).read()
+        self.assertIn("Step ONE.", content)
+
     def test_single_op_path_unchanged(self):
         self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
         raw = self.smt.skill_manage(

--- a/tests/tools/test_skill_manage_batch.py
+++ b/tests/tools/test_skill_manage_batch.py
@@ -22,6 +22,7 @@ SK = (
 class TestSkillManageBatch(unittest.TestCase):
     def setUp(self):
         self.home = tempfile.mkdtemp(prefix="skmbatch_t_")
+        self._keep_dirs = []
         os.environ["HERMES_HOME"] = self.home
         os.environ["HERMES_YOLO_MODE"] = "1"
         os.makedirs(os.path.join(self.home, "skills"), exist_ok=True)
@@ -33,6 +34,8 @@ class TestSkillManageBatch(unittest.TestCase):
         self.smt = smt
 
     def tearDown(self):
+        for path in self._keep_dirs:
+            shutil.rmtree(path, ignore_errors=True)
         shutil.rmtree(self.home, ignore_errors=True)
 
     def _call(self, name, ops):
@@ -187,8 +190,16 @@ class TestSkillManageBatch(unittest.TestCase):
         import shutil as _shutil
 
         self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
+        # A sibling whose name matches the old aside path. Rollback must
+        # not delete it: that name is a valid skill name.
+        sibling = os.path.join(self.home, "skills", "probe.rollback-broken")
+        os.makedirs(sibling)
+        with open(os.path.join(sibling, "SKILL.md"), "w") as fh:
+            fh.write(SK.format(n="probe.rollback-broken").replace("Step 1.", "KEEP ME."))
         state = {"n": 0}
         real_copytree = _shutil.copytree
+        real_mkdtemp = tempfile.mkdtemp
+        batch_roots = []
 
         def flaky_copytree(src, dst, *a, **k):
             state["n"] += 1
@@ -196,7 +207,15 @@ class TestSkillManageBatch(unittest.TestCase):
                 raise OSError("disk full")
             return real_copytree(src, dst, *a, **k)
 
-        with _patch("shutil.copytree", side_effect=flaky_copytree):
+        def tracking_mkdtemp(*a, **k):
+            path = real_mkdtemp(*a, **k)
+            if k.get("prefix") == "skill_batch_":
+                batch_roots.append(path)
+                self._keep_dirs.append(path)
+            return path
+
+        with _patch("shutil.copytree", side_effect=flaky_copytree), \
+             _patch("tempfile.mkdtemp", side_effect=tracking_mkdtemp):
             r = self._call("probe", [
                 {"action": "patch",
                  "old_string": "Step 1.", "new_string": "Step ONE."},
@@ -211,6 +230,13 @@ class TestSkillManageBatch(unittest.TestCase):
         self.assertTrue(os.path.exists(skill_md))
         content = open(skill_md).read()
         self.assertIn("Step ONE.", content)
+        self.assertIn("KEEP ME.", open(os.path.join(sibling, "SKILL.md")).read())
+        self.assertEqual(len(batch_roots), 1, batch_roots)
+        snap_md = os.path.join(batch_roots[0], "probe", "SKILL.md")
+        self.assertTrue(os.path.exists(snap_md), snap_md)
+        snap_content = open(snap_md).read()
+        self.assertIn("Step 1.", snap_content)
+        self.assertNotIn("Step ONE.", snap_content)
 
     def test_single_op_path_unchanged(self):
         self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1682,6 +1682,8 @@ def _skill_manage_batch(
                 return tool_error(f"Could not snapshot '{nm}' for atomic batch: {exc}", success=False)
         snapshots[nm] = (pre_dir, snap)
 
+    rollback_failed = False
+
     def _rollback() -> str:
         notes = []
         for nm, (pre_dir, snap) in snapshots.items():
@@ -1690,13 +1692,34 @@ def _skill_manage_batch(
                 post_dir = Path(post["path"]) if post else None
                 if snap is not None:
                     if post_dir is not None and post_dir.is_dir():
-                        shutil.rmtree(post_dir)
-                    shutil.copytree(snap, pre_dir)
+                        # Never destroy the only other copy before the
+                        # restore lands. Deleting first turned a failed
+                        # copytree (disk full, locked file) into total
+                        # skill loss once the finally below removed the
+                        # snapshot too. Move the broken state aside, and
+                        # delete it only after the snapshot is back.
+                        aside = post_dir.with_name(post_dir.name + ".rollback-broken")
+                        shutil.rmtree(aside, ignore_errors=True)
+                        post_dir.rename(aside)
+                        try:
+                            shutil.copytree(snap, pre_dir)
+                        except Exception:
+                            # Restore failed: put the broken state back so
+                            # the skill survives (half applied) rather than
+                            # leaving nothing.
+                            shutil.rmtree(pre_dir, ignore_errors=True)
+                            aside.rename(pre_dir)
+                            raise
+                        shutil.rmtree(aside, ignore_errors=True)
+                    else:
+                        shutil.copytree(snap, pre_dir)
                 elif post_dir is not None and post_dir.is_dir():
                     # Batch created this skill: remove the partial result.
                     shutil.rmtree(post_dir)
             except Exception as exc:  # noqa: BLE001
                 notes.append(f"ROLLBACK FAILED for '{nm}' ({exc})")
+        nonlocal rollback_failed
+        rollback_failed = bool(notes)
         return "; ".join(notes) if notes else "all touched skills rolled back"
 
     # --- execute ops through the normal single-op path (gate bypassed:
@@ -1748,7 +1771,16 @@ def _skill_manage_batch(
                             "success": True})
     finally:
         _skill_gate_bypass.reset(token)
-        shutil.rmtree(snap_root, ignore_errors=True)
+        if rollback_failed:
+            # Keep the snapshots so the operator can still recover by
+            # hand. Deleting them here is what turned one failed restore
+            # into permanent skill loss.
+            logger.warning(
+                "skill_manage batch rollback failed, snapshots kept at %s",
+                snap_root,
+            )
+        else:
+            shutil.rmtree(snap_root, ignore_errors=True)
 
     return json.dumps(
         {"success": True, "operations_applied": len(results),

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1696,11 +1696,18 @@ def _skill_manage_batch(
                         # restore lands. Deleting first turned a failed
                         # copytree (disk full, locked file) into total
                         # skill loss once the finally below removed the
-                        # snapshot too. Move the broken state aside, and
-                        # delete it only after the snapshot is back.
-                        aside = post_dir.with_name(post_dir.name + ".rollback-broken")
-                        shutil.rmtree(aside, ignore_errors=True)
-                        post_dir.rename(aside)
+                        # snapshot too.
+                        # Keep the broken copy in a private temp dir, not
+                        # next to the skill. A name like
+                        # "<skill>.rollback-broken" is a valid skill name,
+                        # so using it as a sibling can delete a real skill.
+                        aside_parent = Path(tempfile.mkdtemp(prefix="skill_rollback_"))
+                        aside = aside_parent / "broken"
+                        try:
+                            post_dir.rename(aside)
+                        except Exception:
+                            shutil.rmtree(aside_parent, ignore_errors=True)
+                            raise
                         try:
                             shutil.copytree(snap, pre_dir)
                         except Exception:
@@ -1708,9 +1715,19 @@ def _skill_manage_batch(
                             # the skill survives (half applied) rather than
                             # leaving nothing.
                             shutil.rmtree(pre_dir, ignore_errors=True)
-                            aside.rename(pre_dir)
+                            try:
+                                aside.rename(pre_dir)
+                            finally:
+                                if not aside.exists():
+                                    shutil.rmtree(aside_parent, ignore_errors=True)
                             raise
-                        shutil.rmtree(aside, ignore_errors=True)
+                        try:
+                            shutil.rmtree(aside_parent)
+                        except Exception as cleanup_exc:
+                            notes.append(
+                                f"ROLLBACK FAILED for '{nm}' "
+                                f"(could not remove aside copy: {cleanup_exc})"
+                            )
                     else:
                         shutil.copytree(snap, pre_dir)
                 elif post_dir is not None and post_dir.is_dir():


### PR DESCRIPTION
## What does this PR do?

Follow-up to #97692, same batch executor. Rollback used to `rmtree` the live skill directory before `copytree` restored the snapshot. When the copy failed (disk full, locked file, path too long on Windows) the except only added a note, and the `finally` then deleted the snapshot directory too. Nothing survived, and the batch still returned a normal failure payload.

The broken state is now moved to a private temp dir first and deleted only after the snapshot is restored. That temp dir is not under `skills/`, so it cannot collide with a real skill name (the old sibling name `skill.rollback-broken` is a valid skill name). If the restore still fails, the broken state is moved back, so the worst outcome is the half applied batch instead of no skill at all. When rollback reports any failure the snapshots are kept on disk and their location is logged at warning level, instead of being deleted by the `finally`.

## Related Issue

Fixes #97714

Follow-up to #97692.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes a bug)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`: `_rollback()` restores swap-safe (move aside into a private temp dir, copy, delete aside, move back on failure). The `finally` keeps `snap_root` and logs its path when rollback reported any failure.
- `tests/tools/test_skill_manage_batch.py`: restore `copytree` is forced to fail. The half applied skill survives, a sibling named `probe.rollback-broken` is left alone, and the pre-batch snapshot is kept.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_skill_manage_batch.py -q`
2. New test `test_failed_restore_never_destroys_the_skill` fails on current main (`SKILL.md` does not exist after the failed rollback). With the fix the skill survives with the half applied patch, the error carries `ROLLBACK FAILED`, the snapshots are kept, and `probe.rollback-broken` is not deleted.
3. Regression check: `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py tests/tools/test_skill_manage_schema_diet.py`

Ran on Windows 11 with Python 3.11: 63 tests passed across the three skill_manage test files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
