### PR TITLE
fix(desktop): show MoA advisors running in parallel

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -13,7 +13,7 @@ import logging
 import re
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, wait as _futures_wait
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait as _futures_wait
 from types import SimpleNamespace
 from typing import Any
 
@@ -904,12 +904,16 @@ def _run_references_parallel(
             ] = idx
 
         # Collect every reference before returning — the aggregator needs the
-        # complete set, so there is no early-exit / first-completed path
-        # here, other than a user interrupt. Progress callbacks fire as each
-        # reference completes so frontends can render "MOA: k/n refs done".
+        # complete set, so there is no early return other than a user interrupt.
+        # Wake on each completion so frontends can update that stable advisor
+        # slot immediately; the timeout still bounds interrupt polling.
         pending = set(futures)
         while pending:
-            done, pending = _futures_wait(pending, timeout=_REFERENCE_POLL_INTERVAL_S)
+            done, pending = _futures_wait(
+                pending,
+                timeout=_REFERENCE_POLL_INTERVAL_S,
+                return_when=FIRST_COMPLETED,
+            )
             for future in done:
                 idx = futures[future]
                 results[idx] = future.result()

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -812,8 +812,10 @@ def _run_references_parallel(
     another MoA preset are skipped here (recursion guard) with a labelled note.
 
     If ``progress_callback`` is provided it is invoked as each reference
-    completes: ``progress_callback(refs_done, refs_total, label)``. The total
-    matches ``len(reference_models)`` so listeners can render a status-bar
+    settles: ``progress_callback(refs_done, refs_total, label, index, status)``.
+    ``index`` is the stable one-based preset slot and ``status`` is one of
+    ``complete``, ``failed``, ``skipped``, or ``interrupted``. The total matches
+    ``len(reference_models)`` so listeners can render a status-bar
     progress like ``MOA: 2/3 refs done``. Best-effort — failures are logged
     but never break the fan-out (display must never block a turn).
 
@@ -874,6 +876,18 @@ def _run_references_parallel(
                     "[skipped: MoA presets cannot recursively reference MoA]",
                     _RefAccounting(CanonicalUsage()),
                 )
+                completed += 1
+                if progress_callback is not None:
+                    try:
+                        progress_callback(
+                            completed,
+                            total,
+                            _slot_label(slot),
+                            idx + 1,
+                            "skipped",
+                        )
+                    except Exception as exc:  # pragma: no cover - display must never break
+                        logger.debug("MoA progress_callback failed: %s", exc)
                 continue
             futures[
                 executor.submit(
@@ -903,7 +917,18 @@ def _run_references_parallel(
                 if progress_callback is not None:
                     try:
                         label = _slot_label(reference_models[idx])
-                        progress_callback(completed, total, label)
+                        text = results[idx][1]
+                        sentinel = text.lstrip().lower()
+                        status = (
+                            "failed"
+                            if sentinel.startswith("[failed:")
+                            else "interrupted"
+                            if text == _INTERRUPTED_REFERENCE_NOTE
+                            else "skipped"
+                            if sentinel.startswith("[skipped:")
+                            else "complete"
+                        )
+                        progress_callback(completed, total, label, idx + 1, status)
                     except Exception as exc:  # pragma: no cover - display must never break
                         logger.debug("MoA progress_callback failed: %s", exc)
             if not pending:
@@ -955,6 +980,21 @@ def _run_references_parallel(
                                     _label,
                                 )
                         future.add_done_callback(_record_late)
+            if progress_callback is not None:
+                for idx, result in enumerate(results):
+                    if result is None or result[1] != _INTERRUPTED_REFERENCE_NOTE:
+                        continue
+                    completed += 1
+                    try:
+                        progress_callback(
+                            completed,
+                            total,
+                            _slot_label(reference_models[idx]),
+                            idx + 1,
+                            "interrupted",
+                        )
+                    except Exception as exc:  # pragma: no cover - display must never break
+                        logger.debug("MoA progress_callback failed: %s", exc)
     finally:
         executor.shutdown(wait=not interrupted, cancel_futures=interrupted)
 
@@ -2091,6 +2131,17 @@ class MoAChatCompletions:
 
         if _refs_from_cache:
             reference_outputs = list(self._ref_cache_outputs)
+            self._emit(
+                "moa.phase",
+                phase="reference",
+                refs_done=len(reference_outputs),
+                refs_total=len(reference_outputs),
+                aggregator=_slot_label(aggregator),
+                advisors=[label for label, _text, _acct in reference_outputs],
+                concurrency=min(_MAX_REFERENCE_WORKERS, len(reference_outputs)),
+                fanout=fanout_mode,
+                guidance_reused=True,
+            )
             # References already ran (and were accounted) earlier this turn;
             # this create() is a repeat tool-iteration reusing the cached
             # advice. Charging their tokens/cost again here would multiply
@@ -2103,18 +2154,49 @@ class MoAChatCompletions:
             # traced on the MISS that ran the references. A repeat iteration is
             # not a new MoA turn.
             self._pending_trace = None
+            self._emit(
+                "moa.phase",
+                phase="aggregator",
+                refs_done=len(reference_outputs),
+                refs_total=len(reference_outputs),
+                aggregator=_slot_label(aggregator),
+                guidance_reused=True,
+            )
         else:
+            # Publish the stable roster before dispatch. Completion-only events
+            # cannot tell a client which still-running slots exist, so they make
+            # a parallel fan-out look serial until the final advisor settles.
+            if reference_models:
+                self._emit(
+                    "moa.phase",
+                    phase="reference",
+                    refs_done=0,
+                    refs_total=len(reference_models),
+                    aggregator=_slot_label(aggregator),
+                    advisors=[_slot_label(slot) for slot in reference_models],
+                    concurrency=min(_MAX_REFERENCE_WORKERS, len(reference_models)),
+                    fanout=fanout_mode,
+                    guidance_reused=False,
+                )
             # Per-reference progress callback: emits ``moa.progress`` so
             # listeners can render ``MOA: N/M refs done`` in the status bar as
             # each reference completes. The callback is bound to self so it
             # goes through the same display hook as the existing
             # ``moa.reference`` / ``moa.aggregating`` events.
-            def _progress(done: int, total: int, label: str) -> None:
+            def _progress(
+                done: int,
+                total: int,
+                label: str,
+                index: int,
+                status: str,
+            ) -> None:
                 self._emit(
                     "moa.progress",
                     refs_done=done,
                     refs_total=total,
                     label=label,
+                    index=index,
+                    status=status,
                 )
 
             reference_outputs = _run_references_parallel(
@@ -2232,6 +2314,7 @@ class MoAChatCompletions:
                     refs_done=_ref_count,
                     refs_total=_ref_count,
                     aggregator=_slot_label(aggregator),
+                    guidance_reused=False,
                 )
                 self._emit(
                     "moa.aggregating",
@@ -2403,6 +2486,8 @@ def build_moa_facade(agent, preset_name: Any = None) -> MoAClient:
                     None,
                     moa_refs_done=kwargs.get("refs_done"),
                     moa_refs_total=kwargs.get("refs_total"),
+                    moa_index=kwargs.get("index"),
+                    moa_status=kwargs.get("status"),
                 )
             elif event == "moa.phase":
                 # Phase transition (currently only ``phase="aggregator"``
@@ -2416,6 +2501,10 @@ def build_moa_facade(agent, preset_name: Any = None) -> MoAClient:
                     moa_phase=kwargs.get("phase"),
                     moa_refs_done=kwargs.get("refs_done"),
                     moa_refs_total=kwargs.get("refs_total"),
+                    moa_advisors=kwargs.get("advisors"),
+                    moa_concurrency=kwargs.get("concurrency"),
+                    moa_fanout=kwargs.get("fanout"),
+                    moa_guidance_reused=kwargs.get("guidance_reused"),
                 )
             elif event == "moa.aggregating":
                 cb(

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -143,6 +143,7 @@
     "streamdown": "2.5.0",
     "tailwind-merge": "3.6.0",
     "tailwindcss": "4.3.3",
+    "thinking-orbs": "0.3.1",
     "tw-shimmer": "0.4.12",
     "unicode-animations": "1.0.3",
     "unified": "11.0.5",

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -257,6 +257,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       deps.scheduleSessionsRefresh,
       deps.sessionInterrupted,
       deps.sessionStateByRuntimeIdRef,
+      deps.updateMoaProgress,
       deps.updateSessionState,
       deps.upsertToolCall
     ]

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -77,6 +77,7 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
     flushQueuedDeltas,
     nativeSubagentSessionsRef,
     sessionStateByRuntimeIdRef,
+    updateMoaProgress,
     updateSessionState
   } = deps
 
@@ -222,6 +223,14 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
   }
 
   if (event.type === 'moa.reference') {
+    if (sessionId && updateMoaProgress(sessionId, event.type, payload, occurredAt)) {
+      if (isActiveEvent) {
+        setPetActivity({ reasoning: true })
+      }
+
+      return true
+    }
+
     // MoA reference-model output — surface as a labelled thinking chunk
     // (tagged with the source model) before the aggregator's response, so
     // the mixture-of-agents process is visible. Reuses the reasoning
@@ -272,6 +281,14 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
   }
 
   if (event.type === 'moa.progress') {
+    if (sessionId && updateMoaProgress(sessionId, event.type, payload, occurredAt)) {
+      if (isActiveEvent) {
+        setPetActivity({ reasoning: true })
+      }
+
+      return true
+    }
+
     // Live reference fan-out progress ("refs k/n") — surfaced in the same
     // reasoning disclosure the references land in. These lines arrive
     // BEFORE any moa.reference event (references are only emitted once the
@@ -296,6 +313,14 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
   }
 
   if (event.type === 'moa.phase') {
+    if (sessionId && updateMoaProgress(sessionId, event.type, payload, occurredAt)) {
+      if (isActiveEvent) {
+        setPetActivity({ reasoning: true })
+      }
+
+      return true
+    }
+
     // Phase transition — currently only phase="aggregator" (fan-out done,
     // aggregator acting). Append a one-line marker; the first
     // moa.reference that follows replaces the whole block.
@@ -329,6 +354,7 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
     setSessionCompacting(sessionId, false)
 
     flushQueuedDeltas(sessionId)
+    updateMoaProgress(sessionId, event.type, payload, occurredAt)
 
     // Keyed by session so only one window beeps when several are open.
     playCompletionSound(sessionId)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -34,6 +34,12 @@ export interface GatewayEventDeps {
   scheduleSessionsRefresh: () => void
   sessionInterrupted: (sessionId: string) => boolean
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+  updateMoaProgress: (
+    sessionId: string,
+    eventType: string,
+    payload: GatewayEventPayload | undefined,
+    occurredAt: number
+  ) => boolean
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,6 +23,12 @@ import {
   generatedImageEchoSources,
   stripGeneratedImageEchoes
 } from '@/lib/generated-images'
+import {
+  type MoaProgressState,
+  parseMoaProgress,
+  reduceMoaProgress,
+  serializeMoaProgress
+} from '@/lib/moa-progress'
 import { parseTodos } from '@/lib/todos'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
@@ -198,6 +204,7 @@ export function useMessageStream({
   // can cancel it instead of letting parked callbacks pile up while hidden.
   const measureRafRef = useRef<number | null>(null)
   const nativeSubagentSessionsRef = useRef<Set<string>>(new Set())
+  const moaProgressBySessionRef = useRef<Map<string, MoaProgressState>>(new Map())
   // Turns that auto-compacted: skip post-turn hydrate so live scrollback survives.
   const compactedTurnRef = useRef<Set<string>>(new Set())
   // Last session we applied a session.info cwd for — lets us tell an agent
@@ -441,6 +448,51 @@ export function useMessageStream({
       )
     },
     [flushQueuedDeltas, mutateStream, queueDelta]
+  )
+
+  const updateMoaProgress = useCallback(
+    (sessionId: string, eventType: string, payload: GatewayEventPayload | undefined, occurredAt: number) => {
+      const next = reduceMoaProgress(moaProgressBySessionRef.current.get(sessionId), eventType, payload, occurredAt)
+
+      if (!next) {
+        return false
+      }
+
+      moaProgressBySessionRef.current.set(sessionId, next)
+      flushQueuedDeltas(sessionId)
+      const text = serializeMoaProgress(next)
+
+      mutateStream(
+        sessionId,
+        parts => {
+          const index = parts.findIndex(part => part.type === 'reasoning' && parseMoaProgress(part.text))
+
+          if (index < 0) {
+            return appendReasoningPart(parts, text, occurredAt)
+          }
+
+          return parts.map((part, offset) =>
+            offset === index && part.type === 'reasoning'
+              ? ({
+                  ...part,
+                  text,
+                  ...(next.phase === 'settled' ? { completedAt: occurredAt } : {})
+                } as ChatMessagePart)
+              : part
+          )
+        },
+        () => [reasoningPart(text, occurredAt)],
+        {},
+        occurredAt
+      )
+
+      if (next.phase === 'settled') {
+        moaProgressBySessionRef.current.delete(sessionId)
+      }
+
+      return true
+    },
+    [flushQueuedDeltas, mutateStream]
   )
 
   const upsertToolCall = useCallback(
@@ -858,6 +910,7 @@ export function useMessageStream({
     scheduleSessionsRefresh,
     sessionInterrupted,
     sessionStateByRuntimeIdRef,
+    updateMoaProgress,
     updateSessionState,
     upsertToolCall
   })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/moa-orchestration-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/moa-orchestration-event.test.tsx
@@ -1,0 +1,126 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { parseMoaProgress } from '@/lib/moa-progress'
+import type { RpcEvent } from '@/types/hermes'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const SID = 'session-1'
+let stream: MessageStreamHarness
+
+function mountStream() {
+  stream = renderMessageStream(SID)
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}) {
+  act(() => stream.handleEvent({ payload, session_id: SID, type }))
+}
+
+function state() {
+  const parsed = parseMoaProgress(stream.reasoningText())
+
+  expect(parsed).not.toBeNull()
+
+  return parsed!
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('structured MoA orchestration stream', () => {
+  it('shows the stable roster before completion and updates out of order in place', () => {
+    mountStream()
+    emit('message.start')
+    emit('moa.phase', {
+      advisors: Array.from({ length: 10 }, (_, index) => `model-${index + 1}`),
+      aggregator: 'agg-model',
+      concurrency: 8,
+      fanout: 'user_turn',
+      guidance_reused: false,
+      phase: 'reference',
+      refs_done: 0,
+      refs_total: 10
+    })
+
+    expect(state().advisors.map(advisor => advisor.status)).toEqual([
+      'running',
+      'running',
+      'running',
+      'running',
+      'running',
+      'running',
+      'running',
+      'running',
+      'queued',
+      'queued'
+    ])
+
+    emit('moa.progress', { index: 4, label: 'model-4', refs_done: 1, refs_total: 10, status: 'complete' })
+
+    const afterFourth = state()
+    expect(afterFourth.advisors[3].status).toBe('complete')
+    expect(afterFourth.advisors[0].status).toBe('running')
+    expect(afterFourth.advisors[8].status).toBe('running')
+    expect(afterFourth.advisors[9].status).toBe('queued')
+
+    emit('moa.progress', { index: 2, label: 'model-2', refs_done: 2, refs_total: 10, status: 'failed' })
+    expect(state().advisors[1].status).toBe('failed')
+  })
+
+  it('keeps advisor output behind its slot and transitions waiting → acting → settled', () => {
+    mountStream()
+    emit('message.start')
+    emit('moa.phase', {
+      advisors: ['model-a', 'model-b'],
+      aggregator: 'agg-model',
+      concurrency: 2,
+      fanout: 'per_iteration',
+      guidance_reused: false,
+      phase: 'reference',
+      refs_done: 0,
+      refs_total: 2
+    })
+    emit('moa.progress', { index: 2, label: 'model-b', refs_done: 1, refs_total: 2, status: 'complete' })
+    emit('moa.reference', { count: 2, index: 2, label: 'model-b', text: 'second finished first' })
+
+    expect(state().phase).toBe('reference')
+    expect(state().advisors[1]).toMatchObject({ output: 'second finished first', status: 'complete' })
+
+    emit('moa.progress', { index: 1, label: 'model-a', refs_done: 2, refs_total: 2, status: 'interrupted' })
+    emit('moa.reference', { count: 2, index: 1, label: 'model-a', text: '[skipped: interrupted by user]' })
+    emit('moa.phase', {
+      aggregator: 'agg-model',
+      guidance_reused: false,
+      phase: 'aggregator',
+      refs_done: 2,
+      refs_total: 2
+    })
+
+    expect(state().phase).toBe('aggregating')
+    expect(state().advisors[0].status).toBe('interrupted')
+
+    emit('message.complete', { text: 'final answer' })
+    expect(state().phase).toBe('settled')
+  })
+
+  it('distinguishes cached guidance reuse from a fresh fan-out', () => {
+    mountStream()
+    emit('message.start')
+    emit('moa.phase', {
+      advisors: ['model-a', 'model-b'],
+      aggregator: 'agg-model',
+      concurrency: 2,
+      fanout: 'every_n:3',
+      guidance_reused: true,
+      phase: 'reference',
+      refs_done: 2,
+      refs_total: 2
+    })
+
+    expect(state()).toMatchObject({ fanout: 'every_n:3', guidanceReused: true, phase: 'reference' })
+    expect(state().advisors.every(advisor => advisor.status === 'complete')).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/moa-orchestration-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/moa-orchestration-event.test.tsx
@@ -106,9 +106,33 @@ describe('structured MoA orchestration stream', () => {
     expect(state().phase).toBe('settled')
   })
 
-  it('distinguishes cached guidance reuse from a fresh fan-out', () => {
+  it('preserves advisor guidance and timing when a later iteration reuses the cache', () => {
     mountStream()
     emit('message.start')
+    emit('moa.phase', {
+      advisors: ['model-a', 'model-b'],
+      aggregator: 'agg-model',
+      concurrency: 2,
+      fanout: 'every_n:3',
+      guidance_reused: false,
+      phase: 'reference',
+      refs_done: 0,
+      refs_total: 2
+    })
+    emit('moa.progress', { index: 1, label: 'model-a', refs_done: 1, refs_total: 2, status: 'complete' })
+    emit('moa.reference', { count: 2, index: 1, label: 'model-a', text: 'first advisor guidance' })
+    emit('moa.progress', { index: 2, label: 'model-b', refs_done: 2, refs_total: 2, status: 'complete' })
+    emit('moa.reference', { count: 2, index: 2, label: 'model-b', text: 'second advisor guidance' })
+    emit('moa.phase', {
+      aggregator: 'agg-model',
+      guidance_reused: false,
+      phase: 'aggregator',
+      refs_done: 2,
+      refs_total: 2
+    })
+
+    const startedAt = state().startedAt
+
     emit('moa.phase', {
       advisors: ['model-a', 'model-b'],
       aggregator: 'agg-model',
@@ -119,8 +143,21 @@ describe('structured MoA orchestration stream', () => {
       refs_done: 2,
       refs_total: 2
     })
+    emit('moa.phase', {
+      aggregator: 'agg-model',
+      guidance_reused: true,
+      phase: 'aggregator',
+      refs_done: 2,
+      refs_total: 2
+    })
 
-    expect(state()).toMatchObject({ fanout: 'every_n:3', guidanceReused: true, phase: 'reference' })
-    expect(state().advisors.every(advisor => advisor.status === 'complete')).toBe(true)
+    expect(state()).toMatchObject({ fanout: 'every_n:3', guidanceReused: true, phase: 'aggregating', startedAt })
+    expect(state().advisors).toMatchObject([
+      { output: 'first advisor guidance', status: 'complete' },
+      { output: 'second advisor guidance', status: 'complete' }
+    ])
+
+    emit('message.complete', { text: 'final answer' })
+    expect(state()).toMatchObject({ guidanceReused: true, phase: 'settled', startedAt })
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -12,6 +12,7 @@ import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
 import { MarkdownText, MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { McpSetupTool } from '@/components/assistant-ui/mcp-setup-tool'
 import { AgentDeliveryNotice, deliveryTargetFromCommand } from '@/components/assistant-ui/thread/agent-delivery'
+import { MoaOrchestration } from '@/components/assistant-ui/thread/moa-orchestration'
 import { TimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { DelegateTool } from '@/components/assistant-ui/tool/delegate'
 import { ToolFallback, ToolGroupSlot } from '@/components/assistant-ui/tool/fallback'
@@ -21,6 +22,7 @@ import { GeneratedImage } from '@/components/chat/generated-image-result'
 import { SCAFFOLD_LABEL_CLASS, SCAFFOLD_META_CLASS, ScaffoldRow } from '@/components/chat/scaffold-row'
 import { useI18n } from '@/i18n'
 import { generatedImageFromResult } from '@/lib/generated-images'
+import { parseMoaProgress } from '@/lib/moa-progress'
 import { separateGluedReasoningBlocks } from '@/lib/reasoning-blocks'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
@@ -301,8 +303,20 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
     }, undefined)
   )
 
+  const moaOnly = useAuiState(s => {
+    const reasoning = s.message.parts
+      .slice(Math.max(0, startIndex), endIndex + 1)
+      .filter(part => part?.type === 'reasoning' && typeof part.text === 'string' && part.text.trim())
+
+    return reasoning.length > 0 && reasoning.every(part => part.type === 'reasoning' && parseMoaProgress(part.text))
+  })
+
   if (!hasContent) {
     return null
+  }
+
+  if (moaOnly) {
+    return <>{children}</>
   }
 
   return (
@@ -328,6 +342,11 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
 const ReasoningTextPart: ReasoningMessagePartComponent = () => {
   const { status, text } = useMessagePartReasoning()
   const messageRunning = useAuiState(s => s.message.status?.type === 'running')
+  const moa = parseMoaProgress(text)
+
+  if (moa) {
+    return <MoaOrchestration state={moa} />
+  }
 
   return (
     <MarkdownTextContent

--- a/apps/desktop/src/components/assistant-ui/thread/moa-orchestration.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/moa-orchestration.test.tsx
@@ -56,4 +56,10 @@ describe('MoaOrchestration', () => {
     expect(screen.getByTestId('thinking-orb').textContent).toBe('breathing')
     expect(screen.queryByText('parallel')).toBeNull()
   })
+
+  it.each(['aggregating', 'settled'] as const)('keeps cache reuse visible while %s', phase => {
+    render(<MoaOrchestration state={{ ...liveState, guidanceReused: true, phase }} />)
+
+    expect(screen.getByLabelText(/guidance reused/i)).not.toBeNull()
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/moa-orchestration.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/moa-orchestration.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { MoaProgressState } from '@/lib/moa-progress'
+
+import { MoaOrchestration } from './moa-orchestration'
+
+vi.mock('thinking-orbs', () => ({
+  ThinkingOrb: ({ state }: { state: string }) => <span data-testid="thinking-orb">{state}</span>
+}))
+
+const liveState: MoaProgressState = {
+  advisors: [
+    { index: 1, label: 'model-a', status: 'running' },
+    { index: 2, label: 'model-b', output: 'Use the indexed protocol.', status: 'complete' },
+    { index: 3, label: 'model-c', status: 'failed' }
+  ],
+  aggregator: 'agg-model',
+  concurrency: 3,
+  fanout: 'user_turn',
+  guidanceReused: false,
+  phase: 'reference',
+  startedAt: 10
+}
+
+describe('MoaOrchestration', () => {
+  it('renders one compact parallel row and reveals advisor details on demand', () => {
+    render(<MoaOrchestration state={liveState} />)
+
+    const summary = screen.getByLabelText(/2\/3 advisors in parallel.*aggregator waiting/i)
+
+    expect(screen.getByRole('status').textContent).toMatch(/2\/3 advisors in parallel.*aggregator waiting/i)
+    expect(screen.getByTestId('thinking-orb').textContent).toBe('solving')
+    const output = screen.getByText('Use the indexed protocol.')
+    const advisorDetails = output.closest('details')
+
+    expect(advisorDetails?.open).toBe(false)
+
+    fireEvent.click(summary)
+    fireEvent.click(screen.getByText('model-b').closest('summary')!)
+    expect(advisorDetails?.open).toBe(true)
+    expect(screen.getAllByLabelText('model-c: failed')).toHaveLength(2)
+  })
+
+  it('settles to a compact advisor-to-aggregator summary without an active orb', () => {
+    render(<MoaOrchestration state={{ ...liveState, phase: 'settled', settledAt: 28.2 }} />)
+
+    expect(screen.getByLabelText(/3 advisors.*agg-model.*18\.2s/i)).not.toBeNull()
+    expect(screen.queryByTestId('thinking-orb')).toBeNull()
+  })
+
+  it('labels cached guidance reuse instead of claiming a fresh fan-out', () => {
+    render(<MoaOrchestration state={{ ...liveState, guidanceReused: true }} />)
+
+    expect(screen.getByLabelText(/guidance reused/i)).not.toBeNull()
+    expect(screen.getByTestId('thinking-orb').textContent).toBe('breathing')
+    expect(screen.queryByText('parallel')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/moa-orchestration.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/moa-orchestration.tsx
@@ -1,0 +1,142 @@
+import { ThinkingOrb } from 'thinking-orbs'
+
+import { formatElapsed } from '@/components/chat/activity-timer'
+import type { MoaAdvisorState, MoaProgressState } from '@/lib/moa-progress'
+import { cn } from '@/lib/utils'
+
+const SETTLED = new Set(['complete', 'failed', 'interrupted', 'skipped'])
+
+function AdvisorMarker({ advisor }: { advisor: MoaAdvisorState }) {
+  const copy = {
+    complete: 'complete',
+    failed: 'failed',
+    interrupted: 'interrupted',
+    queued: 'queued',
+    running: 'running',
+    skipped: 'skipped'
+  }[advisor.status]
+
+  return (
+    <span
+      aria-label={`${advisor.label}: ${copy}`}
+      className={cn(
+        'relative inline-flex size-2.5 shrink-0 items-center justify-center rounded-full border',
+        advisor.status === 'running' && 'border-primary bg-primary/25',
+        advisor.status === 'queued' && 'rounded-[2px] border-muted-foreground/45',
+        advisor.status === 'complete' &&
+          'border-emerald-500 bg-emerald-500 motion-safe:animate-[ping_450ms_ease-out_1]',
+        advisor.status === 'failed' && 'border-destructive bg-destructive',
+        advisor.status === 'interrupted' && 'border-amber-500 bg-amber-500/70',
+        advisor.status === 'skipped' && 'border-muted-foreground/40 bg-muted-foreground/30'
+      )}
+      role="img"
+    >
+      <span aria-hidden className="text-[7px] font-bold leading-none text-background">
+        {advisor.status === 'complete'
+          ? '✓'
+          : advisor.status === 'failed'
+            ? '×'
+            : advisor.status === 'interrupted'
+              ? '–'
+              : advisor.status === 'skipped'
+                ? '/'
+                : ''}
+      </span>
+    </span>
+  )
+}
+
+function AdvisorDetail({ advisor }: { advisor: MoaAdvisorState }) {
+  const content = advisor.output?.trim()
+
+  if (!content) {
+    return (
+      <div className="flex items-center gap-2 py-1 text-xs text-muted-foreground">
+        <AdvisorMarker advisor={advisor} />
+        <span className="min-w-0 flex-1 truncate">{advisor.label}</span>
+        <span className="capitalize">{advisor.status}</span>
+      </div>
+    )
+  }
+
+  return (
+    <details className="group/advisor py-1 text-xs">
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-muted-foreground marker:content-none">
+        <AdvisorMarker advisor={advisor} />
+        <span className="min-w-0 flex-1 truncate">{advisor.label}</span>
+        <span className="capitalize">{advisor.status}</span>
+        <span aria-hidden>›</span>
+      </summary>
+      <div className="mt-1 whitespace-pre-wrap break-words pl-[18px] text-muted-foreground/85">{content}</div>
+    </details>
+  )
+}
+
+export function MoaOrchestration({ state }: { state: MoaProgressState }) {
+  const settled = state.advisors.filter(advisor => SETTLED.has(advisor.status)).length
+  const failed = state.advisors.filter(advisor => advisor.status === 'failed').length
+  const interrupted = state.advisors.filter(advisor => advisor.status === 'interrupted').length
+  const total = state.advisors.length
+  const duration = state.settledAt ? Math.max(0, state.settledAt - state.startedAt) : null
+  const active = state.phase !== 'settled'
+  const phaseCopy =
+    state.phase === 'reference'
+      ? state.guidanceReused
+        ? 'guidance reused'
+        : `${settled}/${total} advisors in parallel → aggregator waiting`
+      : state.phase === 'aggregating'
+        ? `${total}/${total} advisors → aggregator acting`
+        : `${total} advisors → ${state.aggregator || 'aggregator'}${duration === null ? '' : ` · ${formatElapsed(duration)}`}`
+  const accessible = `Mixture of Agents. ${phaseCopy}.${failed ? ` ${failed} failed.` : ''}${interrupted ? ` ${interrupted} interrupted.` : ''}`
+
+  return (
+    <details className="group/moa my-0.5 text-[length:var(--conversation-tool-font-size)] text-(--ui-text-tertiary)">
+      <summary
+        aria-label={accessible}
+        className="flex cursor-pointer list-none items-center gap-2 rounded-sm py-0.5 marker:content-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <span aria-live={active ? 'polite' : 'off'} className="sr-only" role="status">
+          {accessible}
+        </span>
+        {active ? (
+          <ThinkingOrb
+            aria-label={state.phase === 'aggregating' ? 'Aggregator combining advisor guidance' : 'Reference advisors reasoning'}
+            className="shrink-0"
+            size={20}
+            state={state.phase === 'aggregating' ? 'weaving' : state.guidanceReused ? 'breathing' : 'solving'}
+          />
+        ) : (
+          <span aria-hidden className="inline-flex size-5 items-center justify-center text-emerald-500">
+            ✓
+          </span>
+        )}
+        <span className="font-medium text-foreground/80">MoA</span>
+        {!state.guidanceReused && state.phase === 'reference' ? (
+          <span className="hidden text-muted-foreground sm:inline">parallel</span>
+        ) : null}
+        <span className="min-w-0 flex-1 truncate">{phaseCopy}</span>
+        <span aria-hidden className="flex shrink-0 gap-1">
+          {state.advisors.map(advisor => (
+            <AdvisorMarker advisor={advisor} key={advisor.index} />
+          ))}
+        </span>
+        <span aria-hidden className="transition-transform group-open/moa:rotate-90">
+          ›
+        </span>
+      </summary>
+      <div className="ml-7 mt-1 border-l border-border/60 pl-2">
+        <div className="pb-1 text-[11px] text-muted-foreground">
+          {state.guidanceReused ? `Reused ${state.fanout} guidance` : `Fan-out cadence: ${state.fanout}`}
+        </div>
+        {state.advisors.map(advisor => (
+          <AdvisorDetail advisor={advisor} key={advisor.index} />
+        ))}
+        <div className="flex items-center gap-2 border-t border-border/50 py-1 text-xs text-muted-foreground">
+          <span className={cn('size-2.5 rounded-full', state.phase === 'reference' ? 'border border-muted-foreground/45' : 'bg-primary')} />
+          <span className="min-w-0 flex-1 truncate">{state.aggregator || 'Aggregator'}</span>
+          <span>{state.phase === 'reference' ? 'waiting' : state.phase === 'aggregating' ? 'acting' : 'complete'}</span>
+        </div>
+      </div>
+    </details>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/thread/moa-orchestration.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/moa-orchestration.tsx
@@ -85,8 +85,8 @@ export function MoaOrchestration({ state }: { state: MoaProgressState }) {
         ? 'guidance reused'
         : `${settled}/${total} advisors in parallel → aggregator waiting`
       : state.phase === 'aggregating'
-        ? `${total}/${total} advisors → aggregator acting`
-        : `${total} advisors → ${state.aggregator || 'aggregator'}${duration === null ? '' : ` · ${formatElapsed(duration)}`}`
+        ? `${total}/${total} advisors${state.guidanceReused ? ' · guidance reused' : ''} → aggregator acting`
+        : `${total} advisors${state.guidanceReused ? ' · guidance reused' : ''} → ${state.aggregator || 'aggregator'}${duration === null ? '' : ` · ${formatElapsed(duration)}`}`
   const accessible = `Mixture of Agents. ${phaseCopy}.${failed ? ` ${failed} failed.` : ''}${interrupted ? ` ${interrupted} interrupted.` : ''}`
 
   return (

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -160,6 +160,10 @@ export type GatewayEventPayload = {
   index?: number
   aggregator?: string
   // moa.progress / moa.phase (Mixture of Agents fan-out progress relay)
+  advisors?: unknown[]
+  concurrency?: number
+  fanout?: string
+  guidance_reused?: boolean
   refs_done?: number
   refs_total?: number
   phase?: string

--- a/apps/desktop/src/lib/moa-progress.ts
+++ b/apps/desktop/src/lib/moa-progress.ts
@@ -38,11 +38,15 @@ export function reduceMoaProgress(
   if (eventType === 'moa.phase' && payload?.phase === 'reference' && Array.isArray(payload.advisors)) {
     const concurrency = Math.max(0, Math.min(Number(payload.concurrency) || 0, payload.advisors.length))
     const reused = payload.guidance_reused === true
+    const preserveGuidance = reused ? previous : undefined
 
     return {
       advisors: payload.advisors.map((label, offset) => ({
         index: offset + 1,
         label: String(label),
+        ...(preserveGuidance?.advisors[offset]?.output !== undefined && {
+          output: preserveGuidance.advisors[offset].output
+        }),
         status: reused ? 'complete' : offset < concurrency ? 'running' : 'queued'
       })),
       aggregator: String(payload.aggregator || ''),
@@ -50,7 +54,7 @@ export function reduceMoaProgress(
       fanout: String(payload.fanout || 'user_turn'),
       guidanceReused: reused,
       phase: 'reference',
-      startedAt: occurredAt
+      startedAt: preserveGuidance?.startedAt ?? occurredAt
     }
   }
 

--- a/apps/desktop/src/lib/moa-progress.ts
+++ b/apps/desktop/src/lib/moa-progress.ts
@@ -1,0 +1,142 @@
+import type { GatewayEventPayload } from '@/lib/chat-messages'
+
+export const MOA_PROGRESS_PREFIX = '\u001ehermes-moa-v1:'
+
+export type MoaAdvisorStatus = 'complete' | 'failed' | 'interrupted' | 'queued' | 'running' | 'skipped'
+export type MoaPhase = 'aggregating' | 'reference' | 'settled'
+
+export interface MoaAdvisorState {
+  index: number
+  label: string
+  output?: string
+  status: MoaAdvisorStatus
+}
+
+export interface MoaProgressState {
+  advisors: MoaAdvisorState[]
+  aggregator: string
+  concurrency: number
+  fanout: string
+  guidanceReused: boolean
+  phase: MoaPhase
+  startedAt: number
+  settledAt?: number
+}
+
+function advisorStatus(value: unknown): MoaAdvisorStatus {
+  return ['complete', 'failed', 'interrupted', 'queued', 'running', 'skipped'].includes(String(value))
+    ? (value as MoaAdvisorStatus)
+    : 'complete'
+}
+
+export function reduceMoaProgress(
+  previous: MoaProgressState | undefined,
+  eventType: string,
+  payload: GatewayEventPayload | undefined,
+  occurredAt: number
+): MoaProgressState | undefined {
+  if (eventType === 'moa.phase' && payload?.phase === 'reference' && Array.isArray(payload.advisors)) {
+    const concurrency = Math.max(0, Math.min(Number(payload.concurrency) || 0, payload.advisors.length))
+    const reused = payload.guidance_reused === true
+
+    return {
+      advisors: payload.advisors.map((label, offset) => ({
+        index: offset + 1,
+        label: String(label),
+        status: reused ? 'complete' : offset < concurrency ? 'running' : 'queued'
+      })),
+      aggregator: String(payload.aggregator || ''),
+      concurrency,
+      fanout: String(payload.fanout || 'user_turn'),
+      guidanceReused: reused,
+      phase: 'reference',
+      startedAt: occurredAt
+    }
+  }
+
+  if (!previous) {
+    return undefined
+  }
+
+  if (eventType === 'moa.progress') {
+    const index = typeof payload?.index === 'number' ? payload.index : 0
+    const fallbackIndex = previous.advisors.findIndex(
+      advisor => advisor.label === payload?.label && (advisor.status === 'queued' || advisor.status === 'running')
+    )
+    const targetIndex = index > 0 ? index - 1 : fallbackIndex
+
+    if (targetIndex < 0 || targetIndex >= previous.advisors.length) {
+      return previous
+    }
+
+    const advisors = previous.advisors.map((advisor, offset) =>
+      offset === targetIndex ? { ...advisor, status: advisorStatus(payload?.status) } : advisor
+    )
+    const running = advisors.filter(advisor => advisor.status === 'running').length
+    let available = previous.concurrency - running
+
+    for (let i = 0; i < advisors.length && available > 0; i++) {
+      if (advisors[i].status === 'queued') {
+        advisors[i] = { ...advisors[i], status: 'running' }
+        available -= 1
+      }
+    }
+
+    return { ...previous, advisors }
+  }
+
+  if (eventType === 'moa.reference') {
+    const index = typeof payload?.index === 'number' ? payload.index - 1 : -1
+
+    if (index < 0 || index >= previous.advisors.length) {
+      return previous
+    }
+
+    return {
+      ...previous,
+      advisors: previous.advisors.map((advisor, offset) =>
+        offset === index
+          ? {
+              ...advisor,
+              label: String(payload?.label || advisor.label),
+              output: String(payload?.text || ''),
+              status: advisor.status === 'running' || advisor.status === 'queued' ? 'complete' : advisor.status
+            }
+          : advisor
+      )
+    }
+  }
+
+  if (eventType === 'moa.phase' && payload?.phase === 'aggregator') {
+    return {
+      ...previous,
+      aggregator: String(payload.aggregator || previous.aggregator),
+      guidanceReused: payload.guidance_reused === true || previous.guidanceReused,
+      phase: 'aggregating'
+    }
+  }
+
+  if (eventType === 'message.complete') {
+    return { ...previous, phase: 'settled', settledAt: occurredAt }
+  }
+
+  return previous
+}
+
+export function serializeMoaProgress(state: MoaProgressState): string {
+  return `${MOA_PROGRESS_PREFIX}${JSON.stringify(state)}`
+}
+
+export function parseMoaProgress(text: string): MoaProgressState | null {
+  if (!text.startsWith(MOA_PROGRESS_PREFIX)) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(text.slice(MOA_PROGRESS_PREFIX.length)) as MoaProgressState
+
+    return Array.isArray(parsed.advisors) && typeof parsed.phase === 'string' ? parsed : null
+  } catch {
+    return null
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,7 @@
         "streamdown": "2.5.0",
         "tailwind-merge": "3.6.0",
         "tailwindcss": "4.3.3",
+        "thinking-orbs": "0.3.1",
         "tw-shimmer": "0.4.12",
         "unicode-animations": "1.0.3",
         "unified": "11.0.5",
@@ -17814,6 +17815,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/thinking-orbs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/thinking-orbs/-/thinking-orbs-0.3.1.tgz",
+      "integrity": "sha512-3BG1aeB1RUTxItCml/BBuIz5JRM4kZqGuyx+vouv0fXTtcR9ZNoKjWGneHPx94y74GxgArwJZ1qbJR5dt54kSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0"
       }
     },
     "node_modules/three": {

--- a/tests/agent/test_moa_progress.py
+++ b/tests/agent/test_moa_progress.py
@@ -7,9 +7,8 @@ complete and the phase transitions from ``reference`` to ``aggregator``:
   - ``moa.progress`` — fired once per reference completion with
                        ``refs_done`` and ``refs_total`` (e.g. drives a
                        status-bar ``MOA: 2/3 refs done`` indicator)
-  - ``moa.phase``    — fired once per phase transition (currently only the
-                       ``phase="aggregator"`` transition right before the
-                       aggregator acts)
+  - ``moa.phase``    — announces the complete advisor roster before dispatch,
+                       then the aggregator transition after every slot settles
 
 These tests exercise the real callback surface end-to-end through the
 display hook (``reference_callback``) — no mocks on the dispatch path.
@@ -72,8 +71,8 @@ def _collect_emits(facade):
 
 
 
-def test_moa_phase_transitions_to_aggregator(moa_config, monkeypatch):
-    """A single ``moa.phase`` event with ``phase="aggregator"`` fires after the fan-out."""
+def test_moa_phase_announces_parallel_roster_then_aggregator(moa_config, monkeypatch):
+    """The full stable roster is visible before completion events arrive."""
     from agent.moa_loop import MoAChatCompletions
 
     def fake_call_llm(**kwargs):
@@ -92,14 +91,75 @@ def test_moa_phase_transitions_to_aggregator(moa_config, monkeypatch):
     )
 
     phase_events = [(e, k) for (e, k) in captured if e == "moa.phase"]
-    # Exactly one phase event per turn, identifying the aggregator.
-    assert len(phase_events) == 1
-    _event, kwargs = phase_events[0]
+    assert [kwargs["phase"] for _event, kwargs in phase_events] == [
+        "reference",
+        "aggregator",
+    ]
+    _event, start = phase_events[0]
+    assert start["advisors"] == [
+        "openrouter:anthropic/claude-opus-4.8",
+        "openrouter:openai/gpt-5.5",
+        "openrouter:google/gemini-3-pro",
+    ]
+    assert start["concurrency"] == 3
+    assert start["refs_done"] == 0
+    assert start["guidance_reused"] is False
+
+    _event, kwargs = phase_events[1]
     assert kwargs["phase"] == "aggregator"
     assert kwargs["aggregator"] == "openrouter:anthropic/claude-opus-4.8"
     # counts match the configured reference count
     assert kwargs["refs_done"] == 3
     assert kwargs["refs_total"] == 3
+
+    progress = sorted(
+        (kwargs for event, kwargs in captured if event == "moa.progress"),
+        key=lambda item: item["index"],
+    )
+    assert [item["index"] for item in progress] == [1, 2, 3]
+    assert {item["status"] for item in progress} == {"complete"}
+
+
+def test_moa_cache_reuse_is_explicit(moa_config, monkeypatch):
+    from agent.moa_loop import MoAChatCompletions
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", lambda **_kwargs: _response("advice"))
+    facade = MoAChatCompletions("closed")
+    captured = _collect_emits(facade)
+    messages = [{"role": "user", "content": "plan the migration"}]
+
+    facade.create(model="closed", messages=messages)
+    captured.clear()
+    facade.create(model="closed", messages=messages)
+
+    phases = [kwargs for event, kwargs in captured if event == "moa.phase"]
+    assert [phase["phase"] for phase in phases] == ["reference", "aggregator"]
+    assert all(phase["guidance_reused"] is True for phase in phases)
+    assert not [event for event, _kwargs in captured if event == "moa.progress"]
+
+
+def test_moa_progress_reports_failed_slot_without_reordering(moa_config, monkeypatch):
+    from agent.moa_loop import MoAChatCompletions
+
+    def fake_call_llm(**kwargs):
+        if kwargs.get("task") == "moa_reference" and kwargs.get("model") == "openai/gpt-5.5":
+            raise RuntimeError("advisor unavailable")
+        return _response("advice")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    facade = MoAChatCompletions("closed")
+    captured = _collect_emits(facade)
+
+    facade.create(
+        model="closed",
+        messages=[{"role": "user", "content": "plan the migration"}],
+    )
+
+    progress = {kwargs["index"]: kwargs for event, kwargs in captured if event == "moa.progress"}
+    assert progress[2]["label"] == "openrouter:openai/gpt-5.5"
+    assert progress[2]["status"] == "failed"
+    assert progress[1]["status"] == "complete"
+    assert progress[3]["status"] == "complete"
 
 
 

--- a/tests/agent/test_moa_progress.py
+++ b/tests/agent/test_moa_progress.py
@@ -18,6 +18,7 @@ real provider.
 
 from __future__ import annotations
 
+import threading
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -160,6 +161,61 @@ def test_moa_progress_reports_failed_slot_without_reordering(moa_config, monkeyp
     assert progress[2]["status"] == "failed"
     assert progress[1]["status"] == "complete"
     assert progress[3]["status"] == "complete"
+
+
+def test_moa_progress_emits_later_slot_while_earlier_slot_is_running(monkeypatch):
+    """A settled future updates its stable slot before the whole batch finishes."""
+    from agent import moa_loop
+
+    monkeypatch.setattr(moa_loop, "get_transport", lambda *_args, **_kwargs: None)
+    first_started = threading.Event()
+    later_started = threading.Event()
+    release_first = threading.Event()
+    release_later = threading.Event()
+    later_reported = threading.Event()
+    errors: list[BaseException] = []
+
+    def fake_call_llm(**kwargs):
+        if kwargs["provider"] == "first":
+            first_started.set()
+            assert release_first.wait(timeout=5)
+        else:
+            later_started.set()
+            assert release_later.wait(timeout=5)
+        return _response(f"advice from {kwargs['provider']}")
+
+    def progress(_done, _total, _label, index, status):
+        if index == 2 and status == "complete":
+            later_reported.set()
+
+    def run_fanout():
+        try:
+            moa_loop._run_references_parallel(
+                [
+                    {"provider": "first", "model": "slow"},
+                    {"provider": "later", "model": "fast"},
+                ],
+                [{"role": "user", "content": "review"}],
+                progress_callback=progress,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    worker = threading.Thread(target=run_fanout)
+    worker.start()
+    try:
+        assert first_started.wait(timeout=5)
+        assert later_started.wait(timeout=5)
+        release_later.set()
+        assert later_reported.wait(timeout=2)
+        assert not release_first.is_set()
+    finally:
+        release_first.set()
+        worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert errors == []
 
 
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1093,7 +1093,8 @@ def test_interrupted_but_completed_reference_keeps_real_accounting(monkeypatch):
     # pending (so the interrupt path is taken) even though the underlying
     # call has already completed — the reap must then hit the done() branch
     # and keep the real result instead of writing a placeholder.
-    def fake_wait(pending, timeout=None):
+    def fake_wait(pending, timeout=None, return_when=None):
+        assert return_when is moa_loop.FIRST_COMPLETED
         real_wait(pending)  # let the call actually finish (it billed)
         return set(), set(pending)  # report it as still pending
 

--- a/tests/tui_gateway/test_moa_reference_emit.py
+++ b/tests/tui_gateway/test_moa_reference_emit.py
@@ -70,3 +70,55 @@ def test_moa_reference_relayed_with_label_and_index(server, emits):
     assert payload["count"] == 2
 
 
+def test_moa_progress_preserves_stable_slot_and_terminal_status(server, emits):
+    server._on_tool_progress(
+        "sid-1",
+        "moa.progress",
+        "openrouter:model-b",
+        None,
+        None,
+        moa_refs_done=1,
+        moa_refs_total=3,
+        moa_index=2,
+        moa_status="failed",
+    )
+
+    assert emits == [
+        (
+            "moa.progress",
+            "sid-1",
+            {
+                "label": "openrouter:model-b",
+                "refs_done": 1,
+                "refs_total": 3,
+                "index": 2,
+                "status": "failed",
+            },
+        )
+    ]
+
+
+def test_moa_reference_phase_relays_complete_roster(server, emits):
+    server._on_tool_progress(
+        "sid-1",
+        "moa.phase",
+        "openrouter:aggregator",
+        None,
+        None,
+        moa_phase="reference",
+        moa_refs_done=0,
+        moa_refs_total=10,
+        moa_advisors=[f"openrouter:model-{index}" for index in range(10)],
+        moa_concurrency=8,
+        moa_fanout="every_n:3",
+        moa_guidance_reused=False,
+    )
+
+    event, sid, payload = emits[0]
+    assert (event, sid) == ("moa.phase", "sid-1")
+    assert payload["advisors"] == [f"openrouter:model-{index}" for index in range(10)]
+    assert payload["concurrency"] == 8
+    assert payload["fanout"] == "every_n:3"
+    assert payload["guidance_reused"] is False
+
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7751,6 +7751,16 @@ def _on_tool_progress(
                 "label": str(name or ""),
                 "refs_done": int(refs_done),
                 "refs_total": int(refs_total),
+                **(
+                    {"index": int(_kwargs["moa_index"])}
+                    if _kwargs.get("moa_index") is not None
+                    else {}
+                ),
+                **(
+                    {"status": str(_kwargs["moa_status"])}
+                    if _kwargs.get("moa_status")
+                    else {}
+                ),
             },
         )
         return
@@ -7771,6 +7781,19 @@ def _on_tool_progress(
             phase_payload["refs_total"] = int(refs_total)
         if name:
             phase_payload["aggregator"] = str(name)
+        advisors = _kwargs.get("moa_advisors")
+        if isinstance(advisors, list):
+            phase_payload["advisors"] = [str(label) for label in advisors]
+        concurrency = _kwargs.get("moa_concurrency")
+        if concurrency is not None:
+            phase_payload["concurrency"] = int(concurrency)
+        fanout = _kwargs.get("moa_fanout")
+        if fanout:
+            phase_payload["fanout"] = str(fanout)
+        if _kwargs.get("moa_guidance_reused") is not None:
+            phase_payload["guidance_reused"] = bool(
+                _kwargs.get("moa_guidance_reused")
+            )
         _emit("moa.phase", sid, phase_payload)
         return
     if event_type.startswith("subagent."):


### PR DESCRIPTION
## What does this PR do?

Desktop now shows the real MoA topology as a compact orchestration row: the complete advisor roster appears before the first completion, slots update in place as concurrent calls settle, and the aggregator visibly transitions from waiting to acting. This prevents a parallel fan-out from looking sequential and keeps advisor output collapsed behind per-slot disclosures.

### Symptom

During a multi-advisor MoA turn, Desktop showed only completed advisors as `MoA refs k/n` lines. Advisors still in flight were invisible, completed output replaced the progress trail with stacked prose, and the aggregator phase appeared inside generic reasoning UI.

### Impact

Desktop users could not tell that advisors were running concurrently, which slots were queued or still active, whether failures or interruptions occurred, or when the aggregator crossed the fan-in barrier.

### Bug Cause

**Trigger:** `agent/moa_loop.py::_run_references_parallel` and `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts` during a MoA turn with multiple reference models.

**Causal chain:**
1. The runtime submitted reference calls to a `ThreadPoolExecutor`, but emitted progress only after each call completed.
2. The gateway event contract carried aggregate completion counts and a label, without the initial roster, stable slot index, terminal status, concurrency, cadence, or cache-reuse state.
3. Desktop flattened those events into reasoning strings, so it had no state model with which to render running or queued advisors in place.

**Why it is wrong:** Completion-only events cannot represent the topology before the first completion and cannot safely update duplicate or out-of-order advisor slots.

**Working sibling / contrast:** The MoA runtime itself already fans out concurrently and waits for the complete result set before aggregation; the missing behavior was observability across the runtime, gateway, and Desktop seams.

**Ruled out:** The advisor calls are not serial. The existing executor path and the new stable-index tests confirm that completion order can differ from preset order.

### Fix

The shared MoA event contract now announces the complete roster before dispatch and carries stable slot indexes, settled statuses, concurrency, fan-out cadence, and cached-guidance reuse. Desktop reduces those events into per-session orchestration state and renders one compact expandable row with truthful queued/running/complete/failed/interrupted/skipped markers, an explicit aggregator barrier, collapsed advisor output, accessible status copy, and reduced-motion-aware `thinking-orbs` animation.

Older backends and clients keep the existing text-progress fallback, and non-MoA reasoning rendering is unchanged.

## Related Issue

Closes #97674

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py` - emit the initial advisor roster, stable indexed status updates, aggregator phases, and cached-guidance reuse.
- `tui_gateway/server.py` - preserve the expanded MoA event contract for Desktop and TUI clients.
- `apps/desktop/src/lib/moa-progress.ts` - reduce structured events without reordering advisor slots.
- `apps/desktop/src/components/assistant-ui/thread/moa-orchestration.tsx` - render the compact fan-out/fan-in row and expandable advisor details.
- `apps/desktop/src/app/session/hooks/use-message-stream/` - keep structured MoA state separate from the legacy reasoning-text fallback.
- `apps/desktop/package.json` - pin MIT-licensed `thinking-orbs` 0.3.1 for inline semantic activity states.
- `tests/` and Desktop Vitest files - cover roster start, out-of-order completion, queued capacity, failures, interruptions, aggregation, cache reuse, settlement, accessibility, and expansion.

## How to Test

1. Run a Desktop MoA turn with more than one advisor and verify the complete roster appears before any advisor finishes.
2. Complete advisors out of preset order and verify each stable slot changes in place while the aggregator remains waiting.
3. Verify failed/interrupted slots do not use success styling, cached guidance says it was reused, and the settled row remains expandable.
4. Run the automated checks:

```bash
scripts/run_tests.sh tests/agent/test_moa_progress.py tests/run_agent/test_moa_loop_mode.py tests/tui_gateway/test_moa_reference_emit.py -q
cd apps/desktop
npx vitest run --project ui src/components/assistant-ui/thread/moa-orchestration.test.tsx src/app/session/hooks/use-message-stream/moa-progress-event.test.tsx src/app/session/hooks/use-message-stream/moa-reference-event.test.tsx src/app/session/hooks/use-message-stream/moa-orchestration-event.test.tsx
npm run typecheck
npm run lint -- --quiet
```

Local result: 34 Python tests and 13 Desktop tests passed; typecheck and lint passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant Python tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant protocol behavior is documented in code; user documentation is N/A
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no workflow contract changed
- [x] I've considered cross-platform impact; the renderer behavior is platform-independent and reduced motion is delegated to the pinned package
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed

## Screenshots / Logs

N/A - behavior is covered by the event-contract and renderer tests above.
