### PR TITLE
fix(computer-use): fail closed when no approval prompt surface is wired

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -20,12 +20,17 @@ import pytest
 @pytest.fixture(autouse=True)
 def _reset_backend():
     """Tear down the cached backend between tests."""
-    from tools.computer_use.tool import reset_backend_for_tests
+    from tools.computer_use.tool import reset_backend_for_tests, set_approval_callback
     reset_backend_for_tests()
+    # These tests exercise dispatch and the backend schema, not the approval
+    # prompt. No callback is wired on headless surfaces and _request_approval
+    # fails closed, so grant destructive actions here; conftest clears it.
+    set_approval_callback(lambda action, args, summary: "approve_once")
     # Force the noop backend.
     with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False):
         yield
     reset_backend_for_tests()
+    set_approval_callback(None)
 
 
 @pytest.fixture

--- a/tests/tools/test_computer_use_approval_isolation.py
+++ b/tests/tools/test_computer_use_approval_isolation.py
@@ -55,8 +55,9 @@ def test_a_forgets_a_poisoned_approval_callback():
     def stale_two_arg_callback(action, args):  # wrong arity on purpose
         return "approve_once"
 
-    cu_tool.set_approval_callback(stale_two_arg_callback)
-    # no reset — the autouse fixture must clean this up
+    token = cu_tool.set_approval_callback(stale_two_arg_callback)
+    assert token is not None
+    # deliberately no reset — the autouse fixture must clean this up
 
 
 def test_b_still_fails_closed_without_a_callback():
@@ -80,3 +81,122 @@ def test_b_still_fails_closed_without_a_callback():
     assert payload.get("code") == "approval_unavailable", (
         f"expected the pristine fail-closed denial, got: {result!r}"
     )
+
+
+def _grant_rule_key(session_id, action):
+    """The exact allowlist key the shared-gate bridge derives for a grant."""
+    from tools.computer_use.tool import _shared_approval_rule_key
+
+    return f"plugin_rule:{_shared_approval_rule_key(session_id, action, {})}"
+
+
+def test_headless_context_never_uses_another_contexts_responder():
+    """Session-owned callback identity: a concurrent context with no callback
+    of its own must not route its mutation through another context's
+    responder. It enters the shared headless approval path and fails closed
+    (no interactive user or gateway in the test env)."""
+    import threading
+
+    from tools.computer_use import tool as cu_tool
+
+    backend = _install_backend(cu_tool)
+    invoked = []
+    responder_ready = threading.Event()
+    decision_made = threading.Event()
+
+    def responder(action, args, summary):
+        invoked.append(action)
+        return "approve_once"
+
+    def interactive_context():
+        token = cu_tool.set_approval_callback(responder)
+        try:
+            responder_ready.set()
+            # stay alive with the callback installed while the headless
+            # context decides, so a global slot would be observable
+            decision_made.wait(timeout=5)
+        finally:
+            cu_tool.reset_approval_callback(token)
+
+    thread = threading.Thread(target=interactive_context)
+    thread.start()
+    assert responder_ready.wait(timeout=5)
+
+    result = cu_tool.handle_computer_use({"action": "click", "element": 3})
+    decision_made.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert invoked == [], (
+        "headless context routed through another context's responder"
+    )
+    assert [c[0] for c in backend.calls] == [], f"click dispatched: {result!r}"
+    payload = json.loads(result)
+    assert payload.get("code") == "approval_unavailable"
+
+
+def test_interactive_grant_does_not_authorize_cron_run(monkeypatch):
+    """A grant earned in an interactive approval session is scoped to that
+    session: a cron context (cron_mode defaults to deny) reusing the same
+    computer_use session_id must still be denied."""
+    from tools import approval as approval_mod
+    from tools.computer_use import tool as cu_tool
+
+    backend = _install_backend(cu_tool)
+    monkeypatch.setattr(approval_mod, "get_current_session_key",
+                        lambda *a, **k: "interactive-1")
+    key = _grant_rule_key("cu-session-1", "click")
+    approval_mod.approve_session("interactive-1", key)
+    approval_mod.approve_permanent(key)
+    result = cu_tool.handle_computer_use(
+        {"action": "click", "element": 3}, session_id="cu-session-1")
+    granted = json.loads(result) if isinstance(result, str) else result
+    assert not granted.get("code") and not granted.get("error"), (
+        f"grant did not authorize its own session: {result!r}"
+    )
+
+    backend.calls.clear()
+    monkeypatch.setattr(approval_mod, "get_current_session_key",
+                        lambda *a, **k: "cron-1")
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    result = cu_tool.handle_computer_use(
+        {"action": "click", "element": 3}, session_id="cu-session-1")
+    assert [c[0] for c in backend.calls] == [], (
+        f"cron run used the interactive session's grant: {result!r}"
+    )
+    payload = json.loads(result)
+    assert "cron" in payload.get("error", "").lower()
+    assert payload.get("code") == "approval_unavailable"
+
+
+def test_interactive_grant_does_not_authorize_single_query_run(monkeypatch):
+    """Same scoping for single-query (-q) sessions: the grant stays with the
+    session that earned it, and single_query_mode (default deny) governs."""
+    from tools import approval as approval_mod
+    from tools.computer_use import tool as cu_tool
+
+    backend = _install_backend(cu_tool)
+    monkeypatch.setattr(approval_mod, "get_current_session_key",
+                        lambda *a, **k: "interactive-2")
+    key = _grant_rule_key("cu-session-2", "type")
+    approval_mod.approve_session("interactive-2", key)
+    approval_mod.approve_permanent(key)
+    result = cu_tool.handle_computer_use(
+        {"action": "type", "text": "hi"}, session_id="cu-session-2")
+    granted = json.loads(result) if isinstance(result, str) else result
+    assert not granted.get("code") and not granted.get("error"), (
+        f"grant did not authorize its own session: {result!r}"
+    )
+
+    backend.calls.clear()
+    monkeypatch.setattr(approval_mod, "get_current_session_key",
+                        lambda *a, **k: "single-query-1")
+    monkeypatch.setenv("HERMES_SINGLE_QUERY_SESSION", "1")
+    result = cu_tool.handle_computer_use(
+        {"action": "type", "text": "hi"}, session_id="cu-session-2")
+    assert [c[0] for c in backend.calls] == [], (
+        f"single-query run used the interactive session's grant: {result!r}"
+    )
+    payload = json.loads(result)
+    assert "single-query" in payload.get("error", "").lower()
+    assert payload.get("code") == "approval_unavailable"

--- a/tests/tools/test_computer_use_approval_isolation.py
+++ b/tests/tools/test_computer_use_approval_isolation.py
@@ -7,7 +7,7 @@ changes the behavior of every later computer-use test in the process:
 a raising callback becomes ``verdict = "deny"`` (dispatch tests see an
 empty backend call list), a blocking callback hangs the run. The pair
 below simulates the forgetful test and asserts the next test still sees
-default-allow behavior.
+the pristine fail-closed denial.
 """
 
 import json
@@ -59,17 +59,24 @@ def test_a_forgets_a_poisoned_approval_callback():
     # no reset — the autouse fixture must clean this up
 
 
-def test_b_still_dispatches_with_default_allow():
-    """Without the isolation fixture this fails: the stale callback raises
-    (arity), ``_request_approval`` converts that into a deny, and the
-    backend never sees the click."""
+def test_b_still_fails_closed_without_a_callback():
+    """Without the isolation fixture this fails differently: the stale
+    callback raises (arity), ``_request_approval`` converts that into a
+    "denied by user", and the error never carries the pristine
+    ``approval_unavailable`` code. With the fixture, pristine state is
+    fail-closed: no callback wired means the destructive action is denied
+    with ``approval_unavailable`` and the backend is never touched.
+    """
     from tools.computer_use import tool as cu_tool
 
     backend = _install_backend(cu_tool)
     result = cu_tool.handle_computer_use({"action": "click", "element": 3})
     call_names = [c[0] for c in backend.calls]
-    assert "click" in call_names, (
-        f"leaked approval callback poisoned this test: {result!r}"
+    assert "click" not in call_names, (
+        f"leaked approval callback or stale grant dispatched the click: {result!r}"
     )
     payload = json.loads(result) if isinstance(result, str) else result
-    assert not (isinstance(payload, dict) and payload.get("error"))
+    assert isinstance(payload, dict)
+    assert payload.get("code") == "approval_unavailable", (
+        f"expected the pristine fail-closed denial, got: {result!r}"
+    )

--- a/tests/tools/test_computer_use_approval_isolation.py
+++ b/tests/tools/test_computer_use_approval_isolation.py
@@ -1,13 +1,13 @@
 """Regression: leaked approval callbacks must not poison later tests.
 
-``tools.computer_use.tool._approval_callback`` and the per-session unlock
-stores are module-globals. Without the autouse reset fixture in
-``tests/conftest.py``, a test that installs a callback and "forgets" it
-changes the behavior of every later computer-use test in the process:
-a raising callback becomes ``verdict = "deny"`` (dispatch tests see an
-empty backend call list), a blocking callback hangs the run. The pair
-below simulates the forgetful test and asserts the next test still sees
-the pristine fail-closed denial.
+``tools.computer_use.tool`` keeps the approval callback in a ContextVar
+plus the per-session unlock stores as module-globals. Without the autouse
+reset fixture in ``tests/conftest.py``, a test that installs a callback
+and "forgets" it changes the behavior of every later computer-use test in
+the same context: a raising callback becomes ``verdict = "deny"``
+(dispatch tests see an empty backend call list), a blocking callback
+hangs the run. The pair below simulates the forgetful test and asserts
+the next test still sees the pristine fail-closed denial.
 """
 
 import json

--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -225,6 +225,9 @@ def test_dispatcher_threads_delivery_mode_to_backend():
     from tools.computer_use import tool as cu
     with patch.dict(os.environ, {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False):
         cu.reset_backend_for_tests()
+        # _request_approval fails closed without a wired prompt; this test
+        # covers delivery-mode threading, not approval.
+        cu.set_approval_callback(lambda action, args, summary: "approve_once")
         be = cu._get_backend()
         cu.handle_computer_use({"action": "click", "element": 5,
                                 "delivery_mode": "foreground"})

--- a/tools/computer_use/__init__.py
+++ b/tools/computer_use/__init__.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 from tools.computer_use.tool import (  # noqa: F401
     handle_computer_use,
     release_computer_use_session,
+    reset_approval_callback,
     set_approval_callback,
     check_computer_use_requirements,
     get_computer_use_schema,

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -610,9 +610,19 @@ def _request_approval(action: str, args: Dict[str, Any],
             return None
     cb = _approval_callback
     if cb is None:
-        # No CLI approval wired — default allow. Gateway approval is handled
-        # one layer out via the normal tool-approval infra.
-        return None
+        # No prompt surface is wired (headless, gateway, messaging runs).
+        # Silence is not consent here either: deny, so destructive actions
+        # need an interactive session or a durable config grant (checked
+        # before this point), never an absent handler.
+        return json.dumps({
+            "error": (
+                "approval required, but no approval prompt is available on "
+                "this surface — ask the user to run this action from an "
+                "interactive session or grant it in config"
+            ),
+            "code": "approval_unavailable",
+            "action": action,
+        })
     summary = _summarize_action(action, args)
     try:
         verdict = cb(action, args, summary)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -47,7 +47,8 @@ import re
 import struct
 import sys
 import threading
-from typing import Any, Dict, List, Optional, Tuple
+from contextvars import ContextVar, Token
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from tools.computer_use.backend import (
     ActionResult,
@@ -63,18 +64,28 @@ logger = logging.getLogger(__name__)
 # Approval & safety
 # ---------------------------------------------------------------------------
 
-_approval_callback = None
+_approval_callback_var: ContextVar[Optional[Callable]] = ContextVar(
+    "computer_use_approval_callback", default=None
+)
 
 
-def set_approval_callback(cb) -> None:
+def set_approval_callback(cb):
     """Register a callback for computer_use approval prompts (used by CLI).
 
     Matches the terminal_tool._approval_callback pattern. The callback
     receives (action, args, summary) and returns one of:
       "approve_once" | "approve_session" | "always_approve" | "deny".
+
+    The callback is bound to the current execution context, not the process:
+    a context that never registered one must not observe another context's
+    responder. Returns a token for :func:`reset_approval_callback`.
     """
-    global _approval_callback
-    _approval_callback = cb
+    return _approval_callback_var.set(cb)
+
+
+def reset_approval_callback(token: Token) -> None:
+    """Restore the callback to its state before :func:`set_approval_callback`."""
+    _approval_callback_var.reset(token)
 
 
 # Actions that read, not mutate. Always allowed.
@@ -608,21 +619,17 @@ def _request_approval(action: str, args: Dict[str, Any],
             return None
         if scope_key in _always_allow.get(session_id, set()):
             return None
-    cb = _approval_callback
+    cb = _approval_callback_var.get()
     if cb is None:
-        # No prompt surface is wired (headless, gateway, messaging runs).
-        # Silence is not consent here either: deny, so destructive actions
-        # need an interactive session or a durable config grant (checked
-        # before this point), never an absent handler.
-        return json.dumps({
-            "error": (
-                "approval required, but no approval prompt is available on "
-                "this surface — ask the user to run this action from an "
-                "interactive session or grant it in config"
-            ),
-            "code": "approval_unavailable",
-            "action": action,
-        })
+        # No interactive prompt wired in THIS context (gateway, cron,
+        # messaging, headless runs). Escalate through the same human gate
+        # that dangerous shell commands use: gateway sessions get the normal
+        # approval round-trip, cron honors approvals.cron_mode, single-query
+        # honors approvals.single_query_mode, and a context with no possible
+        # responder fails closed. Grants are keyed to the approving session
+        # (see _request_shared_approval), so an answer given here can never
+        # stand in for an unattended context.
+        return _request_shared_approval(action, args, session_id)
     summary = _summarize_action(action, args)
     try:
         verdict = cb(action, args, summary)
@@ -646,6 +653,59 @@ def _request_approval(action: str, args: Dict[str, Any],
             "action": action,
         })
     return json.dumps({"error": "denied by user", "action": action})
+
+
+def _shared_approval_rule_key(session_id: str, action: str,
+                              args: Dict[str, Any]) -> str:
+    """Allowlist grain for shared-gate computer_use approvals.
+
+    Embeds the *approval* session key so an ``[a]lways`` is scoped to the
+    session that answered it: the gate's session-cache check runs before its
+    cron/single-query branches (issue #61064), and a grant earned
+    interactively must not short-circuit an unattended context that reuses
+    the same computer_use ``session_id``.
+    """
+    from tools.approval import get_current_session_key
+
+    delivery = "foreground" if args.get("delivery_mode") == "foreground" else "background"
+    return (f"computer_use:{get_current_session_key()}:"
+            f"{session_id}:{action}:{delivery}")
+
+
+def _request_shared_approval(action: str, args: Dict[str, Any],
+                             session_id: str = "") -> Optional[str]:
+    """Escalate a destructive action with no wired CLI prompt to the shared
+    human-approval gate (``tools.approval.request_tool_approval``).
+
+    The gate owns the per-context decision policy: gateway sessions get the
+    normal approval round-trip, cron honors ``approvals.cron_mode``,
+    single-query honors ``approvals.single_query_mode``, and a context with
+    no possible responder fails closed.
+    """
+    from tools.approval import request_tool_approval
+
+    summary = _summarize_action(action, args)
+    result = request_tool_approval(
+        tool_name="computer_use",
+        reason=f"computer_use {summary}",
+        rule_key=_shared_approval_rule_key(session_id, action, args),
+    )
+    if result.get("approved"):
+        return None
+    payload: Dict[str, Any] = {
+        "error": result.get("message") or "denied by user",
+        "action": action,
+    }
+    outcome = result.get("outcome")
+    if outcome == "timeout":
+        payload["code"] = "approval_timeout"
+    elif outcome == "denied":
+        payload["code"] = "denied_by_user"
+    else:
+        # Cron/single-query policy denial, or no interactive user or gateway
+        # present at all: the action never ran and there is nobody to ask.
+        payload["code"] = "approval_unavailable"
+    return json.dumps(payload)
 
 
 def _summarize_action(action: str, args: Dict[str, Any]) -> str:

--- a/tools/computer_use_tool.py
+++ b/tools/computer_use_tool.py
@@ -12,6 +12,7 @@ from tools.computer_use.tool import (
     check_computer_use_requirements,
     handle_computer_use,
     release_computer_use_session,
+    reset_approval_callback,
     set_approval_callback,
 )
 from tools.registry import registry


### PR DESCRIPTION
## What does this PR do?

Closes the fail-open approval default in `computer_use`'s `_request_approval()` (#87724): when no approval prompt is wired for the current execution context, destructive actions (click, type, drag, key, …) used to run with zero confirmation — the comment claimed an outer gateway layer handled approval, but `tools/approval.py` never referenced `computer_use` and no such layer exists.

With no wired callback, destructive actions now escalate through the repository's normal human-approval gate (`tools.approval.request_tool_approval`):

- gateway sessions get the standard approval round-trip (embed + buttons, timeout fail-closed);
- cron jobs honor `approvals.cron_mode` (default deny);
- single-query (`-q`) sessions honor `approvals.single_query_mode`;
- a context with no possible responder fails closed with `code: approval_unavailable` — silence is not consent.

Grant scoping: the gate's `rule_key` embeds the approving session key (`computer_use:<session_key>:<cu_session_id>:<action>:<delivery>`), so an "Always" answered in an interactive session is scoped to that session and cannot authorize a cron/single-query/headless context that reuses the same computer_use `session_id`. This deliberately sidesteps the shared-gate ordering defect tracked in #61064 instead of widening it; computer_use's own `_always_allow` / `_session_auto_approve` semantics are unchanged.

Callback ownership: `set_approval_callback` stores the callback in a `ContextVar` (per execution context, not process-global) and returns a token for the new `reset_approval_callback()`. A headless context can no longer observe or drive another concurrent context's responder. This composes #81668 inline; if that PR lands first this commit rebases onto it cleanly.

Read-only actions (`capture`, `wait`, `list_apps`, `list_windows`) never reach the gate. The wired interactive CLI path is unchanged.

## Tests

- pristine state (no callback, no responder): destructive action fails closed with `approval_unavailable`, backend untouched (flipped isolation regression)
- concurrency: a callback-free context never invokes a concurrent context's responder and fails closed
- prior interactive grant → cron run still denied; prior interactive grant → single-query run still denied
- positive controls: a grant authorizes its own session
- local: `tests/tools/test_computer_use*.py`, `tests/computer_use/`, approval suites green on this head

Related: #87724 (defect), #87764 (competing carrier — reviewed; this PR takes the shared-gate route with session-scoped grants), #81668 (callback ownership, composed), #61064 (ordering defect, deliberately sidestepped).

Supersedes the earlier hard-deny iteration of this branch after review.
