### PR TITLE
fix(terminal): detect host binds declared via docker_extra_args

### DIFF
--- a/contributors/emails/dewoller@gmail.com
+++ b/contributors/emails/dewoller@gmail.com
@@ -1,0 +1,1 @@
+dewoller

--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -358,6 +358,52 @@ class TestDockerHostBindApproval:
         assert _tt_mod._docker_has_host_access(
             {"env_type": "modal", "docker_volumes": ["/tmp:/x"]}) is False
 
+    def test_docker_extra_args_host_bind_detected(self):
+        """Host binds expressed as raw docker args also disable the fast path.
+
+        ``docker_extra_args`` is forwarded to ``docker run`` verbatim, so
+        ``-v /host:/c`` mounts exactly what a ``docker_volumes`` entry would.
+        Reading only ``docker_volumes`` lets the identical mount arrive with the
+        approval fast-path still armed, which is the case this guard exists to
+        prevent.
+        """
+        # -v with a host path -> host access.
+        assert _tt_mod._docker_has_host_access(
+            {"env_type": "docker", "docker_volumes": [],
+             "docker_extra_args": ["-v", "/srv/data:/srv/data"]}) is True
+        # --volume long form -> host access.
+        assert _tt_mod._docker_has_host_access(
+            {"env_type": "docker", "docker_volumes": [],
+             "docker_extra_args": ["--volume", "/tmp:/hosttmp"]}) is True
+        # --volume=... joined form -> host access.
+        assert _tt_mod._docker_has_host_access(
+            {"env_type": "docker", "docker_volumes": [],
+             "docker_extra_args": ["--volume=/tmp:/hosttmp"]}) is True
+        # --mount type=bind -> host access.
+        assert _tt_mod._docker_has_host_access(
+            {"env_type": "docker", "docker_volumes": [],
+             "docker_extra_args": ["--mount", "type=bind,source=/etc,target=/etc"]}) is True
+        # Named volume via -v -> not host access.
+        assert _tt_mod._docker_has_host_access(
+            {"env_type": "docker", "docker_volumes": [],
+             "docker_extra_args": ["-v", "myvol:/data"]}) is False
+        # --mount type=volume -> not host access.
+        assert _tt_mod._docker_has_host_access(
+            {"env_type": "docker", "docker_volumes": [],
+             "docker_extra_args": ["--mount", "type=volume,source=myvol,target=/data"]}) is False
+        # Unrelated args -> not host access.
+        assert _tt_mod._docker_has_host_access(
+            {"env_type": "docker", "docker_volumes": [],
+             "docker_extra_args": ["--network", "none"]}) is False
+        # A trailing flag with no value must not IndexError.
+        assert _tt_mod._docker_has_host_access(
+            {"env_type": "docker", "docker_volumes": [],
+             "docker_extra_args": ["-v"]}) is False
+        # Non-list config value must not raise.
+        assert _tt_mod._docker_has_host_access(
+            {"env_type": "docker", "docker_volumes": [],
+             "docker_extra_args": None}) is False
+
     def test_should_skip_container_guards(self):
         """Docker skips only when isolated; other sandboxes always skip."""
         import tools.approval as A

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -372,13 +372,61 @@ def _docker_volume_uses_host_path(volume_spec: str) -> bool:
     )
 
 
+def _docker_mount_spec_uses_host_path(spec: Any) -> bool:
+    """Return True when a ``--mount`` spec bind-mounts a host path.
+
+    Docker defaults ``type`` to ``volume``, so an omitted type is NOT a bind.
+    Only ``type=bind`` reaches host state; named volumes and tmpfs do not.
+    """
+    if not isinstance(spec, str):
+        return False
+    fields = {}
+    for part in spec.split(","):
+        if "=" in part:
+            key, _, value = part.partition("=")
+            fields[key.strip().lower()] = value.strip()
+    if fields.get("type", "volume").lower() != "bind":
+        return False
+    return _docker_volume_uses_host_path(fields.get("source") or fields.get("src") or "")
+
+
+def _docker_extra_args_use_host_path(extra_args: Any) -> bool:
+    """Return True when raw ``docker run`` args bind-mount a host path.
+
+    ``docker_extra_args`` is forwarded to ``docker run`` verbatim, so a ``-v``
+    or ``--mount`` here mounts exactly what a ``docker_volumes`` entry would.
+    Both have to be read: otherwise the same host bind arrives with the
+    approval fast-path still armed, which is what this guard exists to stop.
+    """
+    if not isinstance(extra_args, (list, tuple)):
+        return False
+    args = [a for a in extra_args if isinstance(a, str)]
+    for i, arg in enumerate(args):
+        nxt = args[i + 1] if i + 1 < len(args) else ""
+        if arg in ("-v", "--volume"):
+            if _docker_volume_uses_host_path(nxt):
+                return True
+        elif arg.startswith("--volume="):
+            if _docker_volume_uses_host_path(arg.partition("=")[2]):
+                return True
+        elif arg == "--mount":
+            if _docker_mount_spec_uses_host_path(nxt):
+                return True
+        elif arg.startswith("--mount="):
+            if _docker_mount_spec_uses_host_path(arg.partition("=")[2]):
+                return True
+    return False
+
+
 def _docker_has_host_access(config: Dict[str, Any]) -> bool:
     """Return True when a Docker sandbox exposes host paths through bind mounts."""
     if config.get("env_type") != "docker":
         return False
     if config.get("host_cwd") and config.get("docker_mount_cwd_to_workspace"):
         return True
-    return any(_docker_volume_uses_host_path(vol) for vol in config.get("docker_volumes", []))
+    if any(_docker_volume_uses_host_path(vol) for vol in config.get("docker_volumes", [])):
+        return True
+    return _docker_extra_args_use_host_path(config.get("docker_extra_args", []))
 
 
 def _check_all_guards(command: str, env_type: str,


### PR DESCRIPTION
## What does this PR do?

`_docker_has_host_access()` decides whether a Docker session keeps the approval
fast-path. It reads `docker_mount_cwd_to_workspace` and `docker_volumes` — but not
`docker_extra_args`, which is forwarded to `docker run` verbatim. So `-v /host:/c`
declared there mounts exactly what a `docker_volumes` entry would, while the
function still reports the container as isolated.

Consequence: `_should_skip_container_guards()` short-circuits
`check_dangerous_command()` before its hardline floor, so `rm -rf` against a
bind-mounted host path runs unprompted. Both call sites inherit it — the terminal
guard and the `execute_code` guard, which #54483 wired to the same signal
deliberately.

**This does not propose changing the security model.** It makes the existing one
answer truthfully. On #42750 the maintainer stated the contract directly:

> `tools/approval.py` intentionally retains the fast path for isolated Docker,
> Singularity, Modal, and Daytona backends; Docker exits that path when
> `has_host_access` is true.

A container with a host bind declared via `docker_extra_args` *is* host-exposed
and should exit the fast path. Today it does not. The isolated-container contract
is untouched — an isolated container still takes the fast path.

Per SECURITY.md §2.4 the approval gate is a heuristic, not a boundary, so this is
filed as a normal correctness fix rather than through the private security
channel. It is a config-introspection bug, not a boundary claim.

**Not a deliberate exclusion.** `docker_extra_args` shipped in `ebf2ea584a`
(2026-05-10), seven weeks before the guard in `9860d93f2a` (2026-06-28), whose
message states the general goal "Detect host bind mounts" and then enumerates
only the two mechanisms it covered. `docker_extra_args` is not mentioned anywhere
in that commit, including as an exclusion.

## Relationship to #77666

Adjacent but orthogonal, and worth reading together:

- **#77666** teaches `_docker_volume_uses_host_path()` to parse long-form
  `--mount` syntax inside **`docker_volumes`**.
- **This PR** makes a different config key — **`docker_extra_args`** — get
  inspected at all.

Both touch `--mount` parsing, so they will conflict textually. I am happy to
rebase onto #77666 and reuse its parser rather than carry a second one — say the
word and I will restructure. If #77666 lands first, the `_docker_mount_spec_uses_host_path`
helper here should collapse into theirs.

## Related Issue

No existing issue. Found while auditing a deployment that pins its vault mount
through `docker_volumes` specifically to keep this guard armed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py` — added `_docker_extra_args_use_host_path()` and
  `_docker_mount_spec_uses_host_path()`; `_docker_has_host_access()` now also
  consults `docker_extra_args`.
- `tests/tools/test_modal_sandbox_fixes.py` — added
  `test_docker_extra_args_host_bind_detected` to the existing
  `TestDockerHostBindApproval` class.
- `contributors/emails/dewoller@gmail.com` — attribution mapping for the
  Contributor Attribution Check.

Parses `-v`, `--volume`, `--volume=`, `--mount` and `--mount=`. `--mount` honours
Docker's default of `type=volume`, so only an explicit `type=bind` counts as host
access — a named volume keeps the fast path.

## How to Test

1. Before the change:
   ```python
   from tools.terminal_tool import _docker_has_host_access
   _docker_has_host_access({"env_type": "docker", "docker_volumes": [],
                            "docker_extra_args": ["-v", "/srv/data:/srv/data"]})
   # -> False   (host bind, but reported isolated)
   ```
2. After the change the same call returns `True`, so
   `_should_skip_container_guards("docker", has_host_access=True)` is `False` and
   the command goes through the normal approval flow.
3. `pytest tests/tools/test_modal_sandbox_fixes.py::TestDockerHostBindApproval -q`

Negative coverage included: named volumes, `type=volume`, unrelated flags, a
trailing `-v` with no value, and a non-list config value.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — see the #77666 note above
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6), Python 3.11

On the full-suite item, being precise rather than ticking it: I ran
`tests/tools/test_modal_sandbox_fixes.py`, `test_container_cwd_sanitize.py`,
`test_file_tools_container_config.py`, `test_approved_command_clean_slate.py`,
`test_code_execution*.py`, `test_sandbox_failure_hints.py` and `tests/deploy/`
— 181 passed, 2 xfailed. The complete `tests/tools/` run wedged locally on
Docker/network-dependent tests, and it surfaced one failure,
`test_approval.py::TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`,
which reproduces identically with this patch fully reverted — pre-existing and
unrelated. CI is the authority here, not my laptop.

### Documentation & Housekeeping

- [x] Documentation — N/A (internal helper; no user-facing config change)
- [x] `cli-config.yaml.example` — N/A (no new config keys; `docker_extra_args` already exists)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact considered — pure string parsing; Windows drive paths
      already handled by the existing `_docker_volume_uses_host_path`, which this reuses
- [x] Tool descriptions/schemas — N/A (no tool behavior change beyond correctly
      prompting where it previously did not)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
