### PR TITLE
fix(cli): keep `hermes update --branch` on the requested branch when already up to date

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3733,6 +3733,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # minutes on a non-single-branch checkout. Fetch only what we update
         # against.
         branch = _m()._resolve_update_branch(args)
+        # An explicit `--branch NAME` is a request to land on that branch, not
+        # merely to fast-forward it. Track that intent so the "already up to
+        # date" early-return below does not switch the checkout back to whatever
+        # branch the user happened to start on.
+        branch_explicit = bool(getattr(args, "branch", None))
 
         print("→ Fetching updates...")
         fetch_result = subprocess.run(
@@ -3849,7 +3854,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     prompt_user=prompt_for_restore,
                     input_fn=gw_input_fn,
                 )
-            if current_branch not in {branch, "HEAD"}:
+            if current_branch not in {branch, "HEAD"} and not branch_explicit:
                 subprocess.run(
                     git_cmd + ["checkout", current_branch],
                     cwd=_m().PROJECT_ROOT,
@@ -3919,6 +3924,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
+            elif branch_explicit and current_branch != branch:
+                print(f"✓ Already up to date — now on '{branch}'.")
             else:
                 print("✓ Already up to date!")
             if runtime_repaired is not None and not _m()._is_windows():


### PR DESCRIPTION
## The Problem

`hermes update --branch NAME` updates against a non-default branch and switches the checkout to it (auto-stashing as needed). However, on the "already up to date" early-return path the command unconditionally switched the working tree *back* to whatever branch the user was on before the update. The net effect: when the requested branch happened to be up to date, `hermes update --branch NAME` silently undid the branch switch the user explicitly asked for, leaving them on their original branch with no indication of what happened.

## The Solution

Record whether `--branch` was passed explicitly and honor that intent on the up-to-date path:

- Skip the "restore the previous branch" checkout when the branch was named explicitly, so the checkout stays on the requested branch.
- Emit a clear confirmation (`Already up to date — now on '<branch>'`) so the resulting branch is never ambiguous.

The change is confined to the up-to-date early-return in the update command; the normal fetch/merge path and the default (no `--branch`) behavior are unchanged. The diff is 9 lines in a single file.

## Why this matters

`--branch` is only useful if the checkout actually lands on the requested branch. Reverting HEAD on the up-to-date path made the flag behave inconsistently depending on whether new commits happened to be present — the same command left the user on different branches for reasons unrelated to their request. Honoring the explicit branch on every path makes `--branch` predictable and its outcome self-evident from the command's output.