### PR TITLE
feat(cli): add `hermes update --merge-ref` to merge one upstream ref

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5058,6 +5058,7 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _leftover_pausable_gateway_pids,
     _log_only_write,
     _mark_skip_upstream_prompt,
+    _merge_upstream_ref,
     _npm_bin_exists,
     _npm_lockfile_changed,
     _npm_manifest_paths,

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -25,7 +25,11 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Gateway mode: use file-based IPC for prompts instead of stdin (used internally by /update)",
     )
-    update_parser.add_argument(
+    # --check (read-only status) and --merge-ref (apply-path ref/tag merge)
+    # are mutually exclusive — argparse rejects both at parse time rather than
+    # requiring runtime validation.
+    _check_or_merge_ref = update_parser.add_mutually_exclusive_group()
+    _check_or_merge_ref.add_argument(
         "--check",
         action="store_true",
         default=False,
@@ -59,6 +63,18 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
             "If the local checkout is on a different branch, hermes will "
             "switch to the requested branch first (auto-stashing any "
             "uncommitted changes)."
+        ),
+    )
+    _check_or_merge_ref.add_argument(
+        "--merge-ref",
+        default=None,
+        metavar="TAG_OR_REF",
+        help=(
+            "Merge this single tag or ref from the 'upstream' remote into the "
+            "current fork branch (fetch upstream <ref>, then merge the "
+            "resolved commit; runs even when origin has no new commits). "
+            "Fails closed on conflict: HEAD is restored to its exact "
+            "pre-update state and no install/dependency step runs."
         ),
     )
     update_parser.add_argument(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3734,6 +3734,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # against.
         branch = _m()._resolve_update_branch(args)
 
+        # One explicit tag/ref to merge from the fixed `upstream` remote,
+        # independent of the origin/<branch> pull below. Empty string (argparse
+        # default when unset) normalizes to None. This is not a general
+        # refs/remotes framework — a single fixed remote, one explicit ref per
+        # invocation.
+        merge_ref = str(getattr(args, "merge_ref", None) or "").strip() or None
+
         print("→ Fetching updates...")
         fetch_result = subprocess.run(
             git_cmd + ["fetch", "origin", branch],
@@ -3833,7 +3840,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
         commit_count = int(result.stdout.strip())
 
-        if commit_count == 0:
+        # An explicit --merge-ref must never be swallowed by the "Already up to
+        # date!" early-return below — that path is scoped to the origin/<branch>
+        # comparison and says nothing about whether the requested upstream ref
+        # is merged.
+        if commit_count == 0 and not merge_ref:
             _invalidate_update_cache()
 
             # Even if origin is up to date, the fork may be behind upstream
@@ -3934,7 +3945,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
             return
 
-        print(f"→ Found {commit_count} new commit(s)")
+        if commit_count:
+            print(f"→ Found {commit_count} new commit(s)")
+        else:
+            # commit_count == 0 only reaches here via the merge_ref bypass
+            # above — origin/<branch> is current, but --merge-ref still runs.
+            print(f"→ origin/{branch} is current; proceeding with --merge-ref {merge_ref}")
 
         print("→ Pulling updates...")
         update_succeeded = False
@@ -3978,6 +3994,96 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
                     )
                     sys.exit(1)
+
+            # Explicit --merge-ref. Independent of the origin/<branch> ff-only
+            # merge above — runs whether or not that merge had any new commits
+            # (reachability bypass above). `branch` stays checked out; the ref
+            # merges INTO it, HEAD is never detached.
+            if merge_ref:
+                print(f"→ Fetching '{merge_ref}' from upstream...")
+                merge_ref_fetch = subprocess.run(
+                    git_cmd + ["fetch", "upstream", merge_ref],
+                    cwd=_m().PROJECT_ROOT,
+                    capture_output=True,
+                    text=True, encoding="utf-8", errors="replace",
+                )
+                if merge_ref_fetch.returncode != 0:
+                    print(f"✗ Failed to fetch '{merge_ref}' from upstream.")
+                    stderr = merge_ref_fetch.stderr.strip()
+                    if stderr:
+                        print(f"  {stderr.splitlines()[0]}")
+                    if pre_pull_sha:
+                        subprocess.run(
+                            git_cmd + ["reset", "--hard", pre_pull_sha],
+                            cwd=_m().PROJECT_ROOT,
+                            capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                        )
+                    sys.exit(1)
+
+                # `^{commit}` is required (not just FETCH_HEAD) because the
+                # ref may be an annotated tag — the merge-base --is-ancestor
+                # check needs the actual commit SHA, not the tag object.
+                resolve_result = subprocess.run(
+                    git_cmd + ["rev-parse", "FETCH_HEAD^{commit}"],
+                    cwd=_m().PROJECT_ROOT,
+                    capture_output=True,
+                    text=True, encoding="utf-8", errors="replace",
+                )
+                if resolve_result.returncode != 0:
+                    print(f"✗ Could not resolve '{merge_ref}' to a commit.")
+                    if pre_pull_sha:
+                        subprocess.run(
+                            git_cmd + ["reset", "--hard", pre_pull_sha],
+                            cwd=_m().PROJECT_ROOT,
+                            capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                        )
+                    sys.exit(1)
+                merge_ref_sha = resolve_result.stdout.strip()
+
+                print(f"→ Merging '{merge_ref}' ({merge_ref_sha[:10]}) into {branch}...")
+                # --no-edit: this updater never has a human at the keyboard to
+                # write a merge-commit message (same non-interactivity
+                # assumption as every other git call in this function).
+                merge_ref_result = subprocess.run(
+                    git_cmd + ["merge", "--no-edit", merge_ref_sha],
+                    cwd=_m().PROJECT_ROOT,
+                    capture_output=True,
+                    text=True, encoding="utf-8", errors="replace",
+                )
+                if merge_ref_result.returncode != 0:
+                    # Fail-closed: abandon the in-progress merge, restore HEAD
+                    # to EXACTLY the pre-update SHA, and exit non-zero. Falling
+                    # through past this sys.exit would reach the install/
+                    # dependency steps further down, which must not happen.
+                    print(f"✗ Merging '{merge_ref}' produced conflicts — aborting.")
+                    stderr = merge_ref_result.stderr.strip()
+                    if stderr:
+                        print(f"  {stderr.splitlines()[0]}")
+                    subprocess.run(
+                        git_cmd + ["merge", "--abort"],
+                        cwd=_m().PROJECT_ROOT,
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                    )
+                    if pre_pull_sha:
+                        restore_result = subprocess.run(
+                            git_cmd + ["reset", "--hard", pre_pull_sha],
+                            cwd=_m().PROJECT_ROOT,
+                            capture_output=True,
+                            text=True, encoding="utf-8", errors="replace",
+                        )
+                        if restore_result.returncode == 0:
+                            print(f"  ✓ Restored pre-update HEAD ({pre_pull_sha[:10]}).")
+                        else:
+                            print("  ✗ Failed to restore pre-update HEAD. Recover manually with:")
+                            print(f"    cd {_m().PROJECT_ROOT} && git reset --hard {pre_pull_sha}")
+                    else:
+                        print("  Could not capture pre-pull SHA — recover manually with:")
+                        print(f"    cd {_m().PROJECT_ROOT} && git reflog && git reset --hard <prev-sha>")
+                    sys.exit(1)
+                print(f"✓ Merged '{merge_ref}' into {branch}.")
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -171,7 +171,16 @@ def _merge_upstream_ref(git_cmd, project_root, merge_ref, branch, pre_pull_sha) 
     pre-update state), and the function returns ``False`` so the caller can
     abort before any install/dependency step runs. Returns ``True`` only when
     the ref merged cleanly.
+
+    Because that restore rewinds to the state before the whole update, it also
+    rolls back any ``origin/<branch>`` merge that landed earlier in the same
+    run; the conflict path says so explicitly and points the user at a re-run.
     """
+    # HEAD as it stands on entry — i.e. AFTER any origin/<branch> pull earlier
+    # in this run. If a conflict later forces a restore to pre_pull_sha,
+    # comparing against this tells us whether that restore also rolled back an
+    # origin update the user might expect to have survived.
+    head_before = _capture_head_sha(git_cmd, project_root)
     print(f"→ Fetching '{merge_ref}' from upstream...")
     merge_ref_fetch = subprocess.run(
         git_cmd + ["fetch", "upstream", merge_ref],
@@ -248,6 +257,15 @@ def _merge_upstream_ref(git_cmd, project_root, merge_ref, branch, pre_pull_sha) 
             )
             if restore_result.returncode == 0:
                 print(f"  ✓ Restored pre-update HEAD ({pre_pull_sha[:10]}).")
+                if head_before and head_before != pre_pull_sha:
+                    # The restore rewound past an origin/<branch> update that
+                    # landed earlier in this same run — tell the user so they
+                    # don't assume it survived the merge-ref abort.
+                    print(
+                        f"  Note: an origin/{branch} update pulled earlier in "
+                        "this run was rolled back too — re-run 'hermes update' "
+                        "to re-apply it."
+                    )
             else:
                 print("  ✗ Failed to restore pre-update HEAD. Recover manually with:")
                 print(f"    cd {project_root} && git reset --hard {pre_pull_sha}")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -159,6 +159,106 @@ def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]
     return True, None, None
 
 
+def _merge_upstream_ref(git_cmd, project_root, merge_ref, branch, pre_pull_sha) -> bool:
+    """Fetch one ref/tag from the fixed ``upstream`` remote and merge it into ``branch``.
+
+    Independent of the ``origin/<branch>`` fast-forward pull: runs whether or
+    not that pull had new commits. ``branch`` stays checked out — the ref is
+    merged INTO it, HEAD is never detached.
+
+    Fails closed: on a fetch/resolve error or a merge conflict the in-progress
+    merge is aborted and HEAD is restored to EXACTLY ``pre_pull_sha`` (the
+    pre-update state), and the function returns ``False`` so the caller can
+    abort before any install/dependency step runs. Returns ``True`` only when
+    the ref merged cleanly.
+    """
+    print(f"→ Fetching '{merge_ref}' from upstream...")
+    merge_ref_fetch = subprocess.run(
+        git_cmd + ["fetch", "upstream", merge_ref],
+        cwd=project_root,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+    if merge_ref_fetch.returncode != 0:
+        print(f"✗ Failed to fetch '{merge_ref}' from upstream.")
+        stderr = merge_ref_fetch.stderr.strip()
+        if stderr:
+            print(f"  {stderr.splitlines()[0]}")
+        if pre_pull_sha:
+            subprocess.run(
+                git_cmd + ["reset", "--hard", pre_pull_sha],
+                cwd=project_root,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+            )
+        return False
+
+    # `^{commit}` is required (not just FETCH_HEAD) because the
+    # ref may be an annotated tag — the merge-base --is-ancestor
+    # check needs the actual commit SHA, not the tag object.
+    resolve_result = subprocess.run(
+        git_cmd + ["rev-parse", "FETCH_HEAD^{commit}"],
+        cwd=project_root,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+    if resolve_result.returncode != 0:
+        print(f"✗ Could not resolve '{merge_ref}' to a commit.")
+        if pre_pull_sha:
+            subprocess.run(
+                git_cmd + ["reset", "--hard", pre_pull_sha],
+                cwd=project_root,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+            )
+        return False
+    merge_ref_sha = resolve_result.stdout.strip()
+
+    print(f"→ Merging '{merge_ref}' ({merge_ref_sha[:10]}) into {branch}...")
+    # --no-edit: this updater never has a human at the keyboard to
+    # write a merge-commit message (same non-interactivity
+    # assumption as every other git call in this function).
+    merge_ref_result = subprocess.run(
+        git_cmd + ["merge", "--no-edit", merge_ref_sha],
+        cwd=project_root,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+    if merge_ref_result.returncode != 0:
+        # Fail-closed: abandon the in-progress merge, restore HEAD
+        # to EXACTLY the pre-update SHA, and return False. Falling
+        # through would reach the install/dependency steps in the
+        # caller, which must not happen on a conflicted merge.
+        print(f"✗ Merging '{merge_ref}' produced conflicts — aborting.")
+        stderr = merge_ref_result.stderr.strip()
+        if stderr:
+            print(f"  {stderr.splitlines()[0]}")
+        subprocess.run(
+            git_cmd + ["merge", "--abort"],
+            cwd=project_root,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if pre_pull_sha:
+            restore_result = subprocess.run(
+                git_cmd + ["reset", "--hard", pre_pull_sha],
+                cwd=project_root,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+            )
+            if restore_result.returncode == 0:
+                print(f"  ✓ Restored pre-update HEAD ({pre_pull_sha[:10]}).")
+            else:
+                print("  ✗ Failed to restore pre-update HEAD. Recover manually with:")
+                print(f"    cd {project_root} && git reset --hard {pre_pull_sha}")
+        else:
+            print("  Could not capture pre-pull SHA — recover manually with:")
+            print(f"    cd {project_root} && git reflog && git reset --hard <prev-sha>")
+        return False
+    print(f"✓ Merged '{merge_ref}' into {branch}.")
+    return True
+
+
 # Modules imported on every agent startup. Unlike _UPDATE_CRITICAL_FILES (which
 # is only parsed), these are actually *imported* so that cross-module breakage
 # is caught — a file can be syntactically perfect and still fail to import
@@ -3997,93 +4097,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             # Explicit --merge-ref. Independent of the origin/<branch> ff-only
             # merge above — runs whether or not that merge had any new commits
-            # (reachability bypass above). `branch` stays checked out; the ref
-            # merges INTO it, HEAD is never detached.
-            if merge_ref:
-                print(f"→ Fetching '{merge_ref}' from upstream...")
-                merge_ref_fetch = subprocess.run(
-                    git_cmd + ["fetch", "upstream", merge_ref],
-                    cwd=_m().PROJECT_ROOT,
-                    capture_output=True,
-                    text=True, encoding="utf-8", errors="replace",
-                )
-                if merge_ref_fetch.returncode != 0:
-                    print(f"✗ Failed to fetch '{merge_ref}' from upstream.")
-                    stderr = merge_ref_fetch.stderr.strip()
-                    if stderr:
-                        print(f"  {stderr.splitlines()[0]}")
-                    if pre_pull_sha:
-                        subprocess.run(
-                            git_cmd + ["reset", "--hard", pre_pull_sha],
-                            cwd=_m().PROJECT_ROOT,
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                        )
-                    sys.exit(1)
-
-                # `^{commit}` is required (not just FETCH_HEAD) because the
-                # ref may be an annotated tag — the merge-base --is-ancestor
-                # check needs the actual commit SHA, not the tag object.
-                resolve_result = subprocess.run(
-                    git_cmd + ["rev-parse", "FETCH_HEAD^{commit}"],
-                    cwd=_m().PROJECT_ROOT,
-                    capture_output=True,
-                    text=True, encoding="utf-8", errors="replace",
-                )
-                if resolve_result.returncode != 0:
-                    print(f"✗ Could not resolve '{merge_ref}' to a commit.")
-                    if pre_pull_sha:
-                        subprocess.run(
-                            git_cmd + ["reset", "--hard", pre_pull_sha],
-                            cwd=_m().PROJECT_ROOT,
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                        )
-                    sys.exit(1)
-                merge_ref_sha = resolve_result.stdout.strip()
-
-                print(f"→ Merging '{merge_ref}' ({merge_ref_sha[:10]}) into {branch}...")
-                # --no-edit: this updater never has a human at the keyboard to
-                # write a merge-commit message (same non-interactivity
-                # assumption as every other git call in this function).
-                merge_ref_result = subprocess.run(
-                    git_cmd + ["merge", "--no-edit", merge_ref_sha],
-                    cwd=_m().PROJECT_ROOT,
-                    capture_output=True,
-                    text=True, encoding="utf-8", errors="replace",
-                )
-                if merge_ref_result.returncode != 0:
-                    # Fail-closed: abandon the in-progress merge, restore HEAD
-                    # to EXACTLY the pre-update SHA, and exit non-zero. Falling
-                    # through past this sys.exit would reach the install/
-                    # dependency steps further down, which must not happen.
-                    print(f"✗ Merging '{merge_ref}' produced conflicts — aborting.")
-                    stderr = merge_ref_result.stderr.strip()
-                    if stderr:
-                        print(f"  {stderr.splitlines()[0]}")
-                    subprocess.run(
-                        git_cmd + ["merge", "--abort"],
-                        cwd=_m().PROJECT_ROOT,
-                        capture_output=True,
-                        text=True, encoding="utf-8", errors="replace",
-                    )
-                    if pre_pull_sha:
-                        restore_result = subprocess.run(
-                            git_cmd + ["reset", "--hard", pre_pull_sha],
-                            cwd=_m().PROJECT_ROOT,
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                        )
-                        if restore_result.returncode == 0:
-                            print(f"  ✓ Restored pre-update HEAD ({pre_pull_sha[:10]}).")
-                        else:
-                            print("  ✗ Failed to restore pre-update HEAD. Recover manually with:")
-                            print(f"    cd {_m().PROJECT_ROOT} && git reset --hard {pre_pull_sha}")
-                    else:
-                        print("  Could not capture pre-pull SHA — recover manually with:")
-                        print(f"    cd {_m().PROJECT_ROOT} && git reflog && git reset --hard <prev-sha>")
-                    sys.exit(1)
-                print(f"✓ Merged '{merge_ref}' into {branch}.")
+            # (reachability bypass above). Fails closed (restores pre_pull_sha)
+            # and returns False on a fetch/resolve error or conflict, so we must
+            # not fall through to the install/dependency steps below.
+            if merge_ref and not _merge_upstream_ref(
+                git_cmd, _m().PROJECT_ROOT, merge_ref, branch, pre_pull_sha
+            ):
+                sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/tests/hermes_cli/test_update_merge_ref.py
+++ b/tests/hermes_cli/test_update_merge_ref.py
@@ -93,7 +93,7 @@ def _setup(root: Path):
     return project, branch, pre_pull_sha
 
 
-def test_conflict_aborts_and_restores_pre_pull_sha(tmp_path):
+def test_conflict_aborts_and_restores_pre_pull_sha(tmp_path, capsys):
     project, branch, pre_pull_sha = _setup(tmp_path)
 
     result = _merge_upstream_ref(GIT, str(project), branch, branch, pre_pull_sha)
@@ -107,6 +107,23 @@ def test_conflict_aborts_and_restores_pre_pull_sha(tmp_path):
     assert not (project / ".git" / "MERGE_HEAD").exists()
     # The project's own version survived; upstream's change was not applied.
     assert (project / "shared.txt").read_text() == "project change\n"
+    # HEAD was already at pre_pull_sha (origin did not advance this run), so
+    # the origin-rollback note must NOT be printed.
+    assert "rolled back too" not in capsys.readouterr().out
+
+
+def test_conflict_note_when_origin_update_is_also_rolled_back(tmp_path, capsys):
+    project, branch, _project_head = _setup(tmp_path)
+    # Simulate an origin/<branch> update that advanced HEAD earlier in the same
+    # run: the pre-update SHA is the ancestor, so restoring to it also rewinds
+    # the "project change" commit — the helper must flag that to the user.
+    ancestor = _git(["rev-parse", "HEAD~1"], project).stdout.strip()
+
+    result = _merge_upstream_ref(GIT, str(project), branch, branch, ancestor)
+
+    assert result is False
+    assert _git(["rev-parse", "HEAD"], project).stdout.strip() == ancestor
+    assert "rolled back too" in capsys.readouterr().out
 
 
 def test_clean_merge_of_annotated_tag_succeeds(tmp_path):

--- a/tests/hermes_cli/test_update_merge_ref.py
+++ b/tests/hermes_cli/test_update_merge_ref.py
@@ -1,0 +1,123 @@
+"""Tests for ``_merge_upstream_ref`` — the ``hermes update --merge-ref`` core.
+
+``--merge-ref TAG_OR_REF`` fetches one ref/tag from the fixed ``upstream``
+remote and merges it into the current fork branch, independent of the
+``origin/<branch>`` pull. Its contract is fail-closed: a conflict must abort
+the in-progress merge and restore HEAD to EXACTLY the pre-update SHA so no
+install/dependency step ever runs on a half-merged tree.
+
+These tests drive the real helper against real temporary git repositories
+(no fake-git monkeypatching), so the fetch → resolve → merge → abort → restore
+chain is exercised end to end. The annotated-tag case also covers the
+``FETCH_HEAD^{commit}`` peel leg that a lightweight-ref test would miss.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.update_cmd import _merge_upstream_ref
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git binary required for merge-ref tests"
+)
+
+GIT = ["git"]
+
+
+def _git(args, cwd, check=True):
+    return subprocess.run(
+        GIT + args,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=check,
+    )
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init"], path)
+    # Local identity + no signing so this runs on a bare CI box with no global
+    # git config and no GPG key.
+    _git(["config", "user.email", "test@example.com"], path)
+    _git(["config", "user.name", "Test"], path)
+    _git(["config", "commit.gpgsign", "false"], path)
+
+
+def _commit(path: Path, relpath: str, content: str, message: str) -> str:
+    (path / relpath).write_text(content)
+    _git(["add", relpath], path)
+    _git(["commit", "-m", message], path)
+    return _git(["rev-parse", "HEAD"], path).stdout.strip()
+
+
+def _setup(root: Path):
+    """Build a project repo with an ``upstream`` remote offering two refs.
+
+    Returns ``(project, branch, pre_pull_sha)`` where the project has diverged
+    from a shared base on ``shared.txt``. The ``upstream`` remote carries:
+      * its default branch — diverged on the SAME line (merges → conflict);
+      * annotated tag ``v-clean`` — a base-rooted commit that only ADDS a file
+        (merges → clean, and forces the annotated-tag peel).
+    """
+    project = root / "project"
+    _init_repo(project)
+    base_sha = _commit(project, "shared.txt", "base\n", "base")
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], project).stdout.strip()
+
+    # upstream = clone of project@base (guarantees a common ancestor)
+    upstream = root / "upstream"
+    _git(["clone", str(project), str(upstream)], root)
+    _git(["config", "user.email", "up@example.com"], upstream)
+    _git(["config", "user.name", "Up"], upstream)
+    _git(["config", "commit.gpgsign", "false"], upstream)
+
+    # A base-rooted, non-conflicting commit → annotated tag v-clean.
+    _git(["checkout", "-b", "cleanwork", base_sha], upstream)
+    _commit(upstream, "newfile.txt", "clean\n", "clean add")
+    _git(["tag", "-a", "v-clean", "-m", "clean ref"], upstream)
+    # Upstream's default branch diverges on shared.txt (conflict material).
+    _git(["checkout", branch], upstream)
+    _commit(upstream, "shared.txt", "upstream change\n", "upstream conflict")
+
+    # Project diverges on the same line, then wires the upstream remote.
+    _git(["remote", "add", "upstream", str(upstream)], project)
+    pre_pull_sha = _commit(project, "shared.txt", "project change\n", "project change")
+    return project, branch, pre_pull_sha
+
+
+def test_conflict_aborts_and_restores_pre_pull_sha(tmp_path):
+    project, branch, pre_pull_sha = _setup(tmp_path)
+
+    result = _merge_upstream_ref(GIT, str(project), branch, branch, pre_pull_sha)
+
+    assert result is False
+    # HEAD restored to EXACTLY the pre-update SHA.
+    assert _git(["rev-parse", "HEAD"], project).stdout.strip() == pre_pull_sha
+    # Working tree clean — no lingering conflict markers / staged state.
+    assert _git(["status", "--porcelain"], project).stdout.strip() == ""
+    # No merge left in progress.
+    assert not (project / ".git" / "MERGE_HEAD").exists()
+    # The project's own version survived; upstream's change was not applied.
+    assert (project / "shared.txt").read_text() == "project change\n"
+
+
+def test_clean_merge_of_annotated_tag_succeeds(tmp_path):
+    project, branch, pre_pull_sha = _setup(tmp_path)
+
+    result = _merge_upstream_ref(GIT, str(project), "v-clean", branch, pre_pull_sha)
+
+    assert result is True
+    # A real 3-way merge happened (HEAD advanced past the pre-pull SHA).
+    assert _git(["rev-parse", "HEAD"], project).stdout.strip() != pre_pull_sha
+    assert _git(["status", "--porcelain"], project).stdout.strip() == ""
+    # Upstream's added file landed; the project's own line is preserved.
+    assert (project / "newfile.txt").read_text() == "clean\n"
+    assert (project / "shared.txt").read_text() == "project change\n"


### PR DESCRIPTION
## The Problem

`hermes update` only ever fast-forwards the local checkout against `origin/<branch>`. When `origin` has no new commits it prints "Already up to date!" and returns early. There is no supported way to pull in one specific ref or tag from the `upstream` remote and merge it into the current branch. Operators running Hermes as a fork therefore cannot land an exact upstream release into their branch through the built-in updater — they have to drop to raw git and reproduce the fetch, tag resolution, and merge by hand, without the updater's rollback safety net.

## The Solution

Add a `--merge-ref <tag-or-ref>` flag to `hermes update`:

- Fetches the single named ref or tag from the fixed `upstream` remote and merges the resolved commit into the currently checked-out branch. The branch stays checked out; the ref is merged into it and HEAD is never detached.
- Runs independently of the `origin/<branch>` fast-forward pull, so it still applies even when `origin` is already current — the "Already up to date" early-return no longer swallows the request.
- Is mutually exclusive with `--check`; argparse rejects both flags at parse time rather than relying on runtime validation.
- Resolves the ref via `FETCH_HEAD^{commit}` so an annotated tag merges the commit it points to, not the tag object.
- Fails closed on conflict: the in-progress merge is aborted, HEAD is reset to its exact pre-update SHA, and the command exits non-zero before any install or dependency step runs. If the restore itself fails, the exact recovery command is printed.

## Why this matters

The updater already understands fork checkouts (it detects a fork and can sync with `upstream`). `--merge-ref` closes the gap for that same audience: a fork operator can bring a chosen upstream ref or release tag into their branch with a single command and keep the updater's fail-closed rollback guarantees, instead of running the fetch-resolve-merge sequence manually and risking a half-applied or conflicted tree.