### PR TITLE
feat(agent): LLM-generated session handoff with insight extraction

### DIFF
--- a/agent/handoff.py
+++ b/agent/handoff.py
@@ -1,0 +1,506 @@
+"""Durable session handoff files for compaction and restarts.
+
+Handoffs are an operational continuity layer separate from the in-context
+compression summary: they are written to disk before context is discarded so a
+future continuation can recover goals, decisions, next steps, and changed files.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+from agent.insight_extraction import (
+    DURABLE_FACTS_PROMPT_SECTION as _DURABLE_FACTS_SECTION,
+    normalize_facts,
+    parse_facts_block,
+)
+
+logger = logging.getLogger(__name__)
+
+HANDOFFS_DIRNAME = "handoffs"
+_DEFAULT_EXCERPT_CHARS_PER_TOKEN = 4
+
+# Sentinel returned by _message_excerpt when a transcript has no usable text.
+# Exposed so callers (e.g. insight_extraction) can detect an empty excerpt by
+# identity instead of matching on a localized substring.
+EMPTY_EXCERPT_SENTINEL = "- No textual context available."
+
+
+def _safe_session_id(session_id: str | None) -> str:
+    raw = str(session_id or "unknown-session")
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw).strip("-._")
+    return safe or "unknown-session"
+
+
+def _handoffs_dir(hermes_home: str | Path | None = None) -> Path:
+    root = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    return root / HANDOFFS_DIRNAME
+
+
+def _stringify_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    try:
+        return json.dumps(content, ensure_ascii=False, default=str)
+    except Exception:
+        return str(content)
+
+
+def _message_excerpt(messages: Iterable[dict[str, Any]], *, max_messages: int = 40, max_chars: int = 12_000) -> str:
+    """Return an extractive transcript excerpt suitable for fallback handoffs."""
+    items = list(messages or [])
+    if len(items) > max_messages:
+        head = items[: max_messages // 4]
+        tail = items[-(max_messages - len(head)) :]
+        items = head + [{"role": "system", "content": "... middle messages omitted ..."}] + tail
+
+    lines: list[str] = []
+    used = 0
+    for msg in items:
+        role = msg.get("role", "unknown") if isinstance(msg, dict) else "unknown"
+        content = _stringify_content(msg.get("content") if isinstance(msg, dict) else msg).strip()
+        if not content and isinstance(msg, dict) and msg.get("tool_calls"):
+            content = f"tool_calls: {_stringify_content(msg.get('tool_calls'))}"
+        if not content:
+            continue
+        block = f"- **{role}:** {content}"
+        remaining = max_chars - used
+        if remaining <= 0:
+            break
+        if len(block) > remaining:
+            block = block[: max(0, remaining - 20)] + "… [truncated]"
+        lines.append(block)
+        used += len(block) + 1
+    return "\n".join(lines) or EMPTY_EXCERPT_SENTINEL
+
+
+def _write_latest_pointer(handoffs_dir: Path, target: Path) -> None:
+    latest = handoffs_dir / "latest.md"
+    try:
+        if latest.exists() or latest.is_symlink():
+            latest.unlink()
+        latest.symlink_to(target.name)
+    except Exception:
+        latest.write_text(target.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def _update_index(handoffs_dir: Path, entry: dict[str, Any]) -> None:
+    index_path = handoffs_dir / "index.json"
+    data: list[dict[str, Any]] = []
+    try:
+        raw = json.loads(index_path.read_text(encoding="utf-8"))
+        if isinstance(raw, list):
+            data = [x for x in raw if isinstance(x, dict)]
+    except Exception:
+        data = []
+
+    data = [x for x in data if x.get("session_id") != entry.get("session_id")]
+    data.append(entry)
+    index_path.write_text(
+        json.dumps(data[-500:], ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _gather_git_context(hermes_home: str | Path | None = None) -> str:
+    """Collect recent git log and status from the hermes home directory.
+
+    Returns a combined string of recent commits and status, or an empty
+    string on any failure (e.g. when the directory is not a git repository).
+    """
+    home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    parts: list[str] = []
+
+    try:
+        log_result = subprocess.run(
+            ["git", "log", "--oneline", "-20"],
+            capture_output=True,
+            text=True,
+            cwd=str(home),
+            timeout=10,
+        )
+        if log_result.returncode == 0 and log_result.stdout.strip():
+            parts.append("=== git log --oneline -20 ===")
+            parts.append(log_result.stdout.strip())
+    except Exception:
+        pass
+
+    try:
+        status_result = subprocess.run(
+            ["git", "status", "--short"],
+            capture_output=True,
+            text=True,
+            cwd=str(home),
+            timeout=10,
+        )
+        if status_result.returncode == 0 and status_result.stdout.strip():
+            parts.append("=== git status --short ===")
+            parts.append(status_result.stdout.strip())
+    except Exception:
+        pass
+
+    return "\n".join(parts)
+
+
+def _build_llm_handoff_prompt(
+    *,
+    safe_id: str,
+    now: str,
+    source_info: str,
+    model: str | None,
+    session_id: str | None,
+    reason: str,
+    git_context: str,
+    transcript_excerpt: str,
+) -> str:
+    """Build the LLM prompt for generating a structured handoff summary."""
+    return f"""Analyze the session transcript and git context below. Fill in EVERY section based on what actually happened. Do not write generic filler — only concrete facts.
+
+# Handoff: {safe_id}
+
+**Date:** {now}
+**Source:** {source_info}
+**Model:** {model or ''}
+**Session ID:** {session_id or ''}
+**Reason:** {reason}
+
+## Goal
+[1-2 sentences: what the user was trying to do]
+
+## Done
+- [x] [concrete task — what was completed]
+
+## In progress / Next steps
+- [ ] [task with file paths and specific areas]
+- [ ] [blocked tasks with an explanation]
+
+## Key decisions
+- **[Decision]**: [What was chosen] — [Why, including rejected alternatives]
+
+## Dead ends (do not repeat)
+- [Approach that did not work] — [Why]
+
+## Changed files
+- `path/to/file` — [what changed, one line]
+
+## Current state
+- **Tests/checks:** [status]
+- **Manual verification:** [what was verified]
+
+## Context for the next session
+[2-4 sentences: the most important things for the next agent]
+
+## Recommended first action
+[Exact command or step]
+{_DURABLE_FACTS_SECTION}
+
+---
+Git log:
+{git_context}
+
+Transcript:
+{transcript_excerpt}"""
+
+
+class HandoffLLMError(Exception):
+    """The auxiliary LLM could not produce a structured handoff.
+
+    Raised only in strict mode (e.g. an explicit manual handoff request). In
+    non-strict mode (auto-compaction) an LLM failure silently falls back to an
+    extractive handoff, which is a lossless raw record — not context loss — so no
+    error is surfaced. ``str(self)`` carries the (already-string) cause so a
+    caller can display it; callers should sanitize it before sending anywhere.
+    """
+
+
+def _call_auxiliary_llm(
+    prompt: str, *, main_runtime: dict[str, Any] | None = None, strict: bool = False
+) -> str | None:
+    """Call the auxiliary LLM with a handoff prompt.
+
+    Returns the LLM response text, or None on any failure. When *strict* is True,
+    an exception is re-raised as :class:`HandoffLLMError` instead of being
+    swallowed — a manual handoff request needs the failure surfaced, not hidden
+    behind a silent extractive fallback.
+    """
+    try:
+        from agent.auxiliary_client import call_llm
+
+        response = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=4000,
+            temperature=0.3,
+            main_runtime=main_runtime,
+        )
+        content = response.choices[0].message.content
+        if not isinstance(content, str):
+            content = str(content) if content else ""
+        return content.strip() if content else None
+    except Exception as exc:
+        logger.debug("LLM handoff summarization failed, falling back to extractive mode", exc_info=True)
+        if strict:
+            raise HandoffLLMError(str(exc)) from exc
+        return None
+
+
+def generate_handoff(
+    *,
+    session_id: str | None,
+    messages: Iterable[dict[str, Any]] | None,
+    reason: str,
+    platform: str | None = None,
+    model: str | None = None,
+    parent_session_id: str | None = None,
+    current_session_id: str | None = None,
+    focus_topic: str | None = None,
+    hermes_home: str | Path | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+    llm_summarize: bool = False,
+    strict_llm: bool = False,
+    session_name: str | None = None,
+    gateway_name: str | None = None,
+    main_runtime: dict[str, Any] | None = None,
+    memory_manager: Any | None = None,
+) -> Path:
+    """Write a durable markdown handoff and return its path.
+
+    The extractive path is deliberately dependency-free. It must keep working
+    when auxiliary LLMs are unavailable during shutdown or while a compression
+    failure is already in progress.
+
+    When *llm_summarize* is True, an auxiliary LLM is used to produce a
+    structured summary of the session. If the LLM call fails, the function
+    falls back to the extractive (non-LLM) handoff automatically — UNLESS
+    *strict_llm* is True, in which case the failure raises
+    :class:`HandoffLLMError` instead of silently degrading (the intended
+    behavior for an explicit manual handoff request). *strict_llm* has no
+    effect when *llm_summarize* is False.
+
+    *memory_manager* is optional. When provided and it exposes
+    ``ingest_extracted_facts(facts, session_id=...)``, the durable-facts block
+    emitted by the same handoff LLM call is routed to it — no extra LLM calls.
+    A parse/ingest failure there is never fatal to the handoff write itself.
+    """
+
+    safe_id = _safe_session_id(session_id)
+    handoffs_dir = _handoffs_dir(hermes_home)
+    handoffs_dir.mkdir(parents=True, exist_ok=True)
+    path = handoffs_dir / f"handoff-{safe_id}.md"
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    current = current_session_id or session_id or ""
+
+    # --- LLM summarization path ---
+    if llm_summarize:
+        source_info = (
+            f"{session_name or 'unnamed'} | "
+            f"{'Gateway: ' + gateway_name if gateway_name else 'Terminal'} | "
+            f"Session: {session_id or ''}"
+        )
+        git_context = _gather_git_context(hermes_home)
+        transcript_excerpt = _message_excerpt(
+            messages or [],
+            max_messages=80,
+            max_chars=25_000,
+        )
+        prompt = _build_llm_handoff_prompt(
+            safe_id=safe_id,
+            now=now,
+            source_info=source_info,
+            model=model,
+            session_id=session_id,
+            reason=reason,
+            git_context=git_context,
+            transcript_excerpt=transcript_excerpt,
+        )
+        # strict_llm re-raises an LLM exception as HandoffLLMError (manual
+        # handoff request). Non-strict keeps the silent extractive fallback.
+        llm_content = _call_auxiliary_llm(
+            prompt, main_runtime=main_runtime, strict=strict_llm
+        )
+
+        if llm_content:
+            # The single handoff LLM call also emits a durable-facts JSON block
+            # (see DURABLE_FACTS_PROMPT_SECTION). Recover it and route the facts
+            # to the optional memory manager — zero extra LLM calls. Never fatal:
+            # a parse/ingest failure must not break the handoff write itself.
+            if memory_manager is not None:
+                try:
+                    facts = normalize_facts(parse_facts_block(llm_content))
+                    if facts and hasattr(memory_manager, "ingest_extracted_facts"):
+                        n = memory_manager.ingest_extracted_facts(
+                            facts, session_id=session_id or ""
+                        )
+                        if n:
+                            logger.info(
+                                "handoff insight extraction: routed %d durable fact(s) "
+                                "(session=%s, reason=%s)",
+                                n, session_id, reason,
+                            )
+                except Exception:
+                    logger.debug("handoff insight ingestion failed", exc_info=True)
+
+            # The extractive path below folds extra_metadata (e.g. chat_id/
+            # thread_id) and ``platform`` into metadata_lines, but the LLM writes
+            # llm_content verbatim from its own prompt — which mentions neither —
+            # so those coordinates would be dropped on the LLM-summary path.
+            # Append them deterministically instead of asking the LLM to
+            # reproduce them (it would not reliably). Additive and guarded:
+            # callers that pass platform=None and extra_metadata=None see no
+            # change to llm_content.
+            _llm_meta = {"platform": platform, **(extra_metadata or {})}
+            _meta_lines = [
+                f"{key}: {value}"
+                for key, value in sorted(_llm_meta.items())
+                if value is not None
+            ]
+            if _meta_lines:
+                llm_content = (
+                    f"{llm_content.rstrip()}\n\n" + "\n".join(_meta_lines) + "\n"
+                )
+
+            path.write_text(llm_content, encoding="utf-8")
+            _write_latest_pointer(handoffs_dir, path)
+            _update_index(
+                handoffs_dir,
+                {
+                    "session_id": session_id,
+                    "safe_session_id": safe_id,
+                    "path": str(path),
+                    "created_at": now,
+                    "reason": reason,
+                    "platform": platform,
+                    "model": model,
+                    "parent_session_id": parent_session_id,
+                    "current_session_id": current,
+                    "llm_summarized": True,
+                },
+            )
+            return path
+        # LLM returned empty content. In strict mode surface it rather than
+        # silently degrading; otherwise fall through to the extractive path.
+        if strict_llm:
+            raise HandoffLLMError("auxiliary LLM returned no handoff content")
+        logger.info("LLM handoff summarization failed, using extractive fallback")
+
+    # --- Extractive (default / fallback) path ---
+    excerpt = _message_excerpt(messages or [])
+
+    metadata_lines = [
+        f"Date: {now}",
+        f"Platform: {platform or ''}",
+        f"Model: {model or ''}",
+        f"Parent session: {parent_session_id or ''}",
+        f"Current session: {current}",
+        f"Reason: {reason}",
+    ]
+    if focus_topic:
+        metadata_lines.append(f"Focus: {focus_topic}")
+    if extra_metadata:
+        for key, value in sorted(extra_metadata.items()):
+            if value is not None:
+                metadata_lines.append(f"{key}: {value}")
+
+    content = f"""# Handoff: {safe_id}
+
+{chr(10).join(metadata_lines)}
+
+## Goal
+
+See the extracted context below. If the user's goal is not obvious, first infer
+it from the most recent messages.
+
+## Done
+
+- Recorded a handoff for reason `{reason}`.
+
+## In progress / Next steps
+
+- Recover the current goal from the "Context for the next session" section and
+  the most recent messages.
+- Verify actual state with tools before making claims about services, files, or
+  configuration.
+
+## Key decisions
+
+- The handoff was created as a durable continuity artifact; it complements the
+  compaction summary and does not replace verifying the current state.
+
+## Dead ends — do not repeat
+
+- Do not rely on the old transcript alone after compaction/restart; use this
+  handoff as the starting map of the state.
+
+## Changed files / external artifacts
+
+- Not detected automatically. See the transcript excerpt and git/status checks.
+
+## Checks
+
+- Not run automatically when the handoff was created.
+
+## Context for the next session
+
+{excerpt}
+
+## Recommended first action
+
+Read this handoff, then verify the live state with tools before continuing.
+"""
+    path.write_text(content, encoding="utf-8")
+    _write_latest_pointer(handoffs_dir, path)
+    _update_index(
+        handoffs_dir,
+        {
+            "session_id": session_id,
+            "safe_session_id": safe_id,
+            "path": str(path),
+            "created_at": now,
+            "reason": reason,
+            "platform": platform,
+            "model": model,
+            "parent_session_id": parent_session_id,
+            "current_session_id": current,
+        },
+    )
+    return path
+
+
+def read_handoff_excerpt(path: str | Path, *, max_tokens: int = 12_000) -> str:
+    """Read a handoff file with a rough token budget cap."""
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    max_chars = max(1, int(max_tokens) * _DEFAULT_EXCERPT_CHARS_PER_TOKEN)
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 80)] + "\n\n[... handoff truncated to configured max_tokens budget ...]\n"
+
+
+def write_gateway_active_handoff(entry: dict[str, Any], *, hermes_home: str | Path | None = None) -> Path:
+    """Append/update the gateway-active handoff mapping."""
+    handoffs_dir = _handoffs_dir(hermes_home)
+    handoffs_dir.mkdir(parents=True, exist_ok=True)
+    path = handoffs_dir / "gateway-active.json"
+    data: list[dict[str, Any]] = []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(raw, list):
+            data = [x for x in raw if isinstance(x, dict)]
+    except Exception:
+        data = []
+
+    key = entry.get("session_key") or entry.get("session_id") or entry.get("handoff_path")
+    if key:
+        data = [x for x in data if (x.get("session_key") or x.get("session_id") or x.get("handoff_path")) != key]
+    data.append({**entry, "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds")})
+    path.write_text(json.dumps(data[-500:], ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path

--- a/agent/insight_extraction.py
+++ b/agent/insight_extraction.py
@@ -1,0 +1,189 @@
+"""LLM-salience extraction of durable facts from session context.
+
+Two entry points, one shared parser/normalizer:
+
+* :data:`DURABLE_FACTS_PROMPT_SECTION` is appended to the handoff prompt so the
+  *single* handoff LLM call also emits a machine-parseable durable-facts block
+  — **zero extra LLM calls** for the handoff triggers.
+  :func:`parse_facts_block` then recovers the JSON from that response.
+
+* :func:`extract_facts_from_messages` is a standalone extractor (its own
+  auxiliary-LLM call) for callers that want facts without generating a full
+  handoff — e.g. at session end or before a compaction where no handoff is
+  produced. It is unthrottled; callers are responsible for only invoking it on
+  session boundaries, never per turn.
+
+This module only *extracts and normalizes* candidate facts. Any hard guarantee
+that secrets never reach long-term memory must come from the consuming memory
+store's write path, not from this module; the prompt merely *asks* the model to
+omit them.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+_VALID_CATEGORIES = {"user_pref", "project", "tool", "general"}
+_VALID_SCOPES = {"user", "project"}
+
+DEFAULT_MAX_FACTS = 8
+DEFAULT_MIN_CHARS = 12
+MAX_FACT_CHARS = 200
+
+# Appended verbatim after the handoff sections.
+DURABLE_FACTS_PROMPT_SECTION = """
+
+---
+## Durable facts (JSON, for long-term memory)
+Extract ONLY facts that will be useful in FUTURE sessions. Include:
+user preferences and rules, decisions made, facts about the environment/project,
+corrections ("do not do it this way"), stable information about people.
+Do NOT include: task progress, transient state, things that are easily
+rediscovered, or secrets/tokens/passwords.
+Each fact must be a single self-contained sentence (<=200 characters).
+Return an ARRAY (an empty array [] if there are no facts) strictly inside a
+fenced ```json block:
+```json
+[{"content":"...","category":"user_pref|project|tool|general","scope":"user|project"}]
+```"""
+
+# Greedy-but-bounded: grab the contents of a ```json ... ``` fence.
+_JSON_FENCE_RE = re.compile(r"```json\s*(.+?)\s*```", re.DOTALL | re.IGNORECASE)
+# Fallback: a bare top-level JSON array somewhere in the text.
+_BARE_ARRAY_RE = re.compile(r"\[\s*\{.*?\}\s*\]", re.DOTALL)
+
+
+def _coerce_to_list(raw: Any) -> list[dict]:
+    """Tolerate the model returning a bare object or a {"facts": [...]} wrapper."""
+    if isinstance(raw, dict):
+        if isinstance(raw.get("facts"), list):
+            raw = raw["facts"]
+        elif "content" in raw:
+            raw = [raw]
+        else:
+            return []
+    if not isinstance(raw, list):
+        return []
+    return [x for x in raw if isinstance(x, dict)]
+
+
+def parse_facts_block(text: str) -> list[dict]:
+    """Recover a durable-facts list from an LLM response. Never raises."""
+    if not text or not isinstance(text, str):
+        return []
+    candidates: list[str] = list(_JSON_FENCE_RE.findall(text))
+    if not candidates:
+        m = _BARE_ARRAY_RE.search(text)
+        if m:
+            candidates.append(m.group(0))
+    for blob in candidates:
+        try:
+            return _coerce_to_list(json.loads(blob))
+        except Exception:
+            continue
+    return []
+
+
+def normalize_facts(
+    raw_facts: Iterable[Any] | None,
+    *,
+    max_facts: int = DEFAULT_MAX_FACTS,
+    min_chars: int = DEFAULT_MIN_CHARS,
+    default_origin: str = "agent",
+) -> list[dict]:
+    """Validate, clamp and de-duplicate extracted facts.
+
+    Returns a list of ``{content, category, scope, origin}`` dicts. Invalid or
+    too-short items are dropped; content is clamped to ``MAX_FACT_CHARS``;
+    category/scope are coerced to the allowed enums and kept mutually
+    consistent. Case-insensitive content de-dup within the batch.
+    """
+    out: list[dict] = []
+    seen: set[str] = set()
+    for item in raw_facts or []:
+        if not isinstance(item, dict):
+            continue
+        content = str(item.get("content", "") or "").strip()
+        if len(content) < int(min_chars):
+            continue
+        content = content[:MAX_FACT_CHARS]
+        key = content.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+
+        scope = item.get("scope") if item.get("scope") in _VALID_SCOPES else None
+        category = item.get("category") if item.get("category") in _VALID_CATEGORIES else None
+        if category is None:
+            category = "user_pref" if scope == "user" else "general"
+        if scope is None:
+            scope = "user" if category == "user_pref" else "project"
+
+        out.append(
+            {
+                "content": content,
+                "category": category,
+                "scope": scope,
+                "origin": str(item.get("origin") or default_origin),
+            }
+        )
+        if len(out) >= int(max_facts):
+            break
+    return out
+
+
+def _build_extraction_prompt(transcript_excerpt: str) -> str:
+    return (
+        "Analyze the session transcript and extract long-lived facts for the "
+        "agent's memory."
+        + DURABLE_FACTS_PROMPT_SECTION
+        + "\n\nTranscript:\n"
+        + transcript_excerpt
+    )
+
+
+def extract_facts_from_messages(
+    messages: list[dict] | None,
+    *,
+    main_runtime: dict | None = None,
+    max_facts: int = DEFAULT_MAX_FACTS,
+    min_chars: int = DEFAULT_MIN_CHARS,
+    max_transcript_chars: int = 18_000,
+) -> list[dict]:
+    """Standalone extraction over a transcript. Returns [] on any failure.
+
+    Uses the auxiliary "compression" model (same as the handoff summarizer);
+    callers are responsible for throttling so this is not called per turn.
+    """
+    try:
+        from agent.handoff import _message_excerpt, EMPTY_EXCERPT_SENTINEL
+
+        excerpt = _message_excerpt(
+            messages or [], max_messages=60, max_chars=max_transcript_chars
+        )
+        if not excerpt or excerpt == EMPTY_EXCERPT_SENTINEL:
+            return []
+
+        from agent.auxiliary_client import call_llm
+
+        response = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": _build_extraction_prompt(excerpt)}],
+            max_tokens=1200,
+            temperature=0.2,
+            main_runtime=main_runtime,
+        )
+        content = response.choices[0].message.content
+        if not isinstance(content, str):
+            content = str(content) if content else ""
+        return normalize_facts(
+            parse_facts_block(content), max_facts=max_facts, min_chars=min_chars
+        )
+    except Exception:
+        logger.debug("standalone insight extraction failed", exc_info=True)
+        return []

--- a/cli.py
+++ b/cli.py
@@ -10018,6 +10018,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         elif canonical == "handoff":
             if not self._handle_handoff_command(cmd_original):
                 return False
+        elif canonical == "handoff-session":
+            self._manual_handoff_session(cmd_original)
         elif canonical == "new":
             # Strip inline-skip tokens (now/--yes/-y) before deriving the title
             # so "/new now My Session" yields title="My Session" instead of

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -873,6 +873,59 @@ class CLICommandsMixin:
         _cprint("  Your CLI session is intact.")
         return True
 
+    def _manual_handoff_session(self, cmd_original: str = "") -> None:
+        """Handle ``/handoff-session [--extractive] [focus topic]``.
+
+        Write a durable session handoff file without compressing context.
+        Produces ``handoff-<session_id>.md`` with goals, decisions, next steps,
+        and a transcript excerpt for continuity after compaction or a restart.
+
+        By default the auxiliary LLM summarizes the session (strict: an LLM
+        failure is reported rather than silently downgraded). ``--extractive``
+        forces the dependency-free extractive handoff.
+        """
+        from cli import _cprint
+
+        if not self.agent:
+            _cprint("  No active agent -- send a message first.")
+            return
+
+        tokens = cmd_original.strip().split() if cmd_original else []
+        args = tokens[1:]
+        extractive = "--extractive" in args
+        focus_topic = " ".join(t for t in args if t != "--extractive").strip()
+
+        try:
+            from agent.handoff import generate_handoff, HandoffLLMError
+
+            history = list(self.conversation_history) if self.conversation_history else []
+            try:
+                handoff_path = generate_handoff(
+                    session_id=getattr(self.agent, "session_id", None) or self.session_id,
+                    messages=history,
+                    reason="manual_handoff",
+                    platform="cli",
+                    model=getattr(self.agent, "model", None),
+                    focus_topic=focus_topic or None,
+                    llm_summarize=not extractive,
+                    strict_llm=not extractive,
+                    session_name=getattr(self, "session_name", None),
+                )
+            except HandoffLLMError as exc:
+                # Strict LLM handoff failed — do NOT silently degrade. Tell the
+                # user and offer the explicit extractive recovery.
+                _cprint(f"  Could not generate an LLM handoff: {exc}")
+                _cprint("  Retry, or run /handoff-session --extractive to save a raw extractive handoff.")
+                return
+
+            mode = "extractive" if extractive else "LLM"
+            _cprint(f"  Handoff saved: {handoff_path} ({mode} handoff)")
+            _cprint(f"     Messages: {len(history)}")
+            if focus_topic:
+                _cprint(f"     Focus: {focus_topic}")
+        except Exception as exc:
+            _cprint(f"  Handoff failed: {exc}")
+
     def _handle_resume_command(self, cmd_original: str) -> None:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
         from cli import _cprint, _sync_process_session_id

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -125,6 +125,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[name]"),
     CommandDef("handoff", "Hand off this session to a messaging platform (Telegram, Discord, etc.)", "Session",
                args_hint="<platform>", cli_only=True),
+    CommandDef("handoff-session", "Write a durable session handoff file (LLM-summarized, with extractive fallback)", "Session",
+               args_hint="[--extractive] [focus topic]", cli_only=True),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",
                aliases=("fork",), args_hint="[name]"),
     CommandDef("compress", "Compress conversation context (add 'here [N]' to keep recent N turns; --preview shows what would happen)", "Session",

--- a/tests/agent/test_handoff.py
+++ b/tests/agent/test_handoff.py
@@ -1,0 +1,277 @@
+"""Tests for agent/handoff.py — durable session handoff files."""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from agent.handoff import (
+    generate_handoff,
+    read_handoff_excerpt,
+    write_gateway_active_handoff,
+    _safe_session_id,
+    _message_excerpt,
+    EMPTY_EXCERPT_SENTINEL,
+    HANDOFFS_DIRNAME,
+)
+
+
+@pytest.fixture()
+def handoff_dir(tmp_path):
+    """Return a temporary handoffs directory."""
+    d = tmp_path / HANDOFFS_DIRNAME
+    d.mkdir()
+    return d
+
+
+class TestSafeSessionId:
+    def test_normal_id(self):
+        assert _safe_session_id("abc-123_def") == "abc-123_def"
+
+    def test_special_chars(self):
+        result = _safe_session_id("session/with spaces@#$$$")
+        assert " " not in result
+        assert "@" not in result
+
+    def test_none_returns_unknown(self):
+        assert _safe_session_id(None) == "unknown-session"
+
+    def test_empty_returns_unknown(self):
+        assert _safe_session_id("") == "unknown-session"
+
+
+class TestMessageExcerpt:
+    def test_basic_messages(self):
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = _message_excerpt(msgs)
+        assert "user" in result
+        assert "hello" in result
+        assert "assistant" in result
+        assert "hi there" in result
+
+    def test_truncation(self):
+        msgs = [{"role": "user", "content": "x" * 500}] * 100
+        result = _message_excerpt(msgs, max_messages=10, max_chars=2000)
+        assert len(result) < 500 * 100
+
+    def test_none_content_skipped(self):
+        msgs = [{"role": "assistant", "content": None}]
+        result = _message_excerpt(msgs)
+        assert result.strip() == "" or result == EMPTY_EXCERPT_SENTINEL
+
+    def test_tool_calls_content(self):
+        msgs = [
+            {"role": "assistant", "content": None, "tool_calls": [{"function": {"name": "search"}}]},
+        ]
+        result = _message_excerpt(msgs)
+        assert "tool_calls" in result
+
+    def test_empty_list_returns_fallback(self):
+        result = _message_excerpt([])
+        assert result == EMPTY_EXCERPT_SENTINEL
+
+
+class TestGenerateHandoffExtractive:
+    def test_creates_file(self, tmp_path):
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path):
+            path = generate_handoff(
+                session_id="test-123",
+                messages=[{"role": "user", "content": "do stuff"}],
+                reason="manual_test",
+                hermes_home=tmp_path,
+            )
+        assert path.exists()
+        content = path.read_text()
+        assert "test-123" in content
+        assert "manual_test" in content
+        assert "do stuff" in content
+
+    def test_creates_latest_symlink(self, tmp_path):
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path):
+            path = generate_handoff(
+                session_id="test-symlink",
+                messages=[],
+                reason="test",
+                hermes_home=tmp_path,
+            )
+        latest = path.parent / "latest.md"
+        assert latest.exists()
+
+    def test_updates_index(self, tmp_path):
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path):
+            generate_handoff(
+                session_id="test-index",
+                messages=[],
+                reason="test",
+                hermes_home=tmp_path,
+            )
+        index_path = tmp_path / HANDOFFS_DIRNAME / "index.json"
+        assert index_path.exists()
+        data = json.loads(index_path.read_text())
+        assert len(data) == 1
+        assert data[0]["session_id"] == "test-index"
+
+
+class TestGenerateHandoffLLM:
+    def test_llm_path_writes_content(self, tmp_path):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "# LLM Handoff\n\nGoal: test goal"
+
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path), \
+             patch("agent.handoff._call_auxiliary_llm", return_value="# LLM Handoff\n\nGoal: test goal"):
+            path = generate_handoff(
+                session_id="llm-test",
+                messages=[{"role": "user", "content": "do stuff"}],
+                reason="manual_handoff",
+                llm_summarize=True,
+                hermes_home=tmp_path,
+            )
+
+        content = path.read_text()
+        assert "LLM Handoff" in content
+        assert "test goal" in content
+
+    def test_llm_failure_falls_back_to_extractive(self, tmp_path):
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path), \
+             patch("agent.handoff._call_auxiliary_llm", return_value=None):
+            path = generate_handoff(
+                session_id="llm-fallback",
+                messages=[{"role": "user", "content": "hello world"}],
+                reason="auto_compaction",
+                llm_summarize=True,
+                hermes_home=tmp_path,
+            )
+
+        content = path.read_text()
+        # Should contain extractive fallback content
+        assert "hello world" in content
+        assert "auto_compaction" in content
+
+    def test_llm_index_marks_summarized(self, tmp_path):
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path), \
+             patch("agent.handoff._call_auxiliary_llm", return_value="LLM content"):
+            generate_handoff(
+                session_id="llm-index",
+                messages=[],
+                reason="test",
+                llm_summarize=True,
+                hermes_home=tmp_path,
+            )
+
+        index_path = tmp_path / HANDOFFS_DIRNAME / "index.json"
+        data = json.loads(index_path.read_text())
+        assert data[0].get("llm_summarized") is True
+
+    def test_llm_path_includes_extra_metadata(self, tmp_path):
+        """extra_metadata (chat_id/thread_id) must land in the file content on
+        the LLM-summary path too, not just the extractive path. The LLM writes
+        llm_content verbatim from its own prompt (which never mentions
+        extra_metadata), so generate_handoff must append it deterministically
+        rather than rely on the LLM reproducing it."""
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path), \
+             patch(
+                 "agent.handoff._call_auxiliary_llm",
+                 return_value="# LLM Handoff\n\nGoal: test goal",
+             ):
+            path = generate_handoff(
+                session_id="llm-metadata",
+                messages=[{"role": "user", "content": "do stuff"}],
+                reason="session_expired",
+                platform="telegram",
+                llm_summarize=True,
+                hermes_home=tmp_path,
+                extra_metadata={
+                    "chat_id": "12345",
+                    "thread_id": "678",
+                    "new_session_id": None,
+                },
+            )
+
+        content = path.read_text()
+        # Original LLM content is preserved verbatim, metadata appended.
+        assert "LLM Handoff" in content
+        assert "test goal" in content
+        assert "platform: telegram" in content
+        assert "chat_id: 12345" in content
+        assert "thread_id: 678" in content
+        # None-valued keys are dropped (matches the extractive path's rule).
+        assert "new_session_id" not in content
+
+    def test_llm_path_no_metadata_block_when_extra_metadata_none(self, tmp_path):
+        """Regression guard: callers that pass extra_metadata=None must see
+        byte-identical llm_content — no stray metadata block appended."""
+        llm_text = "# LLM Handoff\n\nGoal: test goal"
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path), \
+             patch("agent.handoff._call_auxiliary_llm", return_value=llm_text):
+            path = generate_handoff(
+                session_id="llm-no-metadata",
+                messages=[{"role": "user", "content": "do stuff"}],
+                reason="manual_handoff",
+                llm_summarize=True,
+                hermes_home=tmp_path,
+            )
+
+        assert path.read_text() == llm_text
+
+    def test_extractive_path_includes_extra_metadata(self, tmp_path):
+        """The extractive (non-LLM) path folds extra_metadata into
+        metadata_lines — pin that behaviour so it does not regress."""
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path):
+            path = generate_handoff(
+                session_id="extractive-metadata",
+                messages=[{"role": "user", "content": "hello"}],
+                reason="session_expired",
+                platform="telegram",
+                hermes_home=tmp_path,
+                extra_metadata={"chat_id": "12345", "thread_id": "678"},
+            )
+
+        content = path.read_text()
+        assert "Platform: telegram" in content
+        assert "chat_id: 12345" in content
+        assert "thread_id: 678" in content
+
+
+class TestReadHandoffExcerpt:
+    def test_reads_full_file(self, tmp_path):
+        f = tmp_path / "handoff.md"
+        f.write_text("full content here", encoding="utf-8")
+        assert read_handoff_excerpt(f) == "full content here"
+
+    def test_truncates_long_file(self, tmp_path):
+        f = tmp_path / "handoff.md"
+        f.write_text("x" * 100_000, encoding="utf-8")
+        result = read_handoff_excerpt(f, max_tokens=1000)
+        assert len(result) < 100_000
+        assert "truncated" in result
+
+
+class TestWriteGatewayActiveHandoff:
+    def test_creates_file(self, tmp_path):
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path):
+            path = write_gateway_active_handoff(
+                {"session_key": "tg:-100:5", "handoff_path": "/tmp/handoff.md"},
+                hermes_home=tmp_path,
+            )
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert len(data) == 1
+        assert data[0]["session_key"] == "tg:-100:5"
+
+    def test_deduplicates_by_key(self, tmp_path):
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path):
+            write_gateway_active_handoff(
+                {"session_key": "tg:-100:5", "handoff_path": "/tmp/old.md"},
+                hermes_home=tmp_path,
+            )
+            write_gateway_active_handoff(
+                {"session_key": "tg:-100:5", "handoff_path": "/tmp/new.md"},
+                hermes_home=tmp_path,
+            )
+        data = json.loads((tmp_path / HANDOFFS_DIRNAME / "gateway-active.json").read_text())
+        assert len(data) == 1
+        assert data[0]["handoff_path"] == "/tmp/new.md"

--- a/tests/agent/test_handoff_strict.py
+++ b/tests/agent/test_handoff_strict.py
@@ -1,0 +1,82 @@
+"""Honest handoff: strict mode surfaces an LLM failure instead of a silent
+extractive fallback labelled as an LLM handoff.
+
+An explicit manual handoff request is strict by default: if the auxiliary LLM
+cannot produce the structured handoff, the caller must be told and offered an
+explicit extractive recovery — NOT handed a low-fidelity extractive handoff
+presented as an LLM one. Auto-compaction stays non-strict (the extractive
+fallback is fine there — it is a durable raw record, not context loss).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import agent.handoff as ho
+from agent.handoff import HandoffLLMError, generate_handoff
+
+
+class TestCallAuxiliaryLLMStrict:
+    def test_strict_reraises_as_handoff_error(self):
+        with patch("agent.auxiliary_client.call_llm", side_effect=Exception("401 user not found")):
+            with pytest.raises(HandoffLLMError):
+                ho._call_auxiliary_llm("prompt", strict=True)
+
+    def test_non_strict_swallows_to_none(self):
+        with patch("agent.auxiliary_client.call_llm", side_effect=Exception("401 user not found")):
+            assert ho._call_auxiliary_llm("prompt", strict=False) is None
+
+
+class TestGenerateHandoffStrict:
+    def test_strict_llm_failure_raises(self, tmp_path):
+        """strict_llm=True + LLM error → HandoffLLMError (no silent extractive)."""
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path), \
+             patch("agent.handoff._call_auxiliary_llm", side_effect=HandoffLLMError("503 overloaded")):
+            with pytest.raises(HandoffLLMError):
+                generate_handoff(
+                    session_id="s1",
+                    messages=[{"role": "user", "content": "hi"}],
+                    reason="manual_handoff",
+                    llm_summarize=True,
+                    strict_llm=True,
+                )
+
+    def test_strict_llm_empty_raises(self, tmp_path):
+        """strict_llm=True + empty LLM content → HandoffLLMError (not extractive)."""
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path), \
+             patch("agent.handoff._call_auxiliary_llm", return_value=None):
+            with pytest.raises(HandoffLLMError):
+                generate_handoff(
+                    session_id="s1",
+                    messages=[{"role": "user", "content": "hi"}],
+                    reason="manual_handoff",
+                    llm_summarize=True,
+                    strict_llm=True,
+                )
+
+    def test_strict_llm_success_returns_path(self, tmp_path):
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path), \
+             patch("agent.handoff._call_auxiliary_llm", return_value="# LLM Handoff\n\nGoal: x"):
+            path = generate_handoff(
+                session_id="s1",
+                messages=[{"role": "user", "content": "hi"}],
+                reason="manual_handoff",
+                llm_summarize=True,
+                strict_llm=True,
+            )
+            assert path.exists()
+            assert "LLM Handoff" in path.read_text(encoding="utf-8")
+
+    def test_non_strict_failure_still_extractive(self, tmp_path):
+        """Auto-compaction default: strict_llm=False + LLM fail → extractive path, no raise."""
+        with patch("agent.handoff.get_hermes_home", return_value=tmp_path), \
+             patch("agent.handoff._call_auxiliary_llm", return_value=None):
+            path = generate_handoff(
+                session_id="s1",
+                messages=[{"role": "user", "content": "hi"}],
+                reason="compression",
+                llm_summarize=True,
+                strict_llm=False,
+            )
+            assert path.exists()  # extractive handoff written, no exception


### PR DESCRIPTION
## The Problem

When a long session hits context compaction, or the process restarts, the in-context conversation is discarded and the rolling compression summary is the only thing that survives. That summary is optimized to keep the model coherent mid-turn — it is not a durable, on-disk record a human or a fresh agent can open later to recover *what the session was actually trying to do*: the goal, the decisions taken (and the alternatives rejected), the next steps, which files changed, and what has and has not been verified. There was also no lightweight way to capture the small number of long-lived facts a session produces (user preferences, project facts, "do not do it this way" corrections) so they are not re-learned from scratch every time.

## The Solution

Two small, self-contained modules plus a minimal CLI entry point:

- **`agent/handoff.py`** writes a durable markdown handoff to disk (`handoffs/handoff-<session_id>.md`, with a `latest.md` pointer and a rolling `index.json`). By default the auxiliary "compression" model summarizes the session into fixed sections (Goal / Done / Next steps / Key decisions / Dead ends / Changed files / Current state / Context / Recommended first action). If the LLM call fails, it falls back automatically to a dependency-free *extractive* handoff — a lossless raw transcript excerpt — so a handoff is always produced even during shutdown or an in-progress compression failure. A `strict_llm` mode (used by the manual command) surfaces an LLM failure as `HandoffLLMError` instead of silently writing a lower-fidelity extractive file dressed up as an LLM summary; the caller can then retry or explicitly ask for the extractive record.

- **`agent/insight_extraction.py`** parses and normalizes durable "facts" from an LLM response (validation, clamping, enum coercion, de-duplication). The same single handoff LLM call also emits a machine-parseable durable-facts JSON block, so facts are recovered with **zero extra LLM calls** and routed to an optional `memory_manager` that exposes `ingest_extracted_facts(facts, session_id=...)` (duck-typed — no dependency on any specific memory backend). A standalone extractor is also provided for callers that want facts without generating a full handoff.

- **CLI wiring**: a new `/handoff-session [--extractive] [focus topic]` command triggers a manual handoff from the terminal (strict by default; `--extractive` forces the no-LLM path). This is the only integration point added; the modules are otherwise standalone and importable.

Secrets are never guaranteed safe by this module — the prompt only *asks* the model to omit tokens/passwords; any hard guarantee must come from the consuming memory store's write path.

## Why this matters

Continuity across compaction and restarts is the difference between a fresh agent re-deriving context (slow, lossy, error-prone) and resuming from an explicit map of goals, decisions, and next steps. The extractive fallback makes the handoff dependable exactly when the system is under stress (shutdown, compression failure, auxiliary LLM unavailable), and the strict mode keeps a manual handoff honest instead of quietly downgrading. Folding insight extraction into the same LLM call adds durable-memory capture at no additional inference cost.

Tests: `tests/agent/test_handoff.py` and `tests/agent/test_handoff_strict.py` cover the extractive path, the LLM path, metadata folding, strict-mode failure surfacing, and the read/index helpers.