### PR TITLE
fix(stt,tts): surface plugin load failures instead of silent fallback, and route plugin max_text_length

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1163,6 +1163,16 @@ def _dispatch_to_plugin_provider(
        plugin as unavailable — **not** ``None`` — because the user
        explicitly opted into this plugin via ``stt.provider`` and the
        generic fallthrough message would be misleading.
+    5. Discovery-failure gating: every call that reaches this function
+       already has an explicitly configured, non-built-in provider name
+       (invariants 1-2 filtered out everything else). So when plugin
+       discovery itself raises (a broken or uninstalled addon that fails
+       to import), that means the plugin the user asked for failed to
+       load. This returns a named error envelope carrying the original
+       exception — **not** ``None`` — so a broken plugin is
+       distinguishable from an unconfigured one and the caller surfaces
+       the real load failure instead of a misleading "not registered"
+       error.
 
     Provider exceptions are caught and converted into the standard
     error envelope (matches the legacy built-in error shapes — the
@@ -1195,9 +1205,19 @@ def _dispatch_to_plugin_provider(
             # recovery pattern.
             _ensure_plugins_discovered(force=True)
             plugin_provider = get_provider(key)
-    except Exception as exc:  # noqa: BLE001 — discovery failure is non-fatal
-        logger.debug("STT plugin dispatch skipped (discovery failed): %s", exc)
-        return None
+    except Exception as exc:  # noqa: BLE001 — surfaced below, not swallowed
+        # An explicitly configured plugin provider that fails to even
+        # load must not be indistinguishable from "no plugin configured"
+        # — return a named envelope instead of a bare None.
+        logger.warning(
+            "STT plugin '%s' failed to load: %s", key, exc, exc_info=True,
+        )
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"STT plugin '{key}' failed to load: {exc}",
+            "provider": key,
+        }
     if plugin_provider is None:
         return None
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -460,6 +460,31 @@ def _resolve_max_text_length(
                 return named_override
             return DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH
 
+        # Plugin-registered TTS provider: its capability travels WITH the
+        # plugin via the existing ABC surface list_models()[].max_text_length
+        # — no provider name is hardcoded here. Discovery is triggered from
+        # inside this resolver (rather than left to the dispatcher's own
+        # discovery) because this function runs earlier in the request; an
+        # installed-but-not-yet-discovered-in-this-process plugin would
+        # otherwise registry-miss and silently fall back to the generic cap.
+        from agent.tts_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        plugin_provider = get_provider(key)
+        if plugin_provider is not None:
+            declared_limits = [
+                model.get("max_text_length")
+                for model in (plugin_provider.list_models() or [])
+                if isinstance(model, dict)
+            ]
+            declared_limits = [
+                limit for limit in declared_limits
+                if isinstance(limit, int) and not isinstance(limit, bool) and limit > 0
+            ]
+            if declared_limits:
+                return max(declared_limits)
+
     return FALLBACK_MAX_TEXT_LENGTH
 
 
@@ -732,6 +757,14 @@ def _dispatch_to_plugin_provider(
     3. Plugin dispatch fires only when ``provider`` matches a registered
        :class:`TTSProvider` whose ``name`` equals the configured value.
        Unknown names return None (caller falls through to Edge default).
+    4. Discovery-failure gating: every call that reaches this function
+       already has an explicitly configured, non-built-in provider name
+       (invariants 1-2 filtered out everything else). So when plugin
+       discovery itself raises (a broken or uninstalled addon that fails
+       to import), that means the plugin the user asked for failed to
+       load. This re-raises instead of returning None, so the caller
+       can't silently fall through to the Edge TTS default while
+       reporting the configured provider as a success.
 
     Plugin exceptions are caught and re-raised — the outer
     ``text_to_speech_tool`` try/except converts them to the standard
@@ -761,9 +794,12 @@ def _dispatch_to_plugin_provider(
             # recovery pattern.
             _ensure_plugins_discovered(force=True)
             plugin_provider = get_provider(key)
-    except Exception as exc:  # noqa: BLE001 — discovery failure is non-fatal
-        logger.debug("tts plugin dispatch skipped (discovery failed): %s", exc)
-        return None
+    except Exception as exc:  # noqa: BLE001 — re-raised below, not swallowed
+        # An explicitly configured plugin provider that fails to even
+        # load must not be indistinguishable from "no plugin configured"
+        # — raise so the caller's outer try/except surfaces a named error
+        # instead of silently falling through to Edge TTS.
+        raise RuntimeError(f"TTS plugin '{key}' failed to load: {exc}") from exc
     if plugin_provider is None:
         return None
 
@@ -3040,6 +3076,22 @@ def text_to_speech_tool(
                 }, ensure_ascii=False)
             logger.info("Generating speech with Piper (local)...")
             _generate_piper_tts(text, file_str, tts_config)
+
+        elif provider not in BUILTIN_TTS_PROVIDERS:
+            # Reaching here means the configured provider is neither a
+            # built-in, a tts.providers.<name> command declaration, nor a
+            # registered plugin (_dispatch_to_plugin_provider returned None
+            # above) — i.e. the user explicitly opted into a provider that
+            # isn't actually available. That must be a terminal, named
+            # error, not a silent reroll through the Edge TTS default below.
+            return json.dumps({
+                "success": False,
+                "error": f"TTS provider '{provider}' is not available: not a "
+                         "built-in, not declared under tts.providers, and no "
+                         "plugin is registered for it. Check tts.provider in "
+                         "config.yaml and that any addon providing it is "
+                         "installed and enabled.",
+            }, ensure_ascii=False)
 
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback


### PR DESCRIPTION
## The Problem

Hermes discovers STT and TTS backends as plugins: a provider name in config (`stt.provider` / `tts.provider`) is matched against the registered plugin providers at runtime. When a configured plugin provider fails to import — a broken or half-installed addon — the failure was swallowed, with no hardcoded provider name involved:

- **STT**: the dispatcher caught the exception and returned `None`, and the caller then produced a generic "provider not registered" error — the same message a plain typo yields. A genuinely broken plugin was therefore indistinguishable from an unconfigured or misspelled one.
- **TTS**: the dispatcher's `None` fell through to the Edge default and reported success, so a misconfigured `tts.provider` silently produced Edge audio instead of failing.

Separately, `_resolve_max_text_length` never consulted the registered plugin before returning the generic 4000-character cap, so a TTS plugin declaring a larger limit via the existing `list_models()[].max_text_length` field had its output truncated unless the user duplicated the limit as a config override.

## The Solution

- **Surface plugin load failures instead of swallowing them.** The STT dispatcher returns a named error envelope carrying the original import exception (a broken plugin is now distinguishable from an unconfigured one); the TTS dispatcher re-raises into the standard error path; and a terminal branch in `text_to_speech_tool` rejects a configured provider that is neither a built-in, a command-type entry, nor a registered plugin — instead of silently rerolling to Edge. The built-in and command-provider branches are unchanged and still take precedence, so only genuinely unavailable providers hit the new error.
- **Route the max-text-length capability from the plugin.** Resolution now consults plugin discovery inside `_resolve_max_text_length` and reads the registered provider's own declared limit. No provider name is hardcoded and no new capability field is added — it reuses the existing `list_models()` surface. Priority order is unchanged: user config override, then plugin declaration, then the generic fallback.

## Why this matters

The plugin discovery mechanism is already provider-agnostic; these two fixes make it honest. An operator who installs an STT/TTS addon and points config at it now gets either the plugin they asked for or a clear error naming what went wrong — never a silent substitution — and a plugin's declared limits are respected without copying them into config. No provider-specific code is added, so every current and future backend benefits equally.