### PR TITLE
feat(moa): compact reference markers for Mixture-of-Agents output on the messenger gateway

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3649,6 +3649,33 @@ class TurnRunner:
                 ctx.progress_queue.put(msg)
             return
 
+        # MoA reference fan-out: surface a COMPACT marker for each reference
+        # model before the aggregator acts, plus an "aggregating" line. Placed
+        # BEFORE the tool_progress_enabled gate and the tool.started-only
+        # filter so MoA turn visibility mirrors the CLI (cli.py renders
+        # moa.reference unconditionally): the markers reach chat regardless of
+        # the tool_progress setting, as long as the progress queue exists
+        # (tool_progress OR thinking_progress on).  Compact by design — the
+        # reference answer body (the ``preview`` arg) is intentionally never
+        # rendered here: the CLI shows the full reference bodies, while
+        # messenger surfaces stay terse.
+        if event_type in {"moa.reference", "moa.aggregating"}:
+            if event_type == "moa.reference":
+                _moa_label = tool_name or "reference"
+                _moa_idx = kwargs.get("moa_index")
+                _moa_cnt = kwargs.get("moa_count")
+                if _moa_idx and _moa_cnt:
+                    moa_msg = f"🧩 {_moa_label} ({_moa_idx}/{_moa_cnt})"
+                else:
+                    moa_msg = f"🧩 {_moa_label}"
+            else:  # moa.aggregating
+                _moa_agg = tool_name or ""
+                moa_msg = (
+                    f"🧩 Aggregating via {_moa_agg}…" if _moa_agg else "🧩 Aggregating…"
+                )
+            ctx.progress_queue.put(moa_msg)
+            return
+
         # If tool_progress is off, only _thinking passes through (above).
         # Regular tool calls are suppressed.
         if not ctx.tool_progress_enabled:


### PR DESCRIPTION
## Problem
When a Mixture-of-Agents (MoA) preset is active, the agent emits display-only
events during a turn:

- `moa.reference` — one per reference model, fired **before** the aggregator
  acts (carries `label`, `text`, `moa_index`, `moa_count`).
- `moa.aggregating` — a single event when the aggregator starts.

These events are already produced upstream by the MoA facade
(`agent/agent_init.py` relay → `agent/moa_loop.py`) and are rendered by the CLI
(`cli.py` renders `moa.reference` / `moa.aggregating` in the TUI). But the
**messenger gateway** (`gateway/run.py`, `TurnRunner.progress_callback`) ignores
them completely. On a messenger platform (e.g. Telegram) a MoA turn therefore
looks like one long silent pause, with no signal that several models are being
consulted and then aggregated.

## Solution
Handle `moa.reference` and `moa.aggregating` inside the gateway
`progress_callback` and push a **compact marker** onto the progress queue:

- `🧩 <label> (i/n)` for each reference model (falls back to `🧩 <label>` when
  the index/count are absent).
- `🧩 Aggregating via <aggregator>…` for the aggregator step (falls back to
  `🧩 Aggregating…`).

The new branch is placed **before** the `tool_progress_enabled` gate and the
`tool.started`-only filter, so it mirrors the CLI (which renders `moa.reference`
unconditionally): the markers reach chat regardless of the `tool_progress`
setting, as long as the progress queue exists (i.e. `tool_progress` **or**
`thinking_progress` is enabled).

The reference **answer body** (the `preview` argument) is intentionally never
rendered in the messenger path — the CLI already shows the full per-reference
bodies, while messenger surfaces are kept terse to avoid flooding the chat.

## Why / Value
Users on messenger platforms get lightweight, real-time visibility into the MoA
fan-out (which models ran, and when aggregation starts) instead of a silent
stall, without dumping the full per-reference answers into the conversation.

## Scope / dependency notes
- **Depends on the existing MoA machinery**, which is already present in
  v0.20.0: `agent/moa_loop.py`, `agent/moa_trace.py`, the `moa.reference` /
  `moa.aggregating` relay in `agent/agent_init.py`, and the CLI renderer in
  `cli.py`. This PR only adds the **gateway/messenger** rendering that was
  missing.
- **Single file, +27 lines**, all in `gateway/run.py`. No change was needed in
  `plugins/platforms/telegram/adapter.py`: the adapter simply drains the shared
  progress queue, so surfacing the markers happens entirely in the gateway
  progress path — the adapter renders whatever the queue holds.
- The MoA callback contract this relies on (`event_type`, `tool_name`/label,
  `moa_index`, `moa_count` in `**kwargs`) matches the existing
  `progress_callback(self, event_type, tool_name=None, preview=None, args=None,
  **kwargs)` signature and the events emitted by `_relay_moa_reference_event`.
  The gateway re-binds this callback on every turn (the per-message
  `agent.tool_progress_callback = ...` assignment), so no gateway-side
  re-attach is needed for the markers to fire on subsequent turns.
- This change is gateway-only. It assumes the agent already emits
  `moa.reference` / `moa.aggregating` for the turn (which v0.20.0 does). The
  first turn immediately after an *in-place* `/model` swap to a MoA preset is
  an edge that depends on the agent-side relay being armed for that turn; that
  agent-side wiring is out of scope here and not modified.

## Testing
- `python -m ast` parse of `gateway/run.py` passes.
- Verified by code reading against tag `v0.20.0` (`3c27eb6`): the base gateway
  has no `moa.reference` / `moa.aggregating` handling, the surrounding
  `progress_callback` region is byte-identical to the insertion anchor, and the
  callback signature exposes the `moa_index` / `moa_count` kwargs used here.
- **Not runtime-tested against a live MoA turn** in this change set. A focused
  gateway test can assert that `🧩 <label> (i/n)` markers appear while the
  reference body does not; maintainers may prefer to add it with their own
  provider fixtures.