### PR TITLE
fix(weixin): preserve inbound preprocessing order per session

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1192,6 +1192,12 @@ class WeixinAdapter(BasePlatformAdapter):
         self._send_session: Optional[aiohttp.ClientSession] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
+        # getUpdates returns an ordered batch, but each message is processed in
+        # its own task.  Media download happens before BasePlatformAdapter's
+        # session guard, so a faster later download can otherwise enter that
+        # guard first.  Refcounts let idle entries disappear without racing a
+        # waiter that has already selected the same lock.
+        self._inbound_order_locks: Dict[str, Tuple[asyncio.Lock, int]] = {}
 
         self._account_id = str(extra.get("account_id") or _wx_secret("WEIXIN_ACCOUNT_ID", "")).strip()
         self._token = str(config.token or extra.get("token") or _wx_secret("WEIXIN_TOKEN", "")).strip()
@@ -1461,10 +1467,46 @@ class WeixinAdapter(BasePlatformAdapter):
                 logger.debug("[%s] old poll session close failed: %s", self.name, exc)
 
     async def _process_message_safe(self, message: Dict[str, Any]) -> None:
+        order_key = self._inbound_order_key(message)
+        entry = self._inbound_order_locks.get(order_key)
+        if entry is None:
+            lock = asyncio.Lock()
+            users = 0
+        else:
+            lock, users = entry
+        self._inbound_order_locks[order_key] = (lock, users + 1)
         try:
-            await self._process_message(message)
+            async with lock:
+                await self._process_message(message)
         except Exception as exc:
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
+        finally:
+            current = self._inbound_order_locks.get(order_key)
+            if current is not None and current[0] is lock:
+                remaining = current[1] - 1
+                if remaining:
+                    self._inbound_order_locks[order_key] = (lock, remaining)
+                else:
+                    self._inbound_order_locks.pop(order_key, None)
+
+    def _inbound_order_key(self, message: Dict[str, Any]) -> str:
+        """Return the same session key used by the generic inbound guard."""
+        from gateway.session import build_session_key
+
+        sender_id = str(message.get("from_user_id") or "").strip()
+        chat_type, effective_chat_id = _guess_chat_type(message, self._account_id)
+        source = self.build_source(
+            chat_id=effective_chat_id,
+            chat_type=chat_type,
+            user_id=sender_id,
+            user_name=sender_id,
+        )
+        return build_session_key(
+            source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            profile=self._session_key_profile(source),
+        )
 
     async def _process_message(self, message: Dict[str, Any]) -> None:
         assert self._poll_session is not None

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -546,6 +546,105 @@ class TestWeixinContentDedup:
         assert event.text == "hello world"
 
 
+class TestWeixinInboundPreprocessingOrder:
+    @staticmethod
+    def _message(sender: str, message_id: str, *, room_id: str = "") -> dict:
+        message = {
+            "from_user_id": sender,
+            "message_id": message_id,
+            "item_list": [{"type": weixin.ITEM_IMAGE, "image_item": {}}],
+        }
+        if room_id:
+            message["room_id"] = room_id
+        return message
+
+    def test_same_session_preprocessing_stays_in_poll_order(self):
+        adapter = _make_adapter()
+        events = []
+
+        async def fake_process(message):
+            message_id = message["message_id"]
+            events.append(f"start:{message_id}")
+            if message_id == "first":
+                await asyncio.sleep(0.05)
+            events.append(f"end:{message_id}")
+
+        adapter._process_message = fake_process
+
+        async def drive():
+            first = asyncio.create_task(
+                adapter._process_message_safe(self._message("wxid-user", "first"))
+            )
+            await asyncio.sleep(0)
+            second = asyncio.create_task(
+                adapter._process_message_safe(self._message("wxid-user", "second"))
+            )
+            await asyncio.gather(first, second)
+
+        asyncio.run(drive())
+
+        assert events == ["start:first", "end:first", "start:second", "end:second"]
+        assert adapter._inbound_order_locks == {}
+
+    def test_different_sessions_still_preprocess_concurrently(self):
+        adapter = _make_adapter()
+        both_started = asyncio.Event()
+        release = asyncio.Event()
+        started = []
+
+        async def fake_process(message):
+            started.append(message["message_id"])
+            if len(started) == 2:
+                both_started.set()
+            await release.wait()
+
+        adapter._process_message = fake_process
+
+        async def drive():
+            tasks = [
+                asyncio.create_task(
+                    adapter._process_message_safe(
+                        self._message("wxid-user", "a", room_id="room-a")
+                    )
+                ),
+                asyncio.create_task(
+                    adapter._process_message_safe(
+                        self._message("wxid-user", "b", room_id="room-b")
+                    )
+                ),
+            ]
+            await asyncio.wait_for(both_started.wait(), timeout=1)
+            release.set()
+            await asyncio.gather(*tasks)
+
+        asyncio.run(drive())
+
+        assert set(started) == {"a", "b"}
+        assert adapter._inbound_order_locks == {}
+
+    def test_failed_preprocessing_releases_session_queue(self):
+        adapter = _make_adapter()
+        processed = []
+
+        async def fake_process(message):
+            processed.append(message["message_id"])
+            if message["message_id"] == "first":
+                raise RuntimeError("broken media")
+
+        adapter._process_message = fake_process
+
+        async def drive():
+            await asyncio.gather(
+                adapter._process_message_safe(self._message("wxid-user", "first")),
+                adapter._process_message_safe(self._message("wxid-user", "second")),
+            )
+
+        asyncio.run(drive())
+
+        assert processed == ["first", "second"]
+        assert adapter._inbound_order_locks == {}
+
+
 class TestWeixinTextDebounce:
     """Text-debounce batching for rapid multi-message bursts (issue #35301).
 
@@ -827,4 +926,3 @@ class TestWeixinVoiceGatewayHandoff:
             "VOICE event body leaked Tencent's STT text — runner would trust "
             "the wrong transcript instead of re-transcribing (#27300)."
         )
-


### PR DESCRIPTION
## What does this PR do?

Weixin's poll loop preserves the order returned by `getUpdates`, but immediately turns every message into an independent task:

```python
for message in response.get("msgs") or []:
    asyncio.create_task(self._process_message_safe(message))
```

For media messages, `_process_message()` then awaits image/video/voice download **before** calling `BasePlatformAdapter.handle_message()`. The generic base adapter correctly serializes agent turns by `session_key`, but it cannot preserve an order it never saw: if image A downloads slowly and the later image B downloads quickly, B reaches the session guard first.

This adds a small per-session preprocessing gate in the Weixin adapter. Its key is produced by the same `build_session_key()` inputs as the generic inbound guard, so it preserves ordering at the correct conversation boundary instead of serializing every chat from one sender. Different sessions still preprocess concurrently.

The registry is reference-counted and removes idle entries. A plain `if not lock.locked(): pop()` is unsafe because `asyncio.Lock.release()` wakes a waiter before that waiter gets CPU; the releasing task could otherwise remove a lock that already has a queued user and let a third message create a second lock.

This only orders the adapter preprocessing stage through entry into `handle_message()`. It does not wait for the agent reply; the existing generic session guard continues to own turn queuing, interruption, command bypasses, and delivery order.

## Related Issue

I could not find an existing Weixin/iLink issue or PR for inbound preprocessing order after searching open, closed, and merged records for ordering, concurrency, sender/session locks, media races, and `getUpdates` task ordering.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor

## Changes Made

- `gateway/platforms/weixin.py`
  - derive the preprocessing gate from the generic gateway session key
  - preserve same-session poll order before media download can reorder it
  - reference-count and remove idle locks
  - retain concurrency across different sessions
- `tests/gateway/test_weixin.py`
  - same-session slow-first preprocessing remains ordered
  - the same sender in two different rooms still runs concurrently
  - a failed first message releases the queue for the next message
  - every case asserts the lock registry returns to empty

## Testing

The new tests were run against current `main` before the source change: **3 failed**. With the fix: **3 passed**.

```text
scripts/run_tests.sh tests/gateway/test_weixin.py -k InboundPreprocessingOrder
3 passed, 0 failed
```

Ruff passes on both changed files. The broader three-file Weixin run completed **38 passed / 7 failed**; all seven failures are existing async tests that this local shared venv cannot collect because it lacks `pytest-asyncio` (the focused tests use `asyncio.run` and execute normally).