### PR TITLE
fix(desktop): coalesce duplicate branch creates

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -117,6 +117,7 @@ const RUNTIME_SESSION_ID = 'rt-new-001'
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
   | 'archiveSession'
+  | 'branchStoredSession'
   | 'createBackendSessionForSend'
   | 'openNewSessionTile'
   | 'removeSession'
@@ -183,6 +184,71 @@ function Harness({
 
   return null
 }
+
+describe('desktop branch creation idempotency', () => {
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    vi.clearAllMocks()
+  })
+
+  it('coalesces duplicate stored-session branch attempts onto one backend child', async () => {
+    const createReady = deferred<{ session_id: string; stored_session_id: string }>()
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        return createReady.promise as never
+      }
+
+      return {} as never
+    })
+
+    let actions: HarnessHandle | null = null
+
+    setSessions([storedSession({ id: 'parent', message_count: 2, title: 'Parent' })])
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'question', role: 'user', timestamp: 1 },
+        { content: 'answer', role: 'assistant', timestamp: 2 }
+      ],
+      session_id: 'parent'
+    } as never)
+
+    render(<Harness onReady={value => (actions = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(actions).not.toBeNull())
+
+    let first!: Promise<boolean>
+    let second!: Promise<boolean>
+
+    act(() => {
+      first = actions!.branchStoredSession('parent')
+      second = actions!.branchStoredSession('parent')
+    })
+
+    await waitFor(() =>
+      expect(requestGateway.mock.calls.filter(([method]) => method === 'session.create')).toHaveLength(1)
+    )
+
+    await act(async () => {
+      createReady.resolve({ session_id: 'runtime-branch', stored_session_id: 'stored-branch' })
+      await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+    })
+
+    expect(requestGateway.mock.calls.filter(([method]) => method === 'session.create')).toHaveLength(1)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.create',
+      expect.objectContaining({
+        messages: [
+          { content: 'question', role: 'user' },
+          { content: 'answer', role: 'assistant' }
+        ],
+        parent_session_id: 'parent',
+        source: 'desktop'
+      })
+    )
+    expect($sessions.get().filter(session => session.id === 'stored-branch')).toHaveLength(1)
+  })
+})
 
 describe('connection-qualified session deletion', () => {
   afterEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -200,6 +200,39 @@ interface SessionActionsOptions {
 // (NOT in this set) still legitimately drops to a draft.
 const createdThisRun = new Set<string>()
 
+interface BranchCreateFlight {
+  promise: Promise<SessionCreateResponse>
+  response?: SessionCreateResponse
+}
+
+const branchMessagesFingerprint = (messages: BranchMessage[]): string =>
+  JSON.stringify(messages.map(({ content, role }) => [role, content]))
+
+function branchCreateKey({
+  branchCount,
+  branchMessages,
+  cwd,
+  parentStoredId,
+  profile,
+  sourceSessionId
+}: {
+  branchCount?: number
+  branchMessages: BranchMessage[]
+  cwd?: string
+  parentStoredId: null | string
+  profile?: null | string
+  sourceSessionId: null | string
+}): string {
+  return JSON.stringify({
+    branchCount: branchCount ?? null,
+    cwd: cwd?.trim() || null,
+    messages: sourceSessionId ? null : branchMessagesFingerprint(branchMessages),
+    parentStoredId,
+    profile: profile?.trim() || null,
+    sourceSessionId
+  })
+}
+
 // Reflect a stored row's persisted token counts into the live usage atom
 // (total is derived, so callers can't drift it out of sync with input/output).
 function applyStoredUsage(stored: { input_tokens?: number | null; output_tokens?: number | null }) {
@@ -332,6 +365,7 @@ export function useSessionActions({
   const { t } = useI18n()
   const copy = t.desktop
   const resumeRequestRef = useRef(0)
+  const branchCreateFlightsRef = useRef(new Map<string, BranchCreateFlight>())
 
   // Follow auto-compression's stored-id rotation only while the exact runtime,
   // selection, and route intent still belong to the rotating conversation.
@@ -1955,20 +1989,53 @@ export function useSessionActions({
         // upsertOptimisticSession's $activeGatewayProfile stamp correct.
         await ensureGatewayProfile(profile)
 
+        const createKey = branchCreateKey({
+          branchCount,
+          branchMessages,
+          cwd,
+          parentStoredId,
+          profile,
+          sourceSessionId
+        })
+
+        let createFlight = branchCreateFlightsRef.current.get(createKey)
+
         // No title: the backend auto-names the branch from its parent's lineage.
-        const branched = sourceSessionId
-          ? await requestGateway<SessionCreateResponse>('session.branch', {
-              session_id: sourceSessionId,
-              ...(branchCount !== undefined ? { count: branchCount } : {})
-            })
-          : await requestGateway<SessionCreateResponse>('session.create', {
-              cols: 96,
-              source: 'desktop',
-              ...(cwd && { cwd }),
-              ...(profile ? { profile } : {}),
-              messages: branchMessages.map(({ content, role }) => ({ content, role })),
-              ...(parentStoredId && { parent_session_id: parentStoredId })
-            })
+        if (!createFlight) {
+          const createPromise = sourceSessionId
+            ? requestGateway<SessionCreateResponse>('session.branch', {
+                session_id: sourceSessionId,
+                ...(branchCount !== undefined ? { count: branchCount } : {})
+              })
+            : requestGateway<SessionCreateResponse>('session.create', {
+                cols: 96,
+                source: 'desktop',
+                ...(cwd && { cwd }),
+                ...(profile ? { profile } : {}),
+                messages: branchMessages.map(({ content, role }) => ({ content, role })),
+                ...(parentStoredId && { parent_session_id: parentStoredId })
+              })
+
+          createFlight = {
+            promise: createPromise
+              .then(response => {
+                const current = branchCreateFlightsRef.current.get(createKey)
+
+                if (current) {
+                  current.response = response
+                }
+
+                return response
+              })
+              .catch(err => {
+                branchCreateFlightsRef.current.delete(createKey)
+                throw err
+              })
+          }
+          branchCreateFlightsRef.current.set(createKey, createFlight)
+        }
+
+        const branched = createFlight.response ?? (await createFlight.promise)
 
         const responseBranchMessages =
           sourceSessionId && branched.messages?.length ? toBranchMessages(toChatMessages(branched.messages)) : []
@@ -2028,6 +2095,7 @@ export function useSessionActions({
           revealTreePane(`session-tile:${routedSessionId}`)
         }
 
+        branchCreateFlightsRef.current.delete(createKey)
         broadcastSessionsChanged()
 
         return true


### PR DESCRIPTION
## Summary

Desktop branch creation could be re-entered while the first branch/resume path was still pending, so a failed or retried renderer transition could call `session.create`/`session.branch` again and accumulate duplicate child sessions. This adds an in-memory single-flight guard around branch creation keyed by the parent/source/profile/prefix, so repeated attempts reuse the existing backend child while it is in flight.

---

## Changes

### `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`

- Added branch-create flight tracking for Desktop branch actions.
- Coalesces duplicate create attempts onto the same pending backend child.
- Clears failed create flights so a real retry can still run.
- Preserves the existing branch open/resume paths after creation succeeds.

### `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`

- Added a regression test for concurrent duplicate stored-session branch attempts.
- Verifies only one `session.create` RPC is sent and both callers resolve successfully.

---

## How to Test

```bash
cd apps/desktop
NODE_OPTIONS=--max-old-space-size=3072 node ../../node_modules/vitest/vitest.mjs run --project ui src/app/session/hooks/use-session-actions.test.tsx
NODE_OPTIONS=--max-old-space-size=3072 node ../../node_modules/typescript/bin/tsc -p . --noEmit
node ../../node_modules/eslint/bin/eslint.js src/app/session/hooks/use-session-actions/index.ts src/app/session/hooks/use-session-actions.test.tsx
```

Result locally:

```text
Vitest: 85 passed
TypeScript: passed
ESLint targeted: passed, 0 warnings
```

---

## Checklist

- [x] Tests pass — 85/85 targeted Desktop UI tests
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Desktop renderer: macOS / Windows / WSL2)
- [x] profile-safe paths used — no hardcoded `~/.hermes`
- [x] `.env` not used for non-credential settings

---

## Risk & Impact

Low. This is renderer-only idempotency around branch creation; it does not change backend session schema, persistence, or the existing navigation behavior.

Type: Bug fix

Closes: #97414
