### PR TITLE
fix(skills): a failed batch rollback never destroys the skill or its snapshot (#97714)

### DIFF
--- a/tests/tools/test_skill_manage_batch.py
+++ b/tests/tools/test_skill_manage_batch.py
@@ -74,6 +74,90 @@ class TestSkillManageBatch(unittest.TestCase):
         self.assertFalse(r["success"])
         self.assertFalse(os.path.exists(os.path.join(self.home, "skills", "fresh")))
 
+    def test_failed_rollback_preserves_snapshot_for_recovery(self):
+        """(#97714) A restore that raises must not destroy both copies.
+
+        The old _rollback() removed the live skill directory BEFORE copying
+        the snapshot back; if the copy then raised (disk full, locked file,
+        Windows path limits), the finally deleted the snapshot too — the
+        skill and its only backup were both gone. A failed restore must
+        leave the operator a recoverable copy, and the error payload must
+        say so instead of implying the rollback ran.
+        """
+        self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])
+        smt = self.smt
+        real_copytree = shutil.copytree
+        skills_dir = os.path.join(self.home, "skills")
+        state = {"armed": False, "snap_dir": None}
+
+        real_rmtree = shutil.rmtree
+        surviving_snaps = []
+
+        def tracking_rmtree(path, *a, **k):
+            p = os.fspath(path).replace("\\", "/")
+            # record every snapshot dir that gets deleted, so the test can
+            # assert whether the backup survived
+            if "skill_batch_" in p:
+                surviving_snaps.append(p)
+            return real_rmtree(path, *a, **k)
+
+        def copytree_gated(src, dst, *a, **k):
+            dstp = os.fspath(dst).replace("\\", "/")
+            if dstp.startswith(skills_dir.replace("\\", "/")) and state["armed"]:
+                raise OSError("simulated restore failure (disk full)")
+            return real_copytree(src, dst, *a, **k)
+
+        real_skill_manage = smt.skill_manage
+
+        # The batch loop calls the module-global skill_manage per op; wrap it
+        # so the first failing op arms the restore failure (the rollback's
+        # copytree then raises on its way back into the skills dir).
+        def gated_skill_manage(*a, **k):
+            result_raw = real_skill_manage(*a, **k)
+            try:
+                ok = json.loads(result_raw).get("success")
+            except Exception:
+                ok = False
+            if not ok:
+                # this was the failing op — rollback runs next
+                state["armed"] = True
+            return result_raw
+
+        smt.shutil.copytree = copytree_gated
+        smt.shutil.rmtree = tracking_rmtree
+        smt.skill_manage = gated_skill_manage
+        try:
+            r = self._call("probe", [
+                {"action": "patch", "old_string": "Step 1.", "new_string": "Step ONE."},
+                {"action": "write_file", "file_path": "bad/nope.md", "file_content": "x"},
+            ])
+        finally:
+            smt.shutil.copytree = real_copytree
+            smt.shutil.rmtree = real_rmtree
+            smt.skill_manage = real_skill_manage
+
+        self.assertFalse(r["success"])
+        self.assertIn("ROLLBACK FAILED", r["error"])
+        # The recoverable copy must still exist: a snapshot dir that was
+        # never deleted. surviving_snaps lists snapshot dirs rmtree touched.
+        # With the fix, the finally skips cleanup when rollback failed, so
+        # check: at least one skill_batch_* dir under temp remains alive.
+        import glob, tempfile as _tf
+        leftovers = [
+            d for d in glob.glob(os.path.join(_tf.gettempdir(), "skill_batch_*"))
+            if os.path.isdir(d) and os.path.exists(
+                os.path.join(d, "probe", "SKILL.md"))
+        ]
+        self.assertTrue(
+            leftovers,
+            "snapshot was deleted despite failed rollback — no recoverable copy left",
+        )
+        # and the payload must point the operator at it
+        self.assertTrue(
+            any("snapshot" in r["error"].lower() for _ in [0]),
+            "error payload should tell the operator a snapshot survives",
+        )
+
     def test_validation_rules(self):
         # delete as SOLE op routes to the real delete (works)
         self._call("probe", [{"action": "create", "content": SK.format(n="probe")}])

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1706,15 +1706,40 @@ def _skill_manage_batch(
                 post = _find_skill(nm)
                 post_dir = Path(post["path"]) if post else None
                 if snap is not None:
+                    # Restore INTO A STAGING COPY first, then swap. The old
+                    # order (rmtree live dir, then copytree back) destroyed
+                    # both copies when the restore raised — disk full, locked
+                    # file, Windows path limits (#97714). Copying beside the
+                    # target can still fail, but until it succeeds the live
+                    # dir is untouched and the snapshot stays in place.
+                    stage = Path(str(pre_dir) + ".rollback")
+                    if stage.is_dir():
+                        shutil.rmtree(stage)
+                    shutil.copytree(snap, stage)
                     if post_dir is not None and post_dir.is_dir():
                         shutil.rmtree(post_dir)
-                    shutil.copytree(snap, pre_dir)
+                    try:
+                        stage.rename(pre_dir)
+                    except OSError as exc:
+                        # Even the atomic swap back failed (e.g. something is
+                        # holding pre_dir on Windows): stop — never touch the
+                        # staged copy again, it is a second recoverable tree.
+                        raise RuntimeError(
+                            f"restore swap failed; recoverable copies at "
+                            f"'{stage}' and snapshot '{snap}'"
+                        ) from exc
                 elif post_dir is not None and post_dir.is_dir():
                     # Batch created this skill: remove the partial result.
                     shutil.rmtree(post_dir)
             except Exception as exc:  # noqa: BLE001
-                notes.append(f"ROLLBACK FAILED for '{nm}' ({exc})")
+                notes.append(
+                    f"ROLLBACK FAILED for '{nm}' ({exc}); snapshot preserved at '{snap}'"
+                    if snap is not None
+                    else f"ROLLBACK FAILED for '{nm}' ({exc})"
+                )
         return "; ".join(notes) if notes else "all touched skills rolled back"
+
+    rollback_failed = False
 
     # --- execute ops through the normal single-op path (gate bypassed:
     #     the batch already cleared/staged it above; ledger + telemetry
@@ -1742,6 +1767,7 @@ def _skill_manage_batch(
                 parsed = {"success": False, "error": "unparseable op result"}
             if not parsed.get("success"):
                 note = _rollback()
+                rollback_failed = "ROLLBACK FAILED" in note
                 fail = {
                     "success": False,
                     "error": (
@@ -1765,7 +1791,11 @@ def _skill_manage_batch(
                             "success": True})
     finally:
         _skill_gate_bypass.reset(token)
-        shutil.rmtree(snap_root, ignore_errors=True)
+        # A failed rollback means the snapshot is the ONLY recoverable copy
+        # — never delete it (#97714: the old unconditional cleanup erased
+        # both the live dir and the backup on a restore error).
+        if not rollback_failed:
+            shutil.rmtree(snap_root, ignore_errors=True)
 
     return json.dumps(
         {"success": True, "operations_applied": len(results),


### PR DESCRIPTION
## What & why
Fixes #97714.

The `operations[]` batch rollback removed the live skill directory **before** restoring from the snapshot, and the `finally` deleted the snapshot root **unconditionally**. When the restore `copytree` raised (disk full, locked file, Windows path limits), the skill directory and its only backup were both gone — the atomicity feature destroyed the skill on rollback error.

## The fix
Rollback now restores into a staging sibling (`<skill>.rollback`) first; the live directory is only swapped away once the staged copy exists, and the snapshot cleanup is skipped whenever any rollback reported `ROLLBACK FAILED`. The failure payload now names the surviving snapshot path so the operator can recover by hand.

- Restore-copy fails → live dir untouched, snapshot preserved.
- Swap fails after rmtree (rare; e.g. a Windows handle holds the dir) → the staged tree is left in place as a second recoverable copy, and the error names both paths.

## How to test
`tests/tools/test_skill_manage_batch.py::test_failed_rollback_preserves_snapshot_for_recovery` monkeypatches the module-level `copytree` to fail only the restore leg (destination under `HERMES_HOME/skills`) and asserts a `skill_batch_*` snapshot dir with the pre-batch `SKILL.md` survives on disk.

- Red on current main: `AssertionError: [] is not true : snapshot was deleted despite failed rollback`
- Green with the fix: full batch suite 9 passed; combined with `test_skill_manager_tool.py`: **69 passed**.
- Reproduced on Windows 11, Python 3.11+; `ruff check` clean.

## Platforms
Tested on Windows 11. The changed code path is pure pathlib/shutil and platform-neutral; the failure mode it guards against (locked/undeletable directories, path-length limits) is most common on Windows.