### PR TITLE
fix(agent): exclude ollama.com from deepseek reasoning_content echo-back

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -836,13 +836,13 @@ def uniquify_tool_call_ids(tool_calls: list) -> list:
 
 _REASONING_ECHO_RULES: tuple = (
     # (family, exact providers (raw), exact providers (lowered),
-    #  model substrings (lowered), base_url hosts)
+    #  model substrings (lowered), base_url hosts, excluded base_url hosts)
     ("kimi", frozenset({"kimi-coding", "kimi-coding-cn"}), frozenset(), (),
-     ("api.kimi.com", "moonshot.ai", "moonshot.cn")),
+     ("api.kimi.com", "moonshot.ai", "moonshot.cn"), ()),
     ("deepseek", frozenset(), frozenset({"deepseek"}), ("deepseek",),
-     ("api.deepseek.com",)),
+     ("api.deepseek.com",), ("ollama.com",)),
     ("mimo", frozenset(), frozenset({"xiaomi"}), ("mimo",),
-     ("api.xiaomimimo.com", "xiaomimimo.com")),
+     ("api.xiaomimimo.com", "xiaomimimo.com"), ()),
 )
 
 
@@ -864,7 +864,12 @@ def matches_reasoning_echo_family(
     """
     from utils import base_url_host_matches
 
-    _, raw_providers, lowered_providers, model_subs, hosts = _family_rule(family)
+    _, raw_providers, lowered_providers, model_subs, hosts, excluded_hosts = _family_rule(family)
+    # Excluded hosts win: an endpoint that does not enforce echo-back
+    # (e.g. ollama.com serving a deepseek-named model) must never match,
+    # regardless of provider/model name.
+    if any(base_url_host_matches(base_url, host) for host in excluded_hosts):
+        return False
     provider_lower = (provider or "").lower()
     model_lower = (model or "").lower()
     if provider in raw_providers or provider_lower in lowered_providers:

--- a/tests/agent/test_message_sanitization_policy.py
+++ b/tests/agent/test_message_sanitization_policy.py
@@ -174,6 +174,11 @@ class TestReasoningEchoFamily:
         ("DeepSeek", "whatever", "https://x", "deepseek"),
         ("openrouter", "deepseek/deepseek-v3", "https://openrouter.ai", "deepseek"),
         ("custom", None, "https://api.deepseek.com", "deepseek"),
+        # ollama-cloud serves deepseek-named models but does NOT enforce
+        # reasoning_content echo-back — excluded host must win over the
+        # model-name substring match.
+        ("ollama-cloud", "deepseek-v4-flash:0731", "https://ollama.com/v1", None),
+        ("ollama-cloud", "deepseek-v4-pro:0813", "https://ollama.com/v1", None),
         ("xiaomi", None, "https://x", "mimo"),
         ("custom", "MiMo-7B", "https://x", "mimo"),
         ("custom", None, "https://api.xiaomimimo.com/v1", "mimo"),


### PR DESCRIPTION
## What does this PR do?

Fixes a false positive in the reasoning_content echo-back family table: `ollama-cloud` (ollama.com/v1) serves deepseek-named models (`deepseek-v4-flash:0731`, `deepseek-v4-pro:0813`) but does **not** enforce `reasoning_content` echo-back — it ignores the field entirely (verified live against ollama.com/v1: replaying a 1400-char `reasoning_content` changes `prompt_tokens` by 0). The deepseek family rule matched on the model-name substring, so every assistant turn's full reasoning text was re-sent on the next request to an endpoint that discards it.

This is a correctness/hygiene fix: Hermes should not send a field the endpoint ignores. It also removes a source of confusion when debugging reasoning-loop issues (the replayed field is not the cause of token burn — see the experiment notes below).

The fix adds an excluded-hosts slot to `_REASONING_ECHO_RULES`; excluded hosts win over provider/model-name matches. `api.deepseek.com`, Kimi, and MiMo behavior is unchanged.

## Related Issue

Fixes #97751

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/message_sanitization.py`:
  - `_REASONING_ECHO_RULES`: added a 6th tuple slot `excluded base_url hosts`; deepseek rule now excludes `ollama.com`
  - `matches_reasoning_echo_family()`: excluded hosts are checked first and return `False` regardless of provider/model-name matches
- `tests/agent/test_message_sanitization_policy.py`:
  - Added 2 parametrized cases: `ollama-cloud` + `deepseek-v4-flash:0731` / `deepseek-v4-pro:0813` → `None` (no echo family)

## How to Test

1. `pytest tests/agent/test_message_sanitization_policy.py -q` → 58 passed
2. Direct check (repro of the false positive):
   ```python
   from agent.message_sanitization import matches_reasoning_echo_family
   # Before fix: True (wrong — ollama-cloud does not enforce echo-back)
   # After fix:  False
   matches_reasoning_echo_family("deepseek", "ollama-cloud", "deepseek-v4-flash:0731", "https://ollama.com/v1")
   ```
3. Regression: `api.deepseek.com` / provider `deepseek` / model `deepseek/deepseek-v3` still match → `True`

## Root Cause Analysis

**Symptom (user report, ollama-cloud + deepseek-v4-flash:0731, reasoning_effort: high):**
1. Final (non-reasoning) output occasionally repeats — minor
2. Reasoning chain itself repeats, cannot advance, burns large amounts of tokens, requires manual interrupt to escape — severe

**Root cause chain (updated after live experiments, 2026-08-29):**
1. `_REASONING_ECHO_RULES` deepseek rule matches on model-name substring "deepseek" → `ollama-cloud`'s `deepseek-v4-flash:0731` is classified as a DeepSeek echo-back endpoint
2. Hermes re-sends the full `reasoning_content` on every subsequent request
3. **Experiment result:** ollama-cloud ignores the field — replaying 0 / 10 / 1400-char `reasoning_content` all yield identical `prompt_tokens` (28.0). So the echo-back does NOT inflate input tokens. It is a correctness issue (sending a field the endpoint discards), not a cost issue.
4. The severe symptom (repeated reasoning chain + token burn) is driven by a different mechanism: when the model degenerates and emits only `reasoning` with empty `content`, Hermes' `_has_structured` check (conversation_loop.py:7862) is True → thinking-prefill continuation (up to 2 full-context re-sends) → then empty-response retry (up to 3 more). Each retry re-sends the full conversation at full price. That amplification is a separate concern (reasoning-degeneration detection) and is NOT addressed by this PR.

**Evidence:**
- Live curl against ollama.com/v1 (2026-08-29): `deepseek-v4-flash:0731` and `qwen3.5:397b` both return `message.keys = ['role', 'content', 'reasoning']`; `reasoning_content` absent
- Token-cost experiment: 3 scenarios (no / short / long `reasoning_content`) → `prompt_tokens` identical (28.0) → endpoint discards the field
- `matches_reasoning_echo_family("deepseek", "ollama-cloud", "deepseek-v4-flash:0731", "https://ollama.com/v1")` → `True` before fix

**Related but distinct:** local Ollama puts thinking in `content` as `  thinking` / `  response` indented tags (no angle brackets); `strip_think_blocks` only strips angle-bracket forms, so detection (`_has_inline_thinking`) and stripping disagree. That is a separate issue (local Ollama only) and is NOT addressed by this PR.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (58/58 in the affected file `tests/agent/test_message_sanitization_policy.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping
- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
