### PR TITLE
fix(kanban): treat review-handoff tools as terminal in the stop guard

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -1,10 +1,10 @@
 """Turn-end guard for kanban workers.
 
-Kanban workers must end with ``kanban_complete`` or ``kanban_block``. Models
-(especially GLM / Qwen families) sometimes narrate the next step
-("Let me write the report now") and stop with ``finish_reason=stop`` and no
-tool calls. Hermes treats that as a clean exit → ``rc=0`` → dispatcher
-``protocol_violation``.
+Kanban workers must end with a terminal board tool that hands the card to
+whoever owns it next. Models (especially GLM / Qwen families) sometimes
+narrate the next step ("Let me write the report now") and stop with
+``finish_reason=stop`` and no tool calls. Hermes treats that as a clean
+exit → ``rc=0`` → dispatcher ``protocol_violation``.
 
 This module is policy-only: when a kanban worker tries to finish without a
 terminal board tool, return a bounded synthetic nudge so the conversation
@@ -17,7 +17,21 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+# Every tool that hands the card off and ends this worker's responsibility
+# for it — not just the two that close it out.  A build worker legitimately
+# finishes with ``kanban_request_review`` (goals.py's continuation and
+# finalize prompts tell it to, for code changes needing same-card review),
+# and a review agent finishes with ``kanban_request_changes`` (the
+# force-loaded sdlc-review skill's decision table tells it to).  Both move
+# the task out of ``running``, so treating them as non-terminal fired this
+# guard at a worker that had already done the right thing — nudging it to
+# call ``kanban_complete`` on a card it must not close.
+_TERMINAL_KANBAN_TOOLS = frozenset({
+    "kanban_complete",
+    "kanban_block",
+    "kanban_request_review",
+    "kanban_request_changes",
+})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -88,3 +88,59 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
 
 
 
+
+
+@pytest.mark.parametrize(
+    "tool_name,who",
+    [
+        ("kanban_request_review", "build worker handing off for same-card review"),
+        ("kanban_request_changes", "review agent sending the card back"),
+    ],
+)
+def test_no_nudge_after_handoff_tool(clear_kanban_env, tool_name, who):
+    """Handoff tools end the worker's turn just like complete/block.
+
+    Both move the card out of ``running``, and the worker is told to call
+    them — goals.py's continuation/finalize prompts name
+    ``kanban_request_review``; the force-loaded sdlc-review skill names
+    ``kanban_request_changes``. Nudging afterwards asks a worker that did
+    the right thing to close a card it must not close.
+    """
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_handoff")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": tool_name, "tool_call_id": "1", "content": "ok"},
+    ]
+    assert session_called_kanban_terminal(messages) is True, who
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
+def test_nudge_still_fires_for_non_terminal_kanban_tool(clear_kanban_env):
+    """Widening the set must not swallow the case the guard exists for."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Let me open the review next.",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": "kanban_comment", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "name": "kanban_comment", "tool_call_id": "1", "content": "ok"},
+    ]
+    assert session_called_kanban_terminal(messages) is False
+    assert build_kanban_stop_nudge(messages=messages) is not None


### PR DESCRIPTION
Covers lifecycle mismatch #2 of #94916. The `dispatch --dry-run` half is deliberately **not** in this PR — see the note at the bottom.

## The bug

`agent/kanban_stop.py` gated its turn-end guard on a two-name set:

```python
_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
```

`kanban_request_review` and `kanban_request_changes` also end a worker's responsibility for a card, so the guard fired at workers that had already done the right thing.

**Build worker.** `_handle_request_review` (`tools/kanban_tools.py`) calls `kb.request_review()`, which moves the card from `running` to `review`. `session_called_kanban_terminal()` then returned `False`, and the nudge told the worker:

> Task `t_...` is still `running`.
> ... Call `kanban_complete(...)` if the work is done, OR `kanban_block(...)`

Both statements are wrong at that point: the card is in `review`, and `kanban_complete` would close a card that must go through review instead. The worker either complies and closes it, or burns its nudge budget and exits as a `protocol_violation`.

This directly contradicts the prompts the same worker is running under — `hermes_cli/goals.py`'s `KANBAN_GOAL_CONTINUATION_TEMPLATE` and `KANBAN_GOAL_FINALIZE_TEMPLATE` both say *"call kanban_request_review with a summary instead"* for code changes needing same-card review.

**Review agent.** Same wall. `dispatch_once`'s review lane spawns through the same `_default_spawn`, which sets `HERMES_KANBAN_TASK`, so `kanban_stop_nudge_enabled()` is true for reviewers too — and the sdlc-review skill that lane force-loads ends its request-changes path on `kanban_request_changes`.

## The fix

Both handoff tools join the set. One frozenset, plus a comment recording why the set is "hands the card off", not "closes the card" — that is the distinction the original two names lost.

## Tests

`tests/agent/test_kanban_stop.py`:

- `test_no_nudge_after_handoff_tool` — parametrized over both tools; asserts `session_called_kanban_terminal()` is `True` and no nudge is built. Both cases fail with `agent/kanban_stop.py` reverted.
- `test_nudge_still_fires_for_non_terminal_kanban_tool` — a `kanban_comment` call still produces a nudge, so widening the set did not swallow the case the guard exists for.

`pytest tests/agent/test_kanban_stop.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_surfaces.py` — 65 passed, plus one failure (`test_review_tools_are_gated_and_visible_to_kanban_workers`) that reproduces identically on unmodified `main` in this environment and is unrelated to this change.

## Deliberately out of scope

- **The `--dry-run` half of #94916.** `dispatch_once` calls `recompute_ready()` unguarded, but that is what makes the preview accurate — the `ready_rows` query that follows reads `status = 'ready'`, so skipping the promotion would make `--dry-run` under-report the tasks it is being asked to preview. A correct fix needs `recompute_ready()` to compute without writing and `dispatch_once` to use the in-memory result; that is a different change. The more clearly wrong part is that `hermes_cli/kanban.py` prints `"Would promote"` for work the DB already committed. Both belong in their own PR.
- **Verifying the tool actually succeeded.** `session_called_kanban_terminal()` matches on tool name, not on result, so a *failed* terminal call already suppresses the nudge today — `kanban_complete` included, and `test_no_nudge_after_kanban_complete` pins that name-based contract with a plain `"done"` payload. This PR keeps that behaviour rather than changing it for four tools at once.