### PR TITLE
test(hermes_time): cover the invalid-timezone fallback path

### DIFF
--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -86,6 +86,22 @@ class TestGetTimezone:
         assert isinstance(tz, ZoneInfo)
         assert str(tz) == "Europe/London"
 
+    def test_invalid_timezone_falls_back_to_none(self, caplog):
+        """An unresolvable IANA name must not raise -- get_timezone() falls
+        back to None (meaning: use server-local time) and logs a warning."""
+        os.environ["HERMES_TIMEZONE"] = "Not/AZone"
+        with caplog.at_level(logging.WARNING):
+            tz = hermes_time.get_timezone()
+        assert tz is None
+        assert "Invalid timezone" in caplog.text
+
+    def test_now_falls_back_when_timezone_invalid(self):
+        """now() stays tz-aware (server-local) instead of crashing when the
+        configured timezone name is invalid."""
+        os.environ["HERMES_TIMEZONE"] = "Not/AZone"
+        result = hermes_time.now()
+        assert result.tzinfo is not None
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes_time.py` and `tests/test_timezone.py`'s own module docstrings both
claim "invalid timezone falls back safely (no crash, warning logged)" is
covered, but no test actually exercised that branch (`_get_zoneinfo`'s
except path in hermes_time.py). This adds the missing coverage.

## Related Issue

No existing issue — found via a coverage audit (docstring-claimed vs.
actually-tested behavior) rather than a bug report.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/test_timezone.py`: add `test_invalid_timezone_falls_back_to_none`
  (asserts `get_timezone()` returns `None` and a warning is logged) and
  `test_now_falls_back_when_timezone_invalid` (asserts `now()` stays
  tz-aware via server-local time instead of raising).

## How to Test

1. `pytest tests/test_timezone.py -v` — new tests pass alongside the
   existing ones.
2. Manually: `HERMES_TIMEZONE=Not/AZone python -c "import hermes_time; print(hermes_time.now())"` — logs a warning, does not crash.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/test_timezone.py -q` and the relevant tests pass
- [x] Tests added (this PR is test-only)
- [ ] Platform tested: Windows 11 (dev environment); logic is OS-independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)