### PR TITLE
fix(todo): don't collapse distinct todo items that share a blank id

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -31,6 +31,18 @@ class TestWriteAndRead:
             {"id": "2", "content": "Other task", "status": "pending"},
         ]
 
+    def test_multiple_blank_ids_are_not_collapsed(self):
+        """Distinct items missing an id must not collide on the shared '?'
+        placeholder — that would silently drop all but the last one."""
+        store = TodoStore()
+        items = store.write([
+            {"id": "", "content": "first", "status": "pending"},
+            {"id": "", "content": "second", "status": "pending"},
+            {"id": "  ", "content": "third", "status": "pending"},
+        ])
+        assert len(items) == 3
+        assert [i["content"] for i in items] == ["first", "second", "third"]
+
     def test_write_moves_active_item_before_earlier_pending_step(self):
         store = TodoStore()
         result = store.write([

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -198,8 +198,12 @@ class TodoStore:
                 # Non-dict items get a synthetic key so _validate can handle them
                 last_index[f"__invalid_{i}"] = i
                 continue
-            item_id = str(item.get("id", "")).strip() or "?"
-            last_index[item_id] = i
+            item_id = str(item.get("id", "")).strip()
+            # Blank ids are NOT duplicates of each other — unlike a real
+            # repeated id (the model updating the same item twice), items
+            # missing an id are independent and must not collapse onto the
+            # shared "?" key _validate later assigns them.
+            last_index[item_id or f"__blank_{i}"] = i
         return [todos[i] for i in sorted(last_index.values())]
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

`TodoStore._dedupe_by_id` normalizes a missing/blank `id` to the literal
`"?"` before deduping. Multiple items with no id then collide on that
shared key, and only the last one survives `write()` in replace mode —
silently dropping the earlier items with no error.

Repro:
```python
from tools.todo_tool import TodoStore
s = TodoStore()
print(s.write([
    {"id": "", "content": "first task", "status": "pending"},
    {"id": "", "content": "second task", "status": "pending"},
    {"id": "", "content": "third task", "status": "pending"},
], merge=False))
# [{'id': '?', 'content': 'third task', 'status': 'pending'}]
# first and second tasks silently disappeared
```

The tool schema marks `id` as `required`, but JSON Schema's `required`
only guarantees presence, not a non-empty string — a model (or a replayed/
malformed history hitting `_hydrate_todo_store`) can still send `""`.

## Related Issue

No existing issue — found via manual code audit + repro, not a bug report.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/todo_tool.py`: `_dedupe_by_id` now keys blank-id items on a
  per-index synthetic key (`__blank_{i}`) instead of the shared `"?"`
  placeholder, mirroring the existing `__invalid_{i}` handling already
  used for non-dict items. Real duplicate (non-blank) ids still collapse
  to the last occurrence as before.
- `tests/tools/test_todo_tool.py`: regression test
  (`test_multiple_blank_ids_are_not_collapsed`).

## How to Test

1. Run the repro above on `main` — only 1 of 3 items survives.
2. Apply this PR, re-run — all 3 items survive.
3. `pytest tests/tools/test_todo_tool.py tests/tools/test_todo_schema_diet.py -q` — all pass (20/20).

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/tools/test_todo_tool.py -q` and it passes
- [x] I've added a test for this change
- [ ] Platform tested: Windows 11 (dev environment); logic is OS-independent (pure string/dict handling, no I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)