### PR TITLE
fix(config): recognize session reset policy fields

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5355,6 +5355,21 @@ _SCHEMA_DEFINED_DICT_KEYS = frozenset({
     "plugins",
 })
 
+# Optional fixed-shape sections that are intentionally absent from
+# DEFAULT_CONFIG until a user opts in. Unlike open dictionaries, their child
+# keys are runtime-defined and should still get typo detection from
+# ``hermes config set``.
+_OPTIONAL_FIXED_CONFIG_SCHEMAS = {
+    "session_reset": {
+        "mode": None,
+        "at_hour": None,
+        "idle_minutes": None,
+        "notify": None,
+        "notify_exclude_platforms": None,
+        "bg_process_max_age_hours": None,
+    },
+}
+
 # Top-level keys that can be ANY user-supplied name (platform/provider dict
 # shapes where the outer key IS user-defined).
 _DYNAMIC_TOP_LEVEL_KEYS = frozenset({
@@ -5383,6 +5398,7 @@ def _known_top_level_keys() -> set[str]:
     keys.update(_OPEN_DICT_TOP_LEVEL_KEYS)
     keys.update(_DYNAMIC_TOP_LEVEL_KEYS)
     keys.update(_SCHEMA_DEFINED_DICT_KEYS)
+    keys.update(_OPTIONAL_FIXED_CONFIG_SCHEMAS)
     return keys
 
 
@@ -5467,7 +5483,9 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
         # providers.<name>.api_key, etc.).
         return True, None
 
-    node: Any = DEFAULT_CONFIG.get(top)
+    node: Any = DEFAULT_CONFIG.get(
+        top, _OPTIONAL_FIXED_CONFIG_SCHEMAS.get(top)
+    )
     consumed = [top]
     for seg in segments[1:]:
         # ``gateway.platforms.<name>.<field>`` (and any other nested

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -164,6 +164,15 @@ class TestInternalActivityResetPolicy:
 
 class TestResetPolicyNotify:
 
+    def test_cli_schema_matches_gateway_policy_fields(self):
+        """CLI validation and gateway runtime fields must not drift."""
+        from hermes_cli import config as cli_config
+
+        schema = getattr(cli_config, "_OPTIONAL_FIXED_CONFIG_SCHEMAS")
+        assert set(schema["session_reset"]) == set(
+            SessionResetPolicy.__dataclass_fields__
+        )
+
     def test_notify_exclude_defaults(self):
         policy = SessionResetPolicy()
         assert "api_server" in policy.notify_exclude_platforms

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -118,6 +118,13 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_session_reset_notify_is_recognized(self, _isolated_hermes_home, capsys):
+        """The gateway's documented auto-reset notice toggle is runtime config."""
+        set_config_value("session_reset.notify", "false")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "notify: false" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)
@@ -544,6 +551,8 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "session_reset.notify",
+        "session_reset.bg_process_max_age_hours",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key
@@ -554,6 +563,7 @@ class TestValidateConfigKey:
         ("gateway.discord.gateway_restart_notification", None),  # no close suggestion
         ("disco", "discord"),
         ("agent.max_turn", "agent.max_turns"),
+        ("session_reset.notfy", "session_reset.notify"),
     ])
     def test_unknown_keys_with_suggestion(self, key, expected_in_suggestion):
         from hermes_cli.config import _validate_config_key

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -262,6 +262,7 @@ session_reset:
   mode: idle        # "idle", "daily", "both", or "none" (default)
   idle_minutes: 1440  # for idle/both: minutes of inactivity before reset
   at_hour: 4          # for daily/both: hour of day (0-23, local time)
+  notify: true        # set false to suppress the user-facing reset notice
 ```
 
 | Mode | Description |

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -792,6 +792,17 @@ in to automatic resets via the `session_reset` section in `config.yaml`:
 - **daily** — reset at a specific hour each day
 - **both** — reset on whichever comes first (idle or daily)
 
+Automatic resets normally send a short explanation to the affected chat. To
+keep the reset policy but suppress that user-facing notice, set:
+
+```yaml
+session_reset:
+  notify: false
+```
+
+`notify_exclude_platforms` can suppress notices only on selected platforms;
+`api_server` and `webhook` are excluded by default.
+
 Before a session is auto-reset, the agent is given a turn to save any important memories or skills from the conversation.
 
 Sessions with **active background processes** are never auto-reset, regardless of policy.


### PR DESCRIPTION
## Summary

- recognize the gateway's existing fixed-shape `session_reset` fields in `hermes config set`
- preserve the opt-in runtime shape: this does not add `session_reset` to `DEFAULT_CONFIG` or change reset behavior
- keep typo suggestions precise (for example, `session_reset.notfy` → `session_reset.notify`)
- document `session_reset.notify: false` as the supported way to keep automatic resets while suppressing user-facing reset notices

## Problem

The gateway already reads `session_reset.notify`, but the CLI validator only knew the top-level `session_reset` root. As a result, the documented command worked while printing a false warning:

```text
⚠ 'session_reset.notify' is not a recognized config key — it was saved anyway, but Hermes may not read it.
```

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_set_config_value.py tests/gateway/test_session_reset_notify.py tests/gateway/test_config.py -j 3 -q` — 163 passed
- isolated review run with `dev,messaging` extras — 174 passed
- `uv run ruff check hermes_cli/config.py tests/hermes_cli/test_set_config_value.py tests/gateway/test_session_reset_notify.py` — passed
- real CLI/runtime smoke test: `hermes config set session_reset.notify false` emitted no unknown-key warning and `load_gateway_config()` resolved `notify=False`
- `npx -y npm@11.17.0 run build:fast` — Docusaurus build succeeded (existing `/docs/llms*.txt` broken-link warnings remain)
