### PR TITLE
fix(bot-mode): avoid inherited stdin on Windows

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -390,6 +390,36 @@ def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
     assert not dm_file.exists()
 
 
+def test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry(
+    tmp_path, monkeypatch
+):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    calls = []
+    responses = [
+        subprocess.CompletedProcess([], 1, stdout="", stderr="HTTP 429 rate limit"),
+        subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+    ]
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return responses.pop(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    returncode = bot_mode_dm._run_delivery(
+        ["hermes", "-p", "researcher"], str(dm_file), stdin_file=False
+    )
+
+    assert returncode == 0
+    assert len(calls) == 2
+    assert [kwargs["stdin"] for _argv, kwargs in calls] == [
+        subprocess.DEVNULL,
+        subprocess.DEVNULL,
+    ]
+    assert not dm_file.exists()
+
+
 @pytest.mark.parametrize("args", [[], ["--run-delivery"], ["--run-delivery", "bad", "x"]])
 def test_delivery_main_rejects_invalid_cli(args):
     assert bot_mode_dm._delivery_main(args) == 2

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -572,6 +572,7 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
             proc = subprocess.run(
                 [*argv, "--query-file", dm_file],
                 check=False,
+                stdin=subprocess.DEVNULL,
                 capture_output=True,
                 text=True,
             )
@@ -587,6 +588,7 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                     proc = subprocess.run(
                         [*argv, "--query-file", dm_file],
                         check=False,
+                        stdin=subprocess.DEVNULL,
                         capture_output=True,
                         text=True,
                     )


### PR DESCRIPTION
## Summary
- prevent query-file Bot Mode DM transports from inheriting Git Bash's invalid Windows stdin pseudo-handle
- apply the same `DEVNULL` contract to the policy-gated retry path
- cover both attempts with a regression test while preserving the real stream used by peer/stdin-file delivery

## Problem
On native Windows, a local `message_agent` delivery launched through Git Bash can fail before the transport child starts:

```text
warning: Making stdin inheritable failed
message_agent delivery failed: OSError: [WinError 6] The handle is invalid
```

The query-file transport never reads stdin, but `subprocess.run` implicitly inherited the shell's unusable pseudo-handle. The retry path had the same bug shape.

## Verification
- `uv run --no-sync python -m pytest tests/tools/test_bot_mode_dm.py::test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry tests/tools/test_bot_mode_dm.py::test_delivery_command_round_trip_through_windows_local_shell -q --tb=short` — 2 passed
- Windows marked gate (`windows_only and not integration`) — 152 passed, 2 skipped
- Bot DM scoped suite excluding two unchanged POSIX permission assertions on Windows — 38 passed, 1 skipped, 2 deselected
- `uv run --no-sync ruff check tools/bot_mode_dm.py tests/tools/test_bot_mode_dm.py`
- `git diff --check`

## Risk
Low. Only query-file transports now receive `stdin=DEVNULL`; peer/stdin-file transports still receive their message stream unchanged.

Refs #48986
