### PR TITLE
fix(telegram): preserve hidden text-link URLs

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9972,7 +9972,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _m.caption:
-                    _event.text = self._clean_bot_trigger_text(_m.caption)
+                    _event.text = self._clean_bot_trigger_text(_event.text)
                 await self._cache_observed_media(_m, _event)
                 self._observe_unmentioned_group_message(
                     _m, _event.message_type, update_id=update.update_id, event=_event
@@ -9987,7 +9987,7 @@ class TelegramAdapter(BasePlatformAdapter):
         
         # Add caption as text
         if msg.caption:
-            event.text = self._clean_bot_trigger_text(msg.caption)
+            event.text = self._clean_bot_trigger_text(event.text)
         
         # Handle stickers: describe via vision tool with caching
         if msg.sticker:
@@ -10540,6 +10540,37 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             return None
 
+    @staticmethod
+    def _message_text_with_link_targets(message: Message) -> str:
+        """Preserve URLs hidden behind Telegram ``text_link`` entities.
+
+        Telegram keeps a hyperlink's target on the entity rather than in the
+        message text.  Without explicitly carrying those targets into the
+        gateway event, forwarded article labels such as ``Article`` and
+        ``Comments`` reach the agent with no actionable URL.
+        """
+        base_text = getattr(message, "text", None) or getattr(message, "caption", None) or ""
+        link_targets: list[str] = []
+
+        entity_groups = (
+            getattr(message, "entities", None) or [],
+            getattr(message, "caption_entities", None) or [],
+        )
+        for entities in entity_groups:
+            for entity in entities:
+                entity_type = str(getattr(entity, "type", "")).split(".")[-1].lower()
+                if entity_type != "text_link":
+                    continue
+                url = str(getattr(entity, "url", "") or "").strip()
+                if url and url not in link_targets and url not in base_text:
+                    link_targets.append(url)
+
+        if not link_targets:
+            return base_text
+
+        separator = "\n\n" if base_text else ""
+        return f"{base_text}{separator}[Linked URLs]:\n" + "\n".join(link_targets)
+
     def _build_message_event(
         self,
         message: Message,
@@ -10685,6 +10716,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     except Exception:
                         reply_to_text = None
 
+        base_text = self._message_text_with_link_targets(message)
+
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt
         _chat_id_str = str(chat.id)
@@ -10695,7 +10728,7 @@ class TelegramAdapter(BasePlatformAdapter):
         )
 
         return MessageEvent(
-            text=message.text or "",
+            text=base_text,
             message_type=msg_type,
             source=source,
             raw_message=message,

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -147,3 +147,50 @@ def test_build_message_event_uses_channel_identity_for_channel_posts(telegram_ad
     assert event.platform_update_id == 12345
 
 
+def _text_link(url):
+    return SimpleNamespace(type="text_link", url=url)
+
+
+def test_build_message_event_preserves_hidden_text_link_targets(telegram_adapter_cls):
+    adapter = _make_adapter(telegram_adapter_cls)
+    msg = _make_channel_message("Article · Comments")
+    msg.entities = [
+        _text_link("https://example.com/article"),
+        _text_link("https://news.ycombinator.com/item?id=123"),
+        _text_link("https://example.com/article"),
+    ]
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.text == (
+        "Article · Comments\n\n"
+        "[Linked URLs]:\n"
+        "https://example.com/article\n"
+        "https://news.ycombinator.com/item?id=123"
+    )
+
+
+def test_build_message_event_preserves_caption_text_link_targets(telegram_adapter_cls):
+    adapter = _make_adapter(telegram_adapter_cls)
+    msg = _make_channel_message(None)
+    msg.caption = "Read the report"
+    msg.caption_entities = [_text_link("https://example.com/report")]
+
+    event = adapter._build_message_event(msg, MessageType.DOCUMENT)
+
+    assert event.text == (
+        "Read the report\n\n"
+        "[Linked URLs]:\n"
+        "https://example.com/report"
+    )
+
+
+def test_build_message_event_does_not_repeat_visible_link_targets(telegram_adapter_cls):
+    adapter = _make_adapter(telegram_adapter_cls)
+    msg = _make_channel_message("https://example.com/article")
+    msg.entities = [_text_link("https://example.com/article")]
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.text == "https://example.com/article"
+


### PR DESCRIPTION
## Summary

- preserve URL targets stored in Telegram text_link entities
- handle both message text and media captions while deduplicating visible or repeated URLs
- retain enriched captions through Telegram media handling

## Why

Telegram forwarded posts can display labels such as Article or Comments while storing the actual destination only in MessageEntity.url. Hermes previously forwarded only the visible label, so the agent received no actionable URL.

## Tests

- scripts/run_tests.sh tests/gateway/test_telegram_channel_posts.py -q
- scripts/run_tests.sh tests/gateway/test_telegram_channel_posts.py tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_audio_vs_voice.py tests/gateway/test_telegram_group_gating.py -q
- venv/bin/ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_channel_posts.py

Result: 46 relevant tests passed; Ruff passed.

## Platform

- Telegram
- macOS