### PR TITLE
fix(signal): don't let code blocks be re-mangled by heading/inline markdown regexes

### DIFF
--- a/gateway/platforms/signal_format.py
+++ b/gateway/platforms/signal_format.py
@@ -48,16 +48,27 @@ def markdown_to_signal(text: str) -> tuple[str, list[str]]:
     styles: list[tuple[int, int, str]] = []
 
     code_block = re.compile(r"```[a-zA-Z0-9_+-]*\n?(.*?)```", re.DOTALL)
+    code_ranges: list[tuple[int, int]] = []
     while match := code_block.search(text):
         inner = match.group(1).rstrip("\n")
         start = match.start()
         text = text[: match.start()] + inner + text[match.end() :]
         styles.append((start, len(inner), "MONOSPACE"))
+        code_ranges.append((start, start + len(inner)))
 
+    # Once de-fenced, a code block's own text (e.g. a Python "# comment" or
+    # "**kwargs") is indistinguishable from prose to the regexes below.
+    # Keep it out of the heading pass and seed `occupied` (below) with it so
+    # the inline patterns skip it too — otherwise code content gets mangled
+    # (its "#"/"**"/"_" markers stripped) and double-styled on top of MONOSPACE.
     heading = re.compile(r"^#{1,6}\s+", re.MULTILINE)
     new_text = ""
     last_end = 0
+    num_code_styles = len(styles)
+    heading_removals: list[tuple[int, int]] = []
     for match in heading.finditer(text):
+        if any(cs <= match.start() < ce for cs, ce in code_ranges):
+            continue
         new_text += text[last_end : match.start()]
         last_end = match.end()
         eol = text.find("\n", match.end())
@@ -68,8 +79,23 @@ def markdown_to_signal(text: str) -> tuple[str, list[str]]:
         new_text += heading_text
         styles.append((start, len(heading_text), "BOLD"))
         last_end = eol
+        heading_removals.append((match.start(), match.end() - match.start()))
     new_text += text[last_end:]
     text = new_text
+
+    # The heading pass above shortens `text` by stripping each "#+ " marker,
+    # which invalidates the absolute positions of the code-block MONOSPACE
+    # styles recorded earlier (a heading before a code block shifted the
+    # block's start left, silently dropping the style once positions ran
+    # past the new, shorter `len(text)`). Shift them by however much was
+    # removed ahead of each one.
+    for _i in range(num_code_styles):
+        _start, _length, _style = styles[_i]
+        _shift = sum(l for p, l in heading_removals if p < _start)
+        styles[_i] = (_start - _shift, _length, _style)
+    # Re-derive code_ranges (now in post-heading `text` coordinates) so the
+    # inline pass below can be seeded with them too.
+    code_ranges = [(s, s + l) for s, l, _ in styles[:num_code_styles]]
 
     patterns = [
         (re.compile(r"\*\*(.+?)\*\*", re.DOTALL), "BOLD"),
@@ -81,7 +107,7 @@ def markdown_to_signal(text: str) -> tuple[str, list[str]]:
     ]
 
     all_matches: list[tuple[int, int, int, int, str]] = []
-    occupied: list[tuple[int, int]] = []
+    occupied: list[tuple[int, int]] = list(code_ranges)
     for pattern, style in patterns:
         for match in pattern.finditer(text):
             ms, me = match.start(), match.end()

--- a/tests/gateway/test_signal_format.py
+++ b/tests/gateway/test_signal_format.py
@@ -210,6 +210,35 @@ class TestMarkdownStripPatch:
         assert "line3" in text
         assert "```" not in text
 
+    def test_code_block_hash_comment_not_treated_as_heading(self):
+        """A Python comment inside a fenced block must not be read as a
+        Markdown heading: the "#" must survive and no BOLD span applies."""
+        md = "```python\n# a comment\nx = 1\n```"
+        text, styles = _m2s(md)
+        assert "# a comment" in text
+        assert not _find_style(styles, "BOLD")
+        assert len(_find_style(styles, "MONOSPACE")) == 1
+
+    def test_code_block_underscores_not_treated_as_italic(self):
+        """Underscore-wrapped code inside a fenced block must not be read as
+        Markdown italics: the underscores must survive intact."""
+        md = "```\n_still_code_\n```"
+        text, styles = _m2s(md)
+        assert "_still_code_" in text
+        assert not _find_style(styles, "ITALIC")
+
+    def test_heading_before_code_block_preserves_monospace_style(self):
+        """A heading earlier in the message must not shift the code block's
+        MONOSPACE span out of range and silently drop it."""
+        md = "# Heading\n\n```\ncode here\n```"
+        text, styles = _m2s(md)
+        assert text == "Heading\n\ncode here"
+        mono = _find_style(styles, "MONOSPACE")
+        assert len(mono) == 1
+        start, length, _ = mono[0].split(":")
+        start, length = int(start), int(length)
+        assert text[start : start + length] == "code here"
+
     def test_links_preserved(self):
         """[text](url) links are kept as-is — Signal auto-linkifies."""
         md = "Check [this link](https://example.com) for details"


### PR DESCRIPTION
## What does this PR do?

`markdown_to_signal()` (`gateway/platforms/signal_format.py`) de-fences
\`\`\`\`\`\`\` code blocks into plain text early — recording only a MONOSPACE
style range for them — before running the heading/bold/italic/strikethrough
passes over that same text. Those later passes have no way to know a given
span came from a code block, so real code gets corrupted:

1. A code comment line starting with `#` (e.g. Python) is read as a
   Markdown heading: the `#` is stripped from the message text and a
   spurious BOLD span is layered on top of MONOSPACE.
2. Underscore/asterisk-wrapped code (e.g. `` _var_ ``) loses its literal
   underscores/asterisks to the italic/bold passes.
3. Separately: if a heading appears *earlier* in the same message, the
   heading pass shortens `text` without adjusting the already-recorded
   code-block style position — once that stale position runs past the
   new (shorter) `len(text)`, the final bounds check silently drops the
   MONOSPACE style for the whole code block.

Net effect: sending almost any real code snippet with a comment or an
underscore over Signal silently corrupts the message content.

## Related Issue

No existing issue — found via manual code audit + repro scripts (see below).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/signal_format.py`:
  - Track `code_ranges` alongside the MONOSPACE styles recorded for each
    de-fenced code block.
  - Skip heading matches that fall inside a code range.
  - Seed the inline-pattern pass's `occupied` list with `code_ranges` so
    bold/italic/strikethrough/backtick matching skips code text too.
  - Re-adjust code-block style positions after the heading pass (which
    shortens `text` by stripping `#+ ` markers), mirroring the existing
    `removals`/`_adjust` pattern already used later for the inline pass.
- `tests/gateway/test_signal_format.py`: 3 new regression tests.

## How to Test

```python
from gateway.platforms.signal_format import markdown_to_signal

# Bug 1: comment inside a code block
markdown_to_signal("```python\n# a comment\nx = 1\n```")
# before: '# a comment' -> '# comment' loses its '#', gets a spurious BOLD
# after:  '# a comment' preserved verbatim, only MONOSPACE

# Bug 2: heading before a code block
markdown_to_signal("# Heading\n\n```\ncode here\n```")
# before: styles == ['0:7:BOLD']              (MONOSPACE silently dropped)
# after:  styles == ['0:7:BOLD', '9:9:MONOSPACE']
```

`pytest tests/gateway/test_signal_format.py -q` → 23 passed (20 existing +
3 new), no regressions. `scripts/check-windows-footguns.py
gateway/platforms/signal_format.py` clean.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/gateway/test_signal_format.py -q` and it passes
- [x] I've added tests for this change
- [ ] Platform tested: Windows 11 (dev environment); logic is pure string/regex handling, no I/O, OS-independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)