### PR TITLE
fix: don't flag auxiliary tasks using the 'main' provider alias as stale

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -409,6 +409,20 @@ describe('ModelSettings', () => {
     // Banner present on load, no switch required.
     expect(await screen.findByText(/still run on/)).toBeTruthy()
   })
+
+  it('does not warn when an aux slot uses the main alias', async () => {
+    getAuxiliaryModels.mockResolvedValueOnce({
+      main: { provider: 'nous', model: 'hermes-4' },
+      tasks: [{ task: 'vision', provider: 'main', model: 'kimi-k3', base_url: '' }]
+    })
+
+    await renderModelSettings()
+    await screen.findByRole('button', { name: 'Apply' })
+
+    // 'main' is a backend-supported alias that tracks the active main provider
+    // (auxiliary_client._normalize_aux_provider) — it can never be a stale pin.
+    expect(screen.queryByText(/still run on/)).toBeNull()
+  })
 })
 
 describe('ModelSettings MoA preset editor', () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -501,7 +501,10 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       .filter(entry => {
         const p = (entry.provider ?? '').toLowerCase()
 
-        return p && p !== 'auto' && p !== mainProvider
+        // 'main' is a backend-supported alias (see _normalize_aux_provider in
+        // agent/auxiliary_client.py) meaning "follow the current main provider"
+        // — it can never be a stale pin, so don't warn on it.
+        return p && p !== 'auto' && p !== 'main' && p !== mainProvider
       })
       .map(entry => ({ task: entry.task, provider: entry.provider, model: entry.model }))
   }, [auxiliary, mainModel])

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7847,7 +7847,10 @@ def _apply_model_assignment_sync(
                 slot_provider = str(slot_cfg.get("provider", "") or "").strip()
                 if (
                     slot_provider
-                    and slot_provider.lower() not in {"auto", ""}
+                    # "main" is a supported alias for the active main provider
+                    # (see auxiliary_client._normalize_aux_provider) and always
+                    # tracks the new main model — never a stale pin.
+                    and slot_provider.lower() not in {"auto", "", "main"}
                     and slot_provider.lower() != new_provider
                 ):
                     stale_aux.append({


### PR DESCRIPTION
## Summary

- Exempt the `main` provider alias in both stale-auxiliary detections: the desktop persistent banner (`model-settings.tsx`) and the switch-time `stale_aux` API response (`hermes_cli/web_server.py`)
- `main` is a backend-supported alias (`auxiliary_client._normalize_aux_provider`, "resolve to the user's actual main provider") that always tracks the active main model, so an aux slot pinned to `main` can never be a stale pin
- Add a regression test: an aux slot with `provider: 'main'` must not trigger the "still run on ..." banner

## Repro (from #97310)

Follow Moonshot's official Hermes integration guide (kimi.com/code/docs/third-party-tools/hermes.html), which prescribes:

```yaml
auxiliary:
  vision:
    provider: main
    model: kimi-k3
```

Settings → Model then shows: "1 auxiliary task (vision) still run on `main`, not your main model" — a false positive on a correct, working configuration.

## Test Plan

- [x] `npx vitest run src/app/settings/model-settings.test.tsx` — 23/23 pass (including the new regression test)
- [x] `npm run typecheck` — clean
- [x] Backend predicate verified against stale/non-stale cases: `main`/`MAIN` no longer flagged; `auto`/empty still unflagged; a genuinely foreign provider pin (e.g. `nous` while main is `kimi-coding`) is still flagged

Closes #97310
