### PR TITLE
fix(agent): preserve productive continuations and force overflow compaction

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -16,6 +16,7 @@ resolved through :func:`_ra` so those patches keep working.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -1964,6 +1965,8 @@ def run_conversation(
     failed = False
     codex_ack_continuations = 0
     length_continue_retries = 0
+    length_no_progress_retries = 0
+    length_fragment_fingerprints = set()
     # Total outer-loop exceptions this turn (#92450) — see _MAX_OUTER_LOOP_ERRORS.
     _outer_error_count = 0
     truncated_tool_call_retries = 0
@@ -3917,6 +3920,8 @@ def run_conversation(
                                         _frag.pop("_length_continuation_nudge", None)
                                 agent._session_messages = messages
                                 length_continue_retries = 0
+                                length_no_progress_retries = 0
+                                length_fragment_fingerprints.clear()
                                 truncated_response_parts = []
                                 retry_count = 0
                                 compression_attempts = 0
@@ -3949,15 +3954,32 @@ def run_conversation(
                                 getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
                                 and not getattr(assistant_message, "content", None)
                             )
-                            if not _is_empty_partial_stub:
+                            _fragment_content = getattr(assistant_message, "content", None)
+                            _fragment_fingerprint = None
+                            if _fragment_content:
+                                _fragment_fingerprint = hashlib.sha256(
+                                    " ".join(_fragment_content.split()).encode("utf-8")
+                                ).hexdigest()
+
+                            _fragment_made_progress = bool(
+                                _fragment_fingerprint
+                                and _fragment_fingerprint not in length_fragment_fingerprints
+                            )
+                            if _fragment_made_progress:
+                                length_fragment_fingerprints.add(_fragment_fingerprint)
+                                length_no_progress_retries = 0
+                            else:
+                                length_no_progress_retries += 1
+
+                            if not _is_empty_partial_stub and _fragment_made_progress:
                                 interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                                # Marked so the ceiling exit can drop the fragment trail.
+                                # Marked so a no-progress exit can drop the fragment trail.
                                 interim_msg["_length_continuation_fragment"] = True
                                 append_message(messages, interim_msg)
                                 if assistant_message.content:
                                     truncated_response_parts.append(assistant_message.content)
 
-                            if length_continue_retries < 4:
+                            if length_no_progress_retries < 3:
                                 _is_partial_stream_stub = (
                                     getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
                                 )
@@ -3971,18 +3993,18 @@ def run_conversation(
                                         f"{agent.log_prefix}↻ Stream interrupted mid "
                                         f"tool-call ({_tool_list}) — requesting "
                                         f"chunked retry "
-                                        f"({length_continue_retries}/4)..."
+                                        f"(attempt {length_continue_retries})..."
                                     )
                                 elif _is_partial_stream_stub:
                                     agent._vprint(
                                         f"{agent.log_prefix}↻ Stream interrupted — "
                                         f"requesting continuation "
-                                        f"({length_continue_retries}/4)..."
+                                        f"(attempt {length_continue_retries})..."
                                     )
                                 else:
                                     agent._vprint(
                                         f"{agent.log_prefix}↻ Requesting continuation "
-                                        f"({length_continue_retries}/4)..."
+                                        f"(attempt {length_continue_retries})..."
                                     )
 
                                 _continue_content = _get_continuation_prompt(
@@ -4001,8 +4023,8 @@ def run_conversation(
                             partial_response = agent._strip_think_blocks(_join_truncated_parts(truncated_response_parts)).strip()
                             if partial_response:
                                 agent._vprint(
-                                    f"{agent.log_prefix}⚠️  Response still truncated "
-                                    f"after 4 continuation attempts — keeping the "
+                                    f"{agent.log_prefix}⚠️  Response continuation made "
+                                    f"no progress for 3 attempts — keeping the "
                                     f"partial response received so far.",
                                     force=True,
                                 )
@@ -4038,7 +4060,7 @@ def run_conversation(
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": "Response remained truncated after 4 continuation attempts",
+                                "error": "Response continuation made no progress after 3 attempts",
                             }
 
                     if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:
@@ -5433,6 +5455,7 @@ def run_conversation(
                             messages, system_message,
                             approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
                             task_id=effective_task_id,
+                            force=True,
                         )
                         conversation_history = conversation_history_after_compression(
                             agent, messages, conversation_history
@@ -5729,6 +5752,7 @@ def run_conversation(
                         messages, system_message,
                         approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
                         task_id=effective_task_id,
+                        force=True,
                     )
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                         # #69870 lock-skip: the provider proved the request
@@ -5893,6 +5917,7 @@ def run_conversation(
                                 messages, system_message,
                                 approx_tokens=request_input_estimate,
                                 task_id=effective_task_id,
+                                force=True,
                             )
                             if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                                 compression_attempts -= 1
@@ -6047,6 +6072,7 @@ def run_conversation(
                         messages, system_message,
                         approx_tokens=estimate_request_tokens_rough(api_messages, tools=agent.tools or None),
                         task_id=effective_task_id,
+                        force=True,
                     )
                     if messages is _overflow_input and compression_skipped_due_to_lock(agent):
                         # #69870 lock-skip: the provider proved the request
@@ -8204,6 +8230,8 @@ def run_conversation(
                     final_response = _join_truncated_parts([*truncated_response_parts, final_response])
                     truncated_response_parts = []
                     length_continue_retries = 0
+                    length_no_progress_retries = 0
+                    length_fragment_fingerprints.clear()
                     # The continuation recovered, so the fragments stay in the transcript.
                     for _frag in messages:
                         if isinstance(_frag, dict):

--- a/tests/run_agent/test_continuation_ceiling_wedge.py
+++ b/tests/run_agent/test_continuation_ceiling_wedge.py
@@ -1,9 +1,9 @@
-"""Regression tests for the post-ceiling session wedge.
+"""Regression tests for the post-no-progress session wedge.
 
-A turn that exhausts all 4 length-continuation attempts must leave the
-session usable: the next user message issues a fresh upstream request,
-inherits no continuation counter, and the partial text that WAS received
-is surfaced instead of dropped.
+A turn that receives three consecutive duplicate continuation fragments must
+leave the session usable: the next user message issues a fresh upstream
+request, inherits no continuation state, and productive partial text is
+surfaced instead of dropped.
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ def loop_agent():
         patch("run_agent.OpenAI"),
     ):
         a = AIAgent(
-            api_key="test-key-1234567890",
+            api_key="test-key",
             base_url="https://openrouter.ai/api/v1",
             quiet_mode=True,
             skip_context_files=True,
@@ -62,16 +62,17 @@ def _run(agent, message, history=None):
         return agent.run_conversation(message, conversation_history=history)
 
 
-class TestContinuationCeilingWedge:
-    def _exhaust_ceiling(self, agent):
+class TestContinuationNoProgressWedge:
+    def _exhaust_no_progress(self, agent):
         agent.client.chat.completions.create.side_effect = [
             _stub("part one "), _stub("part two "),
             _stub("part three "), _stub("part four."),
+            _stub("part four."), _stub("part four."), _stub("part four."),
         ]
         return _run(agent, "write me a long report")
 
-    def test_partial_text_surfaced_at_ceiling(self, loop_agent):
-        result = self._exhaust_ceiling(loop_agent)
+    def test_partial_text_surfaced_at_no_progress_stop(self, loop_agent):
+        result = self._exhaust_no_progress(loop_agent)
         assert result["completed"] is False
         assert result["partial"] is True
         assert "part one" in (result["final_response"] or "")
@@ -82,10 +83,10 @@ class TestContinuationCeilingWedge:
         the provider instead of replaying wedge state."""
         from tests.run_agent.test_run_agent import _mock_response
 
-        result1 = self._exhaust_ceiling(loop_agent)
-        assert "truncated after 4 continuation attempts" in (result1.get("error") or "")
+        result1 = self._exhaust_no_progress(loop_agent)
+        assert "no progress after 3 attempts" in (result1.get("error") or "")
         calls_after_turn1 = loop_agent.client.chat.completions.create.call_count
-        assert calls_after_turn1 == 4
+        assert calls_after_turn1 == 7
 
         loop_agent.client.chat.completions.create.side_effect = [
             _mock_response(content="Hello! How can I help?", finish_reason="stop"),
@@ -100,11 +101,11 @@ class TestContinuationCeilingWedge:
         assert result2["final_response"] == "Hello! How can I help?"
         assert not result2.get("error")
 
-    def test_ceiling_replaces_scaffolding_with_settled_turn(self, loop_agent):
+    def test_no_progress_stop_replaces_scaffolding_with_settled_turn(self, loop_agent):
         """The persisted tail must not keep the continuation scaffolding.
         Unanswered "continue" nudges make every later turn resume the
         truncated response and re-exhaust the same ceiling."""
-        result = self._exhaust_ceiling(loop_agent)
+        result = self._exhaust_no_progress(loop_agent)
         msgs = result["messages"]
 
         nudges = [
@@ -126,7 +127,7 @@ class TestContinuationCeilingWedge:
         for part in ("part one", "part two", "part three", "part four"):
             assert part in content, "Stitched partial must keep every fragment."
 
-    def test_ceiling_not_labeled_network_error(self, loop_agent):
+    def test_no_progress_stop_not_labeled_network_error(self, loop_agent):
         """A finish_reason='length' stub is a truncation, not a network
         error — the user-facing message must not blame the network."""
         printed = []
@@ -137,15 +138,15 @@ class TestContinuationCeilingWedge:
             return original(text, **kwargs)
 
         with patch.object(loop_agent, "_vprint", side_effect=_capture):
-            self._exhaust_ceiling(loop_agent)
+            self._exhaust_no_progress(loop_agent)
 
         network_lines = [line for line in printed if "network error" in line.lower()]
         assert network_lines == [], (
             "Truncation must not be reported as a network error: "
             f"{network_lines!r}"
         )
-        assert any("truncated" in line.lower() for line in printed), (
-            "The user-facing message must name the truncation."
+        assert any("no progress" in line.lower() for line in printed), (
+            "The user-facing message must name the no-progress stop."
         )
 
     def test_continuation_requests_carry_no_marks(self, loop_agent):
@@ -197,10 +198,11 @@ class TestContinuationCeilingWedge:
         loop_agent.client.chat.completions.create.side_effect = [
             _stub("wedge one "), _stub("wedge two "),
             _stub("wedge three "), _stub("wedge four."),
+            _stub("wedge four."), _stub("wedge four."), _stub("wedge four."),
         ]
         result = _run(loop_agent, "another long report", history=reloaded_history)
 
-        assert "truncated after 4 continuation attempts" in (result.get("error") or "")
+        assert "no progress after 3 attempts" in (result.get("error") or "")
         prior = [
             m for m in result["messages"]
             if m.get("role") == "assistant"
@@ -216,7 +218,7 @@ class TestContinuationCeilingWedge:
         own full 4-attempt budget, not the exhausted counter."""
         from tests.run_agent.test_run_agent import _mock_response
 
-        result1 = self._exhaust_ceiling(loop_agent)
+        result1 = self._exhaust_no_progress(loop_agent)
         loop_agent.client.chat.completions.create.side_effect = [
             _stub("second turn partial "),
             _mock_response(content="and the rest.", finish_reason="stop"),
@@ -224,7 +226,7 @@ class TestContinuationCeilingWedge:
         result2 = _run(loop_agent, "try again", history=result1["messages"])
 
         assert result2["completed"] is True, (
-            "One truncation on a fresh turn must continue (1/4), not fail "
+            "One truncation on a fresh turn must continue, not fail "
             "with an inherited exhausted counter."
         )
         assert "second turn partial" in result2["final_response"]

--- a/tests/run_agent/test_continuation_repetition_guard.py
+++ b/tests/run_agent/test_continuation_repetition_guard.py
@@ -30,7 +30,7 @@ def loop_agent():
         patch("run_agent.OpenAI"),
     ):
         a = AIAgent(
-            api_key="test-key-1234567890",
+            api_key="test-key",
             base_url="https://openrouter.ai/api/v1",
             quiet_mode=True,
             skip_context_files=True,
@@ -87,13 +87,18 @@ class TestContinuationRepetitionGuard:
         assert loop_agent.client.chat.completions.create.call_count == 1
 
     def test_legit_truncation_still_continues(self, loop_agent):
-        # Ordinary short truncated fragments still get continuation retries.
+        # Productive unique fragments are not stopped by a fixed retry ceiling.
+        from tests.run_agent.test_run_agent import _mock_response
+
         loop_agent.client.chat.completions.create.side_effect = [
             _stub("part one "), _stub("part two "),
-            _stub("part three "), _stub("part four."),
+            _stub("part three "), _stub("part four "),
+            _stub("part five "), _stub("part six "),
+            _mock_response(content="complete.", finish_reason="stop"),
         ]
 
         result = _run(loop_agent, "write me a long report")
 
-        assert result["partial"] is True
-        assert loop_agent.client.chat.completions.create.call_count == 4
+        assert result["completed"] is True
+        assert result["final_response"].endswith("complete.")
+        assert loop_agent.client.chat.completions.create.call_count == 7

--- a/tests/run_agent/test_provider_overflow_force.py
+++ b/tests/run_agent/test_provider_overflow_force.py
@@ -1,0 +1,60 @@
+"""Provider-proven context overflow must bypass automatic compression cooldown."""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+from tests.run_agent.test_run_agent import _make_tool_defs, _mock_response
+
+
+def test_output_cap_recovery_forces_compression():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = True
+    agent.save_trajectories = False
+    agent.api_mode = "chat_completions"
+    agent.provider = "openrouter"
+    agent.model = "some/model"
+    agent.max_tokens = 65_536
+    agent.context_compressor.context_length = 200_000
+    agent.context_compressor.should_compress = MagicMock(return_value=False)
+
+    overflow = Exception(
+        "max_tokens: 65536 > context_window: 200000 "
+        "- input_tokens: 199000 = available_tokens: 1000"
+    )
+    overflow.status_code = 400
+    overflow.code = 400
+    agent.client.chat.completions.create.side_effect = [
+        overflow,
+        _mock_response(content="done", finish_reason="stop"),
+    ]
+
+    compressed = MagicMock(
+        return_value=([{"role": "user", "content": "hello"}], "You are helpful.")
+    )
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent.context_compressor, "update_model"),
+        patch.object(agent, "_compress_context", compressed),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["completed"] is True
+    compressed.assert_called_once()
+    assert compressed.call_args.kwargs["force"] is True


### PR DESCRIPTION
## Summary
- replace the fixed four-attempt non-tool continuation ceiling with a progress-based guard
- stop only after three consecutive empty or duplicate fragments while preserving session cleanup
- force compaction on provider-proven overflow so automatic cooldown cannot consume the retry budget without changing the transcript
- add regressions for continuation beyond four fragments, duplicate-fragment cleanup, next-turn usability, and forced overflow recovery

## Verification
- `13 passed` across continuation and forced-overflow focused tests
- `16 passed` across output-cap, context overflow, 413, and compression-lock regression coverage
- `git diff --check`