### PR TITLE
fix(photon): persist inbound replay dedupe across restarts

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -11,6 +11,7 @@ import asyncio
 import base64
 import json
 import logging
+import math
 import os
 import re
 import secrets
@@ -41,6 +42,7 @@ from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret
 from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.platforms.event import MessageEvent, MessageType
 from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
+from utils import atomic_json_write
 
 from .auth import load_project_credentials
 # Sidecar dir resolution is lazy (never at import): it probes the filesystem and may
@@ -62,6 +64,7 @@ _MAX_MESSAGE_LENGTH = 8000  # iMessage caps practical size at ~16 KB; conservati
 _RUNTIME_RECORD_NAME = "photon-sidecar.json"
 _DEDUP_MAX_SIZE = 4000  # the gRPC stream is at-least-once and a reconnect can replay
 _DEDUP_WINDOW_SECONDS = 48 * 3600
+_DEDUP_STATE_NAME = "photon-inbound-dedupe.json"
 _FFFC_WAIT_SECONDS = 15.0  # wait for the real attachment after a U+FFFC placeholder
 _NPM_REINSTALL_TIMEOUT = 600  # a wedged self-heal `npm ci` must not stall connect indefinitely
 # Photon / Envoy / spectrum-ts substrings meaning transient upstream overload.
@@ -518,7 +521,10 @@ class PhotonAdapter(BasePlatformAdapter):
         self._sidecar_health_interval = 15.0
         self._probe_failures = 0
         self._last_upstream_activity = 0.0  # monotonic; watchdog skips probe if traffic proved liveness
-        self._seen_messages: Dict[str, float] = {}  # at-least-once stream dedup
+        # At-least-once gRPC replay can outlive a sidecar/gateway restart; keep the window on disk.
+        from hermes_constants import get_hermes_home
+        self._dedup_state_path = get_hermes_home() / "state" / _DEDUP_STATE_NAME
+        self._seen_messages = self._load_seen_messages()
         self._sent_message_ids: Dict[str, float] = {}  # only reactions targeting OUR sends are routed
         self._last_inbound_by_chat: Dict[str, str] = {}  # default target for the react action
         self._recent_richlinks_by_chat: Dict[str, float] = {}  # coalesce preview-art attachments
@@ -716,14 +722,55 @@ class PhotonAdapter(BasePlatformAdapter):
             await self._dispatch_inbound(event)
         except Exception:
             logger.exception("[photon] inbound dispatch failed")
+        else:
+            if msg_id:
+                self._mark_seen_message(msg_id)
 
     def _is_duplicate(self, msg_id: str) -> bool:
         now = time.time()
-        t = self._seen_messages.get(msg_id)
-        if t is not None and now - t < _DEDUP_WINDOW_SECONDS:
-            return True
-        _bounded_put(self._seen_messages, msg_id, now, _DEDUP_MAX_SIZE)
-        return False
+        seen_at = self._seen_messages.get(msg_id)
+        return seen_at is not None and now - seen_at < _DEDUP_WINDOW_SECONDS
+
+    def _mark_seen_message(self, msg_id: str) -> None:
+        """Persist a message ID only after inbound dispatch has succeeded."""
+        _bounded_put(self._seen_messages, msg_id, time.time(), _DEDUP_MAX_SIZE)
+        self._persist_seen_messages()
+
+    def _load_seen_messages(self) -> Dict[str, float]:
+        """Load live provider message IDs from this profile's durable state."""
+        try:
+            raw = json.loads(self._dedup_state_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        now = time.time()
+        live: List[tuple[str, float]] = []
+        for msg_id, seen_at in raw.items():
+            if not isinstance(msg_id, str) or not isinstance(seen_at, (int, float)):
+                continue
+            timestamp = float(seen_at)
+            if not math.isfinite(timestamp):
+                continue
+            # A wall-clock rollback must not turn a valid claim into an unbounded one.
+            timestamp = min(timestamp, now)
+            if now - timestamp < _DEDUP_WINDOW_SECONDS:
+                live.append((msg_id, timestamp))
+        live.sort(key=lambda item: item[1])
+        return dict(live[-_DEDUP_MAX_SIZE:])
+
+    def _persist_seen_messages(self) -> None:
+        """Atomically persist the already-bounded in-memory dedupe window."""
+        try:
+            atomic_json_write(
+                self._dedup_state_path,
+                self._seen_messages,
+                indent=0,
+                separators=(",", ":"),
+                mode=0o600,
+            )
+        except OSError as exc:
+            logger.warning("[photon] failed to persist inbound dedupe state: %s", exc)
 
     async def _fffc_timeout_handler(self, chat_key: str, message_id: str) -> None:
         await asyncio.sleep(_FFFC_WAIT_SECONDS)

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -732,7 +732,10 @@ class PhotonAdapter(BasePlatformAdapter):
         return seen_at is not None and now - seen_at < _DEDUP_WINDOW_SECONDS
 
     def _mark_seen_message(self, msg_id: str) -> None:
-        """Persist a message ID only after inbound dispatch has succeeded."""
+        """Persist after successful dispatch; a crash before this write may replay it.
+
+        This is bounded at-least-once replay suppression, not exactly-once delivery.
+        """
         _bounded_put(self._seen_messages, msg_id, time.time(), _DEDUP_MAX_SIZE)
         self._persist_seen_messages()
 

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -150,12 +150,80 @@ async def test_on_inbound_line_dispatches_and_dedups(
     assert captured[0].text == "ping"
 
 
+@pytest.mark.asyncio
+async def test_inbound_dedup_survives_adapter_restart(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An at-least-once replay is not re-dispatched after gateway restart."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    line = json.dumps(_dm_event("run once", msg_id="restart-replay-1"))
+
+    first = _make_adapter(monkeypatch)
+    first_captured = _capture(first, monkeypatch)
+    await first._on_inbound_line(line)
+
+    restarted = _make_adapter(monkeypatch)
+    restarted_captured = _capture(restarted, monkeypatch)
+    await restarted._on_inbound_line(line)
+
+    assert [event.text for event in first_captured] == ["run once"]
+    assert restarted_captured == []
+
+
 def test_is_duplicate_window(monkeypatch: pytest.MonkeyPatch) -> None:
     adapter = _make_adapter(monkeypatch)
     assert adapter._is_duplicate("id-1") is False
+    adapter._mark_seen_message("id-1")
     assert adapter._is_duplicate("id-1") is True
     assert adapter._is_duplicate("id-2") is False
+    adapter._mark_seen_message("id-2")
     assert adapter._is_duplicate("id-1") is True  # still dup
+
+
+def test_durable_dedup_is_profile_scoped_and_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from plugins.platforms.photon import adapter as adapter_mod
+
+    monkeypatch.setattr(adapter_mod, "_DEDUP_MAX_SIZE", 2)
+    first_home = tmp_path / "first-profile"
+    monkeypatch.setenv("HERMES_HOME", str(first_home))
+    first = _make_adapter(monkeypatch)
+    assert first._is_duplicate("oldest") is False
+    first._mark_seen_message("oldest")
+    first._mark_seen_message("newer")
+    first._mark_seen_message("newest")
+
+    restarted = _make_adapter(monkeypatch)
+    assert restarted._is_duplicate("newest") is True
+    assert restarted._is_duplicate("oldest") is False  # evicted at the bound
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "second-profile"))
+    other_profile = _make_adapter(monkeypatch)
+    assert other_profile._is_duplicate("newest") is False
+
+
+@pytest.mark.asyncio
+async def test_failed_dispatch_is_retried_after_restart(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    line = json.dumps(_dm_event("retry me", msg_id="failed-dispatch-1"))
+    failed = _make_adapter(monkeypatch)
+
+    async def fail_dispatch(event: dict) -> None:
+        raise RuntimeError("injected dispatch failure")
+
+    monkeypatch.setattr(failed, "_dispatch_inbound", fail_dispatch)
+    await failed._on_inbound_line(line)
+
+    restarted = _make_adapter(monkeypatch)
+    captured = _capture(restarted, monkeypatch)
+    await restarted._on_inbound_line(line)
+    assert [event.text for event in captured] == ["retry me"]
 
 
 def test_check_requirements_without_node(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- persist Photon inbound message claims in profile-scoped state
- record IDs only after successful dispatch so failures remain retryable
- validate, expire, and bound restored dedupe entries
- add restart, profile-isolation, capacity, and failed-dispatch coverage

## Verification
- all 132 Photon plugin tests passed
- Ruff, ty, Windows-footgun, and diff checks passed