### PR TITLE
fix(backup): bound incomplete snapshots without losing DB recovery copies

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1112,8 +1112,7 @@ def _copy_quick_snapshot_files(
     """Copy every quick-snapshot candidate into *staging_dir*.
 
     Returns ``(manifest {rel: size}, failed_dbs, oversized_skipped)``. The last two are snapshot
-    incompleteness (#68805): the caller must suppress pruning so the older snapshot that may hold
-    the only recoverable DB survives.
+    incompleteness (#68805): pruning still runs but must keep the latest complete recovery source.
     """
     manifest: Dict[str, int] = {}
     failed_dbs: list[str] = []
@@ -1193,18 +1192,20 @@ def _create_quick_snapshot_locked(
         json.dump(meta, f, indent=2)
     os.replace(staging_dir, root / snap_id)
     # Auto-prune (pre-update callers pass a smaller keep so state.db copies don't accumulate).
-    # Skip when a DB failed to capture OR was skipped for size (#68805): the snapshot is
-    # incomplete and the older one may hold the only recoverable database.
-    if not (failed_dbs or oversized_skipped):
-        _prune_oldest(_snapshot_dirs(root), _QUICK_DEFAULT_KEEP if keep is None else keep, shutil.rmtree, "snapshot")
-    else:
+    # When a present DB failed to capture OR was skipped for size (#68805), preserve the latest
+    # complete recovery source in addition to the retention window. Still prune stale incomplete
+    # snapshots: they contain config/auth copies too, and repeated failures must stay bounded.
+    incomplete = failed_dbs or oversized_skipped
+    retention = _QUICK_DEFAULT_KEEP if keep is None else keep
+    if incomplete:
         if oversized_skipped:
-            print("  ⚠ Skipping snapshot prune: DB file(s) skipped for size: " + ", ".join(oversized_skipped))
+            print("  ⚠ Preserving latest complete snapshot: DB file(s) skipped for size: " + ", ".join(oversized_skipped))
             logger.warning("Quick snapshot skipped oversized DB file(s): %s", ", ".join(oversized_skipped))
         logger.warning(
-            "Skipping snapshot prune because %d DB(s) failed to capture and/or %d were oversized "
-            "— preserving older snapshots as recovery source",
+            "Snapshot incomplete because %d DB(s) failed to capture and/or %d were oversized "
+            "— preserving latest complete recovery source",
             len(failed_dbs), len(oversized_skipped))
+    _prune_quick_snapshots(root, keep=retention, preserve_latest_complete=bool(incomplete))
     logger.info("quick snapshot phase=copy status=complete id=%s files=%d bytes=%d",
                 snap_id, len(manifest), sum(manifest.values()))
     return snap_id
@@ -1514,6 +1515,28 @@ def _prune_oldest(newest_first: List[Path], keep: int, remove, what: str) -> int
         except OSError as exc:
             logger.warning("Failed to prune %s %s: %s", what, p.name, exc)
     return deleted
+
+
+def _prune_quick_snapshots(
+    root: Path,
+    keep: int = _QUICK_DEFAULT_KEEP,
+    *,
+    preserve_latest_complete: bool = False,
+) -> int:
+    """Remove old snapshots, optionally retaining one complete recovery source."""
+    dirs = _snapshot_dirs(root)
+    retained = set(dirs[:keep])
+    if preserve_latest_complete:
+        for d in dirs:
+            try:
+                with open(d / "manifest.json", encoding="utf-8") as f:
+                    meta = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(meta, dict) and not meta.get("failed_dbs") and not meta.get("oversized_skipped"):
+                retained.add(d)
+                break
+    return _prune_oldest([d for d in dirs if d not in retained], 0, shutil.rmtree, "snapshot")
 
 
 def prune_quick_snapshots(keep: int = _QUICK_DEFAULT_KEEP, hermes_home: Optional[Path] = None) -> int:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1112,7 +1112,7 @@ def _copy_quick_snapshot_files(
     """Copy every quick-snapshot candidate into *staging_dir*.
 
     Returns ``(manifest {rel: size}, failed_dbs, oversized_skipped)``. The last two are snapshot
-    incompleteness (#68805): pruning still runs but must keep the latest complete recovery source.
+    incompleteness (#68805): pruning still runs but must keep the newest recovery copy of each omitted DB.
     """
     manifest: Dict[str, int] = {}
     failed_dbs: list[str] = []
@@ -1192,20 +1192,21 @@ def _create_quick_snapshot_locked(
         json.dump(meta, f, indent=2)
     os.replace(staging_dir, root / snap_id)
     # Auto-prune (pre-update callers pass a smaller keep so state.db copies don't accumulate).
-    # When a present DB failed to capture OR was skipped for size (#68805), preserve the latest
-    # complete recovery source in addition to the retention window. Still prune stale incomplete
-    # snapshots: they contain config/auth copies too, and repeated failures must stay bounded.
+    # When a present DB failed to capture or was skipped for size (#68805), preserve the newest
+    # recovery copy of each omitted DB in addition to the retention window. Still prune stale
+    # partial snapshots that add no recovery coverage: they contain config/auth copies and must
+    # stay bounded.
     incomplete = failed_dbs or oversized_skipped
     retention = _QUICK_DEFAULT_KEEP if keep is None else keep
     if incomplete:
         if oversized_skipped:
-            print("  ⚠ Preserving latest complete snapshot: DB file(s) skipped for size: " + ", ".join(oversized_skipped))
+            print("  ⚠ Preserving latest recovery copy: DB file(s) skipped for size: " + ", ".join(oversized_skipped))
             logger.warning("Quick snapshot skipped oversized DB file(s): %s", ", ".join(oversized_skipped))
         logger.warning(
             "Snapshot incomplete because %d DB(s) failed to capture and/or %d were oversized "
-            "— preserving latest complete recovery source",
+            "— preserving latest recovery copy of each omitted DB",
             len(failed_dbs), len(oversized_skipped))
-    _prune_quick_snapshots(root, keep=retention, preserve_latest_complete=bool(incomplete))
+    _prune_quick_snapshots(root, keep=retention, preserve_recovery_for=set(failed_dbs) | set(oversized_skipped))
     logger.info("quick snapshot phase=copy status=complete id=%s files=%d bytes=%d",
                 snap_id, len(manifest), sum(manifest.values()))
     return snap_id
@@ -1521,21 +1522,31 @@ def _prune_quick_snapshots(
     root: Path,
     keep: int = _QUICK_DEFAULT_KEEP,
     *,
-    preserve_latest_complete: bool = False,
+    preserve_recovery_for: Optional[set[str]] = None,
 ) -> int:
-    """Remove old snapshots, optionally retaining one complete recovery source."""
+    """Remove old snapshots while retaining recovery copies for omitted DBs."""
     dirs = _snapshot_dirs(root)
     retained = set(dirs[:keep])
-    if preserve_latest_complete:
+    missing = set(preserve_recovery_for or ())
+    if missing:
         for d in dirs:
             try:
                 with open(d / "manifest.json", encoding="utf-8") as f:
                     meta = json.load(f)
-            except (OSError, json.JSONDecodeError):
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    "Could not inspect snapshot %s while preserving recovery copies: %s",
+                    d.name, exc)
                 continue
-            if isinstance(meta, dict) and not meta.get("failed_dbs") and not meta.get("oversized_skipped"):
+            files = meta.get("files") if isinstance(meta, dict) else None
+            if not isinstance(files, dict):
+                continue
+            covered = missing.intersection(files)
+            if covered:
                 retained.add(d)
-                break
+                missing.difference_update(covered)
+                if not missing:
+                    break
     return _prune_oldest([d for d in dirs if d not in retained], 0, shutil.rmtree, "snapshot")
 
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1466,10 +1466,8 @@ class TestQuickSnapshot:
 
 
 
-    def test_oversized_db_suppresses_pruning(self, hermes_home, capsys):
-        """#68805: an oversized state.db skipped for size must suppress
-        pruning so the older complete snapshot (containing the only
-        recoverable database) is preserved.
+    def test_oversized_db_preserves_latest_recovery_copy(self, hermes_home, capsys):
+        """#68805: an oversized state.db must preserve its latest recovery copy.
 
         Reproduces the reviewer's scenario: keep=1 + a state.db exceeding
         the size cap → the new snapshot omits state.db, failed_dbs stays
@@ -1498,7 +1496,7 @@ class TestQuickSnapshot:
         assert not (second_dir / "state.db").exists()
 
         # Manifest must record the oversized skip
-        with open(second_dir / "manifest.json") as f:
+        with open(second_dir / "manifest.json", encoding="utf-8") as f:
             meta = json.load(f)
         assert "state.db" in meta.get("oversized_skipped", [])
 
@@ -1513,7 +1511,44 @@ class TestQuickSnapshot:
         assert second_id in snap_ids
 
         out = capsys.readouterr().out
-        assert "skipping state.db" in out.lower() or "skipping snapshot prune" in out.lower()
+        assert "skipping state.db" in out.lower()
+
+    def test_alternating_db_failures_preserve_latest_copy_of_each_db(
+        self, hermes_home, monkeypatch
+    ):
+        """A partial snapshot may be the latest recovery source for another DB."""
+        from hermes_cli import backup
+
+        executions_db = hermes_home / "cron" / "executions.db"
+        with sqlite3.connect(executions_db) as conn:
+            conn.execute("CREATE TABLE executions (id INTEGER PRIMARY KEY)")
+
+        real_safe_copy = backup._safe_copy_db
+        failed_name = "executions.db"
+
+        def selective_safe_copy(src, dst):
+            if src.name == failed_name:
+                return False
+            return real_safe_copy(src, dst)
+
+        monkeypatch.setattr(backup, "_safe_copy_db", selective_safe_copy)
+        first_id = backup.create_quick_snapshot(
+            label="state-only", hermes_home=hermes_home, keep=10
+        )
+        assert first_id is not None
+
+        _advance_backup_clock()
+        failed_name = "state.db"
+        second_id = backup.create_quick_snapshot(
+            label="executions-only", hermes_home=hermes_home, keep=1
+        )
+        assert second_id is not None
+
+        root = hermes_home / "state-snapshots"
+        assert (root / first_id / "state.db").exists()
+        assert not (root / first_id / "cron" / "executions.db").exists()
+        assert not (root / second_id / "state.db").exists()
+        assert (root / second_id / "cron" / "executions.db").exists()
 
     @pytest.mark.parametrize("incomplete_kind", ["oversized", "failed"])
     def test_repeated_incomplete_snapshots_prune_stale_partial_copies(
@@ -1537,7 +1572,8 @@ class TestQuickSnapshot:
         for index in range(3):
             _advance_backup_clock()
             (hermes_home / ".env").write_text(
-                f"OPENROUTER_API_KEY=rotated-test-key-{index}\n"
+                f"OPENROUTER_API_KEY=rotated-test-key-{index}\n",
+                encoding="utf-8",
             )
             partial_id = backup.create_quick_snapshot(
                 label=f"partial-{index}",

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1515,6 +1515,52 @@ class TestQuickSnapshot:
         out = capsys.readouterr().out
         assert "skipping state.db" in out.lower() or "skipping snapshot prune" in out.lower()
 
+    @pytest.mark.parametrize("incomplete_kind", ["oversized", "failed"])
+    def test_repeated_incomplete_snapshots_prune_stale_partial_copies(
+        self, hermes_home, monkeypatch, incomplete_kind
+    ):
+        """Incomplete snapshots stay bounded without losing the recovery copy."""
+        from hermes_cli import backup
+
+        complete_id = backup.create_quick_snapshot(
+            label="complete", hermes_home=hermes_home, keep=1
+        )
+        assert complete_id is not None
+
+        snapshot_kwargs = {}
+        if incomplete_kind == "oversized":
+            snapshot_kwargs["max_file_size"] = 1024
+        else:
+            monkeypatch.setattr(backup, "_safe_copy_db", lambda _src, _dst: False)
+
+        partial_ids = []
+        for index in range(3):
+            _advance_backup_clock()
+            (hermes_home / ".env").write_text(
+                f"OPENROUTER_API_KEY=rotated-test-key-{index}\n"
+            )
+            partial_id = backup.create_quick_snapshot(
+                label=f"partial-{index}",
+                hermes_home=hermes_home,
+                keep=1,
+                **snapshot_kwargs,
+            )
+            assert partial_id is not None
+            partial_ids.append(partial_id)
+
+        snapshots = backup.list_quick_snapshots(limit=100, hermes_home=hermes_home)
+        assert {snapshot["id"] for snapshot in snapshots} == {
+            complete_id,
+            partial_ids[-1],
+        }
+        assert (hermes_home / "state-snapshots" / complete_id / "state.db").exists()
+        assert not (
+            hermes_home / "state-snapshots" / partial_ids[0]
+        ).exists(), "stale partial snapshot retained an old credential copy"
+        assert not (
+            hermes_home / "state-snapshots" / partial_ids[1]
+        ).exists(), "stale partial snapshot retained an old credential copy"
+
 
 class TestQuickSnapshotProjectsKanban:
     """Regression for #52889: projects.db / kanban.db must survive an upgrade.


### PR DESCRIPTION
## Summary
- bound retention of repeated incomplete quick snapshots
- preserve the newest recovery copy of every database omitted from the current snapshot
- handle alternating failures where no single older snapshot is complete
- add regression coverage for stale partial snapshots and per-database recovery

## Verification
- 86 focused backup tests passed; 1 skipped
- Ruff and diff checks passed