### PR TITLE
feat(discord): add profile-scoped LLM DM gate

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1713,6 +1713,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.DISCORD and "allow_dms" in platform_cfg:
+                    bridged["allow_dms"] = platform_cfg["allow_dms"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -432,6 +432,7 @@ _GATE_ENV_KEYS = (
     "DISCORD_ALLOWED_ROLES",
     "DISCORD_ALLOWED_CHANNELS",
     "DISCORD_IGNORED_CHANNELS",
+    "DISCORD_ALLOW_DMS",
     "DISCORD_NO_THREAD_CHANNELS",
     "DISCORD_FREE_RESPONSE_CHANNELS",
     "DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS",
@@ -1574,6 +1575,11 @@ class DiscordAdapter(BasePlatformAdapter):
         if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
             return False, False
 
+        msg_guild = getattr(message, "guild", None)
+        is_dm = isinstance(message.channel, discord.DMChannel) or msg_guild is None
+        if is_dm and not self._discord_dms_enabled():
+            return False, False
+
         role_authorized = False
         if getattr(message.author, "bot", False):
             allow_bots = self._get_allow_bots()
@@ -1587,8 +1593,6 @@ class DiscordAdapter(BasePlatformAdapter):
             ):
                 return False, False
         else:
-            msg_guild = getattr(message, "guild", None)
-            is_dm = isinstance(message.channel, discord.DMChannel) or msg_guild is None
             msg_channel_ids = None
             if not is_dm:
                 msg_channel_ids = {str(message.channel.id)}
@@ -6695,6 +6699,24 @@ class DiscordAdapter(BasePlatformAdapter):
         """Per-profile DISCORD_ALLOW_ALL_USERS flag."""
         raw = self._gate_raw("allow_all_users", "DISCORD_ALLOW_ALL_USERS")
         return str(raw or "").strip().lower() in {"true", "1", "yes"}
+
+    def _discord_dms_enabled(self) -> bool:
+        """Whether Discord DMs may enter this profile's LLM conversation path.
+
+        Behavioral configuration lives in ``discord.allow_dms``. The legacy
+        ``DISCORD_ALLOW_DMS`` secret-scope value remains supported during
+        migration, but an explicit profile value wins so multiplexed profiles
+        cannot change each other's policy through process globals. Existing
+        deployments retain their historical default: DMs are enabled.
+        """
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        if isinstance(extra, dict) and "allow_dms" in extra:
+            raw = extra.get("allow_dms")
+        else:
+            raw = self._gate_env("DISCORD_ALLOW_DMS")
+        if raw is None or str(raw).strip() == "":
+            return True
+        return str(raw).strip().lower() in {"true", "1", "yes", "on"}
 
     def _gateway_allow_all_users(self) -> bool:
         """Per-profile GATEWAY_ALLOW_ALL_USERS flag."""

--- a/tests/plugins/platforms/test_discord_dm_gate.py
+++ b/tests/plugins/platforms/test_discord_dm_gate.py
@@ -1,0 +1,129 @@
+"""Discord DM admission is profile-scoped and can be closed to the LLM.
+
+Knight Co handles deterministic approval commands outside the LLM conversation
+path.  Its profile must therefore be able to reject every Discord DM while
+continuing to admit its allowlisted guild channel.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("discord")
+
+from gateway.config import Platform, PlatformConfig
+from plugins.platforms.discord import adapter as adapter_module
+from plugins.platforms.discord.adapter import DiscordAdapter, _GATE_ENV_KEYS
+
+
+class _Dedup:
+    def is_duplicate(self, _message_id):
+        return False
+
+    def contains(self, _message_id):
+        return False
+
+
+class _DMChannel:
+    id = 9001
+
+
+class _GuildChannel:
+    id = 9002
+    parent_id = None
+
+
+def _adapter(extra: dict | None = None, snapshot: dict | None = None) -> DiscordAdapter:
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter.config = PlatformConfig(enabled=True, token="x", extra=dict(extra or {}))
+    adapter._gate_env_snapshot = {
+        key: (snapshot or {}).get(key, "") for key in _GATE_ENV_KEYS
+    }
+    adapter._allowed_user_ids = {"42"}
+    adapter._allowed_role_ids = set()
+    adapter._dedup = _Dedup()
+    bot_user = SimpleNamespace(id=999, bot=True)
+    adapter._client = SimpleNamespace(user=bot_user)
+    adapter._is_allowed_user = lambda *_args, **_kwargs: True
+    adapter._get_parent_channel_id = lambda _channel: None
+    return adapter
+
+
+def _message(channel, *, guild=None):
+    return SimpleNamespace(
+        id=123,
+        author=SimpleNamespace(id=42, bot=False),
+        channel=channel,
+        guild=guild,
+        type=adapter_module.discord.MessageType.default,
+        mentions=[],
+        content="hello",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _dm_channel_type(monkeypatch):
+    monkeypatch.setattr(adapter_module.discord, "DMChannel", _DMChannel)
+    monkeypatch.delenv("DISCORD_ALLOW_DMS", raising=False)
+
+
+def test_dms_are_enabled_by_default():
+    adapter = _adapter()
+    assert adapter._discord_dms_enabled() is True
+    assert adapter._discord_message_admission(_message(_DMChannel()), claim=False) == (
+        True,
+        False,
+    )
+
+
+@pytest.mark.parametrize("value", [False, "false", "0", "no", "off", "FALSE"])
+def test_profile_config_disables_llm_dm_admission(value):
+    adapter = _adapter({"allow_dms": value})
+    assert adapter._discord_dms_enabled() is False
+    assert adapter._discord_message_admission(_message(_DMChannel()), claim=False) == (
+        False,
+        False,
+    )
+
+
+def test_profile_config_takes_precedence_over_legacy_env_snapshot():
+    adapter = _adapter(
+        {"allow_dms": False},
+        snapshot={"DISCORD_ALLOW_DMS": "true"},
+    )
+    assert adapter._discord_dms_enabled() is False
+
+
+def test_real_gateway_loader_preserves_discord_allow_dms(tmp_path, monkeypatch):
+    """The documented config path must survive the real gateway loader."""
+    from gateway import config as gateway_config
+
+    (tmp_path / "config.yaml").write_text(
+        "discord:\n  enabled: true\n  allow_dms: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_config, "get_hermes_home", lambda: tmp_path)
+
+    loaded = gateway_config.load_gateway_config()
+
+    assert loaded.platforms[Platform.DISCORD].extra["allow_dms"] is False
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "FALSE"])
+def test_legacy_env_snapshot_disables_llm_dm_admission(value):
+    adapter = _adapter(snapshot={"DISCORD_ALLOW_DMS": value})
+    assert adapter._discord_dms_enabled() is False
+    assert adapter._discord_message_admission(_message(_DMChannel()), claim=False) == (
+        False,
+        False,
+    )
+
+
+def test_dm_gate_does_not_block_guild_messages():
+    adapter = _adapter({"allow_dms": False})
+    guild_message = _message(_GuildChannel(), guild=SimpleNamespace(id=77))
+    assert adapter._discord_message_admission(guild_message, claim=False) == (
+        True,
+        False,
+    )

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -327,11 +327,12 @@ Wiring multiple Hermes profiles to reply to one another in a shared channel — 
 
 ### Config File (`config.yaml`)
 
-The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Config.yaml settings are applied as defaults — if the equivalent env var is already set, the env var wins.
+The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Config.yaml settings are applied as defaults — if the equivalent env var is already set, the env var normally wins. Security ownership settings such as `discord.allow_dms` are config-first so one profile cannot inherit another profile's process-level policy.
 
 ```yaml
 # Discord-specific settings
 discord:
+  allow_dms: true                  # Set false to keep DMs out of the LLM path
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
@@ -364,7 +365,15 @@ group_sessions_per_user: true     # Isolate sessions per user in shared channels
 
 **Type:** boolean — **Default:** `true`
 
-When enabled, the bot only responds in server channels when directly `@mentioned`. DMs always get a response regardless of this setting.
+When enabled, the bot only responds in server channels when directly `@mentioned`. DMs are independent of mention gating and are controlled by `discord.allow_dms`.
+
+#### `discord.allow_dms`
+
+**Type:** boolean — **Default:** `true`
+
+When `false`, Discord DMs are rejected before entering the LLM conversation path. Guild-channel admission and slash-command authorization are unaffected. Use this for a restricted profile whose privileged DM commands are handled by a separate deterministic broker rather than by the agent.
+
+An explicit profile value takes precedence over the legacy `DISCORD_ALLOW_DMS` environment bridge, which remains supported for migration compatibility.
 
 #### `discord.thread_require_mention`
 


### PR DESCRIPTION
## Summary

Adds `discord.allow_dms` so a profile can keep Discord DMs out of the LLM conversation path without affecting guild-channel admission or slash commands.

This is needed for restricted profiles whose privileged DMs are handled by a separate deterministic broker rather than by the agent. Upstream currently still documents that DMs always get a response (`discord.require_mention` does not apply).

Default remains **enabled** (existing behavior). An explicit profile value wins over the legacy `DISCORD_ALLOW_DMS` env bridge so multiplexed profiles cannot inherit another profile's process-global policy.

## Config

```yaml
discord:
  allow_dms: false
```

## Testing

- `scripts/run_tests.sh tests/plugins/platforms/test_discord_dm_gate.py tests/plugins/platforms/test_discord_gate_isolation.py`
- 36 passed locally (Linux / Python 3.12)
- Contracts covered: default on, config false rejects DMs, legacy env false rejects DMs, profile config precedes env, real `load_gateway_config()` preserves the key, guild messages still admit

## Notes

- Docs point at `config.yaml`; the env var is a migration bridge only.
- No gateway restart / live runtime was used to develop this PR. Cherry-picked from a v0.20.6 local port.