### PR TITLE
feat(camofox): support external noVNC discovery

### DIFF
--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -269,6 +269,63 @@ class TestVncUrlDiscovery:
             assert check_camofox_available() is True
         assert get_vnc_url() == "http://myhost:6080"
 
+    def test_vnc_url_from_camofox_113_status_endpoint(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://myhost:9377")
+        health_resp = _mock_response(json_data={"ok": True})
+        status_resp = _mock_response(json_data={
+            "running": True,
+            "novncPort": 6080,
+            "path": "/vnc.html",
+        })
+        with patch(
+            "tools.browser_camofox.requests.get",
+            side_effect=[health_resp, status_resp],
+        ) as mock_get:
+            assert check_camofox_available() is True
+        assert mock_get.call_args_list[1].args[0] == "http://myhost:9377/vnc/status"
+        assert get_vnc_url() == "http://myhost:6080/vnc.html"
+
+    def test_config_external_vnc_url_overrides_discovery_and_legacy_env(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("CAMOFOX_URL", "http://127.0.0.1:9377")
+        monkeypatch.setenv("CAMOFOX_VNC_URL", "http://legacy.example:6080/vnc.html")
+        config = {"browser": {"camofox": {
+            "vnc_url": "https://gx10.example.ts.net/vnc.html",
+        }}}
+        health_resp = _mock_response(json_data={"ok": True})
+        with (
+            patch("tools.browser_camofox.load_config", return_value=config),
+            patch(
+                "tools.browser_camofox.requests.get", return_value=health_resp
+            ) as mock_get,
+        ):
+            assert check_camofox_available() is True
+        assert mock_get.call_count == 1
+        assert get_vnc_url() == "https://gx10.example.ts.net/vnc.html"
+
+    def test_legacy_external_vnc_url_bridge(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://127.0.0.1:9377")
+        monkeypatch.setenv(
+            "CAMOFOX_VNC_URL", "https://gx10.example.ts.net/vnc.html"
+        )
+        health_resp = _mock_response(json_data={"ok": True})
+        with patch("tools.browser_camofox.requests.get", return_value=health_resp):
+            assert check_camofox_available() is True
+        assert get_vnc_url() == "https://gx10.example.ts.net/vnc.html"
+
+    def test_optional_vnc_status_failure_does_not_fail_browser_health(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("CAMOFOX_URL", "http://myhost:9377")
+        health_resp = _mock_response(json_data={"ok": True})
+        with patch(
+            "tools.browser_camofox.requests.get",
+            side_effect=[health_resp, RuntimeError("optional endpoint unavailable")],
+        ):
+            assert check_camofox_available() is True
+        assert get_vnc_url() is None
+
 
     def test_navigate_includes_vnc_hint(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -149,29 +149,78 @@ def is_camofox_mode() -> bool:
     return bool(get_camofox_url())
 
 
+def _validated_vnc_url(raw: Any) -> Optional[str]:
+    """Return a safe absolute HTTP(S) VNC URL, or ``None``."""
+    value = str(raw or "").strip()
+    if not value:
+        return None
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    return value
+
+
+def _discovered_vnc_url(server_url: str, port: Any, path: str = "") -> Optional[str]:
+    """Build an HTTP(S) VNC URL from validated server metadata."""
+    if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+        return None
+    parsed = urlsplit(server_url)
+    host = parsed.hostname or "localhost"
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    scheme = parsed.scheme if parsed.scheme in {"http", "https"} else "http"
+    safe_path = path if path.startswith("/") and not path.startswith("//") else ""
+    return f"{scheme}://{host}:{port}{safe_path}"
+
+
 def check_camofox_available() -> bool:
-    """Verify the Camofox server is reachable."""
+    """Verify Camofox health and opportunistically cache its noVNC URL."""
     global _vnc_url, _vnc_url_checked
     url = get_camofox_url()
     if not url:
         return False
     try:
         resp = requests.get(f"{url}/health", timeout=5)
-        if resp.status_code == 200 and not _vnc_url_checked:
-            try:
-                data = resp.json()
-                vnc_port = data.get("vncPort")
-                if isinstance(vnc_port, int) and 1 <= vnc_port <= 65535:
-                    from urllib.parse import urlparse
-                    parsed = urlparse(url)
-                    host = parsed.hostname or "localhost"
-                    _vnc_url = f"http://{host}:{vnc_port}"
-            except (ValueError, KeyError):
-                pass
-            _vnc_url_checked = True
-        return resp.status_code == 200
     except Exception:
         return False
+    if resp.status_code != 200:
+        return False
+
+    if not _vnc_url_checked:
+        camofox_cfg = _get_camofox_config()
+        _vnc_url = (
+            _validated_vnc_url(camofox_cfg.get("vnc_url"))
+            or _validated_vnc_url(get_secret("CAMOFOX_VNC_URL", ""))
+        )
+        if _vnc_url is None:
+            try:
+                data = resp.json()
+                _vnc_url = _discovered_vnc_url(url, data.get("vncPort"))
+            except (TypeError, ValueError, KeyError):
+                _vnc_url = None
+
+        # Camofox 1.13 moved noVNC metadata from /health to /vnc/status.
+        # This endpoint is optional: a failure must not make browser health fail.
+        if _vnc_url is None:
+            try:
+                status_resp = requests.get(f"{url}/vnc/status", timeout=5)
+                if status_resp.status_code == 200:
+                    status = status_resp.json()
+                    path = status.get("path")
+                    if not isinstance(path, str):
+                        path = "/vnc.html"
+                    _vnc_url = _discovered_vnc_url(
+                        url,
+                        status.get("novncPort"),
+                        path,
+                    )
+            except Exception:
+                pass
+        _vnc_url_checked = True
+    return True
 
 
 def get_vnc_url() -> Optional[str]:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2377,6 +2377,7 @@ browser:
   dialog_timeout_s: 300          # Safety auto-dismiss under must_respond (seconds)
   camofox:
     managed_persistence: false   # When true, Camofox sessions persist cookies/logins across restarts
+    vnc_url: ""                  # Optional externally reachable noVNC URL (for example, a Tailnet HTTPS URL)
     user_id: ""                  # Optional externally managed Camofox userId
     session_key: ""              # Optional session key sent when Hermes creates a tab
     adopt_existing_tab: false    # Reuse an existing tab for this identity before creating one

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -284,6 +284,22 @@ Then set in `~/.hermes/.env`:
 CAMOFOX_URL=http://localhost:9377
 ```
 
+Camofox's noVNC viewer is discovered automatically. Hermes supports both the
+legacy `vncPort` field on `/health` and Camofox 1.13's `/vnc/status` response.
+If the discovered host/port is not reachable from the operator's device (for
+example, Camofox is behind a reverse proxy), configure the public or Tailnet
+viewer URL explicitly:
+
+```yaml
+browser:
+  camofox:
+    vnc_url: "https://gx10.example.ts.net/vnc.html"
+```
+
+The structured setting takes precedence over the legacy `CAMOFOX_VNC_URL`
+environment bridge. VNC discovery is optional and never determines whether
+the Camofox browser service itself is healthy.
+
 If Camofox is running in Docker and you want it to open web apps served from the host machine, enable loopback rewriting. `CAMOFOX_URL` should still point at the host-published control API, but page URLs such as `http://127.0.0.1:3000` must be opened from inside the container as `http://host.docker.internal:3000`:
 
 ```yaml


### PR DESCRIPTION
## Summary

Camofox 1.13 moved noVNC metadata from `/health` (`vncPort`) to `/vnc/status` (`novncPort` + path). Hermes still only read the legacy `/health` field, so operators behind a Tailnet reverse proxy never got a usable viewer URL.

This change:

- keeps legacy `/health` `vncPort` discovery
- reads Camofox 1.13 `/vnc/status` when needed
- lets `browser.camofox.vnc_url` override discovered/loopback addresses
- keeps the legacy `CAMOFOX_VNC_URL` env bridge as a fallback
- treats VNC discovery as optional — a missing/failed `/vnc/status` does **not** fail browser health

## Config

```yaml
browser:
  camofox:
    vnc_url: \"https://example.ts.net/vnc.html\"
```

## Testing

- `scripts/run_tests.sh tests/tools/test_browser_camofox_persistence.py`
- 19 passed locally (Linux / Python 3.12)

## Notes

Cherry-picked from a v0.20.6 local port. No live gateway/runtime was modified for this PR.