### PR TITLE
fix(dashboard): forward startup query to chat PTY

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16598,6 +16598,7 @@ def _resolve_chat_argv(
     sidecar_url: Optional[str] = None,
     profile: Optional[str] = None,
     active_session_file: Optional[str] = None,
+    query: Optional[str] = None,
 ) -> tuple[list[str], Optional[str], Optional[dict]]:
     """Resolve the argv + cwd + env for the chat PTY.
 
@@ -16682,6 +16683,11 @@ def _resolve_chat_argv(
     # the dashboard PTY path.
     env.setdefault("HERMES_TUI_DISABLE_MOUSE", "1")
     env.setdefault("HERMES_TUI_INLINE", "1")
+    # Never inherit a stale startup query from the dashboard service. Only
+    # the authenticated WebSocket request for this PTY may seed one.
+    env.pop("HERMES_TUI_QUERY", None)
+    if query:
+        env["HERMES_TUI_QUERY"] = query
     # The dashboard terminal is xterm.js, which always renders 24-bit RGB.
     # But chalk inside the TUI child decides its color depth from the
     # SERVER process env — and hosted/cloud deploys run the dashboard under
@@ -16801,6 +16807,7 @@ async def _resolve_chat_argv_async(
     sidecar_url: Optional[str] = None,
     profile: Optional[str] = None,
     active_session_file: Optional[str] = None,
+    query: Optional[str] = None,
 ) -> tuple[list[str], Optional[str], Optional[dict]]:
     """Resolve chat argv without blocking the dashboard event loop.
 
@@ -16819,6 +16826,8 @@ async def _resolve_chat_argv_async(
     }
     if active_session_file is not None:
         kwargs["active_session_file"] = active_session_file
+    if query:
+        kwargs["query"] = query
 
     async with _get_chat_argv_lock(app):
         return await asyncio.to_thread(
@@ -17550,6 +17559,7 @@ async def pty_ws(ws: WebSocket) -> None:
     raw_resume = ws.query_params.get("resume") or None
     resume = raw_resume
     profile = ws.query_params.get("profile") or None
+    query = (ws.query_params.get("query") or "").strip()[:4000] or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
     force_fresh = (ws.query_params.get("fresh") or "").strip().lower() in {
@@ -17581,6 +17591,8 @@ async def pty_ws(ws: WebSocket) -> None:
     }
     if active_session_file is not None:
         resolve_kwargs["active_session_file"] = str(active_session_file)
+    if query:
+        resolve_kwargs["query"] = query
 
     try:
         argv, cwd, env = await _resolve_chat_argv_async(**resolve_kwargs)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4352,6 +4352,43 @@ class TestPtyWebSocket:
         q = {"token": tok, **params}
         return f"/api/pty?{urlencode(q)}"
 
+    def test_resolve_chat_argv_forwards_startup_query(self, monkeypatch):
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (
+                ["node", "dist/entry.js"],
+                "/tmp/ui-tui",
+            ),
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv(
+            query="Continue work on Wealth Engine"
+        )
+
+        assert env["HERMES_TUI_QUERY"] == "Continue work on Wealth Engine"
+
+    def test_query_parameter_is_forwarded_to_async_chat_resolver(self, monkeypatch):
+        captured: dict = {}
+
+        async def fake_resolve(**kwargs):
+            captured.update(kwargs)
+            return (["/bin/sh", "-c", "printf query-forwarded"], None, None)
+
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv_async", fake_resolve)
+
+        with self.client.websocket_connect(
+            self._url(query="  Continue Wealth Engine  ")
+        ) as conn:
+            try:
+                conn.receive_bytes()
+            except Exception:
+                pass
+
+        assert captured["query"] == "Continue Wealth Engine"
+
 
 
     def test_tui_python_command_uses_child_path(self, tmp_path):


### PR DESCRIPTION
## Summary

The TUI already honors `HERMES_TUI_QUERY`, but the web dashboard PTY path never forwarded the authenticated WebSocket `query` parameter into the child env. Dashboard deep-links therefore could not seed the chat the way the CLI/TUI can.

This change:

- reads `query` from the PTY WebSocket (trimmed, capped at 4000 chars)
- forwards it as `HERMES_TUI_QUERY` for that PTY only
- pops any inherited `HERMES_TUI_QUERY` from the dashboard service env so a stale service-level value cannot leak into every chat

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'startup_query or query_parameter'`
- 2 passed locally (Linux / Python 3.12)

## Notes

Internal env bridge only; no new user-facing `.env` setting. Cherry-picked from a v0.20.6 local port.