### PR TITLE
feat(discord): add profile-scoped voice auto-join

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1713,6 +1713,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.DISCORD and "voice_auto_join" in platform_cfg:
+                    bridged["voice_auto_join"] = platform_cfg["voice_auto_join"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13449,6 +13449,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # transcription is forwarded without requiring /voice join.
                 if hasattr(adapter, "_voice_input_callback"):
                     adapter._voice_input_callback = self._handle_voice_channel_input
+                if hasattr(adapter, "_on_voice_disconnect"):
+                    adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+                if hasattr(adapter, "_on_voice_joined"):
+                    adapter._on_voice_joined = self._handle_voice_joined
+                if hasattr(adapter, "_voice_mode_getter"):
+                    adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
+                        self._voice_key(Platform.DISCORD, str(chat_id)), "off"
+                    )
                 connected_count += 1
                 self._update_platform_runtime_status(
                     platform.value, platform_state="connected", error_code=None, error_message=None,
@@ -23022,6 +23030,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = None
         return "Left voice channel."
+
+    def _handle_voice_joined(self, chat_id: str, guild_id: int | None = None) -> None:
+        """Enable persisted voice replies after an engagement auto-join."""
+        key = self._voice_key(Platform.DISCORD, chat_id)
+        if self._voice_mode.get(key) != "all":
+            self._voice_mode[key] = "all"
+            self._save_voice_modes()
+        adapter = self.adapters.get(Platform.DISCORD)
+        if adapter is not None and hasattr(adapter, "_voice_input_callback"):
+            adapter._voice_input_callback = self._handle_voice_channel_input
+        self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+        logger.debug("Voice mode enabled for chat %s (guild=%s)", chat_id, guild_id)
 
     def _handle_voice_timeout_cleanup(self, chat_id: str) -> None:
         """Called by the adapter when a voice channel times out.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -432,6 +432,7 @@ _GATE_ENV_KEYS = (
     "DISCORD_ALLOWED_ROLES",
     "DISCORD_ALLOWED_CHANNELS",
     "DISCORD_IGNORED_CHANNELS",
+    "DISCORD_VOICE_AUTO_JOIN",
     "DISCORD_NO_THREAD_CHANNELS",
     "DISCORD_FREE_RESPONSE_CHANNELS",
     "DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS",
@@ -1102,6 +1103,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
+        self._on_voice_joined: Optional[Callable] = None  # set by run.py
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -4753,6 +4755,67 @@ class DiscordAdapter(BasePlatformAdapter):
         if not member or not member.voice:
             return None
         return member.voice.channel
+
+    def _voice_auto_join_enabled(self) -> bool:
+        """Return the profile-scoped engagement auto-join policy."""
+        extra = getattr(self.config, "extra", {})
+        if isinstance(extra, dict) and "voice_auto_join" in extra:
+            raw = extra["voice_auto_join"]
+        else:
+            raw = self._gate_env("DISCORD_VOICE_AUTO_JOIN")
+        if isinstance(raw, bool):
+            return raw
+        return str(raw or "").strip().lower() in {"1", "true", "yes", "on"}
+
+    async def maybe_auto_join_voice(
+        self,
+        *,
+        guild_id: int,
+        user_id: str,
+        text_channel_id: int,
+        source_dict: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Join the engaged user's current VC when explicitly enabled."""
+        if not self._voice_auto_join_enabled():
+            return False
+        if not guild_id or not user_id or not text_channel_id:
+            return False
+
+        try:
+            voice_channel = await self.get_user_voice_channel(guild_id, user_id)
+        except Exception as exc:
+            logger.debug("Voice auto-join lookup failed: %s", exc)
+            return False
+        if voice_channel is None:
+            return False
+
+        try:
+            join_kwargs: Dict[str, Any] = {"text_channel_id": text_channel_id}
+            if source_dict is not None:
+                join_kwargs["source"] = source_dict
+            success = await self.join_voice_channel(voice_channel, **join_kwargs)
+        except Exception as exc:
+            logger.warning("Voice auto-join failed: %s", exc)
+            return False
+        if not success:
+            return False
+
+        # Re-bind even when join_voice_channel returned early for an existing
+        # connection in this guild.
+        self._voice_text_channels[guild_id] = int(text_channel_id)
+        if source_dict is not None:
+            self._voice_sources[guild_id] = source_dict
+        self._reset_voice_timeout(guild_id)
+
+        callback = self._on_voice_joined
+        if callback is not None:
+            try:
+                result = callback(str(text_channel_id), guild_id=guild_id)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as exc:
+                logger.debug("Voice auto-join callback failed: %s", exc)
+        return True
 
     def _cancel_voice_timeout(self, guild_id: int) -> None:
         task = self._voice_timeout_tasks.pop(guild_id, None)
@@ -8542,6 +8605,24 @@ class DiscordAdapter(BasePlatformAdapter):
         if thread_id:
             self._threads.mark(thread_id)
 
+        # Only an admitted, live guild message may trigger this opt-in path.
+        # Recovered backlog must never move the bot into a voice channel.
+        guild = getattr(message, "guild", None)
+        if (
+            not recovered
+            and guild is not None
+            and self._voice_auto_join_enabled()
+        ):
+            try:
+                await self.maybe_auto_join_voice(
+                    guild_id=int(guild.id),
+                    user_id=str(message.author.id),
+                    text_channel_id=int(message.channel.id),
+                    source_dict=source.to_dict(),
+                )
+            except Exception as exc:
+                logger.debug("Voice auto-join skipped: %s", exc)
+
         # Only live plain text messages use split-message batching. Recovery
         # candidates are already complete historical messages; coalescing them
         # would lose constituent IDs and make later restarts replay them.
@@ -10539,6 +10620,11 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
             seeded_extra[primary_key] = value
             if env_key and not os.getenv(env_key):
                 os.environ[env_key] = str(value)
+    voice_auto_join = _websocket_liveness_cfg.get("voice_auto_join")
+    if voice_auto_join is not None:
+        seeded_extra["voice_auto_join"] = voice_auto_join
+        if not _skip_env_bridge and not os.getenv("DISCORD_VOICE_AUTO_JOIN"):
+            os.environ["DISCORD_VOICE_AUTO_JOIN"] = str(voice_auto_join).lower()
     return seeded_extra or None
 
 

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -1,0 +1,125 @@
+"""Compatibility contracts for opt-in Discord voice engagement auto-join."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.run import GatewayRunner
+from plugins.platforms.discord.adapter import DiscordAdapter, _GATE_ENV_KEYS, _apply_yaml_config
+
+
+def _adapter(extra=None, *, snapshot=None):
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter.config = PlatformConfig(enabled=True, token="test", extra=dict(extra or {}))
+    adapter._gate_env_snapshot = {
+        key: (snapshot or {}).get(key, "") for key in _GATE_ENV_KEYS
+    }
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._on_voice_joined = None
+    return adapter
+
+
+def test_yaml_voice_auto_join_is_seeded_into_profile_extra(monkeypatch):
+    monkeypatch.delenv("DISCORD_VOICE_AUTO_JOIN", raising=False)
+
+    seeded = _apply_yaml_config({}, {"voice_auto_join": True})
+
+    assert seeded["voice_auto_join"] is True
+
+
+def test_real_gateway_loader_preserves_discord_voice_auto_join(tmp_path, monkeypatch):
+    from gateway import config as gateway_config
+
+    (tmp_path / "config.yaml").write_text(
+        "discord:\n  enabled: true\n  voice_auto_join: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_config, "get_hermes_home", lambda: tmp_path)
+
+    loaded = gateway_config.load_gateway_config()
+
+    assert loaded.platforms[Platform.DISCORD].extra["voice_auto_join"] is True
+
+
+def test_profile_voice_auto_join_setting_precedes_legacy_env_snapshot():
+    adapter = _adapter(
+        {"voice_auto_join": False},
+        snapshot={"DISCORD_VOICE_AUTO_JOIN": "true"},
+    )
+
+    assert adapter._voice_auto_join_enabled() is False
+
+
+def test_legacy_voice_auto_join_env_snapshot_remains_supported():
+    adapter = _adapter(snapshot={"DISCORD_VOICE_AUTO_JOIN": "true"})
+
+    assert adapter._voice_auto_join_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_maybe_auto_join_binds_text_source_and_notifies_runner():
+    adapter = _adapter({"voice_auto_join": True})
+    voice_channel = SimpleNamespace(name="Workshop")
+    adapter.get_user_voice_channel = AsyncMock(return_value=voice_channel)
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+    adapter.is_in_voice_channel = MagicMock(return_value=False)
+    adapter._reset_voice_timeout = MagicMock()
+    joined = MagicMock()
+    adapter._on_voice_joined = joined
+    source = {"platform": "discord", "chat_id": "456"}
+
+    result = await adapter.maybe_auto_join_voice(
+        guild_id=123,
+        user_id="789",
+        text_channel_id=456,
+        source_dict=source,
+    )
+
+    assert result is True
+    adapter.join_voice_channel.assert_awaited_once_with(
+        voice_channel,
+        text_channel_id=456,
+        source=source,
+    )
+    assert adapter._voice_text_channels[123] == 456
+    assert adapter._voice_sources[123] == source
+    joined.assert_called_once_with("456", guild_id=123)
+
+
+@pytest.mark.asyncio
+async def test_disabled_auto_join_does_not_probe_member_voice_state():
+    adapter = _adapter({"voice_auto_join": False})
+    adapter.get_user_voice_channel = AsyncMock()
+
+    result = await adapter.maybe_auto_join_voice(
+        guild_id=123,
+        user_id="789",
+        text_channel_id=456,
+    )
+
+    assert result is False
+    adapter.get_user_voice_channel.assert_not_awaited()
+
+
+def test_runner_voice_join_callback_enables_persisted_mode_and_auto_tts():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._voice_mode = {}
+    runner._save_voice_modes = MagicMock()
+    adapter = SimpleNamespace(
+        _auto_tts_enabled_chats=set(),
+        _auto_tts_disabled_chats={"456"},
+        _voice_input_callback=None,
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+
+    runner._handle_voice_joined("456", guild_id=123)
+
+    assert runner._voice_mode["discord:456"] == "all"
+    assert adapter._auto_tts_enabled_chats == {"456"}
+    assert "456" not in adapter._auto_tts_disabled_chats
+    assert callable(adapter._voice_input_callback)
+    runner._save_voice_modes.assert_called_once_with()

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -745,6 +745,19 @@ Hermes Agent supports Discord voice messages:
 - **Text-to-speech**: Use `/voice tts` to have the bot send spoken audio responses alongside text replies.
 - **Discord voice channels**: Hermes can also join a voice channel, listen to users speaking, and talk back in the channel.
 
+Voice-channel joining is explicit by default (`/voice join`). To have an admitted
+live guild message automatically join the sender's current voice channel and
+enable spoken replies for that text chat, opt in per profile:
+
+```yaml
+discord:
+  voice_auto_join: true
+```
+
+Recovered message backlogs never trigger auto-join. The legacy
+`DISCORD_VOICE_AUTO_JOIN=true` environment variable remains supported when the
+profile setting is absent; the profile setting takes precedence.
+
 For the full setup and operational guide, see:
 - [Voice Mode](/user-guide/features/voice-mode)
 - [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes)


### PR DESCRIPTION
## Summary

Adds opt-in, **disabled-by-default** Discord voice auto-join that fires only after an admitted **live guild** message, joining the sender's current voice channel and enabling spoken replies for that text chat.

This is the smaller engagement-on-message design already running on our v0.20.6 port. It is **not** a duplicate of the `on_voice_state_update` allowlist PRs:

- #96527 opt-in voice auto-join with channel/user allowlists + approval prompt
- #59885, #67225, #62499 related voice auto-join variants

Those cover join-on-VC-entry. This PR covers join-on-admitted-text-engagement, which is what `/voice join` already does, just triggered from a live guild message when explicitly enabled.

## Safety

- Default **off**
- Recovered/history backfill never auto-joins
- Profile `discord.voice_auto_join` wins over the legacy `DISCORD_VOICE_AUTO_JOIN` env bridge
- `_apply_yaml_config` skips the env write under profile-scoped multiplex loads
- Real `load_gateway_config()` probe so `PlatformConfig.extra` actually keeps the key

## Config

```yaml
discord:
  voice_auto_join: true
```

## Testing

- `scripts/run_tests.sh tests/gateway/test_discord_voice_auto_join.py tests/plugins/platforms/test_discord_gate_isolation.py`
- 28 passed locally (Linux / Python 3.12)

Happy to close this as duplicate if maintainers prefer #96527 as the only auto-join surface.