### PR TITLE
fix(gateway): bound and secure launchd stdio logs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3678,28 +3678,40 @@ def _timestamped_stderr_gateway_command(error_log: Path, *, external_supervisor:
         inner = [part for part in inner if part != "--replace"]
         if "--external-supervisor" not in inner:
             inner.append("--external-supervisor")
-    return [get_python_path(), "-m", "hermes_cli.stderr_timestamp", "--error-log", str(error_log), "--", *inner]
+    return [
+        get_python_path(),
+        "-m",
+        "hermes_cli.stderr_timestamp",
+        "--output-log",
+        str(error_log.with_name("gateway.stdout.log")),
+        "--error-log",
+        str(error_log),
+        "--",
+        *inner,
+    ]
 
 
 def _spawn_detached_gateway() -> bool:
     """Launch the gateway detached (launchd fallback for macOS 26+). CLI-managed nohup equivalent:
-    stdout → gateway.log, timestamped stderr → gateway.error.log, PID via gateway.pid so stop/status work.
+    raw stdout/stderr go through bounded capture, PID via gateway.pid so stop/status work.
 
     Used when launchctl can no longer bootstrap/kickstart the gateway on macOS 26+ (issue #23387). Mirrors
-    the `nohup hermes gateway run --replace` workaround but keeps it CLI-managed: stdout goes to
-    gateway.log, stderr is timestamped into gateway.error.log, and the PID is tracked via the gateway.pid
+    the `nohup hermes gateway run --replace` workaround but keeps it CLI-managed: raw stdout/stderr go through
+    the same bounded capture used by launchd, and the PID is tracked via the gateway.pid
     file that `run_gateway` writes, so stop/status/restart keep working.
     """
     from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
     log_dir = get_hermes_home() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
+    err_path = log_dir / "gateway.error.log"
     try:
-        with open(log_dir / "gateway.log", "ab") as out:
-            subprocess.Popen(
-                _timestamped_stderr_gateway_command(log_dir / "gateway.error.log"),
-                stdin=subprocess.DEVNULL, stdout=out, stderr=subprocess.DEVNULL,
-                **windows_detach_popen_kwargs(),
-            )
+        subprocess.Popen(
+            _timestamped_stderr_gateway_command(err_path),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            **windows_detach_popen_kwargs(),
+        )
     except OSError:
         return False
     return True
@@ -3817,11 +3829,16 @@ def generate_launchd_plist() -> str:
     <key>ExitTimeOut</key>
     <integer>25</integer>
 {nofile_block}
+    <!-- launchd otherwise creates append-only stdio files using the login
+         session's permissive umask.  The wrapper owns bounded, 0600 capture. -->
+    <key>Umask</key>
+    <integer>63</integer>
+
     <key>StandardOutPath</key>
-    <string>{log_dir}/gateway.log</string>
+    <string>/dev/null</string>
     
     <key>StandardErrorPath</key>
-    <string>{log_dir}/gateway.error.log</string>
+    <string>/dev/null</string>
 </dict>
 </plist>
 """

--- a/hermes_cli/stderr_timestamp.py
+++ b/hermes_cli/stderr_timestamp.py
@@ -1,4 +1,4 @@
-"""Run a child process while prefixing each stderr line with a timestamp."""
+"""Run a child while capturing stdout and timestamping stderr."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ import threading
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Protocol, Sequence
+from typing import Any, BinaryIO, IO, Protocol, Sequence
 
 EXTERNAL_SUPERVISOR_FLAG = "--external-supervisor"
 _DEFAULT_MAX_SIZE_MB = 5
@@ -33,10 +33,15 @@ def _rotation_config() -> tuple[int, int]:
         _, configured_size, configured_backups = _read_logging_config()
     except Exception:
         configured_size = configured_backups = None
-    return (
-        max(int(configured_size or _DEFAULT_MAX_SIZE_MB), 1),
-        max(int(configured_backups or _DEFAULT_BACKUP_COUNT), 0),
-    )
+    try:
+        max_size_mb = max(int(configured_size or _DEFAULT_MAX_SIZE_MB), 1)
+    except (TypeError, ValueError):
+        max_size_mb = _DEFAULT_MAX_SIZE_MB
+    try:
+        backup_count = max(int(configured_backups or _DEFAULT_BACKUP_COUNT), 0)
+    except (TypeError, ValueError):
+        backup_count = _DEFAULT_BACKUP_COUNT
+    return max_size_mb, backup_count
 
 _TIMESTAMP_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?:\s|$)")
 
@@ -70,7 +75,8 @@ class _RotatingWriter:
     ) -> None:
         configured_mb, configured_backups = _rotation_config()
         self._path = log_path
-        self._max_bytes = max(max_bytes or configured_mb * 1024 * 1024, 1)
+        configured_bytes = configured_mb * 1024 * 1024
+        self._max_bytes = max(configured_bytes if max_bytes is None else max_bytes, 1)
         self._backup_count = (
             configured_backups if backup_count is None else max(backup_count, 0)
         )
@@ -85,7 +91,7 @@ class _RotatingWriter:
         prefix = f"{self._path.name}."
         for candidate in self._path.parent.iterdir():
             suffix = candidate.name.removeprefix(prefix)
-            if candidate.name == f"{prefix}{suffix}" and suffix.isdigit():
+            if candidate.name.startswith(prefix) and suffix.isdigit():
                 try:
                     if int(suffix) > self._backup_count:
                         candidate.unlink()
@@ -147,7 +153,7 @@ class _RotatingWriter:
             self._io = None
 
 
-def _copy_stderr_with_timestamps(stderr: BinaryIO, log_path: Path) -> None:
+def _copy_stderr_with_timestamps(stderr: IO[bytes], log_path: Path) -> None:
     writer = _RotatingWriter(log_path)
     try:
         for raw_line in iter(stderr.readline, b""):
@@ -157,7 +163,7 @@ def _copy_stderr_with_timestamps(stderr: BinaryIO, log_path: Path) -> None:
         writer.close()
 
 
-def _copy_stdout(stdout: BinaryIO, log_path: Path) -> None:
+def _copy_stdout(stdout: IO[bytes], log_path: Path) -> None:
     writer = _RotatingWriter(log_path)
     try:
         for raw_line in iter(stdout.readline, b""):
@@ -172,14 +178,14 @@ def _command_exit_code(returncode: int) -> int:
     return returncode
 
 
-def _install_signal_forwarders(proc: subprocess.Popen[bytes]) -> dict[int, object]:
+def _install_signal_forwarders(proc: subprocess.Popen[bytes]) -> dict[int, Any]:
     def _forward(signum: int, _frame: object) -> None:
         try:
             proc.send_signal(signum)
         except ProcessLookupError:
             pass
 
-    previous: dict[int, object] = {}
+    previous: dict[int, Any] = {}
     for signum in (signal.SIGTERM, signal.SIGINT, getattr(signal, "SIGHUP", None)):
         if signum is not None:
             try:

--- a/hermes_cli/stderr_timestamp.py
+++ b/hermes_cli/stderr_timestamp.py
@@ -8,12 +8,35 @@ import re
 import signal
 import subprocess
 import sys
+import threading
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, Sequence, TextIO
+from typing import BinaryIO, Protocol, Sequence
 
 EXTERNAL_SUPERVISOR_FLAG = "--external-supervisor"
+_DEFAULT_MAX_SIZE_MB = 5
+_DEFAULT_BACKUP_COUNT = 3
+
+
+class _LineWriter(Protocol):
+    def write(self, text: str) -> None: ...
+
+    def flush(self) -> None: ...
+
+
+def _rotation_config() -> tuple[int, int]:
+    """Return the canonical Hermes file-log size and retention settings."""
+    try:
+        from hermes_logging import _read_logging_config
+
+        _, configured_size, configured_backups = _read_logging_config()
+    except Exception:
+        configured_size = configured_backups = None
+    return (
+        max(int(configured_size or _DEFAULT_MAX_SIZE_MB), 1),
+        max(int(configured_backups or _DEFAULT_BACKUP_COUNT), 0),
+    )
 
 _TIMESTAMP_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?:\s|$)")
 
@@ -23,22 +46,130 @@ def _timestamp() -> str:
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:23]
 
 
-def _write_timestamped_line(log_file: TextIO, line: str) -> None:
+def _write_timestamped_line(log_file: _LineWriter, line: str) -> None:
     rendered = line.rstrip("\r\n")
     prefix = "" if _TIMESTAMP_PREFIX.match(rendered) else f"{_timestamp()} "
     log_file.write(f"{prefix}{rendered}\n")
     log_file.flush()
 
 
-def _open_log(log_path: Path) -> TextIO:
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    return log_path.open("a", encoding="utf-8", buffering=1)
+class _RotatingWriter:
+    """Owner-only, size-bounded writer for launchd-captured output.
+
+    Rotation happens between writes, matching ``RotatingFileHandler``: one
+    indivisible line can exceed the configured size, but retained history is
+    still bounded by that line plus the configured live/backup file count.
+    """
+
+    def __init__(
+        self,
+        log_path: Path,
+        *,
+        max_bytes: int | None = None,
+        backup_count: int | None = None,
+    ) -> None:
+        configured_mb, configured_backups = _rotation_config()
+        self._path = log_path
+        self._max_bytes = max(max_bytes or configured_mb * 1024 * 1024, 1)
+        self._backup_count = (
+            configured_backups if backup_count is None else max(backup_count, 0)
+        )
+        self._io: BinaryIO | None = None
+        self._prune_and_secure_backups()
+        self._open()
+
+    def _prune_and_secure_backups(self) -> None:
+        """Apply a reduced retention setting immediately, not one rollover later."""
+        if not self._path.parent.exists():
+            return
+        prefix = f"{self._path.name}."
+        for candidate in self._path.parent.iterdir():
+            suffix = candidate.name.removeprefix(prefix)
+            if candidate.name == f"{prefix}{suffix}" and suffix.isdigit():
+                try:
+                    if int(suffix) > self._backup_count:
+                        candidate.unlink()
+                    elif candidate.is_file() and not candidate.is_symlink():
+                        candidate.chmod(0o600)
+                except FileNotFoundError:
+                    pass
+
+    def _open(self) -> BinaryIO:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(self._path, flags, 0o600)
+        try:
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
+            else:  # pragma: no cover - Windows compatibility for unit tests
+                os.chmod(self._path, 0o600)
+            self._io = os.fdopen(fd, "ab", buffering=0)
+        except BaseException:
+            os.close(fd)
+            raise
+        return self._io
+
+    def _rotate(self) -> None:
+        self.close()
+        if self._backup_count == 0:
+            self._path.unlink(missing_ok=True)
+        else:
+            for index in range(self._backup_count, 0, -1):
+                target = self._path.with_name(f"{self._path.name}.{index}")
+                source = (
+                    self._path.with_name(f"{self._path.name}.{index - 1}")
+                    if index > 1
+                    else self._path
+                )
+                if source.exists():
+                    target.unlink(missing_ok=True)
+                    source.replace(target)
+                    if not target.is_symlink():
+                        target.chmod(0o600)
+        self._open()
+
+    def write(self, text: str) -> None:
+        data = text.encode("utf-8", errors="replace")
+        stream = self._io or self._open()
+        if stream.tell() and stream.tell() + len(data) > self._max_bytes:
+            self._rotate()
+            assert self._io is not None
+            stream = self._io
+        stream.write(data)
+
+    def flush(self) -> None:
+        """Writes are unbuffered."""
+
+    def close(self) -> None:
+        if self._io is not None:
+            self._io.close()
+            self._io = None
 
 
 def _copy_stderr_with_timestamps(stderr: BinaryIO, log_path: Path) -> None:
-    with _open_log(log_path) as log_file:
+    writer = _RotatingWriter(log_path)
+    try:
         for raw_line in iter(stderr.readline, b""):
-            _write_timestamped_line(log_file, raw_line.decode("utf-8", errors="replace"))
+            line = raw_line.decode("utf-8", errors="replace")
+            _write_timestamped_line(writer, line)
+    finally:
+        writer.close()
+
+
+def _copy_stdout(stdout: BinaryIO, log_path: Path) -> None:
+    writer = _RotatingWriter(log_path)
+    try:
+        for raw_line in iter(stdout.readline, b""):
+            writer.write(raw_line.decode("utf-8", errors="replace"))
+    finally:
+        writer.close()
+
+
+def _command_exit_code(returncode: int) -> int:
+    if returncode < 0:
+        return 128 + abs(returncode)
+    return returncode
 
 
 def _install_signal_forwarders(proc: subprocess.Popen[bytes]) -> dict[int, object]:
@@ -89,7 +220,8 @@ def _prepare_child_command(command: Sequence[str], environ: Mapping[str, str] | 
 
 
 def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run a command and timestamp each stderr line into a log file.")
+    parser = argparse.ArgumentParser(description="Run a command and capture its output in rotating log files.")
+    parser.add_argument("--output-log", type=Path)
     parser.add_argument("--error-log", required=True, type=Path)
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
@@ -103,24 +235,44 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     log_path: Path = args.error_log
+    output_path: Path | None = args.output_log
 
     try:
-        proc = subprocess.Popen(_prepare_child_command(args.command), stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            _prepare_child_command(args.command),
+            stdout=subprocess.PIPE if output_path else None,
+            stderr=subprocess.PIPE,
+        )
     except OSError as exc:
-        with _open_log(log_path) as log_file:
-            _write_timestamped_line(log_file, f"failed to start stderr-timestamped command: {exc}")
+        writer = _RotatingWriter(log_path)
+        try:
+            _write_timestamped_line(writer, f"failed to start stderr-timestamped command: {exc}")
+        finally:
+            writer.close()
         return 127
 
     assert proc.stderr is not None
+    stdout_thread = None
+    if output_path is not None:
+        assert proc.stdout is not None
+        stdout_thread = threading.Thread(
+            target=_copy_stdout,
+            args=(proc.stdout, output_path),
+            name="gateway-stdout-capture",
+        )
+        stdout_thread.start()
     previous_handlers = _install_signal_forwarders(proc)
     try:
         _copy_stderr_with_timestamps(proc.stderr, log_path)
     finally:
         proc.stderr.close()
+        if stdout_thread is not None:
+            stdout_thread.join()
+        if proc.stdout is not None:
+            proc.stdout.close()
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)
-    returncode = proc.wait()
-    return 128 + abs(returncode) if returncode < 0 else returncode
+    return _command_exit_code(proc.wait())
 
 
 if __name__ == "__main__":

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -347,6 +347,8 @@ def test_spawn_detached_gateway_timestamps_stderr(monkeypatch, tmp_path):
         "/usr/bin/python3",
         "-m",
         "hermes_cli.stderr_timestamp",
+        "--output-log",
+        str(tmp_path / "logs" / "gateway.stdout.log"),
         "--error-log",
         str(tmp_path / "logs" / "gateway.error.log"),
         "--",
@@ -354,7 +356,7 @@ def test_spawn_detached_gateway_timestamps_stderr(monkeypatch, tmp_path):
     ]
     assert kwargs["stdin"] is gateway.subprocess.DEVNULL
     assert kwargs["stderr"] is gateway.subprocess.DEVNULL
-    assert kwargs["stdout"].name == str(tmp_path / "logs" / "gateway.log")
+    assert kwargs["stdout"] is gateway.subprocess.DEVNULL
 
 
 @pytest.mark.skipif(

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1756,6 +1756,8 @@ class TestProfileArg:
             "/usr/bin/python3",
             "-m",
             "hermes_cli.stderr_timestamp",
+            "--output-log",
+            str(profile_dir / "logs" / "gateway.stdout.log"),
             "--error-log",
             str(profile_dir / "logs" / "gateway.error.log"),
             "--",
@@ -1768,6 +1770,19 @@ class TestProfileArg:
             "run",
             "--external-supervisor",
         ]
+
+    def test_launchd_plist_secures_and_delegates_stdio_capture(self, tmp_path, monkeypatch):
+        """launchd must not hold append-only handles to gateway log files."""
+        profile_dir = tmp_path / ".hermes"
+        profile_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+
+        definition = plistlib.loads(gateway_cli.generate_launchd_plist().encode())
+
+        assert definition["Umask"] == 0o77
+        assert definition["StandardOutPath"] == "/dev/null"
+        assert definition["StandardErrorPath"] == "/dev/null"
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"

--- a/tests/hermes_cli/test_stderr_timestamp.py
+++ b/tests/hermes_cli/test_stderr_timestamp.py
@@ -72,6 +72,15 @@ def test_main_captures_stdout_separately(tmp_path):
     assert error_path.read_text(encoding="utf-8").endswith(" failed\n")
 
 
+def test_rotation_config_falls_back_for_malformed_values(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_logging._read_logging_config",
+        lambda: ("INFO", "not-a-size", "not-a-count"),
+    )
+
+    assert stderr_timestamp._rotation_config() == (5, 3)
+
+
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows"
 )

--- a/tests/hermes_cli/test_stderr_timestamp.py
+++ b/tests/hermes_cli/test_stderr_timestamp.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.stderr_timestamp."""
 
 import re
+import stat
 import sys
 
 import pytest
@@ -47,6 +48,58 @@ def test_main_timestamps_each_stderr_line(tmp_path):
     assert re.fullmatch(f"{timestamp} first failure", lines[0])
     assert re.fullmatch(f"{timestamp} second failure without newline", lines[1])
     assert lines[2] == "2026-07-15 12:34:56,789 already timestamped"
+
+
+def test_main_captures_stdout_separately(tmp_path):
+    output_path = tmp_path / "gateway.stdout.log"
+    error_path = tmp_path / "gateway.error.log"
+
+    rc = stderr_timestamp.main(
+        [
+            "--output-log",
+            str(output_path),
+            "--error-log",
+            str(error_path),
+            "--",
+            sys.executable,
+            "-c",
+            "import sys; print('ready'); print('failed', file=sys.stderr)",
+        ]
+    )
+
+    assert rc == 0
+    assert output_path.read_text(encoding="utf-8") == "ready\n"
+    assert error_path.read_text(encoding="utf-8").endswith(" failed\n")
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows"
+)
+def test_rotating_writer_bounds_backups_and_tightens_modes(tmp_path):
+    log_path = tmp_path / "gateway.stdout.log"
+    log_path.write_text("legacy world-readable\n", encoding="utf-8")
+    log_path.chmod(0o644)
+    stale_backup = tmp_path / "gateway.stdout.log.9"
+    stale_backup.write_text("stale", encoding="utf-8")
+
+    writer = stderr_timestamp._RotatingWriter(
+        log_path, max_bytes=32, backup_count=2
+    )
+    try:
+        for index in range(10):
+            writer.write(f"line-{index:02d}-padding\n")
+    finally:
+        writer.close()
+
+    logs = sorted(tmp_path.glob("gateway.stdout.log*"))
+    assert [path.name for path in logs] == [
+        "gateway.stdout.log",
+        "gateway.stdout.log.1",
+        "gateway.stdout.log.2",
+    ]
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o600 for path in logs)
+    assert all(path.stat().st_size <= 32 for path in logs)
+    assert not stale_backup.exists()
 
 
 def test_prepare_upgrades_stale_gateway_argv_under_launchd():

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1083,6 +1083,10 @@ View, tail, and filter Hermes log files. All logs are stored in `~/.hermes/logs/
 | `gui` | `gui.log` | Dashboard / TUI-gateway / PTY-bridge / websocket events |
 | `desktop` | `desktop.log` | Electron desktop app — boot, backend spawn output, and recent Python tracebacks |
 
+On macOS, the managed gateway service keeps structured activity in
+`gateway.log`; raw child-process stdout and timestamped stderr are captured
+separately in the rotating `gateway.stdout.log` and `gateway.error.log` files.
+
 ### Options
 
 | Option | Description |


### PR DESCRIPTION
## Problem

macOS launchd keeps configured stdout and stderr files open in append mode, creates them under the login-session umask, and does not rotate them. This bypasses Hermes' normal bounded logging contract and can continue writing to renamed inodes.

## Change

- set the managed launchd gateway's process umask to 077
- send launchd-owned stdout and stderr handles to `/dev/null`
- capture child stdout in `gateway.stdout.log` and timestamped stderr in `gateway.error.log`
- rotate both streams using canonical logging size and backup settings
- create and tighten live files and retained backups to 0600
- refuse symlink-following opens where `O_NOFOLLOW` is available
- apply the same capture path to the macOS detached fallback
- fall back to canonical defaults when logging rotation settings are malformed
- document where operators can find the separated raw streams

Structured gateway activity remains in `gateway.log`, so `hermes logs gateway` is unchanged.

## Verification

- focused gateway suite — 150 passed, 4 platform-specific skips
- final stderr-capture tests — 11 passed
- Ruff — passed
- Ty for `stderr_timestamp.py` — passed
- `git diff --check` — passed

## Scope and risk

The stock macOS launchd service and macOS detached fallback are affected. The 077 umask deliberately applies to the gateway process and descendants. systemd, Windows services, Nix/Home Manager launchd generation, and structured `gateway.log` behavior remain unchanged.