### PR TITLE
fix(agent): Preserve reasoning and message ID symmetry for Responses API prompt caching

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -459,9 +459,23 @@ _RESPONSE_MESSAGE_STATUSES = {"completed", "incomplete", "in_progress"}
 # The Responses API rejects input[].id longer than this with a non-retryable
 # HTTP 400 ("string too long"). Codex-issued assistant message ids are
 # server-assigned base64 blobs that can run 400+ chars, while Hermes-minted
-# ids (msg_...) stay well under this cap and are worth keeping for
+# ids (msg_... / rs_...) stay well under this cap and are worth keeping for
 # prefix-cache hits. Drop only the oversized ones on replay.
 _MAX_RESPONSES_ITEM_ID_LENGTH = 64
+
+
+def _normalize_replayed_item_id(item_id: Any) -> Optional[str]:
+    """Normalize and validate an item ID for Responses API replay.
+
+    Returns the stripped ID string if non-empty and <= 64 characters,
+    or None if invalid, whitespace-only, non-string, or oversized.
+    """
+    if not isinstance(item_id, str):
+        return None
+    stripped = item_id.strip()
+    if not stripped or len(stripped) > _MAX_RESPONSES_ITEM_ID_LENGTH:
+        return None
+    return stripped
 
 
 def _normalize_responses_message_status(value: Any, *, default: str = "completed") -> str:
@@ -583,71 +597,103 @@ def _chat_messages_to_responses_input(
                 # This applies to every Responses transport including
                 # xAI — see _chat_messages_to_responses_input docstring
                 # for the May 2026 reversal of the earlier xAI gate.
-                codex_reasoning = (
-                    msg.get("codex_reasoning_items")
-                    if replay_encrypted_reasoning
-                    else None
-                )
+                raw_sidecar_items = msg.get("codex_reasoning_items")
+                if not isinstance(raw_sidecar_items, list):
+                    raw_sidecar_items = []
+
+                # Classify items in codex_reasoning_items sidecar:
+                # 1. ordinary reasoning items: dict with encrypted_content and type == "reasoning" (or unset)
+                # 2. native compaction items: dict with encrypted_content and type == "compaction"
+                ordinary_reasoning_items: List[Dict[str, Any]] = []
+                for ri in raw_sidecar_items:
+                    if isinstance(ri, dict) and ri.get("encrypted_content"):
+                        ptype = ri.get("type")
+                        if ptype == "reasoning" or ptype is None:
+                            ordinary_reasoning_items.append(ri)
+
+                stored_reasoning_exists = bool(ordinary_reasoning_items)
+                ordinary_reasoning_replayed_with_valid_id_count = 0
                 has_codex_reasoning = False
-                if isinstance(codex_reasoning, list):
-                    for ri in codex_reasoning:
-                        if isinstance(ri, dict) and ri.get("encrypted_content"):
-                            item_id = ri.get("id")
-                            if item_id and item_id in seen_item_ids:
-                                continue
-                            # Native-compaction gate: a checkpoint is only
-                            # meaningful to the endpoint/model that minted it
-                            # AND only while this request still asks for
-                            # server-side compaction. Once the gate closes
-                            # (model swapped out of the gpt-5.6 family,
-                            # compression disabled, rejection kill switch),
-                            # the persisted checkpoint must not be replayed —
-                            # replaying it is what makes the wire restructure
-                            # below erase pre-checkpoint history forever.
-                            if (
-                                ri.get("type") == "compaction"
-                                and not native_compaction_eligible
-                            ):
-                                continue
-                            # Cross-issuer guard: drop reasoning blocks that
-                            # were minted by a different Responses endpoint.
-                            # The current endpoint cannot decrypt foreign
-                            # encrypted_content and would reject the whole
-                            # request with HTTP 400 invalid_encrypted_content.
-                            # Unstamped (legacy) items pass through.
-                            item_issuer = ri.get("_issuer_kind")
-                            if (
-                                current_issuer_kind is not None
-                                and item_issuer is not None
-                                and item_issuer != current_issuer_kind
-                            ):
-                                global _CROSS_ISSUER_WARN_EMITTED
-                                if not _CROSS_ISSUER_WARN_EMITTED:
-                                    logger.warning(
-                                        "Dropping reasoning item minted by %s while "
-                                        "calling %s — encrypted_content is sealed to "
-                                        "its issuer. This happens when a session "
-                                        "switches model providers mid-conversation.",
-                                        item_issuer, current_issuer_kind,
-                                    )
-                                    _CROSS_ISSUER_WARN_EMITTED = True
-                                continue
-                            # Strip the "id" field — with store=False the
-                            # Responses API cannot look up items by ID and
-                            # returns 404.  The encrypted_content blob is
-                            # self-contained for reasoning chain continuity.
-                            # Also strip the internal "_issuer_kind" stamp;
-                            # it is a Hermes-side metadata key and not part
-                            # of the Responses API schema.
-                            replay_item = {
-                                k: v for k, v in ri.items()
-                                if k not in ("id", "_issuer_kind")
-                            }
-                            items.append(replay_item)
-                            item_sources.append(msg)
-                            if item_id:
-                                seen_item_ids.add(item_id)
-                            has_codex_reasoning = True
+
+                if replay_encrypted_reasoning:
+                    for ri in raw_sidecar_items:
+                        if not isinstance(ri, dict) or not ri.get("encrypted_content"):
+                            continue
+                        item_id = ri.get("id")
+                        if item_id and item_id in seen_item_ids:
+                            continue
+
+                        # Native-compaction gate: a checkpoint is only
+                        # meaningful to the endpoint/model that minted it
+                        # AND only while this request still asks for
+                        # server-side compaction. Once the gate closes
+                        # (model swapped out of the gpt-5.6 family,
+                        # compression disabled, rejection kill switch),
+                        # the persisted checkpoint must not be replayed —
+                        # replaying it is what makes the wire restructure
+                        # below erase pre-checkpoint history forever.
+                        if (
+                            ri.get("type") == "compaction"
+                            and not native_compaction_eligible
+                        ):
+                            continue
+
+                        # Cross-issuer guard: drop reasoning blocks that
+                        # were minted by a different Responses endpoint.
+                        # The current endpoint cannot decrypt foreign
+                        # encrypted_content and would reject the whole
+                        # request with HTTP 400 invalid_encrypted_content.
+                        # Unstamped (legacy) items pass through.
+                        item_issuer = ri.get("_issuer_kind")
+                        if (
+                            current_issuer_kind is not None
+                            and item_issuer is not None
+                            and item_issuer != current_issuer_kind
+                        ):
+                            global _CROSS_ISSUER_WARN_EMITTED
+                            if not _CROSS_ISSUER_WARN_EMITTED:
+                                logger.warning(
+                                    "Dropping reasoning item minted by %s while "
+                                    "calling %s — encrypted_content is sealed to "
+                                    "its issuer. This happens when a session "
+                                    "switches model providers mid-conversation.",
+                                    item_issuer, current_issuer_kind,
+                                )
+                                _CROSS_ISSUER_WARN_EMITTED = True
+                            continue
+
+                        # Strip internal metadata stamps
+                        replay_item = {
+                            k: v for k, v in ri.items()
+                            if k not in ("id", "_issuer_kind")
+                        }
+
+                        # Replay reasoning item ID when present (<= 64 chars) and
+                        # not on GitHub Copilot to maintain identity graph pairing
+                        # with assistant message items for prompt caching (#97427).
+                        is_ordinary = ri.get("type") == "reasoning" or ri.get("type") is None
+                        norm_id = _normalize_replayed_item_id(item_id)
+                        if is_ordinary and norm_id is not None:
+                            ordinary_reasoning_replayed_with_valid_id_count += 1
+                            if not is_github_responses:
+                                replay_item["id"] = norm_id
+
+                        items.append(replay_item)
+                        item_sources.append(msg)
+                        if item_id:
+                            seen_item_ids.add(item_id)
+                        has_codex_reasoning = True
+
+                # Compute reasoning_identity_intact for this turn:
+                # - None: this turn has no stored ordinary reasoning dependency (e.g. text-only turn).
+                # - True: every stored ordinary reasoning item was successfully replayed in this turn
+                #         with a valid non-empty ID <= 64 chars (no deduplication skip, no cross-issuer drop).
+                # - False: reasoning was expected but could not be fully replayed with valid IDs in this turn.
+                reasoning_identity_intact: Optional[bool] = None
+                if stored_reasoning_exists:
+                    reasoning_identity_intact = (
+                        ordinary_reasoning_replayed_with_valid_id_count == len(ordinary_reasoning_items)
+                    )
 
                 # Replay exact assistant message items (with id/phase) from
                 # previous turns so the API can maintain prefix-cache hits.
@@ -689,14 +735,23 @@ def _chat_messages_to_responses_input(
                             "content": normalized_content_parts,
                         }
                         item_id = raw_item.get("id")
+                        norm_msg_id = _normalize_replayed_item_id(item_id)
+
+                        # Keep message ID only when:
+                        # 1. not on GitHub Copilot (which invalidates replayed connection-bound IDs);
+                        # 2. norm_msg_id is valid (non-empty, <= 64 chars);
+                        # 3. reasoning identity chain is intact (reasoning_identity_intact is True) or
+                        #    this turn has no reasoning dependency (reasoning_identity_intact is None).
+                        # If reasoning was present but lost its identity (kill-switch, cross-issuer,
+                        # seen_item_ids dedup skip, missing/oversized ID), the message item must be
+                        # anonymized (id stripped) to prevent orphaned reasoning errors (#97427).
                         if (
                             not is_github_responses
-                            and isinstance(item_id, str)
-                            and item_id.strip()
+                            and norm_msg_id is not None
+                            and (reasoning_identity_intact is True or reasoning_identity_intact is None)
                         ):
-                            stripped_id = item_id.strip()
-                            if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
-                                replay_item["id"] = stripped_id
+                            replay_item["id"] = norm_msg_id
+
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()
@@ -704,22 +759,21 @@ def _chat_messages_to_responses_input(
                         item_sources.append(msg)
                         replayed_message_items += 1
 
-                if replayed_message_items > 0:
-                    pass
-                elif content_parts:
-                    items.append({"role": "assistant", "content": content_parts})
-                    item_sources.append(msg)
-                elif content_text.strip():
-                    items.append({"role": "assistant", "content": content_text})
-                    item_sources.append(msg)
-                elif has_codex_reasoning:
-                    # The Responses API requires a following item after each
-                    # reasoning item (otherwise: missing_following_item error).
-                    # When the assistant produced only reasoning with no visible
-                    # content, emit an empty assistant message as the required
-                    # following item.
-                    items.append({"role": "assistant", "content": ""})
-                    item_sources.append(msg)
+                if replayed_message_items == 0:
+                    if content_parts:
+                        items.append({"role": "assistant", "content": content_parts})
+                        item_sources.append(msg)
+                    elif content_text.strip():
+                        items.append({"role": "assistant", "content": content_text})
+                        item_sources.append(msg)
+                    elif has_codex_reasoning:
+                        # The Responses API requires a following item after each
+                        # reasoning item (otherwise: missing_following_item error).
+                        # When the assistant produced only reasoning with no visible
+                        # content, emit an empty assistant message as the required
+                        # following item.
+                        items.append({"role": "assistant", "content": ""})
+                        item_sources.append(msg)
 
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):
@@ -966,6 +1020,18 @@ def _preflight_codex_input_items(
     is_github_responses: bool = False,
     sanitize_harmony_tokens: bool = False,
 ) -> List[Dict[str, Any]]:
+    """Validate, sanitize, and normalize raw Responses API input items.
+
+    This function operates as a per-item structural normalizer on outgoing
+    items produced by ``_chat_messages_to_responses_input``:
+    - Validates item shapes and content part types;
+    - Sanitizes Harmony tokens and tool names;
+    - Clamps replayed item IDs (<= 64 chars) and drops IDs for GitHub Copilot.
+
+    Note: Cross-turn reasoning-to-message identity dependencies and symmetric
+    degradation are established in ``_chat_messages_to_responses_input``.
+    This preflight layer does not re-infer identity graphs across items.
+    """
     if not isinstance(raw_items, list):
         raise ValueError("Codex Responses input must be a list of input items.")
 
@@ -1069,10 +1135,13 @@ def _preflight_codex_input_items(
                     "type": "reasoning",
                     "encrypted_content": encrypted,
                 }
-                # Do NOT include the "id" in the outgoing item — with
-                # store=False (our default) the API tries to resolve the
-                # id server-side and returns 404.  The id is still used
-                # above for local deduplication via seen_ids.
+                # Preserve valid replayed reasoning ID (matching message item contract)
+                # unless on GitHub Copilot which strips replayed IDs (#97427).
+                if not is_github_responses:
+                    norm_id = _normalize_replayed_item_id(item_id)
+                    if norm_id is not None:
+                        reasoning_item["id"] = norm_id
+
                 summary = item.get("summary")
                 if isinstance(summary, list):
                     reasoning_item["summary"] = (
@@ -1129,14 +1198,10 @@ def _preflight_codex_input_items(
                 "content": normalized_content,
             }
             item_id = item.get("id")
-            if (
-                not is_github_responses
-                and isinstance(item_id, str)
-                and item_id.strip()
-            ):
-                stripped_id = item_id.strip()
-                if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
-                    normalized_item["id"] = stripped_id
+            if not is_github_responses:
+                norm_msg_id = _normalize_replayed_item_id(item_id)
+                if norm_msg_id is not None:
+                    normalized_item["id"] = norm_msg_id
             phase = item.get("phase")
             if isinstance(phase, str) and phase.strip():
                 normalized_item["phase"] = phase.strip()

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -625,3 +625,644 @@ def _xai_reasoning_only_response(reasoning_text):
             )
         ],
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #97427: GPT-5.6 Responses rejects replayed assistant message when
+# Hermes strips its required reasoning item ID.
+# Tests for reasoning/message identity preservation and symmetric degradation.
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_paired_ids_preserved_in_correct_order():
+    """Happy path: reasoning and message items preserve their IDs and maintain
+    strict sequence: user -> reasoning -> message -> function_call -> function_call_output (#97427)."""
+    messages = [
+        {"role": "user", "content": "run ls"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_100", "encrypted_content": "enc_blob_1"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_200",
+                    "phase": "commentary",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "Listing directory..."}],
+                }
+            ],
+            "tool_calls": [
+                {
+                    "call_id": "call_300",
+                    "function": {"name": "terminal", "arguments": '{"command":"ls"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_300", "content": "file1.txt\nfile2.txt"},
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert [item.get("type", item.get("role")) for item in items] == [
+        "user",
+        "reasoning",
+        "message",
+        "function_call",
+        "function_call_output",
+    ]
+
+    reasoning = items[1]
+    message = items[2]
+    call = items[3]
+    output = items[4]
+
+    assert reasoning["id"] == "rs_100"
+    assert reasoning["encrypted_content"] == "enc_blob_1"
+    assert message["id"] == "msg_200"
+    assert message["phase"] == "commentary"
+    assert call["call_id"] == "call_300"
+    assert output["call_id"] == "call_300"
+
+
+def test_minimal_repro_missing_reasoning_id_strips_message_id():
+    """Issue #97427 minimal repro: when reasoning exists but lacks an ID, the
+    assistant message item must be anonymized (id stripped) to prevent orphaned
+    reasoning 400 error."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "enc_blob_legacy"},  # No 'id'
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_legacy_1",
+                    "content": [{"type": "output_text", "text": "done"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert len(items) == 2
+    reasoning = items[0]
+    message = items[1]
+
+    assert reasoning["type"] == "reasoning"
+    assert "id" not in reasoning
+    assert message["type"] == "message"
+    assert "id" not in message
+    assert message["content"] == [{"type": "output_text", "text": "done"}]
+
+
+def test_multi_reasoning_partial_missing_id_strips_all_message_ids_in_turn():
+    """When a turn has multiple reasoning items and any ordinary reasoning item
+    lacks a valid ID, all message items in that turn are anonymized."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_valid_1", "encrypted_content": "blob1"},
+                {"type": "reasoning", "id": "", "encrypted_content": "blob2"},  # Empty ID
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_part_1",
+                    "content": [{"type": "output_text", "text": "chunk1"}],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_part_2",
+                    "content": [{"type": "output_text", "text": "chunk2"}],
+                },
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    reasoning_items = [i for i in items if i.get("type") == "reasoning"]
+    message_items = [i for i in items if i.get("type") == "message"]
+
+    assert len(reasoning_items) == 2
+    assert reasoning_items[0]["id"] == "rs_valid_1"
+    assert "id" not in reasoning_items[1]
+
+    assert len(message_items) == 2
+    assert "id" not in message_items[0]
+    assert "id" not in message_items[1]
+
+
+def test_multi_reasoning_all_valid_preserves_all_ids():
+    """When all reasoning items have valid IDs, both reasoning and message items
+    preserve their IDs."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_1", "encrypted_content": "blob1"},
+                {"type": "reasoning", "id": "rs_2", "encrypted_content": "blob2"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_1",
+                    "content": [{"type": "output_text", "text": "thought part 1"}],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_2",
+                    "content": [{"type": "output_text", "text": "thought part 2"}],
+                },
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    reasoning_items = [i for i in items if i.get("type") == "reasoning"]
+    message_items = [i for i in items if i.get("type") == "message"]
+
+    assert len(reasoning_items) == 2
+    assert reasoning_items[0]["id"] == "rs_1"
+    assert reasoning_items[1]["id"] == "rs_2"
+
+    assert len(message_items) == 2
+    assert message_items[0]["id"] == "msg_1"
+    assert message_items[1]["id"] == "msg_2"
+
+
+def test_cross_issuer_mismatch_drops_reasoning_and_strips_message_id():
+    """When reasoning is dropped due to cross-issuer mismatch, message content/phase
+    is preserved but its id is stripped to avoid orphaned ID errors."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_xai_1",
+                    "encrypted_content": "blob_xai",
+                    "_issuer_kind": "xai_responses",
+                }
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_xai_1",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "analysis from grok"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(
+        messages,
+        current_issuer_kind="codex_backend",
+    )
+
+    reasoning_items = [i for i in items if i.get("type") == "reasoning"]
+    message_items = [i for i in items if i.get("type") == "message"]
+
+    # Reasoning item dropped
+    assert len(reasoning_items) == 0
+
+    # Message item kept with content and phase, but no id
+    assert len(message_items) == 1
+    assert "id" not in message_items[0]
+    assert message_items[0]["phase"] == "commentary"
+    assert message_items[0]["content"] == [{"type": "output_text", "text": "analysis from grok"}]
+
+
+def test_oversized_reasoning_id_triggers_symmetric_message_id_strip():
+    """An oversized reasoning ID (>64 chars) is stripped, which in turn symmetrically
+    strips the assistant message ID."""
+    oversized_rs_id = "rs_" + "a" * 80
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": oversized_rs_id, "encrypted_content": "blob"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_valid_1",
+                    "content": [{"type": "output_text", "text": "ok"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    reasoning = next(i for i in items if i.get("type") == "reasoning")
+    message = next(i for i in items if i.get("type") == "message")
+
+    assert "id" not in reasoning
+    assert "id" not in message
+
+
+def test_oversized_message_id_alone_strips_message_id_only():
+    """When reasoning ID is valid but message ID is oversized (>64 chars), reasoning ID
+    is preserved while message ID alone is stripped."""
+    oversized_msg_id = "msg_" + "b" * 80
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_valid_1", "encrypted_content": "blob"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": oversized_msg_id,
+                    "content": [{"type": "output_text", "text": "ok"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    reasoning = next(i for i in items if i.get("type") == "reasoning")
+    message = next(i for i in items if i.get("type") == "message")
+
+    assert reasoning["id"] == "rs_valid_1"
+    assert "id" not in message
+
+
+def test_replay_kill_switch_strips_reasoning_and_message_id():
+    """When replay_encrypted_reasoning=False (kill switch active), reasoning is not
+    replayed and assistant message ID is symmetrically stripped."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_1", "encrypted_content": "blob"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_1",
+                    "content": [{"type": "output_text", "text": "done"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(
+        messages,
+        replay_encrypted_reasoning=False,
+    )
+
+    reasoning_items = [i for i in items if i.get("type") == "reasoning"]
+    message_items = [i for i in items if i.get("type") == "message"]
+
+    assert len(reasoning_items) == 0
+    assert len(message_items) == 1
+    assert "id" not in message_items[0]
+
+
+def test_text_only_turn_without_stored_reasoning_preserves_message_id():
+    """A text-only assistant turn with no stored reasoning dependency retains its
+    message ID for prompt caching."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Hello world",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_text_only",
+                    "content": [{"type": "output_text", "text": "Hello world"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    message = items[0]
+    assert message["type"] == "message"
+    assert message["id"] == "msg_text_only"
+
+
+def test_github_copilot_strips_both_reasoning_and_message_ids():
+    """On GitHub Copilot (is_github_responses=True), connection-bound IDs are
+    stripped from both reasoning and message items."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_gh_1", "encrypted_content": "blob"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_gh_1",
+                    "content": [{"type": "output_text", "text": "copilot reply"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(messages, is_github_responses=True)
+
+    reasoning = next(i for i in items if i.get("type") == "reasoning")
+    message = next(i for i in items if i.get("type") == "message")
+
+    assert "id" not in reasoning
+    assert "id" not in message
+
+
+def test_compaction_item_does_not_affect_ordinary_reasoning_identity():
+    """A compaction checkpoint in codex_reasoning_items does not count as a missing
+    reasoning identity and does not strip message ID."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "compaction", "encrypted_content": "chk_blob"},  # Compaction checkpoint (no id)
+                {"type": "reasoning", "id": "rs_normal_1", "encrypted_content": "blob"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_normal_1",
+                    "content": [{"type": "output_text", "text": "after compaction"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(
+        messages,
+        native_compaction_eligible=True,
+    )
+
+    reasoning_items = [i for i in items if i.get("type") == "reasoning"]
+    message_items = [i for i in items if i.get("type") == "message"]
+
+    assert len(reasoning_items) == 1
+    assert reasoning_items[0]["id"] == "rs_normal_1"
+    assert len(message_items) == 1
+    assert message_items[0]["id"] == "msg_normal_1"
+
+
+def test_compaction_item_with_id_does_not_break_message_identity():
+    """A compaction checkpoint carrying an ID (e.g. from upstream/custom schemas)
+    has its ID stripped per Responses compaction schema, but does NOT count as a broken
+    ordinary reasoning dependency, preserving subsequent message ID."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "compaction", "id": "cp_chk_1", "encrypted_content": "chk_blob"},
+                {"type": "reasoning", "id": "rs_normal_1", "encrypted_content": "blob"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_normal_1",
+                    "content": [{"type": "output_text", "text": "after compaction"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(
+        messages,
+        native_compaction_eligible=True,
+    )
+
+    compaction_items = [i for i in items if i.get("type") == "compaction"]
+    reasoning_items = [i for i in items if i.get("type") == "reasoning"]
+    message_items = [i for i in items if i.get("type") == "message"]
+
+    # Compaction checkpoint emitted without 'id' as compaction schema is self-contained checkpoint
+    assert len(compaction_items) == 1
+    assert "id" not in compaction_items[0]
+    assert compaction_items[0]["encrypted_content"] == "chk_blob"
+
+    assert len(reasoning_items) == 1
+    assert reasoning_items[0]["id"] == "rs_normal_1"
+
+    assert len(message_items) == 1
+    assert message_items[0]["id"] == "msg_normal_1"
+
+
+def test_turn_with_only_compaction_and_message_preserves_message_id():
+    """When a turn has only a compaction checkpoint (no ordinary reasoning),
+    there is no ordinary reasoning dependency, so the message ID is preserved."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "compaction", "id": "cp_chk_2", "encrypted_content": "chk_blob_only"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_compaction_only_1",
+                    "content": [{"type": "output_text", "text": "compaction turn response"}],
+                }
+            ],
+        }
+    ]
+
+    items = _chat_messages_to_responses_input(
+        messages,
+        native_compaction_eligible=True,
+    )
+
+    compaction_items = [i for i in items if i.get("type") == "compaction"]
+    message_items = [i for i in items if i.get("type") == "message"]
+
+    assert len(compaction_items) == 1
+    assert "id" not in compaction_items[0]
+    assert len(message_items) == 1
+    assert message_items[0]["id"] == "msg_compaction_only_1"
+
+
+def test_converter_to_preflight_end_to_end_pipeline():
+    """End-to-end converter -> preflight pipeline preserves paired IDs on happy path
+    and preserves symmetric degradation on degraded path."""
+    # 1. Happy path: both IDs survive through preflight
+    happy_messages = [
+        {"role": "user", "content": "ping"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_e2e_1", "encrypted_content": "blob1"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_e2e_1",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                }
+            ],
+        },
+    ]
+    raw_happy = _chat_messages_to_responses_input(happy_messages)
+    preflight_happy = _preflight_codex_input_items(raw_happy)
+
+    assert [item.get("type", item.get("role")) for item in preflight_happy] == [
+        "user",
+        "reasoning",
+        "message",
+    ]
+    assert preflight_happy[1]["id"] == "rs_e2e_1"
+    assert preflight_happy[2]["id"] == "msg_e2e_1"
+
+    # 2. Degraded path: reasoning lacks ID -> message ID stripped by converter -> survives preflight
+    degraded_messages = [
+        {"role": "user", "content": "ping"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "blob1"},  # No ID
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_e2e_2",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                }
+            ],
+        },
+    ]
+    raw_degraded = _chat_messages_to_responses_input(degraded_messages)
+    preflight_degraded = _preflight_codex_input_items(raw_degraded)
+
+    assert "id" not in preflight_degraded[1]
+    assert "id" not in preflight_degraded[2]
+
+
+def test_seen_item_ids_dedup_skips_reasoning_and_strips_subsequent_message_id():
+    """When a reasoning item is skipped by seen_item_ids deduplication in a subsequent
+    turn, that turn did not output its own reasoning identity -> its message ID must
+    be stripped to prevent orphaned reasoning errors (#97427)."""
+    messages = [
+        # Turn 1
+        {"role": "user", "content": "question 1"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_shared_1", "encrypted_content": "blob1"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_turn_1",
+                    "content": [{"type": "output_text", "text": "answer 1"}],
+                }
+            ],
+        },
+        # Turn 2 (repeats rs_shared_1 in sidecar, but introduces new msg_turn_2)
+        {"role": "user", "content": "question 2"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_shared_1", "encrypted_content": "blob1"},
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "id": "msg_turn_2",
+                    "content": [{"type": "output_text", "text": "answer 2"}],
+                }
+            ],
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    # Sequence of items:
+    # 0: user (question 1)
+    # 1: reasoning (rs_shared_1, id preserved)
+    # 2: message (msg_turn_1, id preserved)
+    # 3: user (question 2)
+    # 4: message (msg_turn_2, id stripped because rs_shared_1 was deduplicated!)
+    assert [item.get("type", item.get("role")) for item in items] == [
+        "user",
+        "reasoning",
+        "message",
+        "user",
+        "message",
+    ]
+
+    reasoning_turn_1 = items[1]
+    message_turn_1 = items[2]
+    message_turn_2 = items[4]
+
+    assert reasoning_turn_1["id"] == "rs_shared_1"
+    assert message_turn_1["id"] == "msg_turn_1"
+    assert "id" not in message_turn_2
+    assert message_turn_2["content"] == [{"type": "output_text", "text": "answer 2"}]
+
+
+def test_preflight_direct_reasoning_id_handling():
+    """Direct testing of _preflight_codex_input_items on raw reasoning items."""
+    # 1. Valid ID preserved
+    items_valid = _preflight_codex_input_items([
+        {"type": "reasoning", "id": "rs_direct_1", "encrypted_content": "blob"},
+    ])
+    assert items_valid[0]["id"] == "rs_direct_1"
+
+    # 2. Stripped when is_github_responses=True
+    items_gh = _preflight_codex_input_items(
+        [{"type": "reasoning", "id": "rs_direct_1", "encrypted_content": "blob"}],
+        is_github_responses=True,
+    )
+    assert "id" not in items_gh[0]
+
+    # 3. Stripped when oversized (> 64 chars)
+    items_oversized = _preflight_codex_input_items([
+        {"type": "reasoning", "id": "rs_" + "x" * 70, "encrypted_content": "blob"},
+    ])
+    assert "id" not in items_oversized[0]

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -863,10 +863,7 @@ class TestCodexReasoningPreflight:
         reasoning_items = [i for i in normalized if i.get("type") == "reasoning"]
         assert len(reasoning_items) == 1
         assert reasoning_items[0]["encrypted_content"] == "abc123encrypted"
-        # Note: "id" is intentionally excluded from normalized output —
-        # with store=False the API returns 404 on server-side id resolution.
-        # The id is only used for local deduplication via seen_ids.
-        assert "id" not in reasoning_items[0]
+        assert reasoning_items[0]["id"] == "r_001"
         assert reasoning_items[0]["summary"] == [{"type": "summary_text", "text": "Thinking about it"}]
 
     def test_reasoning_item_without_id(self, monkeypatch):
@@ -882,7 +879,7 @@ class TestCodexReasoningPreflight:
 
 
     def test_reasoning_items_replayed_from_history(self, monkeypatch):
-        """Reasoning items stored in codex_reasoning_items get replayed."""
+        """Reasoning items stored in codex_reasoning_items get replayed with ID."""
         agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
                             base_url="https://chatgpt.com/backend-api/codex")
         messages = [
@@ -900,6 +897,7 @@ class TestCodexReasoningPreflight:
         reasoning_items = [i for i in items if isinstance(i, dict) and i.get("type") == "reasoning"]
         assert len(reasoning_items) == 1
         assert reasoning_items[0]["encrypted_content"] == "enc123"
+        assert reasoning_items[0]["id"] == "r_1"
 
 
 # ── Reasoning effort consistency tests ───────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
This PR resolves the `HTTP 400 invalid_request_error` that occurs when using the Responses API (e.g., GPT-5.6). The API enforces a strict identity graph: if an assistant message item provides an `id` (e.g., `msg_...`), its preceding reasoning item MUST also provide its corresponding `id` (`rs_...`).

Previously, reasoning IDs were sometimes stripped (due to cross-turn deduplication via `seen_item_ids`, cross-issuer drops, or length limits), but the subsequent message IDs were still sent. This orphaned the message ID and caused the API to reject the request.

This PR introduces a **symmetric degradation** strategy:
- It tracks whether all ordinary reasoning items in a turn were successfully replayed with valid IDs (`ordinary_reasoning_replayed_with_valid_id_count`).
- If the reasoning identity chain remains intact, it preserves the `msg_*` ID to maximize Prompt Caching hits.
- If the reasoning identity is broken or skipped, it safely anonymizes (strips the `id` from) the subsequent assistant message items in that turn, preventing the 400 error.
- It also strictly segregates `type == "reasoning"` from `type == "compaction"` to ensure native compaction checkpoints don't interfere with the ordinary reasoning graph.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #97427

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `agent/codex_responses_adapter.py`: Added `_normalize_replayed_item_id` helper. Implemented `reasoning_identity_intact` tracking to symmetrically drop message IDs when their corresponding reasoning IDs are dropped. Separated `reasoning` and `compaction` item processing.
- `tests/agent/test_codex_responses_adapter.py`: Added comprehensive regression tests (`test_happy_path_paired_ids_preserved_in_correct_order`, `test_seen_item_ids_dedup_skips_reasoning_and_strips_subsequent_message_id`, etc.) to verify identity preservation and degradation.
- `tests/run_agent/test_provider_parity.py`: Minor test alignments for the new ID normalization behavior.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the directed test suite to verify the symmetric degradation logic:
   `scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py tests/run_agent/test_provider_parity.py`
2. **Manual Reproduction**: Initiate a multi-turn conversation using a Responses API model (e.g., GPT-5.6). Trigger a scenario where a reasoning item is deduplicated (or use a cross-issuer model swap).
3. **Verification**: Prior to this PR, the turn would crash with an `HTTP 400 Item 'msg_...' ... was provided without its required 'reasoning' item: 'rs_...'`. With this PR, the message ID is safely stripped, the request succeeds, and the conversation continues.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](@url:`https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md`)
- [x] My commit messages follow [Conventional Commits](@url:`https://www.conventionalcommits.org/`) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](@url:`https://github.com/NousResearch/hermes-agent/pulls`) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](@url:`https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility`) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](@url:`https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled`)
- [ ] SKILL.md follows the [standard format](@url:`https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format`) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
```text
=== Summary: 3 files, 152 tests passed, 0 failed (100% complete) ===