### PR TITLE
feat(runtime): immutable ResolvedRuntime + central client factory; fixes extra_headers loss in fallback paths

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -682,7 +682,6 @@ def _print_key_banner(key, label: str, warn_missing: bool = False) -> None:
 
 def _init_anthropic_client(agent, api_key, base_url, _provider_timeout):
     """anthropic_messages: native Anthropic SDK (or AnthropicBedrock for Bedrock+Claude)."""
-    from agent.anthropic_adapter import build_anthropic_client
     from agent.anthropic_credentials import resolve_anthropic_token
     agent.client = None
     agent._client_kwargs = {}
@@ -718,17 +717,37 @@ def _init_anthropic_client(agent, api_key, base_url, _provider_timeout):
                 _mm_exc,
             )
 
-    agent.api_key = effective_key
-    agent._anthropic_api_key = effective_key
     # OAuth only for native Anthropic: third-party anthropic_messages providers must never
     # trip OAuth paths — those inject Claude-Code identity headers → 401/403.
     # Only mark the session as OAuth-authenticated when the token genuinely belongs to native Anthropic.
     # Third-party providers (MiniMax, Kimi, GLM, LiteLLM proxies) that accept the Anthropic protocol must
     # never trip OAuth code paths — doing so injects Claude-Code identity headers and system prompts that
     # cause 401/403 on their endpoints. See #1739.
-    from agent.anthropic_credentials import _is_oauth_token as _is_oat
-    agent._is_anthropic_oauth = _is_oat(effective_key) if (_is_native_anthropic and isinstance(effective_key, str)) else False
-    agent._anthropic_client = build_anthropic_client(effective_key, base_url, timeout=_provider_timeout)
+    # Build the complete wire client before touching the live agent.  The
+    # provider-entry header layer must travel with the runtime; rebuilding a
+    # fallback from only key + URL is what originally dropped gateway auth.
+    from agent.runtime_bundle import ResolvedRuntime, build_client_bundle
+    runtime_fields = {
+        "provider": agent.provider,
+        "requested_provider": agent.requested_provider,
+        "model": agent.model,
+        "api_mode": agent.api_mode,
+        "api_key": effective_key,
+        "base_url": base_url or "",
+    }
+    with suppress(Exception):
+        from hermes_cli.config import (
+            get_compatible_custom_providers, get_custom_provider_extra_headers,
+            load_config_readonly,
+        )
+        _headers = get_custom_provider_extra_headers(
+            base_url or "", get_compatible_custom_providers(load_config_readonly())
+        )
+        if _headers:
+            runtime_fields["extra_headers"] = _headers
+    runtime = ResolvedRuntime.from_mapping(runtime_fields)
+    bundle = build_client_bundle(runtime, timeout=_provider_timeout)
+    agent.install_runtime(bundle, reason="agent_init")
     if not agent.quiet_mode:
         print(f"🤖 AI Agent initialized with model: {agent.model} (Anthropic native)")
         _print_key_banner(effective_key, "token")
@@ -914,14 +933,36 @@ def _init_openai_client(agent, api_key, base_url, fallback_model, _provider_time
         if agent.provider == "bedrock" and "bedrock-mantle." in str(client_kwargs.get("base_url", "")):
             raise
 
-    agent._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
+    agent._client_kwargs = client_kwargs  # temporary policy input; install_runtime owns the committed copy
     _apply_openai_header_policy(agent, client_kwargs)
     agent.api_key = client_kwargs.get("api_key", "")
     agent.base_url = client_kwargs.get("base_url", agent.base_url)
     try:
         from agent.ssl_guard import verify_ca_bundle
         verify_ca_bundle()
-        agent.client = agent._create_openai_client(client_kwargs, reason="agent_init", shared=True)
+        if agent.provider == "bedrock":
+            # Bedrock Mantle keeps its SigV4-aware path until that special wire
+            # is migrated behind runtime_bundle.
+            agent.api_key = client_kwargs.get("api_key", "")
+            agent.base_url = client_kwargs.get("base_url", agent.base_url)
+            agent.client = agent._create_openai_client(client_kwargs, reason="agent_init", shared=True)
+        else:
+            from agent.runtime_bundle import ResolvedRuntime, build_client_bundle
+
+            runtime = ResolvedRuntime.from_mapping({
+                "provider": agent.provider,
+                "requested_provider": agent.requested_provider,
+                "model": agent.model,
+                "api_mode": agent.api_mode,
+                **client_kwargs,
+            })
+            bundle = build_client_bundle(
+                runtime,
+                openai_builder=lambda kwargs: agent._create_openai_client(
+                    kwargs, reason="agent_init", shared=True, runtime=runtime
+                ),
+            )
+            agent.install_runtime(bundle, reason="agent_init")
         if not agent.quiet_mode:
             print(f"🤖 AI Agent initialized with model: {agent.model}")
             if base_url:
@@ -2079,7 +2120,7 @@ def _snapshot_primary_runtime(agent):
     # Per-turn restoration snapshot: after a fallback, the next turn restores these so the
     # preferred model gets a fresh attempt.
     _cc = agent.context_compressor
-    agent._primary_runtime = {
+    runtime = {
         "model": agent.model,
         "provider": agent.provider,
         "requested_provider": agent.requested_provider,
@@ -2098,13 +2139,20 @@ def _snapshot_primary_runtime(agent):
         "compressor_provider": getattr(_cc, "provider", agent.provider),
         "compressor_context_length": _cc.context_length,
         "compressor_threshold_tokens": _cc.threshold_tokens,
+        "compressor_api_mode": getattr(_cc, "api_mode", agent.api_mode),
+        "runtime_capabilities": dict(getattr(agent, "runtime_capabilities", {}) or {}),
+        "reasoning_config": dict(getattr(agent, "reasoning_config", {}) or {}) or None,
     }
     if agent.api_mode == "anthropic_messages":
-        agent._primary_runtime.update({
+        runtime.update({
             "anthropic_api_key": agent._anthropic_api_key,
             "anthropic_base_url": agent._anthropic_base_url,
             "is_anthropic_oauth": agent._is_anthropic_oauth,
         })
+    # Keep this historical turn snapshot mutable for plugin/test compatibility.
+    # The authoritative live route is the immutable ``agent._resolved_runtime``
+    # installed by the client bundle.
+    agent._primary_runtime = runtime
 
 
 def _init_usage_state(agent):

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -738,13 +738,14 @@ def _init_anthropic_client(agent, api_key, base_url, _provider_timeout):
     with suppress(Exception):
         from hermes_cli.config import (
             get_compatible_custom_providers, get_custom_provider_extra_headers,
-            load_config_readonly,
+            load_config_readonly, apply_custom_provider_tls_to_client_kwargs,
         )
         _headers = get_custom_provider_extra_headers(
             base_url or "", get_compatible_custom_providers(load_config_readonly())
         )
         if _headers:
             runtime_fields["extra_headers"] = _headers
+        apply_custom_provider_tls_to_client_kwargs(runtime_fields, base_url or "")
     runtime = ResolvedRuntime.from_mapping(runtime_fields)
     bundle = build_client_bundle(runtime, timeout=_provider_timeout)
     agent.install_runtime(bundle, reason="agent_init")
@@ -972,11 +973,15 @@ def _init_openai_client(agent, api_key, base_url, fallback_model, _provider_time
         raise RuntimeError(f"Failed to initialize OpenAI client: {e}")
 
 
-def _build_client(agent, api_key, base_url, fallback_model):
+def _build_client(agent, api_key, base_url, fallback_model, resolved_runtime=None):
     # LLM client per wire mode (raw_codex=True: the main agent needs direct
     # responses.stream()). One provider/model timeout up front so every path applies it.
     agent._anthropic_client = None
     agent._is_anthropic_oauth = False
+    if resolved_runtime is not None and agent.provider not in {"bedrock", "moa"}:
+        from agent.runtime_routes import build_resolved_agent_client
+        build_resolved_agent_client(agent, resolved_runtime)
+        return
     _provider_timeout = get_provider_request_timeout(agent.provider, agent.model)
     if agent.api_mode == "anthropic_messages":
         _init_anthropic_client(agent, api_key, base_url, _provider_timeout)
@@ -2152,7 +2157,12 @@ def _snapshot_primary_runtime(agent):
     # Keep this historical turn snapshot mutable for plugin/test compatibility.
     # The authoritative live route is the immutable ``agent._resolved_runtime``
     # installed by the client bundle.
+    from agent.runtime_bundle import ResolvedRuntime
+    resolved = getattr(agent, "_resolved_runtime", None)
+    if isinstance(resolved, ResolvedRuntime):
+        runtime = {**resolved.as_dict(), **runtime}
     agent._primary_runtime = runtime
+    agent._resolved_runtime = ResolvedRuntime.from_mapping(runtime)
 
 
 def _init_usage_state(agent):
@@ -2252,6 +2262,7 @@ def init_agent(
     checkpoint_max_snapshots: int = 20, checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10, pass_session_id: bool = False,
     requested_provider: str = None, capabilities: Optional[Dict[str, bool]] = None,
+    resolved_runtime=None,
 ):
     """Initialize the AI Agent (body of :meth:`AIAgent.__init__`).
 
@@ -2268,6 +2279,18 @@ def init_agent(
     """
     _install_safe_stdio()
 
+    if resolved_runtime is not None:
+        from agent.runtime_bundle import ResolvedRuntime, mutable_config_copy
+        resolved_runtime = ResolvedRuntime.from_mapping(resolved_runtime)
+        provider, model = resolved_runtime.provider, resolved_runtime.model
+        api_key, base_url, api_mode = resolved_runtime.api_key, resolved_runtime.base_url, resolved_runtime.api_mode
+        requested_provider = resolved_runtime.requested_provider or provider
+        acp_command = acp_command or resolved_runtime.get("command")
+        acp_args = acp_args if acp_args is not None else resolved_runtime.get("args")
+        if request_overrides is None:
+            request_overrides = mutable_config_copy(resolved_runtime.get("request_overrides") or {})
+        if max_tokens is None:
+            max_tokens = resolved_runtime.get("max_output_tokens")
     _params = locals()
     for _name in _PASSTHROUGH_PARAMS:
         setattr(agent, _name, _params[_name])
@@ -2319,7 +2342,7 @@ def init_agent(
     _init_turn_state(agent, run_budget_seconds)
     _setup_logging(agent)
     _set_defaults(agent, _STREAM_STATE)
-    _build_client(agent, api_key, base_url, fallback_model)
+    _build_client(agent, api_key, base_url, fallback_model, resolved_runtime)
     _init_fallback_chain(agent, fallback_model)
     _load_tools(agent, enabled_toolsets, disabled_toolsets)
     _init_session_state(

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -14,6 +14,7 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Tuple
 from hermes_cli.timeouts import get_provider_request_timeout
 from agent.message_sanitization import (
@@ -893,18 +894,26 @@ def _apply_primary_runtime_fields(agent, rt: Dict[str, Any]) -> None:
     agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
     agent.request_overrides = dict(rt.get("request_overrides") or {})
     agent._client_kwargs = dict(rt["client_kwargs"])
+    from agent.runtime_bundle import ResolvedRuntime
+    agent._resolved_runtime = ResolvedRuntime.from_mapping(rt)
 
 
 def _build_anthropic_client_from_runtime(agent, rt: Dict[str, Any]) -> None:
-    """Rebuild the native Anthropic client from a ``_primary_runtime`` snapshot."""
-    from agent.anthropic_adapter import build_anthropic_client
-    agent._anthropic_api_key = rt["anthropic_api_key"]
-    agent._anthropic_base_url = rt["anthropic_base_url"]
-    agent._anthropic_client = build_anthropic_client(
-        rt["anthropic_api_key"], rt["anthropic_base_url"],
+    """Rebuild the Anthropic wire from the immutable runtime snapshot."""
+    from agent.runtime_bundle import ResolvedRuntime, build_client_bundle
+
+    runtime = ResolvedRuntime.from_mapping(rt).with_updates(
+        api_key=rt.get("anthropic_api_key", rt.get("api_key", "")),
+        base_url=rt.get("anthropic_base_url", rt.get("base_url", "")),
+    )
+    bundle = build_client_bundle(
+        runtime,
         timeout=get_provider_request_timeout(agent.provider, agent.model),
     )
-    agent._is_anthropic_oauth = rt["is_anthropic_oauth"]
+    agent._anthropic_api_key = bundle.anthropic_api_key
+    agent._anthropic_base_url = bundle.anthropic_base_url
+    agent._anthropic_client = bundle.anthropic_client
+    agent._is_anthropic_oauth = bundle.is_anthropic_oauth
     agent.client = None
 
 
@@ -923,7 +932,16 @@ def _rebuild_primary_client(agent, rt: Dict[str, Any], *, reason: str) -> None:
     elif agent.api_mode == "anthropic_messages":
         _build_anthropic_client_from_runtime(agent, rt)
     else:
-        agent.client = agent._create_openai_client(dict(rt["client_kwargs"]), reason=reason, shared=True)
+        from agent.runtime_bundle import ResolvedRuntime, build_client_bundle
+
+        runtime = ResolvedRuntime.from_mapping(rt)
+        bundle = build_client_bundle(
+            runtime,
+            openai_builder=lambda kwargs: agent._create_openai_client(
+                kwargs, reason=reason, shared=True, runtime=runtime
+            ),
+        )
+        agent.client = bundle.client
 
 
 def try_recover_primary_transport(
@@ -963,7 +981,7 @@ def try_recover_primary_transport(
             from agent.moa_loop import build_moa_facade
             agent.client = build_moa_facade(agent, agent.model)
         else:
-            agent.client = agent._create_openai_client(dict(rt["client_kwargs"]), reason="primary_recovery", shared=True)
+            _rebuild_primary_client(agent, rt, reason="primary_recovery")
         wait_time = min(3 + retry_count, 8)
         agent._vprint(
             f"{agent.log_prefix}🔁 Transient {error_type} on {agent.provider} — "
@@ -1058,7 +1076,7 @@ def _primary_reset_gate_blocks(agent, rt, primary_provider, primary_runtime_base
 def _restore_runtime_capabilities(agent, rt: Dict[str, Any]) -> None:
     # ``capabilities`` is the legacy key from the initial capability propagation patch.
     raw = rt["runtime_capabilities"] if "runtime_capabilities" in rt else rt.get("capabilities")
-    if isinstance(raw, dict):
+    if isinstance(raw, Mapping):
         agent.runtime_capabilities = dict(raw)
     elif "runtime_capabilities" in rt:
         logger.warning("Ignoring malformed runtime capabilities snapshot")
@@ -1579,7 +1597,7 @@ def anthropic_prompt_cache_policy(
     return False, False
 
 
-def _provider_supplied_client(agent, client_kwargs: dict) -> Any | None:
+def _provider_supplied_client(agent, client_kwargs: dict, *, provider: Optional[str] = None) -> Any | None:
     """Ask the registered ProviderProfile for a custom client, if any. Resolves by provider name,
     then by ``base_url`` prefix so a URL-only runtime (``acp://…``) still reaches its profile.
     A profile that raises is logged and skipped: a third-party plugin must not be able to take
@@ -1589,7 +1607,7 @@ def _provider_supplied_client(agent, client_kwargs: dict) -> Any | None:
     except Exception:
         return None
     profile = None
-    provider_name = (getattr(agent, "provider", "") or "").strip()
+    provider_name = (provider if provider is not None else getattr(agent, "provider", "") or "").strip()
     if provider_name:
         try:
             profile = get_provider_profile(provider_name)
@@ -1666,7 +1684,7 @@ def _gemini_native_client(agent, client_kwargs: dict, httpx_verify, *, reason: s
     return client
 
 
-def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
+def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: bool, runtime=None) -> Any:
     from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
     from agent.ssl_verify import resolve_httpx_verify
     # Treat client_kwargs as read-only: callers pass agent._client_kwargs, and in-place mutation
@@ -1685,9 +1703,15 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # a `_moa_prepared_request` TypeError (#78382) or, when _client_kwargs carry an unrelated relay
     # base_url, leaks the request to a foreign gateway. Rebuild the facade instead (build_moa_facade also
     # re-wires the reference relay, see #53802).
-    if (getattr(agent, "provider", "") or "").strip().lower() == "moa":
+    runtime_provider = (
+        getattr(runtime, "provider", "") if runtime is not None else getattr(agent, "provider", "")
+    ) or ""
+    runtime_model = (
+        getattr(runtime, "model", "") if runtime is not None else getattr(agent, "model", "")
+    ) or ""
+    if runtime_provider.strip().lower() == "moa":
         from agent.moa_loop import build_moa_facade
-        return build_moa_facade(agent, getattr(agent, "model", None) or "default")
+        return build_moa_facade(agent, runtime_model or "default")
     ssl_ca_cert = client_kwargs.pop("ssl_ca_cert", None)
     ssl_verify_cfg = client_kwargs.pop("ssl_verify", None)
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
@@ -1698,14 +1722,14 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # before the built-in ladder so a profile registered from ~/.hermes/plugins/ or a pip entry
     # point can ship a transport without editing this function (what makes an out-of-tree ACP
     # provider possible). None (the default) falls through, so existing providers are unaffected.
-    provider_client = _provider_supplied_client(agent, client_kwargs)
+    provider_client = _provider_supplied_client(agent, client_kwargs, provider=runtime_provider)
     if provider_client is not None:
         _ra().logger.info(
             "%s client created from provider profile (%s, shared=%s) %s",
             agent.provider, reason, shared, agent._client_log_context(),
         )
         return provider_client
-    if agent.provider == "gemini":
+    if runtime_provider.strip().lower() == "gemini":
         client = _gemini_native_client(agent, client_kwargs, httpx_verify, reason=reason, shared=shared)
         if client is not None:
             return client
@@ -1741,7 +1765,7 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     _ensure_copilot_headers(client_kwargs)
     # OpenCode Free is served anonymously: any unrecognized bearer is a 401, so an empty
     # Authorization default_header overrides the SDK's "Bearer <api_key>".
-    if agent.provider == "opencode-free":
+    if runtime_provider.strip().lower() == "opencode-free":
         from hermes_cli.models import opencode_zen_free_headers
         client_kwargs["default_headers"] = {**(client_kwargs.get("default_headers") or {}), **opencode_zen_free_headers()}
     # All primary construction and recovery paths must identify Hermes to the official Codex
@@ -1788,7 +1812,7 @@ _SWITCH_SNAPSHOT_FIELDS = (
     "model", "provider", "requested_provider", "base_url", "api_mode", "api_key", "client",
     "_anthropic_client", "_anthropic_api_key", "_anthropic_base_url", "_is_anthropic_oauth",
     "_config_context_length", "_reasoning_echo_flag", "runtime_capabilities",
-    "_credential_pool", "_credential_pool_entry_id",
+    "_credential_pool", "_credential_pool_entry_id", "_resolved_runtime",
 )
 _MISSING = object()
 
@@ -1847,8 +1871,10 @@ def _resolve_switch_destination(agent, new_model, new_provider, base_url, api_mo
     return api_mode, base_url, destination_capabilities
 
 
-def _build_switched_client(agent, new_provider, api_key, base_url, api_mode, new_norm) -> None:
-    """Build the client for the switched-to destination (MoA facade / native Anthropic / OpenAI wire)."""
+def _build_switched_client(agent, new_provider, api_key, base_url, api_mode, new_norm):
+    """Build a complete client bundle for the switched-to destination."""
+    from agent.runtime_bundle import ClientBundle, ResolvedRuntime, build_client_bundle
+
     if new_norm == "moa":
         from agent.moa_loop import build_moa_facade
         # MoA speaks only chat.completions via the MoAClient facade; the aggregator's real transport
@@ -1858,11 +1884,17 @@ def _build_switched_client(agent, new_provider, api_key, base_url, api_mode, new
         agent.api_key = api_key or "moa-virtual-provider"
         agent.base_url = "moa://local"
         agent._client_kwargs = {}
-        agent.client = build_moa_facade(agent, agent.model)
-        return
+        runtime = ResolvedRuntime.from_mapping({
+            "provider": new_provider,
+            "requested_provider": new_provider,
+            "model": agent.model,
+            "api_mode": agent.api_mode,
+            "api_key": agent.api_key,
+            "base_url": agent.base_url,
+        })
+        return ClientBundle(runtime=runtime, client=build_moa_facade(agent, agent.model))
     if api_mode == "anthropic_messages":
-        from agent.anthropic_adapter import build_anthropic_client
-        from agent.anthropic_credentials import resolve_anthropic_token, _is_oauth_token
+        from agent.anthropic_credentials import resolve_anthropic_token
         # Only fall back to ANTHROPIC_TOKEN for native Anthropic; other anthropic_messages providers
         # must never receive Anthropic credentials.
         is_native_anthropic = new_provider == "anthropic"
@@ -1878,16 +1910,30 @@ def _build_switched_client(agent, new_provider, api_key, base_url, api_mode, new
                     "MiniMax OAuth: failed to install per-request token provider "
                     "on switch (%s); using static bearer.", _mm_exc,
                 )
-        agent.api_key = agent._anthropic_api_key = effective_key
-        agent._anthropic_base_url = base_url or getattr(agent, "_anthropic_base_url", None)
-        agent._anthropic_client = build_anthropic_client(
-            effective_key, agent._anthropic_base_url,
-            timeout=get_provider_request_timeout(agent.provider, agent.model),
+        effective_base = base_url or getattr(agent, "_anthropic_base_url", None) or agent.base_url
+        runtime_fields = {
+            "provider": new_provider,
+            "requested_provider": agent.requested_provider,
+            "model": agent.model,
+            "api_mode": api_mode,
+            "api_key": effective_key,
+            "base_url": effective_base or "",
+        }
+        with contextlib.suppress(Exception):
+            from hermes_cli.config import (
+                get_compatible_custom_providers, get_custom_provider_extra_headers,
+                load_config_readonly,
+            )
+            _headers = get_custom_provider_extra_headers(
+                effective_base or "", get_compatible_custom_providers(load_config_readonly())
+            )
+            if _headers:
+                runtime_fields["extra_headers"] = _headers
+        runtime = ResolvedRuntime.from_mapping(runtime_fields)
+        return build_client_bundle(
+            runtime,
+            timeout=get_provider_request_timeout(new_provider, agent.model),
         )
-        agent._is_anthropic_oauth = bool(is_native_anthropic and isinstance(effective_key, str) and _is_oauth_token(effective_key))
-        agent.client = None
-        agent._client_kwargs = {}
-        return
     effective_base = base_url or agent.base_url
     agent._client_kwargs = {"api_key": api_key or agent.api_key, "base_url": effective_base}
     try:
@@ -1912,7 +1958,21 @@ def _build_switched_client(agent, new_provider, api_key, base_url, api_mode, new
     # Reapply provider headers (OpenRouter HTTP-Referer/X-Title) lost when _client_kwargs was
     # rebuilt; otherwise attribution shows "Unknown".
     agent._apply_client_headers_for_base_url(effective_base)
-    agent.client = agent._create_openai_client(dict(agent._client_kwargs), reason="switch_model", shared=True)
+    runtime = ResolvedRuntime.from_mapping({
+        "provider": new_provider,
+        "requested_provider": agent.requested_provider,
+        "model": agent.model,
+        "api_mode": api_mode,
+        "api_key": agent._client_kwargs.get("api_key", ""),
+        "base_url": effective_base,
+        "client_kwargs": dict(agent._client_kwargs),
+    })
+    return build_client_bundle(
+        runtime,
+        openai_builder=lambda kwargs: agent._create_openai_client(
+            kwargs, reason="switch_model", shared=True, runtime=runtime
+        ),
+    )
 
 
 def _swap_switch_runtime(agent, new_model, new_provider, api_key, base_url, api_mode, old_provider, old_norm, new_norm) -> None:
@@ -1954,7 +2014,8 @@ def _swap_switch_runtime(agent, new_model, new_provider, api_key, base_url, api_
                 "switch_model: credential pool reload failed for %s (%s); "
                 "continuing without pool rotation this turn", new_provider, _pool_exc,
             )
-    _build_switched_client(agent, new_provider, api_key, base_url, api_mode, new_norm)
+    bundle = _build_switched_client(agent, new_provider, api_key, base_url, api_mode, new_norm)
+    agent.install_runtime(bundle, reason="switch_model")
     sync_credential_pool_entry_id(agent)
 
 
@@ -2021,7 +2082,7 @@ def _update_switch_compressor(agent, custom_providers, effective_context_length,
         raise
 
 
-def _build_primary_runtime_snapshot(agent, api_mode) -> Dict[str, Any]:
+def _build_primary_runtime_snapshot(agent, api_mode):
     """The ``_primary_runtime`` record that persists a switch across turns."""
     cc = getattr(agent, "context_compressor", None) or None
     rt = {
@@ -2055,6 +2116,17 @@ def _build_primary_runtime_snapshot(agent, api_mode) -> Dict[str, Any]:
             "anthropic_base_url": agent._anthropic_base_url,
             "is_anthropic_oauth": agent._is_anthropic_oauth,
         })
+    # Preserve resolver-owned transport fields when a switch becomes the new
+    # primary.  They are part of the route identity, not transient client
+    # construction details.
+    resolved = getattr(agent, "_resolved_runtime", None)
+    if resolved is not None:
+        for key in ("source", "extra_headers", "ssl_ca_cert", "ssl_verify"):
+            if key in resolved:
+                rt[key] = resolved[key]
+    # ``_primary_runtime`` is a legacy compatibility snapshot: callers have
+    # historically amended it before a restore.  Keep that surface mutable;
+    # client construction still normalizes it into an immutable runtime.
     return rt
 
 
@@ -2156,6 +2228,8 @@ def switch_model(
     from agent.chat_completion_helpers import _reset_stale_streak
     _reset_stale_streak(agent)
     agent._primary_runtime = _build_primary_runtime_snapshot(agent, api_mode)
+    from agent.runtime_bundle import ResolvedRuntime
+    agent._resolved_runtime = ResolvedRuntime.from_mapping(agent._primary_runtime)
     _finish_switch(agent, new_provider, old_norm, new_norm)
     logger.info(
         "Model switched in-place: %s (%s) -> %s (%s)",

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -325,7 +325,8 @@ def _base_client_kwargs(base_url, timeout) -> tuple[str, Dict[str, Any]]:
 
 
 def _build_anthropic_client_with_bearer_hook(
-    token_provider, base_url: str = None, timeout: float = None, *, drop_context_1m_beta: bool = False
+    token_provider, base_url: Optional[str] = None, timeout: Optional[float] = None, *,
+    drop_context_1m_beta: bool = False, default_headers: Optional[Dict[str, str]] = None,
 ):
     """Anthropic-on-Foundry Entra ID variant of :func:`build_anthropic_client`. The SDK stores
     ``api_key``/``auth_token`` as static strings, so per-request bearer refresh (Microsoft's
@@ -339,6 +340,8 @@ def _build_anthropic_client_with_bearer_hook(
     kwargs["http_client"] = build_bearer_http_client(token_provider, timeout=kwargs["timeout"])
     kwargs["auth_token"] = "entra-id-bearer-via-http-hook"
     headers = _beta_header(_common_betas_for_base_url(normalized_base_url, drop_context_1m_beta=drop_context_1m_beta))
+    if default_headers:
+        headers.update(default_headers)
     return _new_sdk_client(sdk, kwargs, headers)
 
 
@@ -373,7 +376,10 @@ def _auth_style(api_key, base_url, normalized_base_url) -> str:
     return "api_key"
 
 
-def build_anthropic_client(api_key, base_url: str = None, timeout: float = None, *, drop_context_1m_beta: bool = False):
+def build_anthropic_client(
+    api_key, base_url: Optional[str] = None, timeout: Optional[float] = None, *,
+    drop_context_1m_beta: bool = False, default_headers: Optional[Dict[str, str]] = None,
+):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys. ``api_key`` is a static
     ``str`` or a ``Callable[[], str]`` Entra ID bearer provider (routed through
     :func:`_build_anthropic_client_with_bearer_hook`). ``timeout`` overrides the 900s read timeout
@@ -383,7 +389,8 @@ def build_anthropic_client(api_key, base_url: str = None, timeout: float = None,
     sdk = _require_sdk("the Anthropic provider")
     if callable(api_key) and not isinstance(api_key, str):
         return _build_anthropic_client_with_bearer_hook(
-            api_key, base_url, timeout, drop_context_1m_beta=drop_context_1m_beta
+            api_key, base_url, timeout, drop_context_1m_beta=drop_context_1m_beta,
+            default_headers=default_headers,
         )
     normalize_proxy_env_vars()
     normalized_base_url, kwargs = _base_client_kwargs(base_url, timeout)
@@ -403,6 +410,8 @@ def build_anthropic_client(api_key, base_url: str = None, timeout: float = None,
         # get these from profile.default_headers, but this route never sees the profile.
         for k, v in _attribution_headers().items():
             headers.setdefault(k, v)
+    if default_headers:
+        headers.update(default_headers)
     return _new_sdk_client(sdk, kwargs, headers)
 
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -309,24 +309,30 @@ def _client_timeout(timeout):
     return Timeout(timeout=float(read), connect=10.0)
 
 
-def _base_client_kwargs(base_url, timeout) -> tuple[str, Dict[str, Any]]:
+def _base_client_kwargs(base_url, timeout, default_query=None) -> tuple[str, Dict[str, Any]]:
     """Shared SDK constructor kwargs -> ``(normalized_base_url, kwargs)``. Retry is delegated to
     hermes's outer loop (``max_retries=0``): the SDK default of 2 uses its own backoff that ignores
     Retry-After and double-retries inside our loop. Any trailing ``/v1`` is stripped because the
     SDK appends ``/v1/messages``. Azure's ``api-version`` goes through ``default_query`` so the
     base_url is not corrupted into ``/anthropic?api-version=.../v1/messages``."""
     kwargs: Dict[str, Any] = {"timeout": _client_timeout(timeout), "max_retries": 0}
-    normalized = re.sub(r"/v1/?$", "", _normalize_base_url_text(base_url).rstrip("/"))
+    from urllib.parse import parse_qsl, urlsplit, urlunsplit
+    parts = urlsplit(_normalize_base_url_text(base_url))
+    normalized = re.sub(r"/v1/?$", "", urlunsplit(parts._replace(query="")).rstrip("/"))
     if normalized:
         kwargs["base_url"] = normalized
         if _is_azure_anthropic_endpoint(normalized) and "api-version" not in normalized:
             kwargs["default_query"] = {"api-version": "2025-04-15"}
+    query = {**kwargs.get("default_query", {}), **dict(parse_qsl(parts.query)), **(default_query or {})}
+    if query:
+        kwargs["default_query"] = query
     return normalized, kwargs
 
 
 def _build_anthropic_client_with_bearer_hook(
     token_provider, base_url: Optional[str] = None, timeout: Optional[float] = None, *,
     drop_context_1m_beta: bool = False, default_headers: Optional[Dict[str, str]] = None,
+    default_query=None, ssl_ca_cert=None, ssl_verify=None,
 ):
     """Anthropic-on-Foundry Entra ID variant of :func:`build_anthropic_client`. The SDK stores
     ``api_key``/``auth_token`` as static strings, so per-request bearer refresh (Microsoft's
@@ -336,13 +342,23 @@ def _build_anthropic_client_with_bearer_hook(
     sdk = _require_sdk("Azure Foundry Anthropic-style endpoints with Entra ID auth", verb="Install with")
     normalize_proxy_env_vars()
     from agent.azure_identity_adapter import build_bearer_http_client
-    normalized_base_url, kwargs = _base_client_kwargs(base_url, timeout)
-    kwargs["http_client"] = build_bearer_http_client(token_provider, timeout=kwargs["timeout"])
+    normalized_base_url, kwargs = _base_client_kwargs(base_url, timeout, default_query)
+    transport = {}
+    if ssl_ca_cert is not None or ssl_verify is not None:
+        from agent.ssl_verify import resolve_httpx_verify
+        transport["verify"] = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify)
+    kwargs["http_client"] = build_bearer_http_client(token_provider, timeout=kwargs["timeout"], **transport)
     kwargs["auth_token"] = "entra-id-bearer-via-http-hook"
     headers = _beta_header(_common_betas_for_base_url(normalized_base_url, drop_context_1m_beta=drop_context_1m_beta))
     if default_headers:
         headers.update(default_headers)
-    return _new_sdk_client(sdk, kwargs, headers)
+    from agent.runtime_routes import record_client_runtime
+    return record_client_runtime(
+        _new_sdk_client(sdk, kwargs, headers), provider="", api_mode="anthropic_messages",
+        api_key=token_provider, base_url=base_url or "", timeout=timeout,
+        default_headers=default_headers or {}, default_query=kwargs.get("default_query", {}),
+        ssl_ca_cert=ssl_ca_cert, ssl_verify=ssl_verify,
+    )
 
 
 def _new_sdk_client(sdk, kwargs: Dict[str, Any], headers: Dict[str, str]):
@@ -379,6 +395,7 @@ def _auth_style(api_key, base_url, normalized_base_url) -> str:
 def build_anthropic_client(
     api_key, base_url: Optional[str] = None, timeout: Optional[float] = None, *,
     drop_context_1m_beta: bool = False, default_headers: Optional[Dict[str, str]] = None,
+    default_query=None, ssl_ca_cert=None, ssl_verify=None,
 ):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys. ``api_key`` is a static
     ``str`` or a ``Callable[[], str]`` Entra ID bearer provider (routed through
@@ -387,13 +404,24 @@ def build_anthropic_client(
     client-level beta header — the reactive OAuth retry in run_agent uses it after a subscription
     rejects it; fresh clients keep the default so 1M-capable subscriptions keep the capability."""
     sdk = _require_sdk("the Anthropic provider")
+    if ssl_ca_cert is None and ssl_verify is None:
+        from hermes_cli.config import get_custom_provider_tls_settings
+        tls = get_custom_provider_tls_settings(base_url or "")
+        ssl_ca_cert, ssl_verify = tls.get("ssl_ca_cert"), tls.get("ssl_verify")
     if callable(api_key) and not isinstance(api_key, str):
         return _build_anthropic_client_with_bearer_hook(
             api_key, base_url, timeout, drop_context_1m_beta=drop_context_1m_beta,
             default_headers=default_headers,
+            default_query=default_query, ssl_ca_cert=ssl_ca_cert, ssl_verify=ssl_verify,
         )
     normalize_proxy_env_vars()
-    normalized_base_url, kwargs = _base_client_kwargs(base_url, timeout)
+    normalized_base_url, kwargs = _base_client_kwargs(base_url, timeout, default_query)
+    if ssl_ca_cert is not None or ssl_verify is not None:
+        from agent.process_bootstrap import build_keepalive_http_client
+        from agent.ssl_verify import resolve_httpx_verify
+        kwargs["http_client"] = build_keepalive_http_client(
+            base_url or "", verify=resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify),
+        )
     if "default_query" in kwargs:  # historical: this path also strips a stray trailing slash on Azure
         kwargs["base_url"] = normalized_base_url.rstrip("/")
     common_betas = _common_betas_for_base_url(normalized_base_url, drop_context_1m_beta=drop_context_1m_beta)
@@ -412,7 +440,13 @@ def build_anthropic_client(
             headers.setdefault(k, v)
     if default_headers:
         headers.update(default_headers)
-    return _new_sdk_client(sdk, kwargs, headers)
+    from agent.runtime_routes import record_client_runtime
+    return record_client_runtime(
+        _new_sdk_client(sdk, kwargs, headers), provider="", api_mode="anthropic_messages",
+        api_key=api_key, base_url=base_url or "", timeout=timeout,
+        default_headers=default_headers or {}, default_query=kwargs.get("default_query", {}),
+        ssl_ca_cert=ssl_ca_cert, ssl_verify=ssl_verify,
+    )
 
 
 def build_anthropic_bedrock_client(region: str):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -20,6 +20,7 @@ import re
 import threading
 import time
 import uuid
+from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse, parse_qs, urlunparse
@@ -1701,6 +1702,7 @@ class AnthropicAuxiliaryClient:
         self.chat = _ChatShim(_AnthropicCompletionsAdapter(real_client, model, is_oauth=is_oauth, base_url=base_url))
         self.api_key = api_key
         self.base_url = base_url
+        self.is_oauth = is_oauth
 
     def close(self):
         close_fn = getattr(self._real_client, "close", None)
@@ -2523,7 +2525,7 @@ def _runtime_main_value(field: str) -> Any:
     runtime = _RUNTIME_MAIN_CONTEXT.get()
     if runtime is None:
         runtime = _compat_runtime_main()
-    return (runtime.get(field) or "") if isinstance(runtime, dict) else ""
+    return (runtime.get(field) or "") if isinstance(runtime, Mapping) else ""
 
 
 def set_runtime_main(
@@ -2593,7 +2595,7 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
     except Exception as exc:
         logger.debug("Auxiliary client: custom runtime resolution failed: %s", exc)
         runtime = None
-    if not isinstance(runtime, dict):
+    if not isinstance(runtime, Mapping):
         openai_base = os.getenv("OPENAI_BASE_URL", "").strip().rstrip("/")
         if not openai_base:
             return None, None, None
@@ -2657,7 +2659,7 @@ def _validate_base_url(base_url: str) -> None:
         ) from exc
 
 
-def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
+def _try_custom_endpoint(*, timeout: Optional[float] = None) -> Tuple[Optional[Any], Optional[str]]:
     runtime = _resolve_custom_runtime()
     custom_base, custom_key, custom_mode = (*runtime, None) if len(runtime) == 2 else runtime
     if not custom_base or not custom_key:
@@ -2670,26 +2672,43 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     _extra = {"default_query": _dq} if _dq else {}
     # User model.default_headers override SDK fingerprint headers (as on the main client) for strict gateways/WAFs.
     _custom_headers = _apply_user_default_headers(None)
+    _custom_headers = {**(_custom_headers or {}), **_custom_provider_extra_headers(custom_base)}
     if _custom_headers:
         _extra["default_headers"] = _custom_headers
+    if timeout is not None:
+        _extra["timeout"] = timeout
     if custom_mode == "codex_responses":
         real_client = _create_openai_client(api_key=custom_key, base_url=_clean_base, **_extra)
+        with contextlib.suppress(Exception):
+            real_client._hermes_runtime_extra_headers = dict(_custom_headers or {})
         return CodexAuxiliaryClient(real_client, model), model
     if custom_mode == "anthropic_messages":
         # Third-party Anthropic-compatible gateway — never OAuth (that's api.anthropic.com only).
         try:
             from agent.anthropic_adapter import build_anthropic_client
-            real_client = build_anthropic_client(custom_key, custom_base)
+            real_client = build_anthropic_client(
+                custom_key,
+                custom_base,
+                timeout=timeout,
+                default_headers=_custom_headers or None,
+            )
         except ImportError:
             logger.warning(
                 "Custom endpoint declares api_mode=anthropic_messages but the "
                 "anthropic SDK is not installed — falling back to OpenAI-wire."
             )
             return _create_openai_client(api_key=custom_key, base_url=_clean_base, **_extra), model
-        return AnthropicAuxiliaryClient(real_client, model, custom_key, custom_base, is_oauth=False), model
+        wrapper = AnthropicAuxiliaryClient(real_client, model, custom_key, custom_base, is_oauth=False)
+        wrapper._hermes_runtime_extra_headers = dict(_custom_headers or {})
+        return wrapper, model
     # URL-based anthropic detection for custom endpoints without explicit api_mode.
     _fallback_client = _create_openai_client(api_key=custom_key, base_url=_clean_base, **_extra)
-    return _maybe_wrap_anthropic(_fallback_client, model, custom_key, custom_base, custom_mode), model
+    with contextlib.suppress(Exception):
+        _fallback_client._hermes_runtime_extra_headers = dict(_custom_headers or {})
+    wrapped = _maybe_wrap_anthropic(_fallback_client, model, custom_key, custom_base, custom_mode)
+    with contextlib.suppress(Exception):
+        wrapped._hermes_runtime_extra_headers = dict(_custom_headers or {})
+    return wrapped, model
 
 
 def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
@@ -2800,7 +2819,9 @@ def _try_azure_foundry(
     return client, final_model
 
 
-def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
+def _try_anthropic(
+    explicit_api_key: str = None, *, timeout: Optional[float] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client
         from agent.anthropic_credentials import resolve_anthropic_token
@@ -2836,7 +2857,8 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
         return _AuxProbeClientStub(api_key="", base_url=base_url), model
     logger.debug("Auxiliary client: Anthropic native (%s) at %s (oauth=%s)", model, base_url, is_oauth)
     try:
-        real_client = build_anthropic_client(token, base_url)
+        build_kwargs = {"timeout": timeout} if timeout is not None else {}
+        real_client = build_anthropic_client(token, base_url, **build_kwargs)
     except ImportError:
         return None, None  # Adapter imports fine but the anthropic SDK itself is missing.
     return AnthropicAuxiliaryClient(real_client, model, token, base_url, is_oauth=is_oauth), model
@@ -2857,7 +2879,7 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
         main_runtime = _RUNTIME_MAIN_CONTEXT.get()
         if main_runtime is None:
             main_runtime = _compat_runtime_main()
-    if not isinstance(main_runtime, dict):
+    if not isinstance(main_runtime, Mapping):
         return {}
     normalized: Dict[str, Any] = {}
     for field in _MAIN_RUNTIME_CONTEXT_FIELDS:
@@ -3910,7 +3932,9 @@ def _try_configured_fallback_chain(
         fb_model = fb_model_raw or None
         label = f"fallback_chain[{i}]({fb_provider})"
         try:
-            fb_client, resolved_model = _resolve_fallback_entry(entry)
+            fb_client, resolved_model = _resolve_fallback_entry(
+                entry, timeout=_coerce_positive_timeout(entry.get("timeout")),
+            )
         except Exception:
             fb_client, resolved_model = None, None
         if fb_client is not None:
@@ -3946,7 +3970,9 @@ def _fallback_entry_api_key(entry: Dict[str, Any]) -> Optional[str]:
     return resolve_entry_api_key(entry)
 
 
-def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optional[str]]:
+def _resolve_fallback_entry(
+    entry: Dict[str, Any], *, timeout: Optional[float] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
     """Resolve one fallback entry through the central provider router."""
     provider = str(entry.get("provider") or "").strip()
     model = str(entry.get("model") or "").strip() or None
@@ -3956,6 +3982,7 @@ def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optio
         provider, model=model, explicit_base_url=str(entry.get("base_url") or "").strip() or None,
         explicit_api_key=_fallback_entry_api_key(entry),
         api_mode=str(entry.get("api_mode") or entry.get("transport") or "").strip() or None,
+        timeout=timeout,
     )
     if client is not None:
         with contextlib.suppress(Exception):
@@ -3998,7 +4025,9 @@ def _try_main_fallback_chain(
             tried.append(f"{label} (unhealthy)")
             continue
         try:
-            fb_client, resolved_model = _resolve_fallback_entry(entry)
+            fb_client, resolved_model = _resolve_fallback_entry(
+                entry, timeout=_coerce_positive_timeout(entry.get("timeout")),
+            )
         except Exception as exc:
             logger.debug("Auxiliary %s: main fallback %s failed to resolve: %s", task or "call", label, exc)
             fb_client, resolved_model = None, None
@@ -4345,6 +4374,7 @@ class _ResolveRequest(NamedTuple):
     main_runtime: Optional[Dict[str, Any]]
     is_vision: bool
     task: Optional[str]
+    timeout: Optional[float]
 
 
 _ResolveResult = Tuple[Optional[Any], Optional[str]]
@@ -4511,16 +4541,23 @@ def _resolve_custom_branch(req: _ResolveRequest) -> _ResolveResult:
         _clean_base, _dq = _extract_url_query_params(custom_base)
         if _dq:
             extra["default_query"] = _dq
-        _custom_headers = _endpoint_default_headers(custom_base, provider, is_vision=req.is_vision)
+        _custom_headers = _endpoint_default_headers(custom_base, provider, is_vision=req.is_vision) or {}
+        _custom_headers.update(_custom_provider_extra_headers(custom_base))
         if _custom_headers:
             extra["default_headers"] = _custom_headers
+        if req.timeout is not None:
+            extra["timeout"] = req.timeout
         client = _create_openai_client(api_key=custom_key, base_url=_clean_base, **extra)
+        with contextlib.suppress(Exception):
+            client._hermes_runtime_extra_headers = dict(_custom_headers or {})
         client = _wrap_transport(req, client, final_model, wrap_base or custom_base, custom_key)
         return _route_client(req, client, final_model)
     # Try custom first, then API-key providers (Codex excluded here:
     # falling through to Codex with no model is a stale-constant trap).
     for try_fn in (_try_custom_endpoint, _resolve_api_key_provider):
-        client, default = try_fn()
+        client, default = (
+            try_fn(timeout=req.timeout) if try_fn is _try_custom_endpoint else try_fn()
+        )
         if client is not None:
             final_model = _normalize_resolved_model(model or default, provider)
             # ``client.api_key`` may be a callable (Azure Entra bearer provider);
@@ -4533,14 +4570,37 @@ def _resolve_custom_branch(req: _ResolveRequest) -> _ResolveResult:
     return None, None
 
 
-def _named_custom_openai_wire_client(custom_base: str, custom_key: Any):
+def _custom_provider_extra_headers(base_url: str) -> Dict[str, str]:
+    """Return the route-specific header layer without exposing its values to logs."""
+    with contextlib.suppress(Exception):
+        from hermes_cli.config import (
+            get_compatible_custom_providers,
+            get_custom_provider_extra_headers,
+            load_config_readonly,
+        )
+        config = load_config_readonly()
+        return get_custom_provider_extra_headers(
+            base_url, get_compatible_custom_providers(config), config=config,
+        )
+    return {}
+
+
+def _named_custom_openai_wire_client(
+    custom_base: str, custom_key: Any, *, timeout: Optional[float] = None,
+):
     """Plain OpenAI client on the /v1 equivalent of a named custom entry's base URL."""
     _clean_base, _dq = _extract_url_query_params(_to_openai_base_url(custom_base))
     _extra = {"default_query": _dq} if _dq else {}
     _headers = _apply_user_default_headers(None)
+    _headers = {**(_headers or {}), **_custom_provider_extra_headers(custom_base)}
     if _headers:
         _extra["default_headers"] = _headers
-    return _create_openai_client(api_key=custom_key, base_url=_clean_base, **_extra)
+    if timeout is not None:
+        _extra["timeout"] = timeout
+    client = _create_openai_client(api_key=custom_key, base_url=_clean_base, **_extra)
+    with contextlib.suppress(Exception):
+        client._hermes_runtime_extra_headers = dict(_headers or {})
+    return client
 
 
 def _resolve_named_custom_branch(req: _ResolveRequest) -> Optional[_ResolveResult]:
@@ -4584,14 +4644,23 @@ def _resolve_named_custom_branch(req: _ResolveRequest) -> Optional[_ResolveResul
     if entry_api_mode == "anthropic_messages":
         try:
             from agent.anthropic_adapter import build_anthropic_client
-            real_client = build_anthropic_client(custom_key, custom_base)
+            real_client = build_anthropic_client(
+                custom_key,
+                custom_base,
+                timeout=req.timeout,
+                default_headers=_custom_provider_extra_headers(custom_base) or None,
+            )
         except ImportError:
             logger.warning("Named custom provider %r declares api_mode=anthropic_messages but the anthropic SDK "
                            "is not installed — falling back to OpenAI-wire.", provider)
-            return _route_client(req, _named_custom_openai_wire_client(custom_base, custom_key), final_model)
+            return _route_client(
+                req,
+                _named_custom_openai_wire_client(custom_base, custom_key, timeout=req.timeout),
+                final_model,
+            )
         return _route_client(
             req, AnthropicAuxiliaryClient(real_client, final_model, custom_key, custom_base, is_oauth=False), final_model)
-    client = _named_custom_openai_wire_client(custom_base, custom_key)
+    client = _named_custom_openai_wire_client(custom_base, custom_key, timeout=req.timeout)
     # codex_responses, or auto-detect via _wrap_transport (which reads the task-level api_mode).
     if entry_api_mode == "codex_responses":
         client = CodexAuxiliaryClient(client, final_model)
@@ -4614,7 +4683,9 @@ def _resolve_api_key_branch(req: _ResolveRequest, pconfig: Any, resolve_creds: C
     """PROVIDER_REGISTRY ``api_key`` providers (Anthropic via its own resolver), honouring explicit overrides."""
     provider = req.provider
     if provider == "anthropic":
-        client, default_model = _try_anthropic(explicit_api_key=req.explicit_api_key)
+        client, default_model = _try_anthropic(
+            explicit_api_key=req.explicit_api_key, timeout=req.timeout,
+        )
         return _route_or_warn(req, client, default_model,
                               "resolve_provider_client: anthropic requested but no Anthropic credentials found")
     creds = resolve_creds(provider)
@@ -4661,7 +4732,10 @@ def _resolve_api_key_branch(req: _ResolveRequest, pconfig: Any, resolve_creds: C
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return _route_client(req, client, final_model)
     headers = _endpoint_default_headers(base_url, provider, is_vision=req.is_vision, xai=True)
-    client = _create_openai_client(api_key=api_key, base_url=base_url, **({"default_headers": headers} if headers else {}))
+    client_kwargs = {"default_headers": headers} if headers else {}
+    if req.timeout is not None:
+        client_kwargs["timeout"] = req.timeout
+    client = _create_openai_client(api_key=api_key, base_url=base_url, **client_kwargs)
     # Copilot GPT-5+ models (except gpt-5-mini) are only reachable via the Responses API;
     # wrap so call_llm() transparently routes through responses.stream().
     if provider == "copilot" and final_model and not req.raw_codex:
@@ -4775,6 +4849,7 @@ def resolve_provider_client(
     explicit_base_url: str = None, explicit_api_key: str = None, api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None, is_vision: bool = False,
     task: Optional[str] = None,
+    timeout: Optional[float] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Central router: return a configured client (auth, base URL, API format) for a provider + optional model.
     The client always exposes ``.chat.completions.create()``; Codex/Responses providers get an adapter.
@@ -4831,6 +4906,7 @@ def resolve_provider_client(
     req = _ResolveRequest(
         provider, original_provider, model, async_mode, raw_codex,
         explicit_base_url, explicit_api_key, api_mode, main_runtime, is_vision, task,
+        timeout,
     )
     branch = _EXPLICIT_PROVIDER_BRANCHES.get(provider)
     if branch is not None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -184,7 +184,10 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
     # SDK-internal retries by default and let Hermes control the budget; explicit callers can still override
     # via kwargs.
     kwargs.setdefault("max_retries", 0)
-    return OpenAI(api_key=api_key, base_url=base_url, **kwargs)
+    from agent.runtime_routes import record_client_runtime, runtime_for_endpoint
+    resolved = runtime_for_endpoint(None, base_url).as_dict()
+    resolved.update(api_key=api_key, base_url=base_url, **kwargs)
+    return record_client_runtime(OpenAI(api_key=api_key, base_url=base_url, **kwargs), **resolved)
 
 
 # Interrupt protection for atomic aux tasks: a compression summary killed by an ordinary
@@ -1819,7 +1822,12 @@ def _maybe_wrap_anthropic(
         )
         return client_obj
     try:
-        real_client = build_anthropic_client(api_key, base_url)
+        from agent.runtime_bundle import build_client_bundle
+        from agent.runtime_routes import runtime_from_client
+        runtime = runtime_from_client(
+            client_obj, provider="custom", model=model, api_mode="anthropic_messages", base_url=base_url,
+        ).with_updates(api_key=api_key)
+        real_client = build_client_bundle(runtime, anthropic_builder=build_anthropic_client).anthropic_client
     except Exception as exc:
         logger.warning(
             "Failed to build Anthropic client for %s (%s) — falling back to "

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1923,29 +1923,27 @@ def _should_skip_fallback_candidate(agent, fb: dict, fb_key: tuple, fb_provider:
 def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb_base_url: str, fb_api_mode: str) -> None:
     """Install a resolver-built fallback as one complete runtime transaction."""
     from agent.auxiliary_client import AnthropicAuxiliaryClient
-    from agent.runtime_bundle import ClientBundle, ResolvedRuntime, build_client_bundle
+    from agent.runtime_bundle import ClientBundle, build_client_bundle, openai_client_kwargs
+    from agent.runtime_routes import runtime_from_client
 
     is_anthropic = isinstance(fb_client, AnthropicAuxiliaryClient)
-    if fb_api_mode == "anthropic_messages":
+    effective_base = str(getattr(fb_client, "base_url", "") or fb_base_url)
+    runtime = runtime_from_client(
+        fb_client, provider=fb_provider, model=fb_model, api_mode=fb_api_mode, base_url=effective_base,
+    )
+    timeout = runtime.get("timeout")
+    if timeout is None:
         timeout = get_provider_request_timeout(fb_provider, fb_model)
-        effective_key = getattr(fb_client, "api_key", "") or ""
-        effective_base = str(getattr(fb_client, "base_url", "") or fb_base_url)
-        runtime = ResolvedRuntime.from_mapping({
-            "provider": fb_provider,
-            "model": fb_model,
-            "requested_provider": fb_provider,
-            "api_mode": fb_api_mode,
-            "api_key": effective_key,
-            "base_url": effective_base,
-            "extra_headers": getattr(fb_client, "_hermes_runtime_extra_headers", {}) or {},
-        })
+        if timeout is not None:
+            runtime = runtime.with_updates(timeout=timeout)
+    if fb_api_mode == "anthropic_messages":
         if is_anthropic:
             # New resolver paths already return the exact Messages client.  Keep
             # it intact, including any adapter-local auth state.
             bundle = ClientBundle(
                 runtime=runtime,
                 anthropic_client=fb_client._real_client,
-                anthropic_api_key=effective_key,
+                anthropic_api_key=runtime.api_key,
                 anthropic_base_url=effective_base,
                 is_anthropic_oauth=bool(fb_client.is_oauth and fb_provider == "anthropic"),
             )
@@ -1958,27 +1956,7 @@ def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb
         # Keep the exact resolver-built OpenAI client.  The kwargs snapshot is
         # only for a later request-local rebuild; it retains headers and the
         # resolved timeout alongside the same runtime identity.
-        fb_headers = (
-            getattr(fb_client, "_hermes_runtime_extra_headers", None)
-            or getattr(fb_client, "_custom_headers", None)
-            or getattr(fb_client, "default_headers", None)
-        )
-        client_kwargs = {
-            "api_key": getattr(fb_client, "api_key", ""),
-            "base_url": fb_base_url,
-        }
-        if fb_headers:
-            client_kwargs["default_headers"] = dict(fb_headers)
-        timeout = get_provider_request_timeout(fb_provider, fb_model)
-        if timeout is not None:
-            client_kwargs["timeout"] = timeout
-        runtime = ResolvedRuntime.from_mapping({
-            "provider": fb_provider,
-            "model": fb_model,
-            "requested_provider": fb_provider,
-            "api_mode": fb_api_mode,
-            **client_kwargs,
-        })
+        client_kwargs = openai_client_kwargs(runtime)
         bundle = ClientBundle(runtime=runtime, client=fb_client, client_kwargs=client_kwargs)
 
     agent.install_runtime(bundle, reason="fallback")

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1921,31 +1921,67 @@ def _should_skip_fallback_candidate(agent, fb: dict, fb_key: tuple, fb_provider:
 
 
 def _swap_fallback_clients(agent, fb_client, fb_provider: str, fb_model: str, fb_base_url: str, fb_api_mode: str) -> None:
-    """Install the fallback client(s) in place, honoring request_timeout_seconds (None = SDK default)."""
-    timeout = get_provider_request_timeout(fb_provider, fb_model)
+    """Install a resolver-built fallback as one complete runtime transaction."""
+    from agent.auxiliary_client import AnthropicAuxiliaryClient
+    from agent.runtime_bundle import ClientBundle, ResolvedRuntime, build_client_bundle
+
+    is_anthropic = isinstance(fb_client, AnthropicAuxiliaryClient)
     if fb_api_mode == "anthropic_messages":
-        from agent.anthropic_adapter import build_anthropic_client
-        from agent.anthropic_credentials import resolve_anthropic_token, _is_oauth_token
-        is_anthropic = fb_provider == "anthropic"
-        effective_key = fb_client.api_key or (resolve_anthropic_token() if is_anthropic else None) or ""
-        agent.api_key = agent._anthropic_api_key = effective_key
-        agent._anthropic_base_url = fb_base_url
-        agent._anthropic_client = build_anthropic_client(effective_key, fb_base_url, timeout=timeout)
-        agent._is_anthropic_oauth = _is_oauth_token(effective_key) if is_anthropic else False
-        agent.client, agent._client_kwargs = None, {}
-        return
-    agent.api_key = fb_client.api_key
-    agent.client = fb_client
-    # Keep provider headers resolve_provider_client() baked into fb_client (SDK: _custom_headers), else
-    # later request-client rebuilds drop them and User-Agent-sentinel providers (Kimi Coding) 403.
-    fb_headers = getattr(fb_client, "_custom_headers", None) or getattr(fb_client, "default_headers", None)
-    agent._client_kwargs = {"api_key": fb_client.api_key, "base_url": fb_base_url}
-    if fb_headers:
-        agent._client_kwargs["default_headers"] = dict(fb_headers)
-    if timeout is not None:
-        agent._client_kwargs["timeout"] = timeout
-        # Rebuild now so the timeout applies to the very next request, not only after a rotation rebuild.
-        agent._replace_primary_openai_client(reason="fallback_timeout_apply")
+        timeout = get_provider_request_timeout(fb_provider, fb_model)
+        effective_key = getattr(fb_client, "api_key", "") or ""
+        effective_base = str(getattr(fb_client, "base_url", "") or fb_base_url)
+        runtime = ResolvedRuntime.from_mapping({
+            "provider": fb_provider,
+            "model": fb_model,
+            "requested_provider": fb_provider,
+            "api_mode": fb_api_mode,
+            "api_key": effective_key,
+            "base_url": effective_base,
+            "extra_headers": getattr(fb_client, "_hermes_runtime_extra_headers", {}) or {},
+        })
+        if is_anthropic:
+            # New resolver paths already return the exact Messages client.  Keep
+            # it intact, including any adapter-local auth state.
+            bundle = ClientBundle(
+                runtime=runtime,
+                anthropic_client=fb_client._real_client,
+                anthropic_api_key=effective_key,
+                anthropic_base_url=effective_base,
+                is_anthropic_oauth=bool(fb_client.is_oauth and fb_provider == "anthropic"),
+            )
+        else:
+            # Compatibility for plugins/tests that still return a plain wire
+            # client while explicitly selecting Anthropic Messages.  Rebuild
+            # it through the same bundle factory instead of mutating live state.
+            bundle = build_client_bundle(runtime, timeout=timeout)
+    else:
+        # Keep the exact resolver-built OpenAI client.  The kwargs snapshot is
+        # only for a later request-local rebuild; it retains headers and the
+        # resolved timeout alongside the same runtime identity.
+        fb_headers = (
+            getattr(fb_client, "_hermes_runtime_extra_headers", None)
+            or getattr(fb_client, "_custom_headers", None)
+            or getattr(fb_client, "default_headers", None)
+        )
+        client_kwargs = {
+            "api_key": getattr(fb_client, "api_key", ""),
+            "base_url": fb_base_url,
+        }
+        if fb_headers:
+            client_kwargs["default_headers"] = dict(fb_headers)
+        timeout = get_provider_request_timeout(fb_provider, fb_model)
+        if timeout is not None:
+            client_kwargs["timeout"] = timeout
+        runtime = ResolvedRuntime.from_mapping({
+            "provider": fb_provider,
+            "model": fb_model,
+            "requested_provider": fb_provider,
+            "api_mode": fb_api_mode,
+            **client_kwargs,
+        })
+        bundle = ClientBundle(runtime=runtime, client=fb_client, client_kwargs=client_kwargs)
+
+    agent.install_runtime(bundle, reason="fallback")
 
 
 def _update_fallback_context_compressor(agent) -> None:
@@ -2062,6 +2098,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             logger.warning("Could not normalize fallback model %r for provider %r: %s", fb_model, fb_provider, _norm_err)
 
         fb_base_url = str(fb_client.base_url)
+        from agent.auxiliary_client import AnthropicAuxiliaryClient
+        if not fb_api_mode_explicit and isinstance(fb_client, AnthropicAuxiliaryClient):
+            # The resolved client is authoritative when a named provider's
+            # configuration declares the Messages wire on a generic URL.
+            fb_api_mode = "anthropic_messages"
         if not fb_api_mode_explicit and fb_api_mode == "chat_completions":
             fb_api_mode = _fallback_api_mode_resolved(agent, fb_provider, fb_model, fb_base_url)
 
@@ -2071,16 +2112,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # window is resolved instead of the previous model's stale value.
         # See #22387.
         agent._config_context_length = None
-        agent.model, agent.provider, agent.requested_provider = fb_model, fb_provider, fb_provider
-        agent.base_url, agent.api_mode = fb_base_url, fb_api_mode
-        # reasoning_content echo opt-in travels with the active provider; restore_primary_runtime reverts it.
-        agent._reasoning_echo_flag = bool(fb.get("reasoning_echo", False))
-        if hasattr(agent, "_transport_cache"):
-            agent._transport_cache.clear()
-        agent._fallback_activated = True
-
         _rebind_fallback_credential_pool(agent, fb_provider, fb_model)
         _swap_fallback_clients(agent, fb_client, fb_provider, fb_model, fb_base_url, fb_api_mode)
+
+        # ``install_runtime`` commits identity + wire atomically.  Fallback
+        # policy and context-engine bookkeeping remain outside that boundary.
+        agent._reasoning_echo_flag = bool(fb.get("reasoning_echo", False))
+        agent._fallback_activated = True
 
         from agent.agent_runtime_helpers import sync_credential_pool_entry_id
         sync_credential_pool_entry_id(agent)

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -155,6 +155,58 @@ class ClientLifecycleMixin:
         except Exception as exc:
             logger.debug("Shared OpenAI client retire failed (%s) %s error=%s", reason, self._client_log_context(), exc)
 
+    def install_runtime(self, bundle, *, reason: str = "runtime_install"):
+        """Commit a fully built runtime and client pair as one lifecycle change.
+
+        Builders run before this method is called.  The lock therefore covers
+        only the identity/client swap, so a concurrent request observes either
+        the complete old route or the complete new route, never credentials
+        from one route paired with a client from another.
+        """
+        from agent.runtime_bundle import ClientBundle
+
+        if not isinstance(bundle, ClientBundle):
+            raise TypeError("install_runtime requires a ClientBundle")
+        if bundle.client is not None and bundle.anthropic_client is not None:
+            raise ValueError("ClientBundle cannot contain both wire clients")
+
+        runtime = bundle.runtime
+        client_kwargs = dict(bundle.client_kwargs)
+        is_anthropic = bundle.anthropic_client is not None
+        model = runtime.model or getattr(self, "model", "")
+        provider = runtime.provider or getattr(self, "provider", "")
+        requested_provider = runtime.requested_provider or provider
+        api_mode = runtime.api_mode or "chat_completions"
+        api_key = bundle.anthropic_api_key if is_anthropic else client_kwargs.get("api_key", runtime.api_key)
+        base_url = bundle.anthropic_base_url if is_anthropic else client_kwargs.get("base_url", runtime.base_url)
+
+        with self._openai_client_lock():
+            old_clients = (getattr(self, "client", None), getattr(self, "_anthropic_client", None))
+            self.model = model
+            self.provider = provider
+            self.requested_provider = requested_provider
+            self.base_url = base_url or ""
+            self.api_mode = api_mode
+            self.api_key = api_key
+            self.client = bundle.client
+            self._anthropic_client = bundle.anthropic_client
+            self._client_kwargs = client_kwargs
+            self._anthropic_api_key = bundle.anthropic_api_key if is_anthropic else ""
+            self._anthropic_base_url = bundle.anthropic_base_url if is_anthropic else ""
+            self._is_anthropic_oauth = bundle.is_anthropic_oauth if is_anthropic else False
+            self._resolved_runtime = runtime
+            if hasattr(self, "_transport_cache"):
+                self._transport_cache.clear()
+
+        active_ids = {id(client) for client in (bundle.client, bundle.anthropic_client) if client is not None}
+        retired_ids = set()
+        for old_client in old_clients:
+            if old_client is None or id(old_client) in active_ids or id(old_client) in retired_ids:
+                continue
+            retired_ids.add(id(old_client))
+            self._retire_shared_openai_client(old_client, reason=f"install:{reason}")
+        return runtime
+
     def _drain_transports_after_abandonment(self, *, reason: str) -> int:
         """FD-safe transport drain for an abandoned (timed-out) worker; returns sockets shut down.
 

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -163,7 +163,7 @@ class ClientLifecycleMixin:
         the complete old route or the complete new route, never credentials
         from one route paired with a client from another.
         """
-        from agent.runtime_bundle import ClientBundle
+        from agent.runtime_bundle import ClientBundle, mutable_config_copy
 
         if not isinstance(bundle, ClientBundle):
             raise TypeError("install_runtime requires a ClientBundle")
@@ -171,7 +171,7 @@ class ClientLifecycleMixin:
             raise ValueError("ClientBundle cannot contain both wire clients")
 
         runtime = bundle.runtime
-        client_kwargs = dict(bundle.client_kwargs)
+        client_kwargs = mutable_config_copy(bundle.client_kwargs)
         is_anthropic = bundle.anthropic_client is not None
         model = runtime.model or getattr(self, "model", "")
         provider = runtime.provider or getattr(self, "provider", "")
@@ -456,28 +456,25 @@ class ClientLifecycleMixin:
         self._abort_request_slot_client(_OPENAI_SLOT, client, reason=reason)
 
     def _request_anthropic_client_key(self) -> tuple:
-        """Cache key over everything forcing a fresh client: credential, base URL/region, timeout, 1M-beta flag."""
+        """Reuse only an identical complete runtime and beta policy (or legacy wire key)."""
         if getattr(self, "provider", None) == "bedrock":
             return ("bedrock", getattr(self, "_bedrock_region", "us-east-1") or "us-east-1")
+        from agent.runtime_bundle import ResolvedRuntime
+        resolved = getattr(self, "_resolved_runtime", None)
+        if isinstance(resolved, ResolvedRuntime):
+            return ("runtime", resolved, bool(getattr(self, "_oauth_1m_beta_disabled", False)))
         return (
             "direct", self._anthropic_api_key, getattr(self, "_anthropic_base_url", None),
             get_provider_request_timeout(self.provider, self.model), bool(getattr(self, "_oauth_1m_beta_disabled", False)),
         )
 
-    def _build_direct_anthropic_client(self, token: str, base_url: Any) -> Any:
-        """Native Anthropic client for ``token``/``base_url`` with the provider/model request timeout."""
-        from agent.anthropic_adapter import build_anthropic_client
-        return build_anthropic_client(token, base_url, timeout=get_provider_request_timeout(self.provider, self.model))
-
-    def _anthropic_oauth_flag(self, token: str) -> bool:
-        """OAuth flag only on native Anthropic; third-party Anthropic-protocol endpoints must not trip OAuth paths."""
-        from agent.anthropic_credentials import _is_oauth_token
-        return _is_oauth_token(token) if self.provider == "anthropic" else False
-
     def _build_anthropic_client_for_key(self, key: tuple) -> Any:
         from agent.anthropic_adapter import build_anthropic_bedrock_client, build_anthropic_client
         if key[0] == "bedrock":
             return build_anthropic_bedrock_client(key[1])
+        if key[0] == "runtime":
+            from agent.runtime_bundle import build_client_bundle
+            return build_client_bundle(key[1], drop_context_1m_beta=key[2]).anthropic_client
         return build_anthropic_client(key[1], key[2], timeout=key[3], drop_context_1m_beta=key[4])
 
     def _create_request_anthropic_client(self, *, reason: str) -> Any:
@@ -535,6 +532,14 @@ class ClientLifecycleMixin:
 
     def _adopt_openai_credentials(self, api_key: str, base_url: str, *, reason: str) -> bool:
         """Apply a fresh key/base_url to the OpenAI-style kwargs and rebuild the shared client."""
+        from agent.runtime_bundle import ResolvedRuntime
+        if isinstance(getattr(self, "_resolved_runtime", None), ResolvedRuntime):
+            try:
+                self._install_runtime_credentials(api_key.strip(), base_url.strip().rstrip("/"), reason=reason)
+                return True
+            except Exception as exc:
+                logger.warning("Failed to rebuild client after credential update (%s): %s", reason, exc)
+                return False
         self.api_key, self.base_url = api_key.strip(), base_url.strip().rstrip("/")
         self._sync_client_kwargs_credentials()
         return self._replace_primary_openai_client(reason=reason)
@@ -595,9 +600,7 @@ class ClientLifecycleMixin:
         if not _valid_credential_pair(api_key, base_url):
             return False
         if self.api_mode == "anthropic_messages":
-            self.api_key, self.base_url = api_key.strip(), base_url.strip().rstrip("/")
-            self._anthropic_api_key, self._anthropic_base_url = self.api_key, self.base_url
-            self._rebuild_anthropic_client()
+            self._install_runtime_credentials(api_key.strip(), base_url.strip().rstrip("/"), reason="nous_credential_refresh")
             return True
         # Nous requests should not inherit OpenRouter-only attribution headers.
         self._client_kwargs.pop("default_headers", None)
@@ -680,20 +683,23 @@ class ClientLifecycleMixin:
         if not self._should_adopt_env_credentials(api_key, base_url, default_base):
             self._env_creds_seen = (base_url, api_key)
             return False
-        from hermes_cli.route_identity import normalize_route_base_url
-        route_changed = normalize_route_base_url(self.base_url) != normalize_route_base_url(base_url)
-        prior_api_key, prior_base_url = self.api_key, self.base_url
-        prior_client_kwargs = dict(self._client_kwargs)
-        self.api_key, self.base_url = api_key, base_url
-        self._sync_client_kwargs_credentials()
-        # A base-url change moves the route: recompute TLS material and default headers.
-        self._reapply_route_client_config(route_changed=route_changed)
-        if not self._replace_primary_openai_client(reason="env_credential_refresh"):
-            # Leave the baseline un-advanced (retry next turn); roll the agent back to match the live client.
-            self.api_key, self.base_url = prior_api_key, prior_base_url
-            self._client_kwargs.clear()
-            self._client_kwargs.update(prior_client_kwargs)
-            return False
+        from agent.runtime_bundle import ResolvedRuntime
+        if isinstance(getattr(self, "_resolved_runtime", None), ResolvedRuntime):
+            if not self._adopt_openai_credentials(api_key, base_url, reason="env_credential_refresh"):
+                return False
+        else:
+            from hermes_cli.route_identity import normalize_route_base_url
+            route_changed = normalize_route_base_url(self.base_url) != normalize_route_base_url(base_url)
+            prior_api_key, prior_base_url = self.api_key, self.base_url
+            prior_client_kwargs = dict(self._client_kwargs)
+            self.api_key, self.base_url = api_key, base_url
+            self._sync_client_kwargs_credentials()
+            self._reapply_route_client_config(route_changed=route_changed)
+            if not self._replace_primary_openai_client(reason="env_credential_refresh"):
+                self.api_key, self.base_url = prior_api_key, prior_base_url
+                self._client_kwargs.clear()
+                self._client_kwargs.update(prior_client_kwargs)
+                return False
         # Rebind the pool entry id to the adopted key, or the next 429 quarantines the wrong credential.
         try:
             from agent.agent_runtime_helpers import sync_credential_pool_entry_id
@@ -722,6 +728,9 @@ class ClientLifecycleMixin:
         return ok
 
     def _apply_copilot_token(self, token: str, enterprise_base_url: Any, *, reason: str) -> bool:
+        from agent.runtime_bundle import ResolvedRuntime
+        if isinstance(getattr(self, "_resolved_runtime", None), ResolvedRuntime):
+            return self._adopt_openai_credentials(token, enterprise_base_url or self.base_url, reason=reason)
         self.api_key = token
         if enterprise_base_url:
             self.base_url = enterprise_base_url.rstrip("/")
@@ -811,16 +820,30 @@ class ClientLifecycleMixin:
         new_token = new_token.strip() if isinstance(new_token, str) else ""
         if not new_token or new_token == self._anthropic_api_key:
             return False
-        with suppress(Exception):
-            self._anthropic_client.close()
         try:
             base_url = getattr(self, "_anthropic_base_url", None)
-            self._anthropic_client = self._build_direct_anthropic_client(new_token, base_url)
+            self._install_runtime_credentials(new_token, base_url, reason="credential_refresh")
         except Exception as exc:
             logger.warning("Failed to rebuild Anthropic client after credential refresh: %s", exc)
             return False
-        self._anthropic_api_key, self._is_anthropic_oauth = new_token, self._anthropic_oauth_flag(new_token)
         return True
+
+    def _install_runtime_credentials(self, token, base_url, *, reason):
+        from agent.runtime_bundle import ResolvedRuntime, build_client_bundle
+        from agent.runtime_routes import runtime_for_endpoint
+        resolved = getattr(self, "_resolved_runtime", None)
+        if not isinstance(resolved, ResolvedRuntime):
+            resolved = ResolvedRuntime.from_mapping({
+                "provider": self.provider, "model": self.model, "api_mode": self.api_mode,
+                "api_key": getattr(self, "api_key", ""), "base_url": self.base_url,
+                "timeout": get_provider_request_timeout(self.provider, self.model),
+            })
+        runtime = runtime_for_endpoint(resolved.with_updates(api_key=token), base_url)
+        bundle = build_client_bundle(
+            runtime, drop_context_1m_beta=bool(getattr(self, "_oauth_1m_beta_disabled", False)),
+            openai_builder=lambda kwargs: self._create_openai_client(kwargs, reason=reason, shared=True, runtime=runtime),
+        )
+        self.install_runtime(bundle, reason=reason)
 
     # ------------------------------------------------------------------ route-derived client config
     def _apply_client_headers_for_base_url(self, base_url: str, *, apply_user_headers: bool = True) -> None:
@@ -861,18 +884,18 @@ class ClientLifecycleMixin:
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
-        self._credential_pool_entry_id = getattr(entry, "id", None)
         from hermes_cli.route_identity import normalize_route_base_url
         route_changed = normalize_route_base_url(self.base_url) != normalize_route_base_url(runtime_base)
         stripped_base = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
-        if self.api_mode == "anthropic_messages":
-            with suppress(Exception):
-                self._anthropic_client.close()
-            self._anthropic_api_key, self._anthropic_base_url = runtime_key, stripped_base
-            self._anthropic_client = self._build_direct_anthropic_client(runtime_key, self._anthropic_base_url)
-            self._is_anthropic_oauth = self._anthropic_oauth_flag(runtime_key)
-            self.api_key, self.base_url = runtime_key, stripped_base
+        from agent.runtime_bundle import ResolvedRuntime
+        resolved = getattr(self, "_resolved_runtime", None)
+        if self.api_mode == "anthropic_messages" or (
+            isinstance(resolved, ResolvedRuntime) and self.provider not in {"bedrock", "moa"}
+        ):
+            self._install_runtime_credentials(runtime_key, stripped_base, reason="credential_rotation")
+            self._credential_pool_entry_id = getattr(entry, "id", None)
             return
+        self._credential_pool_entry_id = getattr(entry, "id", None)
         self.api_key, self.base_url = runtime_key, stripped_base
         # Inlined (not _sync_client_kwargs_credentials): tests call this unbound on a SimpleNamespace agent.
         self._client_kwargs["api_key"] = self.api_key
@@ -913,4 +936,7 @@ class ClientLifecycleMixin:
 
     def _rebuild_anthropic_client(self) -> None:
         """Rebuild the Anthropic client after an interrupt/stale call (Bedrock SDK for bedrock; honors 1M-beta flag)."""
-        self._anthropic_client = self._build_anthropic_client_for_key(self._request_anthropic_client_key())
+        if self.provider == "bedrock":
+            self._anthropic_client = self._build_anthropic_client_for_key(self._request_anthropic_client_key())
+        else:
+            self._install_runtime_credentials(self._anthropic_api_key, self._anthropic_base_url, reason="rebuild")

--- a/agent/runtime_bundle.py
+++ b/agent/runtime_bundle.py
@@ -1,0 +1,250 @@
+"""Immutable provider runtimes and complete wire-client bundles.
+
+Provider resolution, client construction, and installation are deliberately
+separate operations.  A runtime carries the full transport contract so a
+fallback, credential rotation, or model switch cannot silently rebuild a
+client from only ``api_key`` and ``base_url``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Callable, Optional
+
+
+class _FrozenList(tuple):
+    """Tuple-backed list value that keeps legacy list equality useful in tests."""
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (list, tuple)):
+            return tuple(self) == tuple(other)
+        return NotImplemented
+
+
+def _freeze(value: Any) -> Any:
+    """Freeze JSON-like containers while leaving SDK/client objects opaque."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return _FrozenList(_freeze(item) for item in value)
+    if isinstance(value, tuple):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_freeze(item) for item in value)
+    return value
+
+
+_CORE_FIELDS = frozenset({
+    "provider", "model", "api_mode", "api_key", "base_url",
+    "requested_provider", "source", "extra_headers", "ssl_ca_cert", "ssl_verify",
+})
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class ResolvedRuntime(Mapping[str, Any]):
+    """Immutable, mapping-compatible result of provider resolution.
+
+    Mapping compatibility lets the current facade migrate incrementally.  All
+    values are frozen where they are configuration containers, and unknown
+    resolver fields are retained in ``metadata`` rather than discarded.
+    """
+
+    provider: str
+    model: str = ""
+    api_mode: str = "chat_completions"
+    api_key: Any = ""
+    base_url: str = ""
+    requested_provider: str = ""
+    source: str = ""
+    extra_headers: Mapping[str, str] = field(default_factory=lambda: MappingProxyType({}))
+    ssl_ca_cert: Optional[str] = None
+    ssl_verify: Optional[bool] = None
+    metadata: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}), repr=False)
+    _keys: tuple[str, ...] = field(default=(), repr=False)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any] | "ResolvedRuntime") -> "ResolvedRuntime":
+        if isinstance(value, cls):
+            return value
+        raw = dict(value)
+        headers = raw.get("extra_headers")
+        frozen_headers = _freeze(headers) if isinstance(headers, Mapping) else MappingProxyType({})
+        metadata = MappingProxyType({
+            key: _freeze(item) for key, item in raw.items() if key not in _CORE_FIELDS
+        })
+        ssl_ca_cert = raw.get("ssl_ca_cert")
+        if not isinstance(ssl_ca_cert, str) or not ssl_ca_cert.strip():
+            ssl_ca_cert = None
+        ssl_verify = raw.get("ssl_verify")
+        if not isinstance(ssl_verify, bool):
+            ssl_verify = None
+        return cls(
+            provider=str(raw.get("provider") or ""),
+            model=str(raw.get("model") or ""),
+            api_mode=str(raw.get("api_mode") or "chat_completions"),
+            api_key=raw.get("api_key", ""),
+            base_url=str(raw.get("base_url") or ""),
+            requested_provider=str(raw.get("requested_provider") or ""),
+            source=str(raw.get("source") or ""),
+            extra_headers=frozen_headers,
+            ssl_ca_cert=ssl_ca_cert,
+            ssl_verify=ssl_verify,
+            metadata=metadata,
+            _keys=tuple(raw.keys()),
+        )
+
+    def __getitem__(self, key: str) -> Any:
+        if key not in self._keys:
+            raise KeyError(key)
+        if key in _CORE_FIELDS:
+            return getattr(self, key)
+        return self.metadata[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._keys)
+
+    def __len__(self) -> int:
+        return len(self._keys)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        return dict(self.items()) == dict(other.items())
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a mutable compatibility copy for legacy callers."""
+        return dict(self.items())
+
+    def with_updates(self, **updates: Any) -> "ResolvedRuntime":
+        raw = self.as_dict()
+        raw.update(updates)
+        return type(self).from_mapping(raw)
+
+
+@dataclass(frozen=True, slots=True)
+class ClientBundle:
+    """A completely built client pair plus the immutable runtime that built it."""
+
+    runtime: ResolvedRuntime
+    client: Any = None
+    anthropic_client: Any = None
+    client_kwargs: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    anthropic_api_key: Any = ""
+    anthropic_base_url: str = ""
+    is_anthropic_oauth: bool = False
+
+    @property
+    def active_client(self) -> Any:
+        return self.anthropic_client if self.anthropic_client is not None else self.client
+
+
+class RuntimeWireNotMigratedError(NotImplementedError):
+    """A valid runtime whose special wire remains on its dedicated builder."""
+
+
+OpenAIBuilder = Callable[[dict[str, Any]], Any]
+AnthropicBuilder = Callable[..., Any]
+
+
+def _default_openai_builder(client_kwargs: dict[str, Any]) -> Any:
+    from openai import OpenAI
+
+    return OpenAI(**client_kwargs)
+
+
+def build_client_bundle(
+    runtime: Mapping[str, Any] | ResolvedRuntime,
+    *,
+    openai_builder: Optional[OpenAIBuilder] = None,
+    anthropic_builder: Optional[AnthropicBuilder] = None,
+    timeout: Optional[float] = None,
+) -> ClientBundle:
+    """Build a wire client without mutating an agent.
+
+    ``extra_headers`` is merged after declared/default headers because it is
+    the provider-entry-specific layer.  TLS, query, command, and argument
+    fields stay attached to the same bundle as credentials and endpoint.
+    """
+    resolved = ResolvedRuntime.from_mapping(runtime)
+    provider = resolved.provider.strip().lower()
+    api_mode = resolved.api_mode.strip().lower()
+    if provider in {"bedrock", "moa"} or api_mode == "bedrock_converse":
+        raise RuntimeWireNotMigratedError(
+            f"{provider or api_mode} still uses its dedicated runtime builder"
+        )
+
+    effective_timeout = timeout
+    if effective_timeout is None:
+        raw_timeout = resolved.get("timeout")
+        if isinstance(raw_timeout, (int, float)) and not isinstance(raw_timeout, bool):
+            effective_timeout = float(raw_timeout)
+
+    declared_headers = resolved.get("default_headers")
+    headers = dict(declared_headers) if isinstance(declared_headers, Mapping) else {}
+    headers.update(resolved.extra_headers)
+
+    if api_mode == "anthropic_messages":
+        if anthropic_builder is None:
+            from agent.anthropic_adapter import build_anthropic_client
+
+            anthropic_builder = build_anthropic_client
+        assert anthropic_builder is not None
+        client = anthropic_builder(
+            resolved.api_key,
+            resolved.base_url or None,
+            timeout=effective_timeout,
+            default_headers=headers or None,
+        )
+        is_oauth = False
+        if provider == "anthropic" and isinstance(resolved.api_key, str):
+            from agent.anthropic_credentials import _is_oauth_token
+
+            is_oauth = _is_oauth_token(resolved.api_key)
+        return ClientBundle(
+            runtime=resolved,
+            anthropic_client=client,
+            anthropic_api_key=resolved.api_key,
+            anthropic_base_url=resolved.base_url,
+            is_anthropic_oauth=is_oauth,
+        )
+
+    prior_kwargs = resolved.get("client_kwargs")
+    client_kwargs: dict[str, Any] = (
+        dict(prior_kwargs) if isinstance(prior_kwargs, Mapping) else {}
+    )
+    client_kwargs["api_key"] = resolved.api_key
+    client_kwargs["base_url"] = resolved.base_url
+    if headers:
+        client_kwargs["default_headers"] = headers
+    if effective_timeout is not None:
+        client_kwargs["timeout"] = effective_timeout
+    if resolved.ssl_ca_cert:
+        client_kwargs["ssl_ca_cert"] = resolved.ssl_ca_cert
+    if resolved.ssl_verify is not None:
+        client_kwargs["ssl_verify"] = resolved.ssl_verify
+    default_query = resolved.get("default_query")
+    if isinstance(default_query, Mapping) and default_query:
+        client_kwargs["default_query"] = dict(default_query)
+    command = resolved.get("command")
+    if isinstance(command, str) and command:
+        client_kwargs["command"] = command
+    args = resolved.get("args")
+    if isinstance(args, (list, tuple)):
+        client_kwargs["args"] = list(args)
+
+    client = (openai_builder or _default_openai_builder)(dict(client_kwargs))
+    return ClientBundle(
+        runtime=resolved,
+        client=client,
+        client_kwargs=MappingProxyType(dict(client_kwargs)),
+    )
+
+
+__all__ = [
+    "ClientBundle",
+    "ResolvedRuntime",
+    "RuntimeWireNotMigratedError",
+    "build_client_bundle",
+]

--- a/agent/runtime_bundle.py
+++ b/agent/runtime_bundle.py
@@ -36,6 +36,19 @@ def _freeze(value: Any) -> Any:
     return value
 
 
+def mutable_config_copy(value: Any) -> Any:
+    """Copy configuration containers, including frozen ones, without copying SDK objects."""
+    if isinstance(value, Mapping):
+        return {key: mutable_config_copy(item) for key, item in value.items()}
+    if isinstance(value, (list, _FrozenList)):
+        return [mutable_config_copy(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(mutable_config_copy(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return {mutable_config_copy(item) for item in value}
+    return value
+
+
 _CORE_FIELDS = frozenset({
     "provider", "model", "api_mode", "api_key", "base_url",
     "requested_provider", "source", "extra_headers", "ssl_ca_cert", "ssl_verify",
@@ -115,7 +128,7 @@ class ResolvedRuntime(Mapping[str, Any]):
 
     def as_dict(self) -> dict[str, Any]:
         """Return a mutable compatibility copy for legacy callers."""
-        return dict(self.items())
+        return mutable_config_copy(self)
 
     def with_updates(self, **updates: Any) -> "ResolvedRuntime":
         raw = self.as_dict()
@@ -150,8 +163,16 @@ AnthropicBuilder = Callable[..., Any]
 
 def _default_openai_builder(client_kwargs: dict[str, Any]) -> Any:
     from openai import OpenAI
-
-    return OpenAI(**client_kwargs)
+    from agent.process_bootstrap import build_keepalive_http_client
+    from agent.ssl_verify import resolve_httpx_verify
+    kwargs = mutable_config_copy(client_kwargs)
+    ca = kwargs.pop("ssl_ca_cert", None)
+    verify = kwargs.pop("ssl_verify", None)
+    kwargs["http_client"] = build_keepalive_http_client(
+        kwargs.get("base_url", ""), verify=resolve_httpx_verify(ca_bundle=ca, ssl_verify=verify),
+    )
+    kwargs.setdefault("max_retries", 0)
+    return OpenAI(**kwargs)
 
 
 def build_client_bundle(
@@ -160,6 +181,7 @@ def build_client_bundle(
     openai_builder: Optional[OpenAIBuilder] = None,
     anthropic_builder: Optional[AnthropicBuilder] = None,
     timeout: Optional[float] = None,
+    drop_context_1m_beta: bool = False,
 ) -> ClientBundle:
     """Build a wire client without mutating an agent.
 
@@ -180,6 +202,8 @@ def build_client_bundle(
         raw_timeout = resolved.get("timeout")
         if isinstance(raw_timeout, (int, float)) and not isinstance(raw_timeout, bool):
             effective_timeout = float(raw_timeout)
+    if effective_timeout is not None:
+        resolved = resolved.with_updates(timeout=effective_timeout)
 
     declared_headers = resolved.get("default_headers")
     headers = dict(declared_headers) if isinstance(declared_headers, Mapping) else {}
@@ -191,11 +215,18 @@ def build_client_bundle(
 
             anthropic_builder = build_anthropic_client
         assert anthropic_builder is not None
+        transport = {}
+        for key in ("ssl_ca_cert", "ssl_verify", "default_query"):
+            if resolved.get(key) is not None:
+                transport[key] = mutable_config_copy(resolved[key])
+        if drop_context_1m_beta:
+            transport["drop_context_1m_beta"] = True
         client = anthropic_builder(
             resolved.api_key,
             resolved.base_url or None,
             timeout=effective_timeout,
             default_headers=headers or None,
+            **transport,
         )
         is_oauth = False
         if provider == "anthropic" and isinstance(resolved.api_key, str):
@@ -210,14 +241,34 @@ def build_client_bundle(
             is_anthropic_oauth=is_oauth,
         )
 
+    client_kwargs = openai_client_kwargs(resolved, timeout=effective_timeout)
+    resolved = resolved.with_updates(base_url=client_kwargs["base_url"])
+    if "default_query" in client_kwargs:
+        resolved = resolved.with_updates(default_query=client_kwargs["default_query"])
+    client = (openai_builder or _default_openai_builder)(mutable_config_copy(client_kwargs))
+    return ClientBundle(
+        runtime=resolved,
+        client=client,
+        client_kwargs=_freeze(client_kwargs),
+    )
+
+
+def openai_client_kwargs(runtime: Mapping[str, Any], *, timeout=None) -> dict[str, Any]:
+    """Project transport configuration without carrying another client's owned HTTP handle."""
+    resolved = ResolvedRuntime.from_mapping(runtime)
     prior_kwargs = resolved.get("client_kwargs")
     client_kwargs: dict[str, Any] = (
-        dict(prior_kwargs) if isinstance(prior_kwargs, Mapping) else {}
+        mutable_config_copy(prior_kwargs) if isinstance(prior_kwargs, Mapping) else {}
     )
+    client_kwargs.pop("http_client", None)
     client_kwargs["api_key"] = resolved.api_key
     client_kwargs["base_url"] = resolved.base_url
+    headers = dict(client_kwargs.get("default_headers") or {})
+    headers.update(resolved.get("default_headers") or {})
+    headers.update(resolved.extra_headers)
     if headers:
         client_kwargs["default_headers"] = headers
+    effective_timeout = timeout if timeout is not None else resolved.get("timeout")
     if effective_timeout is not None:
         client_kwargs["timeout"] = effective_timeout
     if resolved.ssl_ca_cert:
@@ -227,19 +278,19 @@ def build_client_bundle(
     default_query = resolved.get("default_query")
     if isinstance(default_query, Mapping) and default_query:
         client_kwargs["default_query"] = dict(default_query)
+    from urllib.parse import parse_qsl, urlsplit, urlunsplit
+    parts = urlsplit(resolved.base_url)
+    if parts.query:
+        client_kwargs["base_url"] = urlunsplit(parts._replace(query=""))
+        client_kwargs["default_query"] = {**dict(parse_qsl(parts.query)), **client_kwargs.get("default_query", {})}
     command = resolved.get("command")
     if isinstance(command, str) and command:
         client_kwargs["command"] = command
     args = resolved.get("args")
-    if isinstance(args, (list, tuple)):
+    if isinstance(args, (list, tuple)) and (command or resolved.base_url.startswith("acp://")):
         client_kwargs["args"] = list(args)
 
-    client = (openai_builder or _default_openai_builder)(dict(client_kwargs))
-    return ClientBundle(
-        runtime=resolved,
-        client=client,
-        client_kwargs=MappingProxyType(dict(client_kwargs)),
-    )
+    return client_kwargs
 
 
 __all__ = [
@@ -247,4 +298,6 @@ __all__ = [
     "ResolvedRuntime",
     "RuntimeWireNotMigratedError",
     "build_client_bundle",
+    "mutable_config_copy",
+    "openai_client_kwargs",
 ]

--- a/agent/runtime_routes.py
+++ b/agent/runtime_routes.py
@@ -1,0 +1,81 @@
+"""Preserve resolved route data across client and agent ownership boundaries."""
+
+from collections.abc import Mapping
+
+from agent.runtime_bundle import ResolvedRuntime, mutable_config_copy
+
+
+def record_client_runtime(client, **fields):
+    """Attach construction data for later fallback adoption, never an owned HTTP client."""
+    fields.pop("http_client", None)
+    client._hermes_resolved_runtime = ResolvedRuntime.from_mapping(fields)
+    return client
+
+
+def runtime_for_endpoint(runtime, base_url):
+    """Keep same-route settings; resolve only destination settings after an endpoint change."""
+    from hermes_cli.route_identity import normalize_route_base_url
+
+    raw = mutable_config_copy(runtime) if isinstance(runtime, Mapping) else {}
+    if raw and normalize_route_base_url(raw.get("base_url")) == normalize_route_base_url(base_url):
+        return ResolvedRuntime.from_mapping(raw).with_updates(base_url=base_url or "")
+    for key in ("extra_headers", "default_headers", "default_query", "ssl_ca_cert", "ssl_verify", "client_kwargs"):
+        raw.pop(key, None)
+    from agent.agent_init import _host_default_headers_factory
+    from providers import get_provider_profile
+    build_headers = _host_default_headers_factory(base_url or "")
+    profile = get_provider_profile(raw.get("provider", ""))
+    if build_headers is not None:
+        raw["default_headers"] = build_headers(raw.get("api_key", ""), base_url or "")
+    elif profile and profile.default_headers:
+        raw["default_headers"] = dict(profile.default_headers)
+    from hermes_cli.config import (
+        apply_custom_provider_tls_to_client_kwargs, get_compatible_custom_providers,
+        get_custom_provider_extra_headers, load_config_readonly,
+    )
+    cfg = load_config_readonly()
+    entries = get_compatible_custom_providers(cfg)
+    apply_custom_provider_tls_to_client_kwargs(raw, base_url or "", entries, config=cfg)
+    raw["extra_headers"] = get_custom_provider_extra_headers(base_url or "", entries, config=cfg)
+    raw["base_url"] = base_url or ""
+    return ResolvedRuntime.from_mapping(raw)
+
+
+def runtime_from_client(client, *, provider, model, api_mode, base_url):
+    """Recover the exact builder snapshot; legacy SDK clients expose a smaller transport contract."""
+    wire = getattr(client, "_real_client", None)
+    resolved = getattr(client, "_hermes_resolved_runtime", None)
+    if not isinstance(resolved, ResolvedRuntime):
+        resolved = getattr(wire, "_hermes_resolved_runtime", None)
+    raw = resolved.as_dict() if isinstance(resolved, ResolvedRuntime) else {}
+    for key in ("default_query", "timeout", "ssl_ca_cert", "ssl_verify"):
+        value = getattr(client, key, None)
+        if key not in raw and isinstance(value, (Mapping, str, int, float, bool)):
+            raw[key] = mutable_config_copy(value)
+    if "default_headers" not in raw:
+        headers = getattr(client, "_custom_headers", None)
+        if isinstance(headers, Mapping):
+            raw["default_headers"] = mutable_config_copy(headers)
+    headers = getattr(client, "_hermes_runtime_extra_headers", None)
+    if isinstance(headers, Mapping) and headers:
+        raw["extra_headers"] = mutable_config_copy(headers)
+    raw.update(provider=provider, model=model, api_mode=api_mode, base_url=base_url,
+               api_key=getattr(client, "api_key", raw.get("api_key", "")))
+    raw.setdefault("requested_provider", provider)
+    return ResolvedRuntime.from_mapping(raw)
+
+
+def build_resolved_agent_client(agent, runtime):
+    """Build a fresh owned client from a resolved input, without resolving ambient credentials."""
+    from agent.runtime_bundle import build_client_bundle
+    runtime = ResolvedRuntime.from_mapping(runtime).with_updates(
+        provider=agent.provider, model=agent.model, api_mode=agent.api_mode,
+        requested_provider=agent.requested_provider,
+    )
+    bundle = build_client_bundle(
+        runtime,
+        openai_builder=lambda kwargs: agent._create_openai_client(
+            kwargs, reason="agent_init", shared=True, runtime=runtime,
+        ),
+    )
+    agent.install_runtime(bundle, reason="agent_init")

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -312,7 +312,8 @@ class CLIAgentSetupMixin:
                 explicit_base_url=self._explicit_base_url)
         except Exception:
             return False
-        if not isinstance(runtime, dict):
+        from collections.abc import Mapping
+        if not isinstance(runtime, Mapping):
             return False
         api_key = runtime.get("api_key")
         base_url = runtime.get("base_url")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
+from agent.runtime_bundle import ResolvedRuntime
+
 logger = logging.getLogger(__name__)
 
 from hermes_cli import auth as auth_mod
@@ -810,8 +812,8 @@ def _opencode_free_runtime(provider, requested_provider, model_cfg, target_model
     return _tag(_models.opencode_zen_free_runtime(provider, model), requested_provider)
 
 
-def resolve_runtime_provider(*, requested: Optional[str] = None, explicit_api_key: Optional[str] = None,
-                             explicit_base_url: Optional[str] = None, target_model: Optional[str] = None) -> Dict[str, Any]:
+def _resolve_runtime_provider_mapping(*, requested: Optional[str] = None, explicit_api_key: Optional[str] = None,
+                                      explicit_base_url: Optional[str] = None, target_model: Optional[str] = None) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution. Ladder (order is behavior — each
     rung returns or raises, else falls to the next):
       1. disabled-provider guard (``providers.<name>.enabled: false``)
@@ -828,6 +830,24 @@ def resolve_runtime_provider(*, requested: Optional[str] = None, explicit_api_ke
     requested_provider = resolve_requested_provider(requested)
     _raise_if_provider_disabled(requested_provider)
     return next(r for r in _ladder_rungs(requested_provider, explicit_api_key, explicit_base_url, target_model) if r)
+
+
+def resolve_runtime_provider(*, requested: Optional[str] = None, explicit_api_key: Optional[str] = None,
+                             explicit_base_url: Optional[str] = None, target_model: Optional[str] = None) -> ResolvedRuntime:
+    """Resolve provider configuration into an immutable runtime value.
+
+    The internal ladder remains mutable while it enriches a result.  The
+    public boundary freezes the complete credential, endpoint, header, and
+    transport contract before another subsystem can consume it.
+    """
+    return ResolvedRuntime.from_mapping(
+        _resolve_runtime_provider_mapping(
+            requested=requested,
+            explicit_api_key=explicit_api_key,
+            explicit_base_url=explicit_base_url,
+            target_model=target_model,
+        )
+    )
 
 
 def _ladder_rungs(requested_provider, explicit_api_key, explicit_base_url, target_model):

--- a/hermes_cli/runtime_provider_custom.py
+++ b/hermes_cli/runtime_provider_custom.py
@@ -91,6 +91,13 @@ def _lift_common_custom_fields(entry: Dict[str, Any], result: Dict[str, Any], *,
     if isinstance(extra_body, dict):
         result["extra_body"] = dict(extra_body)
     _lift_extra_headers(entry, result)
+    from hermes_cli.config import _coerce_ssl_verify
+    ca = entry.get("ssl_ca_cert")
+    if isinstance(ca, str) and ca.strip():
+        result["ssl_ca_cert"] = ca.strip()
+    verify = _coerce_ssl_verify(entry.get("ssl_verify"))
+    if verify is not None:
+        result["ssl_verify"] = verify
     if api_mode:
         result["api_mode"] = api_mode
     _lift_max_output_tokens(entry, result)
@@ -380,6 +387,9 @@ def _apply_custom_provider_extras(custom_provider: Dict[str, Any], target_model:
         result["max_output_tokens"] = custom_provider["max_output_tokens"]
     if custom_provider.get("extra_headers"):
         result["extra_headers"] = dict(custom_provider["extra_headers"])
+    for key in ("ssl_ca_cert", "ssl_verify"):
+        if key in custom_provider:
+            result[key] = custom_provider[key]
     request_overrides = _custom_provider_request_overrides(custom_provider)
     if request_overrides:
         result["request_overrides"] = {**(result.get("request_overrides") or {}), **request_overrides}

--- a/run_agent.py
+++ b/run_agent.py
@@ -270,6 +270,7 @@ class AIAgent(
         checkpoint_max_total_size_mb: int = 500, checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False, requested_provider: str = None,
         capabilities: Dict[str, bool] | None = None,
+        resolved_runtime=None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent`` (same keyword parameters, minus ``tool_delay``)."""
         init_kwargs = {k: v for k, v in locals().items() if k not in ("self", "tool_delay")}

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -319,9 +319,9 @@ class TestMoaAggregatorSharedResolution:
         import yaml
 
         home = self._write_moa_config(tmp_path, monkeypatch)
-        cfg = yaml.safe_load((home / "config.yaml").read_text())
+        cfg = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
         cfg["auxiliary"] = {"title_generation": {"provider": "moa", "model": "opus-gpt"}}
-        (home / "config.yaml").write_text(yaml.safe_dump(cfg))
+        (home / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
 
         resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
             task="title_generation",
@@ -4239,7 +4239,8 @@ class TestCompressionFallbackContextFilter:
 
     # ── L2: configured fallback chain ─────────────────────────────────
 
-    def test_configured_chain_skips_too_small_candidate_for_compression(self, monkeypatch):
+    @pytest.mark.parametrize("entry_timeouts", [(None, None), (10.0, 20.0)])
+    def test_configured_chain_skips_too_small_candidate_for_compression(self, monkeypatch, entry_timeouts):
         """When entry[0] is reachable but too small and entry[1] is large enough,
         _try_configured_fallback_chain must return entry[1], not entry[0]."""
         from agent.auxiliary_client import (
@@ -4252,8 +4253,13 @@ class TestCompressionFallbackContextFilter:
             self._make_chain_entry("small-provider", "tiny-8k"),
             self._make_chain_entry("big-provider", "huge-1m"),
         ]
+        for entry, timeout in zip(entries, entry_timeouts):
+            if timeout is not None:
+                entry["timeout"] = timeout
+        resolved_timeouts = []
 
-        def fake_resolve(entry):
+        def fake_resolve(entry, *, timeout):
+            resolved_timeouts.append(timeout)
             if entry is entries[0]:
                 return small_client, "tiny-8k"
             return large_client, "huge-1m"
@@ -4280,6 +4286,7 @@ class TestCompressionFallbackContextFilter:
             "screening by context window.")
         assert model == "huge-1m"
         assert "big-provider" in label
+        assert resolved_timeouts == list(entry_timeouts)
 
 
     # ── same-provider, different-model chain entries ────────────────────
@@ -4577,13 +4584,17 @@ class TestSynchronousFallbackCachePlans:
         )
         return client, resolved_calls, tools
 
-    def test_direct_anthropic_fallback_uses_entry_destination_for_tool_marker(self, monkeypatch):
-        client, resolved_calls, tools = self._run_configured_fallback(monkeypatch, {
+    @pytest.mark.parametrize("entry_timeout", [None, 20.0])
+    def test_direct_anthropic_fallback_uses_entry_destination_for_tool_marker(self, monkeypatch, entry_timeout):
+        entry = {
             "provider": "anthropic",
             "model": "claude-sonnet-4-6",
             "base_url": "https://api.anthropic.com",
             "api_mode": "anthropic_messages",
-        })
+        }
+        if entry_timeout is not None:
+            entry["timeout"] = entry_timeout
+        client, resolved_calls, tools = self._run_configured_fallback(monkeypatch, entry)
 
         assert resolved_calls == [(
             "anthropic",
@@ -4592,6 +4603,7 @@ class TestSynchronousFallbackCachePlans:
                 "explicit_base_url": "https://api.anthropic.com",
                 "explicit_api_key": None,
                 "api_mode": "anthropic_messages",
+                "timeout": entry_timeout,
             },
         )]
         wire_tools = client.chat.completions.create.call_args.kwargs["tools"]

--- a/tests/agent/test_moa_switch_api_mode.py
+++ b/tests/agent/test_moa_switch_api_mode.py
@@ -16,14 +16,14 @@ same so the primary call always routes through ``MoAClient.chat.completions``.
 
 from __future__ import annotations
 
-import types
-
 import pytest
 
+from run_agent import AIAgent
 
-def _make_fake_agent():
-    """A minimal stand-in carrying only the attributes switch_model touches."""
-    agent = types.SimpleNamespace()
+
+def _make_agent():
+    """Use real lifecycle methods without initializing external clients."""
+    agent = AIAgent.__new__(AIAgent)
     agent.model = "minimax-m3"
     agent.provider = "opencode-go"
     agent.api_mode = "anthropic_messages"
@@ -34,12 +34,14 @@ def _make_fake_agent():
     agent._config_context_length = 123456
     agent._transport_cache = {}
     agent.quiet_mode = True
-    # switch_model re-reads reasoning_echo for the incoming model as part of the
-    # core field swap, before the moa branch runs. On a real AIAgent this is a
-    # method; without it the swap raises and the rollback undoes every field
-    # this test asserts on.
+    agent.context_compressor = None
+    agent._primary_runtime = {}
+    agent._fallback_chain = []
+    agent._anthropic_client = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._is_anthropic_oauth = False
     agent._reasoning_echo_flag = False
-    agent._read_reasoning_echo_from_config = lambda: False
     return agent
 
 
@@ -57,27 +59,17 @@ def test_switch_to_moa_pins_chat_completions(monkeypatch, incoming_api_mode):
     """
     from agent import agent_runtime_helpers as arh
 
-    # Neutralize the post-swap machinery that needs a real AIAgent (credential
-    # pool reload, context-compressor refresh, primary-runtime bookkeeping).
-    # We only assert the api_mode invariant set in the moa client-build branch.
-    monkeypatch.setattr(arh, "load_pool", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda *a, **k: None)
 
-    agent = _make_fake_agent()
-    try:
-        arh.switch_model(
-            agent,
-            new_model="frontier",
-            new_provider="moa",
-            api_key="moa-virtual-provider",
-            base_url="moa://local",
-            api_mode=incoming_api_mode,
-        )
-    except Exception:
-        # switch_model does post-swap work (compressor, pool, runtime) that may
-        # raise against a fake agent. The runtime-field swap — including the
-        # api_mode pin in the moa branch — happens before any of that, so the
-        # invariant we care about is already set even if a later step blew up.
-        pass
+    agent = _make_agent()
+    arh.switch_model(
+        agent,
+        new_model="frontier",
+        new_provider="moa",
+        api_key="moa-virtual-provider",
+        base_url="moa://local",
+        api_mode=incoming_api_mode,
+    )
 
     assert agent.provider == "moa"
     assert agent.base_url == "moa://local"
@@ -88,3 +80,7 @@ def test_switch_to_moa_pins_chat_completions(monkeypatch, incoming_api_mode):
     )
     # The MoAClient facade should be installed as the client.
     assert type(agent.client).__name__ == "MoAClient"
+    assert agent._resolved_runtime.provider == "moa"
+    assert agent._resolved_runtime.model == "frontier"
+    assert agent._resolved_runtime.api_mode == "chat_completions"
+    assert agent._primary_runtime["api_mode"] == "chat_completions"

--- a/tests/agent/test_runtime_boundary_preservation.py
+++ b/tests/agent/test_runtime_boundary_preservation.py
@@ -1,0 +1,111 @@
+"""Runtime configuration survives request ownership, fallback and rotation."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.client_lifecycle import ClientLifecycleMixin
+from agent.runtime_bundle import ResolvedRuntime, build_client_bundle
+
+
+class Agent(ClientLifecycleMixin):
+    def _try_refresh_anthropic_client_credentials(self):
+        return False
+
+
+def runtime(**updates):
+    return ResolvedRuntime.from_mapping({
+        "provider": "custom", "model": "model", "api_mode": "anthropic_messages",
+        "api_key": "old-key", "base_url": "https://route.invalid/v1",
+        "extra_headers": {"X-Route": "one"}, "default_query": {"route": "one"},
+        "timeout": 23, "ssl_ca_cert": "route.pem", **updates,
+    })
+
+
+@pytest.fixture
+def wire(monkeypatch):
+    def build(api_key, base_url, **kwargs):
+        return SimpleNamespace(api_key=api_key, base_url=base_url, kwargs=kwargs, close=lambda: None)
+    monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_client", build)
+    return build
+
+
+def test_request_client_and_reuse_key_preserve_complete_runtime(wire):
+    rt = runtime()
+    agent = Agent()
+    agent.install_runtime(build_client_bundle(rt))
+    request = agent._create_request_anthropic_client(reason="test")
+    assert request.kwargs["default_headers"]["X-Route"] == "one"
+    assert request.kwargs["default_query"] == {"route": "one"}
+    assert request.kwargs["ssl_ca_cert"] == "route.pem"
+    assert request.kwargs["timeout"] == 23
+    agent._close_request_anthropic_client(request, reason="request_complete")
+    old_key = agent._request_anthropic_client_key()
+    agent._resolved_runtime = rt.with_updates(extra_headers={"X-Route": "two"})
+    assert agent._request_anthropic_client_key() != old_key
+    replacement = agent._create_request_anthropic_client(reason="test")
+    assert replacement is not request
+    assert replacement.kwargs["default_headers"]["X-Route"] == "two"
+    assert rt.extra_headers["X-Route"] == "one"
+
+
+def test_rotation_preserves_runtime_and_build_failure_is_atomic(wire, monkeypatch):
+    agent = Agent()
+    agent.install_runtime(build_client_bundle(runtime()))
+    entry = SimpleNamespace(id="second", runtime_api_key="new-key", runtime_base_url=agent.base_url)
+    agent._swap_credential(entry)
+    assert agent._resolved_runtime.api_key == agent.api_key == "new-key"
+    assert agent._anthropic_client.kwargs["default_headers"]["X-Route"] == "one"
+    assert agent._anthropic_client.kwargs["default_query"] == {"route": "one"}
+    installed = agent._resolved_runtime
+    old_client = agent._anthropic_client
+    def fail(*args, **kwargs):
+        raise RuntimeError("build failed")
+    monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_client", fail)
+    entry.id, entry.runtime_api_key = "third", "bad-key"
+    with pytest.raises(RuntimeError, match="build failed"):
+        agent._swap_credential(entry)
+    assert agent._resolved_runtime is installed
+    assert agent._anthropic_client is old_client
+    assert agent.api_key == "new-key"
+    assert agent._credential_pool_entry_id == "second"
+
+
+def test_fallback_rebuild_keeps_resolver_runtime():
+    from agent.chat_completion_helpers import _swap_fallback_clients
+    rt = runtime(api_mode="chat_completions")
+    client = SimpleNamespace(
+        api_key=rt.api_key, base_url=rt.base_url, _hermes_resolved_runtime=rt,
+        _custom_headers=dict(rt.extra_headers), default_query={"route": "one"},
+        timeout=23, ssl_ca_cert="route.pem",
+    )
+    agent = Agent()
+    _swap_fallback_clients(agent, client, rt.provider, rt.model, rt.base_url, rt.api_mode)
+    assert agent.client is client
+    assert agent._resolved_runtime.ssl_ca_cert == rt.ssl_ca_cert
+    assert agent._client_kwargs["ssl_ca_cert"] == rt.ssl_ca_cert
+    assert agent._client_kwargs["default_query"] == {"route": "one"}
+    assert agent._client_kwargs["default_headers"]["X-Route"] == "one"
+    assert agent._client_kwargs["timeout"] == 23
+
+
+@pytest.mark.parametrize("api_mode", ["chat_completions", "anthropic_messages"])
+def test_endpoint_rotation_does_not_leak_previous_route_settings(wire, monkeypatch, api_mode):
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {"custom_providers": [{
+        "name": "next", "base_url": "https://next.invalid/v1", "extra_headers": {"X-Next": "next"},
+    }]})
+    agent = Agent()
+    agent._create_openai_client = lambda kwargs, **kw: SimpleNamespace(kwargs=kwargs, close=lambda: None)
+    rt = runtime(api_mode=api_mode, extra_headers={"X-Secret": "old-route-secret"})
+    agent.install_runtime(build_client_bundle(rt, openai_builder=lambda kwargs: agent._create_openai_client(kwargs)))
+    agent._swap_credential(SimpleNamespace(id="next", runtime_api_key="next-key", runtime_base_url="https://next.invalid/v1"))
+    resolved = agent._resolved_runtime
+    assert resolved.api_key == "next-key"
+    assert resolved.base_url == "https://next.invalid/v1"
+    assert resolved.extra_headers == {"X-Next": "next"}
+    assert resolved.ssl_ca_cert is None
+    assert not resolved.get("default_query")
+    client = agent._anthropic_client if api_mode == "anthropic_messages" else agent.client
+    assert client.kwargs["default_headers"] == {"X-Next": "next"}
+    assert "ssl_ca_cert" not in client.kwargs
+    assert not client.kwargs.get("default_query")

--- a/tests/agent/test_runtime_bundle.py
+++ b/tests/agent/test_runtime_bundle.py
@@ -1,0 +1,91 @@
+"""Behavior contracts for immutable runtime resolution and client bundles."""
+
+from types import MappingProxyType
+
+import pytest
+
+from agent.runtime_bundle import ResolvedRuntime, build_client_bundle
+
+
+def test_resolved_runtime_is_immutable_mapping():
+    source = {
+        "provider": "custom",
+        "model": "btc-model",
+        "api_mode": "chat_completions",
+        "api_key": "secret",
+        "base_url": "https://btc.example/v1",
+        "extra_headers": {"CF-Access-Client-Id": "client-id"},
+        "request_overrides": {"extra_body": {"route": "btc"}},
+    }
+
+    runtime = ResolvedRuntime.from_mapping(source)
+    source["extra_headers"]["CF-Access-Client-Id"] = "mutated"
+
+    assert runtime["provider"] == "custom"
+    assert runtime.extra_headers["CF-Access-Client-Id"] == "client-id"
+    assert isinstance(runtime.extra_headers, MappingProxyType)
+    with pytest.raises(TypeError):
+        runtime.extra_headers["new"] = "value"
+    with pytest.raises(TypeError):
+        runtime["request_overrides"]["new"] = "value"
+
+
+def test_openai_wire_bundle_passes_runtime_headers_and_tls_to_builder():
+    observed = {}
+    client = object()
+
+    def builder(kwargs):
+        observed.update(kwargs)
+        return client
+
+    runtime = ResolvedRuntime.from_mapping(
+        {
+            "provider": "custom",
+            "model": "btc-model",
+            "api_mode": "codex_responses",
+            "api_key": "secret",
+            "base_url": "https://btc.example/v1",
+            "default_headers": {
+                "User-Agent": "HermesAgent/test",
+                "CF-Access-Client-Secret": "stale-default",
+            },
+            "extra_headers": {"CF-Access-Client-Secret": "service-secret"},
+            "ssl_verify": False,
+            "default_query": {"api-version": "2026-08-01"},
+        }
+    )
+
+    bundle = build_client_bundle(runtime, openai_builder=builder, timeout=17)
+
+    assert bundle.client is client
+    assert observed["default_headers"]["CF-Access-Client-Secret"] == "service-secret"
+    assert observed["default_headers"]["User-Agent"] == "HermesAgent/test"
+    assert observed["ssl_verify"] is False
+    assert observed["timeout"] == 17
+    assert observed["default_query"] == {"api-version": "2026-08-01"}
+
+
+def test_anthropic_wire_bundle_merges_runtime_headers_through_builder():
+    observed = {}
+    client = object()
+
+    def builder(api_key, base_url, **kwargs):
+        observed.update(api_key=api_key, base_url=base_url, **kwargs)
+        return client
+
+    runtime = ResolvedRuntime.from_mapping(
+        {
+            "provider": "custom",
+            "model": "claude-proxy",
+            "api_mode": "anthropic_messages",
+            "api_key": "secret",
+            "base_url": "https://btc.example/anthropic",
+            "extra_headers": {"CF-Access-Client-Id": "client-id"},
+        }
+    )
+
+    bundle = build_client_bundle(runtime, anthropic_builder=builder, timeout=23)
+
+    assert bundle.anthropic_client is client
+    assert observed["default_headers"]["CF-Access-Client-Id"] == "client-id"
+    assert observed["timeout"] == 23

--- a/tests/agent/test_runtime_bundle.py
+++ b/tests/agent/test_runtime_bundle.py
@@ -89,3 +89,35 @@ def test_anthropic_wire_bundle_merges_runtime_headers_through_builder():
     assert bundle.anthropic_client is client
     assert observed["default_headers"]["CF-Access-Client-Id"] == "client-id"
     assert observed["timeout"] == 23
+
+
+def test_default_openai_factory_uses_owned_tls_client_and_separate_query(monkeypatch):
+    import ssl
+    import certifi
+    import httpx
+
+    clients = []
+    def http_client(base_url, *, verify):
+        assert isinstance(verify, ssl.SSLContext)
+        client = httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(200, json={})))
+        clients.append(client)
+        return client
+    monkeypatch.setattr("agent.process_bootstrap.build_keepalive_http_client", http_client)
+    runtime = ResolvedRuntime.from_mapping({
+        "provider": "custom", "model": "model", "api_key": "test-key",
+        "base_url": "https://route.invalid/v1?version=test", "ssl_ca_cert": certifi.where(),
+        "default_query": {"route": "one"}, "args": [],
+    })
+    first = build_client_bundle(runtime)
+    second = build_client_bundle(runtime)
+    try:
+        assert first.client._client is not second.client._client
+        assert first.runtime.base_url == "https://route.invalid/v1"
+        assert first.client.default_query == {"version": "test", "route": "one"}
+        assert first.runtime["default_query"] == first.client.default_query
+        assert "args" not in first.client_kwargs
+        first.client.close()
+        assert not second.client.is_closed()
+    finally:
+        first.client.close()
+        second.client.close()

--- a/tests/agent/test_runtime_install.py
+++ b/tests/agent/test_runtime_install.py
@@ -1,0 +1,144 @@
+"""Atomic installation contract for a live AIAgent runtime."""
+
+from types import MappingProxyType
+
+import pytest
+
+from agent.runtime_bundle import ClientBundle, ResolvedRuntime, build_client_bundle
+from run_agent import AIAgent
+
+
+class _RecordingLock:
+    def __init__(self, events):
+        self.events = events
+
+    def __enter__(self):
+        self.events.append("lock-enter")
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.events.append("lock-exit")
+
+
+def _bare_agent(events):
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "old-model"
+    agent.provider = "old-provider"
+    agent.requested_provider = "old-provider"
+    agent.base_url = "https://old.example/v1"
+    agent.api_mode = "chat_completions"
+    agent.api_key = "old-key"
+    agent.client = object()
+    agent._anthropic_client = None
+    agent._client_kwargs = {
+        "api_key": "old-key",
+        "base_url": "https://old.example/v1",
+    }
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = ""
+    agent._is_anthropic_oauth = False
+    agent._client_lock = _RecordingLock(events)
+    agent._transport_cache = {"chat_completions": object()}
+    agent._cached_system_prompt = "stable prompt"
+    agent._session_messages = [{"role": "user", "content": "keep me"}]
+    return agent
+
+
+def test_install_runtime_commits_under_lock_then_retires_old_client():
+    events = []
+    agent = _bare_agent(events)
+    old_client = agent.client
+    new_client = object()
+    retired = []
+
+    def _retire(client, *, reason):
+        events.append("retire")
+        retired.append((client, reason))
+
+    agent._retire_shared_openai_client = _retire
+    runtime = ResolvedRuntime.from_mapping(
+        {
+            "provider": "new-provider",
+            "requested_provider": "custom:new-provider",
+            "model": "new-model",
+            "api_mode": "codex_responses",
+            "api_key": "new-key",
+            "base_url": "https://new.example/v1",
+        }
+    )
+    bundle = ClientBundle(
+        runtime=runtime,
+        client=new_client,
+        client_kwargs=MappingProxyType(
+            {
+                "api_key": "new-key",
+                "base_url": "https://new.example/v1",
+                "timeout": 42.0,
+            }
+        ),
+    )
+
+    installed = agent.install_runtime(bundle, reason="test")
+
+    assert installed is runtime
+    assert events == ["lock-enter", "lock-exit", "retire"]
+    assert retired == [(old_client, "install:test")]
+    assert agent.model == "new-model"
+    assert agent.provider == "new-provider"
+    assert agent.requested_provider == "custom:new-provider"
+    assert agent.base_url == "https://new.example/v1"
+    assert agent.api_mode == "codex_responses"
+    assert agent.api_key == "new-key"
+    assert agent.client is new_client
+    assert agent._anthropic_client is None
+    assert agent._client_kwargs["timeout"] == 42.0
+    assert agent._transport_cache == {}
+    assert agent._resolved_runtime is runtime
+    assert agent._cached_system_prompt == "stable prompt"
+    assert agent._session_messages == [{"role": "user", "content": "keep me"}]
+
+
+def test_bundle_build_failure_leaves_live_runtime_untouched():
+    events = []
+    agent = _bare_agent(events)
+    before = {
+        "model": agent.model,
+        "provider": agent.provider,
+        "requested_provider": agent.requested_provider,
+        "base_url": agent.base_url,
+        "api_mode": agent.api_mode,
+        "api_key": agent.api_key,
+        "client": agent.client,
+        "client_kwargs": dict(agent._client_kwargs),
+        "prompt": agent._cached_system_prompt,
+        "messages": agent._session_messages,
+    }
+    runtime = ResolvedRuntime.from_mapping(
+        {
+            "provider": "broken-provider",
+            "model": "broken-model",
+            "api_mode": "chat_completions",
+            "api_key": "broken-key",
+            "base_url": "https://broken.example/v1",
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="build exploded"):
+        build_client_bundle(
+            runtime,
+            openai_builder=lambda _kwargs: (_ for _ in ()).throw(
+                RuntimeError("build exploded")
+            ),
+        )
+
+    assert events == []
+    assert agent.model == before["model"]
+    assert agent.provider == before["provider"]
+    assert agent.requested_provider == before["requested_provider"]
+    assert agent.base_url == before["base_url"]
+    assert agent.api_mode == before["api_mode"]
+    assert agent.api_key == before["api_key"]
+    assert agent.client is before["client"]
+    assert agent._client_kwargs == before["client_kwargs"]
+    assert agent._cached_system_prompt is before["prompt"]
+    assert agent._session_messages is before["messages"]

--- a/tests/run_agent/test_fallback_credential_isolation.py
+++ b/tests/run_agent/test_fallback_credential_isolation.py
@@ -11,7 +11,7 @@ _swap_credential continue operating on the PRIMARY's credential pool during
 fallback calls, contaminating primary state with fallback-provider errors.
 """
 
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -123,6 +123,7 @@ class TestFallbackCredentialIsolation:
     def test_fallback_attaches_matching_pool_after_clear(self):
         """Provider-switch fallback should attach the fallback provider's pool."""
         from agent.chat_completion_helpers import try_activate_fallback
+        from agent.client_lifecycle import ClientLifecycleMixin
 
         agent = _make_agent(
             provider="ollama-cloud",
@@ -138,7 +139,10 @@ class TestFallbackCredentialIsolation:
         agent._provider_model_requires_responses_api.return_value = False
         agent._anthropic_prompt_cache_policy.return_value = (False, False)
         agent._ensure_lmstudio_runtime_loaded = MagicMock()
-        agent._replace_primary_openai_client = MagicMock()
+        # Runtime installation must mutate the agent, not be a no-op Mock.
+        agent.install_runtime = MethodType(ClientLifecycleMixin.install_runtime, agent)
+        agent._client_lock = None
+        agent._openai_client_lock = MethodType(ClientLifecycleMixin._openai_client_lock, agent)
         agent.context_compressor = None
 
         fallback_client = SimpleNamespace(
@@ -166,6 +170,13 @@ class TestFallbackCredentialIsolation:
         assert agent._credential_pool is fallback_pool
         assert agent._credential_pool.provider == "openai-codex"
         assert agent._transport_cache == {}
+        assert agent.client is fallback_client
+        assert agent._resolved_runtime.provider == agent.provider
+        assert agent._resolved_runtime.model == agent.model
+        assert agent._resolved_runtime.api_mode == agent.api_mode
+        assert agent._resolved_runtime.base_url == agent.base_url
+        assert agent._resolved_runtime.api_key == agent.api_key == "codex-key"
+        assert agent._client_kwargs["base_url"] == agent.base_url
 
 
 # ── Test: _recover_with_credential_pool rejects mismatched pool ──────

--- a/tests/test_profile_isolation_runtime.py
+++ b/tests/test_profile_isolation_runtime.py
@@ -107,8 +107,7 @@ class TestRichSentStorePathResolution:
         import gateway.rich_sent_store as rss
 
         b_seen = _under_override(prof_b, lambda: rss._store_path())
-        assert b_seen.startswith(str(prof_b))
-        assert b_seen.endswith("state/rich_sent_index.json")
+        assert Path(b_seen) == prof_b / "state" / "rich_sent_index.json"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate_resolved_runtime.py
+++ b/tests/tools/test_delegate_resolved_runtime.py
@@ -1,0 +1,70 @@
+"""Delegation consumes immutable runtimes without losing route configuration."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.runtime_bundle import ResolvedRuntime
+from tools.delegate_tool_config import _resolve_child_runtime, _resolve_delegation_credentials
+
+
+def runtime(**updates):
+    return ResolvedRuntime.from_mapping({
+        "provider": "custom", "requested_provider": "custom:route",
+        "model": "child-model", "api_mode": "chat_completions",
+        "api_key": "test-key", "base_url": "https://route.invalid/v1",
+        "extra_headers": {"X-Route": "route"}, "ssl_ca_cert": "route.pem",
+        "default_query": {"route": "one"}, "timeout": 23,
+        "request_overrides": {"extra_body": {"thinking": {"type": "disabled"}}},
+        **updates,
+    })
+
+
+def parent(rt):
+    return SimpleNamespace(
+        model=rt.model, provider=rt.provider, api_mode=rt.api_mode,
+        api_key=rt.api_key, base_url=rt.base_url, _resolved_runtime=rt,
+        _client_kwargs={}, request_overrides=rt.get("request_overrides"),
+    )
+
+
+@pytest.mark.parametrize("direct", [False, True])
+def test_frozen_provider_overrides_are_merged_and_isolated(monkeypatch, direct):
+    rt = runtime()
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", lambda **kw: rt)
+    cfg = {"provider": "custom:route", "request_overrides": {"extra_body": {"route": ["child"]}}}
+    if direct:
+        cfg["base_url"] = rt.base_url
+    creds = _resolve_delegation_credentials(cfg, parent(rt))
+    overrides = creds["request_overrides"]
+    assert overrides["extra_body"]["thinking"]["type"] == "disabled"
+    overrides["extra_body"]["thinking"]["type"] = "enabled"
+    overrides["extra_body"]["route"].append("changed")
+    assert rt["request_overrides"]["extra_body"]["thinking"]["type"] == "disabled"
+    assert cfg["request_overrides"]["extra_body"]["route"] == ["child"]
+
+
+@pytest.mark.parametrize("cfg", [{"model": " auto "}, {"provider": "AUTO"}, {"model": "auto", "provider": "auto"}])
+def test_auto_inherits_live_parent_without_resolving_again(monkeypatch, cfg):
+    def unexpected(**kwargs):
+        pytest.fail("auto must inherit the live parent, not resolve ambient config")
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", unexpected)
+    creds = _resolve_delegation_credentials(cfg, parent(runtime()))
+    assert creds["model"] is None
+    assert creds["provider"] is None
+
+
+def test_child_derives_complete_runtime_and_keeps_parent_immutable():
+    rt = runtime()
+    child = _resolve_child_runtime(
+        parent(rt), {}, rt.api_key, model="other-model", override_provider=None,
+        override_base_url=None, override_api_key=None, override_api_mode=None,
+        override_max_tokens=None, override_acp_command=None, override_acp_args=None,
+    )
+    inherited = child["resolved_runtime"]
+    assert inherited.model == "other-model"
+    assert inherited.extra_headers == rt.extra_headers
+    assert inherited.ssl_ca_cert == rt.ssl_ca_cert
+    assert inherited["default_query"] == rt["default_query"]
+    assert inherited["timeout"] == rt["timeout"]
+    assert rt.model == "child-model"

--- a/tests/tools/test_delegate_runtime_integration.py
+++ b/tests/tools/test_delegate_runtime_integration.py
@@ -1,0 +1,176 @@
+"""Real config -> child constructor -> SDK wire, with HTTP intercepted locally."""
+
+import json
+from types import SimpleNamespace
+
+import certifi
+import httpx
+import pytest
+
+from agent.runtime_bundle import ResolvedRuntime
+from run_agent import AIAgent
+from tools.delegate_tool import _build_child_agent
+from tools.delegate_tool_config import _resolve_delegation_credentials
+
+
+@pytest.fixture
+def wire_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "0")
+    config = {
+        "model": {"default": "ambient-model", "provider": "custom", "context_length": 65536},
+        "compression": {"enabled": False},
+        "delegation": {"max_spawn_depth": 3},
+        "custom_providers": [{
+            "name": "child-route", "base_url": "https://child.invalid/v1",
+            "api_key": "child-key", "model": "gpt-4o-mini",
+            "extra_headers": {"X-Route": "child"}, "ssl_ca_cert": certifi.where(),
+        }],
+    }
+    (tmp_path / "config.yaml").write_text(json.dumps(config), encoding="utf-8")
+    requests, clients, verification = [], [], []
+
+    def respond(request):
+        requests.append(request)
+        if request.url.path.endswith("/messages"):
+            return httpx.Response(200, json={
+                "id": "msg-test", "type": "message", "role": "assistant", "model": "claude-test",
+                "content": [{"type": "text", "text": "OK"}], "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            })
+        return httpx.Response(200, json={
+            "id": "chat-test", "object": "chat.completion", "created": 0, "model": "gpt-4o-mini",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "OK"}, "finish_reason": "stop"}],
+        })
+
+    def http_client(base_url="", *, verify=True, **kwargs):
+        verification.append(verify)
+        client = httpx.Client(transport=httpx.MockTransport(respond))
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(AIAgent, "_build_keepalive_http_client", staticmethod(http_client))
+    monkeypatch.setattr("agent.process_bootstrap.build_keepalive_http_client", http_client)
+    # Metadata discovery is unrelated to routing and must not hit a provider.
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *a, **k: 65536)
+    yield requests, verification
+    for client in clients:
+        client.close()
+
+
+def make_parent(api_mode):
+    rt = ResolvedRuntime.from_mapping({
+        "provider": "custom", "requested_provider": "parent-route", "model": "gpt-4o-mini",
+        "api_mode": api_mode, "api_key": "parent-key", "base_url": "https://parent.invalid/v1",
+        "extra_headers": {"X-Route": "parent"}, "ssl_ca_cert": certifi.where(),
+        "default_query": {"route": "parent"}, "timeout": 23,
+        "request_overrides": {"extra_body": {"thinking": {"type": "disabled"}}},
+    })
+    return AIAgent(
+        resolved_runtime=rt, enabled_toolsets=["file"], quiet_mode=True,
+        skip_memory=True, skip_context_files=True, skip_background_review=True,
+    )
+
+
+def child_of(parent, creds=None):
+    creds = creds or {}
+    return _build_child_agent(
+        0, "test", None, None, creds.get("model"), 2, 1, parent,
+        override_provider=creds.get("provider"), override_base_url=creds.get("base_url"),
+        override_api_key=creds.get("api_key"), override_api_mode=creds.get("api_mode"),
+        override_request_overrides=creds.get("request_overrides"),
+        override_runtime=creds.get("resolved_runtime"),
+    )
+
+
+def send(agent):
+    if agent.api_mode == "anthropic_messages":
+        client = agent._create_request_anthropic_client(reason="test")
+        result = client.messages.create(model=agent.model, max_tokens=8, messages=[{"role": "user", "content": "test"}])
+        agent._close_request_anthropic_client(client, reason="request_complete")
+        assert result.content[0].text == "OK"
+    else:
+        client = agent._create_request_openai_client(reason="test")
+        result = client.chat.completions.create(model=agent.model, messages=[{"role": "user", "content": "test"}])
+        agent._close_request_openai_client(client, reason="request_complete")
+        assert result.choices[0].message.content == "OK"
+
+
+@pytest.mark.parametrize("api_mode", ["chat_completions", "anthropic_messages"])
+def test_nested_children_keep_runtime_and_own_clients(wire_env, api_mode):
+    requests, verification = wire_env
+    parent = make_parent(api_mode)
+    child = child_of(parent, _resolve_delegation_credentials({"model": "auto", "provider": "auto"}, parent))
+    grandchild = child_of(child)
+    try:
+        child_client = child._anthropic_client if api_mode == "anthropic_messages" else child.client
+        parent_client = parent._anthropic_client if api_mode == "anthropic_messages" else parent.client
+        assert child_client is not parent_client
+        child.request_overrides["extra_body"]["thinking"]["type"] = "enabled"
+        assert parent.request_overrides["extra_body"]["thinking"]["type"] == "disabled"
+        assert grandchild.request_overrides["extra_body"]["thinking"]["type"] == "disabled"
+        grandchild._swap_credential(SimpleNamespace(id="rotated", runtime_api_key="rotated-key", runtime_base_url=grandchild.base_url))
+        send(grandchild)
+        assert requests[-1].url.host == "parent.invalid"
+        assert requests[-1].url.params["route"] == "parent"
+        assert requests[-1].headers["X-Route"] == "parent"
+        assert "rotated-key" in (requests[-1].headers.get("Authorization", "") + requests[-1].headers.get("X-Api-Key", ""))
+        assert grandchild._resolved_runtime.api_key == "rotated-key"
+        assert parent.api_key == child.api_key == "parent-key"
+        child_client.close()
+        send(parent)
+        assert requests[-1].headers["X-Route"] == "parent"
+        assert verification and all(value is not False for value in verification)
+    finally:
+        grandchild.close()
+        child.close()
+        parent.close()
+
+
+@pytest.mark.parametrize("direct", [False, True])
+def test_named_provider_resolves_in_profile_and_does_not_inherit_parent_route(wire_env, direct):
+    requests, _ = wire_env
+    parent = make_parent("chat_completions")
+    cfg = {"provider": "child-route", "model": "auto"}
+    if direct:
+        cfg.update(base_url="https://child.invalid/v1", api_key="child-key")
+    creds = _resolve_delegation_credentials(cfg, parent)
+    child = child_of(parent, creds)
+    try:
+        send(child)
+        assert requests[-1].url.host == "child.invalid"
+        assert requests[-1].headers["Authorization"] == "Bearer child-key"
+        assert requests[-1].headers["X-Route"] == "child"
+        assert "route" not in requests[-1].url.params
+        assert not child._fallback_chain
+        assert child.capabilities == {}
+        assert child._resolved_runtime.ssl_ca_cert == certifi.where()
+        assert parent._resolved_runtime.extra_headers["X-Route"] == "parent"
+    finally:
+        child.close()
+        parent.close()
+
+
+@pytest.mark.parametrize("api_mode", ["chat_completions", "anthropic_messages"])
+def test_fallback_resolver_request_rebuild_and_child_share_route_not_clients(wire_env, api_mode):
+    from agent.chat_completion_helpers import try_activate_fallback
+    requests, _ = wire_env
+    parent = make_parent("chat_completions")
+    parent._fallback_chain = [{"provider": "child-route", "model": "gpt-4o-mini", "api_mode": api_mode}]
+    child = None
+    try:
+        assert try_activate_fallback(parent)
+        assert parent._resolved_runtime.ssl_ca_cert == certifi.where()
+        send(parent)
+        assert requests[-1].url.host == "child.invalid"
+        assert requests[-1].headers["X-Route"] == "child"
+        assert "route" not in requests[-1].url.params
+        child = child_of(parent)
+        send(child)
+        assert requests[-1].url.host == "child.invalid"
+        assert requests[-1].headers["X-Route"] == "child"
+        assert child._resolved_runtime.ssl_ca_cert == parent._resolved_runtime.ssl_ca_cert
+    finally:
+        if child is not None:
+            child.close()
+        parent.close()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -121,6 +121,7 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    override_runtime=None,
     # Legacy; accepted for wire compat but ignored (capability is depth-derived).
     role: str = "leaf",
 ):
@@ -162,14 +163,16 @@ def _build_child_agent(
         parent_agent, delegation_cfg, parent_api_key, model=model, override_provider=override_provider,
         override_base_url=override_base_url, override_api_key=override_api_key, override_api_mode=override_api_mode,
         override_max_tokens=override_max_tokens, override_acp_command=override_acp_command,
-        override_acp_args=override_acp_args,
+        override_acp_args=override_acp_args, override_runtime=override_runtime,
     )
     if override_request_overrides is not None:
         # honored whenever set, incl. the inherit branch where
         # _resolve_delegation_credentials already merged OVER the parent's
-        request_overrides = dict(override_request_overrides)
+        request_overrides = _merge_request_overrides(override_request_overrides, None) or {}
     else:
-        request_overrides = {} if override_provider else dict(getattr(parent_agent, "request_overrides", {}) or {})
+        request_overrides = {} if override_provider else (_merge_request_overrides(getattr(parent_agent, "request_overrides", None), None) or {})
+    if rt.get("resolved_runtime") is not None:
+        rt["resolved_runtime"] = rt["resolved_runtime"].with_updates(request_overrides=request_overrides)
     parent_sid = getattr(parent_agent, "session_id", None)
     child_session_db = _open_child_session_db(parent_agent)
     with delegated_child_context():
@@ -311,6 +314,7 @@ def _build_children(
         "override_request_overrides": creds.get("request_overrides"),
         "override_max_tokens": creds.get("max_output_tokens"), "override_acp_command": creds.get("command"),
         "override_acp_args": creds.get("args"),
+        "override_runtime": creds.get("resolved_runtime"),
     }
     children = []
     for i, t in enumerate(task_list):

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
+from agent.runtime_bundle import ResolvedRuntime, mutable_config_copy
 from utils import base_url_hostname, is_truthy_value
 
 logger = logging.getLogger("tools.delegate_tool")  # log-record parity with the origin module
@@ -244,13 +246,12 @@ def _merge_request_overrides(runtime_overrides, explicit_overrides):
     ``extra_body`` is deep-merged ONE level so provider personality (e.g. ``thinking: {type: disabled}``) survives
     unless the explicit dict redefines that exact key. Both sides are deep-copied so transport-side mutation can't
     leak into the config/runtime cache. None when both are empty."""
-    import copy as _copy
-    runtime_overrides = runtime_overrides if isinstance(runtime_overrides, dict) else None
-    explicit_overrides = explicit_overrides if isinstance(explicit_overrides, dict) else None
+    runtime_overrides = runtime_overrides if isinstance(runtime_overrides, Mapping) else None
+    explicit_overrides = explicit_overrides if isinstance(explicit_overrides, Mapping) else None
     if not runtime_overrides and not explicit_overrides:
         return None
-    merged = _copy.deepcopy(runtime_overrides) if runtime_overrides else {}
-    explicit = _copy.deepcopy(explicit_overrides) if explicit_overrides else {}
+    merged = mutable_config_copy(runtime_overrides) if runtime_overrides else {}
+    explicit = mutable_config_copy(explicit_overrides) if explicit_overrides else {}
     runtime_extra = merged.get("extra_body")
     explicit_extra = explicit.pop("extra_body", None)
     merged.update(explicit)
@@ -304,11 +305,12 @@ def _direct_endpoint_credentials(v: dict, explicit_request_overrides) -> dict:
     # provider configured ALONGSIDE base_url: pull that provider's request personality (request_overrides /
     # max_output_tokens) onto the explicit endpoint. Best-effort — a resolution failure only skips the overrides.
     request_overrides = max_output_tokens = None
+    runtime = None
     if v["provider"]:
         try:
             from hermes_cli.runtime_provider import resolve_runtime_provider
             runtime = resolve_runtime_provider(requested=v["provider"], target_model=v["model"])
-            request_overrides = dict(runtime.get("request_overrides") or {}) or None
+            request_overrides = runtime.get("request_overrides")
             max_output_tokens = runtime.get("max_output_tokens")
         except Exception as exc:
             logger.debug(
@@ -316,9 +318,17 @@ def _direct_endpoint_credentials(v: dict, explicit_request_overrides) -> dict:
                 v["provider"], exc,
             )
     # api_key None → inherited from parent in _build_child_agent
+    from agent.runtime_routes import runtime_for_endpoint
+    if isinstance(runtime, Mapping):
+        runtime = ResolvedRuntime.from_mapping(runtime).with_updates(api_key=v["api_key"] or "")
+    resolved = runtime_for_endpoint(runtime, v["base_url"]).with_updates(
+        provider=provider, requested_provider=v["provider"] or provider,
+        model=v["model"] or "", api_key=v["api_key"] or "", api_mode=api_mode,
+    )
     return _credential_bundle(
         v["model"], provider, v["base_url"], v["api_key"], api_mode,
         _merge_request_overrides(request_overrides, explicit_request_overrides), max_output_tokens,
+        resolved_runtime=resolved,
     )
 
 def _runtime_provider_credentials(v: dict, explicit_request_overrides) -> dict:
@@ -355,6 +365,7 @@ def _runtime_provider_credentials(v: dict, explicit_request_overrides) -> dict:
         runtime.get("base_url"), api_key, runtime.get("api_mode"),
         _merge_request_overrides(runtime.get("request_overrides"), explicit_request_overrides) or {},
         runtime.get("max_output_tokens"), command=pinned_command, args=list(runtime.get("args") or []),
+        resolved_runtime=ResolvedRuntime.from_mapping(runtime),
     )
 
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
@@ -364,6 +375,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     None values, child inherits everything. ``request_overrides`` is honored on every branch. Raises ValueError
     with a user-facing message."""
     values = {k: str(cfg.get(k) or "").strip() or None for k in ("model", "provider", "base_url", "api_key")}
+    for key in ("model", "provider"):
+        if (values[key] or "").lower() == "auto":
+            values[key] = None
     values["api_mode"] = str(cfg.get("api_mode") or "").strip().lower() or None
     explicit_request_overrides = cfg.get("request_overrides") if isinstance(cfg.get("request_overrides"), dict) else None
     is_native_sdk_provider = (values["provider"] or "").strip().lower() in _NATIVE_SDK_PROVIDERS
@@ -412,6 +426,7 @@ def _resolve_child_runtime(
     parent_agent, delegation_cfg: dict, parent_api_key: Any, *, model: Optional[str], override_provider: Optional[str],
     override_base_url: Optional[str], override_api_key: Optional[str], override_api_mode: Optional[str],
     override_max_tokens: Optional[int], override_acp_command: Optional[str], override_acp_args: Optional[List[str]],
+    override_runtime: Optional[ResolvedRuntime] = None,
 ) -> Dict[str, Any]:
     """Child credentials, transport and routing (config override > parent inherit) as ``AIAgent`` kwargs. Rules that
     are easy to break: api_mode is re-derived (not inherited) when the child's provider differs from the parent's
@@ -497,4 +512,16 @@ def _resolve_child_runtime(
     child_max_tokens = override_max_tokens if override_max_tokens is not None else getattr(parent_agent, "max_tokens", None)
     if isinstance(child_max_tokens, int):
         kwargs["max_tokens"] = child_max_tokens
+    inherited = getattr(parent_agent, "_resolved_runtime", None)
+    resolved = override_runtime
+    if resolved is None and not override_provider and not override_base_url and isinstance(inherited, ResolvedRuntime):
+        from agent.runtime_routes import runtime_for_endpoint
+        resolved = runtime_for_endpoint(inherited, effective_base_url)
+    if isinstance(resolved, ResolvedRuntime):
+        kwargs["resolved_runtime"] = resolved.with_updates(
+            model=effective_model, api_key=kwargs["api_key"], base_url=effective_base_url or "",
+            api_mode=effective_api_mode or resolved.api_mode,
+            provider="copilot-acp" if override_acp_command else resolved.provider,
+            command=effective_acp_command, args=effective_acp_args,
+        )
     return kwargs

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15,6 +15,7 @@ import sys
 import threading
 import time
 import uuid
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, NamedTuple, Optional  # noqa: F401  (Callable: split modules)
@@ -2166,7 +2167,7 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
 
 
 class _RuntimeFallbackResolution(NamedTuple):
-    runtime: dict
+    runtime: Mapping[str, Any]
     selected_model: str | None
     used_fallback: bool
 
@@ -2230,9 +2231,10 @@ def _resolve_agent_model_runtime(model_override, provider_override) -> tuple[str
     if resolution.used_fallback:
         if not resolution.selected_model:
             raise RuntimeError("Auth fallback resolved without a model")
-        return resolution.selected_model, resolution.runtime
-    resolution.runtime.update({k: v for k, v in overrides.items() if v})
-    return model, resolution.runtime
+        return resolution.selected_model, dict(resolution.runtime)
+    runtime = dict(resolution.runtime)
+    runtime.update({k: v for k, v in overrides.items() if v})
+    return model, runtime
 
 
 def _startup_system_prompt(cfg: dict, task_id: str) -> str:

--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -85,6 +85,30 @@ The runtime resolver returns data such as:
 
 ## Why this matters
 
+### Immutable Runtime Handoffs
+
+`resolve_runtime_provider()` returns a mapping-compatible `ResolvedRuntime`.
+`agent/runtime_bundle.py` freezes nested configuration and builds a `ClientBundle`;
+`ClientLifecycleMixin.install_runtime()` commits the route and client together.
+Use `runtime.as_dict()` when a mutable, recursively independent configuration copy
+is needed. Do not `deepcopy()` a nested frozen mapping or reuse another agent's
+HTTP client.
+
+`AIAgent(resolved_runtime=runtime)` accepts an already-resolved route as the
+authoritative provider, model, credentials and transport input. Delegation derives
+this value from the live parent unless a provider or endpoint is explicitly pinned.
+`delegation.model: auto` and `delegation.provider: auto` mean inherit, not a literal
+wire model or a new environment-based provider search. Explicit request overrides
+win over inherited/provider defaults, without mutating the source configuration.
+
+Children own their clients. Headers, TLS settings, query parameters and timeouts
+survive child construction, fallback adoption, request-local reconstruction and
+credential rotation. Changing endpoints recomputes destination-specific settings
+instead of forwarding the previous endpoint's headers or CA/query configuration.
+Anthropic request reuse compares the complete immutable runtime and beta policy.
+Dedicated MoA and Bedrock builders remain separate; ACP command arguments are not
+sent to an ordinary OpenAI HTTP client.
+
 This resolver is the main reason Hermes can share auth/runtime logic between:
 
 - `hermes chat`


### PR DESCRIPTION
## What does this PR do?

Fixes provider drift during startup, delegation, fallback, model switching, and
transport recovery. A resolved route previously became split across mutable
agent fields and independently rebuilt SDK clients, losing headers, timeout,
API mode, TLS, query, or provider-specific metadata on later requests.

The architecture has one complete value and one installation boundary:

1. `ResolvedRuntime` is an immutable, mapping-compatible provider contract.
2. `build_client_bundle(runtime)` constructs the wire client without mutating a live agent.
3. `AIAgent.install_runtime(bundle)` atomically installs identity and client state under the existing lock, then retires the old client.
4. Startup, auxiliary resolution, subagent inheritance, fallback, credential rotation, primary restoration, and model switching carry this complete contract through their existing policy flows.

The follow-up fixes the remaining boundaries exposed by the new immutable
representation. Each child owns a fresh client; same-route settings survive
handoffs, while an endpoint change resolves destination settings without leaking
the previous route's headers, query, or TLS configuration. Bedrock and MoA retain
their dedicated builders; this PR does not claim those special wires have been
fully migrated.

## Related Issue

Fixes #88463.

Related: #84010 (subagent `auto` inheritance). This updates the existing #97780
architecture PR rather than creating a competing fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (no behavior change outside the repaired paths)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/runtime_bundle.py`: immutable `ResolvedRuntime`, `ClientBundle`, recursive mutable configuration copies, and central transport-aware client construction.
- `agent/runtime_routes.py`: complete runtime handoffs, construction metadata, destination-specific route configuration, and separately owned child clients.
- `hermes_cli/runtime_provider.py` and `runtime_provider_custom.py`: freeze resolver results and retain named-provider TLS and request metadata.
- `tools/delegate_tool_config.py` and `delegate_tool.py`: inherit the live parent runtime, normalize `auto`, accept frozen mappings, and preserve explicit-over-provider request override precedence.
- `agent/agent_init.py` and `run_agent.py`: accept a resolved runtime directly and preserve it in primary snapshots.
- `agent/client_lifecycle.py`: runtime-aware Anthropic request reuse and transactional credential rotation/refresh; failed construction retains the previous client/runtime.
- `agent/auxiliary_client.py`, `anthropic_adapter.py`, and `chat_completion_helpers.py`: retain headers, CA, query, and timeout through fallback and later request-local reconstruction.
- `agent/agent_runtime_helpers.py`: central construction during recovery, restoration, and model switching.
- `tui_gateway/server.py` and `hermes_cli/cli_agent_setup_mixin.py`: accept immutable mapping-compatible resolver results without mutation.
- Regression tests cover immutable overrides, nested delegation, fallback-to-child transitions, request reuse, rotation rollback, transport propagation, and client ownership. Existing fixtures now exercise the real installation contract; Windows test paths and encoding are explicit.
- `website/docs/developer-guide/provider-runtime.md`: document runtime handoffs and ownership.

## How to Test

### Reproduction and Integration Coverage

The follow-up defect tests initially produced nine failures on the architecture
head before these fixes. They exercise the actual delegation resolver and
request-client lifecycle: nested frozen overrides previously raised a
mappingproxy copy error or disappeared; required Anthropic headers were dropped;
rotation left stale runtime state; and literal `auto` escaped inheritance.

Real OpenAI and Anthropic SDK integration tests use temporary `HERMES_HOME`
configuration and offline httpx transports. They construct parents, children,
and grandchildren; activate fallback through the real resolver; rotate
credentials; inspect outgoing request headers/query; and verify separate client
ownership and route isolation. No live model calls or credentials are needed.

### Focused Regression Command

Use the project development venv, or set `HERMES_PYTHON` to its Python executable
when the checkout does not contain a venv:

```bash
bash scripts/run_tests.sh tests/tools/test_delegate*.py \
  tests/agent/test_runtime_bundle.py tests/agent/test_runtime_install.py \
  tests/agent/test_runtime_boundary_preservation.py \
  tests/agent/test_anthropic_adapter.py tests/agent/test_anthropic_request_client_reuse.py \
  tests/agent/test_request_client_reuse.py tests/agent/test_auxiliary_client.py \
  tests/agent/test_auxiliary_client_anthropic_custom.py tests/agent/test_auxiliary_client_ssl_verify.py \
  tests/agent/test_auxiliary_client_azure_foundry.py tests/agent/test_auxiliary_user_default_headers.py \
  tests/agent/test_moa_switch_api_mode.py tests/run_agent/test_primary_runtime_restore.py \
  tests/run_agent/test_openai_client_lifecycle.py tests/run_agent/test_credential_rotation_route_settings.py \
  tests/run_agent/test_fallback_credential_isolation.py tests/run_agent/test_switch_model_rollback.py \
  tests/run_agent/test_env_credential_turn_refresh.py tests/run_agent/test_create_openai_client_reuse.py \
  tests/run_agent/test_request_client_reuse_abort_races.py tests/run_agent/test_credential_pool_interrupt.py \
  tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_runtime_transport_precedence.py \
  tests/test_profile_isolation_runtime.py -j 4 -q
```

### Validation Record

- Focused regression on Windows: **43 files, 738 passed, 0 failed, 1 skipped**. The skipped test asserts POSIX permission bits, unsupported on Windows.
- Ruff `0.15.10` on changed Python files: passed.
- `scripts/check-windows-footguns.py` on the staged Python files: passed.
- `scripts/check_compat_pointers.py`: passed.
- `git diff --check`: passed.
- Earlier architecture-head validation recorded 179 focused tests, 637 TUI gateway tests, and a 41-test switch-boundary refinement rerun. These are historical receipts, not additional tests counted in the latest 738-pass run.

The entire repository suite and a live provider/gateway smoke test have not been
run for this follow-up. The active Hermes installation was not deployed or
restarted. The branch's original base is `245e48008fa814b3251f50755eb656bd9fb86cb1`;
this is not a claim that the branch is synchronized with today's upstream main.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] Commit messages follow Conventional Commits.
- [x] Existing related work was checked; this remains in the original #97780 PR.
- [x] The changes are scoped to provider runtime propagation and its regressions.
- [x] Focused related tests pass; the full repository suite is not claimed.
- [x] Bug regressions and offline real SDK integration tests are included.
- [x] Tested on Windows.

### Documentation & Housekeeping

- [x] Provider runtime developer documentation and relevant docstrings are updated.
- [x] `cli-config.yaml.example`: N/A, no new config keys.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: existing boundary and invariant guidance retained; detailed architecture changes are in the developer guide.
- [x] Cross-platform impact considered; Windows path, encoding, and static checks covered. Linux/macOS execution remains for CI.
- [x] Tool descriptions/schemas: N/A, no new tool or schema fields.
