### PR TITLE
fix: harden session fencing, recovery, and gateway turn safety

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2754,6 +2754,7 @@ from gateway.turn_lease import (
     DEFAULT_LEASE_WAIT,
     SessionTurnLeaseRegistry,
     TurnLeaseTimeoutError,
+    TurnLeaseToken,
 )
 from gateway.session_state import (
     SERVICE_TIER_UNSET as _SERVICE_TIER_UNSET,
@@ -18957,6 +18958,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
+        event._gateway_turn_lease_token = None
         try:
             try:
                 _agent_result = await self._handle_message_with_agent(
@@ -18989,32 +18991,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("post-turn hook failed: %s", _goal_exc)
             return _agent_result
         finally:
-            # MoA one-shot restore must run on EVERY exit path, not just
-            # success. The restore data lives on the per-turn event object
-            # (_moa_restore_override), which is discarded once the event goes
-            # out of scope — so if _handle_message_with_agent raises, a restore
-            # in the try block would be skipped and the MoA override would leak
-            # permanently (every later message silently fans out through MoA).
-            # Putting it in finally guarantees the revert on success, exception,
-            # and interrupt alike.
-            self._restore_moa_one_shot(event, _quick_key)
-            self._restore_pending_one_turn_model_override(_quick_key)
-            # Normal completion/exception/interrupt owns and clears this exact
-            # durable marker.  SIGKILL/OOM skips finally, leaving the marker for
-            # the next unclean startup's recovery pass.
-            await self._clear_durable_active_turn(event)
-            # Unconditional release covers every exit path. _release_running_agent_state
-            # is idempotent (pop-on-absent is harmless) and, called without a
-            # run_generation guard, always clears the slot regardless of which
-            # generation it holds. This evicts the zombie left when session_reset
-            # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
-            # inside _run_agent returns False, and the old sentinel-only check here
-            # missed the leftover real agent — locking the session out forever (#28686).
-            self._release_running_agent_state(_quick_key)
-            # Turn lease (#64934): release THIS turn's lease token — keyed by
-            # (routing key, run generation) so this unwind can only ever free
-            # the lease its own turn acquired, never a newer turn's.
-            self._release_turn_lease(_quick_key, _run_generation)
+            try:
+                # MoA one-shot restore must run on EVERY exit path, not just
+                # success. The restore data lives on the per-turn event object
+                # (_moa_restore_override), which is discarded once the event goes
+                # out of scope — so if _handle_message_with_agent raises, a restore
+                # in the try block would be skipped and the MoA override would leak
+                # permanently (every later message silently fans out through MoA).
+                # Putting it in finally guarantees the revert on success, exception,
+                # and interrupt alike.
+                self._restore_moa_one_shot(event, _quick_key)
+                self._restore_pending_one_turn_model_override(_quick_key)
+                try:
+                    # Normal completion/exception/interrupt owns and clears this exact
+                    # durable marker. SIGKILL/OOM skips finally, leaving the marker for
+                    # the next unclean startup's recovery pass.
+                    await self._clear_durable_active_turn(event)
+                finally:
+                    # _release_running_agent_state is synchronous and idempotent.
+                    self._release_running_agent_state(_quick_key)
+            finally:
+                # This synchronous, event-owned release has no await boundary, so a
+                # repeated cancellation during durable cleanup cannot skip it.
+                self._release_turn_lease(
+                    _quick_key,
+                    _run_generation,
+                    token=getattr(event, "_gateway_turn_lease_token", None),
+                )
 
     def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
         """Revert a ``/moa <prompt>`` one-shot model override after its turn.
@@ -19763,6 +19766,163 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    @staticmethod
+    def _is_canonical_outward_callback_attribute(name: str) -> bool:
+        """Return whether a cached agent attribute can emit beyond this request."""
+        return (
+            name == "callback"
+            or name.endswith("_callback")
+            or name == "_on_session_title"
+        )
+
+    @staticmethod
+    def _select_canonical_turn_result(
+        result: Any,
+        *,
+        binding_name: str,
+        history_boundary: int,
+        expected_session_id: str,
+    ) -> Any:
+        """Select exactly one physical current-turn assistant terminal."""
+        from gateway.canonical_surface import CanonicalTurnResult
+
+        if (
+            not isinstance(result, dict)
+            or result.get("completed") is not True
+            or result.get("session_id", expected_session_id) != expected_session_id
+            or not isinstance(result.get("final_response"), str)
+            or not result["final_response"].strip()
+            or not isinstance(result.get("messages"), list)
+            or isinstance(history_boundary, bool)
+            or not isinstance(history_boundary, int)
+        ):
+            raise ValueError("canonical_turn_refused")
+        messages = result["messages"]
+        if history_boundary < 0 or history_boundary >= len(messages):
+            raise ValueError("canonical_turn_refused")
+        suffix = messages[history_boundary:]
+        if len(suffix) < 2:
+            raise ValueError("canonical_turn_refused")
+        user = suffix[0]
+        if (
+            not isinstance(user, dict)
+            or user.get("role") != "user"
+            or not isinstance(user.get("content"), str)
+            or not user["content"].strip()
+        ):
+            raise ValueError("canonical_turn_refused")
+
+        expect_tool = False
+        expected_tool_call_id: Optional[str] = None
+        terminal: Optional[str] = None
+        for index, row in enumerate(suffix[1:], start=1):
+            if not isinstance(row, dict) or not isinstance(row.get("role"), str):
+                raise ValueError("canonical_turn_refused")
+            role = row["role"]
+            if expect_tool:
+                if (
+                    role != "tool"
+                    or row.get("tool_call_id") != expected_tool_call_id
+                    or not isinstance(row.get("content"), str)
+                    or not row["content"].strip()
+                ):
+                    raise ValueError("canonical_turn_refused")
+                expect_tool = False
+                expected_tool_call_id = None
+                continue
+
+            if role != "assistant":
+                raise ValueError("canonical_turn_refused")
+            if "tool_calls" in row:
+                tool_calls = row["tool_calls"]
+                if (
+                    not isinstance(tool_calls, list)
+                    or len(tool_calls) != 1
+                    or not isinstance(tool_calls[0], dict)
+                    or not isinstance(tool_calls[0].get("id"), str)
+                    or not tool_calls[0]["id"].strip()
+                ):
+                    raise ValueError("canonical_turn_refused")
+                expected_tool_call_id = tool_calls[0]["id"]
+                expect_tool = True
+                continue
+
+            content = row.get("content")
+            if (
+                not isinstance(content, str)
+                or not content.strip()
+                or content != result["final_response"]
+                or index != len(suffix) - 1
+            ):
+                raise ValueError("canonical_turn_refused")
+            terminal = content
+
+        if expect_tool or terminal is None:
+            raise ValueError("canonical_turn_refused")
+        return CanonicalTurnResult(binding_name=binding_name, terminal_text=terminal)
+
+    async def run_bound_existing_turn(
+        self, binding: Any, event: Any, entry: Any, *, reply_sink: Any = None
+    ) -> Any:
+        """Run only an exact pre-existing cached session for canonical ingress."""
+        from gateway.canonical_surface import require_request_local_reply_sink
+
+        require_request_local_reply_sink(reply_sink)
+        if entry.session_key != binding.session_key or entry.session_id != binding.session_id:
+            raise ValueError("canonical_binding_stale")
+        with self._agent_cache_lock:
+            cached = self._agent_cache.get(entry.session_key)
+            if not cached:
+                raise ValueError("canonical_agent_missing")
+            agent = cached[0] if isinstance(cached, tuple) else cached
+            cached_session_id = cached[3] if isinstance(cached, tuple) and len(cached) > 3 else getattr(agent, "session_id", None)
+            if cached_session_id != entry.session_id or getattr(agent, "session_id", None) != entry.session_id:
+                raise ValueError("canonical_agent_missing")
+
+        generation = self._begin_session_run_generation(entry.session_key)
+        try:
+            lease = await self._turn_leases.acquire(
+                entry.session_id,
+                owner_key=f"canonical:{id(event)}",
+                generation=generation,
+            )
+        except Exception:
+            raise ValueError("canonical_turn_busy") from None
+        try:
+            if not bool(getattr(agent, "compression_in_place", True)):
+                raise ValueError("canonical_turn_refused")
+            outward_callbacks = {
+                name: value
+                for name, value in vars(agent).items()
+                if self._is_canonical_outward_callback_attribute(name)
+            }
+            for name in outward_callbacks:
+                setattr(agent, name, None)
+            try:
+                history = await self.async_session_store.load_transcript(entry.session_id)
+                agent_history, _ = _build_gateway_agent_history(history)
+                self._init_cached_agent_for_turn(agent, 0)
+                result = await asyncio.to_thread(
+                    agent.run_conversation,
+                    event.text,
+                    conversation_history=agent_history,
+                    task_id=entry.session_id,
+                )
+                boundary = getattr(agent, "_persist_user_message_idx", None)
+                if isinstance(boundary, bool) or not isinstance(boundary, int):
+                    raise ValueError("canonical_turn_refused")
+                return self._select_canonical_turn_result(
+                    result,
+                    binding_name=binding.name,
+                    history_boundary=boundary,
+                    expected_session_id=entry.session_id,
+                )
+            finally:
+                for name, value in outward_callbacks.items():
+                    setattr(agent, name, value)
+        finally:
+            self._turn_leases.release(lease)
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -20137,6 +20297,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._clear_session_env(_session_env_tokens)
                 raise
             if _lease_token is not None:
+                # The event is the per-turn authority. Capture its exact token
+                # before publishing the mutable shared compatibility slot.
+                event._gateway_turn_lease_token = _lease_token
                 _lease_state = self._session_state(_quick_key).turn
                 _lease_state.lease_token = _lease_token
                 _lease_state.lease_generation = run_generation
@@ -20629,15 +20792,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                                     _idle < _hyg_timeout_seconds
                                                     and _hyg_waited < _hyg_total_ceiling_seconds
                                                 ):
-                                                    logger.info(
-                                                        "Session hygiene compression for "
-                                                        "session %s still streaming after "
-                                                        "%.0fs (last progress %.1fs ago) — "
-                                                        "extending wait (ceiling %.0fs)",
-                                                        session_entry.session_id,
-                                                        _hyg_waited, _idle,
-                                                        _hyg_total_ceiling_seconds,
-                                                    )
                                                     continue
                                                 raise
                                     except HygieneTurnHoldExceeded:
@@ -20925,7 +21079,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             # the fresh child still serializes
                                             # against this turn (#64934).
                                             self._rebind_turn_lease(
-                                                _quick_key, run_generation, _hyg_new_sid
+                                                _quick_key,
+                                                run_generation,
+                                                _hyg_new_sid,
+                                                token=getattr(
+                                                    event,
+                                                    "_gateway_turn_lease_token",
+                                                    None,
+                                                ),
                                             )
                                             await self.async_session_store._save()
                                             await asyncio.to_thread(
@@ -21443,7 +21604,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # serialization boundary must move with it or an alias
                     # key resolving the fresh child could interleave (#64934).
                     self._rebind_turn_lease(
-                        _quick_key, run_generation, session_entry.session_id
+                        _quick_key,
+                        run_generation,
+                        session_entry.session_id,
+                        token=getattr(event, "_gateway_turn_lease_token", None),
                     )
                     await self.async_session_store._save()
                     await self.async_session_store._record_gateway_session_peer(
@@ -27583,60 +27747,122 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._persist_active_agents()
         return True
 
-    def _release_turn_lease(self, session_key: str, run_generation: int) -> bool:
+    def _release_turn_lease(
+        self,
+        session_key: str,
+        run_generation: int,
+        *,
+        token: Optional[TurnLeaseToken] = None,
+    ) -> bool:
         """Release the turn lease acquired by (``session_key``, ``run_generation``).
 
         Companion to the acquisition in ``_handle_message_with_agent``
-        (#64934). The token map is keyed by (routing key, run generation), so
-        this can only ever free the lease its own turn acquired — a stale
-        unwind whose generation was bumped by /stop or /new pops ITS token,
-        and the registry's identity check refuses it if a newer turn already
-        holds the lease. Idempotent and safe for bare test runners built via
+        (#64934). ``state.turn.lease_token``/``lease_generation`` is a SINGLE
+        shared slot per routing key — a second concurrent turn on the same
+        key (a stale unwind, or a fresh turn after /new landing on the same
+        key before the first turn unwound) overwrites it unconditionally.
+        When that happens the first turn's own token is gone from the slot,
+        and looking it up there would either release the WRONG (newer)
+        lease or, with the old generation guard, silently orphan the first
+        turn's own lease forever (no TTL ever reclaims it).
+
+        ``token``, when given, is this call's own lease token — stashed on
+        the per-turn event at acquire time, so it is never shared and can
+        never be clobbered by another turn. It is released directly via
+        ``registry.release()``, which is itself identity-checked (only frees
+        the lease if this token is still its current holder). The shared
+        slot is cleared too, but ONLY if it still points at this same token —
+        never a newer turn's.
+
+        With no ``token``, falls back to the previous generation-checked
+        shared-slot lookup unchanged, for any caller that has no event to
+        stash a token on.
+
+        Idempotent and safe for bare test runners built via
         ``object.__new__`` (getattr defaults).
         """
         if not session_key:
             return False
         registry = getattr(self, "_turn_leases", None)
+        if registry is None:
+            return False
+        if token is not None:
+            if token.owner_key != session_key or token.generation != run_generation:
+                return False
+            state = self._peek_session_state(session_key)
+            try:
+                released = registry.release(token)
+            except Exception:
+                logger.debug("Failed to release turn lease", exc_info=True)
+                return False
+            if not released:
+                return False
+            if state is not None:
+                turn = state.turn
+                if turn.lease_token is token:
+                    turn.lease_token = None
+                    turn.lease_generation = None
+            return True
+
         state = self._peek_session_state(session_key)
-        if state is None or registry is None:
+        if state is not None:
+            turn = state.turn
+            if turn.lease_token is None or turn.lease_generation != run_generation:
+                return False
+            resolved_token = turn.lease_token
+            try:
+                released = registry.release(resolved_token)
+            except Exception:
+                logger.debug("Failed to release turn lease", exc_info=True)
+                return False
+            if not released:
+                return False
+            if turn.lease_token is resolved_token:
+                turn.lease_token = None
+                turn.lease_generation = None
+            return True
+
+        legacy_tokens = getattr(self, "_turn_lease_tokens", None)
+        if not isinstance(legacy_tokens, dict):
             return False
-        turn = state.turn
-        if turn.lease_token is None or turn.lease_generation != run_generation:
+        legacy_key = (session_key, run_generation)
+        resolved_token = legacy_tokens.get(legacy_key)
+        if resolved_token is None:
             return False
-        token = turn.lease_token
-        turn.lease_token = None
-        turn.lease_generation = None
         try:
-            return registry.release(token)
+            released = registry.release(resolved_token)
         except Exception:
             logger.debug("Failed to release turn lease", exc_info=True)
             return False
+        if not released:
+            return False
+        if legacy_tokens.get(legacy_key) is resolved_token:
+            legacy_tokens.pop(legacy_key, None)
+        return True
 
     def _rebind_turn_lease(
-        self, session_key: str, run_generation: int, new_session_id: str
+        self,
+        session_key: str,
+        run_generation: int,
+        new_session_id: str,
+        *,
+        token: Optional[TurnLeaseToken],
     ) -> bool:
-        """Follow a mid-turn session_id rotation with the held turn lease.
-
-        Compression (session-hygiene pre-compression or the agent's own
-        compressor) can rotate ``session_entry.session_id`` while this turn
-        is in flight. The turn's flush targets the NEW id, so the
-        serialization boundary must follow it — otherwise an alias routing
-        key resolving the new id (topic tip-walk onto the fresh child) could
-        start a concurrent turn the lease never sees (#64934 rotation-alias
-        window). Call at every site that reassigns session_entry.session_id
-        mid-turn. Fail-open no-op when there is no held token.
-        """
-        if not session_key or not new_session_id:
+        """Follow a mid-turn session_id rotation with this event's held lease."""
+        if (
+            not session_key
+            or not new_session_id
+            or token is None
+            or token.released
+            or token.owner_key != session_key
+            or token.generation != run_generation
+        ):
             return False
         registry = getattr(self, "_turn_leases", None)
-        state = self._peek_session_state(session_key)
-        if state is None or registry is None:
-            return False
-        turn = state.turn
-        if turn.lease_token is None or turn.lease_generation != run_generation:
+        if registry is None:
             return False
         try:
-            return registry.rebind(turn.lease_token, new_session_id)
+            return registry.rebind(token, new_session_id)
         except Exception:
             logger.debug("Failed to rebind turn lease", exc_info=True)
             return False

--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -209,7 +209,8 @@ class SessionTurnLeaseRegistry:
         token = TurnLeaseToken(session_id, owner_key, int(generation))
         lease = self._get_or_create(session_id)
 
-        if lease.lock.locked():
+        _contended = lease.lock.locked()
+        if _contended:
             holder = lease.holder
             logger.warning(
                 "turn lease contention on session %s: routing key %s (gen %s) "
@@ -231,37 +232,49 @@ class SessionTurnLeaseRegistry:
         # same session. Count even apparently-uncontended acquires: wait_for()
         # may schedule them before the underlying lock coroutine runs.
         lease.pending_acquires += 1
+        acquired = False
+        fully_published = False
         try:
-            await asyncio.wait_for(lease.lock.acquire(), timeout=wait)
-        except asyncio.TimeoutError:
-            holder = lease.holder
-            logger.error(
-                "turn lease wait timed out after %.0fs on session %s "
-                "(waiter: routing key %s gen %s; holder: routing key %s "
-                "gen %s) — failing closed: refusing to run this turn "
-                "UNSERIALIZED against the still-held lease",
-                wait,
-                session_id,
-                owner_key,
-                generation,
-                holder.owner_key if holder else "?",
-                holder.generation if holder else "?",
-            )
-            raise TurnLeaseTimeoutError(
-                session_id,
-                owner_key=owner_key,
-                generation=generation,
-                wait_seconds=wait,
-            ) from None
+            try:
+                await asyncio.wait_for(lease.lock.acquire(), timeout=wait)
+            except asyncio.TimeoutError:
+                holder = lease.holder
+                logger.error(
+                    "turn lease wait timed out after %.0fs on session %s "
+                    "(waiter: routing key %s gen %s; holder: routing key %s "
+                    "gen %s) — failing closed: refusing to run this turn "
+                    "UNSERIALIZED against the still-held lease",
+                    wait,
+                    session_id,
+                    owner_key,
+                    generation,
+                    holder.owner_key if holder else "?",
+                    holder.generation if holder else "?",
+                )
+                raise TurnLeaseTimeoutError(
+                    session_id,
+                    owner_key=owner_key,
+                    generation=generation,
+                    wait_seconds=wait,
+                ) from None
+
+            acquired = True
+            lease.holder = token
+            lease.acquired_at = time.time()
+            lease.last_used = lease.acquired_at
+            fully_published = True
+            return token
+        except BaseException:
+            if acquired and not fully_published:
+                if lease.holder is token:
+                    lease.holder = None
+                lease.acquired_at = 0.0
+                lease.last_used = time.time()
+                if lease.lock.locked():
+                    lease.lock.release()
+            raise
         finally:
             lease.pending_acquires -= 1
-
-        # The lock is held and there is no await before holder publication, so
-        # the lease cannot become evictable after the pending count is cleared.
-        lease.holder = token
-        lease.acquired_at = time.time()
-        lease.last_used = lease.acquired_at
-        return token
 
     def rebind(self, token: Optional[TurnLeaseToken], new_session_id: str) -> bool:
         """Alias a HELD lease onto ``new_session_id`` after mid-turn rotation.
@@ -277,9 +290,7 @@ class SessionTurnLeaseRegistry:
         Mechanism: the SAME ``_SessionLease`` object is registered under the
         new id (the old mapping stays until it goes idle and is evicted), so
         acquirers on either id serialize against one lock — no lock state is
-        moved, no asyncio internals are touched. Only the current holder can
-        rebind (identity-checked like release), and the token follows to the
-        new id so release frees the shared object.
+        moved and the token keeps its acquisition identity.
 
         Edge: if the new id already has a live lease of its own (another
         turn is running on the target session), the two serialization
@@ -318,35 +329,32 @@ class SessionTurnLeaseRegistry:
 
         self._leases[new_session_id] = lease
         lease.last_used = time.time()
-        token.session_id = new_session_id
         return True
 
     def release(self, token: Optional[TurnLeaseToken]) -> bool:
-        """Release ``token``'s lease. Idempotent; ownership-checked.
+        """Release ``token``'s lease transactionally and identity-checked.
 
-        Returns True only when this exact token was the current holder and
-        the lock was freed. A re-release or a stale token whose slot has
-        since been granted to a newer turn are both safe no-ops — a stale
-        unwind can never release a newer turn's lease.
+        Lifecycle state changes only after the synchronous lock release succeeds,
+        so a release failure leaves the exact token and holder retryable.
         """
         if token is None or token.released:
             return False
-        token.released = True
         lease = self._leases.get(token.session_id)
-        if lease is None:
+        if lease is None or lease.holder is not token:
+            if lease is not None:
+                logger.debug(
+                    "turn lease release skipped on session %s: token (key %s "
+                    "gen %s) is not the current holder",
+                    token.session_id,
+                    token.owner_key,
+                    token.generation,
+                )
             return False
-        if lease.holder is not token:
-            logger.debug(
-                "turn lease release skipped on session %s: token (key %s "
-                "gen %s) is not the current holder",
-                token.session_id,
-                token.owner_key,
-                token.generation,
-            )
-            return False
+
+        released_at = time.time()
+        lease.lock.release()
         lease.holder = None
         lease.acquired_at = 0.0
-        lease.last_used = time.time()
-        if lease.lock.locked():
-            lease.lock.release()
+        lease.last_used = released_at
+        token.released = True
         return True

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14499,14 +14499,6 @@ def main():
         help="JSON report path (defaults to <output>.recovery.json)",
     )
 
-    # The one operator path back off the turn-fence generation barrier. Its
-    # arguments live with the command rather than here so that "the target is
-    # required and never defaulted" is a property of a function a test can
-    # build a parser around.
-    from hermes_cli.session_fence_rollback_cmd import add_fence_rollback_parser
-
-    add_fence_rollback_parser(sessions_subparsers)
-
     sessions_subparsers.add_parser("stats", help="Show session store statistics")
 
     sessions_rename = sessions_subparsers.add_parser(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1840,6 +1840,52 @@ def _create_titled_session(title: str) -> Optional[str]:
                 pass
 
 
+def _gateway_routed_session_owner(session_id: str):
+    """Return the live gateway pid serving *session_id*, else ``None``."""
+    try:
+        import json as _json
+        import re as _re
+        import sqlite3 as _sq
+        import subprocess as _sp
+
+        out = _sp.run(
+            ["launchctl", "list", "ai.hermes.gateway"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout
+        m = _re.search(r'"PID"\s*=\s*(\d+)', out)
+        if not m:
+            return None
+        pid = int(m.group(1))
+        os.kill(pid, 0)
+
+        db = get_hermes_home() / "state.db"
+        if not db.exists():
+            return None
+        conn = _sq.connect(f"file:{db}?mode=ro", uri=True, timeout=2.0)
+        try:
+            rows = conn.execute("SELECT entry_json FROM gateway_routing").fetchall()
+        finally:
+            conn.close()
+        for (entry,) in rows:
+            try:
+                if _json.loads(entry).get("session_id") == session_id:
+                    return pid
+            except Exception:
+                continue
+        return None
+    except Exception:
+        return None
+
+
+def _refuse_gateway_routed_session_attach(session_id: str) -> None:
+    if _gateway_routed_session_owner(session_id) is not None:
+        print(
+            "Refusing to attach to a session currently served by the gateway.",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+
+
 def _resolve_continue_arg(args, *, use_tui: bool) -> None:
     """Resolve ``-c/--continue`` into ``args.resume``.
 
@@ -3173,6 +3219,10 @@ def cmd_chat(args):
 
     # Resolve --continue into --resume with the latest session or by name
     _resolve_continue_arg(args, use_tui=use_tui)
+
+    _resume_target = getattr(args, "resume", None)
+    if _resume_target:
+        _refuse_gateway_routed_session_attach(_resume_target)
 
     # --resume @claude / --resume @codex: import a foreign session (Claude
     # Code / Codex CLI) and resume the newly created Hermes session.
@@ -14448,6 +14498,14 @@ def main():
         type=Path,
         help="JSON report path (defaults to <output>.recovery.json)",
     )
+
+    # The one operator path back off the turn-fence generation barrier. Its
+    # arguments live with the command rather than here so that "the target is
+    # required and never defaulted" is a property of a function a test can
+    # build a parser around.
+    from hermes_cli.session_fence_rollback_cmd import add_fence_rollback_parser
+
+    add_fence_rollback_parser(sessions_subparsers)
 
     sessions_subparsers.add_parser("stats", help="Show session store statistics")
 

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -12,11 +12,16 @@ The recovery path deliberately avoids in-place repair:
 
 from __future__ import annotations
 
+import ctypes
+import errno
 import json
 import os
 import shutil
 import sqlite3
+import stat
+import sys
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -24,7 +29,9 @@ from hermes_state import (
     FTS_STORAGE_VERSION,
     SCHEMA_VERSION,
     SessionDB,
+    TURN_FENCE_GENERATION,
     _db_opens_cleanly,
+    register_turn_fence_generation,
 )
 
 
@@ -77,8 +84,278 @@ class SessionRecoverySourceError(SessionRecoveryError):
     """Raised when the source cannot provide the required canonical tables."""
 
 
+class SessionRecoveryDestinationError(SessionRecoveryError):
+    """Raised when the destination connection itself is defective.
+
+    Distinct from :class:`SessionRecoverySourceError`: this means the
+    recovery TOOL failed to set up its own destination connection, not that
+    the source database has corrupted rows. ``_copy_table`` /
+    ``_copy_table_salvage`` swallow ``sqlite3.DatabaseError`` per table and
+    report it as row-level salvage loss, which is correct for genuine source
+    corruption but actively misleading for a defect in this tool — an
+    operator reading "no such function: hermes_turn_fence_generation" as a
+    per-table failure has no way to tell it apart from a damaged b-tree.
+    ``_require_destination_fenced`` below fails fast and loud instead, before
+    any per-table copy gets a chance to misreport it.
+    """
+
+
+_DESTINATION_FENCE_ERROR = (
+    "Recovery destination turn-fence setup is unavailable or incompatible."
+)
+
+
+def _is_current_turn_fence_generation(value: Any, sqlite_type: Any) -> bool:
+    """Return whether a probed scalar has the exact expected SQLite shape."""
+
+    return (
+        sqlite_type == "integer"
+        and type(value) is int
+        and value == TURN_FENCE_GENERATION
+    )
+
+
+def _require_destination_fenced(destination: sqlite3.Connection) -> None:
+    """Fail loudly if ``destination`` cannot satisfy its own turn-fence
+    triggers, before any table copy runs and swallows that as row loss.
+
+    A destination that already has ``hermes_turn_fence_generation()``
+    registered (or genuinely has no turn-fence triggers to call it) passes
+    silently; this does not require triggers to be present.
+    """
+    try:
+        register_turn_fence_generation(destination)
+        row = destination.execute(
+            "SELECT hermes_turn_fence_generation(), "
+            "typeof(hermes_turn_fence_generation())"
+        ).fetchone()
+    except sqlite3.Error:
+        raise SessionRecoveryDestinationError(_DESTINATION_FENCE_ERROR) from None
+    if row is None or not _is_current_turn_fence_generation(row[0], row[1]):
+        raise SessionRecoveryDestinationError(_DESTINATION_FENCE_ERROR) from None
+
+
 def _sidecar_path(db_path: Path, suffix: str) -> Path:
     return db_path if not suffix else db_path.with_name(db_path.name + suffix)
+
+
+_DESTINATION_STAGE_ERROR = "Recovery destination staging or publication failed."
+_DESTINATION_COLLISION_ERROR = "Recovery output already exists or changed during publication."
+_DESTINATION_STAGE_CHANGED_ERROR = "Recovery staging candidate changed before publication."
+
+
+def _identity_from_stat(result: os.stat_result) -> tuple[int, int, int, int]:
+    return (
+        int(result.st_dev),
+        int(result.st_ino),
+        stat.S_IFMT(result.st_mode),
+        int(result.st_nlink),
+    )
+
+
+def _path_identity(path: Path) -> tuple[int, int, int, int]:
+    return _identity_from_stat(os.lstat(path))
+
+
+@dataclass
+class _DestinationStage:
+    directory: Path
+    candidate: Path
+    directory_identity: tuple[int, int, int, int]
+    children: dict[str, tuple[int, int, int, int]] = field(default_factory=dict)
+
+
+def _create_destination_stage(output: Path) -> _DestinationStage:
+    """Make a private candidate directory beside the requested destination."""
+
+    try:
+        directory = Path(
+            tempfile.mkdtemp(prefix=".hermes-session-recovery-", dir=output.parent)
+        )
+        os.chmod(directory, 0o700)
+        if os.stat(directory).st_dev != os.stat(output.parent).st_dev:
+            raise OSError(errno.EXDEV, "staging and destination differ")
+        return _DestinationStage(
+            directory=directory,
+            candidate=directory / output.name,
+            directory_identity=_path_identity(directory),
+        )
+    except OSError:
+        raise SessionRecoveryDestinationError(_DESTINATION_STAGE_ERROR) from None
+
+
+def _stage_child_identity(stage: _DestinationStage, path: Path) -> None:
+    """Record one candidate child, rejecting substitution or hard-linking."""
+
+    try:
+        identity = _path_identity(path)
+    except OSError:
+        raise SessionRecoveryDestinationError(_DESTINATION_STAGE_ERROR) from None
+    if not stat.S_ISREG(identity[2]) or identity[3] != 1:
+        raise SessionRecoverySafetyError(_DESTINATION_STAGE_CHANGED_ERROR)
+    prior = stage.children.get(path.name)
+    if prior is not None and prior != identity:
+        raise SessionRecoverySafetyError(_DESTINATION_STAGE_CHANGED_ERROR)
+    stage.children[path.name] = identity
+
+
+def _refresh_stage_children(stage: _DestinationStage, *, require_main: bool = False) -> None:
+    for suffix in _SIDECAR_SUFFIXES:
+        child = _sidecar_path(stage.candidate, suffix)
+        if os.path.lexists(child):
+            _stage_child_identity(stage, child)
+    if require_main and stage.candidate.name not in stage.children:
+        raise SessionRecoverySafetyError(_DESTINATION_STAGE_CHANGED_ERROR)
+
+
+def _stage_directory_is_owned(stage: _DestinationStage) -> bool:
+    try:
+        return _path_identity(stage.directory) == stage.directory_identity
+    except OSError:
+        return False
+
+
+def _cleanup_destination_stage(stage: _DestinationStage) -> None:
+    """Remove only captured candidate children and an unchanged empty stage."""
+
+    if not _stage_directory_is_owned(stage):
+        return
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_DIRECTORY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        directory_fd = os.open(stage.directory, flags)
+    except OSError:
+        return
+    try:
+        if _identity_from_stat(os.fstat(directory_fd)) != stage.directory_identity:
+            return
+        for name, expected in tuple(stage.children.items()):
+            try:
+                current = _identity_from_stat(
+                    os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+                )
+            except OSError:
+                continue
+            if current != expected:
+                continue
+            try:
+                os.unlink(name, dir_fd=directory_fd)
+            except OSError:
+                continue
+        try:
+            empty = not os.listdir(directory_fd)
+        except OSError:
+            return
+    finally:
+        os.close(directory_fd)
+    if not empty or not _stage_directory_is_owned(stage):
+        return
+    parent_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        parent_fd = os.open(stage.directory.parent, parent_flags)
+    except OSError:
+        return
+    try:
+        if _identity_from_stat(
+            os.stat(stage.directory.name, dir_fd=parent_fd, follow_symlinks=False)
+        ) != stage.directory_identity:
+            return
+        os.rmdir(stage.directory.name, dir_fd=parent_fd)
+    except OSError:
+        return
+    finally:
+        os.close(parent_fd)
+
+
+def _fsync_path(path: Path, *, directory: bool = False) -> None:
+    flags = os.O_RDONLY
+    if directory:
+        flags |= getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _seal_staged_database(stage: _DestinationStage) -> None:
+    """Collapse WAL state and seal the candidate before it enters public space."""
+
+    _refresh_stage_children(stage, require_main=True)
+    try:
+        connection = sqlite3.connect(str(stage.candidate), isolation_level=None)
+        try:
+            connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            journal_mode = connection.execute("PRAGMA journal_mode=DELETE").fetchone()
+            if journal_mode is None or str(journal_mode[0]).lower() != "delete":
+                raise sqlite3.DatabaseError("journal mode was not sealed")
+        finally:
+            connection.close()
+        if _db_opens_cleanly(stage.candidate) is not None:
+            raise sqlite3.DatabaseError("staged database health probe failed")
+        for suffix in ("-wal", "-shm", "-journal"):
+            if os.path.lexists(_sidecar_path(stage.candidate, suffix)):
+                raise sqlite3.DatabaseError("staged sidecar remains")
+        _refresh_stage_children(stage, require_main=True)
+        _fsync_path(stage.candidate)
+        _fsync_path(stage.directory, directory=True)
+    except (OSError, sqlite3.Error):
+        raise SessionRecoveryDestinationError(_DESTINATION_STAGE_ERROR) from None
+
+
+def _publication_barrier(_candidate: Path, _output: Path) -> None:
+    """A testable boundary immediately before the exclusive native rename."""
+
+
+def _native_no_replace_publish(source: Path, destination: Path) -> None:
+    """Use the platform's native exclusive rename; never emulate it."""
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    if sys.platform == "darwin":
+        rename = libc.renameatx_np
+        rename.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+        rename.restype = ctypes.c_int
+        result = rename(-2, os.fsencode(source), -2, os.fsencode(destination), 0x00000004)
+    elif sys.platform.startswith("linux"):
+        try:
+            rename = libc.renameat2
+        except AttributeError as exc:
+            raise OSError(errno.ENOTSUP, "renameat2 unavailable") from exc
+        rename.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+        rename.restype = ctypes.c_int
+        result = rename(-100, os.fsencode(source), -100, os.fsencode(destination), 1)
+    else:
+        raise OSError(errno.ENOTSUP, "no native no-replace rename")
+    if result != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number))
+
+
+def _publish_staged_database(stage: _DestinationStage, output: Path) -> None:
+    """Publish a sealed candidate exactly once without replacing a competitor."""
+
+    _refresh_stage_children(stage, require_main=True)
+    expected = stage.children[stage.candidate.name]
+    if _path_identity(stage.candidate) != expected:
+        raise SessionRecoverySafetyError(_DESTINATION_STAGE_CHANGED_ERROR)
+    if any(os.path.lexists(_sidecar_path(output, suffix)) for suffix in _SIDECAR_SUFFIXES):
+        raise SessionRecoverySafetyError(_DESTINATION_COLLISION_ERROR)
+    _publication_barrier(stage.candidate, output)
+    if _path_identity(stage.candidate) != expected:
+        raise SessionRecoverySafetyError(_DESTINATION_STAGE_CHANGED_ERROR)
+    if any(os.path.lexists(_sidecar_path(output, suffix)) for suffix in _SIDECAR_SUFFIXES):
+        raise SessionRecoverySafetyError(_DESTINATION_COLLISION_ERROR)
+    try:
+        _native_no_replace_publish(stage.candidate, output)
+    except OSError:
+        raise SessionRecoverySafetyError(_DESTINATION_COLLISION_ERROR) from None
+    try:
+        if _path_identity(output) != expected or os.path.lexists(stage.candidate):
+            raise SessionRecoveryDestinationError(_DESTINATION_STAGE_ERROR)
+        _fsync_path(output.parent, directory=True)
+    except OSError:
+        raise SessionRecoveryDestinationError(_DESTINATION_STAGE_ERROR) from None
 
 
 def _resolved_output_path(path: Path) -> Path:
@@ -1389,6 +1666,7 @@ def _recover_via_lost_and_found(
     source: Path,
     snapshot_source: Path,
     snapshot_dir: Path,
+    stage: _DestinationStage,
     output: Path,
     inspection: dict[str, Any],
     disk_space: dict[str, Any],
@@ -1432,14 +1710,28 @@ def _recover_via_lost_and_found(
             + f", and page-level .recover salvage failed: {exc}"
         ) from exc
 
-    destination_db = SessionDB(db_path=output)
+    destination_db = SessionDB(db_path=stage.candidate)
+    _refresh_stage_children(stage, require_main=True)
     destination_db.close()
 
     lf_conn = sqlite3.connect(str(lf_path), isolation_level=None)
     destination_conn = sqlite3.connect(
-        str(output), isolation_level=None, timeout=1.0
+        str(stage.candidate), isolation_level=None, timeout=1.0
     )
     try:
+        # The store's turn-fence triggers on the canonical tables call
+        # hermes_turn_fence_generation(), a UDF that only the connection which
+        # created it knows. SessionDB.close() above tore that connection down,
+        # so this bare reopen must re-register the scalar itself or the first
+        # INSERT into a governed table raises "no such function". This is safe
+        # here (unlike minting the marker on a live production writer): the
+        # output path can never already exist (_validate_paths refuses to
+        # reuse one) and it is never swapped over a running gateway, so there
+        # is no concurrent turn-lease holder this recovery-only connection
+        # could bypass. session_turn_leases (the table that check guards) is
+        # also not part of _CANONICAL_TABLES, so no lease row ever reaches
+        # this database.
+        _require_destination_fenced(destination_conn)
         destination_conn.execute("PRAGMA foreign_keys=OFF")
         mapping = map_lost_and_found_rows(lf_conn, destination_conn)
         stubbing = stub_missing_parent_sessions(destination_conn)
@@ -1448,6 +1740,7 @@ def _recover_via_lost_and_found(
     finally:
         lf_conn.close()
         destination_conn.close()
+    _refresh_stage_children(stage, require_main=True)
 
     copy_report: dict[str, dict[str, Any]] = {
         table: {
@@ -1464,7 +1757,7 @@ def _recover_via_lost_and_found(
     }
 
     verification = _verify_recovered_database(
-        output,
+        stage.candidate,
         expected_counts={"sessions": None, "messages": None},
         copy_report=copy_report,
         allow_partial=True,
@@ -1556,6 +1849,7 @@ def recover_session_database(
     assert output is not None
     disk_space = _disk_space_preflight(source, work_root, output.parent)
 
+    stage: Optional[_DestinationStage] = None
     temp_dir, snapshot_source, inspection = _snapshot_and_inspect(source, work_root)
     try:
         if not inspection.get("recoverable") and not allow_partial:
@@ -1575,16 +1869,22 @@ def recover_session_database(
                 # SQL-level salvage is impossible without readable table
                 # schemas. Fall back to page-level lost_and_found salvage via
                 # the sqlite3 CLI's .recover (a shell-only feature).
-                return _recover_via_lost_and_found(
+                stage = _create_destination_stage(output)
+                report = _recover_via_lost_and_found(
                     source=source,
                     snapshot_source=snapshot_source,
                     snapshot_dir=Path(temp_dir.name),
+                    stage=stage,
                     output=output,
                     inspection=inspection,
                     disk_space=disk_space,
                     missing_required=missing_required,
                 )
+                _seal_staged_database(stage)
+                _publish_staged_database(stage, output)
+                return report
 
+        stage = _create_destination_stage(output)
         source_conn = sqlite3.connect(
             str(snapshot_source),
             isolation_level=None,
@@ -1598,17 +1898,19 @@ def recover_session_database(
                 inspection["tables"][table].get("available") for table in _TOPIC_TABLES
             )
 
-            destination_db = SessionDB(db_path=output)
+            destination_db = SessionDB(db_path=stage.candidate)
             if has_topic_tables:
                 destination_db.apply_telegram_topic_migration()
+            _refresh_stage_children(stage, require_main=True)
             destination_db.close()
             destination_db = None
 
             destination_conn = sqlite3.connect(
-                str(output),
+                str(stage.candidate),
                 isolation_level=None,
                 timeout=1.0,
             )
+            _require_destination_fenced(destination_conn)
             destination_conn.execute("PRAGMA foreign_keys=OFF")
 
             copy_report: dict[str, dict[str, Any]] = {}
@@ -1674,9 +1976,10 @@ def recover_session_database(
                 destination_conn.close()
             if destination_db is not None:
                 destination_db.close()
+        _refresh_stage_children(stage, require_main=True)
 
         verification = _verify_recovered_database(
-            output,
+            stage.candidate,
             expected_counts={
                 table: inspection["tables"][table].get("rows")
                 for table in _CANONICAL_TABLES
@@ -1694,7 +1997,7 @@ def recover_session_database(
             )
             verification["complete"] = False
 
-        return {
+        report = {
             "operation": "recover",
             "allow_partial": allow_partial,
             "source": str(source),
@@ -1718,7 +2021,12 @@ def recover_session_database(
             "verified": bool(verification.get("healthy") and source_unchanged),
             "installed": False,
         }
+        _seal_staged_database(stage)
+        _publish_staged_database(stage, output)
+        return report
     finally:
+        if stage is not None:
+            _cleanup_destination_stage(stage)
         temp_dir.cleanup()
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -87,11 +87,13 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_SQL,
     SCHEMA_VERSION,
+    TURN_FENCE_GENERATION,
     _PREVIEW_CONTENT_SQL,
     _PREVIEW_HEAD_CHARS,
     _PREVIEW_MAX_CHARS,
     _PREVIEW_SCAFFOLD_WINDOW,
     _PREVIEW_SCAFFOLDED_SQL,
+    register_turn_fence_generation,
 )
 from hermes_state_portability import SessionPortabilityMixin
 from hermes_state_schema import SessionSchemaMixin
@@ -175,6 +177,16 @@ class SessionExportTooLargeError(ValueError):
             f"session '{session_id}' has at least {message_count} active messages; "
             f"safe in-memory export limit is {limit}"
         )
+
+
+class IncompatibleSchemaError(RuntimeError):
+    """The on-disk session state cannot be safely opened by this version."""
+
+    __slots__ = ("code",)
+
+    def __init__(self):
+        super().__init__("Session state is incompatible with this Hermes version.")
+        self.code = "STATE_DB_SCHEMA_INCOMPATIBLE"
 
 
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
@@ -1815,6 +1827,96 @@ def is_malformed_schema_error(exc: BaseException) -> bool:
     return any(marker in str(exc).lower() for marker in _MALFORMED_SCHEMA_MARKERS)
 
 
+def _validate_schema_version_scalar(conn: sqlite3.Connection) -> int:
+    """Validate the one canonical, SQLite-typed schema-version scalar."""
+    rows = conn.execute(
+        "SELECT version, typeof(version) FROM schema_version"
+    ).fetchall()
+    if len(rows) != 1:
+        raise IncompatibleSchemaError()
+    version, value_type = rows[0]
+    if (
+        value_type != "integer"
+        or type(version) is not int
+        or version < 0
+        or version > (2**63 - 1)
+        or version > SCHEMA_VERSION
+    ):
+        raise IncompatibleSchemaError()
+    return version
+
+
+def _validate_connection_schema(
+    conn: sqlite3.Connection, *, allow_uninitialized_schema: bool = False
+) -> Optional[int]:
+    """SELECT-only compatibility check for a package-owned connection."""
+    try:
+        has_schema_version = conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'schema_version'"
+        ).fetchone() is not None
+        if not has_schema_version:
+            if not allow_uninitialized_schema:
+                raise IncompatibleSchemaError()
+            version = None
+        else:
+            version = _validate_schema_version_scalar(conn)
+        generation, generation_type = conn.execute(
+            "SELECT hermes_turn_fence_generation(), "
+            "typeof(hermes_turn_fence_generation())"
+        ).fetchone()
+    except IncompatibleSchemaError:
+        raise
+    except sqlite3.DatabaseError:
+        raise IncompatibleSchemaError() from None
+    if (
+        generation_type != "integer"
+        or type(generation) is not int
+        or generation != TURN_FENCE_GENERATION
+    ):
+        raise IncompatibleSchemaError()
+    return version
+
+
+def _probe_existing_state_db_schema(
+    db_path: Path, *, allow_malformed_repair: bool
+) -> int:
+    """Read and validate an existing DB before any package write path opens it."""
+    def probe() -> int:
+        conn = sqlite3.connect(
+            f"file:{db_path}?mode=ro",
+            uri=True,
+            isolation_level=None,
+        )
+        try:
+            return _validate_schema_version_scalar(conn)
+        finally:
+            conn.close()
+
+    try:
+        return probe()
+    except IncompatibleSchemaError:
+        raise
+    except sqlite3.DatabaseError as exc:
+        if not (
+            allow_malformed_repair
+            and is_malformed_schema_error(exc)
+        ):
+            raise IncompatibleSchemaError() from None
+        if not _claim_repair_attempt(db_path):
+            raise
+        report = repair_state_db_schema(db_path)
+        if not report.get("repaired"):
+            raise
+
+    try:
+        return probe()
+    except IncompatibleSchemaError:
+        raise
+    except sqlite3.DatabaseError:
+        raise IncompatibleSchemaError() from None
+
+
 # Markers that mean the host filesystem cannot accept another write. Kept as
 # plain substrings so OSError, sqlite3.OperationalError, and wrapped RPC
 # error strings all match the same helper.
@@ -2854,6 +2956,7 @@ def _connect_repair_durable(
     schema parses again, which is the point at which the pragmas can stick.
     """
     conn = sqlite3.connect(str(db_path), timeout=timeout, isolation_level=None)
+    register_turn_fence_generation(conn)
     _reapply_durability_barriers(conn)
     return conn
 
@@ -3890,6 +3993,169 @@ class SessionTurnLeaseLostError(RuntimeError):
     """
 
 
+class _SerializedCursor(sqlite3.Cursor):
+    """Cursor whose every SQLite entry runs under the connection's RLock.
+
+    See :class:`_SerializedConnectionMixin` for why this exists. Fetches are
+    wrapped too, not just execute: ``fetchone``/``fetchall`` step the VM and
+    build row objects while HOLDING the GIL, which takes the connection mutex
+    — exactly the GIL-held-mutex-wait leg of the deadlock.
+    """
+
+    def _serial(self):
+        return self.connection._hermes_serial_lock
+
+    def execute(self, *args, **kwargs):
+        with self._serial():
+            return super().execute(*args, **kwargs)
+
+    def executemany(self, *args, **kwargs):
+        with self._serial():
+            return super().executemany(*args, **kwargs)
+
+    def executescript(self, *args, **kwargs):
+        with self._serial():
+            return super().executescript(*args, **kwargs)
+
+    def fetchone(self):
+        with self._serial():
+            return super().fetchone()
+
+    def fetchmany(self, *args, **kwargs):
+        with self._serial():
+            return super().fetchmany(*args, **kwargs)
+
+    def fetchall(self):
+        with self._serial():
+            return super().fetchall()
+
+    def __next__(self):
+        with self._serial():
+            return super().__next__()
+
+    def close(self):
+        with self._serial():
+            return super().close()
+
+
+class _SerializedConnectionMixin:
+    """Serialize every SQLite entry on one connection behind an RLock.
+
+    2026-08-25: the gateway froze solid for 80+ minutes in a textbook ABBA
+    deadlock (thread sample in the incident record). The two legs:
+
+    - thread A inside ``sqlite3_step`` (connection mutex HELD, GIL released)
+      hit a turn-fence trigger, whose ``hermes_turn_fence_generation()`` UDF
+      re-enters Python and must WAIT for the GIL;
+    - thread B HOLDING the GIL called into the same shared connection
+      (``check_same_thread=False``) — cursor-description/bind/fetch paths keep
+      the GIL while taking the connection mutex — and blocked on the mutex A
+      holds.
+
+    Neither can proceed; the whole process (event loop included) stops. The
+    same unsynchronized sharing also segfaults outright under load (repro in
+    the incident record exits SIGSEGV without this lock).
+
+    The fix: at most one thread inside SQLite per connection, enforced here at
+    the connection-factory choke point rather than at call sites — 70+ call
+    sites touch ``self._conn`` and at least one (``clear_session_activity_
+    labels``) provably bypassed the writer lock. Waiting on THIS RLock releases
+    the GIL, so the UDF thread can always finish its callback and release the
+    connection mutex: the cycle cannot form, per-connection locks are
+    sufficient, and the turn-fence semantics stay exactly as shipped.
+
+    ``interrupt()`` is deliberately NOT wrapped: it exists to cancel another
+    thread's in-flight statement, so serializing it behind the very statement
+    it should cancel would defeat it (sqlite3_interrupt is safe without the
+    mutex by design).
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._hermes_serial_lock = threading.RLock()
+        super().__init__(*args, **kwargs)
+
+    def cursor(self, factory=None):
+        with self._hermes_serial_lock:
+            return super().cursor(factory or _SerializedCursor)
+
+    # execute/executemany/executescript are implemented HERE in Python, routed
+    # through self.cursor(), instead of delegating to the C shortcuts: on
+    # Python 3.11 the C implementations build a PLAIN Cursor directly (they do
+    # not call the overridden cursor()), so ``conn.execute(...).fetchall()``
+    # would fetch on an unserialized cursor — the exact GIL-held mutex wait
+    # this mixin exists to prevent. Verified empirically: 3.9 routes through
+    # cursor(), 3.11 does not.
+
+    def execute(self, *args, **kwargs):
+        with self._hermes_serial_lock:
+            return self.cursor().execute(*args, **kwargs)
+
+    def executemany(self, *args, **kwargs):
+        with self._hermes_serial_lock:
+            return self.cursor().executemany(*args, **kwargs)
+
+    def executescript(self, *args, **kwargs):
+        with self._hermes_serial_lock:
+            return self.cursor().executescript(*args, **kwargs)
+
+    def commit(self):
+        with self._hermes_serial_lock:
+            return super().commit()
+
+    def rollback(self):
+        with self._hermes_serial_lock:
+            return super().rollback()
+
+    def close(self):
+        with self._hermes_serial_lock:
+            return super().close()
+
+    def __exit__(self, *exc_info):
+        # ``with conn:`` commits/rolls back on exit — an SQLite entry.
+        with self._hermes_serial_lock:
+            return super().__exit__(*exc_info)
+
+    def create_function(self, *args, **kwargs):
+        with self._hermes_serial_lock:
+            return super().create_function(*args, **kwargs)
+
+    def create_collation(self, *args, **kwargs):
+        with self._hermes_serial_lock:
+            return super().create_collation(*args, **kwargs)
+
+    def create_aggregate(self, *args, **kwargs):
+        with self._hermes_serial_lock:
+            return super().create_aggregate(*args, **kwargs)
+
+    def backup(self, *args, **kwargs):
+        with self._hermes_serial_lock:
+            return super().backup(*args, **kwargs)
+
+
+class _SerializedConnection(_SerializedConnectionMixin, sqlite3.Connection):
+    pass
+
+
+_serialized_factory_cache: dict = {}
+
+
+def _serialized_connection_factory(factory: type) -> type:
+    """Mix serialization into *factory* (mirrors ``_tracking_factory``)."""
+    if factory is sqlite3.Connection:
+        return _SerializedConnection
+    if issubclass(factory, _SerializedConnectionMixin):
+        return factory
+    cached = _serialized_factory_cache.get(factory)
+    if cached is None:
+        cached = type(
+            f"Serialized{factory.__name__}",
+            (_SerializedConnectionMixin, factory),
+            {},
+        )
+        _serialized_factory_cache[factory] = cached
+    return cached
+
+
 def _connect_tracked_db(path, tracking_path=None, **kwargs):
     """``sqlite3.connect`` that registers the open fd for lock-safety.
 
@@ -3904,6 +4170,13 @@ def _connect_tracked_db(path, tracking_path=None, **kwargs):
     connect would disable the guard for the lifetime of that connection,
     which is precisely the failure mode this module exists to prevent.
     """
+    # Serialize every connection this package opens (see
+    # _SerializedConnectionMixin): the turn-fence UDF re-enters Python from
+    # inside sqlite3_step, and an unsynchronized shared connection turns that
+    # into a GIL/connection-mutex ABBA deadlock or a segfault.
+    kwargs["factory"] = _serialized_connection_factory(
+        kwargs.get("factory", sqlite3.Connection)
+    )
     try:
         from hermes_cli.sqlite_safe_read import connect_tracked
     except ImportError:
@@ -4513,6 +4786,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     def __init__(self, db_path: Path = None, read_only: bool = False):
         self.db_path = db_path or _default_db_path()
+        path_existed_before_connect = self.db_path.exists()
         # Fail hard (before any connection/pragma/mkdir) if a pytest-context
         # process resolved the developer's production state.db — see the
         # live-DB test-isolation guard block near _default_db_path().
@@ -4613,6 +4887,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # must already exist + be initialised (callers guard on
                 # db_path.exists()); a SELECT against an empty file raises and
                 # the caller degrades per-profile.
+                if path_existed_before_connect:
+                    _probe_existing_state_db_schema(
+                        self.db_path, allow_malformed_repair=False
+                    )
                 self._conn = _connect_tracked_db(
                     f"file:{self.db_path}?mode=ro",
                     tracking_path=self.db_path,
@@ -4622,6 +4900,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                register_turn_fence_generation(self._conn)
+                _validate_connection_schema(self._conn)
                 # FTS capability flags normally come from writable schema
                 # initialisation. Probe existing virtual tables with SELECTs
                 # only so read-only search keeps its FTS and trigram paths.
@@ -4693,6 +4973,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # opaquely or risk further damage). Raise with the clear message.
                 if qpath is None and self.db_path.exists() and is_zeroed_state_db(self.db_path):
                     raise sqlite3.DatabaseError(msg)
+                if qpath is not None:
+                    path_existed_before_connect = False
+
+            if path_existed_before_connect:
+                _probe_existing_state_db_schema(
+                    self.db_path, allow_malformed_repair=True
+                )
 
             def _connect_and_init():
                 self._conn = _connect_tracked_db(
@@ -4708,6 +4995,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                register_turn_fence_generation(self._conn)
+                _validate_connection_schema(
+                    self._conn,
+                    allow_uninitialized_schema=not path_existed_before_connect,
+                )
                 self._wal_active = (
                     apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
                 )
@@ -4754,31 +5046,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             )
                         )
 
-            try:
-                _connect_and_init_with_lock_patience()
-            except sqlite3.DatabaseError as exc:
-                # The malformed-schema class (e.g. a duplicate sqlite_master
-                # row for messages_fts) fails on the very first statement —
-                # before _init_schema can run — so it can't be caught at the
-                # FTS-rebuild layer. Recover by repairing sqlite_master in
-                # place (backup first; canonical sessions/messages preserved),
-                # then reopen once. This is what lets Desktop/Dashboard
-                # self-heal instead of silently showing "no sessions".
-                if not is_malformed_schema_error(exc) or not _claim_repair_attempt(self.db_path):
-                    raise
-                logger.error(
-                    "state.db schema is malformed (%s) — attempting automatic "
-                    "repair (a backup copy is made first).", exc,
-                )
-                try:
-                    if self._conn is not None:
-                        self._conn.close()
-                except Exception:
-                    pass
-                report = repair_state_db_schema(self.db_path)
-                if not report.get("repaired"):
-                    raise
-                _connect_and_init_with_lock_patience()
+            _connect_and_init_with_lock_patience()
 
             # NOTE: the v23 FTS optimization is OPT-IN (`hermes db optimize`),
             # never auto-started on open. Legacy installs keep their working
@@ -4788,6 +5056,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # an unattended open. (An interrupted optimize resumes when the
             # user re-runs the command.)
             initialization_complete = True
+        except IncompatibleSchemaError:
+            _set_last_init_error(
+                "STATE_DB_SCHEMA_INCOMPATIBLE: "
+                "Session state is incompatible with this Hermes version."
+            )
+            raise
         except Exception as exc:
             # Capture the cause so /resume and friends can surface WHY the
             # session DB is unavailable instead of a bare "Session database
@@ -4807,6 +5081,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if not initialization_complete:
                 conn, self._conn = self._conn, None
                 self._close_connection_quietly(conn)
+
+    def ensure_compatible_schema(self) -> None:
+        """Recheck this open connection without repairing or mutating state."""
+        if self._conn is None:
+            raise IncompatibleSchemaError()
+        _validate_connection_schema(self._conn)
 
     # ── Read-path split ──
 
@@ -6112,6 +6392,200 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
 
+    def create_session_strict(
+        self,
+        session_id: str,
+        source: str,
+        model: str = None,
+        model_config: Dict[str, Any] = None,
+        system_prompt: str = None,
+        user_id: str = None,
+        session_key: Optional[str] = None,
+        chat_id: str = None,
+        chat_type: str = None,
+        thread_id: str = None,
+        parent_session_id: str = None,
+        cwd: str = None,
+        profile_name: str = None,
+        git_repo_root: str = None,
+        origin_json: str = None,
+        display_name: str = None,
+    ) -> bool:
+        """Create a session row iff ``session_id`` is not already taken.
+
+        Same column set as :meth:`create_session`, but a PK collision is
+        refused rather than an opportunity to enrich the existing row — NOT
+        A SINGLE COLUMN on a pre-existing row (foreign or otherwise) is ever
+        written, not even a NULL-only backfill. :meth:`create_session`'s
+        ``ON CONFLICT ... DO UPDATE`` fills NULL routing/origin columns
+        (``session_key``/``chat_id``/``chat_type``/...) on ANY row already
+        occupying the id — including one this caller has no relationship to
+        — before any provenance check downstream ever runs. Callers whose
+        id is only *probabilistically* unique (gateway ``/branch``'s
+        timestamp+random id) must use this instead, so a collision is
+        refused untouched rather than silently repointed.
+
+        Returns ``True`` when the row is freshly created, ``False`` when
+        ``session_id`` is already taken. Everything else raises.
+
+        The precondition rule: whether the id is taken is decided by a
+        ``SELECT`` that runs BEFORE any write this method makes — before
+        ``_store_system_prompt`` and before the ``INSERT`` — inside the same
+        ``BEGIN IMMEDIATE`` transaction ``_execute_write`` holds under
+        ``self._lock``. That exclusive write lock is held for the entire
+        call, so no other writer can claim the id between the SELECT and
+        the INSERT. So ``False`` means nothing of ours was written, and any
+        ``sqlite3.IntegrityError`` the INSERT itself raises afterward — a
+        foreign-key violation, a turn-fence trigger's ``RAISE(ABORT)``, a
+        UNIQUE violation on some other column — is a genuine failure, not a
+        collision on this id, and propagates untouched.
+        """
+        def _do(conn):
+            # Must be the first statement in _do, before every other write
+            # (including _store_system_prompt): see precondition rule above.
+            row = conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ?", (session_id,)
+            ).fetchone()
+            if row is not None:
+                return False
+            system_prompt_hash = self._store_system_prompt(conn, system_prompt)
+            conn.execute(
+                """INSERT INTO sessions (
+                   id, source, user_id, session_key, chat_id, chat_type, thread_id,
+                   model, model_config, system_prompt, system_prompt_hash,
+                   parent_session_id, cwd, profile_name, git_repo_root,
+                   origin_json, display_name, started_at
+                )
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    source,
+                    user_id,
+                    session_key,
+                    chat_id,
+                    chat_type,
+                    thread_id,
+                    model,
+                    json.dumps(model_config) if model_config else None,
+                    system_prompt_hash,
+                    parent_session_id,
+                    cwd,
+                    profile_name,
+                    git_repo_root,
+                    origin_json,
+                    display_name,
+                    time.time(),
+                ),
+            )
+            if system_prompt_hash is not None:
+                self._delete_unreferenced_system_prompts(conn)
+            if parent_session_id:
+                # Backfill from the parent — same shape as
+                # _insert_session_row, but this UPDATE only ever touches the
+                # row we just INSERTed (WHERE id = ? on our own fresh id), so
+                # it can never reach across into an existing/foreign row.
+                conn.execute(
+                    """UPDATE sessions
+                       SET cwd = COALESCE(sessions.cwd,
+                                 (SELECT p.cwd FROM sessions p
+                                   WHERE p.id = sessions.parent_session_id)),
+                           git_repo_root = COALESCE(sessions.git_repo_root,
+                                           (SELECT p.git_repo_root FROM sessions p
+                                             WHERE p.id = sessions.parent_session_id)),
+                           git_branch = COALESCE(sessions.git_branch,
+                                        (SELECT p.git_branch FROM sessions p
+                                          WHERE p.id = sessions.parent_session_id)),
+                           profile_name = COALESCE(sessions.profile_name,
+                                          (SELECT p.profile_name FROM sessions p
+                                            WHERE p.id = sessions.parent_session_id))
+                     WHERE id = ? AND parent_session_id IS NOT NULL""",
+                    (session_id,),
+                )
+                conn.execute(
+                    """UPDATE sessions
+                       SET user_id = COALESCE(sessions.user_id,
+                                     (SELECT p.user_id FROM sessions p
+                                       WHERE p.id = sessions.parent_session_id)),
+                           session_key = COALESCE(sessions.session_key,
+                                         (SELECT p.session_key FROM sessions p
+                                           WHERE p.id = sessions.parent_session_id)),
+                           chat_id = COALESCE(sessions.chat_id,
+                                     (SELECT p.chat_id FROM sessions p
+                                       WHERE p.id = sessions.parent_session_id)),
+                           chat_type = COALESCE(sessions.chat_type,
+                                       (SELECT p.chat_type FROM sessions p
+                                         WHERE p.id = sessions.parent_session_id)),
+                           thread_id = COALESCE(sessions.thread_id,
+                                       (SELECT p.thread_id FROM sessions p
+                                         WHERE p.id = sessions.parent_session_id)),
+                           display_name = COALESCE(sessions.display_name,
+                                          (SELECT p.display_name FROM sessions p
+                                            WHERE p.id = sessions.parent_session_id)),
+                           origin_json = COALESCE(sessions.origin_json,
+                                         (SELECT p.origin_json FROM sessions p
+                                           WHERE p.id = sessions.parent_session_id))
+                     WHERE id = ? AND parent_session_id IS NOT NULL
+                       AND EXISTS (
+                           SELECT 1 FROM sessions p
+                           WHERE p.id = sessions.parent_session_id
+                             AND p.end_reason = 'compression'
+                       )""",
+                    (session_id,),
+                )
+            return True
+
+        return bool(
+            self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+        )
+
+    def create_imported_session(
+        self,
+        session_id: str,
+        source: str,
+        messages: List[Dict[str, Any]],
+        *,
+        cwd: str = None,
+        origin_json: str = None,
+        turn_lease_holder=None,
+        turn_lease_ttl_seconds: float = 300.0,
+    ) -> str:
+        """Create a new imported session and its transcript atomically.
+
+        Foreign imports must not expose a prefix transcript: the session row,
+        every parsed message, and their counters either commit together or are
+        all rolled back.  Unlike :meth:`create_session`, an occupied id is an
+        error rather than an opportunity to enrich an existing session.
+        """
+        def _do(conn):
+            # Imports acquire against an absent id before creating its session
+            # row, so the admission check has to precede the strict insert.
+            self._check_transcript_write_guards(
+                conn,
+                session_id,
+                None,
+                turn_lease_holder=turn_lease_holder,
+                turn_lease_ttl_seconds=turn_lease_ttl_seconds,
+            )
+            conn.execute(
+                """INSERT INTO sessions (id, source, cwd, origin_json, started_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (session_id, source, cwd, origin_json, time.time()),
+            )
+            inserted, tool_calls_total = self._insert_message_rows(
+                conn, session_id, messages
+            )
+            conn.execute(
+                """UPDATE sessions
+                   SET message_count = ?, tool_call_count = ?
+                   WHERE id = ?""",
+                (inserted, tool_calls_total, session_id),
+            )
+            return session_id
+
+        return self._execute_write(
+            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        )
+
     def record_gateway_session_peer(
         self,
         session_id: str,
@@ -7050,9 +7524,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     ) -> None:
         """Atomically close a parent and publish its durable compression child.
 
-        The parent closure, child row, and compacted handoff become visible in
-        one transaction. Readers can therefore observe either the live parent or
-        a complete child, never an ended parent with a missing/empty child.
+        The parent closure, child row, compacted handoff, and any carried title
+        with its provenance become visible in one transaction. Readers can
+        therefore observe either the live parent or a complete child, never an
+        ended parent with a missing/empty child or split title identity.
 
         Concurrent-append safety (#75316): when *watermark* is provided (the
         parent's :meth:`get_active_message_watermark` captured at compression
@@ -7085,7 +7560,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     f"Compression lease lost before publication: {parent_session_id}"
                 )
             parent = conn.execute(
-                """SELECT ended_at, cwd, git_branch, git_repo_root,
+                """SELECT ended_at, title, title_source, cwd, git_branch, git_repo_root,
                           user_id, session_key, chat_id, chat_type,
                           thread_id, display_name, origin_json, profile_name
                    FROM sessions WHERE id = ?""",
@@ -7179,6 +7654,35 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
                 (total_messages, total_tool_calls, child_session_id),
             )
+            if parent["title"] is not None:
+                cleared = conn.execute(
+                    "UPDATE sessions SET title = NULL, title_source = NULL "
+                    "WHERE id = ? AND title IS ? AND title_source IS ?",
+                    (
+                        parent_session_id,
+                        parent["title"],
+                        parent["title_source"],
+                    ),
+                )
+                if cleared.rowcount != 1:
+                    raise RuntimeError(
+                        f"Compression parent title changed during publication: "
+                        f"{parent_session_id}"
+                    )
+                assigned = conn.execute(
+                    "UPDATE sessions SET title = ?, title_source = ? "
+                    "WHERE id = ? AND title IS NULL AND title_source IS NULL",
+                    (
+                        parent["title"],
+                        parent["title_source"],
+                        child_session_id,
+                    ),
+                )
+                if assigned.rowcount != 1:
+                    raise RuntimeError(
+                        f"Compression child title changed during publication: "
+                        f"{child_session_id}"
+                    )
             updated = conn.execute(
                 "UPDATE sessions SET ended_at = ?, end_reason = 'compression' "
                 "WHERE id = ? AND ended_at IS NULL",
@@ -7984,16 +8488,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (conversation_id, current_holder),
                     )
             conn.execute(
-                "INSERT OR IGNORE INTO session_turn_leases "
+                "INSERT INTO session_turn_leases "
                 "(conversation_id, holder, acquired_at, expires_at) "
-                "VALUES (?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(conversation_id) DO NOTHING",
                 (conversation_id, holder, now, expires_at),
             )
             owner = conn.execute(
                 "SELECT holder FROM session_turn_leases WHERE conversation_id = ?",
                 (conversation_id,),
             ).fetchone()
-            return owner is not None and owner["holder"] == holder
+            if owner is None:
+                raise sqlite3.DatabaseError(
+                    "SESSION_TURN_LEASE_ACQUIRE_INSERT_MISSING"
+                )
+            return owner["holder"] == holder
 
         return bool(self._execute_write(_do, patience_s=patience_s))
 
@@ -9827,6 +10336,143 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if source not in (self.TITLE_SOURCE_DERIVED, self.TITLE_SOURCE_LLM):
             raise ValueError(f"invalid automatic title source: {source!r}")
         return self._set_session_title(session_id, title, source=source)
+
+    def set_auto_title_for_attempt(
+        self,
+        originating_session_id: str,
+        title: str,
+        *,
+        source: str,
+        expected_title: Optional[str],
+        expected_source: Optional[str],
+    ) -> bool:
+        """Conditionally persist a background title on its live attempt target.
+
+        An automatic title worker can outlive compression of the segment that
+        started it.  Resolve that segment's live compression continuation and
+        require the derived title captured by the originating attempt in the
+        SAME transaction as the LLM upgrade.  This leaves a worker that races a
+        manual title, another LLM result, or a non-compression close with no
+        target it may safely mutate.
+        """
+        if source not in (self.TITLE_SOURCE_DERIVED, self.TITLE_SOURCE_LLM):
+            raise ValueError(f"invalid automatic title source: {source!r}")
+        title = self.sanitize_title(title)
+        if not title:
+            return False
+        if expected_title is None:
+            if expected_source is not None:
+                return False
+        elif expected_source != self.TITLE_SOURCE_DERIVED:
+            return False
+
+        def _resolve_live_target(conn) -> Optional[str]:
+            current = originating_session_id
+            seen = {current} if current else set()
+            for _ in range(100):
+                row = conn.execute(
+                    "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+                    (current,),
+                ).fetchone()
+                if row is None:
+                    return None
+                if row["ended_at"] is None:
+                    return current
+                if row["end_reason"] != "compression":
+                    return None
+                children = conn.execute(
+                    """
+                    SELECT child.id
+                    FROM sessions AS parent
+                    JOIN sessions AS child ON child.parent_session_id = parent.id
+                    WHERE parent.id = ?
+                      AND parent.end_reason = 'compression'
+                      AND COALESCE(json_extract(COALESCE(child.model_config, '{}'),
+                                                '$._branched_from'), '') != ?
+                      AND COALESCE(json_extract(COALESCE(child.model_config, '{}'),
+                                                '$._delegate_from'), '') != ?
+                      AND COALESCE(child.source, '') != 'tool'
+                    ORDER BY child.started_at ASC, child.id ASC
+                    LIMIT 2
+                    """,
+                    (current, current, current),
+                ).fetchall()
+                if len(children) != 1:
+                    return None
+                child_id = children[0]["id"]
+                if not child_id or child_id in seen:
+                    return None
+                seen.add(child_id)
+                current = child_id
+            return None
+
+        def _do(conn):
+            target_id = _resolve_live_target(conn)
+            if target_id is None:
+                return 0
+            current = conn.execute(
+                "SELECT title, title_source, ended_at FROM sessions WHERE id = ?",
+                (target_id,),
+            ).fetchone()
+            if current is None or current["ended_at"] is not None:
+                return 0
+            if expected_title is None:
+                # A collision-declined instant title can still title an active
+                # origin later, but it has no derived identity to carry across
+                # a compression boundary.
+                if (
+                    target_id != originating_session_id
+                    or current["title"] is not None
+                    or current["title_source"] is not None
+                ):
+                    return 0
+            elif (
+                current["title"] != expected_title
+                or current["title_source"] != expected_source
+            ):
+                return 0
+
+            if (
+                current["title"] is not None
+                and self._title_rank(current["title_source"])
+                >= self._title_rank(source)
+            ):
+                return 0
+
+            conflict = conn.execute(
+                "SELECT id FROM sessions WHERE title = ? AND id != ?",
+                (title, target_id),
+            ).fetchone()
+            if conflict:
+                conflict_id = conflict["id"]
+                if self._is_compression_ancestor(
+                    conn, ancestor_id=conflict_id, descendant_id=target_id
+                ):
+                    conn.execute(
+                        "UPDATE sessions SET title = NULL, title_source = NULL "
+                        "WHERE id = ?",
+                        (conflict_id,),
+                    )
+                else:
+                    raise ValueError(
+                        f"Title '{title}' is already in use by session {conflict_id}"
+                    )
+
+            cursor = conn.execute(
+                "UPDATE sessions SET title = ?, title_source = ? "
+                "WHERE id = ? AND ended_at IS NULL AND title IS ? "
+                "AND title_source IS ?",
+                (
+                    title,
+                    source,
+                    target_id,
+                    current["title"],
+                    current["title_source"],
+                ),
+            )
+            return cursor.rowcount
+
+        return bool(self._execute_write(_do))
 
     def set_auto_title_if_empty(self, session_id: str, title: str) -> bool:
         """Back-compat shim: set an LLM title only if nothing better exists.

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -326,7 +326,75 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 26
+SCHEMA_VERSION = 27
+TURN_FENCE_GENERATION = 27
+
+TURN_FENCE_GOVERNED_TABLES = (
+    "messages",
+    "sessions",
+    "system_prompts",
+    "session_model_usage",
+    "session_turn_leases",
+    "compression_locks",
+    "gateway_routing",
+    "async_delegations",
+)
+TURN_FENCE_OPERATIONS = ("INSERT", "UPDATE", "DELETE")
+
+
+def register_turn_fence_generation(conn) -> None:
+    """Register the package generation scalar on one SQLite connection."""
+    conn.create_function(
+        "hermes_turn_fence_generation", 0, lambda: TURN_FENCE_GENERATION
+    )
+
+
+def turn_fence_trigger_name(table: str, operation: str) -> str:
+    return f"turn_fence_{table}_{operation.lower()}"
+
+
+def turn_fence_trigger_sql(table: str, operation: str) -> str:
+    """Build one governed-table generation trigger with a literal barrier."""
+    name = turn_fence_trigger_name(table, operation)
+    return (
+        f"CREATE TRIGGER {name} BEFORE {operation} ON {table} "
+        "BEGIN "
+        "SELECT CASE "
+        "WHEN typeof(hermes_turn_fence_generation()) != 'integer' "
+        f"OR hermes_turn_fence_generation() != {TURN_FENCE_GENERATION} "
+        "THEN RAISE(ABORT, 'state DB generation incompatible') "
+        "END; "
+        "END"
+    )
+
+
+def turn_fence_trigger_definitions() -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (
+            turn_fence_trigger_name(table, operation),
+            turn_fence_trigger_sql(table, operation),
+        )
+        for table in TURN_FENCE_GOVERNED_TABLES
+        for operation in TURN_FENCE_OPERATIONS
+    )
+
+
+#: Back-compat views over the declaration above, for the offline rollback tool
+#: (hermes_cli/session_fence_rollback*.py) and its tests: they read the fence
+#: surface as (table, operation) pairs / trigger names rather than the
+#: table-list x operation-list split above. Derived, not duplicated — moving
+#: TURN_FENCE_GOVERNED_TABLES or TURN_FENCE_OPERATIONS moves these with it.
+TURN_FENCE_SURFACE = tuple(
+    (table, operation)
+    for table in TURN_FENCE_GOVERNED_TABLES
+    for operation in TURN_FENCE_OPERATIONS
+)
+TURN_FENCE_TRIGGERS = tuple(name for name, _sql in turn_fence_trigger_definitions())
+
+#: The scalar function name each trigger body calls (see
+#: :func:`register_turn_fence_generation` / :func:`turn_fence_trigger_sql`),
+#: named so callers do not re-embed the literal.
+TURN_FENCE_FUNCTION_NAME = "hermes_turn_fence_generation"
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -10,6 +10,7 @@ module-level constants live in hermes_state_common.
 
 import logging
 import json
+import re
 import sqlite3
 import time
 from typing import Dict, Optional, Sequence
@@ -27,10 +28,14 @@ from hermes_state_common import (
     LEGACY_FTS_TRIGRAM_SQL,
     SCHEMA_SQL,
     SCHEMA_VERSION,
+    TURN_FENCE_GENERATION,
+    TURN_FENCE_GOVERNED_TABLES,
+    TURN_FENCE_OPERATIONS,
     _FTS_CJK_TRIGGERS,
     _FTS_TRIGGERS,
     _ephemeral_child_sql,
     fts_rebuild_admission,
+    turn_fence_trigger_definitions,
 )
 
 # Moved methods logged under the "hermes_state" logger before the split;
@@ -935,6 +940,413 @@ class SessionSchemaMixin:
         finally:
             cursor.execute("PRAGMA foreign_keys=ON")
 
+    def _session_turn_lease_epoch_rebuild_checkpoint(self, stage: str) -> None:
+        """Test seam for deterministic rollback probes of the legacy rebuild."""
+        del stage
+
+    def _heal_session_turn_leases_legacy_epoch(self, cursor: sqlite3.Cursor) -> None:
+        """Drop the legacy ``epoch`` column from ``session_turn_leases``.
+
+        Installs whose ``session_turn_leases`` table predates this module
+        carry ``epoch INTEGER NOT NULL`` with no ``DEFAULT`` (plus the
+        nullable ``owner_pid`` / ``owner_pid_start``, see below).
+        ``try_acquire_session_turn_lease``'s
+        ``INSERT OR IGNORE INTO session_turn_leases (conversation_id, holder,
+        acquired_at, expires_at) ...`` never populates ``epoch``, the NOT
+        NULL constraint rejects every row, and ``OR IGNORE`` swallows that
+        constraint violation with no error anywhere: the INSERT silently
+        does nothing, the row never exists, the following ``SELECT holder``
+        returns no owner, and ``try_acquire_session_turn_lease`` returns
+        False forever. Every caller then polls the full patience window and
+        reports "Another Hermes process is using this session" while nothing
+        holds it — measured as a 10-hour total outage on a live store.
+
+        There has never been a version-gated migration for this table (grep
+        confirms), so no schema_version bump could have healed it and a
+        store can be sitting at ``schema_version == SCHEMA_VERSION`` today
+        and still be broken. This has to run unconditionally on every open,
+        same pattern as :meth:`_heal_gateway_routing_pk` and
+        :meth:`_heal_session_model_usage_pk` above.
+
+        ``owner_pid`` / ``owner_pid_start`` are deliberately left in place.
+        They are nullable, so they were never the cause of the failure; no
+        code path (grepped repo-wide) reads or writes them on this table;
+        and ``SCHEMA_SQL``'s ``CREATE TABLE IF NOT EXISTS`` never looks at
+        them again once the table exists. Dropping them would fix nothing
+        and only adds DDL surface to what is otherwise a narrowly-scoped
+        repair — left for a separate cleanup if ever wanted.
+        """
+        try:
+            rows = cursor.execute(
+                'PRAGMA table_info("session_turn_leases")'
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return
+        if not rows:
+            # Table doesn't exist yet -- SCHEMA_SQL above just created it
+            # correctly (4 columns, no epoch).
+            return
+
+        def _col(row, idx, name):
+            return row[idx] if isinstance(row, (tuple, list)) else row[name]
+
+        live_cols = {_col(r, 1, "name") for r in rows}
+        if "epoch" not in live_cols:
+            return  # Already the shape hermes_state_common.py declares.
+
+        # DDL is authorized only for the complete observed outage shape.  A
+        # same-named epoch column can be a later extension with a valid
+        # default, different primary key, or otherwise unknown ownership; do
+        # not destructively reinterpret it as the one historical defect.
+        proven_legacy_descriptor = (
+            ("conversation_id", "TEXT", 0, None, 1),
+            ("holder", "TEXT", 1, None, 0),
+            ("acquired_at", "REAL", 1, None, 0),
+            ("expires_at", "REAL", 1, None, 0),
+            ("epoch", "INTEGER", 1, None, 0),
+            ("owner_pid", "INTEGER", 0, None, 0),
+            ("owner_pid_start", "REAL", 0, None, 0),
+        )
+        live_descriptor = tuple(
+            (
+                _col(row, 1, "name"),
+                _col(row, 2, "type"),
+                _col(row, 3, "notnull"),
+                _col(row, 4, "dflt_value"),
+                _col(row, 5, "pk"),
+            )
+            for row in rows
+        )
+        proven_legacy_table_sql = (
+            "CREATE TABLE session_turn_leases ( "
+            "conversation_id TEXT PRIMARY KEY, holder TEXT NOT NULL, "
+            "acquired_at REAL NOT NULL, expires_at REAL NOT NULL, "
+            "epoch INTEGER NOT NULL, owner_pid INTEGER, owner_pid_start REAL )"
+        )
+        table_row = cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+            ("session_turn_leases",),
+        ).fetchone()
+        table_sql = _col(table_row, 0, "sql") if table_row is not None else None
+        if (
+            live_descriptor != proven_legacy_descriptor
+            or not isinstance(table_sql, str)
+            or " ".join(table_sql.split()) != proven_legacy_table_sql
+        ):
+            raise sqlite3.DatabaseError(
+                "SESSION_TURN_LEASE_EPOCH_HEAL_REFUSED: "
+                "session_turn_leases does not match the proven legacy descriptor"
+            )
+
+        logger.info(
+            "session_turn_leases has legacy NOT NULL 'epoch' column with no "
+            "DEFAULT; every acquire has been silently failing on this "
+            "store (INSERT OR IGNORE swallows the NOT NULL violation). "
+            "Dropping the column."
+        )
+
+        if sqlite3.sqlite_version_info >= (3, 35, 0):
+            # DROP COLUMN (SQLite >= 3.35, released 2021-03-12; the
+            # interpreter this repo runs under is 3.50.4) is an in-place
+            # schema edit: unlike a rename+rebuild it does not touch the
+            # table's identity, so the three turn-fence triggers already
+            # attached to session_turn_leases (it is in
+            # TURN_FENCE_GOVERNED_TABLES) are untouched -- nothing to
+            # reinstall, nothing to verify, no schema_version bookkeeping
+            # to disturb. None of those triggers' bodies reference `epoch`
+            # (turn_fence_trigger_sql() only ever calls
+            # hermes_turn_fence_generation(), see hermes_state_common.py),
+            # so SQLite's "column used by a trigger/view" restriction on
+            # DROP COLUMN does not apply here -- verified empirically
+            # (governed table with all three triggers attached, DROP
+            # COLUMN succeeds and the triggers keep firing) before this
+            # was written; see tests/state/test_session_turn_lease_epoch_heal.py.
+            def _epoch_is_still_present() -> bool:
+                return any(
+                    _col(row, 1, "name") == "epoch"
+                    for row in cursor.execute(
+                        'PRAGMA table_info("session_turn_leases")'
+                    ).fetchall()
+                )
+
+            try:
+                cursor.execute(
+                    'ALTER TABLE "session_turn_leases" DROP COLUMN "epoch"'
+                )
+            except sqlite3.OperationalError as exc:
+                # Lock/busy failures must reach the outer open-time patience
+                # loop unchanged.  A real DDL blocker is a durable unsafe
+                # state: refuse the open rather than logging and continuing.
+                if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+                    raise
+                if _epoch_is_still_present():
+                    raise sqlite3.DatabaseError(
+                        "SESSION_TURN_LEASE_EPOCH_HEAL_DROP_FAILED: "
+                        "SQLite could not remove legacy session_turn_leases.epoch"
+                    ) from exc
+                raise
+            if _epoch_is_still_present():
+                raise sqlite3.DatabaseError(
+                    "SESSION_TURN_LEASE_EPOCH_HEAL_INCOMPLETE: "
+                    "session_turn_leases.epoch remains after DROP COLUMN"
+                )
+            return
+
+        # SQLite < 3.35 lacks DROP COLUMN.  The preflight snapshot itself is
+        # destructive authority: a connection that adds an object after an
+        # unlocked census but before RENAME would have that object carried to
+        # the legacy table then deleted without replay.  Take the write lock
+        # first, then authoritatively revalidate the descriptor, table DDL,
+        # and every replayable/dependent schema object before any mutation.
+        projection = (
+            "conversation_id, holder, acquired_at, expires_at, "
+            "owner_pid, owner_pid_start"
+        )
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            rows = cursor.execute(
+                'PRAGMA table_info("session_turn_leases")'
+            ).fetchall()
+            live_cols = {_col(r, 1, "name") for r in rows}
+            if "epoch" not in live_cols:
+                # Another writer completed the repair before this transaction
+                # acquired its lock.  We made no mutation, so commit the
+                # empty transaction and leave the converged table alone.
+                self._conn.commit()
+                return
+            live_descriptor = tuple(
+                (
+                    _col(row, 1, "name"),
+                    _col(row, 2, "type"),
+                    _col(row, 3, "notnull"),
+                    _col(row, 4, "dflt_value"),
+                    _col(row, 5, "pk"),
+                )
+                for row in rows
+            )
+            table_row = cursor.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+                ("session_turn_leases",),
+            ).fetchone()
+            table_sql = _col(table_row, 0, "sql") if table_row is not None else None
+            if (
+                live_descriptor != proven_legacy_descriptor
+                or not isinstance(table_sql, str)
+                or " ".join(table_sql.split()) != proven_legacy_table_sql
+            ):
+                raise sqlite3.DatabaseError(
+                    "SESSION_TURN_LEASE_EPOCH_HEAL_REFUSED: "
+                    "session_turn_leases does not match the proven legacy descriptor"
+                )
+
+            fence_definitions = tuple(
+                (name, sql)
+                for name, sql in turn_fence_trigger_definitions()
+                if name.startswith("turn_fence_session_turn_leases_")
+            )
+            expected_fences = dict(fence_definitions)
+            object_rows = cursor.execute(
+                "SELECT type, name, sql FROM sqlite_master "
+                "WHERE tbl_name = ? AND type IN ('index', 'trigger') "
+                "AND sql IS NOT NULL ORDER BY type, name",
+                ("session_turn_leases",),
+            ).fetchall()
+            preserved_indexes = []
+            preserved_triggers = []
+            for row in object_rows:
+                object_type = _col(row, 0, "type")
+                name = _col(row, 1, "name")
+                sql = _col(row, 2, "sql")
+                if not isinstance(name, str) or not isinstance(sql, str):
+                    raise sqlite3.DatabaseError(
+                        "SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED: "
+                        "session_turn_leases has an unprovable schema object"
+                    )
+                if name in expected_fences:
+                    if object_type != "trigger" or sql != expected_fences[name]:
+                        raise sqlite3.DatabaseError(
+                            "SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED: "
+                            "turn-fence object is not the canonical declaration"
+                        )
+                    continue
+                if "epoch" in sql.lower():
+                    raise sqlite3.DatabaseError(
+                        "SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED: "
+                        "session_turn_leases schema object depends on epoch"
+                    )
+                if object_type == "index":
+                    preserved_indexes.append((name, sql))
+                elif object_type == "trigger":
+                    preserved_triggers.append((name, sql))
+                else:
+                    raise sqlite3.DatabaseError(
+                        "SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED: "
+                        "session_turn_leases has an unsupported schema object"
+                    )
+
+            mentions_lease_table = re.compile(
+                r"(?<![0-9A-Za-z_$])session_turn_leases(?![0-9A-Za-z_$])",
+                re.IGNORECASE,
+            )
+            dependent_rows = cursor.execute(
+                "SELECT type, name, sql FROM sqlite_master "
+                "WHERE type IN ('view', 'trigger') AND tbl_name != ? "
+                "ORDER BY type, name",
+                ("session_turn_leases",),
+            ).fetchall()
+            for row in dependent_rows:
+                object_type = _col(row, 0, "type")
+                name = _col(row, 1, "name")
+                sql = _col(row, 2, "sql")
+                if not isinstance(name, str) or not isinstance(sql, str):
+                    raise sqlite3.DatabaseError(
+                        "SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED: "
+                        "session_turn_leases has an unprovable dependent object"
+                    )
+                if mentions_lease_table.search(sql):
+                    raise sqlite3.DatabaseError(
+                        "SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED: "
+                        "session_turn_leases has an unprovable dependent object"
+                    )
+
+            table_names = cursor.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name != ?",
+                ("session_turn_leases",),
+            ).fetchall()
+            for table_name_row in table_names:
+                table_name = _col(table_name_row, 0, "name")
+                if not isinstance(table_name, str):
+                    raise sqlite3.DatabaseError(
+                        "SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED: "
+                        "session_turn_leases has an unprovable dependent object"
+                    )
+                escaped_table_name = table_name.replace('"', '""')
+                foreign_keys = cursor.execute(
+                    f'PRAGMA foreign_key_list("{escaped_table_name}")'
+                ).fetchall()
+                if any(
+                    isinstance(_col(foreign_key, 2, "table"), str)
+                    and _col(foreign_key, 2, "table").casefold()
+                    == "session_turn_leases"
+                    for foreign_key in foreign_keys
+                ):
+                    raise sqlite3.DatabaseError(
+                        "SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED: "
+                        "session_turn_leases has an unprovable dependent object"
+                    )
+
+            cursor.execute(
+                'ALTER TABLE "session_turn_leases" '
+                'RENAME TO "session_turn_leases_legacy_epoch"'
+            )
+            self._session_turn_lease_epoch_rebuild_checkpoint("rename")
+            cursor.execute(
+                """CREATE TABLE session_turn_leases (
+    conversation_id TEXT PRIMARY KEY,
+    holder TEXT NOT NULL,
+    acquired_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
+    owner_pid INTEGER,
+    owner_pid_start REAL
+)"""
+            )
+            self._session_turn_lease_epoch_rebuild_checkpoint("create")
+            source_rows = [
+                tuple(row)
+                for row in cursor.execute(
+                    f"SELECT {projection} FROM session_turn_leases_legacy_epoch "
+                    "ORDER BY rowid"
+                ).fetchall()
+            ]
+            source_count = cursor.execute(
+                "SELECT COUNT(*) FROM session_turn_leases_legacy_epoch"
+            ).fetchone()[0]
+            cursor.execute(
+                "INSERT INTO session_turn_leases "
+                f"({projection}) SELECT {projection} "
+                "FROM session_turn_leases_legacy_epoch ORDER BY rowid"
+            )
+            self._session_turn_lease_epoch_rebuild_checkpoint("copy")
+            target_rows = [
+                tuple(row)
+                for row in cursor.execute(
+                    f"SELECT {projection} FROM session_turn_leases ORDER BY rowid"
+                ).fetchall()
+            ]
+            target_count = cursor.execute(
+                "SELECT COUNT(*) FROM session_turn_leases"
+            ).fetchone()[0]
+            if (
+                source_count != target_count
+                or len(source_rows) != source_count
+                or target_rows != source_rows
+            ):
+                raise sqlite3.DatabaseError(
+                    "SESSION_TURN_LEASE_EPOCH_REBUILD_VERIFY_FAILED: "
+                    "session_turn_leases copy did not preserve every row"
+                )
+            self._session_turn_lease_epoch_rebuild_checkpoint("verify")
+            cursor.execute("DROP TABLE session_turn_leases_legacy_epoch")
+            self._session_turn_lease_epoch_rebuild_checkpoint("drop")
+            for _name, sql in preserved_indexes:
+                cursor.execute(sql)
+            self._session_turn_lease_epoch_rebuild_checkpoint("index")
+            for _name, sql in preserved_triggers:
+                cursor.execute(sql)
+            for _name, sql in fence_definitions:
+                cursor.execute(sql)
+            actual_fences = {
+                _col(row, 0, "name"): _col(row, 1, "sql")
+                for row in cursor.execute(
+                    "SELECT name, sql FROM sqlite_master "
+                    "WHERE type = 'trigger' AND name IN (?, ?, ?)",
+                    tuple(expected_fences),
+                ).fetchall()
+            }
+            if actual_fences != expected_fences:
+                raise sqlite3.DatabaseError(
+                    "SESSION_TURN_LEASE_EPOCH_REBUILD_VERIFY_FAILED: "
+                    "session_turn_leases turn-fence triggers were not restored"
+                )
+            self._session_turn_lease_epoch_rebuild_checkpoint("trigger")
+            self._conn.commit()
+        except BaseException:
+            self._conn.rollback()
+            raise
+
+    def _apply_turn_fence_generation_delta(self, cursor: sqlite3.Cursor) -> None:
+        """Atomically install and verify the complete v27 trigger barrier."""
+        definitions = turn_fence_trigger_definitions()
+        if len(definitions) != (
+            len(TURN_FENCE_GOVERNED_TABLES) * len(TURN_FENCE_OPERATIONS)
+        ):
+            raise RuntimeError("turn-fence trigger declaration is incomplete")
+        expected = dict(definitions)
+        cursor.execute("BEGIN")
+        try:
+            for name, _sql in definitions:
+                cursor.execute(f"DROP TRIGGER IF EXISTS {name}")
+            for _name, sql in definitions:
+                cursor.execute(sql)
+            placeholders = ", ".join("?" for _name in expected)
+            rows = cursor.execute(
+                "SELECT name, sql FROM sqlite_master "
+                f"WHERE type = 'trigger' AND name IN ({placeholders})",
+                tuple(expected),
+            ).fetchall()
+            if {row[0]: row[1] for row in rows} != expected:
+                raise RuntimeError("turn-fence trigger verification failed")
+            cursor.execute("DELETE FROM schema_version")
+            cursor.execute(
+                "INSERT INTO schema_version (version) VALUES (?)",
+                (SCHEMA_VERSION,),
+            )
+            self._conn.commit()
+        except BaseException:
+            self._conn.rollback()
+            raise
+
     def _init_schema(self):
         """Create tables and FTS if they don't exist, reconcile columns.
 
@@ -969,6 +1381,13 @@ class SessionSchemaMixin:
         # landed — the version-gated rebuild is unreachable there, #73823).
         # Same PK-rebuild constraint as gateway_routing above.
         self._heal_session_model_usage_pk(cursor)
+
+        # Drop the legacy NOT NULL `epoch` column from session_turn_leases
+        # if present. There is no version-gated migration for this table,
+        # so this must run unconditionally like the two heals above (#84512:
+        # measured as a 10-hour outage — every turn-lease acquire silently
+        # failed via INSERT OR IGNORE swallowing the NOT NULL violation).
+        self._heal_session_turn_leases_legacy_epoch(cursor)
 
         # Indexes that reference reconciler-added columns must be created
         # AFTER _reconcile_columns runs — declaring them in SCHEMA_SQL
@@ -1028,10 +1447,7 @@ class SessionSchemaMixin:
         cursor.execute("SELECT version FROM schema_version LIMIT 1")
         row = cursor.fetchone()
         if row is None:
-            cursor.execute(
-                "INSERT INTO schema_version (version) VALUES (?)",
-                (SCHEMA_VERSION,),
-            )
+            current_version = 0
         else:
             current_version = row["version"] if isinstance(row, sqlite3.Row) else row[0]
             # Data migrations that can't be expressed declaratively (row
@@ -1298,13 +1714,13 @@ class SessionSchemaMixin:
             # is the one case we skip (we can't have created the current FTS
             # objects, so claiming the current schema would be a lie).
             if (
-                current_version < SCHEMA_VERSION
+                current_version < TURN_FENCE_GENERATION - 1
                 and fts_migrations_complete
                 and fts5_available
             ):
                 cursor.execute(
                     "UPDATE schema_version SET version = ?",
-                    (SCHEMA_VERSION,),
+                    (TURN_FENCE_GENERATION - 1,),
                 )
 
         # Unique title index — always ensure it exists. Older databases may
@@ -1438,7 +1854,8 @@ class SessionSchemaMixin:
             if getattr(self, "_fts_enabled", False):
                 self._migrate_broad_fts_update_triggers(cursor)
 
-        self._conn.commit()
+        if current_version < SCHEMA_VERSION:
+            self._apply_turn_fence_generation_delta(cursor)
 
     def _run_admitted_startup_rebuild(self, cursor, rebuild_fn) -> None:
         """Run a full trigger-repair FTS rebuild under cross-process admission.

--- a/packet/ai.hermes.gateway-freeze-watchdog.plist
+++ b/packet/ai.hermes.gateway-freeze-watchdog.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.hermes.gateway-freeze-watchdog</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__WATCHDOG_SCRIPT__</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>__WATCHDOG_PATH__</string>
+    <key>WATCHDOG_ROOT</key>
+    <string>__WATCHDOG_ROOT__</string>
+    <key>WATCHDOG_INSPECT_CMD</key>
+    <string>__WATCHDOG_INSPECT_CMD__</string>
+    <key>WATCHDOG_TIME_CMD</key>
+    <string>__WATCHDOG_TIME_CMD__</string>
+    <key>WATCHDOG_SCRIPT_PATH</key>
+    <string>__WATCHDOG_SCRIPT_PATH__</string>
+    <key>WATCHDOG_EXPECTED_SHA256</key>
+    <string>__WATCHDOG_EXPECTED_SHA256__</string>
+    <key>WATCHDOG_HASH_CMD</key>
+    <string>__WATCHDOG_HASH_CMD__</string>
+  </dict>
+</dict>
+</plist>

--- a/packet/gateway-freeze-watchdog.sh
+++ b/packet/gateway-freeze-watchdog.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+set -u
+
+emit() {
+  printf '%s\n' "$1"
+}
+
+is_uint() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+is_token() {
+  [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+is_sha256() {
+  [[ "$1" =~ ^[0-9a-f]{64}$ ]]
+}
+
+read_generation() {
+  local file=$1 line pipes extra
+  [[ -f "$file" && -r "$file" ]] || return 1
+  IFS= read -r line < "$file" || [[ -n "${line:-}" ]] || return 1
+  pipes=${line//[^|]/}
+  [[ "$pipes" == '||' ]] || return 1
+  IFS='|' read -r generation_token process_pid process_start extra <<< "$line"
+  [[ -z "$extra" ]] && is_token "$generation_token" && is_uint "$process_pid" && (( process_pid > 0 )) && is_uint "$process_start" || return 1
+  generation_snapshot=$line
+}
+
+read_record() {
+  local file=$1 line pipes extra
+  [[ -f "$file" && -r "$file" ]] || return 1
+  IFS= read -r line < "$file" || [[ -n "${line:-}" ]] || return 1
+  pipes=${line//[^|]/}
+  [[ "$pipes" == '||' ]] || return 1
+  IFS='|' read -r record_route record_generation record_epoch extra <<< "$line"
+  [[ -z "$extra" ]] && is_token "$record_route" && is_token "$record_generation" && is_uint "$record_epoch" && (( record_epoch > 0 )) || return 1
+}
+
+same_generation() {
+  read_generation "$generation_file" && [[ "$generation_snapshot" == "$captured_generation" ]]
+}
+
+release_lock() {
+  local owner_line
+  if [[ "${owns_lock:-0}" == 1 && -d "$lock_dir" && -f "$lock_dir/owner" ]]; then
+    IFS= read -r owner_line < "$lock_dir/owner" || owner_line=""
+    if [[ "$owner_line" == "$owner_token" ]]; then
+      rm -f -- "$lock_dir/owner"
+      rmdir -- "$lock_dir" 2>/dev/null || true
+    fi
+  fi
+  owns_lock=0
+}
+
+acquire_lock() {
+  if mkdir "$lock_dir" 2>/dev/null; then
+    printf '%s\n' "$owner_token" > "$lock_dir/owner"
+    owns_lock=1
+    return 0
+  fi
+  return 1
+}
+
+request_reset() {
+  ( set -C; printf '%s\n' "$captured_generation" > "$reset_file" ) 2>/dev/null || [[ -e "$reset_file" ]]
+}
+
+clear_strikes() {
+  clear_strikes_result=UNKNOWN
+  if ! acquire_lock; then
+    if request_reset; then
+      clear_strikes_result=BUSY
+    fi
+    return 1
+  fi
+  if same_generation; then
+    if [[ -e "$state_file" ]]; then
+      : > "$state_file"
+    fi
+    if [[ -e "$reset_file" ]] && ! rm -f -- "$reset_file"; then
+      release_lock
+      return 1
+    fi
+    release_lock
+    return 0
+  fi
+  : > "$state_file"
+  release_lock
+  clear_strikes_result=GENERATION_DRIFT
+  return 1
+}
+
+clear_or_fail_closed() {
+  if clear_strikes; then
+    return 0
+  fi
+  emit "A_UNKNOWN B_UNKNOWN DECISION_${clear_strikes_result}"
+  return 1
+}
+
+root=${WATCHDOG_ROOT:-}
+inspect_cmd=${WATCHDOG_INSPECT_CMD:-}
+script_path=${WATCHDOG_SCRIPT_PATH:-}
+expected_sha=${WATCHDOG_EXPECTED_SHA256:-}
+hash_cmd=${WATCHDOG_HASH_CMD:-shasum}
+now=${WATCHDOG_NOW:-}
+
+if [[ -z "$root" || -z "$inspect_cmd" || -z "$script_path" ]] || ! is_sha256 "$expected_sha"; then
+  emit "NOT_MANAGED"
+  exit 0
+fi
+
+actual_line=$("$hash_cmd" -a 256 "$script_path" 2>/dev/null || true)
+actual_sha=${actual_line%% *}
+if ! is_sha256 "$actual_sha" || [[ "$actual_sha" != "$expected_sha" ]]; then
+  emit "NOT_MANAGED"
+  exit 0
+fi
+
+if ! is_uint "$now"; then
+  time_cmd=${WATCHDOG_TIME_CMD:-}
+  if [[ -n "$time_cmd" ]]; then
+    now=$("$time_cmd" 2>/dev/null || true)
+  fi
+fi
+if ! is_uint "$now"; then
+  emit "A_UNKNOWN B_UNKNOWN DECISION_UNKNOWN"
+  exit 0
+fi
+
+generation_file="$root/generation"
+state_file="$root/state"
+recommendation_file="$root/recommendation"
+lock_dir="$root/transition.lock"
+owns_lock=0
+
+if ! read_generation "$generation_file"; then
+  emit "A_UNKNOWN B_UNKNOWN DECISION_UNKNOWN"
+  exit 0
+fi
+captured_generation=$generation_snapshot
+owner_token="${generation_token}.${process_pid}.$$"
+reset_file="$root/reset.${generation_token}"
+trap release_lock EXIT
+
+if inspection=$("$inspect_cmd" "$process_pid" 2>/dev/null); then
+  inspection_status=0
+else
+  inspection_status=$?
+fi
+
+if (( inspection_status != 0 )); then
+  clear_or_fail_closed || exit 0
+  emit "A_UNKNOWN B_UNKNOWN DECISION_UNKNOWN"
+  exit 0
+fi
+
+if [[ "$inspection" == *ESTABLISHED*gateway* ]]; then
+  clear_or_fail_closed || exit 0
+  emit "A_HEALTHY B_SKIPPED DECISION_HEALTHY"
+  exit 0
+fi
+
+if ! IFS= read -r log_epoch < "$root/log_epoch" || ! is_uint "$log_epoch" || (( now < log_epoch )); then
+  clear_or_fail_closed || exit 0
+  emit "A_UNKNOWN B_UNKNOWN DECISION_UNKNOWN"
+  exit 0
+fi
+
+if (( now - log_epoch < 600 )); then
+  clear_or_fail_closed || exit 0
+  emit "A_HEALTHY B_SKIPPED DECISION_HEALTHY"
+  exit 0
+fi
+
+if ! read_record "$root/inbound"; then
+  clear_or_fail_closed || exit 0
+  emit "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN"
+  exit 0
+fi
+inbound_route=$record_route
+inbound_generation=$record_generation
+inbound_epoch=$record_epoch
+
+if [[ "$inbound_generation" != "$generation_token" ]] || (( inbound_epoch < process_start )); then
+  clear_or_fail_closed || exit 0
+  emit "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN"
+  exit 0
+fi
+
+if ! read_record "$root/progress"; then
+  clear_or_fail_closed || exit 0
+  emit "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN"
+  exit 0
+fi
+
+if [[ "$record_route" != "$inbound_route" || "$record_generation" != "$generation_token" ]] || (( record_epoch < process_start || record_epoch < inbound_epoch || now < record_epoch )); then
+  clear_or_fail_closed || exit 0
+  emit "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN"
+  exit 0
+fi
+
+progress_epoch=$record_epoch
+if (( now - progress_epoch < 600 )); then
+  clear_or_fail_closed || exit 0
+  emit "A_SUSPECT B_HEALTHY DECISION_HEALTHY"
+  exit 0
+fi
+
+if [[ -e "$root/response" ]]; then
+  if ! read_record "$root/response" || [[ "$record_route" != "$inbound_route" || "$record_generation" != "$generation_token" ]]; then
+    clear_or_fail_closed || exit 0
+    emit "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN"
+    exit 0
+  fi
+  if (( record_epoch > inbound_epoch )); then
+    clear_or_fail_closed || exit 0
+    emit "A_SUSPECT B_HEALTHY DECISION_HEALTHY"
+    exit 0
+  fi
+fi
+
+if ! acquire_lock; then
+  emit "A_SUSPECT B_SUSPECT DECISION_BUSY"
+  exit 0
+fi
+
+before_strike_cmd=${WATCHDOG_BEFORE_STRIKE_CMD:-}
+if [[ -n "$before_strike_cmd" ]]; then
+  "$before_strike_cmd" "$root" >/dev/null 2>&1 || true
+fi
+
+if ! same_generation; then
+  : > "$state_file"
+  release_lock
+  emit "A_UNKNOWN B_UNKNOWN DECISION_GENERATION_DRIFT"
+  exit 0
+fi
+
+if [[ -e "$reset_file" ]]; then
+  : > "$state_file"
+  if ! rm -f -- "$reset_file"; then
+    release_lock
+    emit "A_UNKNOWN B_UNKNOWN DECISION_UNKNOWN"
+    exit 0
+  fi
+fi
+
+prior_generation=""
+prior_class=""
+prior_count=0
+if [[ -f "$state_file" ]]; then
+  IFS= read -r prior_line < "$state_file" || prior_line=""
+  IFS='|' read -r prior_generation prior_class prior_count prior_extra <<< "$prior_line"
+  if [[ -n "${prior_extra:-}" ]] || ! is_uint "${prior_count:-}"; then
+    prior_generation=""
+    prior_class=""
+    prior_count=0
+  fi
+fi
+
+observation_class="A_SOCKET_ZERO_B_PROGRESS_STALE"
+if [[ "$prior_generation" == "$generation_token" && "$prior_class" == "$observation_class" && "$prior_count" == 1 ]]; then
+  next_count=2
+elif [[ "$prior_generation" == "$generation_token" && "$prior_class" == "$observation_class" && "$prior_count" == 2 ]]; then
+  next_count=2
+else
+  next_count=1
+fi
+
+if ! same_generation; then
+  : > "$state_file"
+  release_lock
+  emit "A_UNKNOWN B_UNKNOWN DECISION_GENERATION_DRIFT"
+  exit 0
+fi
+
+if (( next_count == 1 )); then
+  printf '%s|%s|1\n' "$generation_token" "$observation_class" > "$state_file"
+  release_lock
+  emit "A_SUSPECT B_SUSPECT DECISION_FIRST_STRIKE"
+  exit 0
+fi
+
+if (( prior_count == 2 )); then
+  release_lock
+  emit "A_SUSPECT B_SUSPECT DECISION_ALREADY_RECORDED"
+  exit 0
+fi
+
+printf '%s|%s|2\n' "$generation_token" "$observation_class" > "$state_file"
+if ! same_generation; then
+  : > "$state_file"
+  release_lock
+  emit "A_UNKNOWN B_UNKNOWN DECISION_GENERATION_DRIFT"
+  exit 0
+fi
+
+if [[ ! -e "$recommendation_file" ]]; then
+  ( set -C; printf '%s\n' "RESTART_RECOMMENDED" > "$recommendation_file" ) 2>/dev/null || true
+fi
+
+if [[ -f "$recommendation_file" ]]; then
+  IFS= read -r recommendation < "$recommendation_file" || recommendation=""
+else
+  recommendation=""
+fi
+release_lock
+if [[ "$recommendation" == "RESTART_RECOMMENDED" ]]; then
+  emit "A_SUSPECT B_SUSPECT DECISION_RESTART_RECOMMENDED"
+else
+  emit "A_SUSPECT B_SUSPECT DECISION_UNKNOWN"
+fi

--- a/packet/receipt.json
+++ b/packet/receipt.json
@@ -1,0 +1,5 @@
+{
+  "artifact": "gateway-freeze-watchdog",
+  "authority": "observer_only",
+  "operational_liveness": "UNVERIFIED"
+}

--- a/packet/test-gateway-freeze-watchdog.sh
+++ b/packet/test-gateway-freeze-watchdog.sh
@@ -1,0 +1,514 @@
+#!/usr/bin/env bash
+set -u
+
+base_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+watchdog="$base_dir/gateway-freeze-watchdog.sh"
+plist_template="$base_dir/ai.hermes.gateway-freeze-watchdog.plist"
+receipt="$base_dir/receipt.json"
+passes=0
+failures=0
+roots=()
+
+cleanup() {
+  local root
+  for root in "${roots[@]:-}"; do
+    rm -rf -- "$root"
+  done
+}
+trap cleanup EXIT
+
+pass() {
+  passes=$((passes + 1))
+  printf 'ok %s\n' "$1"
+}
+
+fail() {
+  failures=$((failures + 1))
+  printf 'not ok %s\n' "$1"
+}
+
+assert_eq() {
+  local name=$1 expected=$2 actual=$3
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$name"
+  else
+    fail "$name"
+    printf '  expected: %s\n  actual:   %s\n' "$expected" "$actual"
+  fi
+}
+
+assert_no_state() {
+  local name=$1 root=$2
+  if [[ ! -s "$root/state" ]]; then
+    pass "$name"
+  else
+    fail "$name"
+  fi
+}
+
+make_root() {
+  local root
+  root=$(mktemp -d)
+  roots+=("$root")
+  printf 'gen-a|123|100\n' > "$root/generation"
+  printf '400\n' > "$root/log_epoch"
+  printf 'route-a|gen-a|300\n' > "$root/inbound"
+  printf 'route-a|gen-a|300\n' > "$root/progress"
+  cat > "$root/inspect" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_INSPECT_OUTPUT:-}"
+exit "${FAKE_INSPECT_STATUS:-0}"
+EOF
+  chmod 700 "$root/inspect"
+  printf '%s' "$root"
+}
+
+make_clock() {
+  local root=$1
+  cat > "$root/clock" <<'EOF'
+#!/usr/bin/env bash
+printf '1000\n'
+EOF
+  chmod 700 "$root/clock"
+}
+
+invoke() {
+  local root=$1 digest=${2:-} now output
+  if [[ -z "$digest" ]]; then
+    digest=$(shasum -a 256 "$watchdog" 2>/dev/null | cut -d ' ' -f 1 || true)
+  fi
+  now=${WATCHDOG_NOW_FOR_TEST-1000}
+  output=$(WATCHDOG_ROOT="$root" WATCHDOG_NOW="$now" WATCHDOG_TIME_CMD="${WATCHDOG_TIME_CMD:-}" \
+    PATH="${WATCHDOG_TEST_PATH:-$PATH}" PROHIBITED_ACTION_LOG="${PROHIBITED_ACTION_LOG:-}" \
+    WATCHDOG_INSPECT_CMD="$root/inspect" WATCHDOG_SCRIPT_PATH="$watchdog" \
+    WATCHDOG_EXPECTED_SHA256="$digest" "$watchdog" 2>&1 || true)
+  printf '%s' "$output"
+}
+
+render_plist() {
+  local root=$1 digest rendered
+  digest=$(shasum -a 256 "$watchdog" | cut -d ' ' -f 1)
+  rendered="$root/rendered.plist"
+  python3 - "$plist_template" "$rendered" "$watchdog" "$digest" "$root" <<'PY' || return 1
+import plistlib
+import sys
+from pathlib import Path
+
+template, rendered, script, digest, root = sys.argv[1:]
+text = Path(template).read_text()
+values = {
+    "__WATCHDOG_SCRIPT__": script,
+    "__WATCHDOG_PATH__": str(Path(root) / "fixture-bin"),
+    "__WATCHDOG_ROOT__": root,
+    "__WATCHDOG_INSPECT_CMD__": str(Path(root) / "inspect"),
+    "__WATCHDOG_TIME_CMD__": str(Path(root) / "clock"),
+    "__WATCHDOG_SCRIPT_PATH__": script,
+    "__WATCHDOG_EXPECTED_SHA256__": digest,
+    "__WATCHDOG_HASH_CMD__": "shasum",
+}
+for key, value in values.items():
+    text = text.replace(key, value)
+assert "__WATCHDOG_" not in text
+Path(rendered).write_text(text)
+with Path(rendered).open("rb") as stream:
+    data = plistlib.load(stream)
+assert data["Label"] == "ai.hermes.gateway-freeze-watchdog"
+assert data["StartInterval"] == 300
+assert data["ProgramArguments"] == [script]
+expected_env = {
+    "PATH",
+    "WATCHDOG_ROOT",
+    "WATCHDOG_INSPECT_CMD",
+    "WATCHDOG_TIME_CMD",
+    "WATCHDOG_SCRIPT_PATH",
+    "WATCHDOG_EXPECTED_SHA256",
+    "WATCHDOG_HASH_CMD",
+}
+assert set(data["EnvironmentVariables"]) == expected_env
+assert data["EnvironmentVariables"]["WATCHDOG_EXPECTED_SHA256"] == digest
+assert data["EnvironmentVariables"]["WATCHDOG_SCRIPT_PATH"] == script
+PY
+  plutil -lint "$rendered" >/dev/null
+}
+
+test_inspection_failure_is_unknown() {
+  local root output
+  root=$(make_root)
+  output=$(FAKE_INSPECT_STATUS=1 invoke "$root")
+  assert_eq "inspection failure is A_UNKNOWN with zero-strike decision" \
+    "A_UNKNOWN B_UNKNOWN DECISION_UNKNOWN" "$output"
+  assert_no_state "inspection failure creates no strike state" "$root"
+}
+
+test_zero_sockets_after_stale_log_is_a_suspect() {
+  local root output
+  root=$(make_root)
+  rm -f -- "$root/progress"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "successful full inspection with zero sockets is A_SUSPECT" \
+    "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN" "$output"
+  assert_no_state "zero-socket B_UNKNOWN creates no strike state" "$root"
+}
+
+test_matching_socket_is_healthy() {
+  local root output
+  root=$(make_root)
+  output=$(FAKE_INSPECT_OUTPUT="ESTABLISHED gateway" invoke "$root")
+  assert_eq "matching established socket is A_HEALTHY" \
+    "A_HEALTHY B_SKIPPED DECISION_HEALTHY" "$output"
+}
+
+test_fresh_log_is_healthy() {
+  local root output
+  root=$(make_root)
+  printf '401\n' > "$root/log_epoch"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "zero sockets with fresh log is A_HEALTHY" \
+    "A_HEALTHY B_SKIPPED DECISION_HEALTHY" "$output"
+}
+
+test_same_route_post_inbound_stale_progress_starts_strike() {
+  local root output state
+  root=$(make_root)
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "same-route post-inbound stale progress starts first strike" \
+    "A_SUSPECT B_SUSPECT DECISION_FIRST_STRIKE" "$output"
+  state=$(<"$root/state")
+  assert_eq "first strike is bound to generation and observation class" \
+    "gen-a|A_SOCKET_ZERO_B_PROGRESS_STALE|1" "$state"
+}
+
+test_invalid_progress_is_unknown() {
+  local root output
+  root=$(make_root)
+  rm -f -- "$root/progress"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "missing progress is B_UNKNOWN" "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN" "$output"
+  assert_no_state "missing progress has zero strike" "$root"
+
+  root=$(make_root)
+  printf 'route-a|gen-a|bad\n' > "$root/progress"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "malformed progress is B_UNKNOWN" "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN" "$output"
+
+  root=$(make_root)
+  printf 'route-a|gen-a|0\n' > "$root/progress"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "zero progress is B_UNKNOWN" "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN" "$output"
+
+  root=$(make_root)
+  printf 'route-b|gen-a|300\n' > "$root/progress"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "wrong route progress is B_UNKNOWN" "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN" "$output"
+
+  root=$(make_root)
+  printf 'route-a|gen-b|300\n' > "$root/progress"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "wrong generation progress is B_UNKNOWN" "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN" "$output"
+
+  root=$(make_root)
+  printf 'route-a|gen-a|99\n' > "$root/progress"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "pre-process progress is B_UNKNOWN" "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN" "$output"
+
+  root=$(make_root)
+  printf 'route-a|gen-a|299\n' > "$root/progress"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "pre-inbound progress is B_UNKNOWN" "A_SUSPECT B_UNKNOWN DECISION_UNKNOWN" "$output"
+}
+
+test_nonwedge_progress_is_healthy() {
+  local root output
+  root=$(make_root)
+  printf 'route-a|gen-a|401\n' > "$root/progress"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "fresh progress is B_HEALTHY" "A_SUSPECT B_HEALTHY DECISION_HEALTHY" "$output"
+
+  root=$(make_root)
+  printf 'route-a|gen-a|301\n' > "$root/response"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "later response is B_HEALTHY" "A_SUSPECT B_HEALTHY DECISION_HEALTHY" "$output"
+}
+
+test_injected_clock_is_used() {
+  local root output
+  root=$(make_root)
+  make_clock "$root"
+  output=$(WATCHDOG_NOW_FOR_TEST= WATCHDOG_TIME_CMD="$root/clock" FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "injected clock supports deterministic inspection" \
+    "A_SUSPECT B_SUSPECT DECISION_FIRST_STRIKE" "$output"
+}
+
+test_generation_drift_cancels_strike() {
+  local root output state
+  root=$(make_root)
+  cat > "$root/drift" <<'EOF'
+#!/usr/bin/env bash
+printf 'gen-b|124|101\n' > "$1/generation"
+EOF
+  chmod 700 "$root/drift"
+  output=$(WATCHDOG_BEFORE_STRIKE_CMD="$root/drift" FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "generation drift cancels the transition" \
+    "A_UNKNOWN B_UNKNOWN DECISION_GENERATION_DRIFT" "$output"
+  state=$(<"$root/state")
+  assert_eq "generation drift clears prior strike state" "" "$state"
+}
+
+test_class_and_generation_bound_strikes() {
+  local root output state
+  root=$(make_root)
+  printf 'gen-a|other|1\n' > "$root/state"
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "different observation class starts a first strike" \
+    "A_SUSPECT B_SUSPECT DECISION_FIRST_STRIKE" "$output"
+  state=$(<"$root/state")
+  assert_eq "different observation class is replaced deterministically" \
+    "gen-a|A_SOCKET_ZERO_B_PROGRESS_STALE|1" "$state"
+}
+
+test_second_strike_emits_one_recommendation() {
+  local root first first_recommendation second third recommendation
+  root=$(make_root)
+  first=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  if [[ -e "$root/recommendation" ]]; then
+    first_recommendation="present"
+  else
+    first_recommendation="absent"
+  fi
+  second=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  third=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  recommendation=$(<"$root/recommendation")
+  assert_eq "first strike has no recommendation decision" \
+    "A_SUSPECT B_SUSPECT DECISION_FIRST_STRIKE" "$first"
+  assert_eq "first strike writes no recommendation" "absent" "$first_recommendation"
+  assert_eq "second strike emits fixed recommendation decision" \
+    "A_SUSPECT B_SUSPECT DECISION_RESTART_RECOMMENDED" "$second"
+  assert_eq "recommendation is fixed and metadata-minimal" "RESTART_RECOMMENDED" "$recommendation"
+  assert_eq "later identical observation does not emit again" \
+    "A_SUSPECT B_SUSPECT DECISION_ALREADY_RECORDED" "$third"
+}
+
+test_concurrent_transition_is_serialized() {
+  local root first second entered release out first_pid
+  root=$(make_root)
+  entered="$root/entered"
+  release="$root/release"
+  out="$root/first.out"
+  mkfifo "$entered" "$release"
+  cat > "$root/barrier" <<'EOF'
+#!/usr/bin/env bash
+printf 'entered\n' > "$BARRIER_ENTERED"
+IFS= read -r ignored < "$BARRIER_RELEASE"
+EOF
+  chmod 700 "$root/barrier"
+  BARRIER_ENTERED="$entered" BARRIER_RELEASE="$release" WATCHDOG_BEFORE_STRIKE_CMD="$root/barrier" \
+    FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root" > "$out" &
+  first_pid=$!
+  IFS= read -r ignored < "$entered"
+  second=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  printf 'release\n' > "$release"
+  wait "$first_pid"
+  first=$(<"$out")
+  assert_eq "concurrent invocation observes serialized busy decision" \
+    "A_SUSPECT B_SUSPECT DECISION_BUSY" "$second"
+  assert_eq "lock owner completes a single first transition" \
+    "A_SUSPECT B_SUSPECT DECISION_FIRST_STRIKE" "$first"
+}
+
+start_transition_lock_holder() {
+  local root=$1 entered=$2 release=$3 holder ignored
+  holder="$root/lock-holder"
+  cat > "$holder" <<'EOF'
+#!/usr/bin/env bash
+mkdir "$1/transition.lock"
+printf 'fixture-holder\n' > "$1/transition.lock/owner"
+printf 'entered\n' > "$LOCK_ENTERED"
+IFS= read -r ignored < "$LOCK_RELEASE"
+rm -f -- "$1/transition.lock/owner"
+rmdir -- "$1/transition.lock"
+EOF
+  chmod 700 "$holder"
+  LOCK_ENTERED="$entered" LOCK_RELEASE="$release" "$holder" "$root" &
+  lock_holder_pid=$!
+  IFS= read -r ignored < "$entered"
+}
+
+release_transition_lock_holder() {
+  local release=$1
+  printf 'release\n' > "$release"
+  wait "$lock_holder_pid"
+}
+
+assert_contended_unknown_reset() {
+  local name=$1 kind=$2 root entered release unknown next recommendation
+  root=$(make_root)
+  printf 'gen-a|A_SOCKET_ZERO_B_PROGRESS_STALE|1\n' > "$root/state"
+  entered="$root/entered"
+  release="$root/release"
+  mkfifo "$entered" "$release"
+  start_transition_lock_holder "$root" "$entered" "$release"
+  case "$kind" in
+    A) unknown=$(FAKE_INSPECT_STATUS=1 invoke "$root") ;;
+    B)
+      rm -f -- "$root/progress"
+      unknown=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+      ;;
+  esac
+  assert_eq "$name contended unknown does not claim an uncommitted reset" \
+    "A_UNKNOWN B_UNKNOWN DECISION_BUSY" "$unknown"
+  release_transition_lock_holder "$release"
+  if [[ "$kind" == B ]]; then
+    printf 'route-a|gen-a|300\n' > "$root/progress"
+  fi
+  next=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  assert_eq "$name next same-generation suspect is only a first strike" \
+    "A_SUSPECT B_SUSPECT DECISION_FIRST_STRIKE" "$next"
+  if [[ -e "$root/recommendation" ]]; then
+    recommendation="present"
+  else
+    recommendation="absent"
+  fi
+  assert_eq "$name contended unknown leaves no promotable recommendation" \
+    "absent" "$recommendation"
+}
+
+test_contended_a_unknown_reset_invalidates_prior_strike() {
+  assert_contended_unknown_reset "A_UNKNOWN" A
+}
+
+test_contended_b_unknown_reset_invalidates_prior_strike() {
+  assert_contended_unknown_reset "B_UNKNOWN" B
+}
+
+test_concurrent_second_strike_emits_one_complete_recommendation() {
+  local root first second entered release out first_pid recommendation receipt_shape state
+  root=$(make_root)
+  printf 'gen-a|A_SOCKET_ZERO_B_PROGRESS_STALE|1\n' > "$root/state"
+  entered="$root/entered"
+  release="$root/release"
+  out="$root/first.out"
+  mkfifo "$entered" "$release"
+  cat > "$root/barrier" <<'EOF'
+#!/usr/bin/env bash
+printf 'entered\n' > "$BARRIER_ENTERED"
+IFS= read -r ignored < "$BARRIER_RELEASE"
+EOF
+  chmod 700 "$root/barrier"
+  BARRIER_ENTERED="$entered" BARRIER_RELEASE="$release" WATCHDOG_BEFORE_STRIKE_CMD="$root/barrier" \
+    FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root" > "$out" &
+  first_pid=$!
+  IFS= read -r ignored < "$entered"
+  second=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root")
+  printf 'release\n' > "$release"
+  wait "$first_pid"
+  first=$(<"$out")
+  recommendation=$(<"$root/recommendation")
+  receipt_shape="$(wc -l < "$root/recommendation" | tr -d '[:space:]')|$recommendation"
+  state=$(<"$root/state")
+  assert_eq "one contender publishes the fixed restart recommendation" \
+    "A_SUSPECT B_SUSPECT DECISION_RESTART_RECOMMENDED" "$first"
+  assert_eq "other state-one contender cannot duplicate publication" \
+    "A_SUSPECT B_SUSPECT DECISION_BUSY" "$second"
+  assert_eq "concurrent second-strike receipt is one complete fixed line" \
+    "1|RESTART_RECOMMENDED" "$receipt_shape"
+  assert_eq "concurrent second-strike state is bounded at two" \
+    "gen-a|A_SOCKET_ZERO_B_PROGRESS_STALE|2" "$state"
+}
+
+make_prohibited_action_guards() {
+  local root=$1 guard command
+  guard="$root/prohibited-action-guards"
+  mkdir "$guard"
+  for command in launchctl kill pkill killall hermes bridge bridgectl osascript terminal-notifier notify-send curl wget nc ncat socat cron crontab at systemctl service open; do
+    cat > "$guard/$command" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$(basename "$0")" >> "$PROHIBITED_ACTION_LOG"
+exit 99
+EOF
+    chmod 700 "$guard/$command"
+  done
+  printf '%s' "$guard"
+}
+
+test_observer_never_executes_prohibited_action_surfaces() {
+  local root guard log
+  root=$(make_root)
+  guard=$(make_prohibited_action_guards "$root")
+  log="$root/prohibited-actions.log"
+  WATCHDOG_TEST_PATH="$guard:$PATH" PROHIBITED_ACTION_LOG="$log" \
+    FAKE_INSPECT_STATUS=1 invoke "$root" >/dev/null
+  WATCHDOG_TEST_PATH="$guard:$PATH" PROHIBITED_ACTION_LOG="$log" \
+    FAKE_INSPECT_OUTPUT="ESTABLISHED gateway" invoke "$root" >/dev/null
+  WATCHDOG_TEST_PATH="$guard:$PATH" PROHIBITED_ACTION_LOG="$log" \
+    FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root" >/dev/null
+  WATCHDOG_TEST_PATH="$guard:$PATH" PROHIBITED_ACTION_LOG="$log" \
+    FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root" >/dev/null
+  if [[ -e "$log" ]]; then
+    fail "observer avoids lifecycle notification network scheduler and bridge commands"
+  else
+    pass "observer avoids lifecycle notification network scheduler and bridge commands"
+  fi
+}
+
+test_bad_digest_is_not_managed() {
+  local root output
+  root=$(make_root)
+  output=$(FAKE_INSPECT_OUTPUT="no matching sockets" invoke "$root" "0000000000000000000000000000000000000000000000000000000000000000")
+  assert_eq "digest mismatch is NOT_MANAGED" "NOT_MANAGED" "$output"
+}
+
+test_rendered_plist_is_loadable_and_structural() {
+  local root
+  root=$(make_root)
+  if render_plist "$root"; then
+    pass "rendered plist has exact label cadence closed environment and source binding"
+  else
+    fail "rendered plist has exact label cadence closed environment and source binding"
+  fi
+}
+
+test_candidate_receipt_is_truthful() {
+  if python3 - "$receipt" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text())
+assert data == {
+    "artifact": "gateway-freeze-watchdog",
+    "authority": "observer_only",
+    "operational_liveness": "UNVERIFIED",
+}
+PY
+  then
+    pass "candidate receipt is observer-only with unverified operational liveness"
+  else
+    fail "candidate receipt is observer-only with unverified operational liveness"
+  fi
+}
+
+if [[ -n "${WATCHDOG_TEST_FILTER:-}" ]]; then
+  "$WATCHDOG_TEST_FILTER"
+else
+  test_inspection_failure_is_unknown
+  test_zero_sockets_after_stale_log_is_a_suspect
+  test_matching_socket_is_healthy
+  test_fresh_log_is_healthy
+  test_same_route_post_inbound_stale_progress_starts_strike
+  test_invalid_progress_is_unknown
+  test_nonwedge_progress_is_healthy
+  test_injected_clock_is_used
+  test_generation_drift_cancels_strike
+  test_class_and_generation_bound_strikes
+  test_second_strike_emits_one_recommendation
+  test_concurrent_transition_is_serialized
+  test_contended_a_unknown_reset_invalidates_prior_strike
+  test_contended_b_unknown_reset_invalidates_prior_strike
+  test_concurrent_second_strike_emits_one_complete_recommendation
+  test_observer_never_executes_prohibited_action_surfaces
+  test_bad_digest_is_not_managed
+  test_rendered_plist_is_loadable_and_structural
+  test_candidate_receipt_is_truthful
+fi
+printf 'TOTAL=%d PASS=%d FAIL=%d\n' "$((passes + failures))" "$passes" "$failures"
+(( failures == 0 ))

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -24,7 +24,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.turn_lease import SessionTurnLeaseRegistry, TurnLeaseTimeoutError
+from gateway.turn_lease import (
+    SessionTurnLeaseRegistry,
+    TurnLeaseTimeoutError,
+    TurnLeaseToken,
+)
 
 
 def _run(coro):
@@ -130,8 +134,7 @@ def test_timeout_fails_closed_instead_of_authorizing_an_unserialized_turn():
     _run(scenario())
 
 
-@pytest.mark.asyncio
-async def test_agent_path_propagates_timed_out_lease_before_loading_transcript(
+def test_agent_path_propagates_timed_out_lease_before_loading_transcript(
     monkeypatch, tmp_path
 ):
     """The agent path propagates timeout before transcript work can begin.
@@ -140,38 +143,41 @@ async def test_agent_path_propagates_timed_out_lease_before_loading_transcript(
     transcript loading and agent execution must not start: both would operate
     without the per-session serialization guarantee.
     """
-    from tests.gateway.test_42039_duplicate_user_message import (
-        _bootstrap,
-        _event,
-        _source,
-    )
 
-    runner = _bootstrap(monkeypatch, tmp_path)
-    runner._turn_leases = SessionTurnLeaseRegistry()
-    holder = await runner._turn_leases.acquire(
-        "sess-dedup", owner_key="holder-key", generation=1, timeout=1
-    )
-    assert holder is not None
-    monkeypatch.setenv("HERMES_TURN_LEASE_TIMEOUT", "0.02")
+    async def scenario():
+        from tests.gateway.test_42039_duplicate_user_message import (
+            _bootstrap,
+            _event,
+            _source,
+        )
 
-    runner.session_store.load_transcript.side_effect = AssertionError(
-        "transcript must not load after a turn-lease timeout"
-    )
-    runner._run_agent = pytest.fail
+        runner = _bootstrap(monkeypatch, tmp_path)
+        runner._turn_leases = SessionTurnLeaseRegistry()
+        holder = await runner._turn_leases.acquire(
+            "sess-dedup", owner_key="holder-key", generation=1, timeout=1
+        )
+        assert holder is not None
+        monkeypatch.setenv("HERMES_TURN_LEASE_TIMEOUT", "0.02")
 
-    try:
-        with pytest.raises(TurnLeaseTimeoutError):
-            await runner._handle_message_with_agent(
-                _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
-            )
-    finally:
-        assert runner._turn_leases.release(holder) is True
+        runner.session_store.load_transcript.side_effect = AssertionError(
+            "transcript must not load after a turn-lease timeout"
+        )
+        runner._run_agent = pytest.fail
 
-    runner.session_store.load_transcript.assert_not_called()
+        try:
+            with pytest.raises(TurnLeaseTimeoutError):
+                await runner._handle_message_with_agent(
+                    _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+                )
+        finally:
+            assert runner._turn_leases.release(holder) is True
+
+        runner.session_store.load_transcript.assert_not_called()
+
+    _run(scenario())
 
 
-@pytest.mark.asyncio
-async def test_full_dispatch_rejects_lease_timeout_without_running_goal_hook(
+def test_full_dispatch_rejects_lease_timeout_without_running_goal_hook(
     monkeypatch, tmp_path
 ):
     """A lease rejection is not a completed turn for `/goal` evaluation.
@@ -179,37 +185,43 @@ async def test_full_dispatch_rejects_lease_timeout_without_running_goal_hook(
     The lease wait also has its own clock: a short lease budget must reject
     promptly even while the normal agent inactivity timeout remains long.
     """
-    from tests.gateway.test_42039_duplicate_user_message import _bootstrap, _event
 
-    runner = _bootstrap(monkeypatch, tmp_path)
-    runner._turn_leases = SessionTurnLeaseRegistry()
-    holder = await runner._turn_leases.acquire(
-        "sess-dedup", owner_key="holder-key", generation=1, timeout=1
-    )
-    assert holder is not None
-    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "5")
-    monkeypatch.setenv("HERMES_TURN_LEASE_TIMEOUT", "0.02")
+    async def scenario():
+        from tests.gateway.test_42039_duplicate_user_message import _bootstrap, _event
 
-    runner.session_store.load_transcript.side_effect = AssertionError(
-        "transcript must not load after a turn-lease timeout"
-    )
-    session_env_tokens = object()
-    runner._set_session_env = MagicMock(return_value=session_env_tokens)
-    runner._clear_session_env = MagicMock()
-    runner._run_agent = pytest.fail
-    runner._post_turn_goal_continuation = AsyncMock()
+        runner = _bootstrap(monkeypatch, tmp_path)
+        runner._turn_leases = SessionTurnLeaseRegistry()
+        holder = await runner._turn_leases.acquire(
+            "sess-dedup", owner_key="holder-key", generation=1, timeout=1
+        )
+        assert holder is not None
+        monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "5")
+        monkeypatch.setenv("HERMES_TURN_LEASE_TIMEOUT", "0.02")
 
-    try:
-        response = await asyncio.wait_for(runner._handle_message(_event()), timeout=1)
-    finally:
-        assert runner._turn_leases.release(holder) is True
+        runner.session_store.load_transcript.side_effect = AssertionError(
+            "transcript must not load after a turn-lease timeout"
+        )
+        session_env_tokens = object()
+        runner._set_session_env = MagicMock(return_value=session_env_tokens)
+        runner._clear_session_env = MagicMock()
+        runner._run_agent = pytest.fail
+        runner._post_turn_goal_continuation = AsyncMock()
 
-    assert isinstance(response, str)
-    assert "not processed" in response.lower()
-    assert "resend" in response.lower()
-    runner.session_store.load_transcript.assert_not_called()
-    runner._clear_session_env.assert_called_once_with(session_env_tokens)
-    runner._post_turn_goal_continuation.assert_not_awaited()
+        try:
+            response = await asyncio.wait_for(
+                runner._handle_message(_event()), timeout=1
+            )
+        finally:
+            assert runner._turn_leases.release(holder) is True
+
+        assert isinstance(response, str)
+        assert "not processed" in response.lower()
+        assert "resend" in response.lower()
+        runner.session_store.load_transcript.assert_not_called()
+        runner._clear_session_env.assert_called_once_with(session_env_tokens)
+        runner._post_turn_goal_continuation.assert_not_awaited()
+
+    _run(scenario())
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +266,57 @@ class _GatedLock:
 
     def release(self):
         self._lock.release()
+
+
+class _HolderPublicationFault(BaseException):
+    pass
+
+
+class _FaultingPublicationLease:
+    """Lease double that faults exactly while its holder is unpublished."""
+
+    def __init__(self):
+        self.lock = asyncio.Lock()
+        self._holder = None
+        self.acquired_at = 0.0
+        self.last_used = 0.0
+        self.pending_acquires = 0
+        self.fail_publication = True
+
+    @property
+    def holder(self):
+        return self._holder
+
+    @holder.setter
+    def holder(self, token):
+        if token is not None and self.fail_publication:
+            raise _HolderPublicationFault()
+        self._holder = token
+
+
+def test_acquire_fault_before_holder_publication_releases_unpublished_lock():
+    async def scenario():
+        registry = SessionTurnLeaseRegistry()
+        lease = _FaultingPublicationLease()
+        registry._leases["sess-unpublished"] = lease
+
+        with pytest.raises(_HolderPublicationFault):
+            await registry.acquire(
+                "sess-unpublished", owner_key="key-a", generation=1, timeout=1
+            )
+
+        assert lease.holder is None
+        assert lease.pending_acquires == 0
+        assert not lease.lock.locked()
+
+        lease.fail_publication = False
+        token = await registry.acquire(
+            "sess-unpublished", owner_key="key-b", generation=2, timeout=1
+        )
+        assert token is not None
+        assert registry.release(token) is True
+
+    _run(scenario())
 
 
 def test_registry_does_not_evict_lease_during_waiter_handoff():
@@ -396,7 +459,8 @@ def test_rebind_moves_serialization_to_new_session_id():
         registry = SessionTurnLeaseRegistry()
         token = await registry.acquire("parent", owner_key="key-a", generation=1, timeout=5)
         assert registry.rebind(token, "child") is True
-        assert token is not None and token.session_id == "child"
+        assert token is not None and token.session_id == "parent"
+        assert registry._leases["child"] is registry._leases["parent"]
 
         # Alias key resolving the fresh child id serializes behind the holder.
         waiter = asyncio.create_task(
@@ -453,6 +517,84 @@ def test_rebind_does_not_replace_target_during_waiter_handoff():
 # ---------------------------------------------------------------------------
 
 
+class _FailOnceReleaseLock:
+    """Real lock wrapper whose first release raises without unlocking."""
+
+    def __init__(self, lock):
+        self._lock = lock
+        self._fail = True
+
+    async def acquire(self):
+        return await self._lock.acquire()
+
+    def locked(self):
+        return self._lock.locked()
+
+    def release(self):
+        if self._fail:
+            self._fail = False
+            raise RuntimeError("injected release failure")
+        self._lock.release()
+
+
+def test_release_failure_preserves_slot_token_and_holder_for_retry():
+    from gateway.run import GatewayRunner
+
+    async def scenario():
+        runner = object.__new__(GatewayRunner)
+        registry = SessionTurnLeaseRegistry()
+        runner._turn_leases = registry
+        session_key = "key-release"
+        token = await registry.acquire(
+            "sess-release", owner_key=session_key, generation=1, timeout=1
+        )
+        assert token is not None
+        state = runner._session_state(session_key).turn
+        state.lease_token = token
+        state.lease_generation = 1
+        lease = registry._leases["sess-release"]
+        lease.lock = _FailOnceReleaseLock(lease.lock)
+
+        assert runner._release_turn_lease(session_key, 1, token=token) is False
+        assert state.lease_token is token
+        assert state.lease_generation == 1
+        assert token.released is False
+        assert lease.holder is token
+        assert lease.lock.locked()
+
+        assert runner._release_turn_lease(session_key, 1, token=token) is True
+        assert state.lease_token is None
+        assert state.lease_generation is None
+        assert token.released is True
+        assert lease.holder is None
+        assert not lease.lock.locked()
+
+    _run(scenario())
+
+
+def test_wrong_token_and_same_holder_aba_never_release_successor():
+    async def scenario():
+        registry = SessionTurnLeaseRegistry()
+        first = await registry.acquire(
+            "sess-aba", owner_key="key-a", generation=1, timeout=1
+        )
+        foreign = TurnLeaseToken("sess-aba", "key-a", 1)
+
+        assert registry.release(foreign) is False
+        assert foreign.released is False
+        assert registry._leases["sess-aba"].holder is first
+        assert registry.release(first) is True
+
+        successor = await registry.acquire(
+            "sess-aba", owner_key="key-a", generation=1, timeout=1
+        )
+        assert registry.release(first) is False
+        assert registry._leases["sess-aba"].holder is successor
+        assert registry.release(successor) is True
+
+    _run(scenario())
+
+
 def test_runner_release_turn_lease_is_token_scoped_and_bare_safe():
     from gateway.run import GatewayRunner
 
@@ -476,5 +618,184 @@ def test_runner_release_turn_lease_is_token_scoped_and_bare_safe():
         assert runner._release_turn_lease("key-a", 1) is False
         # Empty key guard.
         assert runner._release_turn_lease("", 1) is False
+
+    _run(scenario())
+
+
+def test_full_dispatch_releases_event_token_after_same_key_slot_overwrite(
+    monkeypatch, tmp_path
+):
+    """A real dispatch finalizer retires A without disturbing overwritten B."""
+    from tests.gateway.test_42039_duplicate_user_message import _bootstrap, _event
+
+    async def scenario():
+        runner = _bootstrap(monkeypatch, tmp_path)
+        registry = SessionTurnLeaseRegistry()
+        runner._turn_leases = registry
+        generations = iter((1, 2))
+        runner._begin_session_run_generation = lambda _key: next(generations)
+        # Simulate only the concurrent same-key dispatch under test: A's
+        # sentinel must not route B through the normal busy-message branch.
+        runner._is_session_running = lambda session_key: False
+        runner._claim_active_session_slot = lambda *_args: (None, None)
+        runner._release_running_agent_state = lambda *_args: True
+        runner._run_post_turn_hooks = AsyncMock()
+        runner._clear_durable_active_turn = AsyncMock()
+
+        a_acquired = asyncio.Event()
+        b_published = asyncio.Event()
+        allow_a_exit = asyncio.Event()
+        allow_b_exit = asyncio.Event()
+        tokens = {}
+
+        async def acquire_then_block(event, _source, session_key, generation):
+            session_id = "sess-old" if generation == 1 else "sess-new"
+            token = await registry.acquire(
+                session_id, owner_key=session_key, generation=generation, timeout=1
+            )
+            assert token is not None
+            event._gateway_turn_lease_token = token
+            turn = runner._session_state(session_key).turn
+            turn.lease_token = token
+            turn.lease_generation = generation
+            tokens[generation] = token
+            if generation == 1:
+                a_acquired.set()
+                await allow_a_exit.wait()
+            else:
+                b_published.set()
+                await allow_b_exit.wait()
+            return str(generation)
+
+        runner._handle_message_with_agent = acquire_then_block
+        task_a = asyncio.create_task(runner._handle_message(_event()))
+        await asyncio.wait_for(a_acquired.wait(), timeout=1)
+        task_b = asyncio.create_task(runner._handle_message(_event()))
+        await asyncio.wait_for(b_published.wait(), timeout=1)
+
+        allow_a_exit.set()
+        assert await asyncio.wait_for(task_a, timeout=1) == "1"
+
+        state = runner._session_state("agent:main:telegram:group:-1001:12345")
+        assert registry._leases["sess-old"].holder is None
+        assert state.turn.lease_token is tokens[2]
+        assert state.turn.lease_generation == 2
+        assert registry._leases["sess-new"].holder is tokens[2]
+
+        allow_b_exit.set()
+        assert await asyncio.wait_for(task_b, timeout=1) == "2"
+        assert registry._leases["sess-new"].holder is None
+
+    _run(scenario())
+
+
+def test_agent_result_rotation_rebinds_event_token_after_slot_overwrite(
+    monkeypatch, tmp_path
+):
+    """The real agent-result rotation follows A's event-owned lease, not B's slot."""
+    from tests.gateway.test_42039_duplicate_user_message import (
+        _bootstrap,
+        _event,
+        _source,
+    )
+
+    async def scenario():
+        runner = _bootstrap(monkeypatch, tmp_path)
+        registry = SessionTurnLeaseRegistry()
+        runner._turn_leases = registry
+        session_key = "agent:main:telegram:group:-1001:12345"
+        entry = runner.session_store.get_or_create_session.return_value
+        entry.session_id = "sess-parent"
+        async_store = runner.async_session_store
+        async_store.get_or_create_session = AsyncMock(return_value=entry)
+        event = _event()
+        tokens = {}
+
+        async def run_agent(**_kwargs):
+            token_a = event._gateway_turn_lease_token
+            tokens["a"] = token_a
+            token_b = await registry.acquire(
+                "sess-other", owner_key=session_key, generation=2, timeout=1
+            )
+            assert token_b is not None
+            tokens["b"] = token_b
+            turn = runner._session_state(session_key).turn
+            turn.lease_token = token_b
+            turn.lease_generation = 2
+            return {
+                "final_response": "ok",
+                "messages": [],
+                "tools": [],
+                "history_offset": 0,
+                "last_prompt_tokens": 0,
+                "session_id": "sess-child",
+            }
+
+        async def save_barrier():
+            assert registry._leases["sess-child"] is registry._leases["sess-parent"]
+            assert registry._leases["sess-child"].holder is tokens["a"]
+            turn = runner._session_state(session_key).turn
+            assert turn.lease_token is tokens["b"]
+            assert turn.lease_generation == 2
+
+        runner._run_agent = run_agent
+        async_store._save = AsyncMock(side_effect=save_barrier)
+        result = await runner._handle_message_with_agent(
+            event, _source(), session_key, 1
+        )
+        assert result == "ok"
+        assert registry.release(tokens["a"]) is True
+        assert registry.release(tokens["b"]) is True
+
+    _run(scenario())
+
+
+def test_repeated_cancellation_during_durable_cleanup_still_releases_turn_lease(
+    monkeypatch, tmp_path
+):
+    """A second cancellation cannot skip the no-await event-token release."""
+    from tests.gateway.test_42039_duplicate_user_message import _bootstrap, _event
+
+    async def scenario():
+        runner = _bootstrap(monkeypatch, tmp_path)
+        registry = SessionTurnLeaseRegistry()
+        runner._turn_leases = registry
+        runner._claim_active_session_slot = lambda *_args: (None, None)
+        runner._release_running_agent_state = lambda *_args: True
+        entry = runner.session_store.get_or_create_session.return_value
+        async_store = runner.async_session_store
+        async_store.get_or_create_session = AsyncMock(return_value=entry)
+        acquired = asyncio.Event()
+        cleanup_entered = asyncio.Event()
+        never = asyncio.Event()
+        event = _event()
+
+        async def mark_after_real_acquire(marked_event, _session_key):
+            assert marked_event._gateway_turn_lease_token is not None
+            acquired.set()
+            await never.wait()
+
+        async def block_durable_cleanup(_event):
+            cleanup_entered.set()
+            await never.wait()
+
+        runner._mark_durable_active_turn = mark_after_real_acquire
+        runner._clear_durable_active_turn = block_durable_cleanup
+        task = asyncio.create_task(runner._handle_message(event))
+        await asyncio.wait_for(acquired.wait(), timeout=1)
+        token = event._gateway_turn_lease_token
+        assert token is not None
+
+        task.cancel()
+        await asyncio.wait_for(cleanup_entered.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        state = runner._session_state("agent:main:telegram:group:-1001:12345").turn
+        assert token.released is True
+        assert registry._leases[entry.session_id].holder is None
+        assert state.lease_token is None
+        assert state.lease_generation is None
 
     _run(scenario())

--- a/tests/hermes_cli/test_gateway_session_attach_guard.py
+++ b/tests/hermes_cli/test_gateway_session_attach_guard.py
@@ -70,3 +70,43 @@ def test_gateway_routed_session_owner_reads_state_db_from_hermes_home(
     monkeypatch.setattr(main_mod.os, "kill", lambda pid, signal: None)
 
     assert main_mod._gateway_routed_session_owner("routed-session") == 4242
+
+
+def test_main_sessions_stats_help_builds_full_parser_without_rollback_module(monkeypatch):
+    import os
+    import site
+    import sys
+
+    import hermes_cli.main as main_mod
+
+    source_root = os.path.dirname(os.path.dirname(main_mod.__file__))
+    script = """
+import sys
+import hermes_cli.main as main_mod
+
+sys.argv = ["hermes", "sessions", "stats", "--help"]
+main_mod._set_process_title = lambda: None
+main_mod._advertise_agent_env = lambda: None
+main_mod._cleanup_quarantined_exes = lambda: None
+main_mod._sweep_stale_bytecode_if_checkout_changed = lambda: None
+main_mod._recover_from_interrupted_install = lambda: None
+main_mod._warn_pending_fleet_restart_on_startup = lambda: None
+main_mod._try_termux_fast_tui_launch = lambda: False
+main_mod._try_termux_fast_cli_launch = lambda: False
+main_mod._try_fast_chat_launch = lambda: False
+main_mod.main()
+"""
+    env = os.environ | {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONPATH": os.pathsep.join([source_root, *site.getsitepackages()]),
+    }
+
+    result = subprocess.run(
+        [sys.executable, "-S", "-c", script],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "usage: hermes sessions stats" in result.stdout

--- a/tests/hermes_cli/test_gateway_session_attach_guard.py
+++ b/tests/hermes_cli/test_gateway_session_attach_guard.py
@@ -1,0 +1,72 @@
+from argparse import Namespace
+import json
+import sqlite3
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+
+def _chat_args(**overrides):
+    values = {"continue_last": None, "in_dir": None, "resume": "routed-session"}
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_cmd_chat_refuses_routed_session_even_with_legacy_environment_override(
+    monkeypatch, capsys
+):
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(main_mod, "_resolve_use_tui", lambda _args: False)
+    monkeypatch.setattr(main_mod, "_apply_safe_mode", lambda _args: None)
+    monkeypatch.setattr(main_mod, "_resolve_continue_arg", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main_mod, "_gateway_routed_session_owner", lambda _session_id: 4242)
+    monkeypatch.setattr(
+        main_mod,
+        "_resolve_session_by_name_or_id",
+        lambda _session_id: pytest.fail("legacy environment override bypassed refusal"),
+    )
+    monkeypatch.setenv("HERMES_ALLOW_GATEWAY_SESSION", "1")
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod.cmd_chat(_chat_args())
+
+    assert excinfo.value.code == 3
+    assert capsys.readouterr().err == (
+        "Refusing to attach to a session currently served by the gateway.\n"
+    )
+
+
+def test_gateway_session_attach_refusal_allows_when_no_live_owner(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(main_mod, "_gateway_routed_session_owner", lambda _session_id: None)
+
+    assert main_mod._refuse_gateway_routed_session_attach("routed-session") is None
+    assert capsys.readouterr().err == ""
+
+
+def test_gateway_routed_session_owner_reads_state_db_from_hermes_home(
+    tmp_path, monkeypatch
+):
+    import hermes_cli.main as main_mod
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    with sqlite3.connect(home / "state.db") as conn:
+        conn.execute("CREATE TABLE gateway_routing (entry_json TEXT)")
+        conn.execute(
+            "INSERT INTO gateway_routing VALUES (?)",
+            (json.dumps({"session_id": "routed-session"}),),
+        )
+
+    def fake_run(command, **_kwargs):
+        assert command == ["launchctl", "list", "ai.hermes.gateway"]
+        return SimpleNamespace(stdout='"PID" = 4242;')
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(main_mod.os, "kill", lambda pid, signal: None)
+
+    assert main_mod._gateway_routed_session_owner("routed-session") == 4242

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -12,11 +12,19 @@ from types import SimpleNamespace
 import pytest
 
 import hermes_state
-from hermes_state import FTS_STORAGE_VERSION, SCHEMA_VERSION, SessionDB
+from hermes_state import (
+    FTS_STORAGE_VERSION,
+    SCHEMA_VERSION,
+    SessionDB,
+    register_turn_fence_generation,
+)
 from hermes_cli import session_recovery
 from hermes_cli.session_recovery import (
+    SessionRecoveryDestinationError,
     SessionRecoverySafetyError,
     SessionRecoverySourceError,
+    _is_current_turn_fence_generation,
+    _require_destination_fenced,
     inspect_session_database,
     recover_session_database,
 )
@@ -426,6 +434,10 @@ def test_partial_recovery_keeps_messages_when_sessions_are_unsalvageable(
     # sessions unrecoverable, messages intact — the reported shape.
     conn = sqlite3.connect(str(source), isolation_level=None)
     try:
+        # The source was built via SessionDB, whose turn-fence triggers on
+        # `sessions` need hermes_turn_fence_generation() registered on
+        # whichever connection issues the DELETE that simulates corruption.
+        register_turn_fence_generation(conn)
         conn.execute("DELETE FROM sessions")
     finally:
         conn.close()
@@ -646,6 +658,300 @@ def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
         )
     finally:
         conn.close()
+
+
+def test_recover_exact_path_copies_rows_into_a_real_v27_store(
+    tmp_path: Path,
+) -> None:
+    """The exact (non-``--allow-partial``) path must copy into a real store.
+
+    Regression: the destination is opened with a bare ``sqlite3.connect()``
+    after the initializing ``SessionDB`` handle is closed. A v27 store's
+    canonical tables (``sessions``, ``messages``, ...) carry BEFORE INSERT/
+    UPDATE/DELETE turn-fence triggers that call ``hermes_turn_fence_
+    generation()`` — a UDF only ever registered on the connection that
+    created it. Reopening raw and never re-registering it makes the very
+    first insert into any canonical table fail with
+    ``OperationalError: no such function: hermes_turn_fence_generation``,
+    which ``_copy_table`` swallows per-table as ``status: "failed"``. Every
+    row must instead land, exactly.
+    """
+    source = tmp_path / "healthy-source.db"
+    output = tmp_path / "healthy-recovered.db"
+    expected = _make_source(source)
+
+    report = recover_session_database(source, output, work_dir=tmp_path, chunk_size=4)
+
+    for table in ("sessions", "messages"):
+        assert report["copy"][table]["status"] == "complete", report["copy"][table]
+        assert "error" not in report["copy"][table], report["copy"][table]
+
+    assert report["complete"] is True
+    assert report["partial"] is False
+    assert report["verified"] is True
+    assert report["output"] == str(output)
+    assert ".hermes-session-recovery-" not in json.dumps(report)
+    assert output.exists()
+    for suffix in ("-wal", "-shm", "-journal"):
+        assert not os.path.lexists(output.with_name(output.name + suffix))
+
+    with sqlite3.connect(str(output)) as verify:
+        verify.row_factory = sqlite3.Row
+        session_count = verify.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        message_count = verify.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    assert session_count == expected["sessions"]
+    assert message_count == expected["messages"]
+
+
+def test_recover_into_destination_without_fence_triggers_still_works(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fix must not depend on the destination having fence triggers.
+
+    Simulates an older-shaped destination schema (canonical tables present,
+    turn-fence trigger barrier never installed) by disabling the delta that
+    installs it while ``recover_session_database`` builds the destination.
+    ``register_turn_fence_generation`` is harmless either way — it only
+    registers a scalar function, and nothing in the destination references
+    it when there are no triggers to call it — so recovery must still
+    succeed.
+    """
+    def _stamp_schema_version_without_triggers(self, cursor) -> None:
+        # Stamp schema_version as the real delta does, but skip installing
+        # the turn-fence triggers themselves — reproducing the shape of an
+        # older store that is otherwise fully migrated.
+        cursor.execute("DELETE FROM schema_version")
+        cursor.execute(
+            "INSERT INTO schema_version (version) VALUES (?)",
+            (hermes_state.SCHEMA_VERSION,),
+        )
+        self._conn.commit()
+
+    monkeypatch.setattr(
+        hermes_state.SessionDB,
+        "_apply_turn_fence_generation_delta",
+        _stamp_schema_version_without_triggers,
+    )
+
+    source = tmp_path / "healthy-source-notriggers.db"
+    output = tmp_path / "healthy-recovered-notriggers.db"
+    expected = _make_source(source)
+
+    report = recover_session_database(source, output, work_dir=tmp_path, chunk_size=4)
+
+    with sqlite3.connect(str(output)) as verify:
+        trigger_count = verify.execute(
+            "SELECT COUNT(*) FROM sqlite_master "
+            "WHERE type = 'trigger' AND name LIKE 'turn_fence_%'"
+        ).fetchone()[0]
+        session_count = verify.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        message_count = verify.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+
+    assert trigger_count == 0, "fixture must genuinely lack the fence triggers"
+    assert report["copy"]["sessions"]["status"] == "complete", report["copy"]["sessions"]
+    assert report["copy"]["messages"]["status"] == "complete", report["copy"]["messages"]
+    assert report["complete"] is True
+    assert report["verified"] is True
+    assert session_count == expected["sessions"]
+    assert message_count == expected["messages"]
+
+
+def test_destination_fence_probe_rejects_bool_even_with_integer_sqlite_type(
+) -> None:
+    """SQLite considers bool an integer, but the recovery fence must not."""
+
+    assert not _is_current_turn_fence_generation(True, "integer")
+    assert _is_current_turn_fence_generation(hermes_state.TURN_FENCE_GENERATION, "integer")
+
+
+@pytest.mark.parametrize(
+    "fault",
+    (
+        "no-registration",
+        "registration-raises",
+        "stale-int",
+        "string",
+        "bytes",
+        "float",
+        "none",
+        "bool",
+        "udf-raises",
+    ),
+)
+def test_exact_recovery_destination_fence_failures_leave_no_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+) -> None:
+    source = tmp_path / "source.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+    source_hash = _sha256(source)
+
+    def register_fault(conn: sqlite3.Connection) -> None:
+        if fault == "no-registration":
+            return
+        if fault == "registration-raises":
+            raise sqlite3.OperationalError("private setup failure")
+        values = {
+            "stale-int": hermes_state.TURN_FENCE_GENERATION - 1,
+            "string": "27",
+            "bytes": b"27",
+            "float": 27.0,
+            "none": None,
+            "bool": True,
+        }
+        if fault == "udf-raises":
+            def raises_generation() -> None:
+                raise RuntimeError("private callback failure")
+
+            callback = raises_generation
+        else:
+            callback = lambda: values[fault]
+        conn.create_function("hermes_turn_fence_generation", 0, callback)
+
+    monkeypatch.setattr(session_recovery, "register_turn_fence_generation", register_fault)
+    if fault == "bool":
+        monkeypatch.setattr(
+            session_recovery,
+            "_is_current_turn_fence_generation",
+            lambda _value, _sqlite_type: False,
+        )
+
+    with pytest.raises(SessionRecoveryDestinationError) as excinfo:
+        recover_session_database(source, output, work_dir=tmp_path)
+
+    assert str(excinfo.value) == (
+        "Recovery destination turn-fence setup is unavailable or incompatible."
+    )
+    assert _sha256(source) == source_hash
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        assert not os.path.lexists(output.with_name(output.name + suffix))
+
+
+def test_sessions_recover_cli_maps_destination_error_without_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from hermes_cli.sessions_cmd import cmd_sessions
+
+    source = tmp_path / "source.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+    source_hash = _sha256(source)
+
+    def fail_destination_setup(_connection: sqlite3.Connection) -> None:
+        raise sqlite3.OperationalError("private setup failure")
+
+    monkeypatch.setattr(
+        session_recovery,
+        "register_turn_fence_generation",
+        fail_destination_setup,
+    )
+
+    args = SimpleNamespace(
+        sessions_action="recover",
+        source=source,
+        output=output,
+        inspect_only=False,
+        allow_partial=False,
+        report=None,
+        work_dir=tmp_path,
+        chunk_size=4,
+    )
+    assert cmd_sessions(args) == 1
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out.splitlines() == [
+        "Recovering canonical session data into a new database…",
+        "Error: session recovery failed: "
+        "Recovery destination turn-fence setup is unavailable or incompatible.",
+        "The supplied source database was not replaced or deleted.",
+    ]
+    for forbidden in ("✓", "Partial recovery", "BEST-EFFORT", "Recovery report"):
+        assert forbidden not in captured.out
+    assert "private setup failure" not in captured.out
+
+    report_path = output.with_name(output.name + ".recovery.json")
+    assert not report_path.exists()
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        assert not os.path.lexists(output.with_name(output.name + suffix))
+    assert _sha256(source) == source_hash
+
+
+@pytest.mark.parametrize("target", ("main", "wal", "shm", "journal"))
+def test_recovery_publication_collision_preserves_existing_sentinel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    target: str,
+) -> None:
+    source = tmp_path / "source.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+    source_hash = _sha256(source)
+    sentinel = output.with_name(
+        output.name if target == "main" else f"{output.name}-{target}"
+    )
+    sentinel_bytes = f"sentinel-{target}".encode()
+    sentinel_identity: tuple[int, int] | None = None
+
+    def insert_competitor(_candidate: Path, _final: Path) -> None:
+        nonlocal sentinel_identity
+        sentinel.write_bytes(sentinel_bytes)
+        created = sentinel.stat()
+        sentinel_identity = (created.st_dev, created.st_ino)
+
+    monkeypatch.setattr(
+        session_recovery,
+        "_publication_barrier",
+        insert_competitor,
+    )
+
+    with pytest.raises(SessionRecoverySafetyError):
+        recover_session_database(source, output, work_dir=tmp_path)
+
+    sentinel_stat = sentinel.stat()
+    assert sentinel_identity is not None
+    assert sentinel.read_bytes() == sentinel_bytes
+    assert (sentinel_stat.st_dev, sentinel_stat.st_ino) == sentinel_identity
+    assert not output.exists() or target == "main"
+    assert _sha256(source) == source_hash
+
+
+def test_recovery_publication_refuses_substituted_stage_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+    source_hash = _sha256(source)
+    replacement_bytes = b"substituted stage candidate"
+    replacement: Path | None = None
+    replacement_identity: tuple[int, int] | None = None
+
+    def substitute(candidate: Path, _final: Path) -> None:
+        nonlocal replacement, replacement_identity
+        candidate.unlink()
+        candidate.write_bytes(replacement_bytes)
+        replacement = candidate
+        created = candidate.stat()
+        replacement_identity = (created.st_dev, created.st_ino)
+
+    monkeypatch.setattr(session_recovery, "_publication_barrier", substitute)
+
+    with pytest.raises(SessionRecoverySafetyError):
+        recover_session_database(source, output, work_dir=tmp_path)
+
+    assert replacement is not None
+    assert replacement_identity is not None
+    assert replacement.read_bytes() == replacement_bytes
+    current = replacement.stat()
+    assert (current.st_dev, current.st_ino) == replacement_identity
+    assert not output.exists()
+    assert _sha256(source) == source_hash
 
 
 

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -8,13 +8,16 @@ b-tree/schema header bytes), not mocked cursor exceptions.
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 import shutil
 import sqlite3
 from pathlib import Path
 
 import pytest
 
-from hermes_state import SessionDB
+from hermes_state import SessionDB, register_turn_fence_generation
 from hermes_cli import session_recovery
 from hermes_cli.session_lost_and_found import (
     classify_lost_and_found_row,
@@ -23,6 +26,7 @@ from hermes_cli.session_lost_and_found import (
     stub_missing_parent_sessions,
 )
 from hermes_cli.session_recovery import (
+    SessionRecoveryDestinationError,
     SessionRecoverySafetyError,
     SessionRecoverySourceError,
     _probe_populated_edge,
@@ -233,6 +237,87 @@ def test_unreadable_schema_without_cli_names_the_sqlite3_requirement(
     assert not output.exists()
 
 
+@pytest.mark.parametrize(
+    "fault",
+    (
+        "no-registration",
+        "registration-raises",
+        "stale-int",
+        "string",
+        "bytes",
+        "float",
+        "none",
+        "bool",
+        "udf-raises",
+    ),
+)
+def test_lost_and_found_destination_fence_failures_leave_no_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+) -> None:
+    source = tmp_path / "schemaless.db"
+    output = tmp_path / "recovered.db"
+    _make_schema_unreadable_source(source)
+    source_hash = hashlib.sha256(source.read_bytes()).hexdigest()
+    schema_ref = tmp_path / "schema-ref.db"
+    SessionDB(db_path=schema_ref).close()
+
+    import hermes_cli.session_lost_and_found as laf
+
+    monkeypatch.setattr(laf, "find_sqlite3_cli", lambda: "synthetic-sqlite3")
+
+    def run_synthetic_recover(
+        _snapshot: Path,
+        lost_and_found: Path,
+        _sqlite3_bin: str,
+    ) -> dict[str, str]:
+        _make_synthetic_lost_and_found(lost_and_found, schema_ref)
+        return {"mode": "synthetic"}
+
+    monkeypatch.setattr(laf, "run_cli_lost_and_found_recover", run_synthetic_recover)
+
+    def register_fault(conn: sqlite3.Connection) -> None:
+        if fault == "no-registration":
+            return
+        if fault == "registration-raises":
+            raise sqlite3.OperationalError("private setup failure")
+        values = {
+            "stale-int": 26,
+            "string": "27",
+            "bytes": b"27",
+            "float": 27.0,
+            "none": None,
+            "bool": True,
+        }
+        if fault == "udf-raises":
+            def raises_generation() -> None:
+                raise RuntimeError("private callback failure")
+
+            callback = raises_generation
+        else:
+            callback = lambda: values[fault]
+        conn.create_function("hermes_turn_fence_generation", 0, callback)
+
+    monkeypatch.setattr(session_recovery, "register_turn_fence_generation", register_fault)
+    if fault == "bool":
+        monkeypatch.setattr(
+            session_recovery,
+            "_is_current_turn_fence_generation",
+            lambda _value, _sqlite_type: False,
+        )
+
+    with pytest.raises(SessionRecoveryDestinationError) as excinfo:
+        recover_session_database(source, output, work_dir=tmp_path, allow_partial=True)
+
+    assert str(excinfo.value) == (
+        "Recovery destination turn-fence setup is unavailable or incompatible."
+    )
+    assert hashlib.sha256(source.read_bytes()).hexdigest() == source_hash
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        assert not (output.with_name(output.name + suffix)).exists()
+
+
 @pytest.mark.skipif(
     not HAVE_SQLITE3_CLI,
     reason="sqlite3 CLI not on PATH; .recover is a shell-only feature",
@@ -270,6 +355,11 @@ def test_lost_and_found_lane_recovers_schema_unreadable_source(
         "BEST-EFFORT" in warning
         for warning in report["verification"]["warnings"]
     )
+    assert report["output"] == str(output)
+    assert ".hermes-session-recovery-" not in json.dumps(report)
+    assert output.exists()
+    for suffix in ("-wal", "-shm", "-journal"):
+        assert not os.path.lexists(output.with_name(output.name + suffix))
 
     conn = sqlite3.connect(str(output))
     try:
@@ -482,6 +572,11 @@ def test_mapper_rebuilds_sessiondb_from_synthetic_lost_and_found(
     lf_conn = sqlite3.connect(str(lf_path), isolation_level=None)
     dest = sqlite3.connect(str(output), isolation_level=None)
     try:
+        # ``output`` was created via SessionDB then closed, same as the real
+        # lost-and-found salvage path in session_recovery.py: this reopen
+        # needs its own hermes_turn_fence_generation() registration or the
+        # turn-fence triggers on the canonical tables reject the first write.
+        register_turn_fence_generation(dest)
         dest.execute("PRAGMA foreign_keys=OFF")
         mapping = map_lost_and_found_rows(lf_conn, dest)
         stubbing = stub_missing_parent_sessions(dest)

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -71,6 +71,58 @@ def test_turn_lease_is_scoped_to_conversation_root(tmp_path):
     db.release_session_turn_lease("child", root_holder)
 
 
+def test_turn_lease_only_ignores_conversation_id_conflict(tmp_path):
+    """A different UNIQUE constraint must not become ordinary contention."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("conversation-a", source="test")
+    db.create_session("conversation-b", source="test")
+    db._conn.execute(
+        "CREATE UNIQUE INDEX session_turn_leases_holder_unique_for_test "
+        "ON session_turn_leases(holder)"
+    )
+
+    holder = f"pid={os.getpid()}:turn=shared"
+    assert db.try_acquire_session_turn_lease(
+        "conversation-a", holder, ttl_seconds=5
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        db.try_acquire_session_turn_lease(
+            "conversation-b", holder, ttl_seconds=5
+        )
+
+    rows = db._conn.execute(
+        "SELECT conversation_id, holder FROM session_turn_leases "
+        "ORDER BY conversation_id"
+    ).fetchall()
+    assert [tuple(row) for row in rows] == [("conversation-a", holder)]
+
+
+def test_turn_lease_raises_when_insert_is_ignored_without_owner(tmp_path):
+    """A silent insert refusal must not be reported as contention."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("conversation", source="test")
+    db._conn.execute(
+        """CREATE TRIGGER session_turn_leases_ignore_insert_for_test
+        BEFORE INSERT ON session_turn_leases
+        BEGIN
+            SELECT RAISE(IGNORE);
+        END"""
+    )
+
+    holder = f"pid={os.getpid()}:turn=ignored"
+    with pytest.raises(sqlite3.DatabaseError) as exc_info:
+        db.try_acquire_session_turn_lease(
+            "conversation", holder, ttl_seconds=5
+        )
+
+    assert str(exc_info.value) == "SESSION_TURN_LEASE_ACQUIRE_INSERT_MISSING"
+    assert db._conn.execute(
+        "SELECT 1 FROM session_turn_leases WHERE conversation_id = ?",
+        ("conversation",),
+    ).fetchone() is None
+
+
 def test_turn_lease_does_not_serialize_delegate_child_with_parent(tmp_path):
     """Only compression continuation segments share a conversation lease."""
     db = SessionDB(tmp_path / "state.db")

--- a/tests/state/test_session_turn_lease_epoch_heal.py
+++ b/tests/state/test_session_turn_lease_epoch_heal.py
@@ -1,0 +1,848 @@
+"""Unconditional session_turn_leases legacy-epoch heal (#84512).
+
+Installs whose ``session_turn_leases`` table predates this module carry a
+legacy ``epoch INTEGER NOT NULL`` column with no ``DEFAULT`` (plus the
+nullable ``owner_pid`` / ``owner_pid_start``).
+A legacy implementation of ``try_acquire_session_turn_lease`` used
+``INSERT OR IGNORE INTO session_turn_leases (conversation_id, holder,
+acquired_at, expires_at) ...`` without populating ``epoch``, so every insert
+violated the NOT NULL constraint and the ignore-on-constraint behavior hid the
+failure. The row was never created, the following ``SELECT holder ...``
+returned no owner, and ``try_acquire_session_turn_lease`` returned False
+forever, with no error anywhere. Measured as a 10-hour total outage on a live
+store: every acquire polled its full patience window and reported "Another
+Hermes process is using this session" while nothing held it.
+
+There has never been a version-gated migration for this table (grep
+confirms), so a store can be sitting at ``schema_version == SCHEMA_VERSION``
+today and still be broken -- ``_heal_session_turn_leases_legacy_epoch`` has
+to run unconditionally on every open, same pattern as
+``_heal_gateway_routing_pk`` / ``_heal_session_model_usage_pk``.
+"""
+
+import sqlite3
+
+import pytest
+
+import hermes_state
+from hermes_state import SessionDB
+from hermes_state_common import (
+    SCHEMA_VERSION,
+    register_turn_fence_generation,
+    turn_fence_trigger_definitions,
+)
+
+LEGACY_SQL = """
+    CREATE TABLE session_turn_leases (
+        conversation_id TEXT PRIMARY KEY,
+        holder TEXT NOT NULL,
+        acquired_at REAL NOT NULL,
+        expires_at REAL NOT NULL,
+        epoch INTEGER NOT NULL,
+        owner_pid INTEGER,
+        owner_pid_start REAL
+    )
+"""
+
+_GOVERNED_TRIGGER_NAMES = tuple(
+    sorted(
+        name
+        for name, _sql in turn_fence_trigger_definitions()
+        if name.startswith("turn_fence_session_turn_leases_")
+    )
+)
+
+
+def _make_legacy_epoch_db(db_path, with_triggers=True):
+    """Build a state.db from raw sqlite3 with the true legacy 7-column
+    ``session_turn_leases`` shape, ``schema_version`` already at current
+    (proving the heal cannot depend on the version gate), and -- unless
+    ``with_triggers`` is False -- the real turn-fence triggers already
+    attached, exactly as a prior open of post-v27 code would have installed
+    them (the trigger body never references ``epoch``, so nothing about
+    installing them required the modern column shape)."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+    conn.execute(
+        "INSERT INTO schema_version (version) VALUES (?)", (SCHEMA_VERSION,)
+    )
+    conn.execute(LEGACY_SQL)
+    if with_triggers:
+        for name, sql in turn_fence_trigger_definitions():
+            if name.startswith("turn_fence_session_turn_leases_"):
+                conn.execute(sql)
+    conn.commit()
+    conn.close()
+
+
+def _cols(db):
+    rows = db._conn.execute(
+        'PRAGMA table_info("session_turn_leases")'
+    ).fetchall()
+    return sorted(r["name"] for r in rows)
+
+
+def _governed_triggers(db):
+    rows = db._conn.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='trigger' AND tbl_name='session_turn_leases'"
+    ).fetchall()
+    return sorted(r[0] for r in rows)
+
+
+def _lease_store_snapshot(db_path):
+    """Exact observable schema/data state used by refusal/rollback tests."""
+    conn = sqlite3.connect(db_path)
+    try:
+        return {
+            "objects": conn.execute(
+                "SELECT type, name, tbl_name, sql FROM sqlite_master "
+                "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+            ).fetchall(),
+            "columns": conn.execute(
+                'PRAGMA table_info("session_turn_leases")'
+            ).fetchall(),
+            "rows": conn.execute(
+                'SELECT * FROM session_turn_leases ORDER BY rowid'
+            ).fetchall(),
+            "schema_version": conn.execute(
+                "SELECT version FROM schema_version ORDER BY rowid"
+            ).fetchall(),
+        }
+    finally:
+        conn.close()
+
+
+def _make_schema_current_epoch_variant(db_path, table_sql):
+    """Replace one already-current lease table with a seeded epoch variant."""
+    fresh = SessionDB(db_path=db_path)
+    fresh.close()
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("DROP TABLE session_turn_leases")
+        conn.execute(table_sql)
+        conn.execute(
+            "INSERT INTO session_turn_leases "
+            "(conversation_id, holder, acquired_at, expires_at, epoch, "
+            "owner_pid, owner_pid_start) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("seed", "holder", 1.0, 2.0, 7, 123, 456.0),
+        )
+        conn.execute(
+            "CREATE INDEX idx_session_turn_leases_expires "
+            "ON session_turn_leases(expires_at)"
+        )
+        for name, sql in turn_fence_trigger_definitions():
+            if name.startswith("turn_fence_session_turn_leases_"):
+                conn.execute(sql)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_compatible_fallback_objects(db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        register_turn_fence_generation(conn)
+        conn.execute(
+            "INSERT INTO session_turn_leases "
+            "(conversation_id, holder, acquired_at, expires_at, epoch, "
+            "owner_pid, owner_pid_start) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("seed-second", "holder-second", 3.0, 4.0, 8, 456, 789.0),
+        )
+        conn.execute(
+            "CREATE INDEX session_turn_leases_owner_pid_idx "
+            "ON session_turn_leases(owner_pid)"
+        )
+        conn.execute(
+            """CREATE TRIGGER session_turn_leases_owner_pid_guard
+            BEFORE UPDATE OF owner_pid ON session_turn_leases
+            BEGIN
+                SELECT NEW.owner_pid_start;
+            END"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestSessionTurnLeasesEpochHeal:
+    def test_RED_legacy_epoch_column_silently_breaks_every_acquire(
+        self, tmp_path
+    ):
+        """RED, direct: build the true legacy shape by hand (no heal
+        involved -- this exercises exactly what _reconcile_columns +
+        SCHEMA_SQL do on a fresh connection with no heal call) and show
+        try_acquire returns False with no row, no exception."""
+        conn = sqlite3.connect(tmp_path / "raw.db")
+        conn.execute(LEGACY_SQL)
+        conn.execute(
+            "INSERT OR IGNORE INTO session_turn_leases "
+            "(conversation_id, holder, acquired_at, expires_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("conv-red", "holder-A", 1.0, 2.0),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT * FROM session_turn_leases WHERE conversation_id = ?",
+            ("conv-red",),
+        ).fetchone()
+        assert row is None, (
+            "the INSERT OR IGNORE silently no-ops on the legacy shape -- "
+            "this is the exact mechanism, reproduced without any Hermes code"
+        )
+        conn.close()
+
+    def test_legacy_shape_fails_before_and_succeeds_after_heal(
+        self, tmp_path
+    ):
+        """The real try_acquire_session_turn_lease: False (no row) on a
+        store carrying the legacy epoch column, True (row present) once
+        SessionDB opens it and the heal runs -- with the pre-existing
+        turn-fence triggers left intact throughout."""
+        db_path = tmp_path / "state.db"
+        _make_legacy_epoch_db(db_path, with_triggers=True)
+
+        # RED: reproduce with the real acquire path directly against the
+        # legacy table, bypassing SessionDB/the heal entirely. The governed
+        # triggers fire on any raw connection, so register the same UDF
+        # SessionDB registers on every connection it opens (see
+        # hermes_state._connect_and_init) -- otherwise this fails with
+        # "no such function" rather than exercising the NOT NULL swallow.
+        raw = sqlite3.connect(db_path)
+        raw.row_factory = sqlite3.Row
+        register_turn_fence_generation(raw)
+        raw.execute(
+            "INSERT OR IGNORE INTO session_turn_leases "
+            "(conversation_id, holder, acquired_at, expires_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("conv-1", "holder-A", 1.0, 2.0),
+        )
+        raw.commit()
+        pre_row = raw.execute(
+            "SELECT * FROM session_turn_leases WHERE conversation_id = ?",
+            ("conv-1",),
+        ).fetchone()
+        assert pre_row is None
+        raw.close()
+
+        # GREEN: open through SessionDB, which runs the heal unconditionally
+        # on every open, then acquire for real.
+        db = SessionDB(db_path=db_path)
+        try:
+            assert "epoch" not in _cols(db)
+            assert _governed_triggers(db) == list(_GOVERNED_TRIGGER_NAMES)
+
+            assert db.try_acquire_session_turn_lease(
+                "conv-1", "holder-A", ttl_seconds=30
+            )
+            row = db._conn.execute(
+                "SELECT holder FROM session_turn_leases "
+                "WHERE conversation_id = 'conv-1'"
+            ).fetchone()
+            assert row is not None and row["holder"] == "holder-A"
+        finally:
+            db.close()
+
+    @pytest.mark.parametrize(
+        "table_sql",
+        (
+            LEGACY_SQL.replace("epoch INTEGER NOT NULL,", "epoch INTEGER,"),
+            LEGACY_SQL.replace(
+                "epoch INTEGER NOT NULL,", "epoch INTEGER NOT NULL DEFAULT 1,"
+            ),
+            LEGACY_SQL.replace("epoch INTEGER NOT NULL,", "epoch TEXT NOT NULL,"),
+            """
+                CREATE TABLE session_turn_leases (
+                    conversation_id TEXT,
+                    holder TEXT NOT NULL,
+                    acquired_at REAL NOT NULL,
+                    expires_at REAL NOT NULL,
+                    epoch INTEGER PRIMARY KEY,
+                    owner_pid INTEGER,
+                    owner_pid_start REAL
+                )
+            """,
+            """
+                CREATE TABLE session_turn_leases (
+                    conversation_id TEXT PRIMARY KEY,
+                    holder TEXT NOT NULL,
+                    epoch INTEGER NOT NULL,
+                    acquired_at REAL NOT NULL,
+                    expires_at REAL NOT NULL,
+                    owner_pid INTEGER,
+                    owner_pid_start REAL
+                )
+            """,
+            LEGACY_SQL.replace(
+                "owner_pid_start REAL", "owner_pid_start REAL, unproven_extension TEXT"
+            ),
+            LEGACY_SQL.replace(
+                "owner_pid_start REAL", "owner_pid_start REAL, CHECK (holder <> '')"
+            ),
+        ),
+        ids=(
+            "nullable",
+            "default",
+            "different-type",
+            "epoch-pk",
+            "wrong-order",
+            "extension",
+            "unknown-check",
+        ),
+    )
+    def test_schema_current_unproven_epoch_descriptor_refuses_without_mutation(
+        self, tmp_path, table_sql
+    ):
+        """Only the complete seven-column outage descriptor authorizes DDL."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, table_sql)
+        before = _lease_store_snapshot(db_path)
+
+        with pytest.raises(
+            sqlite3.DatabaseError, match="SESSION_TURN_LEASE_EPOCH_HEAL_REFUSED"
+        ):
+            SessionDB(db_path=db_path)
+
+        assert _lease_store_snapshot(db_path) == before
+
+    def test_modern_drop_failure_refuses_open_and_preserves_legacy_store(self, tmp_path):
+        """A real epoch-dependent index makes DROP fail loud and atomic."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, LEGACY_SQL)
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "CREATE INDEX session_turn_leases_epoch_blocker "
+                "ON session_turn_leases(epoch)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        before = _lease_store_snapshot(db_path)
+
+        with pytest.raises(
+            sqlite3.DatabaseError, match="SESSION_TURN_LEASE_EPOCH_HEAL_DROP_FAILED"
+        ):
+            SessionDB(db_path=db_path)
+
+        assert _lease_store_snapshot(db_path) == before
+
+    def test_pre_335_rebuild_preserves_seeded_rows_and_compatible_objects(
+        self, tmp_path, monkeypatch
+    ):
+        """Fallback retains owner values, explicit objects, and all fences."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, LEGACY_SQL)
+        _seed_compatible_fallback_objects(db_path)
+        before = _lease_store_snapshot(db_path)
+        before_sql = {name: sql for _kind, name, _table, sql in before["objects"]}
+
+        monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 34, 1))
+        db = SessionDB(db_path=db_path)
+        try:
+            assert _cols(db) == [
+                "acquired_at",
+                "conversation_id",
+                "expires_at",
+                "holder",
+                "owner_pid",
+                "owner_pid_start",
+            ]
+            assert [
+                tuple(row)
+                for row in db._conn.execute(
+                    "SELECT conversation_id, holder, acquired_at, expires_at, "
+                    "owner_pid, owner_pid_start FROM session_turn_leases "
+                    "ORDER BY conversation_id"
+                ).fetchall()
+            ] == [
+                ("seed", "holder", 1.0, 2.0, 123, 456.0),
+                ("seed-second", "holder-second", 3.0, 4.0, 456, 789.0),
+            ]
+            after_sql = {
+                name: sql
+                for _kind, name, _table, sql in _lease_store_snapshot(db_path)[
+                    "objects"
+                ]
+            }
+            for name in (
+                "idx_session_turn_leases_expires",
+                "session_turn_leases_owner_pid_idx",
+                "session_turn_leases_owner_pid_guard",
+                *_GOVERNED_TRIGGER_NAMES,
+            ):
+                assert after_sql[name] == before_sql[name]
+            assert db._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name = 'session_turn_leases_legacy_epoch'"
+            ).fetchone() is None
+            assert db.try_acquire_session_turn_lease(
+                "fallback-open", "holder", ttl_seconds=30
+            )
+        finally:
+            db.close()
+
+    def test_pre_335_rebuild_captures_late_compatible_objects_after_begin(
+        self, tmp_path, monkeypatch
+    ):
+        """The fallback snapshots objects only after its write lock is held."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, LEGACY_SQL)
+        late_index = "session_turn_leases_late_owner_pid_idx"
+        late_trigger = "session_turn_leases_late_owner_pid_guard"
+        injected = False
+        expected_objects = {}
+        original_execute = hermes_state._SerializedCursor.execute
+
+        def create_objects_before_begin(cursor, sql, parameters=()):
+            nonlocal injected, expected_objects
+            if sql == "BEGIN IMMEDIATE" and not injected:
+                injected = True
+                writer = sqlite3.connect(db_path)
+                try:
+                    writer.execute(
+                        f"CREATE INDEX {late_index} "
+                        "ON session_turn_leases(owner_pid)"
+                    )
+                    writer.execute(
+                        f"""CREATE TRIGGER {late_trigger}
+                        BEFORE UPDATE OF owner_pid ON session_turn_leases
+                        BEGIN
+                            SELECT NEW.owner_pid_start;
+                        END"""
+                    )
+                    writer.commit()
+                    expected_objects = dict(
+                        writer.execute(
+                            "SELECT name, sql FROM sqlite_master "
+                            "WHERE name IN (?, ?) ORDER BY name",
+                            (late_index, late_trigger),
+                        ).fetchall()
+                    )
+                finally:
+                    writer.close()
+            return original_execute(cursor, sql, parameters)
+
+        monkeypatch.setattr(
+            hermes_state._SerializedCursor,
+            "execute",
+            create_objects_before_begin,
+        )
+        monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 34, 1))
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert injected
+            actual_objects = dict(
+                db._conn.execute(
+                    "SELECT name, sql FROM sqlite_master "
+                    "WHERE name IN (?, ?) ORDER BY name",
+                    (late_index, late_trigger),
+                ).fetchall()
+            )
+            assert actual_objects == expected_objects
+            assert db._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name = 'session_turn_leases_legacy_epoch'"
+            ).fetchone() is None
+        finally:
+            db.close()
+
+    def test_pre_335_rebuild_refuses_epoch_dependent_objects_without_mutation(
+        self, tmp_path, monkeypatch
+    ):
+        """The fallback preflights definitions it cannot safely recreate."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, LEGACY_SQL)
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "CREATE INDEX session_turn_leases_epoch_blocker "
+                "ON session_turn_leases(epoch)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        before = _lease_store_snapshot(db_path)
+
+        monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 34, 1))
+        with pytest.raises(
+            sqlite3.DatabaseError, match="SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED"
+        ):
+            SessionDB(db_path=db_path)
+
+        assert _lease_store_snapshot(db_path) == before
+
+    @pytest.mark.parametrize(
+        "stage", ("rename", "create", "copy", "verify", "drop", "index", "trigger")
+    )
+    def test_pre_335_rebuild_rolls_back_every_stage_failure(
+        self, tmp_path, monkeypatch, stage
+    ):
+        """Every rebuild stage either commits together or leaves no residue."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, LEGACY_SQL)
+        _seed_compatible_fallback_objects(db_path)
+        before = _lease_store_snapshot(db_path)
+
+        def fail_selected_stage(_db, checkpoint):
+            if checkpoint == stage:
+                raise sqlite3.OperationalError(f"forced fallback {stage} failure")
+
+        monkeypatch.setattr(
+            SessionDB,
+            "_session_turn_lease_epoch_rebuild_checkpoint",
+            fail_selected_stage,
+            raising=False,
+        )
+        monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 34, 1))
+
+        with pytest.raises(sqlite3.OperationalError, match=f"forced fallback {stage}"):
+            SessionDB(db_path=db_path)
+
+        assert _lease_store_snapshot(db_path) == before
+
+    def test_owner_pid_columns_are_left_in_place(self, tmp_path):
+        """Nullable legacy columns are not the cause of the outage and are
+        deliberately not removed by this heal."""
+        db_path = tmp_path / "state.db"
+        _make_legacy_epoch_db(db_path, with_triggers=True)
+        db = SessionDB(db_path=db_path)
+        try:
+            cols = _cols(db)
+            assert "owner_pid" in cols
+            assert "owner_pid_start" in cols
+        finally:
+            db.close()
+
+    def test_healthy_db_is_a_noop_idempotent(self, tmp_path):
+        """A DB already at the correct 4-column shape is untouched and
+        keeps working -- re-running the heal directly is also a no-op."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session("s1", "cli")
+            assert _cols(db) == [
+                "acquired_at",
+                "conversation_id",
+                "expires_at",
+                "holder",
+            ]
+            assert db.try_acquire_session_turn_lease(
+                "s1", "holder-A", ttl_seconds=30
+            )
+            db.release_session_turn_lease("s1", "holder-A")
+
+            cur = db._conn.cursor()
+            db._heal_session_turn_leases_legacy_epoch(cur)
+
+            assert _cols(db) == [
+                "acquired_at",
+                "conversation_id",
+                "expires_at",
+                "holder",
+            ]
+            assert db.try_acquire_session_turn_lease(
+                "s1", "holder-B", ttl_seconds=30
+            )
+        finally:
+            db.close()
+
+    def test_no_legacy_leftover_table_and_index_present(self, tmp_path):
+        """Whichever path ran (DROP COLUMN or rebuild fallback), no
+        *_legacy_epoch residue is left behind and the expires_at index
+        exists."""
+        db_path = tmp_path / "state.db"
+        _make_legacy_epoch_db(db_path, with_triggers=True)
+        db = SessionDB(db_path=db_path)
+        try:
+            left = db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='session_turn_leases_legacy_epoch'"
+            ).fetchone()
+            assert left is None
+            idx = db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND name='idx_session_turn_leases_expires'"
+            ).fetchone()
+            assert idx is not None
+        finally:
+            db.close()
+
+    def test_pre_335_rebuild_fallback_also_heals_and_reinstalls_triggers(
+        self, tmp_path, monkeypatch
+    ):
+        """Force the < 3.35 rebuild branch (no DROP COLUMN support) and
+        confirm it heals the column AND reinstalls the fence triggers that
+        the RENAME would otherwise have carried away from the new table."""
+        db_path = tmp_path / "state.db"
+        _make_legacy_epoch_db(db_path, with_triggers=True)
+
+        monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 34, 1))
+        db = SessionDB(db_path=db_path)
+        try:
+            assert "epoch" not in _cols(db)
+            assert _governed_triggers(db) == list(_GOVERNED_TRIGGER_NAMES)
+            assert db.try_acquire_session_turn_lease(
+                "conv-legacy-sqlite", "holder-A", ttl_seconds=30
+            )
+        finally:
+            db.close()
+
+    def test_guard_every_not_null_no_default_column_is_insert_populated(
+        self, tmp_path
+    ):
+        """Exercise the real acquisition path against a fresh current schema.
+
+        The class of bug that caused the outage is a NOT NULL column without a
+        DEFAULT that the acquisition path fails to populate. Discover that
+        contract from the live table and inspect the row produced by the real
+        ``try_acquire_session_turn_lease`` call, so a future required column
+        omission turns this red instead of silently shipping an unpopulated
+        lease.
+
+        This remains scoped to session_turn_leases because the production
+        acquisition path creates one row for this table. It is a behavior
+        invariant over the actual schema and row, not a parser for production
+        source or SQL spelling.
+        """
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            assert db.try_acquire_session_turn_lease(
+                "guard-conversation", "guard-holder", ttl_seconds=30
+            )
+            row = db._conn.execute(
+                "SELECT * FROM session_turn_leases WHERE conversation_id = ?",
+                ("guard-conversation",),
+            ).fetchone()
+            assert row is not None
+
+            declared = db._conn.execute(
+                'PRAGMA table_info("session_turn_leases")'
+            ).fetchall()
+            not_null_no_default = {
+                column[1]
+                for column in declared
+                if column[3] and column[4] is None
+            }
+            unpopulated = {
+                column for column in not_null_no_default if row[column] is None
+            }
+            assert unpopulated == set(), (
+                f"session_turn_leases declares NOT NULL/no-DEFAULT columns "
+                f"{unpopulated} that the real acquisition path did not "
+                "populate -- this is exactly the class of bug that caused "
+                "the 10-hour outage"
+            )
+        finally:
+            db.close()
+
+    @pytest.mark.parametrize(
+        ("name", "ddl"),
+        (
+            (
+                "session_turn_leases_dependent_view",
+                "CREATE VIEW session_turn_leases_dependent_view AS "
+                "SELECT conversation_id FROM session_turn_leases",
+            ),
+            (
+                "session_turn_leases_external_dependency",
+                "CREATE TRIGGER session_turn_leases_external_dependency "
+                "AFTER UPDATE ON schema_version BEGIN "
+                "SELECT count(*) FROM session_turn_leases; END",
+            ),
+        ),
+        ids=("view", "external-trigger"),
+    )
+    def test_pre_335_rebuild_refuses_unprovable_dependent_objects_without_mutation(
+        self, tmp_path, monkeypatch, name, ddl
+    ):
+        """Views and external triggers cannot be proven safe for table replay."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, LEGACY_SQL)
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(ddl)
+            conn.commit()
+        finally:
+            conn.close()
+        before = _lease_store_snapshot(db_path)
+
+        monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 34, 1))
+        with pytest.raises(
+            sqlite3.DatabaseError, match="SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED"
+        ):
+            SessionDB(db_path=db_path)
+
+        assert _lease_store_snapshot(db_path) == before
+        assert any(row[1] == name for row in before["objects"])
+
+    def test_pre_335_rebuild_refuses_wrong_body_for_canonical_fence_name(
+        self, tmp_path, monkeypatch
+    ):
+        """A canonical fence name is not authority for a different trigger body."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, LEGACY_SQL)
+        fence_name = _GOVERNED_TRIGGER_NAMES[0]
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(f"DROP TRIGGER {fence_name}")
+            conn.execute(
+                f"CREATE TRIGGER {fence_name} BEFORE INSERT "
+                "ON session_turn_leases BEGIN SELECT 1; END"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        before = _lease_store_snapshot(db_path)
+
+        monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 34, 1))
+        with pytest.raises(
+            sqlite3.DatabaseError, match="SESSION_TURN_LEASE_EPOCH_REBUILD_REFUSED"
+        ):
+            SessionDB(db_path=db_path)
+
+        assert _lease_store_snapshot(db_path) == before
+
+    def test_modern_drop_postcondition_refuses_sabotaged_epoch_removal(
+        self, tmp_path, monkeypatch
+    ):
+        """A successful DROP that leaves epoch behind cannot publish a false heal."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, LEGACY_SQL)
+        original_execute = hermes_state._SerializedCursor.execute
+        sabotaged = False
+
+        def restore_epoch_after_drop(cursor, sql, parameters=()):
+            nonlocal sabotaged
+            result = original_execute(cursor, sql, parameters)
+            if (
+                sql == 'ALTER TABLE "session_turn_leases" DROP COLUMN "epoch"'
+                and not sabotaged
+            ):
+                sabotaged = True
+                original_execute(
+                    cursor,
+                    'ALTER TABLE "session_turn_leases" ADD COLUMN "epoch" '
+                    "INTEGER NOT NULL DEFAULT 0",
+                )
+            return result
+
+        monkeypatch.setattr(
+            hermes_state._SerializedCursor, "execute", restore_epoch_after_drop
+        )
+        with pytest.raises(
+            sqlite3.DatabaseError, match="SESSION_TURN_LEASE_EPOCH_HEAL_INCOMPLETE"
+        ):
+            SessionDB(db_path=db_path)
+
+        assert sabotaged
+        after = _lease_store_snapshot(db_path)
+        assert any(column[1] == "epoch" for column in after["columns"])
+        assert after["rows"] == [("seed", "holder", 1.0, 2.0, 123, 456.0, 0)]
+        assert not any(
+            row[0] == "table" and row[1] == "session_turn_leases_legacy_epoch"
+            for row in after["objects"]
+        )
+
+    def test_modern_locked_drop_retries_through_open_boundary(self, tmp_path, monkeypatch):
+        """A real busy DROP reaches SessionDB's existing open-time retry loop."""
+        db_path = tmp_path / "state.db"
+        _make_schema_current_epoch_variant(db_path, LEGACY_SQL)
+        original_connect = hermes_state._connect_tracked_db
+        original_execute = hermes_state._SerializedCursor.execute
+        connection_attempts = 0
+        lock_holder = None
+        busy_seen = False
+
+        def count_connections(*args, **kwargs):
+            nonlocal connection_attempts
+            connection_attempts += 1
+            return original_connect(*args, **kwargs)
+
+        def lock_the_real_drop(cursor, sql, parameters=()):
+            nonlocal busy_seen, lock_holder
+            if (
+                sql == 'ALTER TABLE "session_turn_leases" DROP COLUMN "epoch"'
+                and lock_holder is None
+            ):
+                lock_holder = sqlite3.connect(db_path)
+                lock_holder.execute("BEGIN IMMEDIATE")
+                try:
+                    return original_execute(cursor, sql, parameters)
+                except sqlite3.OperationalError as exc:
+                    if "locked" not in str(exc).lower() and "busy" not in str(exc).lower():
+                        raise
+                    busy_seen = True
+                    lock_holder.rollback()
+                    raise
+            return original_execute(cursor, sql, parameters)
+
+        monkeypatch.setattr(hermes_state, "_connect_tracked_db", count_connections)
+        monkeypatch.setattr(hermes_state._SerializedCursor, "execute", lock_the_real_drop)
+        db = None
+        try:
+            db = SessionDB(db_path=db_path)
+            assert busy_seen
+            assert connection_attempts >= 2
+            assert "epoch" not in _cols(db)
+        finally:
+            if db is not None:
+                db.close()
+            if lock_holder is not None:
+                lock_holder.rollback()
+                lock_holder.close()
+
+    def test_pre_335_rebuild_rollback_leaves_same_connection_usable(
+        self, tmp_path, monkeypatch
+    ):
+        """A failed fallback rolls back without poisoning its open connection."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            conn = db._conn
+            conn.execute('DROP TABLE "session_turn_leases"')
+            conn.execute(LEGACY_SQL)
+            for name, sql in turn_fence_trigger_definitions():
+                if name.startswith("turn_fence_session_turn_leases_"):
+                    conn.execute(sql)
+            conn.execute(
+                "INSERT INTO session_turn_leases "
+                "(conversation_id, holder, acquired_at, expires_at, epoch, "
+                "owner_pid, owner_pid_start) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("seed", "holder", 1.0, 2.0, 7, 123, 456.0),
+            )
+            conn.commit()
+            _seed_compatible_fallback_objects(db_path)
+            before = _lease_store_snapshot(db_path)
+
+            monkeypatch.setattr(sqlite3, "sqlite_version_info", (3, 34, 1))
+            with monkeypatch.context() as scoped:
+                def fail_copy(_db, checkpoint):
+                    if checkpoint == "copy":
+                        raise sqlite3.OperationalError("forced fallback copy failure")
+
+                scoped.setattr(
+                    SessionDB,
+                    "_session_turn_lease_epoch_rebuild_checkpoint",
+                    fail_copy,
+                )
+                with pytest.raises(
+                    sqlite3.OperationalError, match="forced fallback copy failure"
+                ):
+                    db._heal_session_turn_leases_legacy_epoch(conn.cursor())
+
+            assert _lease_store_snapshot(db_path) == before
+            assert tuple(
+                conn.execute(
+                    "SELECT holder, owner_pid, owner_pid_start FROM session_turn_leases "
+                    "WHERE conversation_id = 'seed'"
+                ).fetchone()
+            ) == ("holder", 123, 456.0)
+
+            db._heal_session_turn_leases_legacy_epoch(conn.cursor())
+            assert "epoch" not in _cols(db)
+            assert db.try_acquire_session_turn_lease(
+                "same-connection-fallback", "holder", ttl_seconds=30
+            )
+        finally:
+            db.close()

--- a/tests/state/test_turn_fence_generation_current_main.py
+++ b/tests/state/test_turn_fence_generation_current_main.py
@@ -1,0 +1,230 @@
+"""Behavioral coverage for the v27 state-store generation fence."""
+
+import sqlite3
+
+import pytest
+
+import hermes_state
+from hermes_state import SCHEMA_SQL, SessionDB
+from hermes_state_common import TURN_FENCE_GENERATION, TURN_FENCE_GOVERNED_TABLES
+
+
+class _FailAfterOneTurnFenceTriggerCursor(sqlite3.Cursor):
+    trigger_creations = 0
+
+    def execute(self, sql, parameters=()):
+        if sql.lstrip().upper().startswith("CREATE TRIGGER TURN_FENCE_"):
+            type(self).trigger_creations += 1
+            if type(self).trigger_creations == 2:
+                raise sqlite3.OperationalError("forced v27 trigger failure")
+        return super().execute(sql, parameters)
+
+
+class _FailAfterOneTurnFenceTriggerConnection(
+    hermes_state._SerializedConnectionMixin, sqlite3.Connection
+):
+    def cursor(self, factory=None):
+        return super().cursor(factory or _FailAfterOneTurnFenceTriggerCursor)
+
+
+def test_turn_fence_generation_v27_trigger_failure_rolls_back_before_schema_publication(
+    tmp_path, monkeypatch
+):
+    """A partial v27 trigger install leaves the complete v26 state intact."""
+    db_path = tmp_path / "state.db"
+    seed = sqlite3.connect(str(db_path))
+    seed.executescript(SCHEMA_SQL)
+    seed.execute("INSERT INTO schema_version (version) VALUES (26)")
+    seed.commit()
+    seed.close()
+
+    _FailAfterOneTurnFenceTriggerCursor.trigger_creations = 0
+    real_connect = hermes_state._connect_tracked_db
+
+    def connect_with_v27_failure(*args, **kwargs):
+        kwargs["factory"] = _FailAfterOneTurnFenceTriggerConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(hermes_state, "_connect_tracked_db", connect_with_v27_failure)
+
+    with pytest.raises(sqlite3.OperationalError, match="forced v27 trigger failure"):
+        SessionDB(db_path=db_path)
+
+    check = sqlite3.connect(str(db_path))
+    try:
+        assert check.execute("SELECT version FROM schema_version").fetchall() == [(26,)]
+        assert check.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'trigger' AND name LIKE 'turn_fence_%'"
+        ).fetchall() == []
+    finally:
+        check.close()
+
+
+def _governed_write_cases(conn):
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at) VALUES ('messages-parent', 'cli', 1)"
+    )
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) "
+        "VALUES ('messages-parent', 'user', 'before', 1)"
+    )
+    message_id = conn.execute("SELECT id FROM messages").fetchone()[0]
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at) VALUES ('sessions-update', 'cli', 1)"
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at) VALUES ('sessions-delete', 'cli', 1)"
+    )
+    conn.execute("INSERT INTO system_prompts (hash, prompt) VALUES ('prompts-update', 'before')")
+    conn.execute("INSERT INTO system_prompts (hash, prompt) VALUES ('prompts-delete', 'before')")
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at) VALUES ('usage-parent', 'cli', 1)"
+    )
+    conn.execute(
+        "INSERT INTO session_model_usage (session_id, model) VALUES ('usage-parent', 'usage-update')"
+    )
+    conn.execute(
+        "INSERT INTO session_model_usage (session_id, model) VALUES ('usage-parent', 'usage-delete')"
+    )
+    conn.execute(
+        "INSERT INTO session_turn_leases (conversation_id, holder, acquired_at, expires_at) "
+        "VALUES ('leases-update', 'before', 1, 2)"
+    )
+    conn.execute(
+        "INSERT INTO session_turn_leases (conversation_id, holder, acquired_at, expires_at) "
+        "VALUES ('leases-delete', 'before', 1, 2)"
+    )
+    conn.execute(
+        "INSERT INTO compression_locks (session_id, holder, acquired_at, expires_at) "
+        "VALUES ('locks-update', 'before', 1, 2)"
+    )
+    conn.execute(
+        "INSERT INTO compression_locks (session_id, holder, acquired_at, expires_at) "
+        "VALUES ('locks-delete', 'before', 1, 2)"
+    )
+    conn.execute(
+        "INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at) "
+        "VALUES ('', 'routing-update', '{}', 1)"
+    )
+    conn.execute(
+        "INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at) "
+        "VALUES ('', 'routing-delete', '{}', 1)"
+    )
+    conn.execute(
+        "INSERT INTO async_delegations "
+        "(delegation_id, origin_session, state, dispatched_at, updated_at) "
+        "VALUES ('async-update', 'origin', 'pending', 1, 1)"
+    )
+    conn.execute(
+        "INSERT INTO async_delegations "
+        "(delegation_id, origin_session, state, dispatched_at, updated_at) "
+        "VALUES ('async-delete', 'origin', 'pending', 1, 1)"
+    )
+    return (
+        ("messages", "INSERT", "INSERT INTO messages (session_id, role, content, timestamp) VALUES ('messages-parent', 'user', 'insert', 2)", "SELECT COUNT(*) FROM messages WHERE content = 'insert'"),
+        ("messages", "UPDATE", f"UPDATE messages SET content = 'after' WHERE id = {message_id}", f"SELECT content FROM messages WHERE id = {message_id}"),
+        ("messages", "DELETE", f"DELETE FROM messages WHERE id = {message_id}", f"SELECT COUNT(*) FROM messages WHERE id = {message_id}"),
+        ("sessions", "INSERT", "INSERT INTO sessions (id, source, started_at) VALUES ('sessions-insert', 'cli', 1)", "SELECT COUNT(*) FROM sessions WHERE id = 'sessions-insert'"),
+        ("sessions", "UPDATE", "UPDATE sessions SET source = 'other' WHERE id = 'sessions-update'", "SELECT source FROM sessions WHERE id = 'sessions-update'"),
+        ("sessions", "DELETE", "DELETE FROM sessions WHERE id = 'sessions-delete'", "SELECT COUNT(*) FROM sessions WHERE id = 'sessions-delete'"),
+        ("system_prompts", "INSERT", "INSERT INTO system_prompts (hash, prompt) VALUES ('prompts-insert', 'insert')", "SELECT COUNT(*) FROM system_prompts WHERE hash = 'prompts-insert'"),
+        ("system_prompts", "UPDATE", "UPDATE system_prompts SET prompt = 'after' WHERE hash = 'prompts-update'", "SELECT prompt FROM system_prompts WHERE hash = 'prompts-update'"),
+        ("system_prompts", "DELETE", "DELETE FROM system_prompts WHERE hash = 'prompts-delete'", "SELECT COUNT(*) FROM system_prompts WHERE hash = 'prompts-delete'"),
+        ("session_model_usage", "INSERT", "INSERT INTO session_model_usage (session_id, model) VALUES ('usage-parent', 'usage-insert')", "SELECT COUNT(*) FROM session_model_usage WHERE model = 'usage-insert'"),
+        ("session_model_usage", "UPDATE", "UPDATE session_model_usage SET api_call_count = 7 WHERE model = 'usage-update'", "SELECT api_call_count FROM session_model_usage WHERE model = 'usage-update'"),
+        ("session_model_usage", "DELETE", "DELETE FROM session_model_usage WHERE model = 'usage-delete'", "SELECT COUNT(*) FROM session_model_usage WHERE model = 'usage-delete'"),
+        ("session_turn_leases", "INSERT", "INSERT INTO session_turn_leases (conversation_id, holder, acquired_at, expires_at) VALUES ('leases-insert', 'holder', 1, 2)", "SELECT COUNT(*) FROM session_turn_leases WHERE conversation_id = 'leases-insert'"),
+        ("session_turn_leases", "UPDATE", "UPDATE session_turn_leases SET holder = 'after' WHERE conversation_id = 'leases-update'", "SELECT holder FROM session_turn_leases WHERE conversation_id = 'leases-update'"),
+        ("session_turn_leases", "DELETE", "DELETE FROM session_turn_leases WHERE conversation_id = 'leases-delete'", "SELECT COUNT(*) FROM session_turn_leases WHERE conversation_id = 'leases-delete'"),
+        ("compression_locks", "INSERT", "INSERT INTO compression_locks (session_id, holder, acquired_at, expires_at) VALUES ('locks-insert', 'holder', 1, 2)", "SELECT COUNT(*) FROM compression_locks WHERE session_id = 'locks-insert'"),
+        ("compression_locks", "UPDATE", "UPDATE compression_locks SET holder = 'after' WHERE session_id = 'locks-update'", "SELECT holder FROM compression_locks WHERE session_id = 'locks-update'"),
+        ("compression_locks", "DELETE", "DELETE FROM compression_locks WHERE session_id = 'locks-delete'", "SELECT COUNT(*) FROM compression_locks WHERE session_id = 'locks-delete'"),
+        ("gateway_routing", "INSERT", "INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at) VALUES ('', 'routing-insert', '{}', 1)", "SELECT COUNT(*) FROM gateway_routing WHERE session_key = 'routing-insert'"),
+        ("gateway_routing", "UPDATE", "UPDATE gateway_routing SET entry_json = '{\"after\": true}' WHERE session_key = 'routing-update'", "SELECT entry_json FROM gateway_routing WHERE session_key = 'routing-update'"),
+        ("gateway_routing", "DELETE", "DELETE FROM gateway_routing WHERE session_key = 'routing-delete'", "SELECT COUNT(*) FROM gateway_routing WHERE session_key = 'routing-delete'"),
+        ("async_delegations", "INSERT", "INSERT INTO async_delegations (delegation_id, origin_session, state, dispatched_at, updated_at) VALUES ('async-insert', 'origin', 'pending', 1, 1)", "SELECT COUNT(*) FROM async_delegations WHERE delegation_id = 'async-insert'"),
+        ("async_delegations", "UPDATE", "UPDATE async_delegations SET state = 'done' WHERE delegation_id = 'async-update'", "SELECT state FROM async_delegations WHERE delegation_id = 'async-update'"),
+        ("async_delegations", "DELETE", "DELETE FROM async_delegations WHERE delegation_id = 'async-delete'", "SELECT COUNT(*) FROM async_delegations WHERE delegation_id = 'async-delete'"),
+    )
+
+
+def test_turn_fence_generation_unregistered_connection_cannot_mutate_any_governed_operation(
+    tmp_path,
+):
+    """Every governed INSERT, UPDATE, and DELETE fails before mutation."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        cases = _governed_write_cases(db._conn)
+        db._conn.commit()
+        assert {table for table, _operation, _sql, _probe in cases} == set(
+            TURN_FENCE_GOVERNED_TABLES
+        )
+        assert len(cases) == len(TURN_FENCE_GOVERNED_TABLES) * 3
+
+        raw = sqlite3.connect(str(db.db_path))
+        try:
+            for _table, _operation, sql, probe in cases:
+                before = raw.execute(probe).fetchall()
+                with pytest.raises(sqlite3.DatabaseError):
+                    raw.execute(sql)
+                assert raw.execute(probe).fetchall() == before
+        finally:
+            raw.close()
+    finally:
+        db.close()
+
+
+def test_turn_fence_generation_wrong_or_throwing_function_fails_before_mutation(
+    tmp_path,
+):
+    """The trigger requires the exact integer generation, not mere presence."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        for value in (
+            TURN_FENCE_GENERATION - 1,
+            "27",
+            b"27",
+            27.0,
+            None,
+            True,
+        ):
+            raw = sqlite3.connect(str(db.db_path))
+            try:
+                raw.create_function(
+                    "hermes_turn_fence_generation", 0, lambda value=value: value
+                )
+                with pytest.raises(sqlite3.DatabaseError):
+                    raw.execute(
+                        "INSERT INTO gateway_routing "
+                        "(scope, session_key, entry_json, updated_at) "
+                        "VALUES ('', ?, '{}', 1)",
+                        (f"wrong-{type(value).__name__}",),
+                    )
+                assert raw.execute(
+                    "SELECT COUNT(*) FROM gateway_routing "
+                    "WHERE session_key = ?",
+                    (f"wrong-{type(value).__name__}",),
+                ).fetchone() == (0,)
+            finally:
+                raw.close()
+
+        raw = sqlite3.connect(str(db.db_path))
+        try:
+            def raises_generation():
+                raise RuntimeError("generation unavailable")
+
+            raw.create_function("hermes_turn_fence_generation", 0, raises_generation)
+            with pytest.raises(sqlite3.DatabaseError):
+                raw.execute(
+                    "INSERT INTO gateway_routing "
+                    "(scope, session_key, entry_json, updated_at) "
+                    "VALUES ('', 'throws', '{}', 1)"
+                )
+            assert raw.execute(
+                "SELECT COUNT(*) FROM gateway_routing WHERE session_key = 'throws'"
+            ).fetchone() == (0,)
+        finally:
+            raw.close()
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

- enforce generation-bound session-state writes and fail-closed legacy lease-schema healing
- make recovery no-clobber and harden gateway turn-lease ownership, rollback, release, and cancellation cleanup
- refuse CLI attachment to a session actively served by the gateway
- add an observer-only two-strike watchdog packet that emits a restart recommendation without performing lifecycle actions

## Verification

- state lease/fence matrix: 55 passed
- recovery matrix: 38 passed
- gateway turn-lease matrix: 18 passed
- gateway hygiene matrix: 17 passed
- CLI guard/parser matrix: 17 passed
- watchdog harness: 44 passed
- exact 18-path scope, syntax, diff, and public-safety checks passed

No watchdog installation, activation, service restart, or live-state mutation is included. Operational liveness remains unverified.