### PR TITLE
fix(cron): accept bare duration units like 'hour' in schedule parsing

### DIFF
--- a/contributors/emails/salch-cred@users.noreply.github.com
+++ b/contributors/emails/salch-cred@users.noreply.github.com
@@ -1,0 +1,1 @@
+salch-cred

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -716,13 +716,14 @@ def parse_duration(s: str) -> int:
         "30m" → 30
         "2h" → 120
         "1d" → 1440
+        "hour" → 60 (bare unit, no leading number)
     """
     s = s.strip().lower()
-    match = re.match(r'^(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
+    match = re.match(r'^(\d*)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
     if not match:
         raise ValueError(f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'")
     
-    value = int(match.group(1))
+    value = int(match.group(1)) if match.group(1) else 1
     unit = match.group(2)[0]  # First char: m, h, or d
     
     multipliers = {'m': 1, 'h': 60, 'd': 1440}

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -721,7 +721,10 @@ def parse_duration(s: str) -> int:
     s = s.strip().lower()
     match = re.match(r'^(\d*)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
     if not match:
-        raise ValueError(f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'")
+        raise ValueError(
+            f"Invalid duration: '{s}'. Use format like '30m', '2h', '1d', "
+            "or a bare unit like 'hour' (defaults to 1)."
+        )
     
     value = int(match.group(1)) if match.group(1) else 1
     unit = match.group(2)[0]  # First char: m, h, or d


### PR DESCRIPTION
Fixes the schedule-parser/UI mismatch where `"every hour"` (advertised as a valid example) errors with `Invalid duration: 'hour'`, while `"every 1h"` works.

## Root cause

`cron/jobs.py` `parse_duration()` matched `re.match(r'^(\d+)\s*(...)$')` — a leading digit was mandatory. `parse_schedule("every hour")` strips `"every "` → `"hour"` → `parse_duration("hour")` failed the regex and raised. Bare-unit phrases like `"hour"` / `"day"` had no way to parse.

## Fix

Made the leading number optional, defaulting to `1` when absent:

```python
match = re.match(r'^(\d*)\s*(m|min|...|hour|hours|d|day|days)$', s)
value = int(match.group(1)) if match.group(1) else 1
```

Now `"hour"` → 60, `"day"` → 1440, `"min"` → 1, and existing forms (`"30m"`, `"2h"`, `"1d"`, `"every 2h"`) are unchanged.

## Validation

- `parse_duration("hour")` → 60; `"day"` → 1440; `"min"` → 1.
- `parse_schedule("every hour")` → `{kind: interval, minutes: 60}`.
- Existing `"30m"`, `"2h"`, `"1d"`, `"every 2h"`, `"every 30m"` all unchanged.
