### PR TITLE
fix(peer): keep remote DMs alive across Windows gateways

### DIFF
--- a/hermes_cli/subcommands/peer.py
+++ b/hermes_cli/subcommands/peer.py
@@ -9,8 +9,8 @@ bot on THIS machine a transport to message bots on THAT machine:
     hermes peer dm spark/researcher "..."      # named profile (multiplexed peer)
 
 ``dm`` resolves the remote agent's canonical "Bot Chat" session (by title,
-creating it when missing), runs ONE synchronous agent turn over the peer's
-existing ``POST /api/sessions/{id}/chat`` endpoint, and prints the reply on
+creating it when missing), runs ONE agent turn over the peer's existing
+``POST /api/sessions/{id}/chat/stream`` endpoint, and prints the reply on
 stdout — the exact cross-machine twin of the local
 ``hermes -p <bot> chat --in ~ -c "Bot Chat" ...`` bot-messaging command, so
 the Bot Mode protocol composes over it unchanged.
@@ -97,6 +97,53 @@ def _request(url: str, key: str, *, method: str = "GET", body: dict | None = Non
     if not isinstance(parsed, dict):
         raise RuntimeError("Peer returned a non-object JSON response")
     return parsed
+
+
+def _request_chat_stream(url: str, key: str, message: str) -> dict:
+    """Run one peer chat turn and project its terminal SSE event."""
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"message": message}).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "User-Agent": "hermes-peer-dm",
+        },
+    )
+    completed = None
+    event = ""
+    data_lines: list[str] = []
+
+    with urllib.request.urlopen(req, timeout=DM_TIMEOUT_S) as resp:  # noqa: S310 — user-registered peer URL
+        for raw_line in resp:
+            line = raw_line.decode("utf-8", "replace").rstrip("\r\n")
+            if line.startswith("event:"):
+                event = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[len("data:") :].lstrip())
+            elif not line:
+                if event in {"assistant.completed", "error"}:
+                    payload_text = "\n".join(data_lines)
+                    try:
+                        payload = json.loads(payload_text)
+                    except ValueError as exc:
+                        raise RuntimeError(f"Peer returned invalid {event} event: {payload_text[:200]}") from exc
+                    if not isinstance(payload, dict):
+                        raise RuntimeError(f"Peer returned a non-object {event} event")
+                    if event == "error":
+                        raise RuntimeError(str(payload.get("message") or "Peer chat failed"))
+                    completed = payload
+                event = ""
+                data_lines = []
+
+    if completed is None:
+        raise RuntimeError("Peer chat stream ended without a completed assistant response")
+    return {
+        "session_id": completed.get("session_id"),
+        "message": {"role": "assistant", "content": completed.get("content") or ""},
+    }
 
 
 def _base_url(peer: dict, profile: str | None) -> str:
@@ -262,12 +309,14 @@ def cmd_peer(args) -> int:
         base = _base_url(peer, profile)
         try:
             session_id = _ensure_bot_chat(base, key)
-            result = _request(
-                f"{base}/api/sessions/{urllib.parse.quote(session_id, safe='')}/chat",
+            # The buffered /chat route cannot send its HTTP status until the
+            # whole agent turn finishes. The streaming twin prepares headers
+            # immediately and emits keepalives, so long peer turns remain
+            # reachable through clients and network paths with idle timeouts.
+            result = _request_chat_stream(
+                f"{base}/api/sessions/{urllib.parse.quote(session_id, safe='')}/chat/stream",
                 key,
-                method="POST",
-                body={"message": message},
-                timeout=DM_TIMEOUT_S,
+                message,
             )
         except urllib.error.HTTPError as exc:
             print(f"Peer '{peer_name}' rejected the request (HTTP {exc.code}): {_http_error_detail(exc)}", file=sys.stderr)

--- a/tests/gateway/test_peer_dm_hidden_e2e.py
+++ b/tests/gateway/test_peer_dm_hidden_e2e.py
@@ -33,6 +33,7 @@ def _build_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/api/sessions", adapter._handle_list_sessions)
     app.router.add_post("/api/sessions", adapter._handle_create_session)
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
+    app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
     return app
 
 

--- a/tests/hermes_cli/test_peer_cmd.py
+++ b/tests/hermes_cli/test_peer_cmd.py
@@ -92,6 +92,7 @@ def test_dm_unknown_peer_and_missing_key(monkeypatch):
 class _FakePeer(BaseHTTPRequestHandler):
     sessions: list = []
     chats: list = []
+    chat_paths: list = []
     auth_seen: list = []
 
     def _json(self, payload, status=200):
@@ -120,15 +121,22 @@ class _FakePeer(BaseHTTPRequestHandler):
             # (verified live Aug 2026 — a flat fake hid a parser bug).
             return self._json({"object": "hermes.session", "session": {"id": "bc_1", "title": body.get("title")}}, 201)
 
-        if self.path.startswith("/api/sessions/") and self.path.endswith("/chat"):
+        if self.path.startswith("/api/sessions/") and self.path.endswith("/chat/stream"):
             type(self).chats.append(body.get("message"))
-            return self._json(
-                {
-                    "object": "hermes.session.chat.completion",
-                    "session_id": "bc_1",
-                    "message": {"role": "assistant", "content": "reply from the other machine"},
-                }
+            type(self).chat_paths.append(self.path)
+            payload = json.dumps(
+                {"session_id": "bc_1", "content": "reply from the other machine"}
             )
+            wire = f"event: assistant.completed\ndata: {payload}\n\nevent: done\ndata: {{}}\n\n".encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(wire)))
+            self.end_headers()
+            self.wfile.write(wire)
+            return
+
+        if self.path.startswith("/api/sessions/") and self.path.endswith("/chat"):
+            return self._json({"error": {"message": "buffered chat route must not be used"}}, 500)
 
         return self._json({"error": {"message": "not found"}}, 404)
 
@@ -140,6 +148,7 @@ class _FakePeer(BaseHTTPRequestHandler):
 def fake_peer_server():
     _FakePeer.sessions = []
     _FakePeer.chats = []
+    _FakePeer.chat_paths = []
     _FakePeer.auth_seen = []
     server = HTTPServer(("127.0.0.1", 0), _FakePeer)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -170,6 +179,7 @@ def test_dm_creates_bot_chat_then_chats(monkeypatch, capsys, fake_peer_server):
     # One Bot Chat was created (none existed), then the chat turn ran on it.
     assert _FakePeer.sessions == ["bc_1"]
     assert _FakePeer.chats == ["Message from 🤖 dixie (@dixie): disk status?"]
+    assert _FakePeer.chat_paths == ["/api/sessions/bc_1/chat/stream"]
     # Every request carried the peer key.
     assert all(a == "Bearer secret-key-123456" for a in _FakePeer.auth_seen)
 


### PR DESCRIPTION
## What does this PR do?

`hermes peer dm` can time out while waiting for the HTTP status line from a Windows peer gateway even though the same gateway, credentials, session, and agent turn work through curl. This change sends the turn through the gateway's existing session SSE endpoint, which prepares the HTTP response before agent execution and emits keepalives until completion.

### Symptom

A controller calling `hermes peer dm <peer> "..."` can fail with `Could not reach peer '<peer>': timed out`. The timeout occurs in `http.client._read_status()` before any response status is received.

### Impact

Cross-machine bot DMs to affected Windows gateways fail completely. Users can reach the gateway through other endpoints and can work around the failure with curl, but the built-in peer command cannot deliver the message.

### Bug Cause

**Trigger:** `hermes_cli/subcommands/peer.py` used `POST /api/sessions/{session_id}/chat` for the remote agent turn.

**Causal chain:**
1. `hermes peer dm` opens the buffered session-chat request.
2. The aiohttp handler cannot prepare that response until the complete agent turn returns.
3. On the affected controller-to-Windows path, the client remains in `http.client._read_status()` without a status line and eventually times out.

**Why it is wrong:** Agent turns can legitimately take minutes, but the buffered route provides neither early response headers nor keepalive traffic while the turn runs.

**Working sibling / contrast:** `POST /api/sessions/{session_id}/chat/stream` prepares an SSE response before starting the turn, emits `run.started` immediately, sends periodic keepalives, and reports the final answer in `assistant.completed`.

**Ruled out:** The reported bearer key, session route, model, TCP connectivity, and gateway availability all work through curl and other gateway endpoints. The gateway also has no User-Agent-specific branch for this request.

### Fix

Route peer DM turns through the existing session-chat SSE endpoint and project the terminal `assistant.completed` event into the command's existing result shape. Canonical Bot Chat lookup and creation still use the existing JSON request helper, and CLI output remains unchanged.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/subcommands/peer.py` - send remote DM turns over session SSE and parse the completed assistant response.
- `tests/hermes_cli/test_peer_cmd.py` - require peer DMs to use the streaming route and preserve bearer auth, session creation, and reply output.
- `tests/gateway/test_peer_dm_hidden_e2e.py` - exercise the stock peer client against the real aiohttp streaming handler and SQLite session store.

## How to Test

1. Run the peer command unit and loopback HTTP suite.
2. Run the real aiohttp gateway and SQLite peer DM integration suite.

```bash
scripts/run_tests.sh tests/hermes_cli/test_peer_cmd.py -q
scripts/run_tests.sh tests/gateway/test_peer_dm_hidden_e2e.py -q
```

Result: 16 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] Config example changes are N/A because this changes no config keys
- [x] Contributor guide changes are N/A because this changes no architecture or workflow
- [x] I've considered cross-platform impact; the client remains stdlib-only and the endpoint is shared across platforms
- [x] Tool description/schema changes are N/A because this changes no model tool
