### PR TITLE
fix(desktop): mark previous reply spoken before submitting the next voice turn

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-stale-reply.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-stale-reply.test.tsx
@@ -1,0 +1,138 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { MicRecording } from './use-mic-recorder'
+import { useVoiceConversation } from './use-voice-conversation'
+
+// Regression: after a reply finished playing, the NEXT voice turn must not
+// re-speak that reply while the model is thinking. The normal (silence-detected)
+// submit path has to mark the previous reply spoken BEFORE submitting — the
+// barge path already did — otherwise the turn-drive effect sees `awaiting` plus
+// an "unspoken" previous reply and plays it through the whole-text fallback
+// until the new answer arrives and barges in.
+
+const playSpeechText = vi.fn(async (_text: string, _options: unknown) => true)
+
+vi.mock('@/lib/voice-barge-in', () => ({
+  monitorSpeechDuringPlayback: () => vi.fn()
+}))
+
+vi.mock('@/lib/voice-playback', () => ({
+  markVoicePlaybackInterrupted: vi.fn(),
+  playSpeechText: (text: string, options: unknown) => playSpeechText(text, options),
+  startSpeechStream: vi.fn(async () => null),
+  stopVoicePlayback: vi.fn()
+}))
+
+vi.mock('@/lib/thinking-sound', () => ({
+  startThinkingSound: vi.fn(),
+  stopThinkingSound: vi.fn()
+}))
+
+const micHandle = {
+  cancel: vi.fn(),
+  start: vi.fn(async () => undefined),
+  stop: vi.fn<() => Promise<MicRecording | null>>(async () => null)
+}
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({ handle: micHandle, level: 0, recording: false })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          configureSpeechToText: 'configure STT',
+          couldNotStartSession: 'could not start',
+          microphoneFailed: 'mic failed',
+          playbackFailed: 'playback failed',
+          transcriptionFailed: 'transcription failed',
+          unavailable: 'unavailable'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+describe('useVoiceConversation stale reply on next turn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    micHandle.start.mockResolvedValue(undefined)
+    micHandle.stop.mockResolvedValue(null)
+  })
+
+  afterEach(cleanup)
+
+  it('marks the previous reply spoken before submitting so it is not re-spoken while thinking', async () => {
+    const calls: string[] = []
+
+    // The previous turn's answer still sits at the bottom of the thread and —
+    // as in the field — is NOT yet marked spoken when the user's next
+    // utterance lands. It stays "pending to speak" until consumed.
+    let staleReplyUnspoken = true
+
+    const consumePendingResponse = vi.fn(() => {
+      calls.push('consume')
+      staleReplyUnspoken = false
+    })
+
+    // Mirrors the real app: submitting a turn makes the agent busy.
+    const onBusyChange: { current: (busy: boolean) => void } = { current: () => undefined }
+
+    const onSubmit = vi.fn(async () => {
+      calls.push('submit')
+      onBusyChange.current(true)
+    })
+
+    const hook = renderHook(
+      ({ busy }: { busy: boolean }) =>
+        useVoiceConversation({
+          busy,
+          consumePendingResponse,
+          enabled: true,
+          onInterrupt: vi.fn(),
+          onStopWord: vi.fn(),
+          onSubmit,
+          onTranscribeAudio: vi.fn(async () => 'what should we do today'),
+          pendingResponse: () => (staleReplyUnspoken ? { id: 'reply-1', pending: false, text: 'old answer' } : null)
+        }),
+      { initialProps: { busy: false } }
+    )
+
+    onBusyChange.current = busy => hook.rerender({ busy })
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+
+    // start() consumes once so an already-present reply is never read when the
+    // conversation opens; only the submit-time ordering is under test here.
+    calls.length = 0
+
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['q'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+
+    await act(async () => {
+      hook.result.current.stopTurn()
+    })
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+
+    // Consumed strictly before the new prompt goes out (barge-path parity).
+    expect(calls).toEqual(['consume', 'submit'])
+
+    // And the stale reply never reaches the whole-text fallback player.
+    await waitFor(() => expect(hook.result.current.status).toBe('thinking'))
+    expect(playSpeechText).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -185,6 +185,13 @@ export function useVoiceConversation({
 
           awaitingSpokenResponseRef.current = true
           dropSpeechSession()
+          // The reply we just finished playing is stale the moment a new turn
+          // is submitted. Mark it spoken BEFORE submit (barge path parity):
+          // otherwise the turn-drive effect sees `awaiting` + an "unspoken"
+          // previous reply and re-speaks it via the whole-text fallback while
+          // the model is still thinking — the old answer plays until the new
+          // one arrives and barges in.
+          consumePendingResponse()
           await onSubmit(transcript)
           setStatus('thinking')
         } catch (error) {
@@ -200,7 +207,7 @@ export function useVoiceConversation({
         turnClosingRef.current = false
       }
     },
-    [handle, onSubmit, onTranscribeAudio, voiceCopy.transcriptionFailed]
+    [consumePendingResponse, handle, onSubmit, onTranscribeAudio, voiceCopy.transcriptionFailed]
   )
 
   const startListening = useCallback(async () => {


### PR DESCRIPTION
## What does this PR do?

Stops the Desktop voice conversation loop from re-speaking the **previous** assistant reply while the model is generating the next one.

After a reply finished playing, submitting the next voice turn via the normal (silence-detected) path set `awaitingSpokenResponseRef` and submitted — but never marked the just-played reply as spoken. The turn-drive effect then saw `awaiting` + an "unspoken" previous reply, opened speech for it, fell back to whole-text playback (`playSpeechText`), and the old answer played until the new reply arrived and barged in. The barge-in submit path (`submitCapturedUtterance`) already calls `consumePendingResponse()` before `onSubmit`; this PR gives the normal path the same treatment. A submitted turn makes any existing reply stale by definition, so consuming it before submit is the right invariant regardless of how the spoken anchor got out of sync.

## Related Issue

Fixes #97788

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts`: call `consumePendingResponse()` before `onSubmit(transcript)` in `handleTurn` (barge-path parity) and add it to the callback deps.
- `apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-stale-reply.test.tsx`: regression test — with a previous reply still reported as unspoken, submitting the next turn must consume it **before** `onSubmit` and must never hand it to `playSpeechText`. Fails on `main` (`expected [ 'submit' ] to deeply equal [ 'consume', 'submit' ]`), passes with the fix.

## How to Test

1. Desktop, `tts.provider: edge` (any provider without streaming TTS works), start a voice conversation.
2. Say something, let the reply play fully.
3. Say something else and go quiet (no interruption). On `main`, the previous reply is spoken again while the model thinks; with this PR it stays silent until the new reply.
4. `cd apps/desktop && ../../node_modules/.bin/vitest run src/app/chat/composer/hooks/` → 107 tests pass (106 existing + 1 new). `tsc --noEmit -p tsconfig.json` clean.

Gateway log on `main` for step 3 (TTS generated before the new prompt is accepted, same byte size as the previous reply):

```
17:19:31,965 Transcribed hermes-desktop-voice-oxjd2048.webm via local whisper
17:19:32,140 Generating speech with Edge TTS...
17:19:32,282 tui prompt accepted: ... kind=user chars=23
17:19:32,462 TTS audio saved: tts_20260829_171932_138877.mp3 (38,016 bytes)   <- previous reply (same size as tts_20260829_171917_098279.mp3)
17:19:35,409 TTS audio saved: tts_20260829_171935_025804.mp3 (27,792 bytes)   <- new reply
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#91391 / #92334 touch adjacent code but not this path)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, TypeScript-only change; desktop vitest suite for the composer hooks passes
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Hermes Desktop

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only logic, no platform-specific code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
