### PR TITLE
fix(profiles): prune orphan aliases

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1232,6 +1232,73 @@ def check_macos_full_disk_access() -> None:
     )
 
 
+def _check_profiles(*, should_fix: bool, issues: list, manual_issues: list) -> int:
+    """Report profile health and optionally remove verified orphan aliases."""
+    try:
+        from hermes_cli.profiles import (
+            _scan_profile_wrappers,
+            list_profiles,
+            profile_exists,
+        )
+
+        named_profiles = [p for p in list_profiles() if not p.is_default]
+        orphan_wrappers = [
+            (wrapper, target)
+            for wrapper, target in _scan_profile_wrappers()
+            if not profile_exists(target)
+        ]
+    except Exception:
+        # Profile diagnostics must not prevent Doctor's other checks from
+        # completing when a profile directory is temporarily unreadable.
+        return 0
+
+    if not named_profiles and not orphan_wrappers:
+        return 0
+
+    _section("Profiles")
+    if named_profiles:
+        check_ok(f"{len(named_profiles)} profile(s) found")
+        for profile in named_profiles:
+            parts = []
+            if profile.gateway_running:
+                parts.append("gateway running")
+            if profile.model:
+                parts.append(profile.model[:30])
+            if not (profile.path / "config.yaml").exists():
+                parts.append("⚠ missing config")
+            if not (profile.path / ".env").exists():
+                parts.append("no .env")
+            if profile.alias_path is None:
+                parts.append("no alias")
+            status = ", ".join(parts) if parts else "configured"
+            check_ok(f"  {profile.name}: {status}")
+
+    fixed = 0
+    for wrapper, target in orphan_wrappers:
+        description = (
+            f"Orphan alias: {wrapper.name} → profile '{target}' no longer exists"
+        )
+        if not should_fix:
+            check_warn(description)
+            issues.append(
+                f"Remove orphan alias {wrapper}: run 'hermes doctor --fix'."
+            )
+            continue
+
+        try:
+            wrapper.unlink()
+        except OSError as exc:
+            check_warn(f"Could not remove {description.lower()}", str(exc))
+            manual_issues.append(
+                f"Remove orphan alias {wrapper} manually: {exc}"
+            )
+        else:
+            check_ok(f"Removed {description.lower()}")
+            fixed += 1
+
+    return fixed
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -3313,48 +3380,11 @@ def run_doctor(args):
         except Exception as _e:
             check_warn(f"{_active_memory_provider} check failed", str(_e))
 
-    try:
-        from hermes_cli.profiles import list_profiles, _get_wrapper_dir, profile_exists
-        import re as _re
-
-        named_profiles = [p for p in list_profiles() if not p.is_default]
-        if named_profiles:
-            _section("Profiles")
-            check_ok(f"{len(named_profiles)} profile(s) found")
-            wrapper_dir = _get_wrapper_dir()
-            for p in named_profiles:
-                parts = []
-                if p.gateway_running:
-                    parts.append("gateway running")
-                if p.model:
-                    parts.append(p.model[:30])
-                if not (p.path / "config.yaml").exists():
-                    parts.append("⚠ missing config")
-                if not (p.path / ".env").exists():
-                    parts.append("no .env")
-                wrapper = wrapper_dir / p.name
-                if not wrapper.exists():
-                    parts.append("no alias")
-                status = ", ".join(parts) if parts else "configured"
-                check_ok(f"  {p.name}: {status}")
-
-            # Check for orphan wrappers
-            if wrapper_dir.is_dir():
-                for wrapper in wrapper_dir.iterdir():
-                    if not wrapper.is_file():
-                        continue
-                    try:
-                        content = wrapper.read_text(encoding="utf-8")
-                        if "hermes -p" in content:
-                            _m = _re.search(r"hermes -p (\S+)", content)
-                            if _m and not profile_exists(_m.group(1)):
-                                check_warn(f"Orphan alias: {wrapper.name} → profile '{_m.group(1)}' no longer exists")
-                    except Exception:
-                        pass
-    except ImportError:
-        pass
-    except Exception:
-        pass
+    fixed_count += _check_profiles(
+        should_fix=should_fix,
+        issues=issues,
+        manual_issues=manual_issues,
+    )
 
     # Opt-in live backend probes run AFTER all static checks, only with
     # `hermes doctor --live` (real network calls; bounded + read-only).

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -528,7 +528,11 @@ def create_wrapper_script(name: str, target: Optional[str] = None) -> Optional[P
     if is_windows:
         wrapper_path = wrapper_dir / f"{canon}.bat"
         try:
-            wrapper_path.write_text(f"@echo off\r\nhermes -p {profile} %*\r\n", encoding="utf-8")
+            wrapper_path.write_text(
+                f"@echo off\r\nhermes -p {profile} %*\r\n",
+                encoding="utf-8",
+                newline="",
+            )
             return wrapper_path
         except OSError as e:
             print(f"⚠ Could not create wrapper at {wrapper_path}: {e}")
@@ -628,53 +632,113 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
 
 
 # Cap how much of a wrapper file we read when reverse-looking-up its profile.
-# Real wrappers are a few hundred bytes of shell; the needle (``hermes -p X``)
-# sits near the top. The wrapper dir (e.g. ``~/.local/bin``) commonly also holds
-# large unrelated binaries (ffmpeg, node, …) — reading those whole, N times, was
-# the dominant cost in ``list_profiles`` (~4.5s). Reading a small head slice and
-# skipping NUL-bearing (binary) content keeps the scan to a single cheap pass.
+# Real wrappers are a few hundred bytes of shell. The wrapper dir (e.g.
+# ``~/.local/bin``) commonly also holds large unrelated binaries (ffmpeg, node,
+# …) — reading those whole, N times, was the dominant cost in ``list_profiles``
+# (~4.5s). Read only this bounded slice and reject anything larger so exact
+# wrapper validation stays a single cheap pass.
 _WRAPPER_READ_LIMIT = 8192
+
+
+def _scan_profile_wrappers() -> List[Tuple[Path, str]]:
+    """Return verified Hermes profile wrappers as ``(path, profile)`` pairs.
+
+    ``~/.local/bin`` is a shared executable directory, so a loose substring
+    match is not a safe basis for deletion.  Accept only the exact wrapper
+    shape emitted by :func:`create_wrapper_script` for the current platform,
+    with a valid alias filename and profile id.  Reads stay bounded and strict
+    UTF-8 so unrelated binaries and oversized scripts are ignored cheaply.
+    """
+    wrapper_dir = _get_wrapper_dir()
+    if not wrapper_dir.is_dir():
+        return []
+
+    is_windows = sys.platform == "win32"
+    wrappers: List[Tuple[Path, str]] = []
+    try:
+        entries = sorted(wrapper_dir.iterdir())
+    except OSError:
+        return wrappers
+
+    for entry in entries:
+        try:
+            if not entry.is_file() or entry.is_symlink():
+                continue
+        except OSError:
+            continue
+
+        if is_windows:
+            if entry.suffix != ".bat":
+                continue
+            alias = entry.stem
+        else:
+            if entry.suffix:
+                continue
+            alias = entry.name
+        try:
+            validate_alias_name(alias)
+        except ValueError:
+            continue
+
+        try:
+            with open(entry, "r", encoding="utf-8", errors="strict") as f:
+                content = f.read(_WRAPPER_READ_LIMIT + 1)
+        except (OSError, UnicodeDecodeError):
+            continue
+        if len(content) > _WRAPPER_READ_LIMIT:
+            continue
+
+        profile = ""
+        if is_windows:
+            match = re.fullmatch(
+                r"@echo off\n(?:\n)?hermes -p "
+                r"([a-z0-9][a-z0-9_-]{0,63}) %\*\n(?:\n)?",
+                content,
+            )
+            if match:
+                profile = match.group(1)
+        else:
+            lines = content.splitlines(keepends=True)
+            if (
+                len(lines) != 2
+                or lines[0] != "#!/bin/sh\n"
+                or not lines[1].endswith("\n")
+            ):
+                continue
+            try:
+                argv = shlex.split(lines[1][:-1], posix=True)
+            except ValueError:
+                continue
+            if (
+                len(argv) == 5
+                and argv[0] == "exec"
+                and Path(argv[1]).name == "hermes"
+                and argv[2] == "-p"
+                and argv[4] == "$@"
+            ):
+                profile = argv[3]
+
+        try:
+            validate_profile_name(profile)
+        except ValueError:
+            continue
+        wrappers.append((entry, profile))
+
+    return wrappers
 
 
 def build_alias_map() -> dict[str, str]:
     """Single-pass reverse map ``{canonical_profile -> alias_name}``.
 
     Scans the wrapper dir ONCE (vs. :func:`find_alias_for_profile` per profile)
-    and reads only a small head slice of each candidate wrapper, skipping
-    binaries. A custom alias (file name != profile) wins over the profile-named
-    wrapper, matching ``find_alias_for_profile``'s preference; deterministic via
-    sorted iteration.
+    and reads only a small bounded slice of each candidate wrapper, skipping
+    binaries and non-generated scripts. A custom alias (file name != profile)
+    wins over the profile-named wrapper, matching ``find_alias_for_profile``'s
+    preference; deterministic via sorted iteration.
     """
-    wrapper_dir = _get_wrapper_dir()
     result: dict[str, str] = {}
-    if not wrapper_dir.is_dir():
-        return result
     is_windows = sys.platform == "win32"
-    prefix = "hermes -p "
-
-    for entry in sorted(wrapper_dir.iterdir()):
-        if not entry.is_file():
-            continue
-        # Only our own wrappers are named with the alias and (on Windows) .bat.
-        if is_windows and entry.suffix != ".bat":
-            continue
-        if not is_windows and entry.suffix:
-            continue
-        try:
-            with open(entry, "r", encoding="utf-8", errors="strict") as f:
-                content = f.read(_WRAPPER_READ_LIMIT)
-        except (OSError, UnicodeDecodeError):
-            # UnicodeDecodeError = a binary on PATH (ffmpeg etc.) — not a wrapper.
-            continue
-        idx = content.find(prefix)
-        if idx == -1:
-            continue
-        rest = content[idx + len(prefix):]
-        # Profile id is the first whitespace-delimited token after the flag.
-        canon = rest.split(None, 1)[0].strip() if rest.strip() else ""
-        if not canon:
-            continue
-        canon = normalize_profile_name(canon)
+    for entry, canon in _scan_profile_wrappers():
         alias = entry.stem if is_windows else entry.name
         # Custom alias (name != profile) preferred; otherwise keep the
         # profile-named wrapper. Don't overwrite a custom alias already found.

--- a/tests/hermes_cli/test_profile_orphan_aliases.py
+++ b/tests/hermes_cli/test_profile_orphan_aliases.py
@@ -1,0 +1,168 @@
+"""Regression coverage for Doctor's orphan profile-alias cleanup (#94750)."""
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import doctor, profiles
+
+
+@pytest.fixture()
+def profile_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return tmp_path
+
+
+def _write_posix_wrapper(home: Path, alias: str, target: str) -> Path:
+    wrapper = home / ".local" / "bin" / alias
+    wrapper.parent.mkdir(parents=True, exist_ok=True)
+    wrapper.write_text(
+        f'#!/bin/sh\nexec /opt/hermes/bin/hermes -p {target} "$@"\n',
+        encoding="utf-8",
+    )
+    return wrapper
+
+
+def test_scanner_recognizes_generated_posix_wrapper(profile_home, monkeypatch):
+    monkeypatch.setattr(profiles.sys, "platform", "linux")
+    wrapper = _write_posix_wrapper(profile_home, "pirzl", "pirzl")
+
+    assert profiles._scan_profile_wrappers() == [(wrapper, "pirzl")]
+
+
+def test_scanner_recognizes_generated_windows_wrapper(profile_home, monkeypatch):
+    monkeypatch.setattr(profiles.sys, "platform", "win32")
+    wrapper = profiles.create_wrapper_script("pirzl")
+
+    assert profiles._scan_profile_wrappers() == [(wrapper, "pirzl")]
+
+
+def test_scanner_recognizes_existing_windows_wrapper_with_doubled_crlf(
+    profile_home, monkeypatch
+):
+    monkeypatch.setattr(profiles.sys, "platform", "win32")
+    wrapper = profile_home / ".local" / "bin" / "pirzl.bat"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_bytes(b"@echo off\r\r\nhermes -p pirzl %*\r\r\n")
+
+    assert profiles._scan_profile_wrappers() == [(wrapper, "pirzl")]
+
+
+@pytest.mark.parametrize(
+    ("name", "content"),
+    [
+        ("unrelated", '#!/bin/sh\nprintf "hermes -p gone"\n'),
+        ("malformed", '#!/bin/sh\nexec hermes -p gone "$@"\necho extra\n'),
+        ("binary", b"\xff\x00hermes -p gone"),
+        ("BadAlias", '#!/bin/sh\nexec hermes -p gone "$@"\n'),
+    ],
+)
+def test_scanner_ignores_untrusted_posix_files(
+    profile_home, monkeypatch, name, content
+):
+    monkeypatch.setattr(profiles.sys, "platform", "linux")
+    candidate = profile_home / ".local" / "bin" / name
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        candidate.write_bytes(content)
+    else:
+        candidate.write_text(content, encoding="utf-8")
+
+    assert profiles._scan_profile_wrappers() == []
+
+
+def test_scanner_ignores_wrapper_for_other_platform(profile_home, monkeypatch):
+    posix = _write_posix_wrapper(profile_home, "posix", "gone")
+    windows = posix.with_name("windows.bat")
+    windows.write_text(
+        "@echo off\r\nhermes -p gone %*\r\n",
+        encoding="utf-8",
+        newline="",
+    )
+
+    monkeypatch.setattr(profiles.sys, "platform", "linux")
+    assert profiles._scan_profile_wrappers() == [(posix, "gone")]
+    monkeypatch.setattr(profiles.sys, "platform", "win32")
+    assert profiles._scan_profile_wrappers() == [(windows, "gone")]
+
+
+def test_doctor_reports_last_profile_orphan_without_removing_it(
+    profile_home, monkeypatch, capsys
+):
+    monkeypatch.setattr(profiles.sys, "platform", "linux")
+    wrapper = _write_posix_wrapper(profile_home, "pirzl", "pirzl")
+    issues = []
+    manual_issues = []
+
+    fixed = doctor._check_profiles(
+        should_fix=False, issues=issues, manual_issues=manual_issues
+    )
+
+    output = capsys.readouterr().out
+    assert fixed == 0
+    assert wrapper.exists()
+    assert "Orphan alias: pirzl" in output
+    assert "profile 'pirzl' no longer exists" in output
+    assert issues == [f"Remove orphan alias {wrapper}: run 'hermes doctor --fix'."]
+    assert manual_issues == []
+
+
+def test_doctor_fix_removes_and_counts_every_orphan(profile_home, monkeypatch, capsys):
+    monkeypatch.setattr(profiles.sys, "platform", "linux")
+    wrappers = [
+        _write_posix_wrapper(profile_home, "pirzl", "pirzl"),
+        _write_posix_wrapper(profile_home, "old-family", "old-family"),
+    ]
+
+    fixed = doctor._check_profiles(should_fix=True, issues=[], manual_issues=[])
+
+    output = capsys.readouterr().out
+    assert fixed == 2
+    assert all(not wrapper.exists() for wrapper in wrappers)
+    assert "Removed orphan alias: pirzl" in output
+    assert "Removed orphan alias: old-family" in output
+
+
+def test_doctor_leaves_live_profile_wrapper_untouched(profile_home, monkeypatch):
+    monkeypatch.setattr(profiles.sys, "platform", "linux")
+    profile_dir = profile_home / ".hermes" / "profiles" / "live"
+    profile_dir.mkdir(parents=True)
+    wrapper = _write_posix_wrapper(profile_home, "talk-to-live", "live")
+    issues = []
+
+    fixed = doctor._check_profiles(should_fix=True, issues=issues, manual_issues=[])
+
+    assert fixed == 0
+    assert wrapper.exists()
+    assert issues == []
+
+
+def test_doctor_reports_unlink_failure_and_preserves_wrapper(
+    profile_home, monkeypatch, capsys
+):
+    monkeypatch.setattr(profiles.sys, "platform", "linux")
+    wrapper = _write_posix_wrapper(profile_home, "pirzl", "pirzl")
+    real_unlink = Path.unlink
+
+    def deny_or_unlink(path, *args, **kwargs):
+        if path == wrapper:
+            raise PermissionError("permission denied")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", deny_or_unlink)
+    manual_issues = []
+
+    fixed = doctor._check_profiles(
+        should_fix=True, issues=[], manual_issues=manual_issues
+    )
+
+    output = capsys.readouterr().out
+    assert fixed == 0
+    assert wrapper.exists()
+    assert "Could not remove orphan alias: pirzl" in output
+    assert manual_issues == [
+        f"Remove orphan alias {wrapper} manually: permission denied"
+    ]


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Fixes both remaining parts of #94750:

Extends `hermes doctor --fix` to remove stale profile alias wrappers that target deleted profiles.

Alias cleanup uses a shared, bounded scanner that recognizes only platform-appropriate wrappers generated by Hermes. This prevents Doctor from treating unrelated executables in `~/.local/bin` as aliases.

A normal `hermes doctor` run remains read-only and provides removal guidance. With `--fix`, Doctor removes every verified orphan wrapper, counts each repair, and reports failures without claiming the wrapper was removed.

No new commands, configuration keys, environment variables, or public APIs are introduced.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #94750

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Added `_scan_profile_wrappers()` in `hermes_cli/profiles.py`:
  - Recognizes Hermes-generated POSIX and Windows wrappers.
  - Uses bounded, strict UTF-8 reads.
  - Ignores unrelated executables, malformed scripts, binary files, symlinks, invalid alias filenames, and wrappers for another platform.
  - Preserves compatibility with existing Windows wrappers containing doubled CRLF translation.
- Reused the scanner in `build_alias_map()` so alias display and orphan cleanup use the same validation rules.
- Updated Windows wrapper creation to write CRLF deterministically.
- Added `_check_profiles()` in `hermes_cli/doctor.py`:
  - Detects orphan aliases even when no named profiles remain.
  - Keeps normal Doctor runs read-only.
  - Removes verified orphan aliases with `hermes doctor --fix`.
  - Reports and counts each successful repair.
  - Preserves and reports wrappers that cannot be removed.
- Added regression coverage in `tests/hermes_cli/test_profile_orphan_aliases.py`.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the profile and Doctor regression suites:

```bash
pytest tests/hermes_cli/test_profile_orphan_aliases.py -q
pytest tests/hermes_cli/test_profiles.py -q
pytest tests/hermes_cli/test_doctor.py -q
```

2. Verify orphan cleanup manually:

```
mkdir -p ~/.local/bin
printf '#!/bin/sh\nexec hermes -p deleted-profile "$@"\n' > ~/.local/bin/stale-profile
chmod +x ~/.local/bin/stale-profile

hermes doctor
test -e ~/.local/bin/stale-profile

hermes doctor --fix
test ! -e ~/.local/bin/stale-profile
```

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 --> macOS, Apple Silicon, Python 3.11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

  - [x] I've updated relevant documentation (README, docs/, docstrings) — N/A; no user workflow or public interface was added
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A; no config changes
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — POSIX and Windows wrapper formats are covered
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-tool changes

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
Focused verification:

tests/hermes_cli/test_profile_orphan_aliases.py
12 passed

tests/hermes_cli/test_profiles.py
56 passed, 2 skipped

tests/hermes_cli/test_doctor.py
65 passed

ruff check
All checks passed!
```