### PR TITLE
fix(update): surface why a bundled-skill sync failed instead of a bare "sync failed"

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11134,6 +11134,11 @@ def cmd_profile(args):
                         "No bundled skills seeded (--no-skills). "
                         "Delete .no-bundled-skills in the profile to opt back in."
                     )
+                elif result and result.get("error"):
+                    print(
+                        "⚠ Skills could not be seeded ({}). "
+                        "Run `{} update` to retry.".format(result["error"], name)
+                    )
                 elif result:
                     copied = len(result.get("copied", []))
                     print(f"{copied} bundled skills synced.")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1381,7 +1381,9 @@ def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> Optional[dict
     """Seed bundled skills into a profile via subprocess.
 
     Uses subprocess because sync_skills() caches HERMES_HOME at module level.
-    Returns the sync result dict, or None on failure.
+    Returns the sync result dict, or a ``{"error": ...}`` dict describing the
+    failure (exit code + last stderr line, timeout, or exception) — callers
+    can surface the reason even when ``quiet=True`` (#97792).
 
     Profiles that opted out of bundled skills (via ``hermes profile create
     --no-skills`` — which writes ``.no-bundled-skills`` to the profile root)
@@ -1401,19 +1403,22 @@ def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> Optional[dict
         )
         if result.returncode == 0 and result.stdout.strip():
             return json.loads(result.stdout.strip())
+        # quiet suppresses success chatter, not error detail: keep returning
+        # the reason so `hermes update` can print why a profile failed (#97792).
+        stderr_tail = result.stderr.strip().splitlines() or ["no stderr"]
         if not quiet:
             print(f"⚠ Skill seeding returned exit code {result.returncode}")
             if result.stderr.strip():
                 print(f"  {result.stderr.strip()[:200]}")
-        return None
+        return {"error": f"rc={result.returncode}: {stderr_tail[-1][:200]}"}
     except subprocess.TimeoutExpired:
         if not quiet:
             print("⚠ Skill seeding timed out (60s)")
-        return None
+        return {"error": "timed out after 60s"}
     except Exception as e:
         if not quiet:
             print(f"⚠ Skill seeding failed: {e}")
-        return None
+        return {"error": f"{type(e).__name__}: {e}"}
 
 
 def backfill_profile_envs(quiet: bool = False) -> List[str]:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1377,6 +1377,18 @@ def create_profile(
     return profile_dir
 
 
+# The failure reason flows into user-facing status lines (`hermes update`,
+# `hermes profile create`); a raw stderr tail from a crashing child can carry
+# ANSI escape sequences or carriage resets that garble those lines (#97792).
+_REASON_ESCAPE_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07")
+
+
+def _reason_text(stderr: str) -> str:
+    # Carriage returns become spaces *before* any splitlines() so a mid-line
+    # \r cannot turn the tail into an empty last line.
+    return _REASON_ESCAPE_RE.sub("", stderr).replace("\r", " ")
+
+
 def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> Optional[dict]:
     """Seed bundled skills into a profile via subprocess.
 
@@ -1405,12 +1417,12 @@ def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> Optional[dict
             return json.loads(result.stdout.strip())
         # quiet suppresses success chatter, not error detail: keep returning
         # the reason so `hermes update` can print why a profile failed (#97792).
-        stderr_tail = result.stderr.strip().splitlines() or ["no stderr"]
+        stderr_tail = _reason_text(result.stderr).strip().splitlines() or ["no stderr"]
         if not quiet:
             print(f"⚠ Skill seeding returned exit code {result.returncode}")
             if result.stderr.strip():
                 print(f"  {result.stderr.strip()[:200]}")
-        return {"error": f"rc={result.returncode}: {stderr_tail[-1][:200]}"}
+        return {"error": f"rc={result.returncode}: {stderr_tail[-1].strip()[:200]}"}
     except subprocess.TimeoutExpired:
         if not quiet:
             print("⚠ Skill seeding timed out (60s)")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8643,7 +8643,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if not result["copied"] and not result.get("updated"):
                 print("  ✓ Skills are up to date")
         except Exception as e:
-            logger.debug("Skills sync during update failed: %s", e)
+            logger.warning("Skills sync during update failed: %s", e)
 
         # Sync bundled skills to all profiles (including the active one).
         # seed_profile_skills() uses subprocess with an explicit HERMES_HOME so
@@ -8665,6 +8665,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         r = seed_profile_skills(p.path, quiet=True)
                         if r and r.get("skipped_opt_out"):
                             status = "opted out (--no-skills)"
+                        elif r and r.get("error"):
+                            status = f"sync failed ({r['error']})"
                         elif r:
                             copied = len(r.get("copied", []))
                             updated = len(r.get("updated", []))

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -680,6 +680,43 @@ class TestCmdUpdateProfileSkillSync:
 
         assert default_p.path in synced_paths
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_failed_profile_sync_prints_reason(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """#97792: a failed per-profile sync prints *why*, not a bare "sync failed".
+
+        seed_profile_skills() returns an {"error": ...} dict on failure; the
+        update loop must surface that reason instead of masking it.
+        """
+        from pathlib import Path
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        default_p = SimpleNamespace(name="default", path=Path("/fake/.hermes"))
+        failing_p = SimpleNamespace(name="design", path=Path("/fake/.hermes/profiles/design"))
+
+        def fake_seed(path, quiet=False):
+            if path == failing_p.path:
+                return {"error": "rc=1: ValueError: bad manifest"}
+            return {"copied": [], "updated": [], "user_modified": []}
+
+        empty_sync = {"copied": [], "updated": [], "user_modified": [], "cleaned": []}
+
+        with (
+            patch("hermes_cli.profiles.list_profiles", return_value=[default_p, failing_p]),
+            patch("hermes_cli.profiles.seed_profile_skills", side_effect=fake_seed),
+            patch("tools.skills_sync.sync_skills", return_value=empty_sync),
+        ):
+            cmd_update(mock_args)
+
+        out = capsys.readouterr().out
+        assert "design: sync failed (rc=1: ValueError: bad manifest)" in out
+        assert "design: up to date" not in out
+
 
 class TestCmdUpdateBranchFlag:
     """``hermes update --branch <name>`` targets the requested branch.

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -261,6 +261,69 @@ class TestNoSkillsOptOut:
 
 
 # ===================================================================
+# TestSeedProfileSkillsFailureReason
+# ===================================================================
+
+class TestSeedProfileSkillsFailureReason:
+    """#97792: a failed child sync must return *why*, even under quiet=True.
+
+    Previously every failure path returned a bare None, so `hermes update`
+    printed "sync failed" with no diagnostic anywhere (stderr was captured
+    then dropped, and the reason never reached a log file either).
+    """
+
+    def test_nonzero_exit_returns_reason_with_stderr_tail(self, profile_env, monkeypatch):
+        import subprocess as _sp
+
+        profile_dir = create_profile("orchestrator", no_alias=True)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: _sp.CompletedProcess(
+                args=a, returncode=1,
+                stdout="",
+                stderr="Traceback (most recent call last):\nValueError: bad manifest",
+            ),
+        )
+        r = seed_profile_skills(profile_dir, quiet=True)
+        assert r == {"error": "rc=1: ValueError: bad manifest"}
+
+    def test_zero_exit_empty_stdout_returns_reason(self, profile_env, monkeypatch):
+        import subprocess as _sp
+
+        profile_dir = create_profile("orchestrator", no_alias=True)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: _sp.CompletedProcess(args=a, returncode=0, stdout="", stderr=""),
+        )
+        r = seed_profile_skills(profile_dir, quiet=True)
+        assert r == {"error": "rc=0: no stderr"}
+
+    def test_timeout_returns_reason(self, profile_env, monkeypatch):
+        import subprocess as _sp
+
+        profile_dir = create_profile("orchestrator", no_alias=True)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: (_ for _ in ()).throw(_sp.TimeoutExpired(cmd=a, timeout=60)),
+        )
+        r = seed_profile_skills(profile_dir, quiet=True)
+        assert r == {"error": "timed out after 60s"}
+
+    def test_malformed_stdout_returns_exception_reason(self, profile_env, monkeypatch):
+        import subprocess as _sp
+
+        profile_dir = create_profile("orchestrator", no_alias=True)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: _sp.CompletedProcess(
+                args=a, returncode=0, stdout="not json", stderr=""
+            ),
+        )
+        r = seed_profile_skills(profile_dir, quiet=True)
+        assert r.get("error", "").startswith("JSONDecodeError:")
+
+
+# ===================================================================
 # TestBackfillProfileEnvs
 # ===================================================================
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -287,6 +287,22 @@ class TestSeedProfileSkillsFailureReason:
         r = seed_profile_skills(profile_dir, quiet=True)
         assert r == {"error": "rc=1: ValueError: bad manifest"}
 
+    def test_stderr_tail_is_sanitized_for_status_lines(self, profile_env, monkeypatch):
+        import subprocess as _sp
+
+        profile_dir = create_profile("orchestrator", no_alias=True)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: _sp.CompletedProcess(
+                args=a, returncode=1,
+                stdout="",
+                stderr="\x1b[31mValueError\x1b[0m: bad manifest\r\x1b[K",
+            ),
+        )
+        r = seed_profile_skills(profile_dir, quiet=True)
+        # The reason reaches user-facing lines without ANSI/control characters.
+        assert r == {"error": "rc=1: ValueError: bad manifest"}
+
     def test_zero_exit_empty_stdout_returns_reason(self, profile_env, monkeypatch):
         import subprocess as _sp
 


### PR DESCRIPTION
## What does this PR do?

When `hermes update` syncs bundled skills into profiles and a profile's sync fails, the user sees the bare string `sync failed` with no diagnostic information anywhere — the child process's exit code and stderr are captured and then discarded, and the in-process sync failure is logged only at debug level, so it never reaches `~/.hermes/logs/errors.log` either (#97792).

Root cause: `seed_profile_skills()` in `hermes_cli/profiles.py` returns `None` for **every** failure mode (non-zero exit, empty stdout, timeout, exception) whenever the caller passes `quiet=True`, dropping the return code and stderr on the floor. The update loop in `hermes_cli/update_cmd.py` then has nothing to print but "sync failed".

The fix follows the shape suggested in the issue:

- `seed_profile_skills()` failure paths now return an `{"error": ...}` dict describing the failure — `rc=<code>: <last stderr line>` for child failures, `"timed out after 60s"` for timeouts, `"<ExceptionType>: <msg>"` for everything else (including a malformed child stdout). `quiet` now only suppresses success chatter, not error detail. The non-quiet `print` behavior is unchanged.
- `hermes_cli/update_cmd.py` prints `sync failed (rc=1: ValueError: bad manifest)` instead of a bare `sync failed`, and promotes the in-process sync exception from `logger.debug` to `logger.warning` so it lands in `errors.log`.
- `hermes_cli/main.py` (the `hermes profile create` seeding path, the other caller that consumes the return value) prints the reason in its "Skills could not be seeded" message. The other two callers (`web_routers/profiles.py`, `tui_gateway/methods_profiles.py`) ignore the return value and are unaffected.

One subtlety worth noting: without the new `elif r.get("error")` branches, a returned error dict is truthy and would be misreported as a *successful* sync with zero copies ("up to date"), so the callers had to learn about the new shape in the same change. The tests pin this: a failing profile must print `sync failed (rc=...)`, never `up to date`.

## Related Issue

Fixes #97792

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — `seed_profile_skills()` failure paths return `{"error": ...}` (rc + last stderr line / timeout / exception) instead of `None`; docstring updated
- `hermes_cli/update_cmd.py` — profile sync loop prints the error reason (`sync failed (rc=...)`); in-process sync exception logged at `warning` instead of `debug`
- `hermes_cli/main.py` — profile-create seeding path surfaces the error reason in the retry hint
- `tests/hermes_cli/test_profiles.py` — 4 new tests pinning the failure-return contract: non-zero exit with stderr tail, rc=0/empty stdout, timeout, malformed stdout (JSONDecodeError)
- `tests/hermes_cli/test_cmd_update.py` — new test pinning that a failed profile prints `sync failed (rc=1: ...)` and is never masked as `up to date`

## How to Test

1. `pytest tests/hermes_cli/test_profiles.py -q` — Observed result: 60 passed, 2 skipped (4 of them the new `TestSeedProfileSkillsFailureReason` cases).
2. `pytest tests/hermes_cli/test_cmd_update.py -q -k CmdUpdateProfileSkillSync` — Observed result: 3 passed, including the new `test_failed_profile_sync_prints_reason`.
3. Manual reproduction of the issue shape: make a seeded profile's child sync fail (e.g. point the subprocess at a broken state) and run `hermes update` — Observed result before: `design: sync failed` and nothing in any log; after: `design: sync failed (rc=1: <last stderr line>)` and a `WARNING Skills sync during update failed: ...` line when the in-process path fails.
4. `ruff check` on the five touched files — Observed result: all checks passed. (`ruff format --check` reports the same pre-existing reformat list on these files as on a clean `upstream/main` checkout; no new formatting debt is introduced.)

Note on the local run environment for step 2: on a dev machine that runs real `ai.hermes.gateway*` LaunchAgents, the cmd_update integration tests hit the live fleet-restart gate (`sys.exit(1)` at update_cmd.py:9984) before reaching their assertions — the same happens on a clean `upstream/main` checkout, so it is a pre-existing local-environment artifact, not caused by this diff. CI's Linux runners have no launchd and do not take that path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring of `seed_profile_skills` updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific code touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no new skill.

## Screenshots / Logs

Before (from the issue, v0.20.5 → v0.20.6 update on a 7-profile install):

```
→ Syncing bundled skills to all profiles...
  default: sync failed
  creative: ~3 user-modified
  design: sync failed
  ...
```

After (pinned by `test_failed_profile_sync_prints_reason`):

```
→ Syncing bundled skills to all profiles...
  default: up to date
  design: sync failed (rc=1: ValueError: bad manifest)
```
