### PR TITLE
fix(agent): strip anthropic_content_blocks on the chat_completions wire

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -331,6 +331,13 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "effect_disposition" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
                 or "api_content" in msg  # persist-what-you-send sidecar
+                # Anthropic-only interned replay channel (set by
+                # normalize_response for interleaved signed-thinking + tool_use
+                # turns). Consumed by the anthropic adapter; NEVER valid on an
+                # OpenAI-wire request, so a chat_completions target (Palantir
+                # GPT/Gemini proxy, Groq, …) rejects it with HTTP 400
+                # ("property 'anthropic_content_blocks' is unsupported").
+                or "anthropic_content_blocks" in msg
             ):
                 needs_sanitize = True
                 break
@@ -402,6 +409,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "effect_disposition" in msg
                 or "timestamp" in msg  # #47868 — leak into strict providers
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or "anthropic_content_blocks" in msg  # Anthropic-only replay channel
             ):
                 out_msg = mutable_msg()
                 out_msg.pop("codex_reasoning_items", None)
@@ -410,6 +418,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg.pop("effect_disposition", None)
                 out_msg.pop("timestamp", None)  # #47868 — leak into strict providers
                 out_msg.pop("api_content", None)  # persist-what-you-send sidecar
+                out_msg.pop("anthropic_content_blocks", None)  # Anthropic-only replay channel
 
 
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -146,6 +146,44 @@ class TestChatCompletionsBasic:
         msgs = [{"role": "user", "content": "hi"}]
         assert transport.convert_messages(msgs) is msgs
 
+    def test_convert_messages_strips_anthropic_content_blocks(self, transport):
+        """The ``anthropic_content_blocks`` interned replay channel is an
+        Anthropic-only, in-memory field: ``normalize_response`` attaches it to
+        an assistant turn that interleaves signed *thinking* blocks with
+        ``tool_use`` so the Anthropic adapter can replay the turn verbatim and
+        keep the thinking-block signatures valid. It is consumed by the
+        Anthropic adapter and is NEVER part of the OpenAI Chat Completions
+        schema, so a chat_completions target (an OpenAI-compatible proxy, or a
+        fallback from an Anthropic primary onto an OpenAI-wire provider) rejects
+        it with HTTP 400 ``property 'anthropic_content_blocks' is unsupported``.
+        Same leak class as ``timestamp`` (#47868) / ``codex_reasoning_items``.
+        """
+        blocks = [
+            {"type": "thinking", "thinking": "plan the read", "signature": "sig-1"},
+            {"type": "tool_use", "id": "toolu_1", "name": "read_file",
+             "input": {"path": "x"}},
+        ]
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "anthropic_content_blocks": blocks,
+                "tool_calls": [
+                    {"id": "toolu_1", "type": "function",
+                     "function": {"name": "read_file",
+                                  "arguments": '{"path": "x"}'}}
+                ],
+            },
+        ]
+        result = transport.convert_messages(msgs)
+        assert "anthropic_content_blocks" not in result[1]
+        assert result[1]["content"] == "ok"
+        assert result[1]["role"] == "assistant"
+        assert result[1]["tool_calls"] == msgs[1]["tool_calls"]
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[1]["anthropic_content_blocks"] == blocks
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 


### PR DESCRIPTION
## What

`ChatCompletionsTransport.convert_messages` did not strip the
`anthropic_content_blocks` message field before sending a request on the
OpenAI (chat_completions) wire. Add it to both the sanitize-detection
predicate and the strip block, alongside the existing
`codex_reasoning_items` / `codex_message_items` / `timestamp` /
`api_content` internal-field scrubbing.

## Why

`anthropic_content_blocks` is a Hermes-internal, Anthropic-only channel. It
is attached to an assistant turn by `normalize_response` **only** when that
turn interleaves *signed thinking* blocks with `tool_use`, so that the
Anthropic adapter can replay the turn verbatim and keep the thinking-block
signatures valid (reconstructing from the parallel `reasoning_details` +
`tool_calls` lists reorders the blocks and invalidates the signatures).

On the native Anthropic Messages wire the adapter consumes this field, so it
never reaches the API. But nothing stripped it on the **chat_completions**
path. As soon as such a turn is replayed through a chat_completions target —
an OpenAI-compatible proxy, or a fallback from an Anthropic primary to an
OpenAI-wire provider — the field leaks onto the wire and a strict provider
rejects the whole request:

```
HTTP 400: 'messages.N' : for 'role:assistant' the following must be
satisfied[('messages.N' : property 'anthropic_content_blocks' is unsupported)]
```

Because the offending turn sits in history, every subsequent request in the
session hits the same 400 until the turn is compacted away.

This is the same bug class as the `codex_reasoning_items` / `timestamp` /
`api_content` leaks that are already handled a few lines above — an
internal-only message field escaping onto a strict OpenAI-compatible wire.

## Scope

`reasoning_details` is intentionally **not** stripped here: it has its own
provider-aware stripper and is legitimately required on the OpenRouter wire.
This change only removes the Anthropic-only replay channel, which is never
valid on any chat_completions request.

## Reproduction

Build an assistant message carrying `anthropic_content_blocks` (a signed
`thinking` block followed by a `tool_use` block) plus the parallel
`tool_calls`, and run it through `convert_messages(model=<any OpenAI-wire
model>)`. Before: the outgoing message still contains
`anthropic_content_blocks`. After: it is stripped, leaving `content`,
`role`, and `tool_calls`.

## Test

Added coverage asserts that `convert_messages` drops
`anthropic_content_blocks` from an assistant turn while preserving
`content`, `role`, and `tool_calls`.
