### PR TITLE
fix(tests): stop pytest collection aborting on Windows

### DIFF
--- a/tests/hermes_cli/test_doctor_journal_modes.py
+++ b/tests/hermes_cli/test_doctor_journal_modes.py
@@ -142,7 +142,10 @@ class TestReadJournalMode:
             holder.close()
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        getattr(os, "geteuid", lambda: 1)() == 0,
+        reason="root ignores file permissions",
+    )
     def test_read_only_directory_is_still_readable(self, tmp_path):
         db = tmp_path / "state.db"
         _make_db(db, journal_mode="WAL")
@@ -387,7 +390,10 @@ class TestReportDatabaseJournalModes:
         assert "state.db: rollback journal mode" in out
 
     @pytest.mark.skipif(os.name == "nt", reason="chmod is a no-op on Windows")
-    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    @pytest.mark.skipif(
+        getattr(os, "geteuid", lambda: 1)() == 0,
+        reason="root ignores file permissions",
+    )
     def test_unreadable_database_does_not_crash(self, tmp_path, capsys):
         db = tmp_path / "state.db"
         _make_db(db)

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -24,6 +24,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import textwrap
 import time
 from pathlib import Path
@@ -32,10 +33,16 @@ import pytest
 
 
 # Both tests share the same handoff file: the leaker writes here, the
-# verifier reads here. We park it in $TMPDIR with a unique-per-run name
-# so concurrent invocations of the suite don't clobber each other.
-_HANDOFF_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-isolation-probe"
-_HANDOFF_DIR.mkdir(exist_ok=True)
+# verifier reads here. We park it in the system temp dir with a
+# unique-per-run name so concurrent invocations of the suite don't
+# clobber each other.
+#
+# tempfile.gettempdir() already honours TMPDIR on POSIX and TEMP/TMP on
+# Windows. The previous hardcoded /tmp fallback resolved to \tmp on the
+# current drive on Windows, which does not exist, so this mkdir raised
+# at import time and aborted collection for the entire suite.
+_HANDOFF_DIR = Path(tempfile.gettempdir()) / "hermes-isolation-probe"
+_HANDOFF_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _handoff_path_for(nonce: str) -> Path:


### PR DESCRIPTION
Closes #83935.

On Windows, `python -m pytest` over the whole suite aborts during collection, so zero tests run. Two modules do POSIX-only work at import time. `scripts/run_tests_parallel.py` is unaffected because it spawns one pytest per file, which is why CI stays green while the suite is unrunnable locally.

## Measured, on Windows 11 / Python 3.11.15

| file | before | after |
|---|---|---|
| `tests/test_run_tests_parallel.py` | 0 collected, `FileNotFoundError: [WinError 3] '\tmp\hermes-isolation-probe'` | 10 collected |
| `tests/hermes_cli/test_doctor_journal_modes.py` | 0 collected, `AttributeError: module 'os' has no attribute 'geteuid'` | 36 collected |

Both re-run on WSL after the change: 46 collected, no errors.

## 1. `/tmp` hardcoded at module scope

`_HANDOFF_DIR` came from `os.environ.get("TMPDIR", "/tmp")`. `TMPDIR` is not set on Windows, so the fallback resolved to `\tmp` on the current drive. The `mkdir` runs at import time, so it raised during collection rather than in a test.

`tempfile.gettempdir()` already honours `TMPDIR` on POSIX and `TEMP`/`TMP` on Windows, so the behaviour is unchanged everywhere it previously worked.

**Worth flagging for anyone trying to reproduce this:** it does not fail on a machine that happens to have a `C:\tmp` directory. Mine did, and the first run collected 10 tests cleanly. I only saw the real failure after renaming that directory. If someone cannot reproduce the issue, that is the first thing to check.

## 2. `os.geteuid()` in `skipif` conditions

The issue names one occurrence. There are two, at lines 145 and 390. A `skipif` condition is evaluated when the class body executes, so the module cannot be imported on Windows regardless of what the condition would have returned.

The `@pytest.mark.skipif(os.name == "nt", ...)` decorator directly above each one does not help, for the same reason: both decorators' conditions are evaluated before either is applied.

The same file already uses the deferred form at line 293, with a comment explaining exactly this. These two were missed.

## Not included

`ruff check` passes on both files. `ruff format --check` reports these files as unformatted, but it did so before this change too, and reformatting them would bury a 19-line fix under several hundred lines of unrelated churn. Left alone deliberately.

The issue also suggests a Windows CI job or a `pytest --collect-only` smoke check. That seems right, and collection-time breakage is invisible to the per-file runner CI uses, but it is a separate change and I did not want to bundle it.