### PR TITLE
fix(proxy): identify Nous requests as Hermes

### DIFF
--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import FrozenSet, Optional
+from typing import FrozenSet, Mapping, Optional
 
 
 @dataclass(frozen=True)
@@ -58,6 +58,11 @@ class UpstreamAdapter(ABC):
         ``http://127.0.0.1:<port>/v1/chat/completions``. Requests to paths
         not in this set get a 404 with a helpful error body.
         """
+
+    @property
+    def upstream_headers(self) -> Mapping[str, str]:
+        """Provider-required request headers that override client headers."""
+        return {}
 
     @abstractmethod
     def is_authenticated(self) -> bool:

--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -11,6 +11,7 @@ import logging
 import threading
 from typing import Any, Dict, FrozenSet, Optional
 
+from hermes_cli import __version__ as HERMES_VERSION
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_NOUS_INFERENCE_URL,
@@ -61,6 +62,13 @@ class NousPortalAdapter(UpstreamAdapter):
     @property
     def allowed_paths(self) -> FrozenSet[str]:
         return _ALLOWED_PATHS
+
+    @property
+    def upstream_headers(self) -> Dict[str, str]:
+        # The Portal's Cloudflare policy rejects SDK fingerprints such as
+        # ``OpenAI/Python`` with error 1010. Identify the credential-attaching
+        # proxy itself rather than forwarding the downstream client's UA.
+        return {"User-Agent": f"HermesAgent/{HERMES_VERSION}"}
 
     def is_authenticated(self) -> bool:
         state = self._read_state()

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -142,6 +142,10 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 upstream_url = f"{upstream_url}?{request.query_string}"
 
             fwd_headers = _filter_request_headers(request.headers)
+            # Provider requirements take precedence over downstream SDK
+            # fingerprints. In particular, Nous Portal's Cloudflare policy
+            # rejects OpenAI/Python user agents with error 1010.
+            fwd_headers.update(adapter.upstream_headers)
             fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
 
             logger.debug(

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -238,12 +238,14 @@ class FakeAdapter(UpstreamAdapter):
 
     def __init__(self, base_url: str, bearer: str = "test-bearer",
                  allowed=None, raise_on_credential=False,
-                 retry_bearer: str | None = None):
+                 retry_bearer: str | None = None,
+                 upstream_headers: Dict[str, str] | None = None):
         self._base_url = base_url
         self._bearer = bearer
         self._allowed = frozenset(allowed or ["/chat/completions"])
         self._raise = raise_on_credential
         self._retry_bearer = retry_bearer
+        self._upstream_headers = upstream_headers or {}
         self.calls = 0
         self.retry_calls = 0
 
@@ -255,6 +257,9 @@ class FakeAdapter(UpstreamAdapter):
 
     @property
     def allowed_paths(self): return self._allowed
+
+    @property
+    def upstream_headers(self): return self._upstream_headers
 
     def is_authenticated(self): return True
 
@@ -297,6 +302,7 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
             "method": request.method,
             "path": request.path,
             "auth": request.headers.get("Authorization"),
+            "user_agent": request.headers.get("User-Agent"),
             "body": body.decode("utf-8") if body else "",
         })
         return web.json_response({"echoed": True, "path": request.path})
@@ -358,6 +364,32 @@ def test_server_strips_client_auth_header():
                     await resp.read()
             assert captured["requests"][0]["auth"] == "Bearer ours"
             assert "SHOULD_NOT_LEAK" not in captured["requests"][0]["auth"]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_adapter_headers_override_client_headers():
+    """Provider-required headers must win over client SDK fingerprints."""
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            upstream_headers={"User-Agent": "HermesAgent/test"},
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={},
+                    headers={"User-Agent": "OpenAI/Python test"},
+                ) as resp:
+                    await resp.read()
+            assert captured["requests"][0]["user_agent"] == "HermesAgent/test"
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()


### PR DESCRIPTION
## Summary

- let upstream adapters declare provider-required request headers
- identify Nous subscription proxy requests as `HermesAgent/<version>`
- make provider headers override downstream SDK fingerprints while preserving default adapter behavior

Fixes #97796.

## Problem

`hermes proxy --provider nous` attaches Nous credentials but forwards the downstream client's `User-Agent`. OpenAI Python callers therefore reach the Portal as `OpenAI/Python ...`, which the Portal's Cloudflare policy has rejected with HTTP 403 / error 1010. Changing only that upstream header made the same live completion succeed with HTTP 200.

This is the proxy-path sibling of #12999, which fixed the same Cloudflare policy class for the `/v1/models` probe.

## Approach

`UpstreamAdapter.upstream_headers` defaults to an empty mapping, so every existing adapter keeps current behavior. `NousPortalAdapter` supplies the Hermes User-Agent. The proxy applies those trusted adapter requirements after filtering client headers and before setting proxy-owned authorization.

## Verification

- `scripts/run_tests.sh -j 1 tests/hermes_cli/test_proxy.py -q` — 5 passed
- regression sabotage: restoring the old forwarding code makes `test_server_adapter_headers_override_client_headers` fail with `OpenAI/Python test`; restoring the fix returns to 5 passed
- `python -m compileall -q hermes_cli/proxy`
- `git diff --check`

## Risk

Low and provider-scoped. Other adapters return the empty default mapping. Nous requests change only the upstream User-Agent; request body, endpoint, credentials, and response streaming are unchanged.
