### PR TITLE
fix(proxy): identify Nous subscription requests as Hermes

### DIFF
--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -7,6 +7,7 @@ local proxy can forward requests to. The adapter is responsible for:
   - refreshing/minting credentials when needed
   - reporting the resolved upstream base URL
   - declaring which request paths it accepts
+  - declaring provider-required request headers, if any
 
 The proxy server is otherwise provider-agnostic.
 """
@@ -15,7 +16,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import FrozenSet, Optional
+from typing import Dict, FrozenSet, Optional
 
 
 @dataclass(frozen=True)
@@ -58,6 +59,18 @@ class UpstreamAdapter(ABC):
         ``http://127.0.0.1:<port>/v1/chat/completions``. Requests to paths
         not in this set get a 404 with a helpful error body.
         """
+
+    @property
+    def upstream_headers(self) -> Dict[str, str]:
+        """Request headers this provider requires on every forwarded request.
+
+        Applied after client headers are filtered and before the proxy adds
+        its own ``Authorization``, so a provider requirement (e.g. a
+        provider-specific ``User-Agent``) overrides the downstream SDK
+        fingerprint. Empty by default — adapters without provider-specific
+        requirements keep forwarding client headers unchanged.
+        """
+        return {}
 
     @abstractmethod
     def is_authenticated(self) -> bool:

--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -62,6 +62,20 @@ class NousPortalAdapter(UpstreamAdapter):
     def allowed_paths(self) -> FrozenSet[str]:
         return _ALLOWED_PATHS
 
+    @property
+    def upstream_headers(self) -> Dict[str, str]:
+        # The Portal's Cloudflare policy rejects SDK fingerprints like
+        # ``OpenAI/Python`` with HTTP 403 (error 1010) before inference sees
+        # the request, so the credential-attaching proxy must identify itself
+        # as Hermes regardless of the downstream client. Same policy class
+        # already fixed for the /v1/models probe (#12999).
+        try:
+            from hermes_cli import __version__
+            _v = str(__version__)
+        except Exception:
+            _v = "0"
+        return {"User-Agent": f"HermesAgent/{_v}"}
+
     def is_authenticated(self) -> bool:
         state = self._read_state()
         if state is None:

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -72,6 +72,22 @@ def _filter_request_headers(headers: "aiohttp.typedefs.LooseHeaders") -> dict:
     return out
 
 
+def _apply_upstream_headers(forwarded: dict, overrides: dict) -> dict:
+    """Apply adapter-declared provider headers over the filtered client set.
+
+    With no overrides the client's headers pass through unchanged. Declared
+    keys are matched case-insensitively — a client may send ``user-agent``
+    in any casing, and a plain ``dict.update`` would forward both case
+    variants upstream as duplicate headers.
+    """
+    if not overrides:
+        return forwarded
+    overridden = {key.lower() for key in overrides}
+    out = {k: v for k, v in forwarded.items() if k.lower() not in overridden}
+    out.update(overrides)
+    return out
+
+
 def _filter_response_headers(headers) -> dict:
     """Strip hop-by-hop headers from the upstream response."""
     out = {}
@@ -142,6 +158,7 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 upstream_url = f"{upstream_url}?{request.query_string}"
 
             fwd_headers = _filter_request_headers(request.headers)
+            fwd_headers = _apply_upstream_headers(fwd_headers, adapter.upstream_headers)
             fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
 
             logger.debug(

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -238,12 +238,14 @@ class FakeAdapter(UpstreamAdapter):
 
     def __init__(self, base_url: str, bearer: str = "test-bearer",
                  allowed=None, raise_on_credential=False,
-                 retry_bearer: str | None = None):
+                 retry_bearer: str | None = None,
+                 upstream_headers: dict | None = None):
         self._base_url = base_url
         self._bearer = bearer
         self._allowed = frozenset(allowed or ["/chat/completions"])
         self._raise = raise_on_credential
         self._retry_bearer = retry_bearer
+        self._upstream_headers = dict(upstream_headers) if upstream_headers else {}
         self.calls = 0
         self.retry_calls = 0
 
@@ -255,6 +257,9 @@ class FakeAdapter(UpstreamAdapter):
 
     @property
     def allowed_paths(self): return self._allowed
+
+    @property
+    def upstream_headers(self): return dict(self._upstream_headers)
 
     def is_authenticated(self): return True
 
@@ -297,6 +302,9 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
             "method": request.method,
             "path": request.path,
             "auth": request.headers.get("Authorization"),
+            # All User-Agent values that reached the upstream, in any casing —
+            # catches both the value and case-variant duplicates.
+            "user_agents": request.headers.getall("User-Agent", []),
             "body": body.decode("utf-8") if body else "",
         })
         return web.json_response({"echoed": True, "path": request.path})
@@ -363,6 +371,72 @@ def test_server_strips_client_auth_header():
             await upstream_runner.cleanup()
 
     asyncio.run(run())
+
+
+def test_server_applies_adapter_upstream_headers_over_client_ua():
+    """Adapter-declared headers must override the downstream SDK fingerprint.
+
+    The Nous Portal rejects ``OpenAI/Python`` User-Agents with Cloudflare 403
+    (error 1010); a client may also send the header in lowercase, and both
+    case variants must collapse into the single adapter value (#97796).
+    """
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            bearer="ours",
+            upstream_headers={"User-Agent": "HermesAgent/test"},
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={},
+                    headers={"user-agent": "OpenAI/Python 4.104.0"},
+                ) as resp:
+                    await resp.read()
+            assert captured["requests"][0]["user_agents"] == ["HermesAgent/test"]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_preserves_client_ua_without_adapter_overrides():
+    """Adapters with no upstream_headers keep forwarding client headers unchanged."""
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={},
+                    headers={"User-Agent": "OpenAI/Python 4.104.0"},
+                ) as resp:
+                    await resp.read()
+            assert captured["requests"][0]["user_agents"] == ["OpenAI/Python 4.104.0"]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_nous_adapter_declares_hermes_user_agent():
+    """The Nous adapter identifies the proxy as Hermes regardless of client SDK."""
+    from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+
+    headers = NousPortalAdapter().upstream_headers
+    assert set(headers) == {"User-Agent"}
+    assert headers["User-Agent"].startswith("HermesAgent/")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`hermes proxy --provider nous` forwarded the downstream client's `User-Agent` verbatim to the Nous Portal inference endpoint, so OpenAI SDK clients identified the credential-attaching proxy as `OpenAI/Python ...` — and the Portal's Cloudflare policy rejected that fingerprint with HTTP 403 / error 1010 before the request reached inference. This is the same Cloudflare policy class already fixed for the `/v1/models` probe in #12999, but the subscription proxy has a separate forwarding path.

The fix lets an adapter declare provider-required headers and applies them on the proxy's forwarding path, so the proxy identifies itself upstream as Hermes regardless of the downstream SDK:

- `UpstreamAdapter` gains an `upstream_headers` property, empty by default — adapters without provider-specific requirements keep forwarding client headers unchanged (e.g. the xAI adapter).
- `NousPortalAdapter` declares `User-Agent: HermesAgent/<version>`, mirroring the existing probe header in `hermes_cli/models.py`.
- The server applies adapter headers after client-header filtering and before adding the Hermes-owned `Authorization`. Declared keys are matched case-insensitively: a client may send `user-agent` in any casing, and a plain `dict.update` would forward both case variants upstream as duplicate headers.

## Related Issue

Fixes #97796

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/proxy/adapters/base.py`: added `UpstreamAdapter.upstream_headers` property (default empty) + docstring responsibility note.
- `hermes_cli/proxy/adapters/nous_portal.py`: `NousPortalAdapter.upstream_headers` returns `User-Agent: HermesAgent/<hermes_cli.__version__>`.
- `hermes_cli/proxy/server.py`: added `_apply_upstream_headers()` and wired it into the forwarding path between `_filter_request_headers()` and the bearer rewrite.
- `tests/hermes_cli/test_proxy.py`: `FakeAdapter` accepts `upstream_headers`; the fake upstream's echo captures all `User-Agent` values (any casing) to catch duplicates; three new tests (see How to Test).

## How to Test

1. `pytest tests/hermes_cli/test_proxy.py -q` — all 7 tests pass.
2. `test_server_applies_adapter_upstream_headers_over_client_ua` — integration test through the real aiohttp proxy + fake upstream: a lowercase `user-agent: OpenAI/Python 4.104.0` client header is replaced by the adapter's `HermesAgent/test` value, and exactly one User-Agent reaches the upstream. Observed result: passes with the fix; fails under the previous forwarding behavior (verified by temporarily unwiring `_apply_upstream_headers`).
3. `test_server_preserves_client_ua_without_adapter_overrides` — adapters with no `upstream_headers` still forward the client's `User-Agent` unchanged. Observed result: passes.
4. `test_nous_adapter_declares_hermes_user_agent` — `NousPortalAdapter().upstream_headers` is exactly `{"User-Agent": "HermesAgent/<version>"}`. Observed result: passes.
5. Regression sweep over all test files importing `hermes_cli.proxy` (`test_proxy.py`, `test_iron_proxy_cli.py`, `test_nous_inference_url_validation.py`, `test_cli_status_command.py`, `test_unknown_command.py`): 40 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A
