### PR TITLE
fix(desktop): restore Windows Explorer file drops

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
@@ -3,7 +3,7 @@ import { type DragEvent as ReactDragEvent, useRef, useState } from 'react'
 import { triggerHaptic } from '@/lib/haptics'
 
 import { extractDroppedFiles, HERMES_PATHS_MIME, partitionDroppedFiles } from '../../hooks/use-composer-actions'
-import { dragHasAttachments, droppedFileInlineRefs, type InlineRefInput } from '../inline-refs'
+import { createDragLifecycleGate, type DragLifecycleGate, droppedFileInlineRefs, type InlineRefInput } from '../inline-refs'
 import type { ChatBarProps } from '../types'
 
 interface UseComposerDropArgs {
@@ -19,6 +19,12 @@ interface UseComposerDropArgs {
  * resolves directly; OS/Finder drops (absolute local paths a remote gateway
  * can't read, image bytes vision needs) route through the upload pipeline.
  * Off the keystroke path; consumes `insertInlineRefs` + the attach handler.
+ *
+ * Windows sparse drag (#97702): the shared `createDragLifecycleGate`
+ * arms on the first dragenter signal (typed file drag OR a fully-empty
+ * Windows Explorer transfer) and keeps dragover alive for the same drag,
+ * so the app-lifetime react-dnd HTML5Backend's capture-time
+ * `dropEffect='none'` cannot suppress the eventual drop.
  */
 export function useComposerDrop({
   cwd,
@@ -28,14 +34,24 @@ export function useComposerDrop({
 }: UseComposerDropArgs) {
   const [dragActive, setDragActive] = useState(false)
   const dragDepthRef = useRef(0)
+  // One gate per composer instance; stable across re-renders.
+  const gateRef = useRef<DragLifecycleGate | null>(null)
+  const gate = gateRef.current ?? (gateRef.current = createDragLifecycleGate(HERMES_PATHS_MIME))
 
   const resetDragState = () => {
     dragDepthRef.current = 0
+    gate.reset()
     setDragActive(false)
   }
 
   const handleDragEnter = (event: ReactDragEvent<HTMLFormElement>) => {
-    if (!onAttachDroppedItems || !dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    // A genuinely new drag (not a nested-child re-enter) must reset
+    // any unrecovered gate state before the new drag is evaluated.
+    if (dragDepthRef.current === 0) {
+      gate.reset()
+    }
+
+    if (!onAttachDroppedItems || !gate.onEnter(event.dataTransfer)) {
       return
     }
 
@@ -48,7 +64,7 @@ export function useComposerDrop({
   }
 
   const handleDragOver = (event: ReactDragEvent<HTMLFormElement>) => {
-    if (!onAttachDroppedItems || !dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    if (!onAttachDroppedItems || !gate.onOver(event.dataTransfer)) {
       return
     }
 
@@ -65,7 +81,10 @@ export function useComposerDrop({
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
 
     if (dragDepthRef.current === 0) {
+      gate.onLeave(true)
       setDragActive(false)
+    } else {
+      gate.onLeave(false)
     }
   }
 
@@ -105,7 +124,7 @@ export function useComposerDrop({
   }
 
   const handleInputDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    if (!gate.onOver(event.dataTransfer)) {
       return
     }
 
@@ -115,7 +134,7 @@ export function useComposerDrop({
   }
 
   const handleInputDrop = (event: ReactDragEvent<HTMLDivElement>) => {
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    if (!gate.onOver(event.dataTransfer)) {
       return
     }
 

--- a/apps/desktop/src/app/chat/composer/inline-refs.test.ts
+++ b/apps/desktop/src/app/chat/composer/inline-refs.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+
+import { HERMES_PATHS_MIME } from '../hooks/use-composer-actions'
+
+import { createDragLifecycleGate, dragHasAttachments, isSparseExternalFileDrag } from './inline-refs'
+
+/**
+ * Minimal stand-in for `DataTransfer`. jsdom ships a `DataTransfer` shim
+ * whose `types`/`items`/`files`/`setData`/`getData` behave well enough for
+ * the lifecycle tests below, but it cannot model a Windows Explorer drag
+ * whose `types` AND `items` are *both* empty during `dragenter` (the
+ * constructors always set `types: ['Files']`). We use this local shim so
+ * the regression test is hermetic and never depends on jsdom internals.
+ */
+function fakeTransfer(types: string[] = [], items: { kind: string }[] = []): DataTransfer {
+  return {
+    types: Object.freeze([...types]),
+    items: Object.freeze([...items].map(item => Object.freeze(item))) as unknown as DataTransferItemList,
+    files: Object.freeze([]) as unknown as FileList
+  } as unknown as DataTransfer
+}
+
+describe('dragHasAttachments', () => {
+  it('accepts the custom HERMES_PATHS_MIME drag', () => {
+    const t = fakeTransfer([HERMES_PATHS_MIME])
+    expect(dragHasAttachments(t, HERMES_PATHS_MIME)).toBe(true)
+  })
+
+  it('accepts a typed "Files" drag (Chromium, macOS)', () => {
+    const t = fakeTransfer(['Files'])
+    expect(dragHasAttachments(t, HERMES_PATHS_MIME)).toBe(true)
+  })
+
+  it('accepts a drag whose items include a file kind', () => {
+    const t = fakeTransfer([], [{ kind: 'file' }])
+    expect(dragHasAttachments(t, HERMES_PATHS_MIME)).toBe(true)
+  })
+
+  it('rejects a fully-empty transfer (Windows sparse dragenter is not yet a file)', () => {
+    // REGRESSION PROOF for the pre-fix behaviour: a sparse transfer must NOT
+    // be reported as "has attachments" by this helper, because the file list
+    // is only materialised at `drop`. The stateful gate is what handles the
+    // dragenter/dragover path, and the drop handler still has to verify
+    // `extractDroppedFiles(...).length > 0`.
+    const t = fakeTransfer()
+    expect(dragHasAttachments(t, HERMES_PATHS_MIME)).toBe(false)
+  })
+
+  it('rejects a text drag', () => {
+    const t = fakeTransfer(['text/plain'])
+    expect(dragHasAttachments(t, HERMES_PATHS_MIME)).toBe(false)
+  })
+
+  it('rejects null', () => {
+    expect(dragHasAttachments(null, HERMES_PATHS_MIME)).toBe(false)
+  })
+})
+
+describe('isSparseExternalFileDrag', () => {
+  it('flags a fully-empty transfer (Windows Explorer / Chromium sparse case)', () => {
+    const t = fakeTransfer()
+    expect(isSparseExternalFileDrag(t)).toBe(true)
+  })
+
+  it('does NOT flag a transfer with even a single type (text/plain, Files, etc.)', () => {
+    // Any non-empty `types` array is an explicit signal from the source —
+    // either a real file drag (`Files`), an in-app drag (`HERMES_PATHS_MIME`),
+    // or a text drag. Those are NOT the Windows sparse case and are routed
+    // through the existing `dragHasAttachments` path.
+    expect(isSparseExternalFileDrag(fakeTransfer(['text/plain']))).toBe(false)
+    expect(isSparseExternalFileDrag(fakeTransfer(['Files']))).toBe(false)
+  })
+
+  it('does NOT flag a transfer with non-empty items', () => {
+    expect(isSparseExternalFileDrag(fakeTransfer([], [{ kind: 'string' }]))).toBe(false)
+    expect(isSparseExternalFileDrag(fakeTransfer([], [{ kind: 'file' }]))).toBe(false)
+  })
+
+  it('rejects null', () => {
+    expect(isSparseExternalFileDrag(null)).toBe(false)
+  })
+})
+
+describe('createDragLifecycleGate (#97702)', () => {
+  it('arms on a typed file dragenter and keeps dragover accepting', () => {
+    const gate = createDragLifecycleGate(HERMES_PATHS_MIME)
+    const t = fakeTransfer(['Files'])
+
+    expect(gate.onEnter(t)).toBe(true)
+    // Dragover fires many times before drop; each must stay true so the
+    // app-lifetime HTML5Backend capture-time `dropEffect='none'` does not
+    // suppress the eventual drop.
+    expect(gate.onOver(t)).toBe(true)
+    expect(gate.onOver(t)).toBe(true)
+  })
+
+  it('arms on a fully-empty dragenter (Windows sparse case) and keeps dragover open', () => {
+    const gate = createDragLifecycleGate(HERMES_PATHS_MIME)
+    const empty = fakeTransfer()
+
+    // First dragenter on the composer: empty transfer, but the only known
+    // production signal of an external OS file drag. The gate must accept
+    // (and the bubble-phase handler must preventDefault) so drop survives.
+    expect(gate.onEnter(empty)).toBe(true)
+    // Subsequent dragovers in the same drag are still empty — the gate
+    // must stay armed.
+    expect(gate.onOver(empty)).toBe(true)
+    expect(gate.onOver(empty)).toBe(true)
+  })
+
+  it('REJECTS a sparse dragover that has no prior dragenter from this drag', () => {
+    const gate = createDragLifecycleGate(HERMES_PATHS_MIME)
+    const empty = fakeTransfer()
+
+    // No enter yet — a stray dragover with no preceding enter for this drag
+    // must NOT arm the gate. This is the "don't blanket-classify every
+    // empty DataTransfer" invariant: an in-app drag that happens to expose
+    // an empty transfer cannot flash the file-drop overlay.
+    expect(gate.onOver(empty)).toBe(false)
+    expect(gate.onOver(empty)).toBe(false)
+  })
+
+  it('REJECTS a dragenter whose transfer carries a non-file, non-MIME type', () => {
+    // A text drag (types=['text/plain']) is not a file drag and must not
+    // arm the gate, even though it is not "fully empty".
+    const gate = createDragLifecycleGate(HERMES_PATHS_MIME)
+    const text = fakeTransfer(['text/plain'])
+
+    expect(gate.onEnter(text)).toBe(false)
+    // And without an armed enter, dragover must also reject — no sticky
+    // "file drag" overlay.
+    expect(gate.onOver(text)).toBe(false)
+  })
+
+  it('disarms on onLeave(true) at root depth, so a new drag starts clean', () => {
+    const gate = createDragLifecycleGate(HERMES_PATHS_MIME)
+    const empty = fakeTransfer()
+
+    expect(gate.onEnter(empty)).toBe(true)
+    expect(gate.onOver(empty)).toBe(true)
+    gate.onLeave(true)
+    // After leaving the root, a stray dragover must NOT be accepted —
+    // and a brand-new drag must be re-evaluable from scratch.
+    expect(gate.onOver(empty)).toBe(false)
+    expect(gate.onEnter(empty)).toBe(true)
+  })
+
+  it('does NOT disarm on onLeave(false) (nested child leave preserves the drag)', () => {
+    const gate = createDragLifecycleGate(HERMES_PATHS_MIME)
+    const empty = fakeTransfer()
+
+    expect(gate.onEnter(empty)).toBe(true)
+    gate.onLeave(false)
+    // Nested-child dragleave must not close the gate — depth==0 is the
+    // caller's job to track.
+    expect(gate.onOver(empty)).toBe(true)
+  })
+
+  it('reset() always disarms (drop, unmount, abort)', () => {
+    const gate = createDragLifecycleGate(HERMES_PATHS_MIME)
+    const empty = fakeTransfer()
+
+    expect(gate.onEnter(empty)).toBe(true)
+    gate.reset()
+    expect(gate.onOver(empty)).toBe(false)
+  })
+
+  it('rejects a null transfer on both enter and over', () => {
+    const gate = createDragLifecycleGate(HERMES_PATHS_MIME)
+    expect(gate.onEnter(null)).toBe(false)
+    expect(gate.onOver(null)).toBe(false)
+  })
+
+  it('does not carry state between independent gate instances', () => {
+    // Each drop zone must own its gate — an arm in one zone must not
+    // leak into another. This is the React-ref-isolation invariant.
+    const a = createDragLifecycleGate(HERMES_PATHS_MIME)
+    const b = createDragLifecycleGate(HERMES_PATHS_MIME)
+    const empty = fakeTransfer()
+
+    a.onEnter(empty)
+    expect(b.onOver(empty)).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/inline-refs.ts
+++ b/apps/desktop/src/app/chat/composer/inline-refs.ts
@@ -49,6 +49,120 @@ export function dragHasAttachments(transfer: DataTransfer | null, pathsMime: str
   return Array.from(transfer.items || []).some(item => item.kind === 'file')
 }
 
+/**
+ * Windows Explorer / Chromium sparse external file drag.
+ *
+ * During `dragenter`/`dragover` the OS can expose an entirely empty
+ * `DataTransfer` (no `types`, no `items` with `kind=file`) while the `File`
+ * payload only materialises at `drop`. The ONLY known production source of
+ * such a fully empty native DataTransfer on this app is an external OS file
+ * drag — internal in-app drags always carry at least `text/plain` or the
+ * `application/x-hermes-paths` custom MIME. An empty dragenter is therefore
+ * a credible signal of an external file drag, even though it is not yet
+ * proof of one. Callers that use this for `preventDefault` MUST still
+ * verify `extractDroppedFiles(...).length > 0` at drop time.
+ *
+ * This intentionally does NOT consider transfers with a non-empty `types`
+ * array: those are either real file drags (`Files`), in-app drags
+ * (`application/x-hermes-paths`), or unrelated text drags (`text/plain`) —
+ * the existing `dragHasAttachments` helper already classifies them.
+ */
+export function isSparseExternalFileDrag(transfer: DataTransfer | null): boolean {
+  if (!transfer) {
+    return false
+  }
+
+  const types = transfer.types
+
+  if (types && types.length !== 0) {
+    return false
+  }
+
+  const items = transfer.items
+
+  if (items && items.length !== 0) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Stateful, event-lifecycle-aware drag accept gate. Use this to wrap a
+ * native HTML5 drop zone so the bubble-phase `dragover` keeps drop alive
+ * for the Windows Explorer sparse case (see {@link isSparseExternalFileDrag})
+ * WITHOUT blanket-classifying every empty `DataTransfer` as a file drag.
+ *
+ * Invariants:
+ * - `onEnter` arms the gate on the FIRST credible signal (typed file drag
+ *   OR a fully-empty transfer). Once armed, subsequent `onOver` calls
+ *   accept the drag even if the transfer is still empty.
+ * - A `dragover` that fires WITHOUT a prior `dragenter` for this drag does
+ *   NOT arm the gate and is rejected — no spurious "file drag active" UI.
+ * - `onLeave(atRootDepth: true)` and `reset()` clear the gate. The caller
+ *   tracks nested dragenter/leave depth and only calls `onLeave(true)` when
+ *   depth returns to 0.
+ * - This is intentionally NOT a React hook so the gate can be unit-tested
+ *   without a renderer; callers keep it in a `useRef` for stability.
+ */
+export interface DragLifecycleGate {
+  /** Returns true if the dragenter should be accepted (and preventDefault'd). */
+  onEnter(transfer: DataTransfer | null): boolean
+  /** Returns true if the dragover should keep drop alive (and preventDefault'd). */
+  onOver(transfer: DataTransfer | null): boolean
+  /** Caller passes `true` when leaving the root depth to disarm the gate. */
+  onLeave(atRootDepth: boolean): void
+  /** Force-clear the gate (drop, unmount, or explicit abort). */
+  reset(): void
+}
+
+export function createDragLifecycleGate(pathsMime: string): DragLifecycleGate {
+  let crediblyArmed = false
+
+  return {
+    onEnter(transfer) {
+      if (dragHasAttachments(transfer, pathsMime)) {
+        crediblyArmed = true
+
+        return true
+      }
+
+      if (isSparseExternalFileDrag(transfer)) {
+        // Tentative arm: an empty transfer is the only known signal of a
+        // Windows Explorer / Chromium sparse file drag. The drop handler
+        // must still gate on `extractDroppedFiles(...).length > 0`.
+        crediblyArmed = true
+
+        return true
+      }
+
+      return false
+    },
+
+    onOver(transfer) {
+      if (dragHasAttachments(transfer, pathsMime)) {
+        return true
+      }
+
+      // Stay open for the same drag we tentatively armed on enter — the
+      // browser keeps re-firing dragover until drop or dragleave, and
+      // dropping the gate here would let the app-lifetime HTML5Backend's
+      // capture-time `dropEffect='none'` suppress the eventual drop.
+      return crediblyArmed
+    },
+
+    onLeave(atRootDepth) {
+      if (atRootDepth) {
+        crediblyArmed = false
+      }
+    },
+
+    reset() {
+      crediblyArmed = false
+    }
+  }
+}
+
 export function droppedFileInlineRef(candidate: DroppedFile, cwd: string | null | undefined) {
   if (!candidate.path) {
     return null

--- a/apps/desktop/src/app/chat/hooks/use-file-drop-zone.test.tsx
+++ b/apps/desktop/src/app/chat/hooks/use-file-drop-zone.test.tsx
@@ -1,0 +1,216 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { DroppedFile } from './use-composer-actions'
+import { useFileDropZone } from './use-file-drop-zone'
+
+/**
+ * jsdom's bundled `DataTransfer` constructor sets `types: ['Files']`
+ * unconditionally, so we cannot use it to model a Windows Explorer sparse
+ * drag (both `types` and `items` empty at dragenter, payload only at drop).
+ * The shape below covers everything `useFileDropZone` and the
+ * `extractDroppedFiles` helper read in the test path, including the
+ * `item(i)` method `extractDroppedFiles` calls on `FileList`.
+ */
+function makeTransfer(options: {
+  types?: string[]
+  files?: File[]
+  items?: { kind: string; getAsFile: () => File | null }[]
+} = {}): DataTransfer {
+  const types = options.types ?? []
+  const items = options.items ?? options.files?.map(file => ({ kind: 'file', getAsFile: () => file })) ?? []
+  const files = options.files ?? []
+
+  const fileListLike = Object.assign([...files], {
+    item: (i: number) => files[i] ?? null,
+    length: files.length
+  })
+
+  return {
+    types: Object.freeze([...types]) as unknown as DOMStringList,
+    items: Object.freeze([...items]) as unknown as DataTransferItemList,
+    files: fileListLike as unknown as FileList,
+    getData: () => '',
+    setData: () => undefined,
+    clearData: () => undefined,
+    setDragImage: () => undefined,
+    dropEffect: 'none',
+    effectAllowed: 'all'
+  } as unknown as DataTransfer
+}
+
+function Harness({
+  onDropFiles,
+  enabled
+}: {
+  onDropFiles: ReturnType<typeof vi.fn<(files: DroppedFile[]) => void>>
+  enabled?: boolean
+}) {
+  const { dragKind, dropHandlers } = useFileDropZone({
+    enabled: enabled ?? true,
+    onDropFiles
+  })
+
+  return (
+    <div data-drag-kind={dragKind ?? 'none'} data-testid="zone" {...dropHandlers}>
+      <input data-testid="inner" />
+    </div>
+  )
+}
+
+afterEach(cleanup)
+
+/**
+ * Regression: Windows Explorer / Chromium exposes a *fully empty* native
+ * DataTransfer during `dragenter`/`dragover` and only populates `files`
+ * at `drop`. The pre-fix code rejected that dragenter (returning early
+ * without `preventDefault`), which let the app-lifetime react-dnd
+ * HTML5Backend's capture-time `dropEffect='none'` suppress the eventual
+ * drop. The new stateful gate must (a) accept the sparse dragenter, (b)
+ * keep `dragover` alive for the same drag, and (c) still hand the real
+ * `File` payload to `onDropFiles` at drop.
+ */
+describe('useFileDropZone (#97702 Windows sparse file drag)', () => {
+  it('accepts a sparse dragenter, keeps dragover alive, and ingests the file at drop', () => {
+    const onDropFiles = vi.fn<(files: DroppedFile[]) => void>()
+    const file = new File(['hello'], 'greeting.txt', { type: 'text/plain' })
+    // Dragenter / dragover: empty (sparse). Drop: payload materialises.
+    const sparse = makeTransfer()
+    const populated = makeTransfer({ types: ['Files'], files: [file] })
+
+    render(<Harness onDropFiles={onDropFiles} />)
+    const zone = screen.getByTestId('zone')
+
+    // 1. Dragenter with a fully empty transfer — the only known production
+    //    signal of a Windows Explorer drag. The gate must accept (and the
+    //    handler must preventDefault) so the eventual drop survives.
+    act(() => {
+      fireEvent.dragEnter(zone, { dataTransfer: sparse })
+    })
+    expect(zone.getAttribute('data-drag-kind')).toBe('files')
+    // Browsers fire several dragovers before drop — each must keep the
+    // gate armed (preventDefault'd, dropEffect='copy').
+    act(() => {
+      fireEvent.dragOver(zone, { dataTransfer: sparse })
+    })
+    act(() => {
+      fireEvent.dragOver(zone, { dataTransfer: sparse })
+    })
+    expect(zone.getAttribute('data-drag-kind')).toBe('files')
+
+    // 2. Drop with the real payload: a real File must be ingested, not
+    //    silently swallowed, and the overlay must clear.
+    act(() => {
+      fireEvent.drop(zone, { dataTransfer: populated })
+    })
+
+    expect(onDropFiles).toHaveBeenCalledTimes(1)
+    expect(onDropFiles.mock.calls[0]?.[0]?.[0]?.file?.name).toBe('greeting.txt')
+    expect(zone.getAttribute('data-drag-kind')).toBe('none')
+  })
+
+  it('REJECTS a sparse dragover that has no prior dragenter (no blanket accept)', () => {
+    const onDropFiles = vi.fn<(files: DroppedFile[]) => void>()
+    const sparse = makeTransfer()
+
+    render(<Harness onDropFiles={onDropFiles} />)
+    const zone = screen.getByTestId('zone')
+
+    // No dragenter — a stray dragover alone must NOT set dragKind or
+    // preventDefault. The fix is intentionally NOT "classify every empty
+    // DataTransfer as a file drag"; it is "trust a sparse dragenter as
+    // a credible signal, then keep the gate armed for that drag's
+    // dragovers".
+    act(() => {
+      fireEvent.dragOver(zone, { dataTransfer: sparse })
+    })
+    act(() => {
+      fireEvent.dragOver(zone, { dataTransfer: sparse })
+    })
+    expect(zone.getAttribute('data-drag-kind')).toBe('none')
+
+    // And a drop that follows a never-armed drag must NOT call
+    // onDropFiles — the zone never accepted the drag.
+    act(() => {
+      fireEvent.drop(zone, { dataTransfer: sparse })
+    })
+    expect(onDropFiles).not.toHaveBeenCalled()
+  })
+
+  it('still accepts a typed "Files" dragenter (existing typed-drag path is unchanged)', () => {
+    const onDropFiles = vi.fn<(files: DroppedFile[]) => void>()
+    const typed = makeTransfer({ types: ['Files'] })
+
+    render(<Harness onDropFiles={onDropFiles} />)
+    const zone = screen.getByTestId('zone')
+
+    act(() => {
+      fireEvent.dragEnter(zone, { dataTransfer: typed })
+    })
+    expect(zone.getAttribute('data-drag-kind')).toBe('files')
+  })
+
+  it('rejects a text drag (text/plain) at the enter and over steps', () => {
+    const onDropFiles = vi.fn<(files: DroppedFile[]) => void>()
+    const text = makeTransfer({ types: ['text/plain'] })
+
+    render(<Harness onDropFiles={onDropFiles} />)
+    const zone = screen.getByTestId('zone')
+
+    act(() => {
+      fireEvent.dragEnter(zone, { dataTransfer: text })
+    })
+    act(() => {
+      fireEvent.dragOver(zone, { dataTransfer: text })
+    })
+    expect(zone.getAttribute('data-drag-kind')).toBe('none')
+  })
+
+  it('disarms after a root-depth dragleave, so a subsequent sparse drag re-evaluates', () => {
+    const onDropFiles = vi.fn<(files: DroppedFile[]) => void>()
+    const sparse = makeTransfer()
+    const populated = makeTransfer({ types: ['Files'], files: [new File(['x'], 'a.txt')] })
+
+    render(<Harness onDropFiles={onDropFiles} />)
+    const zone = screen.getByTestId('zone')
+
+    act(() => {
+      fireEvent.dragEnter(zone, { dataTransfer: sparse })
+    })
+    act(() => {
+      fireEvent.dragLeave(zone, { dataTransfer: sparse })
+    })
+    expect(zone.getAttribute('data-drag-kind')).toBe('none')
+
+    // A second, independent drag must work as cleanly as the first.
+    act(() => {
+      fireEvent.dragEnter(zone, { dataTransfer: sparse })
+    })
+    expect(zone.getAttribute('data-drag-kind')).toBe('files')
+    act(() => {
+      fireEvent.drop(zone, { dataTransfer: populated })
+    })
+    expect(onDropFiles).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when enabled: false (sparse or typed)', () => {
+    const onDropFiles = vi.fn<(files: DroppedFile[]) => void>()
+    const sparse = makeTransfer()
+
+    render(<Harness enabled={false} onDropFiles={onDropFiles} />)
+    const zone = screen.getByTestId('zone')
+
+    act(() => {
+      fireEvent.dragEnter(zone, { dataTransfer: sparse })
+    })
+    act(() => {
+      fireEvent.dragOver(zone, { dataTransfer: sparse })
+    })
+    expect(zone.getAttribute('data-drag-kind')).toBe('none')
+
+    act(() => {
+      fireEvent.drop(zone, { dataTransfer: makeTransfer({ types: ['Files'], files: [new File(['x'], 'a.txt')] }) })
+    })
+    expect(onDropFiles).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/hooks/use-file-drop-zone.ts
+++ b/apps/desktop/src/app/chat/hooks/use-file-drop-zone.ts
@@ -1,6 +1,6 @@
 import { type DragEvent as ReactDragEvent, useCallback, useEffect, useRef, useState } from 'react'
 
-import { dragHasAttachments } from '@/app/chat/composer/inline-refs'
+import { createDragLifecycleGate, type DragLifecycleGate } from '@/app/chat/composer/inline-refs'
 import { ESCAPE_PRIORITY, pushEscapeLayer } from '@/lib/escape-layers'
 
 import { type DroppedFile, extractDroppedFiles, HERMES_PATHS_MIME } from './use-composer-actions'
@@ -9,9 +9,6 @@ import { type DroppedFile, extractDroppedFiles, HERMES_PATHS_MIME } from './use-
  *  native drags only ever resolve to `'files'` here (sessions left native
  *  DnD; see session-drag.ts). */
 export type DragKind = 'files' | 'session' | null
-
-const dragKindOf = (event: ReactDragEvent): DragKind =>
-  dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) ? 'files' : null
 
 interface FileDropZoneOptions {
   /** When false the zone ignores drags entirely. */
@@ -34,11 +31,18 @@ export function useFileDropZone({ enabled = true, onDropFiles }: FileDropZoneOpt
   const [dragKind, setDragKind] = useState<DragKind>(null)
   const depth = useRef(0)
   const aborted = useRef(false)
+  // One stateful gate per zone; stable across re-renders. The gate's enter/
+  // over/leave semantics are the Windows sparse-drag fix (#97702) — a single
+  // boolean would either blank-accept every empty transfer or fail to keep
+  // the drag alive across the dragover→drop handoff.
+  const gateRef = useRef<DragLifecycleGate | null>(null)
+  const gate = gateRef.current ?? (gateRef.current = createDragLifecycleGate(HERMES_PATHS_MIME))
 
   const reset = useCallback(() => {
     depth.current = 0
+    gate.reset()
     setDragKind(null)
-  }, [])
+  }, [gate])
 
   // Esc aborts a file drag — the same "never mind" a session drag gets. Native
   // DnD can't be cancelled at the OS level, so we drop the overlay and arm a
@@ -73,9 +77,13 @@ export function useFileDropZone({ enabled = true, onDropFiles }: FileDropZoneOpt
 
   const onDragEnter = useCallback(
     (event: ReactDragEvent) => {
-      const kind = enabled ? dragKindOf(event) : null
+      // A genuinely new drag (not a nested-child re-enter) must reset
+      // any unrecovered gate state before evaluating the new drag.
+      if (depth.current === 0) {
+        gate.reset()
+      }
 
-      if (!kind) {
+      if (!enabled || !gate.onEnter(event.dataTransfer)) {
         return
       }
 
@@ -87,34 +95,35 @@ export function useFileDropZone({ enabled = true, onDropFiles }: FileDropZoneOpt
       }
 
       depth.current += 1
-      setDragKind(kind)
+      setDragKind('files')
     },
-    [enabled]
+    [enabled, gate]
   )
 
   const onDragOver = useCallback(
     (event: ReactDragEvent) => {
-      if (!enabled || !dragKindOf(event)) {
+      if (!enabled || !gate.onOver(event.dataTransfer)) {
         return
       }
 
       event.preventDefault()
       event.dataTransfer.dropEffect = 'copy'
     },
-    [enabled]
+    [enabled, gate]
   )
 
   const onDragLeave = useCallback(() => {
     if (enabled && --depth.current <= 0) {
+      gate.onLeave(true)
       reset()
+    } else {
+      gate.onLeave(false)
     }
-  }, [enabled, reset])
+  }, [enabled, gate, reset])
 
   const onDrop = useCallback(
     (event: ReactDragEvent) => {
-      const kind = enabled ? dragKindOf(event) : null
-
-      if (!kind) {
+      if (!enabled || !gate.onOver(event.dataTransfer)) {
         return
       }
 
@@ -138,7 +147,7 @@ export function useFileDropZone({ enabled = true, onDropFiles }: FileDropZoneOpt
         onDropFiles(files)
       }
     },
-    [enabled, onDropFiles, reset]
+    [enabled, gate, onDropFiles, reset]
   )
 
   return {

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -29,7 +29,8 @@ import { useComposerUndo } from '@/app/chat/composer/hooks/use-composer-undo'
 import { useEmojiCompletions } from '@/app/chat/composer/hooks/use-emoji-completions'
 import { useSlashCompletions } from '@/app/chat/composer/hooks/use-slash-completions'
 import {
-  dragHasAttachments,
+  createDragLifecycleGate,
+  type DragLifecycleGate,
   droppedFileInlineRefs,
   type InlineRefInput,
   insertInlineRefsIntoEditor
@@ -98,6 +99,16 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const draftRef = useRef(draft)
   const composingRef = useRef(false)
   const dragDepthRef = useRef(0)
+  // One stateful gate per edit composer. See inline-refs.createDragLifecycleGate
+  // for the #97702 Windows-sparse-drag rationale; an external Explorer drag
+  // exposes empty types/items on dragenter until the drop fires, and a static
+  // predicate would either blank-accept or fail to keep dropEffect=copy alive.
+  const dragGateRef = useRef<DragLifecycleGate | null>(null)
+
+  const dragGate =
+    dragGateRef.current ??
+    (dragGateRef.current = createDragLifecycleGate(HERMES_PATHS_MIME))
+
   const [dragActive, setDragActive] = useState(false)
   const [trigger, setTrigger] = useState<TriggerState | null>(null)
   const [triggerActive, setTriggerActive] = useState(0)
@@ -487,11 +498,18 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
 
   const resetDragState = useCallback(() => {
     dragDepthRef.current = 0
+    dragGate.reset()
     setDragActive(false)
-  }, [])
+  }, [dragGate])
 
   const handleDragEnter = (event: ReactDragEvent<HTMLElement>) => {
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    // A genuinely new drag (not a nested-child re-enter) must reset
+    // any unrecovered gate state before evaluating the new drag.
+    if (dragDepthRef.current === 0) {
+      dragGate.reset()
+    }
+
+    if (!dragGate.onEnter(event.dataTransfer)) {
       return
     }
 
@@ -504,7 +522,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   }
 
   const handleDragOver = (event: ReactDragEvent<HTMLElement>) => {
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    if (!dragGate.onOver(event.dataTransfer)) {
       return
     }
 
@@ -517,12 +535,15 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
 
     if (dragDepthRef.current === 0) {
+      dragGate.onLeave(true)
       setDragActive(false)
+    } else {
+      dragGate.onLeave(false)
     }
   }
 
   const handleDrop = (event: ReactDragEvent<HTMLElement>) => {
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    if (!dragGate.onOver(event.dataTransfer)) {
       return
     }
 


### PR DESCRIPTION
## What does this PR do?

Restores desktop file drag-and-drop from Windows Explorer by handling Chromium's sparse external drag lifecycle without weakening final attachment validation.



### Root cause

Windows Explorer can expose an empty `DataTransfer.types`/`items` collection during `dragenter` and `dragover`, then populate `DataTransfer.files` only for `drop`. The desktop composer previously treated those sparse hover events as non-file drags and returned without calling `preventDefault()`.

Because the app-lifetime `react-dnd` HTML5 backend also observes the drag, the unclaimed hover was assigned `dropEffect = "none"`. Chromium then suppressed the native `drop`, so the existing file extraction path never ran even though it can process the populated files correctly.

### Fix

- add a stateful drag-lifecycle gate that provisionally claims sparse external hover events
- preserve the strict attachment classifier for all normal detection paths
- revalidate the actual payload on `drop` before accepting any attachment
- apply the same lifecycle behavior to the main composer and user-edit composer
- keep the app-lifetime HTML5 backend and sidebar drag-and-drop behavior unchanged
- add regression coverage for sparse Windows-style hover events, lifecycle reset, normal file drops, rejected non-file drops, and the drop-zone integration

### Duplicate analysis

Searched open/closed PRs and related drag-and-drop issues before implementation. No existing PR for #97702 or equivalent sparse-hover lifecycle fix was found. #66546 concerns a distinct post-drop Explorer image preview/base64 freeze; other nearby reports concern queued-prompt reordering, upload/path handling, or post-drop rendering.

### Risk and mitigation

A sparse hover is provisional because Chromium has not exposed the payload yet. The gate is limited to an active drag lifecycle, resets on leave/drop, and never turns an empty payload into an attachment by itself. The final `drop` must still contain candidates accepted by the existing strict file/path validation.

## Related Issue

Fixes #97702

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or updating tests)
- [ ] Refactor (no functional changes)
- [ ] New skill or feature skill

## Changes Made

- Introduced reusable sparse external-drag detection and lifecycle gating in the composer attachment utilities.
- Wired the gate into both drop-zone and composer-level handlers.
- Added behavior-focused unit and React integration tests for the Windows Explorer regression.
- Avoided changing React DnD ownership or duplicating attachment extraction logic.

## How to Test

From the repository root:

```bash
npm ci
npm --workspace apps/desktop exec -- vitest run \
  src/app/chat/composer/inline-refs.test.ts \
  src/app/chat/hooks/use-file-drop-zone.test.tsx
npm --workspace apps/desktop run typecheck
npm --workspace apps/desktop run lint
npm --workspace apps/desktop run build
```

Optional manual Windows verification:

1. Open the desktop app on Windows.
2. Drag a supported file from Windows Explorer over the main composer.
3. Confirm the drop overlay appears and the cursor permits copying.
4. Drop the file and confirm it becomes an attachment.
5. Repeat in the user-message edit composer.
6. Confirm sidebar/internal React DnD interactions still work.

Validation performed on a Windows host:

- focused Vitest regression suite: **25 passed** across 2 files
- desktop TypeScript typecheck: **passed**
- desktop ESLint: **passed** (pre-existing unrelated warnings only)
- desktop production build: **passed**
- complete desktop Vitest run: **802 files passed, 17 files failed**; the remaining failures are unrelated existing host/environment expectations (including locale formatting and a spaced Git executable path), not failures in the changed attachment tests

No manual packaged-app Explorer E2E is claimed here.

## Checklist

### Code

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for duplicate PRs/issues before submitting
- [x] This PR contains only changes related to the issue
- [ ] I ran `pytest` and all tests pass — N/A: desktop-only TypeScript change; JavaScript validation is documented above
- [x] I added or updated tests for the changed behavior
- [x] I tested on the relevant host platform (Windows automated validation; manual packaged-app Explorer E2E not claimed)

### Documentation & Housekeeping

- [x] Documentation updated, or N/A for this change
- [x] CLI/config reference updated, or N/A for this change
- [x] Contributing/AGENTS guidance updated, or N/A for this change
- [x] Cross-platform behavior considered, or N/A for this change
- [x] Tool schemas updated, or N/A for this change

## Screenshots / Logs

The focused regression suite exercises the sparse Windows-style sequence directly:

```text
Test Files  2 passed (2)
Tests       25 passed (25)
```
