### PR TITLE
fix(delegation): size child context files by model window

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -147,6 +147,97 @@ class TestChildSystemPrompt(unittest.TestCase):
         self.assertIn("YOUR TASK", prompt)
         self.assertNotIn("CONTEXT", prompt)
 
+    @patch("agent.prompt_builder.build_context_files_prompt")
+    def test_forwards_explicit_context_length(self, mock_context_prompt):
+        mock_context_prompt.return_value = "project conventions"
+
+        prompt = _build_child_system_prompt(
+            "Fix the tests",
+            workspace_path="/tmp/workspace",
+            context_length=131072,
+        )
+
+        mock_context_prompt.assert_called_once_with(
+            cwd="/tmp/workspace", skip_soul=True, context_length=131072
+        )
+        self.assertIn("project conventions", prompt)
+
+
+class TestChildPromptContextLength(unittest.TestCase):
+    def _build_with_context_length(self, compressor_length, metadata_result=None, metadata_error=None):
+        parent = _make_mock_parent()
+        child = MagicMock()
+        child.context_compressor.context_length = compressor_length
+
+        def construct_child(**kwargs):
+            self.assertNotIn("project-context-", kwargs["ephemeral_system_prompt"])
+            return child
+
+        metadata = MagicMock()
+        if metadata_error is not None:
+            metadata.side_effect = metadata_error
+        else:
+            metadata.return_value = metadata_result
+
+        with (
+            patch("tools.delegate_tool._resolve_workspace_hint", return_value="/tmp/workspace"),
+            patch("run_agent.AIAgent", side_effect=construct_child),
+            patch(
+                "agent.prompt_builder.build_context_files_prompt",
+                side_effect=lambda **kwargs: f"project-context-{kwargs['context_length']}",
+            ) as context_prompt,
+            patch("agent.model_metadata.get_model_context_length", metadata),
+        ):
+            result = _build_child_agent(
+                task_index=0,
+                goal="test",
+                context=None,
+                toolsets=None,
+                model="delegated-model",
+                max_iterations=5,
+                parent_agent=parent,
+                task_count=1,
+                override_provider="delegated-provider",
+                override_base_url="https://delegated.example/v1",
+                override_api_key="delegated-key",
+            )
+
+        return result, context_prompt, metadata
+
+    def test_prefers_valid_child_compressor_context_length(self):
+        child, context_prompt, metadata = self._build_with_context_length(262144)
+
+        self.assertIn("project-context-262144", child.ephemeral_system_prompt)
+        context_prompt.assert_called_once_with(
+            cwd="/tmp/workspace", skip_soul=True, context_length=262144
+        )
+        metadata.assert_not_called()
+
+    def test_invalid_child_compressor_falls_back_to_delegated_model_metadata(self):
+        child, context_prompt, metadata = self._build_with_context_length(0, 131072)
+
+        self.assertIn("project-context-131072", child.ephemeral_system_prompt)
+        context_prompt.assert_called_once_with(
+            cwd="/tmp/workspace", skip_soul=True, context_length=131072
+        )
+        metadata.assert_called_once_with(
+            "delegated-model",
+            base_url="https://delegated.example/v1",
+            api_key="delegated-key",
+            provider="delegated-provider",
+        )
+
+    def test_metadata_failure_preserves_none_best_effort_fallback(self):
+        child, context_prompt, metadata = self._build_with_context_length(
+            None, metadata_error=RuntimeError("metadata unavailable")
+        )
+
+        self.assertIn("project-context-None", child.ephemeral_system_prompt)
+        context_prompt.assert_called_once_with(
+            cwd="/tmp/workspace", skip_soul=True, context_length=None
+        )
+        metadata.assert_called_once()
+
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
         result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1175,6 +1175,7 @@ def _build_child_system_prompt(
     context: Optional[str] = None,
     *,
     workspace_path: Optional[str] = None,
+    context_length: Optional[int] = None,
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
@@ -1215,7 +1216,9 @@ def _build_child_system_prompt(
             from agent.prompt_builder import build_context_files_prompt
 
             _ctx_files = build_context_files_prompt(
-                cwd=str(workspace_path), skip_soul=True
+                cwd=str(workspace_path),
+                skip_soul=True,
+                context_length=context_length,
             )
         except Exception:
             logger.debug(
@@ -1274,6 +1277,38 @@ def _build_child_system_prompt(
             f"is capped at max_spawn_depth={max_spawn_depth}. {child_note}"
         )
     return "\n".join(parts)
+
+
+def _resolve_child_prompt_context_length(
+    child: Any,
+    *,
+    model: str,
+    provider: Optional[str],
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> Optional[int]:
+    """Best-effort resolve the context window used for child project files."""
+    compressor = getattr(child, "context_compressor", None)
+    compressor_length = getattr(compressor, "context_length", None)
+    if type(compressor_length) is int and compressor_length > 0:
+        return compressor_length
+
+    try:
+        from agent.model_metadata import get_model_context_length
+
+        metadata_length = get_model_context_length(
+            model,
+            base_url=base_url or "",
+            api_key=api_key or "",
+            provider=provider or "",
+        )
+        if type(metadata_length) is int and metadata_length > 0:
+            return metadata_length
+    except Exception:
+        logger.debug(
+            "subagent: child prompt context-length resolution failed", exc_info=True
+        )
+    return None
 
 
 def _resolve_workspace_hint(parent_agent) -> Optional[str]:
@@ -1728,10 +1763,11 @@ def _build_child_agent(
         child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
+    # Bootstrap construction with only role/task semantics. Workspace context
+    # is loaded once, after AIAgent has resolved the child's actual window.
     child_prompt = _build_child_system_prompt(
         goal,
         context,
-        workspace_path=workspace_hint,
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
@@ -2013,6 +2049,26 @@ def _build_child_agent(
                 except Exception:
                     pass
             raise
+    child_prompt_context_length = _resolve_child_prompt_context_length(
+        child,
+        model=effective_model,
+        provider=effective_provider,
+        base_url=effective_base_url,
+        api_key=effective_api_key,
+    )
+    setattr(
+        child,
+        "ephemeral_system_prompt",
+        _build_child_system_prompt(
+            goal,
+            context,
+            workspace_path=workspace_hint,
+            context_length=child_prompt_context_length,
+            role=effective_role,
+            max_spawn_depth=max_spawn,
+            child_depth=child_depth,
+        ),
+    )
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     # Ownership transfer for the dedicated handle: the child's close() must
     # release it (nothing else holds a reference), and no parent teardown can


### PR DESCRIPTION
## Summary
- propagate the delegated child model context window into project context-file loading
- prefer the constructed child compressor window, with best-effort delegated-model metadata fallback
- keep workspace context loading one-shot and preserve the existing `None`/exception fallback

## Test plan
- `scripts/run_tests.sh tests/tools/test_delegate.py -q` (74 passed)

## TDD receipt
- RED: 4 new focused regressions failed before the implementation
- GREEN: the focused regressions and the complete delegate test file pass