### PR TITLE
fix(desktop): surface persistent group holds

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -72,6 +72,7 @@ import {
 import type { GroupChatRoom } from './group-chat'
 import { GroupClarifyCard, GroupImageControls, GroupMentionInput } from './group-chat-parts'
 import type { GroupRoomPrompt } from './group-chat-parts'
+import { GroupHoldStatus } from './group-hold-status'
 import {
   botGroups,
   groupChatMemberBots,
@@ -1233,6 +1234,11 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
         </div>
       ) : null}
       {header}
+      <GroupHoldStatus
+        holds={room.holds}
+        memberLabel={member => displayName(member, botRosterMeta(member, allMeta))}
+        members={members}
+      />
       {activityPanel}
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
         <div className="grid gap-1.5 px-2.5 pb-2">

--- a/apps/desktop/src/plugins/hermes-bots/group-hold-status.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-hold-status.test.tsx
@@ -1,0 +1,166 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { translateBots } from './i18n-test-helper'
+import type { GroupMember } from './types'
+
+const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+  const base = await pluginSdkMock(host)
+
+  return {
+    ...base,
+    Button: (props: React.ComponentProps<'button'>) => <button type="button" {...props} />,
+    cn: (...values: unknown[]) => values.filter(Boolean).join(' '),
+    Codicon: ({ name }: { name: string }) => <span aria-hidden data-icon={name} />,
+    ConfirmDialog: () => null,
+    CopyButton: () => null,
+    Dialog: () => null,
+    DialogContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogDescription: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogFooter: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogHeader: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogTitle: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+    relativeTime: () => 'now',
+    RowButton: (props: React.ComponentProps<'button'>) => <button type="button" {...props} />,
+    Tip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    useI18n: () => ({ t: { common: { cancel: 'Cancel', save: 'Save' } } }),
+    usePluginI18n: () => translateBots
+  }
+})
+
+vi.mock('./group-chat-parts', () => ({
+  GroupClarifyCard: () => null,
+  GroupImageControls: () => null,
+  GroupMentionInput: (props: { 'aria-label'?: string }) => <textarea aria-label={props['aria-label']} />
+}))
+
+const MEMBERS: GroupMember[] = [
+  { name: 'research', title: 'Research' },
+  { name: 'builder', title: 'Builder' }
+]
+
+beforeEach(() => {
+  vi.resetModules()
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn()
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('durable group holds', () => {
+  it('shows an accessible all-members status without relying on the activity feed', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ builder: { at: 2 }, research: { at: 1 } }}
+        memberLabel={member => member.title || member.name}
+        members={MEMBERS}
+      />
+    )
+
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('All 2 bots are paused')
+    expect(status.textContent).toContain('Mention a paused bot or send @all resume to release them.')
+    expect(status.querySelector('[data-icon="debug-pause"]')).not.toBeNull()
+  })
+
+  it('keeps unmatched holds visible instead of reporting all current members held', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ builder: { at: 1 }, 'mac-mini::research': { at: 2 } }}
+        memberLabel={member => member.title || member.name}
+        members={[{ name: 'builder', title: 'Builder' }]}
+      />
+    )
+
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('Paused:')
+    expect(status.textContent).toContain('Builder')
+    expect(status.textContent).toContain('research')
+    expect(status.textContent).not.toContain('All 1 bots are paused')
+  })
+
+  it('names a partial hold and disappears after the production resume directive clears it', async () => {
+    const [{ GroupHoldStatus }, { applyGroupHoldDirective }] = await Promise.all([
+      import('./group-hold-status'),
+      import('./group-rounds')
+    ])
+
+    const held = { builder: { at: 2 } }
+
+    const view = render(
+      <GroupHoldStatus holds={held} memberLabel={member => member.title || member.name} members={MEMBERS} />
+    )
+
+    expect(screen.getByRole('status').textContent).toContain('Paused: Builder')
+
+    const released = applyGroupHoldDirective(held, { everyone: true, mentioned: [] }, '@all resume', {})
+    view.rerender(
+      <GroupHoldStatus holds={released} memberLabel={member => member.title || member.name} members={MEMBERS} />
+    )
+
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('keeps a persisted source-scoped hold visible while its roster row is unavailable', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ 'mac-mini::builder': { at: 2 } }}
+        memberLabel={member => member.title || member.name}
+        members={[]}
+      />
+    )
+
+    expect(screen.getByRole('status').textContent).toContain('Paused: builder')
+  })
+
+  it('source-qualifies same-named holds whose roster rows are unavailable', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ 'mac-mini::builder': { at: 1 }, 'laptop::builder': { at: 2 } }}
+        memberLabel={member => member.title || member.name}
+        members={[]}
+      />
+    )
+
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('builder (mac-mini)')
+    expect(status.textContent).toContain('builder (laptop)')
+  })
+
+  it('projects hydrated holds into the real group workspace', async () => {
+    const [{ GroupChatWorkspace }, chat] = await Promise.all([import('./group-chat-view'), import('./group-chat')])
+
+    chat.$groupChats.set({
+      Core: {
+        holds: { research: { at: 1 } },
+        log: [],
+        members: MEMBERS,
+        watermarks: {}
+      }
+    })
+
+    render(<GroupChatWorkspace group="Core" members={MEMBERS} />)
+
+    expect(screen.getByRole('status').textContent).toContain('Paused: Research')
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-hold-status.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-hold-status.tsx
@@ -1,0 +1,60 @@
+import { Codicon } from '@hermes/plugin-sdk'
+
+import { groupMemberKey } from './group-membership'
+import { useBots } from './i18n'
+import type { GroupHold, GroupMember } from './types'
+
+interface GroupHoldStatusProps {
+  holds?: Record<string, GroupHold>
+  memberLabel: (member: GroupMember) => string
+  members: GroupMember[]
+}
+
+/** Durable room-level explanation for sticky Stop holds. Activity is scoped to
+ * one run and disappears across epochs/reloads; this status reads the room's
+ * persisted hold map instead. */
+export function GroupHoldStatus(props: GroupHoldStatusProps) {
+  const b = useBots()
+  const held = new Set(Object.keys(props.holds || {}))
+  const memberKeys = new Set(props.members.map(groupMemberKey))
+  const heldMembers = props.members.filter(member => held.has(groupMemberKey(member)))
+
+  const unavailableHeldLabels = [...held]
+    .filter(key => !memberKeys.has(key))
+    .map(key => {
+      const [source, name] = key.split('::')
+
+      return source && name ? `${name} (${source})` : key
+    })
+
+  const heldLabels = [...heldMembers.map(props.memberLabel), ...unavailableHeldLabels]
+
+  const allHeld =
+    props.members.length > 0 &&
+    unavailableHeldLabels.length === 0 &&
+    props.members.every(member => held.has(groupMemberKey(member)))
+
+  const label = allHeld
+    ? b.group.allHeldStatus(props.members.length)
+    : heldLabels.length
+      ? b.group.heldMembersStatus(heldLabels.join(', '))
+      : null
+
+  if (!label) {
+    return null
+  }
+
+  return (
+    <div
+      className="flex items-start gap-1.5 border-b border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary) px-2.5 py-1.5 text-[0.7rem]"
+      data-slot="group-hold-status"
+      role="status"
+    >
+      <Codicon aria-hidden className="mt-0.5 shrink-0 text-(--ui-text-secondary)" name="debug-pause" />
+      <div className="min-w-0">
+        <div className="font-medium text-(--ui-text-primary)">{label}</div>
+        <div className="text-(--ui-text-tertiary)">{b.group.holdReleaseHint}</div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -156,6 +156,9 @@ type BotsMessages = {
     hideActivity: string
     stop: string
     stopHint: string
+    allHeldStatus: (count: number) => string
+    heldMembersStatus: (members: string) => string
+    holdReleaseHint: string
     needsYourInput: string
     pictureGenerationFailed: string
     nameTaken: (name: string) => string
@@ -354,6 +357,9 @@ const en: BotsMessages = {
     hideActivity: 'Hide room activity',
     stop: 'Stop',
     stopHint: 'Stop this run — interrupts the member on turn and holds the rest',
+    allHeldStatus: count => `All ${count} bots are paused`,
+    heldMembersStatus: members => `Paused: ${members}`,
+    holdReleaseHint: 'Mention a paused bot or send @all resume to release them.',
     needsYourInput: 'A bot in this group chat needs your input',
     pictureGenerationFailed: 'Group picture generation failed',
     nameTaken: name => `A group named “${name}” already exists.`,
@@ -545,6 +551,9 @@ const ja: BotsMessages = {
     hideActivity: '部屋のアクティビティを隠す',
     stop: '停止',
     stopHint: 'この実行を停止 — ターン中のメンバーを中断し、残りを保留します',
+    allHeldStatus: count => `すべてのボット（${count}体）が一時停止中`,
+    heldMembersStatus: members => `一時停止中: ${members}`,
+    holdReleaseHint: '一時停止中のボットにメンションするか、@all resume を送信して再開します。',
     needsYourInput: 'このグループチャットのボットが入力を待っています',
     pictureGenerationFailed: 'グループ画像の生成に失敗しました',
     nameTaken: name => `「${name}」という名前のグループはすでに存在します。`,
@@ -735,6 +744,9 @@ const zh: BotsMessages = {
     hideActivity: '隐藏房间活动',
     stop: '停止',
     stopHint: '停止本次运行 — 中断当前回合的成员，并暂停其余成员',
+    allHeldStatus: count => `全部 ${count} 个机器人已暂停`,
+    heldMembersStatus: members => `已暂停：${members}`,
+    holdReleaseHint: '提及已暂停的机器人，或发送 @all resume 以恢复它们。',
     needsYourInput: '此群聊中有机器人需要你输入',
     pictureGenerationFailed: '群组图片生成失败',
     nameTaken: name => `已存在名为“${name}”的群聊。`,
@@ -925,6 +937,9 @@ const zhHant: BotsMessages = {
     hideActivity: '隱藏房間活動',
     stop: '停止',
     stopHint: '停止本次執行 — 中斷目前回合的成員，並暫停其餘成員',
+    allHeldStatus: count => `全部 ${count} 個機器人已暫停`,
+    heldMembersStatus: members => `已暫停：${members}`,
+    holdReleaseHint: '提及已暫停的機器人，或傳送 @all resume 以恢復它們。',
     needsYourInput: '此群組聊天中有機器人需要您的輸入',
     pictureGenerationFailed: '群組圖片產生失敗',
     nameTaken: name => `已存在名為「${name}」的群組聊天。`,


### PR DESCRIPTION
## What does this PR do?

Sticky Group Chat Stop holds intentionally survive later turns and app reloads, but the Activity feed is run/epoch-scoped. That lifetime mismatch can reopen a room with every bot silently paused and no durable explanation.

This PR projects the canonical `room.holds` map into a persistent, accessible status row in the real Group Chat workspace. It names partially held bots, summarizes an all-held room, and explains the existing release gestures (`@member` or `@all resume`) without changing hold authority or mutation semantics.

## Related Issue

Fixes #97740

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `GroupHoldStatus`, a flat room-level status derived only from persisted holds.
- Distinguish all-members holds from partial holds and retain a readable fallback for source-qualified keys while roster data is unavailable.
- Add release guidance plus English, Japanese, Simplified Chinese, and Traditional Chinese copy.
- Wire the status between the Group Chat header and run-scoped Activity panel.
- Add component, canonical-resume, source-scoped hydration-shape, and real-workspace regression coverage.

## How to Test

1. Create a Group Chat with at least two bots.
2. Send `@all stop`; confirm the room shows that all bots are paused and explains `@all resume`.
3. Reopen/reload the room; confirm the status remains even though old Activity entries do not.
4. Send `@all resume` or mention a paused bot; confirm the status clears through the existing hold directive.

Automated verification on Windows 11:

- `npm run test:ui -- src/plugins/hermes-bots/group-hold-status.test.tsx src/plugins/hermes-bots/group-rounds.test.ts src/plugins/hermes-bots/group-activity.test.ts src/plugins/hermes-bots/group-chat-view.test.ts` — **68 passed**
- `npm run test:ui -- src/plugins/hermes-bots` — **562 passed**
- `npm run check:lint` — **passed** (0 errors; existing repository warnings are outside changed files)
- `npm run build` — **passed**, including renderer, Electron main/preload, native staging, and dist assertion
- Regression sabotage: removing the workspace projection makes the selected test fail with no accessible `status`; restoring it passes

Full renderer disclosure (`npm run test:ui`, default parallelism):

- Final candidate: **6,719 passed, 9 failed**
- Clean `origin/main@aff5125f`: **6,714 passed, 8 failed**
- Every failure is in the same three unrelated files; the candidate's one additional failure is a timeout in the already baseline-failing `MessagingView` file, not a new failing file
- Those three files pass **12/12** together in isolation on the final candidate

Desktop platform disclosure (`npm run test:desktop:platforms` on Windows):

- Candidate: **1,909 passed, 46 failed**
- Clean `origin/main@aff5125f`: **1,908 passed, 47 failed**
- Every candidate failure is also present on baseline, in untouched POSIX/macOS filesystem/path-emulation or temporary-repository tests

Neither full-suite result is reported as green; both comparisons show no new failure from this renderer-only diff.

## Risk and Scope

Presentation-only. This PR does not change hold classification, persistence, release, routing, orchestration, or Activity retention. Removing `GroupHoldStatus` reverts the UI behavior.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop TypeScript-only change; relevant gates are listed above
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 x64

### Documentation & Housekeeping

- [x] Documentation update — N/A; no public API or configuration changed
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; renderer-only React/TypeScript with no platform branch
- [x] Tool descriptions/schemas update — N/A; no tool behavior changed

## Screenshots / Logs

No screenshot is attached: the isolated Windows Desktop E2E sandbox exceeded its existing 90-second `beforeAll` boot ceiling before the visual test body ran, so no synthetic screenshot was substituted. The production build and real-workspace DOM regression both pass as documented above.
