### PR TITLE
fix(desktop): merge todo patches instead of replacing the Tasks list

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
@@ -22,6 +22,22 @@ describe('ComposerStatusStack collapsed todo indicator', () => {
     $todosBySession.set({})
   })
 
+  it('shows a running indicator while the todo group is expanded', () => {
+    $todosBySession.set({
+      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]
+    })
+
+    render(
+      <MemoryRouter>
+        <ComposerStatusStack queue={null} sessionId="session-1" />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Wire the status stack')).toBeTruthy()
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
+    expect(screen.getByText('Tasks 0/1')).toBeTruthy()
+  })
+
   it('shows a running indicator next to the collapsed todo label', () => {
     $todosBySession.set({
       'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,12 +23,12 @@ import {
   generatedImageEchoSources,
   stripGeneratedImageEchoes
 } from '@/lib/generated-images'
-import { parseTodos } from '@/lib/todos'
+import { nextTodosFromToolEvent } from '@/lib/todos'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { upsertSubagent } from '@/store/subagents'
-import { setSessionTodos } from '@/store/todos'
+import { $todosBySession, setSessionTodos } from '@/store/todos'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -462,7 +462,7 @@ export function useMessageStream({
       // The composer status stack owns todo display now (no inline panel) —
       // mirror every todo state the tool reports into its session store.
       if (payload?.name === 'todo') {
-        const todos = parseTodos(payload.todos) ?? parseTodos(payload.result) ?? parseTodos(payload.args)
+        const todos = nextTodosFromToolEvent($todosBySession.get()[sessionId] ?? [], payload)
 
         if (todos) {
           setSessionTodos(sessionId, todos)

--- a/apps/desktop/src/components/chat/status-section.tsx
+++ b/apps/desktop/src/components/chat/status-section.tsx
@@ -7,7 +7,7 @@ interface StatusSectionProps {
    *  `Button` with `size="micro"` + `variant="text"` or `"link"`. */
   accessory?: ReactNode
   children: ReactNode
-  /** Optional inline status shown only while the group is collapsed. */
+  /** Optional inline status next to the label (running spinner, etc). */
   collapsedIndicator?: ReactNode
   defaultCollapsed?: boolean
   /** Optional glyph between the caret and the label (e.g. a `Codicon`). */
@@ -42,7 +42,7 @@ export function StatusSection({
           <DisclosureCaret className="shrink-0" open={!collapsed} size="1em" />
           {icon && <span className="flex shrink-0 items-center">{icon}</span>}
           <span className="min-w-0 truncate">{label}</span>
-          {collapsed && collapsedIndicator && <span className="flex shrink-0 items-center">{collapsedIndicator}</span>}
+          {collapsedIndicator && <span className="flex shrink-0 items-center">{collapsedIndicator}</span>}
         </button>
         {accessory && <div className="flex shrink-0 items-center gap-1">{accessory}</div>}
       </div>

--- a/apps/desktop/src/lib/todos.test.ts
+++ b/apps/desktop/src/lib/todos.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { latestSessionTodos, parseTodos } from './todos'
+import { latestSessionTodos, mergeTodoItems, nextTodosFromToolEvent, parseTodoPatch, parseTodos } from './todos'
 
 describe('parseTodos', () => {
   it('parses todo arrays with valid ids, content, and statuses', () => {
@@ -76,5 +76,79 @@ describe('latestSessionTodos', () => {
   it('returns null when no todo tool calls exist', () => {
     expect(latestSessionTodos([{ parts: [{ type: 'text', text: 'hi' }] }])).toBeNull()
     expect(latestSessionTodos([])).toBeNull()
+  })
+})
+
+describe('mergeTodoItems', () => {
+  const list = [
+    { content: 'Fix C', id: 'c', status: 'in_progress' as const },
+    { content: 'Fix D', id: 'd', status: 'pending' as const },
+    { content: 'Fix A', id: 'a', status: 'pending' as const }
+  ]
+
+  it('updates status by id and keeps the rest of the list', () => {
+    expect(mergeTodoItems(list, [{ id: 'c', status: 'completed' }])).toEqual([
+      { content: 'Fix C', id: 'c', status: 'completed' },
+      { content: 'Fix D', id: 'd', status: 'pending' },
+      { content: 'Fix A', id: 'a', status: 'pending' }
+    ])
+  })
+
+  it('appends a new item and fills missing content', () => {
+    expect(mergeTodoItems(list, [{ id: 'v', status: 'pending' }])).toEqual([
+      ...list,
+      { content: '(no description)', id: 'v', status: 'pending' }
+    ])
+  })
+})
+
+describe('nextTodosFromToolEvent', () => {
+  const current = [
+    { content: 'Fix C', id: 'c', status: 'pending' as const },
+    { content: 'Fix D', id: 'd', status: 'pending' as const }
+  ]
+
+  it('replaces from the full tool result', () => {
+    expect(
+      nextTodosFromToolEvent(current, {
+        todos: [
+          { content: 'Fix C', id: 'c', status: 'completed' },
+          { content: 'Fix D', id: 'd', status: 'in_progress' }
+        ]
+      })
+    ).toEqual([
+      { content: 'Fix C', id: 'c', status: 'completed' },
+      { content: 'Fix D', id: 'd', status: 'in_progress' }
+    ])
+  })
+
+  it('merges a status-only start payload instead of replacing the list', () => {
+    expect(
+      nextTodosFromToolEvent(current, {
+        args: { merge: true, todos: [{ id: 'c', status: 'completed' }] }
+      })
+    ).toEqual([
+      { content: 'Fix C', id: 'c', status: 'completed' },
+      { content: 'Fix D', id: 'd', status: 'pending' }
+    ])
+  })
+
+  it('does not wipe the list when a merge payload has no usable items', () => {
+    expect(nextTodosFromToolEvent(current, { args: { merge: true, todos: [] } })).toBeNull()
+  })
+
+  it('still replaces when merge is off', () => {
+    expect(
+      nextTodosFromToolEvent(current, {
+        args: { todos: [{ content: 'Only this', id: 'c', status: 'completed' }] }
+      })
+    ).toEqual([{ content: 'Only this', id: 'c', status: 'completed' }])
+  })
+})
+
+describe('parseTodoPatch', () => {
+  it('keeps status-only items that parseTodos would drop', () => {
+    expect(parseTodos([{ id: 'c', status: 'completed' }])).toEqual([])
+    expect(parseTodoPatch([{ id: 'c', status: 'completed' }])).toEqual([{ id: 'c', status: 'completed' }])
   })
 })

--- a/apps/desktop/src/lib/todos.ts
+++ b/apps/desktop/src/lib/todos.ts
@@ -6,6 +6,14 @@ export interface TodoItem {
   status: TodoStatus
 }
 
+/** One item from a `merge: true` write. Content is optional so a status-only
+ *  patch still applies to an existing row. */
+export interface TodoPatch {
+  content?: string
+  id: string
+  status: TodoStatus
+}
+
 const STATUSES: readonly TodoStatus[] = ['pending', 'in_progress', 'completed', 'cancelled']
 
 const isRecord = (v: unknown): v is Record<string, unknown> => Boolean(v && typeof v === 'object' && !Array.isArray(v))
@@ -21,6 +29,24 @@ function parseArray(value: unknown[]): TodoItem[] {
     const content = String(item.content ?? '').trim()
 
     return id && content ? [{ content, id, status: item.status }] : []
+  })
+}
+
+function parsePatchArray(value: unknown[]): TodoPatch[] {
+  return value.flatMap(item => {
+    if (!isRecord(item) || !isStatus(item.status)) {
+      return []
+    }
+
+    const id = String(item.id ?? '').trim()
+
+    if (!id) {
+      return []
+    }
+
+    const content = String(item.content ?? '').trim()
+
+    return content ? [{ content, id, status: item.status }] : [{ id, status: item.status }]
   })
 }
 
@@ -49,6 +75,82 @@ function parse(value: unknown, depth: number): null | TodoItem[] {
 }
 
 export const parseTodos = (value: unknown): null | TodoItem[] => parse(value, 0)
+
+function parsePatch(value: unknown, depth: number): null | TodoPatch[] {
+  if (depth > 2) {
+    return null
+  }
+
+  if (Array.isArray(value)) {
+    return parsePatchArray(value)
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return parsePatch(JSON.parse(value), depth + 1)
+    } catch {
+      return null
+    }
+  }
+
+  if (isRecord(value) && Object.hasOwn(value, 'todos')) {
+    return parsePatch(value.todos, depth + 1)
+  }
+
+  return null
+}
+
+export const parseTodoPatch = (value: unknown): null | TodoPatch[] => parsePatch(value, 0)
+
+export const todoArgsWantMerge = (args: unknown): boolean => isRecord(args) && args.merge === true
+
+/** Same as TodoStore.write(merge=True): update by id, append new items. */
+export function mergeTodoItems(current: readonly TodoItem[], patch: readonly TodoPatch[]): TodoItem[] {
+  const next = current.map(item => ({ ...item }))
+  const indexById = new Map(next.map((item, index) => [item.id, index]))
+
+  for (const item of patch) {
+    const index = indexById.get(item.id)
+
+    if (index === undefined) {
+      next.push({ content: item.content?.trim() || '(no description)', id: item.id, status: item.status })
+      indexById.set(item.id, next.length - 1)
+      continue
+    }
+
+    if (item.content) {
+      next[index].content = item.content
+    }
+
+    next[index].status = item.status
+  }
+
+  return next
+}
+
+/** Live tool event to the next list. `payload.todos` / `result` is the full
+ *  store, so replace. `args` with `merge: true` patches by id so a status-only
+ *  start event does not wipe the rest of the checklist. */
+export function nextTodosFromToolEvent(
+  current: readonly TodoItem[],
+  payload: { args?: unknown; arguments?: unknown; result?: unknown; todos?: unknown }
+): null | TodoItem[] {
+  const fromResult = parseTodos(payload.todos) ?? parseTodos(payload.result)
+
+  if (fromResult) {
+    return fromResult
+  }
+
+  const args = payload.args ?? payload.arguments
+
+  if (todoArgsWantMerge(args)) {
+    const patch = parseTodoPatch(args)
+
+    return patch && patch.length > 0 ? mergeTodoItems(current, patch) : null
+  }
+
+  return parseTodos(args)
+}
 
 /** Latest parseable todo list from one message's aui content parts (tool-call
  *  parts named `todo`; live parts carry `todos`, hydrated ones args/result). */


### PR DESCRIPTION
## What does this PR do?

`todo` with `merge: true` updates items by id on the Python store. The desktop Tasks panel treated `tool.start` `args.todos` as a full replace. A one-item patch became `Tasks 1/1`. A status-only patch (id and status, no content) parsed to an empty list, so the panel vanished until `tool.complete` shipped the full store. The in-progress spinner also hid unless the group was collapsed, which made `Tasks 0/5` look stuck.

`tool.start` now merges by id when `args.merge` is true. Status-only items still apply. The full result still replaces. The running spinner sits next to the header while the list is open.

## Related Issue

Fixes #97810

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `apps/desktop/src/lib/todos.ts`: `nextTodosFromToolEvent` prefers the full result, then merges `args` by id when `merge: true`. Status-only patches keep existing content.
- `apps/desktop/src/app/session/hooks/use-message-stream/index.ts`: live `todo` events go through that helper.
- `apps/desktop/src/components/chat/status-section.tsx`: show the running indicator next to the header even when the group is expanded.
- `apps/desktop/src/lib/todos.test.ts` and `apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx`: merge, status-only patch, and expanded-header spinner.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. From `apps/desktop`: `npx vitest run src/lib/todos.test.ts src/app/chat/composer/status-stack/collapsed-indicator.test.tsx`
2. `nextTodosFromToolEvent` with a five-item current list and `args: { merge: true, todos: [{ id: "c", status: "completed" }] }` must return five items with `c` completed.
3. In the desktop app, a live `todo` merge that marks one item in_progress must keep the other rows and show the header spinner. Completing items must move `Tasks 0/5` to `1/5`, then `2/5`, not jump to `5/5` at the end.

Ran on Windows 11: 16 passed in that filter. Live-checked in the desktop client on this branch.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
On current main, merge:true start with [{id:"c", status:"completed"}]:
  parseTodos(args) -> []  (no content)
  panel replaced / cleared until tool.complete

With this PR:
  nextTodosFromToolEvent keeps the other rows and sets c to completed
```

```
=== Summary: 2 files, 16 tests passed, 0 failed ===
```
