### PR TITLE
fix(desktop): summarize multi-file patch cards

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -216,6 +216,143 @@ describe('buildToolView file edit diffs', () => {
     expect(view.subtitle).toBe('src/demo.ts')
     expect(view.detail).toBe('')
   })
+
+  it('extracts the filename from a pending single-file V4A patch', () => {
+    const patch = [
+      '\x2a\x2a\x2a Begin Patch',
+      '\x2a\x2a\x2a Update File: src/components/demo.ts',
+      '@@',
+      '-old',
+      '+new',
+      '\x2a\x2a\x2a End Patch'
+    ].join('\n')
+
+    const view = buildToolView(
+      part({ args: { mode: 'patch', patch }, result: undefined, toolName: 'patch' }),
+      patchDiff
+    )
+
+    expect(view.title).toBe('demo.ts')
+    expect(view.subtitle).toBe('src/components/demo.ts')
+  })
+
+  it('summarizes all files represented by a multi-file V4A patch', () => {
+    const patch = [
+      '\x2a\x2a\x2a Begin Patch',
+      '\x2a\x2a\x2a Update File: src/demo.ts',
+      '@@',
+      '-old',
+      '+new',
+      '\x2a\x2a\x2a Add File: tests/demo.test.ts',
+      '+test',
+      '\x2a\x2a\x2a End Patch'
+    ].join('\n')
+
+    const view = buildToolView(
+      part({ args: { mode: 'patch', patch }, result: undefined, toolName: 'patch' }),
+      patchDiff
+    )
+
+    expect(view.title).toBe('demo.ts +1 file')
+    expect(view.subtitle).toBe('src/demo.ts')
+  })
+
+  it('combines legacy completed patch result path categories', () => {
+    const view = buildToolView(
+      part({
+        args: { mode: 'patch' },
+        result: {
+          files_created: ['tests/demo.test.ts'],
+          files_deleted: ['src/legacy.ts'],
+          files_modified: ['src/demo.ts'],
+          success: true
+        },
+        toolName: 'patch'
+      }),
+      patchDiff
+    )
+
+    expect(view.title).toBe('demo.ts +2 files')
+    expect(view.subtitle).toBe('src/demo.ts')
+  })
+
+  it('localizes multi-file V4A patch counts', () => {
+    const patch = [
+      '\x2a\x2a\x2a Begin Patch',
+      '\x2a\x2a\x2a Update File: src/demo.ts',
+      '\x2a\x2a\x2a Add File: tests/demo.test.ts',
+      '+test',
+      '\x2a\x2a\x2a End Patch'
+    ].join('\n')
+
+    const title = (locale: 'ar' | 'en' | 'ja' | 'zh' | 'zh-hant') => {
+      setRuntimeI18nLocale(locale)
+
+      return buildToolView(part({ args: { mode: 'patch', patch }, result: undefined, toolName: 'patch' }), '').title
+    }
+
+    expect(title('en')).toBe('demo.ts +1 file')
+    expect(title('ar')).toBe('demo.ts +ملف واحد')
+    expect(title('ja')).toBe('demo.ts +1 ファイル')
+    expect(title('zh')).toBe('demo.ts +1 个文件')
+    expect(title('zh-hant')).toBe('demo.ts +1 個檔案')
+  })
+
+  it('ignores V4A-looking headers outside patch boundaries', () => {
+    const patch = [
+      '\x2a\x2a\x2a Update File: before.ts',
+      '\x2a\x2a\x2a Begin Patch',
+      '\x2a\x2a\x2a Update File: src/actual.ts',
+      '@@',
+      '-old',
+      '+new',
+      '\x2a\x2a\x2a End Patch',
+      '\x2a\x2a\x2a Add File: after.ts'
+    ].join('\n')
+
+    const view = buildToolView(part({ args: { mode: 'patch', patch }, result: undefined, toolName: 'patch' }), '')
+
+    expect(view.title).toBe('actual.ts')
+    expect(view.subtitle).toBe('src/actual.ts')
+  })
+
+  it('does not parse V4A-looking headers without a begin marker', () => {
+    const patch = '\x2a\x2a\x2a Update File: not-a-patch.ts'
+    const view = buildToolView(part({ args: { mode: 'patch', patch }, result: undefined, toolName: 'patch' }), '')
+
+    expect(view.title).not.toContain('not-a-patch.ts')
+    expect(view.subtitle).toBe('')
+  })
+
+  it('requires whole-line V4A boundaries', () => {
+    const prose = [
+      'Example prose: \x2a\x2a\x2a Begin Patch',
+      '\x2a\x2a\x2a Update File: decoy.ts'
+    ].join('\n')
+
+    const proseView = buildToolView(
+      part({ args: { mode: 'patch', patch: prose }, result: undefined, toolName: 'patch' }),
+      ''
+    )
+
+    const patch = [
+      '\x2a\x2a\x2a Begin Patch',
+      '\x2a\x2a\x2a Update File: docs/guide.md',
+      '+\x2a\x2a\x2a End Patch',
+      '\x2a\x2a\x2a Add File: tests/guide.test.ts',
+      '+test',
+      '\x2a\x2a\x2a End Patch'
+    ].join('\n')
+
+    const patchView = buildToolView(
+      part({ args: { mode: 'patch', patch }, result: undefined, toolName: 'patch' }),
+      ''
+    )
+
+    expect(proseView.title).not.toContain('decoy.ts')
+    expect(proseView.subtitle).toBe('')
+    expect(patchView.title).toBe('guide.md +1 file')
+  })
 })
 
 describe('buildToolView title actions', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -58,18 +58,104 @@ export function countDiffLineStats(diff: string): DiffLineStats {
   return { added, removed }
 }
 
-export function fileEditPath(args: Record<string, unknown>, result: Record<string, unknown>): string {
-  return (
-    firstStringField(args, ['path', 'file', 'filepath']) ||
-    firstStringField(result, ['path', 'file', 'filepath', 'resolved_path']) ||
-    htmlPathFromInlineDiff(firstStringField(result, ['inline_diff', 'diff']))
+function uniqueFilePaths(paths: string[]): string[] {
+  return Array.from(new Set(paths.map(path => path.trim()).filter(Boolean)))
+}
+
+function v4aFilePaths(patch: string): string[] {
+  if (!patch) {
+    return []
+  }
+
+  const paths: string[] = []
+  const lines = patch.split('\n')
+  const marker = String.fromCharCode(42).repeat(3)
+
+  const isBoundary = (line: string, label: 'Begin' | 'End') =>
+    line.replace(/\r$/, '') === `${marker} ${label} Patch`
+
+  const startIndex = lines.findIndex(line => isBoundary(line, 'Begin'))
+
+  if (startIndex < 0) {
+    return []
+  }
+
+  const relativeEndIndex = lines
+    .slice(startIndex + 1)
+    .findIndex(line => isBoundary(line, 'End'))
+
+  const endIndex = relativeEndIndex < 0 ? lines.length : startIndex + 1 + relativeEndIndex
+
+  for (const line of lines.slice(startIndex + 1, endIndex)) {
+    const file = /^\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*(.+?)\s*$/.exec(line)
+
+    if (file?.[1]) {
+      paths.push(file[1])
+
+      continue
+    }
+
+    const move = /^\*\*\*\s*Move\s+File:\s*(.+?)\s*->\s*(.+?)\s*$/.exec(line)
+
+    if (move?.[1] && move[2]) {
+      paths.push(move[1], move[2])
+    }
+  }
+
+  return uniqueFilePaths(paths)
+}
+
+function fileEditPaths(args: Record<string, unknown>, result: Record<string, unknown>): string[] {
+  const requestedPath = firstStringField(args, ['path', 'file', 'filepath'])
+
+  if (requestedPath) {
+    return [requestedPath]
+  }
+
+  const modifiedPaths = ['files_modified', 'files_created', 'files_deleted'].flatMap(key =>
+    Array.isArray(result[key]) ? result[key].filter((value): value is string => typeof value === 'string') : []
   )
+
+  if (modifiedPaths.length) {
+    return uniqueFilePaths(modifiedPaths)
+  }
+
+  const resolvedPath = firstStringField(result, ['path', 'file', 'filepath', 'resolved_path'])
+
+  if (resolvedPath) {
+    return [resolvedPath]
+  }
+
+  const patchPaths = v4aFilePaths(firstStringField(args, ['patch']))
+
+  if (patchPaths.length) {
+    return patchPaths
+  }
+
+  const diffPath = htmlPathFromInlineDiff(firstStringField(result, ['inline_diff', 'diff']))
+
+  return diffPath ? [diffPath] : []
+}
+
+export function fileEditPath(args: Record<string, unknown>, result: Record<string, unknown>): string {
+  return fileEditPaths(args, result)[0] || ''
 }
 
 export function fileEditBasename(path: string): string {
   const normalized = path.replace(/\\/g, '/').trim()
 
   return normalized.split('/').filter(Boolean).pop() || normalized
+}
+
+function fileEditTitle(paths: string[]): string {
+  const first = paths[0] ? fileEditBasename(paths[0]) : ''
+  const additional = paths.length - 1
+
+  if (!first || additional <= 0) {
+    return first
+  }
+
+  return `${first} ${translateNow('assistant.tool.titleTemplates.additionalFiles', additional)}`
 }
 
 function numericField(record: Record<string, unknown>, key: string): number | undefined {
@@ -1398,10 +1484,10 @@ function dynamicTitle(
   }
 
   if (isFileEditTool(part.toolName)) {
-    const path = fileEditPath(args, result)
+    const paths = fileEditPaths(args, result)
 
-    if (path) {
-      return { title: fileEditBasename(path) }
+    if (paths.length) {
+      return { title: fileEditTitle(paths) }
     }
   }
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2626,6 +2626,8 @@ export const ar = defineLocale({
         actionCommand: (action, command) => `${action} ${command}`,
         actionQuoted: (action, value) => `${action} “${value}”`,
         actionTarget: (action, target) => `${action} ${target}`,
+        additionalFiles: count =>
+          count === 1 ? '+ملف واحد' : count === 2 ? '+ملفان' : `+${count} ملفات`,
         prefixedDone: (prefix, action) => `${prefix} ${action}`,
         runningPrefixedTool: (prefix, action) => `جار تشغيل ${prefix.toLowerCase()} ${action.toLowerCase()}`,
         runningTool: action => `جار تشغيل ${action.toLowerCase()}`

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3332,6 +3332,7 @@ export const en: Translations = {
         actionCommand: (action, command) => `${action} ${command}`,
         actionQuoted: (action, value) => `${action} “${value}”`,
         actionTarget: (action, target) => `${action} ${target}`,
+        additionalFiles: count => `+${count} ${count === 1 ? 'file' : 'files'}`,
         prefixedDone: (prefix, action) => `${prefix} ${action}`,
         runningPrefixedTool: (prefix, action) => `Running ${prefix.toLowerCase()} ${action.toLowerCase()}`,
         runningTool: action => `Running ${action.toLowerCase()}`

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2933,6 +2933,7 @@ export const ja = defineLocale({
         actionCommand: (action, command) => `${action} ${command}`,
         actionQuoted: (action, value) => `「${value}」を${action}`,
         actionTarget: (action, target) => `${target} を${action}`,
+        additionalFiles: count => `+${count} ファイル`,
         prefixedDone: (prefix, action) => `${prefix} ${action}`,
         runningPrefixedTool: (prefix, action) => `${prefix} ${action}を実行中`,
         runningTool: action => `${action}を実行中`

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2892,6 +2892,7 @@ export interface Translations {
         actionCommand: (action: string, command: string) => string
         actionQuoted: (action: string, value: string) => string
         actionTarget: (action: string, target: string) => string
+        additionalFiles: (count: number) => string
         prefixedDone: (prefix: string, action: string) => string
         runningPrefixedTool: (prefix: string, action: string) => string
         runningTool: (action: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2837,6 +2837,7 @@ export const zhHant = defineLocale({
         actionCommand: (action, command) => `${action} ${command}`,
         actionQuoted: (action, value) => `${action}「${value}」`,
         actionTarget: (action, target) => `${action} ${target}`,
+        additionalFiles: count => `+${count} 個檔案`,
         prefixedDone: (prefix, action) => `${prefix}${action}`,
         runningPrefixedTool: (prefix, action) => `正在執行${prefix}${action}`,
         runningTool: action => `正在執行 ${action}`

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3489,6 +3489,7 @@ export const zh: Translations = {
         actionCommand: (action, command) => `${action} ${command}`,
         actionQuoted: (action, value) => `${action}“${value}”`,
         actionTarget: (action, target) => `${action} ${target}`,
+        additionalFiles: count => `+${count} 个文件`,
         prefixedDone: (prefix, action) => `${prefix}${action}`,
         runningPrefixedTool: (prefix, action) => `正在运行${prefix}${action}`,
         runningTool: action => `正在运行 ${action}`


### PR DESCRIPTION
## Summary

- show the first touched filename on pending V4A patch cards
- summarize additional files for multi-file pending and completed patches
- localize the additional-file count in all shipped Desktop locales
- ignore marker-looking prose outside a real `*** Begin Patch` boundary

## Problem

Desktop patch cards can render raw patch arguments or a generic label while a V4A patch is pending. Multi-file results also collapse to a single path, hiding the actual scope of the edit.

## Approach

The fallback model now collects unique paths from, in order:

1. an explicit single-file argument;
2. structured `files_modified` / `files_created` / `files_deleted` results;
3. a bounded V4A patch body;
4. the existing inline-diff fallback.

The visible title stays compact (`demo.ts +2 files`) while the subtitle retains the first full path. Existing single-file behavior is unchanged.

## Verification

- `npm --prefix apps/desktop run test:ui -- src/components/assistant-ui/tool/fallback-model.test.ts` — 42 passed
- full Desktop TypeScript typecheck passed
- scoped ESLint passed with 0 errors and 0 warnings
- regression sabotage: restoring substring boundary matching and English fallback makes the exact whole-line and Arabic tests fail; restoring the fix returns to 42 passed
- `git diff --check`

## Risk

UI presentation only. Patch execution and parsing are untouched. Missing or malformed boundaries fall back to the existing generic card instead of guessing filenames.
