### PR TITLE
fix(projects): report whether workspace moved

### DIFF
--- a/tests/tools/test_project_tools.py
+++ b/tests/tools/test_project_tools.py
@@ -1,0 +1,47 @@
+import json
+
+from hermes_cli import projects_db
+from tools import project_tools
+
+
+def test_project_create_without_path_reports_that_chat_was_not_moved(monkeypatch, tmp_path):
+    monkeypatch.setattr(projects_db, "projects_db_path", lambda: tmp_path / "projects.db")
+    callback_calls = []
+    project_tools.set_project_workspace_callback(lambda *args: callback_calls.append(args) or True)
+
+    result = json.loads(project_tools.project_create("Empty", task_id="session-1"))
+
+    assert result["success"] is True
+    assert result["moved"] is False
+    assert "not moved" in result["warning"].lower()
+    assert callback_calls == []
+
+
+def test_project_switch_to_empty_project_reports_that_chat_was_not_moved(monkeypatch, tmp_path):
+    monkeypatch.setattr(projects_db, "projects_db_path", lambda: tmp_path / "projects.db")
+    callback_calls = []
+    project_tools.set_project_workspace_callback(lambda *args: callback_calls.append(args) or True)
+    with projects_db.connect_closing() as conn:
+        projects_db.create_project(conn, name="Empty")
+
+    result = json.loads(project_tools.project_switch("empty", task_id="session-1"))
+
+    assert result["success"] is True
+    assert result["moved"] is False
+    assert "not moved" in result["warning"].lower()
+    assert callback_calls == []
+
+
+def test_project_create_reports_successful_workspace_move(monkeypatch, tmp_path):
+    monkeypatch.setattr(projects_db, "projects_db_path", lambda: tmp_path / "projects.db")
+    callback_calls = []
+    project_tools.set_project_workspace_callback(lambda *args: callback_calls.append(args) or True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    result = json.loads(project_tools.project_create("Anchored", path=str(workspace), task_id="session-1"))
+
+    assert result["success"] is True
+    assert result["moved"] is True
+    assert "warning" not in result
+    assert callback_calls == [("session-1", str(workspace), "Anchored")]

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -62,6 +62,23 @@ def test_methods_registered():
         assert m in server._methods
 
 
+def test_project_workspace_callback_reports_unknown_session_as_not_moved(tmp_path):
+    assert server._apply_project_workspace("missing-session", str(tmp_path)) is False
+
+
+def test_project_workspace_callback_skips_finalized_session_for_live_continuation(monkeypatch, tmp_path):
+    finalized = {"_finalized": True, "cwd": "/dead", "session_key": "shared-key"}
+    live = {"cwd": "/live", "session_key": "shared-key"}
+    monkeypatch.setattr(server, "_sessions", {"dead-sid": finalized, "live-sid": live})
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_session_cwd_and_schedule_git_meta", lambda _session, _cwd: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    assert server._apply_project_workspace("shared-key", str(tmp_path)) is True
+    assert finalized["cwd"] == "/dead"
+    assert live["cwd"] == str(tmp_path)
+
+
 def test_for_cwd_is_a_long_handler():
     # git-probe handler must run off the dispatch thread.
     assert "projects.for_cwd" in server._LONG_HANDLERS

--- a/tools/project_tools.py
+++ b/tools/project_tools.py
@@ -22,10 +22,10 @@ from tools.registry import registry
 # ``(task_id, primary_path, project_name)`` and re-anchors that session's
 # workspace + refreshes the sidebar. ``None`` in CLI / messaging contexts — the
 # DB write still happens; there's just no live GUI session to move.
-_workspace_callback: Optional[Callable[[str, str, str], None]] = None
+_workspace_callback: Optional[Callable[[str, str, str], Optional[bool]]] = None
 
 
-def set_project_workspace_callback(fn: Optional[Callable[[str, str, str], None]]) -> None:
+def set_project_workspace_callback(fn: Optional[Callable[[str, str, str], Optional[bool]]]) -> None:
     global _workspace_callback
     _workspace_callback = fn
 
@@ -39,13 +39,16 @@ def _primary_path(proj) -> Optional[str]:
     return proj.folders[0].path if proj.folders else None
 
 
-def _apply_workspace(task_id: Optional[str], path: Optional[str], name: str) -> None:
+def _apply_workspace(task_id: Optional[str], path: Optional[str], name: str) -> bool:
     cb = _workspace_callback
-    if cb and task_id and path:
-        try:
-            cb(task_id, path, name)
-        except Exception:
-            pass
+    if not (cb and task_id and path):
+        return False
+    try:
+        result = cb(task_id, path, name)
+        # Legacy callbacks returned None after successfully applying the move.
+        return result is not False
+    except Exception:
+        return False
 
 
 def _resolve(conn, token: str):
@@ -119,9 +122,22 @@ def project_create(name: str, path: Optional[str] = None, task_id: Optional[str]
         return json.dumps({"success": False, "error": "project vanished after create"})
 
     primary = _primary_path(proj)
-    _apply_workspace(task_id, primary, proj.name)
-
-    return json.dumps({"success": True, "id": proj.id, "slug": proj.slug, "name": proj.name, "primary_path": primary})
+    moved = _apply_workspace(task_id, primary, proj.name)
+    result = {
+        "success": True,
+        "id": proj.id,
+        "slug": proj.slug,
+        "name": proj.name,
+        "primary_path": primary,
+        "moved": moved,
+    }
+    if not moved:
+        result["warning"] = (
+            "Project created, but this chat was not moved because the project has no folder."
+            if not primary
+            else "Project created, but the live chat workspace could not be moved."
+        )
+    return json.dumps(result)
 
 
 def project_switch(project: str, task_id: Optional[str] = None) -> str:
@@ -134,9 +150,22 @@ def project_switch(project: str, task_id: Optional[str] = None) -> str:
         pdb.set_active(conn, proj.id)
 
     primary = _primary_path(proj)
-    _apply_workspace(task_id, primary, proj.name)
-
-    return json.dumps({"success": True, "id": proj.id, "slug": proj.slug, "name": proj.name, "primary_path": primary})
+    moved = _apply_workspace(task_id, primary, proj.name)
+    result = {
+        "success": True,
+        "id": proj.id,
+        "slug": proj.slug,
+        "name": proj.name,
+        "primary_path": primary,
+        "moved": moved,
+    }
+    if not moved:
+        result["warning"] = (
+            "Active project changed, but this chat was not moved because the project has no folder."
+            if not primary
+            else "Active project changed, but the live chat workspace could not be moved."
+        )
+    return json.dumps(result)
 
 
 def _handle_project(args, **kw):
@@ -150,7 +179,6 @@ def _handle_project(args, **kw):
         return project_switch(project=args.get("name", ""), task_id=tid)
     return json.dumps({"success": False, "error": "action must be one of: create, switch, list."})
 
-
 # Consolidated (#95681, maintainer-directed): project_list/create/switch each
 # re-taught "desktop Projects (named workspaces)"; one action enum says it
 # once (244 -> ~145 tok).
@@ -162,9 +190,11 @@ registry.register(
         "description": (
             "Desktop Projects (named workspaces). create: make one and switch "
             "this chat into it — pass path to anchor it to a repo/folder (the "
-            "chat's workspace moves there, the sidebar follows). switch: move "
+            "chat's workspace moves there, the sidebar follows); without path, "
+            "the project is empty and the chat cannot move. switch: move "
             "this chat into an existing project by name/slug/id — the "
-            "intentional way to move the session, not `cd`. list: all "
+            "intentional way to move the session, not `cd`; an empty project "
+            "cannot receive the chat. list: all "
             "projects + which is active."
         ),
         "parameters": {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8050,13 +8050,17 @@ def _agent_cbs(sid: str) -> dict:
     return callbacks
 
 
-def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
+def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> bool:
     """Intentional workspace move from the project_* tools: re-anchor the live
     session's cwd to the chosen project's folder and push session.info so the
     desktop follows (refresh tree + scope into the project). This is the ONLY
-    auto-cwd path — driven by an explicit tool call, never a terminal `cd`."""
+    auto-cwd path — driven by an explicit tool call, never a terminal `cd`.
+
+    Returns whether a live session was actually found and moved, so the calling
+    tool cannot mistake an active-project pointer update for session membership.
+    """
     if not path:
-        return
+        return False
 
     # The tool's task_id is the durable session_key, but _sessions is keyed by a
     # short sid uuid (and the desktop routes events by that sid). Resolve it.
@@ -8064,20 +8068,20 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
     sid = ""
     session = None
     with _sessions_lock:
-        if key in _sessions:
-            sid, session = key, _sessions[key]
+        direct = _sessions.get(key)
+        if direct is not None and not direct.get("_finalized"):
+            sid, session = key, direct
         else:
-            for cand_sid, cand in _sessions.items():
-                if cand.get("session_key") == key or getattr(cand.get("agent"), "session_id", None) == key:
-                    sid, session = cand_sid, cand
-                    break
+            found = _find_live_session_by_key(key)
+            if found is not None:
+                sid, session = found
 
     if session is None:
-        return
+        return False
 
     resolved = os.path.abspath(os.path.expanduser(str(path)))
     if not os.path.isdir(resolved):
-        return
+        return False
 
     session["cwd"] = resolved
     session["explicit_cwd"] = True
@@ -8102,6 +8106,8 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
         _emit("session.info", sid, info)
     except Exception:
         logger.debug("failed to emit session.info after project workspace move", exc_info=True)
+
+    return True
 
 
 def _wire_callbacks(sid: str):


### PR DESCRIPTION
## Summary

- report whether `desktop_project create` / `switch` actually moved the live chat workspace
- return `moved: false` plus a truthful warning for empty projects or unavailable sessions
- make the gateway workspace callback return its real outcome
- preserve legacy callbacks that return `None` after a successful move

## Problem

The project tools currently return success after updating the durable project DB even when the live chat cannot move—for example, an empty project has no folder, or the task no longer names a live gateway session. The caller can therefore claim that the chat moved when only the active-project pointer changed.

## Approach

The durable project operation remains successful. The response now distinguishes that from the live workspace side effect with a `moved` boolean and warning. The consolidated `desktop_project` description also states that empty projects cannot receive a chat.

## Verification

- `scripts/run_tests.sh -j 2 tests/tools/test_project_tools.py tests/tui_gateway/test_projects_rpc.py -q` — 36 passed
- regression sabotage: restoring the old project/gateway source makes the move-result tests fail; removing the finalized-session guard separately mutates the dead record and fails its regression test
- `python -m compileall -q tools/project_tools.py tui_gateway/server.py`
- `git diff --check`

## Risk

Backward-compatible response expansion: existing success/id/name/path fields remain. The only callback contract change is a boolean result from the built-in gateway callback; legacy `None` callbacks remain treated as successful.
