### PR TITLE
fix(todo): keep task state live across merges and reconnects

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1790,9 +1790,10 @@ def init_agent(
     except Exception:
         pass
     
-    # In-memory todo list for task planning (one per agent/session)
-    from tools.todo_tool import TodoStore
-    agent._todo_store = TodoStore()
+    # Session-scoped todo list. The active copy stays in memory for fast tool
+    # calls while revisioned snapshots persist through the existing state DB.
+    from tools.todo_tool import create_session_todo_store
+    agent._todo_store = create_session_todo_store(agent)
     
     # Load config once for memory, skills, and compression sections
     try:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -854,6 +854,12 @@ def build_turn_context(
         else:
             with persist_lock:
                 agent._ensure_db_session()
+        # History hydration runs before the first-row create above. Persist its
+        # revisioned todo snapshot now that the FK target is guaranteed to
+        # exist; already-persisted stores make this a no-op.
+        persist_todos = getattr(agent._todo_store, "persist_current", None)
+        if callable(persist_todos):
+            persist_todos()
     except Exception:
         logger.warning(
             "Turn-start session row creation failed for session=%s",

--- a/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
@@ -22,6 +22,22 @@ describe('ComposerStatusStack collapsed todo indicator', () => {
     $todosBySession.set({})
   })
 
+  it('shows a running indicator while the todo group is expanded', () => {
+    $todosBySession.set({
+      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]
+    })
+
+    render(
+      <MemoryRouter>
+        <ComposerStatusStack queue={null} sessionId="session-1" />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Wire the status stack')).toBeTruthy()
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
+    expect(screen.getByText('Tasks 0/1')).toBeTruthy()
+  })
+
   it('shows a running indicator next to the collapsed todo label', () => {
     $todosBySession.set({
       'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/tools.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/tools.ts
@@ -4,6 +4,7 @@ import { flashPetActivity, setPetActivity } from '@/store/pet'
 import { pruneDelegateFallbackSubagents, upsertSubagent } from '@/store/subagents'
 import { reportMcpToolResult } from '@/store/suggestion-providers/repair'
 import { invalidateSkillSuggestionIndex } from '@/store/suggestion-providers/skill'
+import { restoreSessionTodosFromSnapshot } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
 import { notifyWorkspaceChanged, toolChangedPath, toolMayMutateFiles } from '@/store/workspace-events'
@@ -16,6 +17,14 @@ import type { GatewayEventContext } from './types'
 export function handleToolEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, isActiveEvent, occurredAt } = ctx
   const { flushQueuedDeltas, nativeSubagentSessionsRef, sessionInterrupted, updateSessionState, upsertToolCall } = deps
+
+  if (event.type === 'todo.updated') {
+    if (sessionId && !sessionInterrupted(sessionId)) {
+      restoreSessionTodosFromSnapshot(sessionId, payload, true)
+    }
+
+    return true
+  }
 
   if (event.type === 'tool.generating') {
     // Announced while the model is still emitting the call's JSON, so it

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,7 +23,7 @@ import {
   generatedImageEchoSources,
   stripGeneratedImageEchoes
 } from '@/lib/generated-images'
-import { parseTodos } from '@/lib/todos'
+import { parseTodoRevision, parseTodos } from '@/lib/todos'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
@@ -465,7 +465,7 @@ export function useMessageStream({
         const todos = parseTodos(payload.todos) ?? parseTodos(payload.result) ?? parseTodos(payload.args)
 
         if (todos) {
-          setSessionTodos(sessionId, todos)
+          setSessionTodos(sessionId, todos, parseTodoRevision(payload))
         }
       }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,12 +23,12 @@ import {
   generatedImageEchoSources,
   stripGeneratedImageEchoes
 } from '@/lib/generated-images'
-import { parseTodoRevision, parseTodos } from '@/lib/todos'
+import { nextTodosFromToolEvent, parseTodoRevision } from '@/lib/todos'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { upsertSubagent } from '@/store/subagents'
-import { setSessionTodos } from '@/store/todos'
+import { $todosBySession, setSessionTodos } from '@/store/todos'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -462,7 +462,7 @@ export function useMessageStream({
       // The composer status stack owns todo display now (no inline panel) —
       // mirror every todo state the tool reports into its session store.
       if (payload?.name === 'todo') {
-        const todos = parseTodos(payload.todos) ?? parseTodos(payload.result) ?? parseTodos(payload.args)
+        const todos = nextTodosFromToolEvent($todosBySession.get()[sessionId] ?? [], payload)
 
         if (todos) {
           setSessionTodos(sessionId, todos, parseTodoRevision(payload))

--- a/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
@@ -56,4 +56,18 @@ describe('useMessageStream turn-end todo cleanup', () => {
 
     expect($todosBySession.get()[SID]).toBeUndefined()
   })
+
+  it('applies a dedicated todo snapshot immediately', () => {
+    mountStream()
+
+    act(() =>
+      stream.handleEvent({
+        payload: { revision: 3, todos: [todo('live', 'in_progress')] },
+        session_id: SID,
+        type: 'todo.updated'
+      })
+    )
+
+    expect($todosBySession.get()[SID]?.[0]?.id).toBe('live')
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -118,6 +118,7 @@ import {
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { forgetSessionUnread } from '@/store/session-unread'
 import { $archivedSessions } from '@/store/sidebar-archive'
+import { restoreSessionTodosFromSnapshot } from '@/store/todos'
 import {
   dropTranscriptTail,
   dropTranscriptTailEverywhere,
@@ -1173,6 +1174,8 @@ export function useSessionActions({
                   ? false
                   : resolveResumedBusy(activated.running ?? cachedViewState.busy, Boolean(latestCachedState?.busy))
 
+              restoreSessionTodosFromSnapshot(cachedRuntimeId, activated.todo_state, running)
+
               const activatedTurnStartedAt =
                 typeof activated.turn_started_at === 'number' && activated.turn_started_at > 0
                   ? activated.turn_started_at * 1000
@@ -1612,6 +1615,8 @@ export function useSessionActions({
           (resumed as { running?: boolean }).running,
           Boolean(sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.busy)
         )
+
+        restoreSessionTodosFromSnapshot(resumed.session_id, resumed.todo_state, resumedRunning)
 
         // Crash-survivable turn progress: fold a journaled in-flight tail
         // (persisted by use-session-state-cache while the turn streamed;

--- a/apps/desktop/src/components/chat/status-section.tsx
+++ b/apps/desktop/src/components/chat/status-section.tsx
@@ -7,7 +7,7 @@ interface StatusSectionProps {
    *  `Button` with `size="micro"` + `variant="text"` or `"link"`. */
   accessory?: ReactNode
   children: ReactNode
-  /** Optional inline status shown only while the group is collapsed. */
+  /** Optional inline status next to the label (running spinner, etc). */
   collapsedIndicator?: ReactNode
   defaultCollapsed?: boolean
   /** Optional glyph between the caret and the label (e.g. a `Codicon`). */
@@ -42,7 +42,7 @@ export function StatusSection({
           <DisclosureCaret className="shrink-0" open={!collapsed} size="1em" />
           {icon && <span className="flex shrink-0 items-center">{icon}</span>}
           <span className="min-w-0 truncate">{label}</span>
-          {collapsed && collapsedIndicator && <span className="flex shrink-0 items-center">{collapsedIndicator}</span>}
+          {collapsedIndicator && <span className="flex shrink-0 items-center">{collapsedIndicator}</span>}
         </button>
         {accessory && <div className="flex shrink-0 items-center gap-1">{accessory}</div>}
       </div>

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -71,6 +71,7 @@ export type GatewayEventPayload = {
   inline_diff?: string
   duration_s?: number
   todos?: unknown
+  revision?: number
   model?: string
   provider?: string
   reasoning_effort?: string

--- a/apps/desktop/src/lib/todos.test.ts
+++ b/apps/desktop/src/lib/todos.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { latestSessionTodos, parseTodoRevision, parseTodos } from './todos'
+import {
+  latestSessionTodos,
+  mergeTodoItems,
+  nextTodosFromToolEvent,
+  parseTodoPatch,
+  parseTodoRevision,
+  parseTodos
+} from './todos'
 
 describe('parseTodos', () => {
   it('parses todo arrays with valid ids, content, and statuses', () => {
@@ -89,5 +96,79 @@ describe('latestSessionTodos', () => {
   it('returns null when no todo tool calls exist', () => {
     expect(latestSessionTodos([{ parts: [{ type: 'text', text: 'hi' }] }])).toBeNull()
     expect(latestSessionTodos([])).toBeNull()
+  })
+})
+
+describe('mergeTodoItems', () => {
+  const list = [
+    { content: 'Fix C', id: 'c', status: 'in_progress' as const },
+    { content: 'Fix D', id: 'd', status: 'pending' as const },
+    { content: 'Fix A', id: 'a', status: 'pending' as const }
+  ]
+
+  it('updates status by id and keeps the rest of the list', () => {
+    expect(mergeTodoItems(list, [{ id: 'c', status: 'completed' }])).toEqual([
+      { content: 'Fix C', id: 'c', status: 'completed' },
+      { content: 'Fix D', id: 'd', status: 'pending' },
+      { content: 'Fix A', id: 'a', status: 'pending' }
+    ])
+  })
+
+  it('appends a new item and fills missing content', () => {
+    expect(mergeTodoItems(list, [{ id: 'v', status: 'pending' }])).toEqual([
+      ...list,
+      { content: '(no description)', id: 'v', status: 'pending' }
+    ])
+  })
+})
+
+describe('nextTodosFromToolEvent', () => {
+  const current = [
+    { content: 'Fix C', id: 'c', status: 'pending' as const },
+    { content: 'Fix D', id: 'd', status: 'pending' as const }
+  ]
+
+  it('replaces from the full tool result', () => {
+    expect(
+      nextTodosFromToolEvent(current, {
+        todos: [
+          { content: 'Fix C', id: 'c', status: 'completed' },
+          { content: 'Fix D', id: 'd', status: 'in_progress' }
+        ]
+      })
+    ).toEqual([
+      { content: 'Fix C', id: 'c', status: 'completed' },
+      { content: 'Fix D', id: 'd', status: 'in_progress' }
+    ])
+  })
+
+  it('merges a status-only start payload instead of replacing the list', () => {
+    expect(
+      nextTodosFromToolEvent(current, {
+        args: { merge: true, todos: [{ id: 'c', status: 'completed' }] }
+      })
+    ).toEqual([
+      { content: 'Fix C', id: 'c', status: 'completed' },
+      { content: 'Fix D', id: 'd', status: 'pending' }
+    ])
+  })
+
+  it('does not wipe the list when a merge payload has no usable items', () => {
+    expect(nextTodosFromToolEvent(current, { args: { merge: true, todos: [] } })).toBeNull()
+  })
+
+  it('still replaces when merge is off', () => {
+    expect(
+      nextTodosFromToolEvent(current, {
+        args: { todos: [{ content: 'Only this', id: 'c', status: 'completed' }] }
+      })
+    ).toEqual([{ content: 'Only this', id: 'c', status: 'completed' }])
+  })
+})
+
+describe('parseTodoPatch', () => {
+  it('keeps status-only items that parseTodos would drop', () => {
+    expect(parseTodos([{ id: 'c', status: 'completed' }])).toEqual([])
+    expect(parseTodoPatch([{ id: 'c', status: 'completed' }])).toEqual([{ id: 'c', status: 'completed' }])
   })
 })

--- a/apps/desktop/src/lib/todos.test.ts
+++ b/apps/desktop/src/lib/todos.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { latestSessionTodos, parseTodos } from './todos'
+import { latestSessionTodos, parseTodoRevision, parseTodos } from './todos'
 
 describe('parseTodos', () => {
   it('parses todo arrays with valid ids, content, and statuses', () => {
@@ -31,6 +31,19 @@ describe('parseTodos', () => {
     expect(parseTodos(undefined)).toBeNull()
     expect(parseTodos('not json')).toBeNull()
     expect(parseTodos({ message: 'no todos here' })).toBeNull()
+  })
+})
+
+describe('parseTodoRevision', () => {
+  it('parses direct and wrapped revisions', () => {
+    expect(parseTodoRevision({ revision: 3 })).toBe(3)
+    expect(parseTodoRevision({ result: '{"revision":4}' })).toBe(4)
+  })
+
+  it('rejects invalid revisions', () => {
+    expect(parseTodoRevision({ revision: -1 })).toBeNull()
+    expect(parseTodoRevision({ revision: 1.5 })).toBeNull()
+    expect(parseTodoRevision({ revision: '3' })).toBeNull()
   })
 })
 

--- a/apps/desktop/src/lib/todos.ts
+++ b/apps/desktop/src/lib/todos.ts
@@ -6,6 +6,14 @@ export interface TodoItem {
   status: TodoStatus
 }
 
+/** One item from a `merge: true` write. Content is optional so a status-only
+ *  patch still applies to an existing row. */
+export interface TodoPatch {
+  content?: string
+  id: string
+  status: TodoStatus
+}
+
 const STATUSES: readonly TodoStatus[] = ['pending', 'in_progress', 'completed', 'cancelled']
 
 const isRecord = (v: unknown): v is Record<string, unknown> => Boolean(v && typeof v === 'object' && !Array.isArray(v))
@@ -21,6 +29,24 @@ function parseArray(value: unknown[]): TodoItem[] {
     const content = String(item.content ?? '').trim()
 
     return id && content ? [{ content, id, status: item.status }] : []
+  })
+}
+
+function parsePatchArray(value: unknown[]): TodoPatch[] {
+  return value.flatMap(item => {
+    if (!isRecord(item) || !isStatus(item.status)) {
+      return []
+    }
+
+    const id = String(item.id ?? '').trim()
+
+    if (!id) {
+      return []
+    }
+
+    const content = String(item.content ?? '').trim()
+
+    return content ? [{ content, id, status: item.status }] : [{ id, status: item.status }]
   })
 }
 
@@ -75,6 +101,83 @@ function parseRevision(value: unknown, depth: number): null | number {
 }
 
 export const parseTodoRevision = (value: unknown): null | number => parseRevision(value, 0)
+
+function parsePatch(value: unknown, depth: number): null | TodoPatch[] {
+  if (depth > 2) {
+    return null
+  }
+
+  if (Array.isArray(value)) {
+    return parsePatchArray(value)
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return parsePatch(JSON.parse(value), depth + 1)
+    } catch {
+      return null
+    }
+  }
+
+  if (isRecord(value) && Object.hasOwn(value, 'todos')) {
+    return parsePatch(value.todos, depth + 1)
+  }
+
+  return null
+}
+
+export const parseTodoPatch = (value: unknown): null | TodoPatch[] => parsePatch(value, 0)
+
+export const todoArgsWantMerge = (args: unknown): boolean => isRecord(args) && args.merge === true
+
+/** Same as TodoStore.write(merge=True): update by id, append new items. */
+export function mergeTodoItems(current: readonly TodoItem[], patch: readonly TodoPatch[]): TodoItem[] {
+  const next = current.map(item => ({ ...item }))
+  const indexById = new Map(next.map((item, index) => [item.id, index]))
+
+  for (const item of patch) {
+    const index = indexById.get(item.id)
+
+    if (index === undefined) {
+      next.push({ content: item.content?.trim() || '(no description)', id: item.id, status: item.status })
+      indexById.set(item.id, next.length - 1)
+
+      continue
+    }
+
+    if (item.content) {
+      next[index].content = item.content
+    }
+
+    next[index].status = item.status
+  }
+
+  return next
+}
+
+/** Live tool event to the next list. `payload.todos` / `result` is the full
+ *  store, so replace. `args` with `merge: true` patches by id so a status-only
+ *  start event does not wipe the rest of the checklist. */
+export function nextTodosFromToolEvent(
+  current: readonly TodoItem[],
+  payload: { args?: unknown; arguments?: unknown; result?: unknown; todos?: unknown }
+): null | TodoItem[] {
+  const fromResult = parseTodos(payload.todos) ?? parseTodos(payload.result)
+
+  if (fromResult) {
+    return fromResult
+  }
+
+  const args = payload.args ?? payload.arguments
+
+  if (todoArgsWantMerge(args)) {
+    const patch = parseTodoPatch(args)
+
+    return patch && patch.length > 0 ? mergeTodoItems(current, patch) : null
+  }
+
+  return parseTodos(args)
+}
 
 /** Latest parseable todo list from one message's aui content parts (tool-call
  *  parts named `todo`; live parts carry `todos`, hydrated ones args/result). */

--- a/apps/desktop/src/lib/todos.ts
+++ b/apps/desktop/src/lib/todos.ts
@@ -50,6 +50,32 @@ function parse(value: unknown, depth: number): null | TodoItem[] {
 
 export const parseTodos = (value: unknown): null | TodoItem[] => parse(value, 0)
 
+function parseRevision(value: unknown, depth: number): null | number {
+  if (depth > 2) {
+    return null
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return parseRevision(JSON.parse(value), depth + 1)
+    } catch {
+      return null
+    }
+  }
+
+  if (!isRecord(value)) {
+    return null
+  }
+
+  if (typeof value.revision === 'number' && Number.isSafeInteger(value.revision) && value.revision >= 0) {
+    return value.revision
+  }
+
+  return Object.hasOwn(value, 'result') ? parseRevision(value.result, depth + 1) : null
+}
+
+export const parseTodoRevision = (value: unknown): null | number => parseRevision(value, 0)
+
 /** Latest parseable todo list from one message's aui content parts (tool-call
  *  parts named `todo`; live parts carry `todos`, hydrated ones args/result). */
 export function todosFromMessageContent(content: unknown): null | TodoItem[] {

--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -3,9 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TodoItem } from '@/lib/todos'
 
 import {
+  $todoRevisionsBySession,
   $todosBySession,
   clearActiveSessionTodos,
   clearSessionTodos,
+  restoreSessionTodosFromSnapshot,
   setSessionTodos,
   todosForHydration
 } from './todos'
@@ -101,5 +103,35 @@ describe('todosForHydration (stale-active guard on restore)', () => {
 
   it('returns null when there is nothing stored', () => {
     expect(todosForHydration(null)).toBeNull()
+  })
+})
+
+describe('revisioned snapshots', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    clearSessionTodos('s1')
+  })
+
+  afterEach(() => {
+    clearSessionTodos('s1')
+    vi.useRealTimers()
+  })
+
+  it('rejects a snapshot older than the latest live update', () => {
+    setSessionTodos('s1', [todo('new', 'in_progress')], 5)
+    setSessionTodos('s1', [todo('old', 'pending')], 4)
+
+    expect($todosBySession.get().s1?.[0]?.id).toBe('new')
+    expect($todoRevisionsBySession.get().s1).toBe(5)
+  })
+
+  it('restores an active snapshot only while the session is running', () => {
+    const snapshot = { revision: 7, todos: [todo('active', 'in_progress')] }
+
+    restoreSessionTodosFromSnapshot('s1', snapshot, false)
+    expect($todosBySession.get().s1).toBeUndefined()
+
+    restoreSessionTodosFromSnapshot('s1', snapshot, true)
+    expect($todosBySession.get().s1?.[0]?.id).toBe('active')
   })
 })

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -2,7 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import { keyedTimeouts } from '@/lib/keyed-timeouts'
 import { stableRecord } from '@/lib/stable-array'
-import type { TodoItem } from '@/lib/todos'
+import { parseTodoRevision, parseTodos, type TodoItem } from '@/lib/todos'
 
 import { $sessions, lineageAliases } from './session'
 import { $sessionStates } from './session-states'
@@ -17,6 +17,7 @@ import { $sessionStates } from './session-states'
  *   above the composer forever.
  */
 export const $todosBySession = atom<Record<string, TodoItem[]>>({})
+export const $todoRevisionsBySession = atom<Record<string, number>>({})
 
 export const todoListActive = (todos: readonly TodoItem[]) =>
   todos.some(t => t.status === 'pending' || t.status === 'in_progress')
@@ -69,8 +70,31 @@ export function todosForHydration(todos: readonly TodoItem[] | null): TodoItem[]
 const FINISHED_LINGER_MS = 4_000
 const clearTimers = keyedTimeouts()
 
-export function setSessionTodos(sid: string, todos: TodoItem[]) {
+function acceptRevision(sid: string, revision?: null | number): boolean {
+  const revisions = $todoRevisionsBySession.get()
+  const current = revisions[sid]
+
+  if (revision == null) {
+    return current == null
+  }
+
+  if (current != null && revision < current) {
+    return false
+  }
+
+  if (current !== revision) {
+    $todoRevisionsBySession.set({ ...revisions, [sid]: revision })
+  }
+
+  return true
+}
+
+export function setSessionTodos(sid: string, todos: TodoItem[], revision?: null | number) {
   if (!sid) {
+    return
+  }
+
+  if (!acceptRevision(sid, revision)) {
     return
   }
 
@@ -78,21 +102,32 @@ export function setSessionTodos(sid: string, todos: TodoItem[]) {
   $todosBySession.set({ ...$todosBySession.get(), [sid]: todos })
 
   if (!todoListActive(todos)) {
-    clearTimers.schedule(sid, FINISHED_LINGER_MS, () => clearSessionTodos(sid))
+    clearTimers.schedule(sid, FINISHED_LINGER_MS, () => dropSessionTodos(sid, false))
   }
 }
 
-export function clearSessionTodos(sid: string) {
+function dropSessionTodos(sid: string, forgetRevision: boolean) {
   clearTimers.cancel(sid)
 
   const map = $todosBySession.get()
 
-  if (!(sid in map)) {
-    return
+  if (sid in map) {
+    const { [sid]: _drop, ...rest } = map
+    $todosBySession.set(rest)
   }
 
-  const { [sid]: _drop, ...rest } = map
-  $todosBySession.set(rest)
+  if (forgetRevision) {
+    const revisions = $todoRevisionsBySession.get()
+
+    if (sid in revisions) {
+      const { [sid]: _drop, ...rest } = revisions
+      $todoRevisionsBySession.set(rest)
+    }
+  }
+}
+
+export function clearSessionTodos(sid: string) {
+  dropSessionTodos(sid, true)
 }
 
 // Drop a still-active todo list (any pending/in_progress item) — used at turn
@@ -107,5 +142,25 @@ export function clearActiveSessionTodos(sid: string) {
     return
   }
 
-  clearSessionTodos(sid)
+  dropSessionTodos(sid, false)
+}
+
+/** Apply a session.resume/activate or todo.updated full snapshot. Idle
+ * sessions keep the existing stale-active guard; running sessions restore the
+ * active plan because the backend has proved that turn is still live. */
+export function restoreSessionTodosFromSnapshot(sid: string, snapshot: unknown, running: boolean) {
+  const todos = parseTodos(snapshot)
+
+  if (!sid || todos === null) {
+    return
+  }
+
+  const revision = parseTodoRevision(snapshot)
+  const visible = running ? todos : todosForHydration(todos)
+
+  if (visible !== null) {
+    setSessionTodos(sid, visible, revision)
+  } else if (acceptRevision(sid, revision)) {
+    dropSessionTodos(sid, false)
+  }
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -683,6 +683,12 @@ export interface SessionResumeResponse {
   session_key?: string
   started_at?: number
   status?: string
+  /** Latest full task snapshot. Revisions let the renderer reject a response
+   * that raced with a newer live update. */
+  todo_state?: {
+    revision?: number
+    todos?: unknown
+  }
   /** Epoch seconds the current turn started, or null when idle. */
   turn_started_at?: number | null
 }

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -14,6 +14,7 @@ export type GatewayEventName =
   | 'tool.progress'
   | 'tool.complete'
   | 'tool.generating'
+  | 'todo.updated'
   | 'clarify.request'
   | 'approval.request'
   | 'sudo.request'

--- a/cli.py
+++ b/cli.py
@@ -10102,8 +10102,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self.agent._last_flushed_db_idx = 0
             if hasattr(self.agent, "_todo_store"):
                 try:
-                    from tools.todo_tool import TodoStore
-                    self.agent._todo_store = TodoStore()
+                    from tools.todo_tool import create_session_todo_store
+                    self.agent._todo_store = create_session_todo_store(self.agent)
                 except Exception:
                     pass
             if hasattr(self.agent, "_invalidate_system_prompt"):

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1152,8 +1152,8 @@ class CLICommandsMixin:
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):
                 try:
-                    from tools.todo_tool import TodoStore
-                    self.agent._todo_store = TodoStore()
+                    from tools.todo_tool import create_session_todo_store
+                    self.agent._todo_store = create_session_todo_store(self.agent)
                 except Exception:
                     pass
             if hasattr(self.agent, "_invalidate_system_prompt"):
@@ -1510,8 +1510,8 @@ class CLICommandsMixin:
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):
                 try:
-                    from tools.todo_tool import TodoStore
-                    self.agent._todo_store = TodoStore()
+                    from tools.todo_tool import create_session_todo_store
+                    self.agent._todo_store = create_session_todo_store(self.agent)
                 except Exception:
                     pass
             if hasattr(self.agent, "_invalidate_system_prompt"):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7668,6 +7668,119 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         self._execute_write(_do)
 
+    @staticmethod
+    def _todo_state_from_row(row) -> Optional[Dict[str, Any]]:
+        """Decode one persisted todo-state row, failing closed on corruption."""
+        if row is None:
+            return None
+        try:
+            raw = row["todos_json"] if isinstance(row, sqlite3.Row) else row[0]
+            revision = row["revision"] if isinstance(row, sqlite3.Row) else row[1]
+            updated_at = row["updated_at"] if isinstance(row, sqlite3.Row) else row[2]
+            owner = row["owner_session_id"] if isinstance(row, sqlite3.Row) else row[3]
+            todos = json.loads(raw)
+            if not isinstance(todos, list):
+                return None
+            return {
+                "todos": todos,
+                "revision": max(0, int(revision or 0)),
+                "updated_at": float(updated_at or 0),
+                "owner_session_id": str(owner or ""),
+            }
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+
+    @staticmethod
+    def _select_session_todo_state(conn, session_id: str):
+        """Return the nearest copy-on-write todo snapshot in a lineage."""
+        return conn.execute(
+            """WITH RECURSIVE lineage(id, parent_session_id, depth) AS (
+                   SELECT id, parent_session_id, 0
+                     FROM sessions
+                    WHERE id = ?
+                   UNION ALL
+                   SELECT parent.id, parent.parent_session_id, lineage.depth + 1
+                     FROM sessions AS parent
+                     JOIN lineage ON parent.id = lineage.parent_session_id
+               )
+               SELECT state.todos_json,
+                      state.revision,
+                      state.updated_at,
+                      lineage.id AS owner_session_id
+                 FROM lineage
+                 JOIN session_todo_state AS state
+                   ON state.session_id = lineage.id
+                ORDER BY lineage.depth ASC
+                LIMIT 1""",
+            (session_id,),
+        ).fetchone()
+
+    def get_session_todo_state(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return the current todo snapshot, inheriting through session lineage.
+
+        A compression child or manual branch starts from its nearest ancestor's
+        snapshot. Its first write creates an independent row for the child, so
+        later updates never mutate the parent or a sibling branch.
+        """
+        if not session_id:
+            return None
+        with self._read_ctx() as conn:
+            if conn is None:
+                return None
+            row = self._select_session_todo_state(conn, session_id)
+        state = self._todo_state_from_row(row)
+        if row is not None and state is None:
+            logger.warning("Ignoring malformed todo state for session %s", session_id)
+        return state
+
+    def save_session_todo_state(
+        self,
+        session_id: str,
+        todos: List[Dict[str, Any]],
+        revision: int,
+    ) -> Dict[str, Any]:
+        """Persist a full revisioned todo snapshot with stale-writer rejection.
+
+        The caller supplies the next revision from its in-memory store. A
+        concurrent writer that already committed that revision wins; the stale
+        caller receives the winning snapshot and can reconcile immediately.
+        """
+        if not session_id:
+            return {"todos": [], "revision": 0, "updated_at": 0}
+        if not isinstance(todos, list):
+            raise TypeError("todos must be a list")
+
+        normalized_revision = max(0, int(revision))
+        encoded = json.dumps(todos, ensure_ascii=False, separators=(",", ":"))
+
+        def _do(conn):
+            current = self._todo_state_from_row(
+                self._select_session_todo_state(conn, session_id)
+            )
+            if current is not None and current["revision"] >= normalized_revision:
+                return current
+
+            updated_at = time.time()
+            conn.execute(
+                """INSERT INTO session_todo_state
+                       (session_id, revision, todos_json, updated_at)
+                   VALUES (?, ?, ?, ?)
+                   ON CONFLICT(session_id) DO UPDATE SET
+                       revision = excluded.revision,
+                       todos_json = excluded.todos_json,
+                       updated_at = excluded.updated_at
+                   WHERE excluded.revision > session_todo_state.revision""",
+                (session_id, normalized_revision, encoded, updated_at),
+            )
+            return {
+                "todos": json.loads(encoded),
+                "revision": normalized_revision,
+                "updated_at": updated_at,
+                "owner_session_id": session_id,
+            }
+
+        return self._execute_write(_do)
+
     def get_compression_ineffective_count(self, session_id: str) -> int:
         """Return the persisted ineffective-compaction strike count.
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -494,6 +494,17 @@ CREATE TABLE IF NOT EXISTS gateway_hygiene_state (
     failure_streak INTEGER NOT NULL DEFAULT 0
 );
 
+-- Authoritative todo snapshot for one physical session segment. Compression
+-- continuations and branches inherit the nearest ancestor snapshot until they
+-- write their own copy, so state follows a conversation without coupling
+-- sibling branches together.
+CREATE TABLE IF NOT EXISTS session_todo_state (
+    session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    revision INTEGER NOT NULL DEFAULT 0,
+    todos_json TEXT NOT NULL DEFAULT '[]',
+    updated_at REAL NOT NULL
+);
+
 -- Per-backend liveness heartbeat (#94895). Each serve / tui_gateway process
 -- registers a row at startup and refreshes ``last_heartbeat`` periodically.
 -- The startup orphan sweep (sessions.startup_orphan_reap) consults this

--- a/run_agent.py
+++ b/run_agent.py
@@ -4790,6 +4790,7 @@ class AIAgent:
 
         # Walk history backwards to find the most recent todo tool response
         last_todo_response = None
+        last_todo_revision = 0
         for idx in range(len(history) - 1, -1, -1):
             msg = history[idx]
             if msg.get("role") != "tool":
@@ -4815,15 +4816,32 @@ class AIAgent:
                 data = json.loads(content)
                 if "todos" in data and isinstance(data["todos"], list):
                     last_todo_response = data["todos"]
+                    last_todo_revision = data.get("revision", 1)
                     break
             except (json.JSONDecodeError, TypeError):
                 continue
 
-        if last_todo_response:
-            # Replay the items into the store (replace mode)
-            self._todo_store.write(last_todo_response, merge=False)
-            if not self.quiet_mode:
-                self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
+        if last_todo_response is not None:
+            # The state DB is authoritative when it has an equal/newer
+            # revision. History remains the compatibility and crash-recovery
+            # fallback for sessions that predate snapshots or whose latest
+            # snapshot write failed. Empty lists matter: they are an
+            # authoritative clear after an earlier non-empty plan.
+            current_revision = int(
+                self._todo_store.snapshot().get("revision", 0) or 0
+            )
+            try:
+                history_revision = max(0, int(last_todo_revision or 0))
+            except (TypeError, ValueError):
+                history_revision = 1
+            if history_revision > current_revision:
+                self._todo_store.restore(
+                    last_todo_response,
+                    revision=history_revision,
+                    persisted=False,
+                )
+                if not self.quiet_mode:
+                    self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
         _set_interrupt(False)
 
     @classmethod

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -904,6 +904,57 @@ class TestHydrateTodoStore:
             agent._hydrate_todo_store(history)
         assert not agent._todo_store.has_items()
 
+    def test_newer_database_snapshot_wins_over_history(self, agent):
+        agent._todo_store.restore(
+            [{"id": "db", "content": "Current", "status": "in_progress"}],
+            revision=5,
+            persisted=True,
+        )
+        history = [
+            self._assistant_todo_call(),
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": json.dumps(
+                    {
+                        "todos": [
+                            {"id": "old", "content": "Old", "status": "pending"}
+                        ],
+                        "revision": 4,
+                    }
+                ),
+            },
+        ]
+
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+
+        assert agent._todo_store.snapshot()["revision"] == 5
+        assert agent._todo_store.read()[0]["id"] == "db"
+
+    def test_history_recovers_newer_snapshot(self, agent):
+        history = [
+            self._assistant_todo_call(),
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": json.dumps(
+                    {
+                        "todos": [
+                            {"id": "new", "content": "Recovered", "status": "pending"}
+                        ],
+                        "revision": 2,
+                    }
+                ),
+            },
+        ]
+
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+
+        assert agent._todo_store.snapshot()["revision"] == 2
+        assert agent._todo_store.read()[0]["id"] == "new"
+
 
 
 

--- a/tests/state/test_session_todo_state.py
+++ b/tests/state/test_session_todo_state.py
@@ -1,0 +1,76 @@
+"""Durable, revisioned todo snapshots follow session lineage safely."""
+
+from hermes_state import SessionDB
+
+
+def _todo(item_id: str, status: str = "pending") -> list[dict[str, str]]:
+    return [{"id": item_id, "content": f"Task {item_id}", "status": status}]
+
+
+def test_snapshot_survives_database_reopen(tmp_path):
+    path = tmp_path / "state.db"
+    db = SessionDB(db_path=path)
+    db.create_session("session", source="test")
+    db.save_session_todo_state("session", _todo("one"), 1)
+    db.close()
+
+    reopened = SessionDB(db_path=path)
+    try:
+        state = reopened.get_session_todo_state("session")
+        assert state["todos"] == _todo("one")
+        assert state["revision"] == 1
+        assert state["owner_session_id"] == "session"
+    finally:
+        reopened.close()
+
+
+def test_stale_revision_is_rejected(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("session", source="test")
+        db.save_session_todo_state("session", _todo("current"), 3)
+
+        result = db.save_session_todo_state("session", _todo("stale"), 2)
+
+        assert result["revision"] == 3
+        assert result["todos"] == _todo("current")
+        assert db.get_session_todo_state("session")["todos"] == _todo("current")
+    finally:
+        db.close()
+
+
+def test_child_inherits_then_diverges_copy_on_write(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="test")
+        db.create_session("child-a", source="test", parent_session_id="parent")
+        db.create_session("child-b", source="test", parent_session_id="parent")
+        db.save_session_todo_state("parent", _todo("parent"), 4)
+
+        inherited = db.get_session_todo_state("child-a")
+        assert inherited["todos"] == _todo("parent")
+        assert inherited["owner_session_id"] == "parent"
+
+        db.save_session_todo_state("child-a", _todo("branch"), 5)
+
+        assert db.get_session_todo_state("child-a")["todos"] == _todo("branch")
+        assert db.get_session_todo_state("parent")["todos"] == _todo("parent")
+        assert db.get_session_todo_state("child-b")["todos"] == _todo("parent")
+    finally:
+        db.close()
+
+
+def test_profiles_with_same_session_id_are_isolated(tmp_path):
+    first = SessionDB(db_path=tmp_path / "first.db")
+    second = SessionDB(db_path=tmp_path / "second.db")
+    try:
+        first.create_session("same", source="test")
+        second.create_session("same", source="test")
+        first.save_session_todo_state("same", _todo("first"), 1)
+        second.save_session_todo_state("same", _todo("second"), 1)
+
+        assert first.get_session_todo_state("same")["todos"] == _todo("first")
+        assert second.get_session_todo_state("same")["todos"] == _todo("second")
+    finally:
+        first.close()
+        second.close()

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -130,11 +130,57 @@ class TestTodoToolFunction:
         result = json.loads(todo_tool(store=store))
         assert result["summary"]["total"] == 1
         assert result["summary"]["pending"] == 1
+        assert result["revision"] == 1
 
 
     def test_no_store_returns_error(self):
         result = json.loads(todo_tool())
         assert "error" in result
+
+
+class TestTodoStoreSnapshots:
+    def test_revision_only_advances_when_state_changes(self):
+        store = TodoStore()
+        items = [{"id": "1", "content": "Task", "status": "pending"}]
+
+        store.write(items)
+        first = store.snapshot()
+        store.write(items)
+
+        assert first["revision"] == 1
+        assert store.snapshot() == first
+
+    def test_loads_and_persists_revisioned_snapshots(self):
+        writes = []
+        initial = {
+            "todos": [{"id": "1", "content": "Task", "status": "pending"}],
+            "revision": 7,
+        }
+
+        def save(todos, revision):
+            writes.append((todos, revision))
+            return {"todos": todos, "revision": revision}
+
+        store = TodoStore(load_state=lambda: initial, save_state=save)
+        store.write([{"id": "1", "content": "Task", "status": "completed"}])
+
+        assert writes[-1][1] == 8
+        assert store.snapshot()["revision"] == 8
+
+    def test_missing_session_retries_the_same_revision(self):
+        attempts = []
+
+        def save(todos, revision):
+            attempts.append(revision)
+            return None if len(attempts) == 1 else {"todos": todos, "revision": revision}
+
+        store = TodoStore(save_state=save)
+        items = [{"id": "1", "content": "Task", "status": "pending"}]
+
+        store.write(items)
+        store.write(items)
+
+        assert attempts == [1, 1]
 
 
 class TestTodoStoreBounds:

--- a/tests/tui_gateway/test_todo_state_events.py
+++ b/tests/tui_gateway/test_todo_state_events.py
@@ -1,0 +1,80 @@
+"""Todo snapshots bypass optional tool-progress display settings."""
+
+import json
+
+import tui_gateway.server as server
+
+
+def test_todo_completion_always_emits_snapshot_and_compat_event(monkeypatch):
+    sid = "todo-state-test"
+    events = []
+    session = {
+        "agent": None,
+        "edit_snapshots": {},
+        "tool_started_at": {},
+        "tool_progress_mode": "off",
+    }
+    monkeypatch.setitem(server._sessions, sid, session)
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: False)
+    monkeypatch.setattr(server, "_tool_lifecycle_required_for_ui", lambda _name: False)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, event_sid, payload=None: events.append(
+            (event, event_sid, payload)
+        ),
+    )
+
+    state = {
+        "todos": [{"id": "1", "content": "Work", "status": "in_progress"}],
+        "revision": 9,
+    }
+    server._on_tool_complete(sid, "call-1", "todo", {}, json.dumps(state))
+
+    assert [event[0] for event in events] == ["tool.complete", "todo.updated"]
+    assert events[-1] == ("todo.updated", sid, state)
+    assert session["todo_state"] == state
+
+
+def test_non_todo_completion_stays_suppressed_when_progress_is_off(monkeypatch):
+    sid = "ordinary-tool-test"
+    events = []
+    monkeypatch.setitem(
+        server._sessions,
+        sid,
+        {
+            "agent": None,
+            "edit_snapshots": {},
+            "tool_started_at": {},
+            "tool_progress_mode": "off",
+        },
+    )
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: False)
+    monkeypatch.setattr(server, "_tool_lifecycle_required_for_ui", lambda _name: False)
+    monkeypatch.setattr(server, "_emit", lambda *args: events.append(args))
+
+    server._on_tool_complete(sid, "call-1", "terminal", {}, "ok")
+
+    assert events == []
+
+
+def test_live_snapshot_prefers_the_highest_revision():
+    class Store:
+        @staticmethod
+        def snapshot():
+            return {"todos": [], "revision": 4}
+
+    class Agent:
+        _todo_store = Store()
+
+    session = {
+        "agent": Agent(),
+        "todo_state": {
+            "todos": [{"id": "1", "content": "Current", "status": "pending"}],
+            "revision": 5,
+        },
+    }
+
+    payload = server._attach_todo_state({}, session)
+
+    assert payload["todo_state"]["revision"] == 5

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -2,10 +2,10 @@
 """
 Todo Tool Module - Planning & Task Management
 
-Provides an in-memory task list the agent uses to decompose complex tasks,
-track progress, and maintain focus across long conversations. The state
-lives on the AIAgent instance (one per session) and is re-injected into
-the conversation after context compression events.
+Provides a session-scoped task list the agent uses to decompose complex tasks,
+track progress, and maintain focus across long conversations. The active copy
+lives on the AIAgent instance and revisioned snapshots can persist through the
+session state database. It is re-injected after context compression events.
 
 Design:
 - Single `todo` tool: provide `todos` param to write, omit to read
@@ -15,7 +15,11 @@ Design:
 """
 
 import json
-from typing import Dict, Any, List, Optional
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+
+logger = logging.getLogger(__name__)
 
 
 # Valid status values for todo items
@@ -45,7 +49,7 @@ TODO_INJECTION_HEADER = (
 
 class TodoStore:
     """
-    In-memory todo list. One instance per AIAgent (one per session).
+    Session todo list with an in-memory working copy and optional persistence.
 
     Items are ordered -- list position is priority. Each item has:
       - id: unique string identifier (agent-chosen)
@@ -53,8 +57,29 @@ class TodoStore:
       - status: pending | in_progress | completed | cancelled
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        load_state: Optional[Callable[[], Optional[Dict[str, Any]]]] = None,
+        save_state: Optional[
+            Callable[[List[Dict[str, str]], int], Optional[Dict[str, Any]]]
+        ] = None,
+    ):
         self._items: List[Dict[str, str]] = []
+        self._revision = 0
+        self._persisted_revision = 0
+        self._save_state = save_state
+
+        if load_state is not None:
+            try:
+                state = load_state()
+                if isinstance(state, dict) and isinstance(state.get("todos"), list):
+                    self.restore(
+                        state["todos"],
+                        revision=state.get("revision", 0),
+                        persisted=True,
+                    )
+            except Exception:
+                logger.warning("Failed to load persisted todo state", exc_info=True)
 
     def write(self, todos: List[Dict[str, Any]], merge: bool = False) -> List[Dict[str, str]]:
         """
@@ -65,6 +90,7 @@ class TodoStore:
             merge: if False, replace the entire list. If True, update
                    existing items by id and append new ones.
         """
+        before = self.read()
         if not merge:
             # Replace mode: new list entirely
             self._items = self._normalize_order(
@@ -105,6 +131,11 @@ class TodoStore:
         # (list order is priority).
         if len(self._items) > MAX_TODO_ITEMS:
             self._items = self._items[:MAX_TODO_ITEMS]
+        if self._items != before:
+            self._revision += 1
+        # Retry a previously failed persistence attempt even when the model
+        # repeats an identical full snapshot on its next call.
+        self.persist_current()
         return self.read()
 
     def read(self) -> List[Dict[str, str]]:
@@ -114,6 +145,54 @@ class TodoStore:
     def has_items(self) -> bool:
         """Check if there are any items in the list."""
         return bool(self._items)
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return the full state clients can reconcile atomically."""
+        return {"todos": self.read(), "revision": self._revision}
+
+    def restore(
+        self,
+        todos: List[Dict[str, Any]],
+        *,
+        revision: Any = 0,
+        persisted: bool = False,
+    ) -> List[Dict[str, str]]:
+        """Restore a trusted snapshot without manufacturing a new revision."""
+        self._items = self._normalize_order(
+            [self._validate(t) for t in self._dedupe_by_id(todos)]
+        )[:MAX_TODO_ITEMS]
+        try:
+            self._revision = max(0, int(revision or 0))
+        except (TypeError, ValueError):
+            self._revision = 0
+        self._persisted_revision = self._revision if persisted else -1
+        return self.read()
+
+    def persist_current(self) -> None:
+        """Persist the current snapshot once and adopt backend authority.
+
+        Persistence is optional so standalone stores and tests keep their
+        original in-memory behavior. A stale concurrent writer receives the
+        already-committed snapshot from the backend and reconciles to it.
+        """
+        if self._save_state is None or self._persisted_revision == self._revision:
+            return
+        try:
+            state = self._save_state(self.read(), self._revision)
+            if isinstance(state, dict) and isinstance(state.get("todos"), list):
+                self.restore(
+                    state["todos"],
+                    revision=state.get("revision", self._revision),
+                    persisted=True,
+                )
+            # A missing database/session is not a successful write. Leave the
+            # revision dirty so turn-start persistence can retry after the
+            # session row exists.
+        except Exception:
+            # The canonical tool result is still persisted in conversation
+            # history, so a transient state-store failure must not fail the
+            # agent's task-management call. The next turn retries.
+            logger.warning("Failed to persist todo state", exc_info=True)
 
     def format_for_injection(self) -> Optional[str]:
         """
@@ -270,6 +349,7 @@ def todo_tool(
 
     return json.dumps({
         "todos": items,
+        "revision": store.snapshot()["revision"],
         "summary": {
             "total": len(items),
             "pending": pending,
@@ -278,6 +358,35 @@ def todo_tool(
             "cancelled": cancelled,
         },
     }, ensure_ascii=False)
+
+
+def create_session_todo_store(agent: Any) -> TodoStore:
+    """Create a todo store bound to an agent's current durable session.
+
+    The closures resolve ``agent.session_id`` and ``agent._session_db`` at
+    call time. Compression and session switches can therefore re-home the same
+    agent without leaving todo writes pinned to an obsolete physical segment.
+    """
+
+    def _load_state() -> Optional[Dict[str, Any]]:
+        db = getattr(agent, "_session_db", None)
+        session_id = str(getattr(agent, "session_id", "") or "")
+        getter = getattr(db, "get_session_todo_state", None)
+        if not session_id or not callable(getter):
+            return None
+        return getter(session_id)
+
+    def _save_state(
+        todos: List[Dict[str, str]], revision: int
+    ) -> Optional[Dict[str, Any]]:
+        db = getattr(agent, "_session_db", None)
+        session_id = str(getattr(agent, "session_id", "") or "")
+        saver = getattr(db, "save_session_todo_state", None)
+        if not session_id or not callable(saver):
+            return None
+        return saver(session_id, todos, revision)
+
+    return TodoStore(load_state=_load_state, save_state=_save_state)
 
 
 def check_todo_requirements() -> bool:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -473,17 +473,20 @@ def _(rid, params: dict) -> dict:
                     history = live.get("history") or []
                     return _ok(
                         rid,
-                        {
-                            "session_id": live_sid,
-                            "stored_session_id": str(live.get("session_key") or ""),
-                            "message_count": len(history),
-                            "messages": [] if omit_messages else _history_to_messages(history),
-                            "info": {
-                                "model": _resolve_model(),
-                                "lazy": True,
-                                "profile_name": profile or "",
+                        _attach_todo_state(
+                            {
+                                "session_id": live_sid,
+                                "stored_session_id": str(live.get("session_key") or ""),
+                                "message_count": len(history),
+                                "messages": [] if omit_messages else _history_to_messages(history),
+                                "info": {
+                                    "model": _resolve_model(),
+                                    "lazy": True,
+                                    "profile_name": profile or "",
+                                },
                             },
-                        },
+                            live,
+                        ),
                     )
 
                 # Stranded-session adoption (#93296 follow-up): before session
@@ -561,6 +564,11 @@ def _(rid, params: dict) -> dict:
             if tip and tip != target:
                 target = tip
                 found = db.get_session(target) or found
+
+        # A full snapshot is cheap to read and makes every resume path an
+        # authoritative recovery point for task UI state, including deferred
+        # agent builds and reconnects that missed the live event.
+        resume_todo_state = _read_persisted_todo_state(db, target)
 
         # Every interactive resume path materializes the model history, even when
         # omit_messages suppresses the response copy. Count the complete lineage
@@ -682,6 +690,7 @@ def _(rid, params: dict) -> dict:
                 close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
                 profile_home=profile_home,
                 lazy=True,
+                todo_state=resume_todo_state,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -704,19 +713,22 @@ def _(rid, params: dict) -> dict:
             messages = [] if omit_messages else _history_to_messages(display_history)
             return _ok(
                 rid,
-                {
-                    "session_id": sid,
-                    "resumed": target,
-                    "message_count": len(display_history) if omit_messages else len(messages),
-                    "messages": messages,
-                    "messages_omitted": omit_messages,
-                    "info": _lazy_resume_info(cwd, profile=profile),
-                    "inflight": None,
-                    "running": child_running,
-                    "session_key": target,
-                    "started_at": record["created_at"],
-                    "status": "streaming" if child_running else "idle",
-                },
+                _attach_todo_state(
+                    {
+                        "session_id": sid,
+                        "resumed": target,
+                        "message_count": len(display_history) if omit_messages else len(messages),
+                        "messages": messages,
+                        "messages_omitted": omit_messages,
+                        "info": _lazy_resume_info(cwd, profile=profile),
+                        "inflight": None,
+                        "running": child_running,
+                        "session_key": target,
+                        "started_at": record["created_at"],
+                        "status": "streaming" if child_running else "idle",
+                    },
+                    record,
+                ),
             )
 
         # Desktop can ask for a bounded acknowledgement and hydrate the display
@@ -750,6 +762,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                todo_state=resume_todo_state,
             )
             record["resume_history_ready"] = threading.Event()
             record["resume_hydrating"] = True
@@ -765,24 +778,27 @@ def _(rid, params: dict) -> dict:
             _schedule_session_cap_enforcement()
             return _ok(
                 rid,
-                {
-                    "session_id": sid,
-                    "resumed": target,
-                    "message_count": record["resume_message_count"],
-                    "messages": [],
-                    "hydrating": True,
-                    "info": _lazy_resume_info(
-                        cwd,
-                        model=model_override.get("model") or "",
-                        provider=overrides.get("provider_override") or "",
-                        profile=profile,
-                    ),
-                    "inflight": None,
-                    "running": False,
-                    "session_key": target,
-                    "started_at": record["created_at"],
-                    "status": "resuming",
-                },
+                _attach_todo_state(
+                    {
+                        "session_id": sid,
+                        "resumed": target,
+                        "message_count": record["resume_message_count"],
+                        "messages": [],
+                        "hydrating": True,
+                        "info": _lazy_resume_info(
+                            cwd,
+                            model=model_override.get("model") or "",
+                            provider=overrides.get("provider_override") or "",
+                            profile=profile,
+                        ),
+                        "inflight": None,
+                        "running": False,
+                        "session_key": target,
+                        "started_at": record["created_at"],
+                        "status": "resuming",
+                    },
+                    record,
+                ),
             )
 
         # Cold resume default: register the live session and read its stored
@@ -846,6 +862,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                todo_state=resume_todo_state,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -875,7 +892,7 @@ def _(rid, params: dict) -> dict:
             }
             if auto_continue is not None:
                 payload["auto_continue"] = auto_continue
-            return _ok(rid, payload)
+            return _ok(rid, _attach_todo_state(payload, record))
 
         # Build the agent OUTSIDE the lock — _make_agent can block for seconds
         # (MCP discovery, prompt/skill build, AIAgent construction). Holding
@@ -1077,7 +1094,7 @@ def _(rid, params: dict) -> dict:
     }
     if auto_continue is not None:
         payload["auto_continue"] = auto_continue
-    return _ok(rid, payload)
+    return _ok(rid, _attach_todo_state(payload, session))
 
 
 @method("session.cwd.set")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3263,6 +3263,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # Session DB row deferred to first run_conversation() call.
             # pending_title applied post-first-message (see cli.exec handler).
             current["agent"] = agent
+            _session_todo_state(current)
             # Baseline for the per-turn config sync; the profile home
             # override is still active here.
             current["config_model_seen"] = _config_model_target()
@@ -7603,6 +7604,59 @@ def _tool_summary(name: str, result: str, duration_s: float | None) -> str | Non
     return f"{text}{suffix}" if text else None
 
 
+def _normalize_todo_state(value: object) -> dict | None:
+    """Return a client-safe full todo snapshot or ``None`` when malformed."""
+    if not isinstance(value, dict) or not isinstance(value.get("todos"), list):
+        return None
+    try:
+        revision = max(0, int(value.get("revision") or 0))
+    except (TypeError, ValueError):
+        return None
+    return {"todos": list(value["todos"]), "revision": revision}
+
+
+def _session_todo_state(session: dict) -> dict | None:
+    """Return the newest live/cached todo snapshot for a runtime session."""
+    cached = _normalize_todo_state(session.get("todo_state"))
+    live = None
+    agent = session.get("agent")
+    store = getattr(agent, "_todo_store", None)
+    snapshot = getattr(store, "snapshot", None)
+    if callable(snapshot):
+        try:
+            live = _normalize_todo_state(snapshot())
+        except Exception:
+            logger.debug("failed to read live todo state", exc_info=True)
+
+    if live is not None and (
+        cached is None or live["revision"] >= cached["revision"]
+    ):
+        cached = live
+    if cached is not None:
+        session["todo_state"] = cached
+    return cached
+
+
+def _attach_todo_state(payload: dict, session: dict) -> dict:
+    """Attach the authoritative todo snapshot to a session response."""
+    state = _session_todo_state(session)
+    if state is not None:
+        payload["todo_state"] = state
+    return payload
+
+
+def _read_persisted_todo_state(db, session_id: str) -> dict | None:
+    """Read a todo snapshot while remaining compatible with adapter DBs."""
+    getter = getattr(db, "get_session_todo_state", None)
+    if not callable(getter):
+        return None
+    try:
+        return _normalize_todo_state(getter(session_id))
+    except Exception:
+        logger.debug("failed to read persisted todo state", exc_info=True)
+        return None
+
+
 def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
     session = _sessions.get(sid)
     if session is not None:
@@ -7659,13 +7713,15 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
         result_text = _tool_result_text(result)
         if result_text:
             payload["result_text"] = result_text
+    todo_state = None
     if name == "todo":
-        try:
-            data = json.loads(result)
-            if isinstance(data, dict) and isinstance(data.get("todos"), list):
-                payload["todos"] = data.get("todos")
-        except Exception:
-            pass
+        todo_state = _normalize_todo_state(payload.get("result"))
+        if todo_state is not None:
+            payload.update(todo_state)
+            if session is not None:
+                cached = _normalize_todo_state(session.get("todo_state"))
+                if cached is None or todo_state["revision"] >= cached["revision"]:
+                    session["todo_state"] = todo_state
     try:
         from agent.display import render_edit_diff_with_delta
 
@@ -7680,8 +7736,18 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
             payload["inline_diff"] = "\n".join(rendered)
     except Exception:
         pass
-    if _tool_progress_enabled(sid) or payload.get("inline_diff") or _tool_lifecycle_required_for_ui(name):
+    if (
+        _tool_progress_enabled(sid)
+        or payload.get("inline_diff")
+        or _tool_lifecycle_required_for_ui(name)
+        or name == "todo"
+    ):
         _emit("tool.complete", sid, payload)
+    # Task state is application data, not optional tool-progress chrome. A
+    # dedicated full-snapshot event lets every client reconcile immediately
+    # without interpreting provider text or partial merge arguments.
+    if todo_state is not None:
+        _emit("todo.updated", sid, todo_state)
 
 
 def _on_tool_progress(
@@ -8872,6 +8938,7 @@ def _init_session(
             # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
             "transport": current_transport() or _stdio_transport,
         }
+        _session_todo_state(_sessions[sid])
     _init_owns_db = False
     if session_db is not None:
         db = session_db
@@ -10244,6 +10311,7 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    todo_state: dict | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -10280,6 +10348,7 @@ def _deferred_session_record(
         "source": source,
         "tool_progress_mode": _load_tool_progress_mode(),
         "tool_started_at": {},
+        "todo_state": todo_state,
         "transport": current_transport() or _stdio_transport,
     }
 
@@ -10709,7 +10778,7 @@ def _live_session_payload(
         payload["pending_approval"] = approval
     if clarify := _pending_clarify_request_payload(sid):
         payload["pending_clarify"] = clarify
-    return payload
+    return _attach_todo_state(payload, session)
 
 
 def _main_runtime_from_agent(agent) -> dict | None:


### PR DESCRIPTION
## Summary

- persist full, revisioned todo snapshots in the existing session database
- emit a provider-neutral `todo.updated` event independently of optional tool-progress display settings
- restore authoritative todo state through session resume/activation and reject stale renderer updates
- merge `merge: true` live patches by task id, including status-only updates, without hiding the rest of the list
- keep the running indicator visible while the Tasks section is expanded

## Why

The Tasks panel currently depends on the optional `tool.complete` projection. A suppressed or missed event, renderer restart, or reminted runtime can therefore leave the panel stale even though the canonical tool result is correct.

This change keeps the transcript as an audit/fallback source while adding a compact session snapshot for live reconciliation. Compression continuations and branches inherit the nearest snapshot copy-on-write, so sibling branches remain isolated. Completion is never guessed from assistant text.

This is provider- and model-independent and does not change the todo tool schema presented to models beyond returning its monotonic revision.

This also incorporates the focused desktop fix from #97811 by @Adolanium, preserving its original commit and authorship.

## Verification

- backend regression suite: 30 passed
- combined desktop todo regression suite: 33 passed
- full desktop TypeScript typecheck
- production desktop build
- isolated Hermes desktop acceptance run: a 10-step process updated the Tasks panel live (captured at 4/10) and finished with 10/10 completed in the durable snapshot

Addresses #19477.

## Desktop acceptance

The live Tasks panel after four of ten deterministic mock steps:

![Hermes Tasks panel updating at 4/10](https://raw.githubusercontent.com/itsflownium/hermes-agent/pr-assets-97815/hermes-todo-sync-e2e.jpg)
