### PR TITLE
fix(gateway): handle missing unix server on Windows

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -526,7 +526,7 @@ async def loop_heartbeat_forever(
     # disables the witness, and the payload flag tells probes that staleness is
     # no longer sufficient authority to escalate.
     #
-    # Windows: asyncio.start_unix_server raises (no AF_UNIX event-loop
+    # Windows: asyncio.start_unix_server is absent (no AF_UNIX event-loop
     # support), so the witness is PERMANENTLY absent there — the payload
     # records loop_tick_socket=False and every stale-file probe classifies
     # UNKNOWN, never WEDGED. That is deliberate fail-safe: a wedged native
@@ -569,9 +569,15 @@ async def loop_heartbeat_forever(
                 logger.debug(
                     "stale loop-tick socket sweep failed", exc_info=True
                 )
-        tick_server = await asyncio.start_unix_server(
-            _tick_socket_handler, path=str(tick_socket_path)
-        )
+        if not hasattr(asyncio, "start_unix_server"):
+            logger.info(
+                "Loop tick socket unsupported on this platform — liveness "
+                "probes will not escalate on a stale heartbeat"
+            )
+        else:
+            tick_server = await asyncio.start_unix_server(
+                _tick_socket_handler, path=str(tick_socket_path)
+            )
     except Exception:
         tick_server = None
         logger.warning(

--- a/tests/gateway/test_shutdown_watchdog.py
+++ b/tests/gateway/test_shutdown_watchdog.py
@@ -32,6 +32,49 @@ def test_resolve_shutdown_watchdog_delay_adds_grace():
     assert resolve_shutdown_watchdog_delay(10, grace_s=5) == 15.0
 
 
+def test_loop_heartbeat_missing_unix_server_is_clean_platform_fallback(
+    tmp_path, monkeypatch
+):
+    """Native Windows disables the UNIX witness without an exception warning."""
+    monkeypatch.delattr(asyncio, "start_unix_server", raising=False)
+
+    with patch("gateway.shutdown_watchdog.logger") as watchdog_logger:
+        asyncio.run(
+            loop_heartbeat_forever(
+                interval_s=1.0,
+                home=tmp_path,
+                should_continue=lambda: False,
+            )
+        )
+
+    watchdog_logger.warning.assert_not_called()
+    payload = json.loads(get_loop_heartbeat_path(tmp_path).read_text(encoding="utf-8"))
+    assert payload["loop_tick_socket"] is False
+
+
+def test_loop_heartbeat_unix_server_bind_failure_still_warns(tmp_path, monkeypatch):
+    """A supported platform's real witness bind failure remains diagnostic."""
+
+    async def fail_bind(*_args, **_kwargs):
+        raise OSError("test bind failure")
+
+    monkeypatch.setattr(asyncio, "start_unix_server", fail_bind, raising=False)
+
+    with patch("gateway.shutdown_watchdog.logger") as watchdog_logger:
+        asyncio.run(
+            loop_heartbeat_forever(
+                interval_s=1.0,
+                home=tmp_path,
+                should_continue=lambda: False,
+            )
+        )
+
+    watchdog_logger.warning.assert_called_once()
+    assert watchdog_logger.warning.call_args.kwargs["exc_info"] is True
+    payload = json.loads(get_loop_heartbeat_path(tmp_path).read_text(encoding="utf-8"))
+    assert payload["loop_tick_socket"] is False
+
+
 def test_arm_shutdown_watchdog_fires_with_dump_and_exit(tmp_path):
     done = threading.Event()
     fired = threading.Event()


### PR DESCRIPTION
## Summary

Native Windows gateways no longer print an `AttributeError` traceback on every startup when `asyncio.start_unix_server` is unavailable. The loop heartbeat now takes the already-documented witness-disabled path explicitly and emits an informational message, while real bind failures on supported platforms still retain warning-level exception context. Regression coverage pins both the fail-safe `loop_tick_socket: false` payload and the absence of an exception warning.

## Test plan

- `scripts/run_tests.sh tests/gateway/test_shutdown_watchdog.py -q --tb=short` (`HERMES_PYTHON` pointed at the verified pytest-capable interpreter for the shallow clone)
- `scripts/run_tests.sh tests/gateway/test_loop_liveness_watchdog.py -q -k 'test_loop_scheduling_witness_is_served_by_the_loop_itself' --tb=short`
- `python -m py_compile gateway/shutdown_watchdog.py tests/gateway/test_shutdown_watchdog.py`
- Native Windows gateway restart: WhatsApp connected, heartbeat fresh, and no `start_unix_server` traceback

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.6_sol](https://img.shields.io/badge/GPT_5.6_sol-000000)
