### PR TITLE
fix(cron): honor cron.execution_retention instead of a hardcoded 1000-row cap

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -21,7 +21,14 @@ from hermes_time import now as _hermes_now
 # dashboard operations that temporarily enter another profile cannot leak that
 # profile's execution records into the import-time home.
 EXECUTIONS_FILE: Optional[Path] = None
-MAX_TERMINAL_EXECUTIONS = 1000
+
+# Terminal-row cap. ``None`` resolves from ``cron.execution_retention`` at prune
+# time (mirrors ``cron.output_retention`` in cron/jobs.py), so a config change
+# takes effect without a reinstall. Assigning an int overrides config outright —
+# the sentinel is ``None`` rather than the default value so that a test or
+# embedder setting the override to exactly 1000 is still honoured.
+_DEFAULT_MAX_TERMINAL_EXECUTIONS = 1000
+MAX_TERMINAL_EXECUTIONS: Optional[int] = None
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
@@ -126,8 +133,32 @@ def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
     return current is not None and current == started_at
 
 
+def _max_terminal_executions() -> int:
+    """Resolve the ledger's terminal-row cap from ``cron.execution_retention``.
+
+    Mirrors ``_cron_output_keep`` in cron/jobs.py. ``load_config_readonly`` is
+    safe here because this path only reads.
+    """
+    if MAX_TERMINAL_EXECUTIONS is not None:  # test/embedder override
+        return max(0, int(MAX_TERMINAL_EXECUTIONS))
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+        if not isinstance(cron_cfg, dict):
+            return _DEFAULT_MAX_TERMINAL_EXECUTIONS
+        keep = int(cron_cfg.get("execution_retention", _DEFAULT_MAX_TERMINAL_EXECUTIONS))
+    except Exception:
+        return _DEFAULT_MAX_TERMINAL_EXECUTIONS
+    # A non-positive cap would delete every terminal row on each write, losing
+    # the audit trail the ledger exists to keep, so it falls back rather than
+    # being honoured. Use the module override for a deliberate zero.
+    return keep if keep > 0 else _DEFAULT_MAX_TERMINAL_EXECUTIONS
+
+
 def _prune_unlocked(conn: sqlite3.Connection) -> None:
-    limit = max(0, int(MAX_TERMINAL_EXECUTIONS))
+    limit = _max_terminal_executions()
     conn.execute(
         """DELETE FROM executions WHERE id IN (
              SELECT id FROM executions

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2778,6 +2778,13 @@ DEFAULT_CONFIG = {
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
+        # Terminal execution-ledger retention: cron/executions.db keeps the N
+        # most recent terminal rows (completed/failed/unknown) and prunes older
+        # ones on each terminal write. Claimed/running rows are never pruned.
+        # This is a ROW cap, not a day count — size it from the fleet's measured
+        # runs per day. Non-positive values fall back to the default rather than
+        # wiping the audit trail. Default 1000.
+        "execution_retention": 1000,
         # Timeout (seconds) for a no-agent cron script. Also overridable via
         # HERMES_CRON_SCRIPT_TIMEOUT. Keep this in sync with
         # cron.scheduler._DEFAULT_SCRIPT_TIMEOUT so config set recognizes the

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -83,6 +83,92 @@ def test_retention_bounds_terminal_history_but_preserves_inflight(monkeypatch, t
     assert executions.latest_execution("live")["status"] == "running"
 
 
+def _config_cap(monkeypatch, executions, cron_cfg):
+    """Point the cap resolver at a fake config and clear the module override."""
+    monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", None)
+    import hermes_cli.config as hermes_config
+
+    monkeypatch.setattr(
+        hermes_config, "load_config_readonly", lambda: {"cron": cron_cfg}
+    )
+
+
+def test_retention_cap_is_driven_by_cron_execution_retention(monkeypatch, tmp_path):
+    """``cron.execution_retention`` must actually bound the ledger.
+
+    Regression: the cap was a hard-coded module constant, so an operator who set
+    ``cron.execution_retention`` saw the value echoed by ``hermes config get``
+    while pruning silently kept using the built-in 1000-row default.
+    """
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _config_cap(monkeypatch, executions, {"execution_retention": 5})
+
+    assert executions._max_terminal_executions() == 5
+    for index in range(9):
+        row = executions.create_execution(f"done-{index}", source="builtin")
+        executions.finish_execution(row["id"], success=True)
+
+    records = executions.list_executions(limit=100)
+    assert len([row for row in records if row["status"] == "completed"]) == 5
+
+
+def test_retention_cap_rejects_unusable_config_values(monkeypatch, tmp_path):
+    """Missing, non-numeric, non-positive, and malformed values fall back.
+
+    A non-positive value would delete every terminal row on each write, so it is
+    not honoured as "prune everything"; the module override exists for that.
+    """
+    executions = _point_ledger(monkeypatch, tmp_path)
+    default = executions._DEFAULT_MAX_TERMINAL_EXECUTIONS
+
+    for cron_cfg in (
+        {},
+        {"execution_retention": 0},
+        {"execution_retention": -1},
+        {"execution_retention": "lots"},
+        {"execution_retention": None},
+        "not-a-mapping",
+    ):
+        _config_cap(monkeypatch, executions, cron_cfg)
+        assert executions._max_terminal_executions() == default, cron_cfg
+
+
+def test_retention_module_override_beats_config(monkeypatch, tmp_path):
+    """An explicit int override stays authoritative for tests and embedders."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _config_cap(monkeypatch, executions, {"execution_retention": 5000})
+    monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", 2)
+
+    assert executions._max_terminal_executions() == 2
+
+
+def test_retention_override_equal_to_default_is_honoured(monkeypatch, tmp_path):
+    """The sentinel is ``None``, so an override of exactly 1000 still wins.
+
+    Guards the alternative sentinel design (``!= _DEFAULT``), under which an
+    override set to the default value is silently ignored and config leaks back
+    in.
+    """
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _config_cap(monkeypatch, executions, {"execution_retention": 7})
+    monkeypatch.setattr(
+        executions, "MAX_TERMINAL_EXECUTIONS", executions._DEFAULT_MAX_TERMINAL_EXECUTIONS
+    )
+
+    assert executions._max_terminal_executions() == 1000
+
+
+def test_execution_retention_is_a_registered_config_default():
+    """``hermes config set cron.execution_retention`` must recognise the key.
+
+    Without the defaults entry the setting is unknown to the config surface, so
+    an operator cannot set it through the supported path.
+    """
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["cron"]["execution_retention"] == 1000
+
+
 def test_corrupt_store_fails_closed_without_overwrite(monkeypatch, tmp_path):
     executions = _point_ledger(monkeypatch, tmp_path)
     executions.EXECUTIONS_FILE.parent.mkdir(parents=True)

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -334,6 +334,20 @@ Inspect recent attempts with `hermes cron runs [job-id] --limit 20` (alias:
 `history`). Terminal history is bounded; active attempts are never pruned. The
 ledger is included in quick backups.
 
+Terminal rows are capped at 1000 by default. Raise the cap when a busy fleet
+needs a longer audit window:
+
+```yaml
+cron:
+  execution_retention: 2500   # default 1000
+```
+
+The new cap applies on the next terminal execution write. This is a **row cap,
+not a day count** — estimate it from the fleet's measured runs per day plus
+headroom for schedule growth. Raising the cap cannot restore rows that were
+already pruned, so a longer window accumulates from the change onward. A
+non-positive value falls back to the default rather than wiping the ledger.
+
 ### Repeated-failure review nudge
 
 Each job tracks a `failure_streak` — consecutive failed runs (delivery


### PR DESCRIPTION
## What does this PR do?

`cron.execution_retention` was documented config that no code read. `cron/executions.py` hard-coded `MAX_TERMINAL_EXECUTIONS = 1000`, so setting the key changed nothing while `hermes config get cron.execution_retention` echoed the operator's value straight back.

The failure is quiet, and it corrupts audits rather than breaking anything loudly. On my fleet the key was set to `2500`, yet the ledger held **exactly 1000** terminal rows spanning 4.55 days at ~220 runs/day. A retention audit then compared that span against the assumed 2500 cap and concluded that history had been lost before the increase and the cap "was not full". The cap was full — at 1000. Any tooling reasoning about a requested audit window inherits that wrong conclusion.

The approach mirrors the existing sibling `_cron_output_keep()` in `cron/jobs.py` rather than inventing a new pattern:

- An explicit int in `MAX_TERMINAL_EXECUTIONS` still wins, so the existing `monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", 3)` test and any embedder override keep working. The default becomes `None`, meaning "resolve from config". The sentinel is `None` rather than a `!= _DEFAULT` comparison so that an override set to exactly `1000` is still honoured instead of silently falling through to config.
- Config is read via `load_config_readonly()` — the prune path only reads, so it skips the defensive deepcopy.
- Unreadable config, a non-numeric value, a non-mapping `cron` section, or a non-positive value falls back to the 1000 default. A non-positive cap would delete every terminal row on each write, destroying the audit trail the ledger exists to keep, so it is deliberately **not** honored as "prune everything". The module override remains available for a deliberate zero.

`cron.execution_retention` is also registered in `hermes_cli/config_defaults.py`. Without that entry `hermes config set cron.execution_retention` does not recognise the key, so the setting is unreachable through the supported path even once pruning reads it. The cron docs gain the row-cap-vs-day-count caveat.

## Related Issue

No existing issue — I searched open and closed issues and PRs for `execution_retention` and `MAX_TERMINAL_EXECUTIONS` and found none. Happy to file one first if you'd prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor

## How Has This Been Tested?

`tests/cron/test_execution_ledger.py`: **24 passed, 0 failed** via the canonical runner (`bash scripts/run_tests.sh`).

Five new tests cover config-driven capping, unusable values (missing / `0` / `-1` / non-numeric / `None` / non-mapping), the module override, an override equal to the default, and the defaults registration.

Two positive controls confirm the tests discriminate rather than merely passing:

| Variant under test | Result |
|---|---|
| This fix | 24 passed, 0 failed |
| Reverted to the hardcoded cap | **5 of the new tests fail** |
| `!= _DEFAULT` sentinel instead of `None` | **3 fail**, incl. `test_retention_override_equal_to_default_is_honoured` |

Full `tests/cron/`: **1058 passed, 3 failed**. The 3 failures are pre-existing and reproduce identically on unmodified `origin/main` in a clean `git worktree` — `TestScriptTimeoutTreeKill::test_cancel_path_also_tree_kills` plus two `test_script_claim_heartbeat.py` cancel tests, all blocked by the repo's own `tests/conftest.py` `_live_system_guard`, which refuses `os.kill`/`os.killpg` on PIDs outside the test process group. Unrelated to retention.

Live path confirmed: with `cron.execution_retention: 2500` configured, the resolver returns `2500` where it previously returned `1000`.

## Note

Supersedes #98362, which fixed the same bug independently. Neither version was complete alone: #98362's `!= _DEFAULT` sentinel silently ignores an override equal to the default, while this branch's original form omitted the `config_defaults.py` registration. This PR combines both halves.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
