### PR TITLE
fix(update_cmd): self-heal first-party modules deleted by stash restore (#97787)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -649,6 +649,7 @@ _UPDATE_CRITICAL_MODULES = (
     "run_agent",
     "model_tools",
     "toolsets",
+    "hermes_cli.tools_config",
 )
 
 
@@ -8486,11 +8487,37 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _m().PROJECT_ROOT
         )
         if not import_ok:
-            print()
-            print(f"  ⚠ {failing_module} still fails to import after updating:")
-            print(f"      {import_error}")
-            print("    Run `hermes update` again — if it persists, reinstall:")
-            print("    https://hermes-agent.nousresearch.com")
+            # Self-healing: if a first-party module file is missing from the
+            # working tree (e.g. a stash restore re-applied a local deletion
+            # from before the update — issue #97787), try restoring it from
+            # HEAD before falling through to the warning.  This catches the
+            # specific case where `git stash apply` silently re-deletes a
+            # file that the update just pulled in.
+            if failing_module and "." in failing_module:
+                module_path = failing_module.replace(".", "/") + ".py"
+                module_full_path = _m().PROJECT_ROOT / module_path
+                if not module_full_path.exists():
+                    restore_result = subprocess.run(
+                        git_cmd + ["checkout", "HEAD", "--", module_path],
+                        cwd=_m().PROJECT_ROOT,
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                    )
+                    if restore_result.returncode == 0:
+                        # Re-validate after restoring the file.
+                        import_ok, _, _ = _validate_critical_modules_import(
+                            _m().PROJECT_ROOT
+                        )
+                        if import_ok:
+                            print()
+                            print(f"  ✓ Restored missing {module_path} from HEAD")
+                            print("    (a pre-update stash had marked it deleted)")
+            if not import_ok:
+                print()
+                print(f"  ⚠ {failing_module} still fails to import after updating:")
+                print(f"      {import_error}")
+                print("    Run `hermes update` again — if it persists, reinstall:")
+                print("    https://hermes-agent.nousresearch.com")
 
         node_failures = _update_node_dependencies()
         _m()._build_web_ui(_m().PROJECT_ROOT / "web")


### PR DESCRIPTION
## Summary

When a user has a critical module (e.g. `hermes_cli/tools_config.py`) marked as deleted in their working tree, `hermes update` stashes the deletion, pulls (restoring the file), then re-applies the stash — silently re-deleting the file. This causes a `ModuleNotFoundError` crash on the next gateway message, breaking all messaging platforms.

Reported in #97787.

## Root Cause

The update flow:
1. `_stash_local_changes_if_needed()` — stashes local changes including file deletions (`--include-untracked`)
2. `git pull` — restores the file from upstream
3. `_validate_critical_files_syntax()` — passes (file exists, pre-stash-restore)
4. `_restore_stashed_changes()` — re-applies the stash, re-deleting the file
5. `_validate_critical_modules_import()` — runs post-stash-restore, but `hermes_cli.tools_config` was NOT in `_UPDATE_CRITICAL_MODULES`, so the missing module went undetected

The post-pull syntax check (step 3) runs BEFORE stash restore, so it can't catch this. The post-restore import check (step 5) WOULD catch it — but only if the module is in the critical modules list.

## Fix

Two changes in `hermes_cli/update_cmd.py`:

1. **Add `hermes_cli.tools_config` to `_UPDATE_CRITICAL_MODULES`** — so the post-restore import check detects its absence and triggers the self-healing path.

2. **Self-healing: auto-restore missing first-party modules from HEAD** — when the import check fails and the module's file is missing from the working tree, attempt `git checkout HEAD -- <path>` to restore it, then re-validate. Only fall through to the warning if the restore fails or the module still won't import after restoration.

This follows the existing self-healing pattern already used for `state.db` corruption (line 6901+) and stale bytecode (line 6877).

## Test Plan

- [ ] Manual: mark `hermes_cli/tools_config.py` as deleted (`git rm`), run `hermes update`, verify the file is auto-restored
- [ ] Existing: `_validate_critical_modules_import` still passes with all modules present
- [ ] No regression: normal update flow (no local changes) is unaffected

Closes #97787