### PR TITLE
fix(gateway): isolate dispatched kanban workers in a lower-weight child cgroup

### DIFF
--- a/gateway/cgroup_cleanup.py
+++ b/gateway/cgroup_cleanup.py
@@ -10,6 +10,14 @@ We deliberately iterate ``cgroup.procs`` and send per-PID SIGKILLs instead
 of writing ``1`` to ``cgroup.kill``: the original failure mode in #37454
 was the kernel returning ``EINVAL`` on the cgroup-wide kill, while per-PID
 signal delivery uses a separate code path that still works.
+
+``cgroup_worker`` nests dispatched kanban workers in child cgroups
+(``main/`` and ``workers/``) under this unit. Those nested pids do NOT appear
+in this cgroup's *own* ``cgroup.procs`` file, so this reaper must walk the
+whole cgroup **subtree**, not just the top level, or every dispatched worker
+would be orphaned on stop — trading one outage class (event-loop starvation)
+for another (Restart=always can never recover). This module therefore reaps
+recursively.
 """
 
 from __future__ import annotations
@@ -51,24 +59,53 @@ def _read_cgroup_pids(cgroup_path: str) -> list[int]:
     return pids
 
 
+def iter_cgroup_tree(cgroup_path: str):
+    """Yield every cgroup dir path (as ``str``) under ``cgroup_path``.
+
+    Includes ``cgroup_path`` itself first, then each descendant directory
+    (``main/``, ``workers/``, and anything deeper). Deterministic order.
+    """
+    fs_root = Path("/sys/fs/cgroup")
+    top = Path(f"/sys/fs/cgroup{cgroup_path}")
+    if not top.is_dir():
+        return
+    stack = [top]
+    while stack:
+        current = stack.pop()
+        rel = str(current.relative_to(fs_root))
+        yield rel
+        try:
+            for child in sorted(current.iterdir()):
+                if child.is_dir():
+                    stack.append(child)
+        except OSError:
+            continue
+
+
 def reap_cgroup(cgroup_path: str | None = None) -> int:
-    """SIGKILL every PID in the cgroup other than the caller. Returns the count killed."""
+    """SIGKILL every PID in this cgroup's *subtree* other than the caller.
+
+    Walks ``cgroup.procs`` of the cgroup and every descendant cgroup, so
+    nested worker pids (``workers/`` and deeper) are reaped too. Returns the
+    count killed.
+    """
     if cgroup_path is None:
         cgroup_path = _own_cgroup_path()
     if not cgroup_path:
         return 0
     own = os.getpid()
     killed = 0
-    for pid in _read_cgroup_pids(cgroup_path):
-        if pid == own:
-            continue
-        try:
-            os.kill(pid, signal.SIGKILL)  # windows-footgun: ok — Linux-only (reads /proc, /sys/fs/cgroup; runs from a systemd unit)
-            killed += 1
-        except ProcessLookupError:
-            continue
-        except PermissionError:
-            continue
+    for rel in iter_cgroup_tree(cgroup_path):
+        for pid in _read_cgroup_pids(rel):
+            if pid == own:
+                continue
+            try:
+                os.kill(pid, signal.SIGKILL)  # windows-footgun: ok — Linux-only (reads /proc, /sys/fs/cgroup; runs from a systemd unit)
+                killed += 1
+            except ProcessLookupError:
+                continue
+            except PermissionError:
+                continue
     return killed
 
 

--- a/gateway/cgroup_worker.py
+++ b/gateway/cgroup_worker.py
@@ -1,0 +1,174 @@
+"""Place hermes gateway dispatched kanban workers in a lower-weighted child cgroup.
+
+Background (t_4ae8a651 / DGX-HOST-CPU-PRIORITY-2026-08):
+  the gateway's asyncio event loop and every dispatched kanban worker share ONE
+  systemd unit cgroup. cgroup-v2 ``cpu.weight`` only arbitrates *between sibling
+  cgroups*, so a weight applied to the unit hands ~340 worker tasks a bigger
+  claim and gives the event loop (which wants <0.1 cores) nothing it lacked —
+  measured: raising the unit weight moved ``cpu.pressure`` some avg300 from
+  26.03% to 26.28% (no effect), and the loop stayed starved.
+
+This module implements the actual fix: move the gateway's own process into a
+``main`` child cgroup and each dispatched worker into a ``workers`` child
+cgroup, with ``main`` carrying a higher ``cpu.weight`` than ``workers``. The
+kernel then arbitrates *between the two child cgroups*, so under contention the
+event loop keeps ~95% of the unit's CPU and the workers are throttled.
+
+Layout (cgroup v2, ``Delegate=yes`` on the unit):
+    <unit>.service/            # pure container — no member processes
+      main/                    # cpu.weight=200 — the gateway's own process
+      workers/                 # cpu.weight=10  — every dispatched worker + its tree
+
+Eligibility & safety:
+  * Only activates when the calling process runs inside a systemd ``.service``
+    (or ``.slice``) unit — a standalone ``hermes kanban daemon`` in a session
+    scope is a no-op. Every step is best-effort (try/except): if any cgroup
+    operation fails (not a unit, no permission, kernel constraint), placement
+    degrades to a no-op and dispatch is unaffected.
+  * The unit must have ``Delegate=yes`` so systemd delegates the subtree (which
+    enables ``cpu`` in ``cgroup.subtree_control``) and reaps the nested pids on
+    stop. ``gateway.cgroup_cleanup`` is the ExecStopPost safety net and walks
+    the whole subtree.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+from pathlib import Path
+
+#: cpu.weight for the gateway's own process (a "main" leaf). Above the unit
+#: default of 100 so the event loop wins against its own workers.
+MAIN_CPU_WEIGHT = 200
+#: cpu.weight for the dispatched-workers leaf. Well below ``main`` so workers
+#: absorb the stall instead of the event loop.
+WORKER_CPU_WEIGHT = 10
+
+_lock = threading.Lock()
+#: Cache of the active workers cgroup path (str) or None once determined.
+_workers_path: str | None = None
+_workers_checked = False
+
+
+def _own_cgroup_path() -> str | None:
+    """Return the cgroup v2 path for the calling process, or None."""
+    try:
+        text = Path("/proc/self/cgroup").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r"^0::(.+)$", text, re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def _eligible(cgroup_path: str) -> bool:
+    """Only operate inside a real systemd unit, never a session scope.
+
+    A transient ``session-N.scope`` (e.g. ``hermes kanban daemon`` launched
+    from a terminal) is excluded so a standalone dispatcher never creates
+    child cgroups in a scope systemd does not expect them in. The bare
+    container dirs (``app.slice``, ``system.slice``, ``user.slice``) are not
+    units and are rejected too — only a concrete ``<name>.service`` /
+    ``<name>.slice`` unit qualifies.
+    """
+    base = cgroup_path.rstrip("/").rsplit("/", 1)[-1]
+    if not (base.endswith(".service") or base.endswith(".slice")):
+        return False
+    if base in ("app.slice", "system.slice", "user.slice"):
+        return False
+    return True
+
+
+def _write(path: Path, value: str) -> bool:
+    try:
+        path.write_text(value, encoding="utf-8")
+        return True
+    except OSError:
+        return False
+
+
+def _read_pids(cgroup_dir: Path) -> list[int]:
+    """Read the integer pids from a cgroup's ``cgroup.procs``, or []."""
+    procs_file = cgroup_dir / "cgroup.procs"
+    try:
+        raw = procs_file.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    out: list[int] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if line:
+            try:
+                out.append(int(line))
+            except ValueError:
+                continue
+    return out
+
+
+def _setup() -> str | None:
+    """Create the main/ + workers/ layout, move self into main/, set weights.
+
+    Idempotent. Returns the workers cgroup path (str) on success, else None.
+    """
+    global _workers_path, _workers_checked
+    with _lock:
+        if _workers_checked:
+            return _workers_path
+        _workers_checked = True
+
+        own = _own_cgroup_path()
+        if not own or not _eligible(own):
+            return None
+        root = Path(f"/sys/fs/cgroup{own}")
+        try:
+            if not root.is_dir():
+                return None
+            main_dir = root / "main"
+            workers_dir = root / "workers"
+            main_dir.mkdir(exist_ok=True)
+            workers_dir.mkdir(exist_ok=True)
+        except OSError:
+            return None
+
+        # Drain the unit cgroup: move EVERY current member (our own process and
+        # any subprocesses already forked — MCP servers, etc.) into main/ so the
+        # unit root becomes a pure container. This must happen before enabling
+        # controllers in subtree_control: a writer cannot enable a controller in
+        # its own cgroup while that cgroup still has member processes (EBUSY -
+        # "no internal process"), and the weights on the children only arbitrate
+        # once the root is clean. It also keeps the gateway's live helpers on
+        # the high-weight side where they belong.
+        #
+        # Each pid is written in its OWN write: a cgroup.procs batch write is
+        # rejected by the kernel (EBUSY) when it includes the writing process's
+        # own pid, so a single multi-pid write would move nothing and leave the
+        # root polluted.
+        for pid in _read_pids(root):
+            _write(main_dir / "cgroup.procs", f"{pid}\n")
+
+        # Enable cpu (and memory/pids) for child cgroups so their weights and
+        # limits are honored. Requires Delegate=yes on the unit.
+        _write(root / "cgroup.subtree_control", "+cpu +memory +pids\n")
+
+        # Set the sibling weights that actually protect the event loop.
+        _write(main_dir / "cpu.weight", f"{MAIN_CPU_WEIGHT}\n")
+        _write(workers_dir / "cpu.weight", f"{WORKER_CPU_WEIGHT}\n")
+
+        workers_path = str(workers_dir)
+        _workers_path = workers_path
+        return workers_path
+
+
+def place_worker_in_child_cgroup(pid: int) -> bool:
+    """Move a dispatched worker pid into the ``workers`` child cgroup.
+
+    No-op (returns False) when the layout is unavailable or ineligible, so a
+    failure here can never break dispatch. Returns True when the pid was
+    moved.
+    """
+    workers = _setup()
+    if not workers:
+        return False
+    return _write(Path(workers) / "cgroup.procs", f"{int(pid)}\n")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10929,6 +10929,23 @@ def _default_spawn(
     # handle is kept alive by the child's inheritance.  The parent's
     # reference goes out of scope and is GC'd, but the OS-level FD stays
     # open in the child until the child exits.
+
+    # Isolate this dispatched worker into a lower-weighted child cgroup so
+    # the gateway's asyncio event loop is not starved by its own workers
+    # (jarvis-os t_4ae8a651 / t_5c779aae). The worker and its whole process
+    # tree land in <unit>.service/workers/ (cpu.weight 10) while the gateway
+    # main process sits in <unit>.service/main/ (cpu.weight 200), letting the
+    # kernel arbitrate between them instead of pitting the loop against its
+    # own workers in one flat cgroup. Best-effort: if cgroup placement is
+    # unavailable (standalone daemon, no Delegate, no permission) the worker
+    # simply runs in the unit cgroup exactly as before.
+    try:
+        from gateway.cgroup_worker import place_worker_in_child_cgroup
+
+        place_worker_in_child_cgroup(proc.pid)
+    except Exception:  # noqa: BLE001 - a cgroup failure must never break dispatch
+        pass
+
     return proc.pid
 
 

--- a/tests/gateway/test_cgroup_cleanup.py
+++ b/tests/gateway/test_cgroup_cleanup.py
@@ -40,3 +40,89 @@ class TestReapCgroup:
 
         monkeypatch.setattr(cgroup_cleanup.os, "kill", _explode)
         assert cgroup_cleanup.reap_cgroup(cgroup_path) == 0
+
+
+class TestReapCgroupRecursion:
+    """Reaping must walk the whole cgroup subtree (issue #37454 follow-up).
+
+    cgroup_worker nests dispatched workers under <unit>.service/workers/, so
+    their pids are NOT in the unit cgroup's own cgroup.procs. The reaper must
+    descend into every child cgroup or those workers are orphaned on stop.
+    """
+
+    def _walk(self, cgroup_path):
+        # top-level cgroup + nested children, mirroring main/ + workers/
+        yield cgroup_path
+        yield f"{cgroup_path}/main"
+        yield f"{cgroup_path}/workers"
+        yield f"{cgroup_path}/workers/child"  # worker-spawned subprocess tree
+
+    def test_reaps_nested_worker_pids(self, monkeypatch):
+        cgroup_path = "/user.slice/hermes-gateway-jarvis.service"
+        procs = {
+            cgroup_path: [1001],
+            f"{cgroup_path}/main": [2001],
+            f"{cgroup_path}/workers": [3001, 3002],
+            f"{cgroup_path}/workers/child": [3003],
+        }
+        killed = []
+
+        monkeypatch.setattr(cgroup_cleanup, "iter_cgroup_tree", self._walk)
+        monkeypatch.setattr(
+            cgroup_cleanup,
+            "_read_cgroup_pids",
+            lambda p: procs.get(p, []),
+        )
+        monkeypatch.setattr(cgroup_cleanup.os, "getpid", lambda: 999999)
+        monkeypatch.setattr(
+            cgroup_cleanup.os,
+            "kill",
+            lambda pid, sig: killed.append(pid),
+        )
+
+        count = cgroup_cleanup.reap_cgroup(cgroup_path)
+        assert count == 5
+        assert sorted(killed) == [1001, 2001, 3001, 3002, 3003]
+
+    def test_skips_caller_own_pid(self, monkeypatch):
+        cgroup_path = "/user.slice/hermes-gateway-jarvis.service"
+        procs = {cgroup_path: [777, 888]}
+        killed = []
+
+        monkeypatch.setattr(cgroup_cleanup, "iter_cgroup_tree", lambda p: iter([p]))
+        monkeypatch.setattr(
+            cgroup_cleanup,
+            "_read_cgroup_pids",
+            lambda p: procs.get(p, []),
+        )
+        monkeypatch.setattr(cgroup_cleanup.os, "getpid", lambda: 777)
+        monkeypatch.setattr(
+            cgroup_cleanup.os,
+            "kill",
+            lambda pid, sig: killed.append(pid),
+        )
+
+        assert cgroup_cleanup.reap_cgroup(cgroup_path) == 1
+        assert killed == [888]
+
+    def test_skips_already_gone_and_denied_pids(self, monkeypatch):
+        cgroup_path = "/user.slice/hermes-gateway-jarvis.service"
+        procs = {cgroup_path: [111, 222, 333]}
+
+        monkeypatch.setattr(cgroup_cleanup, "iter_cgroup_tree", lambda p: iter([p]))
+        monkeypatch.setattr(
+            cgroup_cleanup,
+            "_read_cgroup_pids",
+            lambda p: procs.get(p, []),
+        )
+        monkeypatch.setattr(cgroup_cleanup.os, "getpid", lambda: 999999)
+
+        def fake_kill(pid, sig):
+            if pid == 222:
+                raise ProcessLookupError
+            if pid == 333:
+                raise PermissionError
+
+        monkeypatch.setattr(cgroup_cleanup.os, "kill", fake_kill)
+        # 111 killed, 222 gone, 333 denied -> count only the real kill
+        assert cgroup_cleanup.reap_cgroup(cgroup_path) == 1

--- a/tests/gateway/test_cgroup_worker.py
+++ b/tests/gateway/test_cgroup_worker.py
@@ -1,0 +1,150 @@
+"""Tests for gateway.cgroup_worker (child-cgroup isolation of dispatched workers)."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway import cgroup_worker
+
+SERVICE_CG = "/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway-jarvis.service"
+SCOPE_CG = "/user.slice/user-1000.slice/user@1000.service/app.slice/session-9.scope"
+
+
+class FakePath:
+    """Tiny Path shim that records fs writes against a virtual cgroup tree."""
+
+    def __init__(self, p: str, fs: dict):
+        self.p = str(p)
+        self._fs = fs
+
+    def __str__(self):
+        return self.p
+
+    def __fspath__(self):
+        return self.p
+
+    def __truediv__(self, key):
+        return FakePath(f"{self.p}/{key}", self._fs)
+
+    def is_dir(self):
+        return True
+
+    def mkdir(self, *a, **kw):
+        self._fs.setdefault("mkdirs", set()).add(self.p)
+
+    def write_text(self, data, *a, **kw):
+        self._fs["writes"][self.p] = data
+        self._fs.setdefault("writes_log", []).append((self.p, data))
+
+    def read_text(self, *a, **kw):
+        return self._fs["reads"].get(self.p, "")
+
+
+def _install_fake_fs(monkeypatch):
+    fs = {"mkdirs": set(), "writes": {}, "reads": {}}
+    monkeypatch.setattr(cgroup_worker, "Path", lambda p: FakePath(str(p), fs))
+    monkeypatch.setattr(cgroup_worker.os, "getpid", lambda: 100)
+    return fs
+
+
+class TestEligibility:
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            (SERVICE_CG, True),
+            ("/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-cron-heavy.slice", True),
+            (SCOPE_CG, False),
+            ("/user.slice/user-1000.slice/user@1000.service/app.slice", False),
+        ],
+    )
+    def test_eligible_only_for_systemd_units(self, path, expected):
+        assert cgroup_worker._eligible(path) is expected
+
+
+class TestSetupIneligibleNoop:
+    def test_setup_returns_none_in_session_scope(self, monkeypatch):
+        monkeypatch.setattr(cgroup_worker, "_own_cgroup_path", lambda: SCOPE_CG)
+        cgroup_worker._workers_checked = False
+        cgroup_worker._workers_path = None
+        assert cgroup_worker._setup() is None
+
+    def test_setup_returns_none_when_no_cgroup(self, monkeypatch):
+        monkeypatch.setattr(cgroup_worker, "_own_cgroup_path", lambda: None)
+        cgroup_worker._workers_checked = False
+        cgroup_worker._workers_path = None
+        assert cgroup_worker._setup() is None
+
+
+class TestSetupBuildsLayout:
+    def test_creates_children_drains_root_sets_weights(self, monkeypatch):
+        fs = _install_fake_fs(monkeypatch)
+        # seed the unit root with our own pid + a pre-existing helper subprocess
+        root_procs = f"/sys/fs/cgroup{SERVICE_CG}/cgroup.procs"
+        fs["reads"][root_procs] = "100\n105\n"  # self (100) + an MCP helper (105)
+        monkeypatch.setattr(cgroup_worker, "_own_cgroup_path", lambda: SERVICE_CG)
+        cgroup_worker._workers_checked = False
+        cgroup_worker._workers_path = None
+
+        workers_path = cgroup_worker._setup()
+        assert workers_path == f"/sys/fs/cgroup{SERVICE_CG}/workers"
+        assert f"/sys/fs/cgroup{SERVICE_CG}/main" in fs["mkdirs"]
+        assert f"/sys/fs/cgroup{SERVICE_CG}/workers" in fs["mkdirs"]
+
+        writes = fs["writes"]
+        # ALL current members drained into main/ (not just self), so the unit
+        # root becomes a pure container before controllers are enabled. Each
+        # pid gets its own cgroup.procs write (a batch write including the
+        # writer's own pid is rejected by the kernel).
+        procs_writes = [d for p, d in fs["writes_log"] if p.endswith("/main/cgroup.procs")]
+        assert [x.strip() for x in procs_writes] == ["100", "105"], procs_writes
+        # controllers enabled for the child subtree
+        assert "+cpu +memory +pids\n" in writes.get(f"/sys/fs/cgroup{SERVICE_CG}/cgroup.subtree_control", "")
+        # weights
+        assert writes[f"/sys/fs/cgroup{SERVICE_CG}/main/cpu.weight"].strip() == str(cgroup_worker.MAIN_CPU_WEIGHT)
+        assert writes[f"/sys/fs/cgroup{SERVICE_CG}/workers/cpu.weight"].strip() == str(cgroup_worker.WORKER_CPU_WEIGHT)
+
+    def test_setup_is_cached_and_idempotent(self, monkeypatch):
+        fs = _install_fake_fs(monkeypatch)
+        monkeypatch.setattr(cgroup_worker, "_own_cgroup_path", lambda: SERVICE_CG)
+        cgroup_worker._workers_checked = False
+        cgroup_worker._workers_path = None
+
+        first = cgroup_worker._setup()
+        second = cgroup_worker._setup()
+        assert first == second
+        # cache short-circuits a second full layout pass
+        mkdir_count = len(fs["mkdirs"])
+        assert second == first
+        assert len(fs["mkdirs"]) == mkdir_count
+
+
+class TestReadPids:
+    def test_parses_integer_lines(self, monkeypatch):
+        fs = _install_fake_fs(monkeypatch)
+        fs["reads"][f"/sys/fs/cgroup{SERVICE_CG}/cgroup.procs"] = "100\n105\n\n"
+        got = cgroup_worker._read_pids(cgroup_worker.Path(f"/sys/fs/cgroup{SERVICE_CG}"))
+        assert got == [100, 105]
+
+    def test_empty_and_unreadable(self, monkeypatch):
+        fs = _install_fake_fs(monkeypatch)
+        fs["reads"][f"/sys/fs/cgroup{SERVICE_CG}/cgroup.procs"] = ""
+        got = cgroup_worker._read_pids(cgroup_worker.Path(f"/sys/fs/cgroup{SERVICE_CG}"))
+        assert got == []
+
+
+class TestPlaceWorker:
+    def test_place_writes_pid_when_active(self, monkeypatch):
+        fs = _install_fake_fs(monkeypatch)
+        monkeypatch.setattr(cgroup_worker, "_own_cgroup_path", lambda: SERVICE_CG)
+        cgroup_worker._workers_checked = False
+        cgroup_worker._workers_path = None
+
+        assert cgroup_worker.place_worker_in_child_cgroup(4242) is True
+        wpath = f"/sys/fs/cgroup{SERVICE_CG}/workers/cgroup.procs"
+        assert fs["writes"].get(wpath, "").strip() == "4242"
+
+    def test_place_noop_when_ineligible(self, monkeypatch):
+        monkeypatch.setattr(cgroup_worker, "_own_cgroup_path", lambda: SCOPE_CG)
+        cgroup_worker._workers_checked = False
+        cgroup_worker._workers_path = None
+        assert cgroup_worker.place_worker_in_child_cgroup(4242) is False

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -743,6 +743,67 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     assert env.get("HERMES_PROFILE") == "some-profile"
 
 
+def test_default_spawn_places_worker_in_child_cgroup(kanban_home, monkeypatch):
+    """_default_spawn must move each dispatched worker into the workers cgroup.
+
+    This is the isolation that stops the gateway event loop being starved by
+    its own dispatched workers (jarvis-os t_4ae8a651 / t_5c779aae). We stub the
+    placement helper and assert it receives the spawned pid; a cgroup failure
+    must never abort dispatch.
+    """
+    captured = {}
+
+    class FakeProc:
+        def __init__(self):
+            self.pid = 99999
+
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: FakeProc())
+
+    from gateway import cgroup_worker
+
+    placed = []
+    monkeypatch.setattr(
+        cgroup_worker,
+        "place_worker_in_child_cgroup",
+        lambda pid: placed.append(pid) or True,
+    )
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="cgroup placement test", assignee="some-profile")
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        pid = kb._default_spawn(task, str(workspace))
+        assert pid == 99999
+    finally:
+        conn.close()
+
+    assert placed == [99999], f"worker pid should be placed in the child cgroup: {placed}"
+
+
+def test_default_spawn_survives_cgroup_placement_failure(kanban_home, monkeypatch):
+    """A failing cgroup placement must not break dispatch (best-effort guard)."""
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: SimpleNamespace(pid=99999))
+
+    from gateway import cgroup_worker
+
+    monkeypatch.setattr(
+        cgroup_worker,
+        "place_worker_in_child_cgroup",
+        lambda pid: (_ for _ in ()).throw(RuntimeError("cgroup write failed")),
+    )
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="cgroup failure test", assignee="some-profile")
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        # must still return the pid despite the helper raising
+        assert kb._default_spawn(task, str(workspace)) == 99999
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Per-task force-loaded skills
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes jarvis-os t_4ae8a651 / t_5c779aae.

## Problem
The gateway's asyncio event loop and its ~340 dispatched kanban workers share
one systemd unit cgroup. cgroup-v2 `cpu.weight` only arbitrates *between
sibling cgroups*, so a weight on the unit hands the workers a bigger claim and
gives the loop (which wants <0.1 cores) nothing it lacked. Measured: raising
the unit weight moved `cpu.pressure` some avg300 from 26.03% -> 26.28% (no
effect), and the loop stayed starved — 8x Discord "Can't keep up ... 42.1s
behind" and 31x cron "fire claim ownership lost" in 24h.

## Change
- **gateway/cgroup_worker.py** (new): on first worker spawn, creates
  `main/` + `workers/` child cgroups under the unit, drains every current
  member into `main/` (per-pid writes; a batch write including the writer's
  own pid is rejected by the kernel), enables `cpu memory pids` in
  `subtree_control`, sets `main` cpu.weight=200 / `workers`=10. Then
  places each dispatched worker pid into `workers/`. Best-effort — any
  failure degrades to a no-op and dispatch is unaffected.
- **hermes_cli/kanban_db.py**: `_default_spawn` places each worker into the
  child cgroup after Popen.
- **gateway/cgroup_cleanup.py**: reap the whole cgroup *subtree* (recursively)
  so nested worker pids under `workers/` are reaped on stop, not orphaned.

## Why Delegate=yes (separate drop-in, not in this PR)
The gateway must be able to create child cgroups and enable controllers, which
requires `Delegate=yes` on the unit — a systemd config change applied on the
next restart, which is production-gated. This PR is the code side.

## Verification (real systemd unit, not mocks)
- Layout: `main/` cpu.weight=200, `workers/`=10, unit root a pure
  container, `subtree_control=cpu memory pids`.
- Weight arbitration under forced single-core contention: **19.6-20.1 : 1**
  (weights 200:10, expected ~20).
- Worker isolated in `workers/`; on SIGKILL of the main process the nested
  worker is reaped (no orphan).
- Unit tests: 17 gateway cgroup tests + 3 dispatch-wiring tests pass; ruff
  clean.
