### PR TITLE
fix(disk-cleanup): protect active Kanban workspaces

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -147,7 +147,7 @@ ALLOWED_CATEGORIES = {
 _EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
     "logs", "memories", "sessions", "cron", "cronjobs",
     "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
-    "hermes-agent", "backups", "profiles", ".worktrees",
+    "hermes-agent", "backups", "profiles", "kanban", ".worktrees",
     # User-authored project trees — never sweep empty directories
     # inside these (#75403).
     "patches", "projects", "skins", "themes", "contributors",
@@ -585,7 +585,7 @@ def guess_category(path: Path) -> Optional[str]:
             # inside these just because they happen to be named test_* or
             # tmp_* (#75403, also #32164, #37721).
             "patches", "projects", "skins", "themes", "contributors",
-            "profiles", "backups", "optional-skills",
+            "profiles", "backups", "optional-skills", "kanban",
         }:
             return None
         if top == "cron" or top == "cronjobs":

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -134,6 +134,15 @@ class TestGuessCategory:
         p.write_text("[]")
         assert dg.guess_category(p) is None
 
+    def test_kanban_workspace_test_file_not_tracked(self, _isolate_env):
+        dg = _load_lib()
+        workspace = _isolate_env / "kanban" / "workspaces" / "t_active"
+        workspace.mkdir(parents=True)
+        p = workspace / "test_probe.py"
+        p.write_text("x")
+
+        assert dg.guess_category(p) is None
+
     def test_ordinary_file_returns_none(self, _isolate_env):
         dg = _load_lib()
         p = _isolate_env / "notes.md"
@@ -226,6 +235,47 @@ class TestStaleCronEntryMigration:
 
 
 class TestTrackForgetQuick:
+    def test_quick_preserves_empty_kanban_workspace(self, _isolate_env):
+        dg = _load_lib()
+        workspace = _isolate_env / "kanban" / "workspaces" / "t_active"
+        workspace.mkdir(parents=True)
+
+        dg.quick()
+
+        assert workspace.is_dir()
+
+    def test_quick_drops_stale_kanban_test_entry_without_deleting_file(
+        self, _isolate_env
+    ):
+        dg = _load_lib()
+        workspace = _isolate_env / "kanban" / "workspaces" / "t_active"
+        workspace.mkdir(parents=True)
+        p = workspace / "test_probe.py"
+        p.write_text("x")
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(p),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": 1,
+        }]))
+
+        summary = dg.quick()
+
+        assert summary["deleted"] == 0
+        assert p.is_file()
+        assert json.loads(tracked_file.read_text()) == []
+
+    def test_quick_removes_disposable_empty_directory(self, _isolate_env):
+        dg = _load_lib()
+        disposable = _isolate_env / "scratch" / "empty"
+        disposable.mkdir(parents=True)
+
+        dg.quick()
+
+        assert not disposable.exists()
+
     def test_track_then_quick_deletes_test(self, _isolate_env):
         dg = _load_lib()
         p = _isolate_env / "test_a.py"


### PR DESCRIPTION
## Summary
- treat the top-level `kanban/` tree as durable during empty-directory cleanup
- exclude task-local `test_*` / `tmp_*` files under `kanban/` from auto-tracking, so existing stale-entry revalidation drops stale state without deleting the file
- retain ordinary test-file deletion and ordinary empty-directory sweeping through control regressions

## TDD evidence
RED on pre-fix `aff5125f8edf5095aef5d3d79bbbb101c95b9413`:
- `scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py -k test_quick_preserves_empty_kanban_workspace -q`
- result: `1 failed`; `workspace.is_dir()` was `False` after `quick()`

GREEN on `12ec7370400b3e7cf4ef8ffb86a92c197f0ce2e3` (rebased onto `origin/main`):
- `uv run pytest tests/plugins/test_disk_cleanup_plugin.py -q` -> `31 passed`
- `scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py -q` -> `31 tests passed, 0 failed`
- `uv run ruff check plugins/disk-cleanup/disk_cleanup.py tests/plugins/test_disk_cleanup_plugin.py` -> exit 0
- `git diff --check origin/main...HEAD` -> exit 0

## Scope
Only:
- `plugins/disk-cleanup/disk_cleanup.py`
- `tests/plugins/test_disk_cleanup_plugin.py`

No Desktop-update or runtime deployment files are included. Runtime deployment/read-back remains owned by the pre-created audit child after merge.