### PR TITLE
fix(opencode): delisted keyless free models no longer 401 the picker — catalog revalidates live (#95914, salvage #95943)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -572,11 +572,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # tier, so a relay-delisted model stops appearing in the picker and a
     # newly-live one becomes selectable without a release. This floor keeps the
     # picker populated when the relay is unreachable. Note: this floor may lag
-    # the live relay (e.g. x-preview-f-free was delisted 2026-08-26) — that is
-    # intentional; the live revalidation is the source of truth when reachable.
-    # deepseek-v4-flash-free and mimo-v2.5-free are back on the live list.
+    # the live relay — that is intentional; the live revalidation is the
+    # source of truth when reachable. Known-delisted models are REMOVED from
+    # the floor (x-preview-f-free delisted 2026-08-26 — offline fallback must
+    # not offer a model that 401s). deepseek-v4-flash-free and mimo-v2.5-free
+    # are back on the live list.
     "opencode-free": [
-        "x-preview-f-free",  # "Ox Alpha" stealth model — free, 1M ctx, ZDR
         "deepseek-v4-flash-free",
         "hy3-free",
         "mimo-v2.5-free",
@@ -4113,7 +4114,9 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     # empty. This is what keeps a relay-delisted model (e.g. x-preview-f-free)
     # from lingering in the picker until a release re-syncs the snapshot.
     if normalized == "opencode-free":
-        return _fetch_opencode_free_models() or list(_PROVIDER_MODELS.get(normalized, []))
+        return _fetch_opencode_free_models(
+            force_refresh=force_refresh
+        ) or list(_PROVIDER_MODELS.get(normalized, []))
 
     # ── Profile-based generic live fetch (all simple api-key providers) ──
     # Handles any provider registered in providers/ with auth_type="api_key".
@@ -5475,6 +5478,14 @@ _OPENCODE_KEYLESS_EXTRA_SLUGS = frozenset({"big-pickle"})
 # subscription twin of the Zen keyless Ox Alpha (verified 2026-08-21).
 _OPENCODE_FREE_KEYED_SUFFIX_MODELS = frozenset({"ox-alpha-free"})
 
+# In-process memo for _fetch_opencode_free_models(): (fetched_at, ids-or-None).
+# Direct provider_model_ids("opencode-free") callers (model validation, healing)
+# can run several times per resolution — without this each would block on a
+# network round-trip. Failures are memoized too (negative caching) so an
+# unreachable relay doesn't stall every validation for `timeout` seconds.
+_opencode_free_live_memo: Optional[tuple[float, Optional[list[str]]]] = None
+_OPENCODE_FREE_LIVE_MEMO_TTL = 300.0  # 5 min; SWR disk cache handles the rest
+
 
 def is_opencode_zen_free_model(model_id: Optional[str]) -> bool:
     """True when ``model_id`` is an OpenCode Zen free-tier slug.
@@ -5511,7 +5522,9 @@ def opencode_zen_free_headers() -> dict:
     }
 
 
-def _fetch_opencode_free_models(timeout: float = 8.0) -> Optional[list[str]]:
+def _fetch_opencode_free_models(
+    timeout: float = 8.0, *, force_refresh: bool = False
+) -> Optional[list[str]]:
     """Fetch the live keyless OpenCode Free catalog from the Zen relay.
 
     GETs ``{_OPENCODE_ZEN_FREE_BASE_URL}/models`` ANONYMOUSLY (the free tier
@@ -5522,6 +5535,13 @@ def _fetch_opencode_free_models(timeout: float = 8.0) -> Optional[list[str]]:
     treated as a failure for the same reason (a relay with zero free models is
     not worth trusting over the floor).
 
+    A short in-process memo (``_OPENCODE_FREE_LIVE_MEMO_TTL``) keeps direct
+    ``provider_model_ids("opencode-free")`` callers — model validation runs
+    it several times per resolution — from issuing one blocking network
+    round-trip each. The picker's cross-process freshness still comes from
+    the SWR disk cache one layer up; ``force_refresh=True`` (the SWR refresh
+    path) bypasses and repopulates the memo.
+
     The Zen ``/models`` dump also lists paid/subscription IDs (e.g. Go
     ``ox-alpha-free`` is KEYED despite the suffix), so a bare ``*-free`` suffix
     filter is not safe on its own — this mirrors the existing
@@ -5531,6 +5551,12 @@ def _fetch_opencode_free_models(timeout: float = 8.0) -> Optional[list[str]]:
     import urllib.request
 
     from hermes_cli.urllib_security import open_credentialed_url
+
+    now = time.time()
+    if not force_refresh:
+        memo = _opencode_free_live_memo
+        if memo is not None and now - memo[0] < _OPENCODE_FREE_LIVE_MEMO_TTL:
+            return list(memo[1]) if memo[1] else None
 
     url = f"{_OPENCODE_ZEN_FREE_BASE_URL.rstrip('/')}/models"
     req = urllib.request.Request(url)
@@ -5543,6 +5569,7 @@ def _fetch_opencode_free_models(timeout: float = 8.0) -> Optional[list[str]]:
             data = json.loads(resp.read().decode())
         items = data if isinstance(data, list) else data.get("data", [])
     except Exception:
+        _set_opencode_free_live_memo(None)
         return None
     ids = [m["id"] for m in items if isinstance(m, dict) and isinstance(m.get("id"), str)]
     # Filter to the anonymous-servable free tier. The Zen dump can contain
@@ -5553,7 +5580,35 @@ def _fetch_opencode_free_models(timeout: float = 8.0) -> Optional[list[str]]:
         if mid.lower().endswith("-free")
         and mid.lower() not in _OPENCODE_FREE_KEYED_SUFFIX_MODELS
     ]
-    return live_free if live_free else None
+    result = live_free if live_free else None
+    _set_opencode_free_live_memo(result)
+    return result
+
+
+def _set_opencode_free_live_memo(ids: Optional[list[str]]) -> None:
+    global _opencode_free_live_memo
+    _opencode_free_live_memo = (time.time(), list(ids) if ids else None)
+
+
+def _opencode_free_known_model_slugs() -> set[str]:
+    """Lowercased keyless free-tier slugs known right now — WITHOUT network I/O.
+
+    Union of the static ``_PROVIDER_MODELS["opencode-free"]`` floor, the
+    in-process live memo, and the SWR disk-cache entry. Used by the
+    ``opencode_zen_free_runtime`` healing path, which runs during model
+    resolution and must never block on a live fetch. Union (not replacement)
+    so a stale cache can only widen healing, never silently disable it.
+    """
+    known = {m.lower() for m in _PROVIDER_MODELS.get("opencode-free", [])}
+    memo = _opencode_free_live_memo
+    if memo is not None and memo[1]:
+        known.update(m.lower() for m in memo[1])
+    try:
+        entry = _load_provider_models_cache().get("opencode-free") or {}
+        known.update(str(m).lower() for m in entry.get("models", []) or [])
+    except Exception:
+        pass
+    return known
 
 
 def opencode_zen_free_runtime(provider_id: Optional[str], model_id: Optional[str]) -> Optional[dict]:
@@ -5573,13 +5628,16 @@ def opencode_zen_free_runtime(provider_id: Optional[str], model_id: Optional[str
     stopped being a reliable keyless signal when ``ox-alpha-free`` appeared
     on the Go relay as a KEYED subscription model (2026-08-21) — suffix-based
     healing would have routed it to a Zen relay that doesn't serve it.
+    Membership means the union of the cached LIVE keyless catalog (in-process
+    memo / SWR disk cache — never a blocking fetch on this hot path) and the
+    static floor, so a newly-live free model heals without a release.
     """
     family = opencode_provider_family(provider_id)
     if family is None:
         return None
     if family != "opencode-free":
         bare = normalize_opencode_model_id(provider_id, model_id).strip().lower()
-        if bare not in {m.lower() for m in _PROVIDER_MODELS.get("opencode-free", [])}:
+        if bare not in _opencode_free_known_model_slugs():
             return None
     normalized = normalize_opencode_model_id(provider_id, model_id)
     api_mode = opencode_model_api_mode("opencode-zen", normalized)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -566,16 +566,20 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3.5-lightning-free",
         "muse-spark-1.2-contributor-free",
     ],
-    # OpenCode free tier — keyless (no OpenCode account needed). Synced
-    # against live GET /zen/v1/models + anonymous probes (2026-08-21);
-    # deepseek-v4-flash-free delisted (promo ended, now 401s).
-    # big-pickle + mimo-v2.5-free delisted (UA-gated: the relay 429s
-    # FreeUsageLimitError for every client except User-Agent
-    # "opencode/latest"; we send honest Hermes attribution and don't
-    # impersonate other clients — verified 2026-08-21).
+    # OpenCode free tier — keyless (no OpenCode account needed). This is the
+    # OFFLINE FLOOR only: provider_model_ids("opencode-free") revalidates live
+    # against GET /zen/v1/models (keyless) and filters to the anonymous free
+    # tier, so a relay-delisted model stops appearing in the picker and a
+    # newly-live one becomes selectable without a release. This floor keeps the
+    # picker populated when the relay is unreachable. Note: this floor may lag
+    # the live relay (e.g. x-preview-f-free was delisted 2026-08-26) — that is
+    # intentional; the live revalidation is the source of truth when reachable.
+    # deepseek-v4-flash-free and mimo-v2.5-free are back on the live list.
     "opencode-free": [
         "x-preview-f-free",  # "Ox Alpha" stealth model — free, 1M ctx, ZDR
+        "deepseek-v4-flash-free",
         "hy3-free",
+        "mimo-v2.5-free",
         "laguna-s-2.1-free",
         "nemotron-3-ultra-free",
         "nemotron-3.5-lightning-free",
@@ -4100,12 +4104,16 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         except Exception:
             pass
 
-    # OpenCode Free: curated keyless list only. models.dev's cost.input==0
-    # filter lags reality (deepseek-v4-flash-free stayed "free" there after
-    # its promo ended and the relay began 401ing keyless requests), so the
-    # curated list — synced against anonymous live probes — is authoritative.
+    # OpenCode Free: keyless live catalog, revalidated against the Zen relay
+    # every TTL. models.dev's cost.input==0 filter lags reality
+    # (deepseek-v4-flash-free stayed "free" there after its promo ended and the
+    # relay began 401ing keyless requests), so we filter the live /zen/v1/models
+    # dump to the anonymous-servable `*-free` tier ourselves and fall back to
+    # the curated _PROVIDER_MODELS floor only when the live fetch fails or is
+    # empty. This is what keeps a relay-delisted model (e.g. x-preview-f-free)
+    # from lingering in the picker until a release re-syncs the snapshot.
     if normalized == "opencode-free":
-        return list(_PROVIDER_MODELS.get(normalized, []))
+        return _fetch_opencode_free_models() or list(_PROVIDER_MODELS.get(normalized, []))
 
     # ── Profile-based generic live fetch (all simple api-key providers) ──
     # Handles any provider registered in providers/ with auth_type="api_key".
@@ -4196,6 +4204,12 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
 #     to a live fetch — the picker keeps working.
 
 _PROVIDER_MODELS_CACHE_TTL = 3600  # 1h
+# Providers whose catalog is served with NO credential and therefore gets a
+# stable (constant) credential fingerprint in the disk cache. The opencode-free
+# catalog is anonymous — its freshness comes from TTL revalidation, not from
+# user-rotatable credentials — so folding in unrelated auth.json mtimes would
+# only needlessly bust the SWR cache.
+_KEYLESS_STABLE_CACHE_PROVIDERS = frozenset({"opencode-free"})
 # Stale-while-revalidate window: an expired-but-same-credentials entry is
 # served IMMEDIATELY (picker opens stay instant) while a background daemon
 # thread re-fetches the live catalog and rewrites the disk cache for the
@@ -4295,6 +4309,14 @@ def _credential_fingerprint(provider: str) -> str:
     import os as _os
 
     parts: list[str] = []
+
+    # Keyless providers have no credential to fingerprint: the catalog is
+    # served anonymously, so nothing the user rotates (env vars, auth files,
+    # base URLs) should invalidate the cached entry. A stable fingerprint keeps
+    # the SWR disk cache alive across unrelated re-auths and only busts on TTL
+    # expiry — matching how the live catalog genuinely changes.
+    if (provider or "").strip().lower() in _KEYLESS_STABLE_CACHE_PROVIDERS:
+        return "keyless:" + (provider or "").strip().lower()
 
     # Env vars from PROVIDER_REGISTRY for this slug
     try:
@@ -5447,6 +5469,12 @@ _OPENCODE_ZEN_FREE_BASE_URL = "https://opencode.ai/zen/v1"
 # (big-pickle is OpenCode's rotating free stealth slot.)
 _OPENCODE_KEYLESS_EXTRA_SLUGS = frozenset({"big-pickle"})
 
+# Models whose slug carries ``-free`` but are NOT anonymous-servable: they are
+# KEYED (Go-subscription) models and must be excluded from the keyless free
+# catalog even though the suffix looks free. ox-alpha-free is the Go relay's
+# subscription twin of the Zen keyless Ox Alpha (verified 2026-08-21).
+_OPENCODE_FREE_KEYED_SUFFIX_MODELS = frozenset({"ox-alpha-free"})
+
 
 def is_opencode_zen_free_model(model_id: Optional[str]) -> bool:
     """True when ``model_id`` is an OpenCode Zen free-tier slug.
@@ -5481,6 +5509,51 @@ def opencode_zen_free_headers() -> dict:
         "X-Title": "Hermes Agent",
         "User-Agent": f"HermesAgent/{_v}",
     }
+
+
+def _fetch_opencode_free_models(timeout: float = 8.0) -> Optional[list[str]]:
+    """Fetch the live keyless OpenCode Free catalog from the Zen relay.
+
+    GETs ``{_OPENCODE_ZEN_FREE_BASE_URL}/models`` ANONYMOUSLY (the free tier
+    rejects any unrecognized Authorization bearer with 401) and filters the
+    dump to the anonymous-servable ``*-free`` tier. Returns ``None`` on any
+    network/auth/parse failure so callers fall back to the curated
+    ``_PROVIDER_MODELS["opencode-free"]`` floor; an empty filtered result is
+    treated as a failure for the same reason (a relay with zero free models is
+    not worth trusting over the floor).
+
+    The Zen ``/models`` dump also lists paid/subscription IDs (e.g. Go
+    ``ox-alpha-free`` is KEYED despite the suffix), so a bare ``*-free`` suffix
+    filter is not safe on its own — this mirrors the existing
+    ``opencode_zen_free_runtime`` contract, which uses membership in the
+    verified keyless catalog as the routing criterion.
+    """
+    import urllib.request
+
+    from hermes_cli.urllib_security import open_credentialed_url
+
+    url = f"{_OPENCODE_ZEN_FREE_BASE_URL.rstrip('/')}/models"
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/json")
+    for k, v in opencode_zen_free_headers().items():
+        if k.lower() != "authorization":  # never send a bearer keylessly
+            req.add_header(k, v)
+    try:
+        with open_credentialed_url(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode())
+        items = data if isinstance(data, list) else data.get("data", [])
+    except Exception:
+        return None
+    ids = [m["id"] for m in items if isinstance(m, dict) and isinstance(m.get("id"), str)]
+    # Filter to the anonymous-servable free tier. The Zen dump can contain
+    # keyed/Go IDs; only the verified free set belongs in the keyless picker.
+    live_free = [
+        mid
+        for mid in ids
+        if mid.lower().endswith("-free")
+        and mid.lower() not in _OPENCODE_FREE_KEYED_SUFFIX_MODELS
+    ]
+    return live_free if live_free else None
 
 
 def opencode_zen_free_runtime(provider_id: Optional[str], model_id: Optional[str]) -> Optional[dict]:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -112,7 +112,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-sonnet-5", "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["x-preview-f-free", "gpt-5.6-sol", "gpt-5.4", "gpt-5.3-codex", "claude-opus-5", "claude-sonnet-5", "gemini-3.7-flash", "glm-5.2", "kimi-k3", "minimax-m3"],
-    "opencode-free": ["x-preview-f-free", "hy3-free", "laguna-s-2.1-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free"],
+    "opencode-free": ["deepseek-v4-flash-free", "hy3-free", "mimo-v2.5-free", "laguna-s-2.1-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free"],
     "opencode-go": ["kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "gpt-5.6-luna", "grok-4.5", "glm-5.3", "glm-5.3-flash", "glm-5.2", "mimo-v2.5-pro", "mimo-v2.5", "minimax-m3", "minimax-m2.7", "qwen3.8-max", "qwen3.7-max", "deepseek-v4-pro", "hy3"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",

--- a/tests/agent/test_opencode_free_provider.py
+++ b/tests/agent/test_opencode_free_provider.py
@@ -91,9 +91,11 @@ class TestOpenCodeFreeModelLists:
         for mid in _PROVIDER_MODELS["opencode-free"]:
             assert is_opencode_zen_free_model(mid), mid
 
-    def test_ox_alpha_is_listed(self):
+    def test_delisted_ox_alpha_not_in_floor(self):
+        """x-preview-f-free was delisted by the relay 2026-08-26 (401s keyless);
+        the offline floor must not offer it (#95914)."""
         from hermes_cli.models import _PROVIDER_MODELS
-        assert "x-preview-f-free" in _PROVIDER_MODELS["opencode-free"]
+        assert "x-preview-f-free" not in _PROVIDER_MODELS["opencode-free"]
 
 
 class TestOpenCodeFreeRuntimeKeyless:

--- a/tests/hermes_cli/test_opencode_free_live_catalog.py
+++ b/tests/hermes_cli/test_opencode_free_live_catalog.py
@@ -1,0 +1,129 @@
+"""Regression tests for #95914 — keyless opencode-free catalog live revalidation.
+
+The opencode-free (keyless) model catalog used to be served exclusively from a
+hardcoded in-repo snapshot (_PROVIDER_MODELS["opencode-free"]). When the OpenCode
+Zen relay delisted a free model (e.g. x-preview-f-free, 2026-08-26), the picker
+kept offering it and selecting it failed with a non-retryable HTTP 401
+("Model x-preview-f-free is not supported"). The SWR disk cache only refreshed
+AUTHED providers (its entries were keyed by a credential fingerprint, which
+keyless providers have none of), so the keyless catalog never revalidated.
+
+The fix makes provider_model_ids("opencode-free") revalidate LIVE against
+GET /zen/v1/models (anonymous, filtered to the free tier) and gives the keyless
+provider a stable disk-cache fingerprint so the picker's SWR path serves stale
+immediately while refreshing off-thread — the same behavior authed providers
+already get.
+
+These tests PROVE the fix: reverting the live-fetch wiring makes the
+delisted-model / newly-live-model assertions fail (the catalog reverts to the
+static snapshot only).
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.models import (
+    _KEYLESS_STABLE_CACHE_PROVIDERS,
+    _PROVIDER_MODELS,
+    cached_provider_model_ids,
+    provider_model_ids,
+)
+
+# Static floor (may lag the live relay by design — it is only the offline fallback).
+_STATIC_FLOOR = list(_PROVIDER_MODELS["opencode-free"])
+
+# The live relay's current free tier. x-preview-f-free was DELISTED 2026-08-26;
+# deepseek-v4-flash-free + mimo-v2.5-free are back on the live list.
+_LIVE_FREE_MODELS = [
+    "deepseek-v4-flash-free",
+    "hy3-free",
+    "mimo-v2.5-free",
+    "laguna-s-2.1-free",
+    "nemotron-3-ultra-free",
+    "nemotron-3.5-lightning-free",
+    "muse-spark-1.2-contributor-free",
+]
+
+# The raw live /zen/v1/models dump also lists paid/subscription + KEYED-free IDs
+# (e.g. ox-alpha-free is a Go-subscription model despite the suffix). The filter
+# must keep only anonymous-servable free models.
+_LIVE_RAW_IDS = _LIVE_FREE_MODELS + [
+    "claude-sonnet-5",          # paid
+    "gpt-5.6-sol",              # paid
+    "ox-alpha-free",            # KEYED Go-subscription (suffix looks free)
+]
+
+
+class TestProviderModelIdsOpencodeFree:
+    def test_live_catalog_revalidation_excludes_delisted(self):
+        """The delisted model must NOT appear when the live relay no longer lists it."""
+        with patch(
+            "hermes_cli.models._fetch_opencode_free_models",
+            return_value=list(_LIVE_FREE_MODELS),
+        ):
+            result = provider_model_ids("opencode-free")
+
+        assert "x-preview-f-free" not in result  # delisted — REVERT-PROOF
+        assert "deepseek-v4-flash-free" in result  # newly-live — REVERT-PROOF
+        assert "mimo-v2.5-free" in result  # newly-live — REVERT-PROOF
+
+    def test_live_catalog_filters_out_keyed_free_suffix_model(self):
+        """ox-alpha-free (KEYED Go-subscription) must never enter the keyless picker."""
+        with patch(
+            "hermes_cli.models._fetch_opencode_free_models",
+            return_value=list(_LIVE_FREE_MODELS),
+        ):
+            result = provider_model_ids("opencode-free")
+        assert "ox-alpha-free" not in result
+
+    def test_falls_back_to_static_floor_when_live_fetch_fails(self):
+        """On live-fetch failure/empty, the static floor keeps the picker populated."""
+        with patch("hermes_cli.models._fetch_opencode_free_models", return_value=None):
+            result = provider_model_ids("opencode-free")
+        assert result == _STATIC_FLOOR
+        assert result  # never empty on a transient outage
+
+    def test_empty_live_result_falls_back_to_static_floor(self):
+        """An empty live result (no free models) is not trusted over the floor."""
+        with patch("hermes_cli.models._fetch_opencode_free_models", return_value=[]):
+            result = provider_model_ids("opencode-free")
+        assert result == _STATIC_FLOOR
+
+
+class TestOpencodeFreeCacheFingerprint:
+    def test_keyless_provider_has_stable_fingerprint(self):
+        """opencode-free is in the stable-fingerprint set (no credential to rotate)."""
+        assert "opencode-free" in _KEYLESS_STABLE_CACHE_PROVIDERS
+
+        import hermes_cli.models as mod
+
+        fp1 = mod._credential_fingerprint("opencode-free")
+        fp2 = mod._credential_fingerprint("opencode-free")
+        assert fp1 == fp2
+        assert fp1.startswith("keyless:opencode-free")
+
+    def test_cached_picker_path_revalidates_live(self):
+        """cached_provider_model_ids('opencode-free') serves the live catalog and
+        persists it under a stable fingerprint (SWR cache path the picker uses)."""
+        import time
+
+        import hermes_cli.models as mod
+
+        with (
+            patch.object(mod, "_load_provider_models_cache", return_value={}),
+            patch.object(
+                mod,
+                "_fetch_opencode_free_models",
+                return_value=list(_LIVE_FREE_MODELS),
+            ) as fetch,
+            patch.object(mod, "_save_provider_models_cache") as save,
+        ):
+            out = cached_provider_model_ids("opencode-free")
+
+        assert out == list(_LIVE_FREE_MODELS)
+        fetch.assert_called_once()
+        # The persisted entry carries the stable keyless fingerprint so future
+        # SWR lookups match and don't re-fetch on unrelated auth changes.
+        written = save.call_args[0][0]
+        entry = written["opencode-free"]
+        assert entry["fp"].startswith("keyless:opencode-free")
+        assert isinstance(entry["at"], float) and not isinstance(entry["at"], bool)

--- a/tests/hermes_cli/test_opencode_free_live_catalog.py
+++ b/tests/hermes_cli/test_opencode_free_live_catalog.py
@@ -127,3 +127,95 @@ class TestOpencodeFreeCacheFingerprint:
         entry = written["opencode-free"]
         assert entry["fp"].startswith("keyless:opencode-free")
         assert isinstance(entry["at"], float) and not isinstance(entry["at"], bool)
+
+
+class TestOpencodeFreeFollowUps:
+    """Follow-up hardening on top of the salvaged live-catalog fix (#95943)."""
+
+    def _reset_memo(self, mod):
+        mod._opencode_free_live_memo = None
+
+    def test_fetch_memoizes_success_in_process(self):
+        """Direct provider_model_ids() callers must not each pay a network
+        round-trip: the second call within the memo TTL is served in-process."""
+        import hermes_cli.models as mod
+
+        self._reset_memo(mod)
+        calls = {"n": 0}
+
+        def fake_open(req, timeout):
+            calls["n"] += 1
+            import io, json as _json
+
+            class _Resp(io.BytesIO):
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *a):
+                    return False
+
+            return _Resp(
+                _json.dumps({"data": [{"id": m} for m in _LIVE_FREE_MODELS]}).encode()
+            )
+
+        with patch("hermes_cli.urllib_security.open_credentialed_url", fake_open):
+            first = mod._fetch_opencode_free_models()
+            second = mod._fetch_opencode_free_models()
+        assert first == second == list(_LIVE_FREE_MODELS)
+        assert calls["n"] == 1  # memo served the second call
+        self._reset_memo(mod)
+
+    def test_fetch_memoizes_failure_negative_cache(self):
+        """An unreachable relay is memoized too — repeated validations must not
+        each block for the full network timeout."""
+        import hermes_cli.models as mod
+
+        self._reset_memo(mod)
+        calls = {"n": 0}
+
+        def fake_open(req, timeout):
+            calls["n"] += 1
+            raise OSError("relay down")
+
+        with patch("hermes_cli.urllib_security.open_credentialed_url", fake_open):
+            assert mod._fetch_opencode_free_models() is None
+            assert mod._fetch_opencode_free_models() is None
+        assert calls["n"] == 1
+        self._reset_memo(mod)
+
+    def test_heal_union_includes_live_only_model(self):
+        """A newly-live free model absent from the static floor must still heal
+        opencode-go/zen selections to the keyless Zen relay (sibling-site widen:
+        opencode_zen_free_runtime used to check the floor only)."""
+        import hermes_cli.models as mod
+
+        live_only = "ling-3.0-flash-fin-free"
+        assert live_only not in {m.lower() for m in _PROVIDER_MODELS["opencode-free"]}
+
+        self._reset_memo(mod)
+        with patch.object(mod, "_load_provider_models_cache", return_value={}):
+            assert mod.opencode_zen_free_runtime("opencode-go", live_only) is None
+
+        mod._set_opencode_free_live_memo(_LIVE_FREE_MODELS + [live_only])
+        try:
+            with patch.object(mod, "_load_provider_models_cache", return_value={}):
+                rt = mod.opencode_zen_free_runtime("opencode-go", live_only)
+            assert rt is not None and rt["source"] == "opencode-zen-free-keyless"
+        finally:
+            self._reset_memo(mod)
+
+    def test_heal_union_reads_swr_disk_cache(self):
+        """A fresh process (empty memo) still heals live-only models via the
+        SWR disk-cache entry — no blocking fetch on the resolution hot path."""
+        import hermes_cli.models as mod
+
+        live_only = "ling-3.0-flash-fin-free"
+        self._reset_memo(mod)
+        entry = {"opencode-free": {"fp": "keyless:opencode-free", "at": 0.0, "models": [live_only]}}
+        with patch.object(mod, "_load_provider_models_cache", return_value=entry):
+            rt = mod.opencode_zen_free_runtime("opencode-zen", live_only)
+        assert rt is not None
+
+    def test_static_floor_excludes_delisted_model(self):
+        """The offline floor must not offer a model known to 401 (#95914)."""
+        assert "x-preview-f-free" not in _PROVIDER_MODELS["opencode-free"]

--- a/tests/hermes_cli/test_opencode_zen_free_keyless.py
+++ b/tests/hermes_cli/test_opencode_zen_free_keyless.py
@@ -64,7 +64,7 @@ class TestFreeSlugDetection:
 
 class TestFreeRuntime:
     def test_zen_provider_free_model(self):
-        rt = opencode_zen_free_runtime("opencode-zen", "x-preview-f-free")
+        rt = opencode_zen_free_runtime("opencode-zen", "hy3-free")
         assert rt is not None
         assert rt["base_url"] == "https://opencode.ai/zen/v1"
         assert rt["api_key"] == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER
@@ -74,7 +74,7 @@ class TestFreeRuntime:
     def test_go_provider_heals_to_zen(self):
         # Free slugs only exist on the Zen relay; a Go selection must be
         # routed to Zen (the Go relay rejects the model outright).
-        rt = opencode_zen_free_runtime("opencode-go", "x-preview-f-free")
+        rt = opencode_zen_free_runtime("opencode-go", "hy3-free")
         assert rt is not None
         assert rt["base_url"] == "https://opencode.ai/zen/v1"
 
@@ -114,13 +114,13 @@ class TestRuntimeProviderKeylessRouting:
             return resolve_runtime_provider(requested=provider, target_model=model)
 
     def test_zen_free_model_resolves_keyless(self):
-        rt = self._resolve("opencode-zen", "x-preview-f-free")
+        rt = self._resolve("opencode-zen", "hy3-free")
         assert rt["api_key"] == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER
         assert rt["base_url"] == "https://opencode.ai/zen/v1"
         assert rt["api_mode"] == "chat_completions"
 
     def test_go_free_model_resolves_keyless_on_zen(self):
-        rt = self._resolve("opencode-go", "x-preview-f-free")
+        rt = self._resolve("opencode-go", "hy3-free")
         assert rt["api_key"] == OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER
         assert rt["base_url"] == "https://opencode.ai/zen/v1"
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -41,7 +41,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **CommandCode** | `COMMANDCODE_API_KEY` in `~/.hermes/.env` (provider: `commandcode`, alias: `commandcode-chat`; Claude models via `commandcode-anthropic`, alias: `commandcode-claude`). Works with GOAT/Pro/Max/Provider plans (not the $1 Go plan — no API access). |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
-| **OpenCode Free** | Keyless — no API key or account needed (provider: `opencode-free`, aliases: `free`, `opencode_free`). Select via `hermes model` or `/model free`; requests are sent anonymously |
+| **OpenCode Free** | Keyless — no API key or account needed (provider: `opencode-free`, aliases: `free`, `opencode_free`). Select via `hermes model` or `/model free`; requests are sent anonymously. The model list refreshes automatically from OpenCode's live catalog, so rotating free promotions appear (and delisted ones disappear) without a Hermes update |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |


### PR DESCRIPTION
## Summary

The keyless `opencode-free` model picker now revalidates live against OpenCode's Zen relay: relay-delisted free models stop appearing (no more `HTTP 401: Model x-preview-f-free is not supported` on selection) and newly-live promotions become selectable without a Hermes release. Closes #95914.

Salvage of #95943 by @Jackal991 (first submitter, authorship preserved), rebased onto current main with follow-up hardening. #97506 by @MiRHaDi independently proposed the same fix one day later — the healing-path coverage idea is credited to that PR.

Root cause: the keyless catalog was served exclusively from the hardcoded `_PROVIDER_MODELS["opencode-free"]` snapshot, and the SWR disk cache only revalidated authed providers (entries keyed by a credential fingerprint keyless providers lack).

## Changes

- `hermes_cli/models.py`: `provider_model_ids("opencode-free")` fetches `GET /zen/v1/models` anonymously, filters to the anonymous-servable `*-free` tier (excluding KEYED suffix-fakes like `ox-alpha-free`), falls back to the static floor offline; stable `keyless:` cache fingerprint so the picker gets normal SWR treatment (@Jackal991)
- Follow-up (ours): `opencode_zen_free_runtime` healing widened to the union of floor + live memo + SWR disk cache — a newly-live free model heals opencode-go/zen selections too (sibling site the original missed)
- Follow-up: in-process 5-min memo (with negative caching) on the live fetch, so direct validation callers don't each block on a network round-trip
- Follow-up: delisted `x-preview-f-free` removed from the offline floor and `setup.py` sample list; newly-live `deepseek-v4-flash-free`/`mimo-v2.5-free` added
- Tests: contributor's 6 regression tests + 5 of ours (memoization, negative cache, union healing x2, floor exclusion); stale fixtures moved to a live exemplar
- Docs: `providers.md` notes the catalog now auto-refreshes

## Validation

| | Before (origin/main) | After (branch) |
|---|---|---|
| Live repro | picker offers delisted `x-preview-f-free`; missing 3 live free models | delisted gone, `deepseek-v4-flash-free`/`mimo-v2.5-free`/`ling-3.0-flash-fin-free` present |
| Heal live-only model via opencode-go | `None` (refused) | routes keyless to Zen relay |
| Second catalog call | n/a | 0.0000s (memo, no network) |
| Targeted suites | — | 132 passed (9 files) + 44 on edited files |

**Live repro:** confirmed on origin/main against the real Zen relay before the fix, and re-confirmed end-to-end on the branch with a temp HERMES_HOME (live fetch, memo, healing, disk-cache fingerprint `keyless:opencode-free`).

## Infographic

![Live keyless catalog infographic](https://v3b.fal.media/files/b/0aa844f9/kUZgLJlM6UAIAPV4aUBRj_Ba9sOL2d.png)
