### PR TITLE
fix(desktop): ::preview inline widgets work on remote/URL connections

### DIFF
--- a/apps/desktop/src/components/assistant-ui/inline-preview-directive.tsx
+++ b/apps/desktop/src/components/assistant-ui/inline-preview-directive.tsx
@@ -5,8 +5,8 @@ import { requestComposerSubmit } from '@/app/chat/composer/focus'
 import { useSessionView } from '@/app/chat/session-view'
 import { useIsDark } from '@/components/assistant-ui/embeds/use-is-dark'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
+import { readDesktopFileText } from '@/lib/desktop-fs'
 import { localPreviewTarget } from '@/lib/local-preview'
-import { isRemoteGateway } from '@/lib/media'
 
 /**
  * `::preview{file="…"}` — a workspace HTML file rendered LIVE inside the
@@ -253,9 +253,12 @@ export function InlinePreviewDirective({
 }) {
   const file = attrs.file ?? ''
 
-  // Not renderable inline: hand the whole leaf to the classic card. Remote
-  // gateways lack a local-file door; non-HTML has nothing to frame.
-  if (!file || isRemoteGateway() || !HTML_FILE_RE.test(file)) {
+  // Not renderable inline: hand the leaf to the classic card. Non-HTML has
+  // nothing to frame. (Remote gateways used to bail here too — that predates
+  // the mode-aware fs bridge; the frame now reads through readDesktopFileText,
+  // which fetches over the authenticated /api/fs bridge in remote mode, so a
+  // URL connection — including a same-machine `hermes serve` — renders live.)
+  if (!file || !HTML_FILE_RE.test(file)) {
     return file ? <PreviewAttachment source="explicit-link" target={file} /> : null
   }
 
@@ -297,7 +300,7 @@ function InlineHtmlFrame({
 
     let alive = true
 
-    void Promise.resolve(window.hermesDesktop?.readFileText(path))
+    void Promise.resolve(readDesktopFileText(path))
       .then(result => {
         if (!alive) {
           return


### PR DESCRIPTION
Found via a maintainer-run live premise battery of the desktop platform guidance: `::preview{file="....html"}` silently degraded to a plain file card on the maintainer's own setup (desktop wired to a same-machine `hermes serve` as a URL connection) — the guidance's "LIVE inline page" claim was false for every remote-mode connection.

## Root cause — a vestigial guard
`InlinePreviewDirective` bailed to `PreviewAttachment` on `isRemoteGateway()`, commented "remote gateways lack a local-file door." True when written: the frame read via `window.hermesDesktop.readFileText` (local-disk Electron IPC only). The codebase has since grown the mode-aware fs bridge (`readDesktopFileText`: local → same IPC; remote → authenticated GET /api/fs/read-text), and editors/previews migrated — this directive never did, so the bail-out outlived its reason.

## Fix
- The frame reads through `readDesktopFileText` (mode-aware bridge).
- The `isRemoteGateway()` bail is deleted, with an archaeology note in the comment. The srcdoc render + theme-token prelude never needed local disk — just the bytes.
- Non-HTML and empty targets still fall back to the card unchanged.

Also explains the maintainer's companion symptom: "Open preview shows a blank page" — the pane loads widget HTML raw, where the theme tokens are undefined (invisible text). Widget HTML is only meant to render inside the directive's themed frame; this fix mounts that frame where it previously refused.

## Verification
tsc clean; all 14 inline-preview-directive tests pass (parse/attribute/security layers untouched). The live E2E — widget with theme tokens, transparency, flush-left, auto-size, and data-hermes-send talk-back on the maintainer's URL-connection setup — is the maintainer's post-merge battery after `hermes update` (renderer changes need the packaged app).