### PR TITLE
fix(profiles): make_targz writes to a temp file and renames, not the destination directly

### DIFF
--- a/hermes_cli/archive_safe.py
+++ b/hermes_cli/archive_safe.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 import shutil
 import tarfile
+import tempfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
@@ -51,10 +52,31 @@ def normalize_archive_parts(member_name: str) -> list[str]:
 
 
 def make_targz(base: str, root_dir: str, base_dir: str) -> str:
-    """Create ``<base>.tar.gz`` of ``root_dir/base_dir`` in GNU tar format."""
+    """Create ``<base>.tar.gz`` of ``root_dir/base_dir`` in GNU tar format.
+
+    Writes to a sibling temp file and renames onto ``archive_path`` only
+    after the archive is fully written. ``tarfile.open`` on a path truncates
+    the destination the instant it opens, so writing there directly means a
+    failure partway through ``tf.add`` (disk full, permission loss,
+    interruption) destroys whatever was already at that path — including an
+    existing export the caller chose to overwrite.
+    """
     archive_path = f"{base}.tar.gz"
-    with tarfile.open(archive_path, "w:gz", format=tarfile.GNU_FORMAT) as tf:
-        tf.add(str(Path(root_dir) / base_dir), arcname=base_dir)
+    dest_dir = os.path.dirname(archive_path) or "."
+    fd, tmp_path = tempfile.mkstemp(
+        dir=dest_dir, prefix=".archive_", suffix=".tar.gz.tmp"
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            with tarfile.open(fileobj=f, mode="w:gz", format=tarfile.GNU_FORMAT) as tf:
+                tf.add(str(Path(root_dir) / base_dir), arcname=base_dir)
+        os.replace(tmp_path, archive_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     return archive_path
 
 

--- a/tests/hermes_cli/test_archive_safe.py
+++ b/tests/hermes_cli/test_archive_safe.py
@@ -1,0 +1,77 @@
+"""Tests for the shared tar.gz writer (``hermes_cli.archive_safe.make_targz``).
+
+``make_targz`` backs both ``hermes profile export`` and ``hermes kanban
+export``. The contract pinned down here: a failure partway through writing
+the archive (disk full, permission loss, interruption) must never destroy a
+pre-existing file at the destination path — the same failure-atomicity
+guarantee the desktop gateway-download path already has.
+"""
+
+from __future__ import annotations
+
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parents[2]
+if str(_WORKTREE) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE))
+
+from hermes_cli.archive_safe import make_targz
+
+
+def _stage_source(tmp_path: Path) -> None:
+    payload = tmp_path / "src" / "inner"
+    payload.mkdir(parents=True)
+    (payload / "file.txt").write_text("hello")
+
+
+def test_make_targz_preserves_existing_file_on_mid_write_failure(tmp_path, monkeypatch):
+    _stage_source(tmp_path)
+    base = str(tmp_path / "out")
+    archive_path = Path(f"{base}.tar.gz")
+    sentinel = b"PRE-EXISTING ARCHIVE THAT MUST SURVIVE A FAILED RE-EXPORT"
+    archive_path.write_bytes(sentinel)
+
+    def _boom(self, *a, **k):
+        raise RuntimeError("simulated failure mid-add (disk full / permission loss)")
+
+    monkeypatch.setattr(tarfile.TarFile, "add", _boom)
+
+    with pytest.raises(RuntimeError):
+        make_targz(base, str(tmp_path), "src")
+
+    assert archive_path.read_bytes() == sentinel, (
+        "a mid-write failure must not truncate/replace a pre-existing archive"
+    )
+    leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".archive_")]
+    assert leftovers == [], f"temp file was not cleaned up on failure: {leftovers}"
+
+
+def test_make_targz_round_trips_content(tmp_path):
+    _stage_source(tmp_path)
+    base = str(tmp_path / "out")
+
+    result = make_targz(base, str(tmp_path), "src")
+
+    assert result == f"{base}.tar.gz"
+    with tarfile.open(result, "r:gz") as tf:
+        names = sorted(m.name for m in tf.getmembers())
+        assert "src/inner/file.txt" in names
+        member = tf.extractfile("src/inner/file.txt")
+        assert member is not None
+        assert member.read() == b"hello"
+
+
+def test_make_targz_overwrites_existing_file_on_success(tmp_path):
+    _stage_source(tmp_path)
+    base = str(tmp_path / "out")
+    archive_path = Path(f"{base}.tar.gz")
+    archive_path.write_bytes(b"stale archive from a previous export")
+
+    make_targz(base, str(tmp_path), "src")
+
+    with tarfile.open(archive_path, "r:gz") as tf:
+        assert "src/inner/file.txt" in {m.name for m in tf.getmembers()}


### PR DESCRIPTION
## Summary

`make_targz()` (`hermes_cli/archive_safe.py`) — the shared writer behind both `hermes profile export` and `hermes kanban export` — opened the destination `.tar.gz` path directly with `tarfile.open(archive_path, "w:gz")`, which truncates the file the instant it opens. If `tf.add()` fails partway through (disk full, permission revoked mid-write, process killed), whatever was previously at that path is destroyed and replaced with a truncated/corrupt archive.

This is the exact same failure shape `a7e7de6407` fixed for the desktop gateway file-save path — one commit earlier in the same merge window — but the fix was never propagated to this shared archive-writing primitive, even though board export gained a brand-new caller into it (`export_board`) in that same window. The existing `export_profile` caller carries the same bug and predates the refactor.

Reproduced empirically against a pre-existing file at the destination path:
```
before: 38 bytes
after (current buggy behavior): 28 bytes
content survives? False
```

## Fix

`make_targz()` now writes into a sibling temp file created with `tempfile.mkstemp()` in the same directory as the destination (so the final step is a same-volume, atomic `os.replace()`), and only replaces the destination after the archive is fully written and the file descriptor is closed. The temp file is unlinked on any failure. This mirrors the mkstemp + os.replace pattern already established elsewhere in this codebase (`agent/secret_sources/_cache.py`, `cron/jobs.py`, `gateway/status.py`, `gateway/rich_sent_store.py`).

## Test plan

- [x] New regression test (`tests/hermes_cli/test_archive_safe.py`) reproduces the bug via a monkeypatched `tarfile.TarFile.add` failure mid-write and asserts a pre-existing archive survives untouched, with no leftover temp file.
- [x] Mutation-verified: stashed the fix, confirmed the new test fails against the original code (sentinel content replaced by a truncated gzip header), restored the fix, confirmed it passes.
- [x] Added round-trip and overwrite-on-success tests to confirm normal behavior is unchanged.
- [x] Full `tests/hermes_cli/test_kanban_transfer.py` (22 tests) and `tests/hermes_cli/test_profile_export_credentials.py` + `tests/hermes_cli/test_profiles.py` (60 tests, 2 pre-existing skips) pass unchanged.