### PR TITLE
fix(slack): sanitize resolved clarify message blocks

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7861,7 +7861,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel=channel_id,
                 ts=msg_ts,
                 text=decision_text,
-                blocks=updated_blocks,
+                blocks=sanitize_blocks(updated_blocks),
             )
         except Exception as e:
             logger.warning("[Slack] Failed to update clarify message: %s", e)

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -186,6 +186,63 @@ class TestSlackClarifyChoiceAction:
         assert entry is not None
         assert not entry.event.is_set()
 
+    @pytest.mark.asyncio
+    async def test_choice_update_sanitizes_slack_reescaped_question(self):
+        from plugins.platforms.slack.block_kit import MAX_SECTION_TEXT
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "3.3"})
+        mock_client.chat_update = AsyncMock(return_value={"ok": True})
+
+        question = "Approve this exact content? " + ("&" * 700)
+        await adapter.send_clarify(
+            chat_id="C1",
+            question=question,
+            choices=["Approve", "Reject"],
+            clarify_id="cid-reescaped-question",
+            session_key="sk-reescaped-question",
+        )
+        cm.register(
+            "cid-reescaped-question",
+            "sk-reescaped-question",
+            question,
+            ["Approve", "Reject"],
+        )
+
+        sent_blocks = mock_client.chat_postMessage.await_args.kwargs["blocks"]
+        sent_question = sent_blocks[0]["text"]["text"]
+        assert len(sent_question) == MAX_SECTION_TEXT
+        interaction_question = sent_question.replace("&", "&amp;")
+        assert len(interaction_question) > MAX_SECTION_TEXT
+
+        body = {
+            "message": {
+                "ts": "3.3",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": interaction_question},
+                    },
+                    {"type": "actions", "elements": [{"type": "button"}]},
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "will", "id": "U_WILL"},
+        }
+        action = {
+            "action_id": "hermes_clarify_choice_0",
+            "value": "cid-reescaped-question|0",
+        }
+
+        await adapter._handle_clarify_action(AsyncMock(), body, action)
+
+        updated_blocks = mock_client.chat_update.await_args.kwargs["blocks"]
+        assert all(block["type"] != "actions" for block in updated_blocks)
+        assert len(updated_blocks[0]["text"]["text"]) <= MAX_SECTION_TEXT
+
 
 # ===========================================================================
 # _handle_clarify_action — "Other" → text-capture → typed reply (c)


### PR DESCRIPTION
## What does this PR do?

Fixes Slack clarification cards that remain visibly interactive after a choice has already resolved. Slack may return the original question with additional HTML escaping in the interaction payload; reusing that text directly in `chat.update` can exceed Slack's 3,000-character Block Kit limit and cause `invalid_blocks`.

This applies the existing shared `sanitize_blocks()` boundary to resolved clarification-card updates. It does not change how choices are rendered.

## Related Issue

Fixes #97823

Related: #77547

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Route resolved Slack clarification blocks through `sanitize_blocks()` before `chat.update`.
- Add a producer-shaped regression that starts from a valid sent question, simulates Slack re-escaping it in the interaction payload, and verifies the resolved card removes its actions while respecting the 3,000-character limit.

## How to Test

1. Run `uv run --frozen --extra dev --extra slack pytest tests/gateway/test_slack.py tests/gateway/test_slack_clarify_buttons.py -q`.
2. Run `uv run --frozen --extra dev ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack_clarify_buttons.py`.
3. Run `uv run --frozen python scripts/check-windows-footguns.py --all`.

The new regression fails on the previous implementation with a 5,376-character update section and passes after the sanitizer is applied.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: no documentation change required
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#compatibility-guide) — Windows footgun scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: no model-facing tool behavior changed

## Screenshots / Logs

Focused affected suites: **240 passed**. Ruff, `git diff --check`, and the Windows-footgun scan also passed.
