### PR TITLE
fix(model-metadata): resolve routed OpenRouter context windows correctly

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -774,42 +774,11 @@ def lookup_models_dev_context(
     if not isinstance(models, dict):
         return _default_override_context(provider)
 
-    # Exact match
-    entry = models.get(model)
-    if entry:
+    entry = _find_model_entry(models, model, provider=provider)
+    if entry is not None:
         ctx = _extract_context(entry)
         if ctx:
             return ctx
-
-    # Case-insensitive match
-    model_lower = model.lower()
-    for mid, mdata in models.items():
-        if mid.lower() == model_lower:
-            ctx = _extract_context(mdata)
-            if ctx:
-                return ctx
-
-    # Suffix-aware fallback: some providers (e.g. ollama-cloud) store
-    # model IDs with :cloud / -cloud suffixes in models.dev while the
-    # live API returns bare names.  Without this, kimi-k2.6 misses the
-    # kimi-k2.6:cloud entry and falls through to stale OpenRouter metadata
-    # reporting 32768 — tripping the 64k minimum-context guard.
-    # The suffix-stripping in fetch_ollama_cloud_models() handles the
-    # model-picker UX; this handles the context-length lookup path.
-    for suffix in (":cloud", "-cloud"):
-        suffixed_key = model + suffix
-        entry = models.get(suffixed_key)
-        if entry:
-            ctx = _extract_context(entry)
-            if ctx:
-                return ctx
-        # Also try case-insensitive
-        suffixed_lower = model_lower + suffix
-        for mid, mdata in models.items():
-            if mid.lower() == suffixed_lower:
-                ctx = _extract_context(mdata)
-                if ctx:
-                    return ctx
 
     # Catalog miss — a _default override may fill the gap (#84482).
     return _default_override_context(provider)
@@ -1127,39 +1096,78 @@ def _get_provider_models(
     return models
 
 
-def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, Any]]:
-    """Find a model entry: exact, case-insensitive, then suffix fallback.
+_OPENROUTER_ROUTING_SUFFIXES = frozenset({
+    ":exacto",
+    ":extended",
+    ":floor",
+    ":free",
+    ":nitro",
+    ":online",
+    ":thinking",
+})
 
-    The ``:cloud``/``-cloud`` suffix fallback mirrors
-    ``lookup_models_dev_context`` so "is this model in the catalog" means
-    the same thing to every consumer — important for ``model_overrides``
-    fill-gap ``_default`` semantics, where a suffix-keyed catalog model
-    (e.g. ``kimi-k2.6:cloud``) must count as KNOWN and keep its catalog
-    metadata rather than being displaced by a ``_default``.
-    """
-    # Exact match
-    entry = models.get(model)
-    if isinstance(entry, dict):
-        return entry
 
-    # Case-insensitive match
+def _catalog_model_id(provider: Optional[str], model: str) -> str:
+    """Return the provider's metadata identity without routing directives."""
+    provider_id = PROVIDER_TO_MODELS_DEV.get(provider or "", provider or "")
+    if provider_id.lower() != "openrouter":
+        return model
+
     model_lower = model.lower()
-    for mid, mdata in models.items():
-        if mid.lower() == model_lower and isinstance(mdata, dict):
-            return mdata
+    for suffix in _OPENROUTER_ROUTING_SUFFIXES:
+        if model_lower.endswith(suffix):
+            return model[: -len(suffix)]
+    return model
 
-    # Suffix-aware fallback (e.g. ollama-cloud stores kimi-k2.6:cloud
-    # while the live API returns the bare name).
-    for suffix in (":cloud", "-cloud"):
-        entry = models.get(model + suffix)
+
+def _find_model_entry_with_id(
+    models: Dict[str, Any], model: str, *, provider: Optional[str] = None
+) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """Find a catalog model and return its canonical catalog ID and entry."""
+    candidates = [model]
+    catalog_model = _catalog_model_id(provider, model)
+    if catalog_model != model:
+        candidates.append(catalog_model)
+
+    for candidate in candidates:
+        entry = models.get(candidate)
         if isinstance(entry, dict):
-            return entry
-        suffixed_lower = model_lower + suffix
+            return candidate, entry
+
+        candidate_lower = candidate.lower()
         for mid, mdata in models.items():
-            if mid.lower() == suffixed_lower and isinstance(mdata, dict):
-                return mdata
+            if mid.lower() == candidate_lower and isinstance(mdata, dict):
+                return mid, mdata
+
+    # Some providers (e.g. ollama-cloud) store model IDs with :cloud /
+    # -cloud suffixes in models.dev while their live API returns bare names.
+    for candidate in candidates:
+        candidate_lower = candidate.lower()
+        for suffix in (":cloud", "-cloud"):
+            suffixed_key = candidate + suffix
+            entry = models.get(suffixed_key)
+            if isinstance(entry, dict):
+                return suffixed_key, entry
+            suffixed_lower = candidate_lower + suffix
+            for mid, mdata in models.items():
+                if mid.lower() == suffixed_lower and isinstance(mdata, dict):
+                    return mid, mdata
 
     return None
+
+
+def _find_model_entry(
+    models: Dict[str, Any], model: str, *, provider: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Find a model entry using its provider-aware metadata identity.
+
+    OpenRouter routing suffixes are provider-facing directives, not part of
+    the underlying model identity. The full ID remains untouched outside
+    catalog matching. ``:cloud``/``-cloud`` fallback remains available for
+    catalogs that key hosted variants by their suffix.
+    """
+    match = _find_model_entry_with_id(models, model, provider=provider)
+    return match[1] if match is not None else None
 
 
 def get_model_capabilities(
@@ -1190,7 +1198,11 @@ def get_model_capabilities(
       - family     (str)   → model_family
     """
     models = _get_provider_models(provider, allow_network=allow_network)
-    entry = _find_model_entry(models, model) if models is not None else None
+    entry = (
+        _find_model_entry(models, model, provider=provider)
+        if models is not None
+        else None
+    )
 
     # Select the override AFTER the catalog lookup: explicit overrides
     # always apply; _default entries only fill gaps for catalog misses.
@@ -1534,16 +1546,17 @@ def get_model_info(
             return _parse_model_info(mid, merged, mdev_id)
         return _parse_model_info(mid, raw, mdev_id)
 
-    # Exact match
-    raw = models.get(model_id)
-    if isinstance(raw, dict):
-        return _with_override(model_id, raw)
-
-    # Case-insensitive fallback
-    model_lower = model_id.lower()
-    for mid, mdata in models.items():
-        if mid.lower() == model_lower and isinstance(mdata, dict):
-            return _with_override(mid, mdata)
+    match = _find_model_entry_with_id(models, model_id, provider=provider_id)
+    if match is not None:
+        matched_id, raw = match
+        # Routing directives remain part of the provider-facing model ID even
+        # though catalog metadata comes from the underlying bare model.
+        result_id = (
+            model_id
+            if _catalog_model_id(provider_id, model_id) != model_id
+            else matched_id
+        )
+        return _with_override(result_id, raw)
 
     # Model not in catalog — an override (explicit or _default) may still
     # provide the metadata.

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -217,6 +217,29 @@ class TestEstimateRequestTokensRough:
 # =========================================================================
 
 class TestDefaultContextLengths:
+    def test_openrouter_routing_suffix_falls_back_to_bare_models_dev_entry(self):
+        registry = {
+            "openrouter": {
+                "models": {
+                    "z-ai/glm-5.3-flash": {
+                        "limit": {"context": 1_310_720, "output": 131_072},
+                    },
+                },
+            },
+        }
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata._query_ollama_api_show", return_value=None), \
+             patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            context = get_model_context_length(
+                "z-ai/glm-5.3-flash:floor",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+            )
+
+        assert context == 1_310_720
+
     def test_nvidia_deepseek_v4_pro_context_is_endpoint_scoped(self):
         """NVIDIA's 262K NIM window must not lower DeepSeek V4 globally."""
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -134,6 +134,74 @@ class TestLookupModelsDevContext:
         mock_fetch.return_value = SAMPLE_REGISTRY
         assert lookup_models_dev_context("anthropic", "claude-opus-4-6") == 1000000
 
+    @pytest.mark.parametrize(
+        "suffix",
+        (":free", ":extended", ":thinking", ":nitro", ":floor", ":exacto", ":online"),
+    )
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_openrouter_routing_suffix_uses_bare_catalog_entry(self, mock_fetch, suffix):
+        mock_fetch.return_value = {
+            "openrouter": {
+                "models": {
+                    "z-ai/glm-5.3-flash": {
+                        "limit": {"context": 1_310_720, "output": 131_072},
+                    },
+                },
+            },
+        }
+
+        assert (
+            lookup_models_dev_context("openrouter", f"z-ai/glm-5.3-flash{suffix}")
+            == 1_310_720
+        )
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_openrouter_routing_suffix_normalization_is_provider_scoped(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_REGISTRY
+
+        assert lookup_models_dev_context("anthropic", "claude-opus-4-6:free") is None
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_unknown_openrouter_suffix_does_not_alias_catalog_model(self, mock_fetch):
+        mock_fetch.return_value = {
+            "openrouter": {
+                "models": {
+                    "z-ai/glm-5.3-flash": {"limit": {"context": 1_310_720}},
+                },
+            },
+        }
+
+        assert lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash:beta") is None
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_openrouter_routing_suffix_preserves_full_id_for_model_info(self, mock_fetch):
+        mock_fetch.return_value = {
+            "openrouter": {
+                "models": {
+                    "z-ai/glm-5.3-flash": {
+                        "tool_call": True,
+                        "reasoning": True,
+                        "modalities": {"input": ["text", "image"]},
+                        "limit": {"context": 1_310_720, "output": 131_072},
+                    },
+                },
+            },
+        }
+        routed_id = "z-ai/glm-5.3-flash:floor"
+
+        caps = get_model_capabilities("openrouter", routed_id)
+        info = get_model_info("openrouter", routed_id)
+
+        assert caps is not None
+        assert caps.context_window == 1_310_720
+        assert caps.max_output_tokens == 131_072
+        assert caps.supports_tools is True
+        assert caps.supports_reasoning is True
+        assert caps.supports_vision is True
+        assert info is not None
+        assert info.id == routed_id
+        assert info.context_window == 1_310_720
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

OpenRouter users who select a routed model ID such as `z-ai/glm-5.3-flash:floor` now receive the underlying model's models.dev metadata instead of a hardcoded family fallback. This keeps context pressure and compaction thresholds aligned with the catalog while preserving the full routed ID for provider requests and model info.

### Symptom

`get_model_context_length("z-ai/glm-5.3-flash:floor", provider="openrouter")` resolved to 202,752 tokens, while the bare catalog model resolved to 1,310,720 tokens.

### Impact

Affected OpenRouter sessions can compact much earlier than the selected model's catalog context window requires. Capability and rich model-info lookups also treat routed IDs as unknown even when the underlying model exists in models.dev.

### Bug Cause

**Trigger:** `agent/models_dev.py` / `lookup_models_dev_context()` and `_find_model_entry()` when an OpenRouter model ID ends in a routing suffix.

**Causal chain:**
1. OpenRouter passes a full routed model ID such as `z-ai/glm-5.3-flash:floor` into metadata resolution.
2. Catalog matching only checks the full ID plus the Ollama-specific `:cloud` and `-cloud` variants, so the bare models.dev entry is missed.
3. Context resolution falls through to the generic GLM family default and reports a much smaller window.

**Why it is wrong:** OpenRouter routing suffixes select provider-routing behavior; they do not identify a different underlying model for catalog metadata.

**Working sibling / contrast:** The same model without the routing suffix matches models.dev and resolves its catalog metadata correctly.

**Ruled out:** This is not missing catalog data. The bare `z-ai/glm-5.3-flash` entry is present and the regression test proves that only the routed identity misses before normalization.

### Fix

Catalog lookup now strips only the documented OpenRouter routing suffixes and only for the OpenRouter provider. Context, capability, and rich model-info paths share this provider-aware lookup, while unknown suffixes and non-OpenRouter providers retain exact matching behavior. The provider-facing model ID remains unchanged.

## Related Issue

Closes #97820

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/models_dev.py` - centralize provider-aware catalog matching and normalize OpenRouter routing suffixes for metadata lookup.
- `tests/agent/test_models_dev.py` - cover all supported routing suffixes, provider scoping, unknown suffixes, capabilities, and full-ID preservation.
- `tests/agent/test_model_metadata.py` - exercise the end-to-end context-length resolution path for a routed OpenRouter model.

## How to Test

1. Run the related metadata suites:

```bash
scripts/run_tests.sh tests/agent/test_models_dev.py tests/agent/test_model_metadata.py -q
```

2. Confirm all 190 tests pass, including the routed `z-ai/glm-5.3-flash:floor` context regression.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the related test suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A; behavior and supported suffixes are documented in code and regression tests
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; matching is pure string logic with platform-independent tests
- [x] Tool description/schema updates are N/A; no tool behavior changed
