### PR TITLE
fix(browser): add getResponseBodyForInterception and getResourceContent to the CDP binary-redaction table

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -338,6 +338,75 @@ def test_fetch_get_response_body_base64_discriminator_passes_through(cdp_server)
     assert result["result"]["body"] == body_b64
 
 
+def test_get_response_body_for_interception_base64_discriminator_passes_through(cdp_server):
+    """Network.getResponseBodyForInterception pins the same body/base64Encoded
+    contract as Network.getResponseBody — same protocol-defined shape,
+    deprecated but still a live method (#94138 sibling gap)."""
+    body_b64 = "/" + "gAAAA" + "E" * 60 + "=="
+    cdp_server.on(
+        "Network.getResponseBodyForInterception",
+        lambda params, sid: {"body": body_b64, "base64Encoded": True},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Network.getResponseBodyForInterception")
+    )
+
+    assert result["success"] is True
+    assert result["result"]["body"] == body_b64
+
+
+def test_get_response_body_for_interception_text_discriminator_still_redacts(cdp_server):
+    """Same method with base64Encoded: false — the body is text and a real
+    secret in it must still be redacted."""
+    fake_key = "sk-" + "CDPINTERCEPTBODY1234567890"
+    cdp_server.on(
+        "Network.getResponseBodyForInterception",
+        lambda params, sid: {"body": f"leak {fake_key} here", "base64Encoded": False},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Network.getResponseBodyForInterception")
+    )
+
+    assert result["success"] is True
+    assert "CDPINTERCEPTBODY" not in json.dumps(result)
+
+
+def test_get_resource_content_base64_discriminator_passes_through(cdp_server):
+    """Page.getResourceContent's content field honors the same
+    body/base64Encoded contract on its own carrier key (#94138 sibling gap)."""
+    content_b64 = "/" + "gAAAA" + "F" * 60 + "=="
+    cdp_server.on(
+        "Page.getResourceContent",
+        lambda params, sid: {"content": content_b64, "base64Encoded": True},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Page.getResourceContent")
+    )
+
+    assert result["success"] is True
+    assert result["result"]["content"] == content_b64
+
+
+def test_get_resource_content_text_discriminator_still_redacts(cdp_server):
+    """Same method with base64Encoded: false — the content is text and a real
+    secret in it must still be redacted."""
+    fake_key = "sk-" + "CDPRESOURCECONTENT1234567890"
+    cdp_server.on(
+        "Page.getResourceContent",
+        lambda params, sid: {"content": f"leak {fake_key} here", "base64Encoded": False},
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(method="Page.getResourceContent")
+    )
+
+    assert result["success"] is True
+    assert "CDPRESOURCECONTENT" not in json.dumps(result)
+
+
 def test_runtime_evaluate_spoofed_base64_flag_still_redacts(cdp_server):
     """base64Encoded is trusted ONLY on the protocol-defined carrier paths.
     A Runtime.evaluate by-value object carrying

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -68,6 +68,8 @@ _CDP_FLAGGED_BINARY_PATHS: Dict[str, tuple] = {
     "Fetch.getResponseBody": (("body",),),
     "IO.read": (("data",),),
     "Network.getRequestPostData": (("postData",),),
+    "Network.getResponseBodyForInterception": (("body",),),
+    "Page.getResourceContent": (("content",),),
 }
 
 


### PR DESCRIPTION
## Summary

`#97078` (merged) built `_CDP_ALWAYS_BINARY_PATHS`/`_CDP_FLAGGED_BINARY_PATHS` in `tools/browser_cdp_tool.py` so `redact_sensitive_text`'s Fernet-shaped pattern (`gAAAA[A-Za-z0-9_=-]{20,}`) can't corrupt opaque base64 payloads returned by CDP calls (#94138). Four methods were covered: `Network.getResponseBody`, `Fetch.getResponseBody`, `IO.read`, `Network.getRequestPostData`.

Two protocol methods with the exact same `{field, base64Encoded}` shape were missed:
- `Network.getResponseBodyForInterception` → `{body, base64Encoded}`
- `Page.getResourceContent` → `{content, base64Encoded}`

Both are deprecated-but-still-live CDP methods a model can reach through the raw `browser_cdp` passthrough tool. A binary payload returned through either currently falls through to full-text redaction and gets corrupted the same way the four already-covered methods did before #97078.

## Fix

Add both methods to `_CDP_FLAGGED_BINARY_PATHS` with their respective carrier field, following the exact same pattern as the four existing entries.

## Test plan

- [x] Added 4 new tests mirroring the existing `Network.getResponseBody`/`Fetch.getResponseBody` coverage: a base64-flagged pass-through test and a text-discriminator-still-redacts test for each of the two methods.
- [x] Mutation-verified: stashed the fix, confirmed the two pass-through tests fail against the original code — the base64 payload gets corrupted from `/gAAAAEEEE...EEEE==` down to a truncated `/gAAAAE...EE==` mask, reproducing the exact corruption #94138 described. Restored the fix, confirmed both pass again.
  - Note: the redaction pattern requires a non-alphanumeric character immediately before `gAAAA` (regex lookbehind), so the fixture uses a `/` prefix rather than an arbitrary alphanumeric one — an earlier fixture attempt with an alphanumeric prefix didn't actually exercise the redaction path and would have passed regardless of the fix.
- [x] Full `tests/tools/test_browser_cdp_tool.py` + `tests/tools/test_browser_cdp_override.py` (44 tests) pass unchanged.