### PR TITLE
fix(update): regenerate dangling editable finder after interrupted install on Windows

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -616,14 +616,59 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
         except OSError:
             attempts = 0
 
-        if attempts >= _EARLY_CORE_INSTALL_MAX_ATTEMPTS:
+        # #97819: dangling editable finder (MAPPING points at deleted
+        # site-packages copy) must be healed even when the full-install
+        # attempt budget is exhausted.  Try a cheap ``pip install -e . --no-deps``
+        # regeneration first without consuming an attempt; if that fails
+        # allow one more full reinstall despite the ceiling.
+        _finder_dangling = False
+        _finder_reasons: list[str] = []
+        try:
+            _finder_dangling, _finder_reasons = ir.editable_finder_is_dangling(root)
+        except Exception:
+            pass
+        if _finder_dangling:
             print(
-                "⚠ Pending interrupted-update install has already failed "
-                f"{attempts} times in the early pass — leaving it for the "
-                "post-import recovery path.",
+                f"⚠ Editable finder MAPPING is dangling: {', '.join(_finder_reasons[:3])} — regenerating editable install...",
                 file=sys.stderr,
             )
-            return False
+            try:
+                ir._clean_stale_site_packages_physical_copies(root)
+            except Exception:
+                pass
+            try:
+                if ir._regenerate_editable_finder(root):
+                    _still, _reasons2 = ir.editable_finder_is_dangling(root)
+                    if not _still:
+                        print("  ✓ Editable finder regenerated in early pass.", file=sys.stderr)
+                        try:
+                            core_marker.unlink()
+                        except OSError:
+                            pass
+                        return True
+                    print(
+                        f"  ⚠ Finder still dangling after lightweight regen: {', '.join(_reasons2[:2])} — will retry full install...",
+                        file=sys.stderr,
+                    )
+                else:
+                    print("  ⚠ Lightweight finder regeneration failed — will retry full install...", file=sys.stderr)
+            except Exception:
+                pass
+            if attempts >= _EARLY_CORE_INSTALL_MAX_ATTEMPTS:
+                print(
+                    "  → Dangling finder detected — retrying full install despite attempt ceiling...",
+                    file=sys.stderr,
+                )
+            # fall through to full install even at ceiling
+        else:
+            if attempts >= _EARLY_CORE_INSTALL_MAX_ATTEMPTS:
+                print(
+                    "⚠ Pending interrupted-update install has already failed "
+                    f"{attempts} times in the early pass — leaving it for the "
+                    "post-import recovery path.",
+                    file=sys.stderr,
+                )
+                return False
 
         if not _claim_recovery_lock(root):
             return False
@@ -636,6 +681,26 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
                 file=sys.stderr,
             )
             ir.run_core_install(root)
+            # #97819: post-install finder health sweep — a stale physical
+            # copy could have poisoned the just-finished reinstall.
+            try:
+                _is_dangling, _reasons = ir.editable_finder_is_dangling(root)
+                if _is_dangling:
+                    print(
+                        f"  ⚠ Editable finder still dangling after full reinstall: {', '.join(_reasons[:2])} — regenerating...",
+                        file=sys.stderr,
+                    )
+                    ir._clean_stale_site_packages_physical_copies(root)
+                    if ir._regenerate_editable_finder(root):
+                        _is_dangling2, _reasons2 = ir.editable_finder_is_dangling(root)
+                        if _is_dangling2:
+                            raise RuntimeError(f"editable finder still dangling: {_reasons2}")
+                    else:
+                        raise RuntimeError(f"finder regeneration failed after dangling: {_reasons}")
+            except RuntimeError:
+                raise
+            except Exception:
+                pass
         except Exception as exc:
             new_attempts = ir.bump_marker_attempts(core_marker)
             print(

--- a/hermes_cli/_install_repair.py
+++ b/hermes_cli/_install_repair.py
@@ -28,12 +28,295 @@ import shutil
 import subprocess
 import sys
 import time
+import pathlib
 from pathlib import Path
 
 # Single source of truth for the recovery-lock lifecycle and uv lookup —
 # _early_recovery already owns both, and importing it is free (stdlib-only).
 from hermes_cli import _early_recovery as _er
 
+# ---------------------------------------------------------------------------
+# Editable finder health & stale physical-copy cleanup  (#97819)
+# ---------------------------------------------------------------------------
+_HERMES_EDITABLE_FALLBACK_TOP_LEVELS: frozenset[str] = frozenset(
+    {
+        "hermes_cli",
+        "gateway",
+        "tools",
+        "agent",
+        "cron",
+        "acp_adapter",
+        "plugins",
+        "providers",
+        "tui_gateway",
+        "hermes_constants",
+        "hermes_state",
+        "hermes_state_common",
+        "hermes_state_portability",
+        "hermes_state_schema",
+        "hermes_state_search",
+        "hermes_bootstrap",
+        "hermes_logging",
+        "hermes_time",
+        "run_agent",
+        "cli",
+        "model_tools",
+        "toolsets",
+        "toolset_distributions",
+        "batch_runner",
+        "trajectory_compressor",
+        "utils",
+        "mcp_serve",
+        "registration_lifecycle",
+    }
+)
+
+def _get_site_packages_dir(root: pathlib.Path) -> pathlib.Path | None:
+    try:
+        from hermes_constants import project_venv_dir
+        venv_dir = project_venv_dir(pathlib.Path(root))
+        if venv_dir is not None and pathlib.Path(venv_dir).is_dir():
+            win = pathlib.Path(venv_dir) / "Lib" / "site-packages"
+            if win.is_dir():
+                return win
+            lib = pathlib.Path(venv_dir) / "lib"
+            if lib.is_dir():
+                for py in lib.glob("python*"):
+                    cand = py / "site-packages"
+                    if cand.is_dir():
+                        return cand
+                cand = lib / "site-packages"
+                if cand.is_dir():
+                    return cand
+            return None
+    except Exception:
+        pass
+    for name in ("venv", ".venv"):
+        venv_dir = pathlib.Path(root) / name
+        if not venv_dir.is_dir():
+            continue
+        win = venv_dir / "Lib" / "site-packages"
+        if win.is_dir():
+            return win
+        lib = venv_dir / "lib"
+        if lib.is_dir():
+            for py in lib.glob("python*"):
+                cand = py / "site-packages"
+                if cand.is_dir():
+                    return cand
+    return None
+
+def _hermes_top_levels_from_pyproject(root: pathlib.Path) -> set[str]:
+    fallback = set(_HERMES_EDITABLE_FALLBACK_TOP_LEVELS)
+    pyproject = pathlib.Path(root) / "pyproject.toml"
+    if not pyproject.is_file():
+        return fallback
+    try:
+        import tomllib
+        with open(pyproject, "rb") as fh:
+            data = tomllib.load(fh)
+    except Exception:
+        return fallback
+    tops: set[str] = set()
+    try:
+        tool = data.get("tool", {}) if isinstance(data, dict) else {}
+        setuptools = tool.get("setuptools", {}) if isinstance(tool, dict) else {}
+        py_mods = setuptools.get("py-modules", []) or []
+        for mod in py_mods:
+            if isinstance(mod, str) and mod.strip():
+                tops.add(mod.strip().split(".")[0])
+        pkgs = setuptools.get("packages", {}) if isinstance(setuptools, dict) else {}
+        find = pkgs.get("find", {}) if isinstance(pkgs, dict) else {}
+        include = find.get("include", []) if isinstance(find, dict) else []
+        for inc in include:
+            if isinstance(inc, str) and inc.strip():
+                base = inc.strip().split(".")[0].split("*")[0].strip()
+                if base:
+                    tops.add(base)
+    except Exception:
+        return fallback
+    return tops or fallback
+
+def _clean_stale_site_packages_physical_copies(root: pathlib.Path) -> list[str]:
+    site_packages = _get_site_packages_dir(pathlib.Path(root))
+    if not site_packages or not pathlib.Path(site_packages).is_dir():
+        return []
+    tops = _hermes_top_levels_from_pyproject(pathlib.Path(root))
+    removed: list[str] = []
+    root_resolved = None
+    try:
+        root_resolved = pathlib.Path(root).resolve()
+    except Exception:
+        root_resolved = pathlib.Path(root)
+    for name in sorted(tops):
+        for suffix in ("", ".py"):
+            target = pathlib.Path(site_packages) / f"{name}{suffix}"
+            if not target.exists():
+                continue
+            if target.name.startswith("__editable__"):
+                continue
+            try:
+                if target.is_symlink():
+                    try:
+                        if target.resolve().is_relative_to(root_resolved):
+                            continue
+                    except AttributeError:
+                        try:
+                            if str(target.resolve()).lower().startswith(str(root_resolved).lower()):
+                                continue
+                        except Exception:
+                            pass
+                    except Exception:
+                        pass
+                if target.is_dir() and not target.is_symlink():
+                    import shutil
+                    shutil.rmtree(target)
+                    removed.append(str(target))
+                elif target.is_file():
+                    target.unlink()
+                    removed.append(str(target))
+                    try:
+                        pycache = pathlib.Path(site_packages) / "__pycache__"
+                        if pycache.is_dir():
+                            for pyc in pycache.glob(f"{name}.*.pyc"):
+                                try:
+                                    pyc.unlink()
+                                except OSError:
+                                    pass
+                    except Exception:
+                        pass
+            except OSError:
+                pass
+    if removed:
+        import sys
+        print(f"  \u2713 Cleaned {len(removed)} stale site-packages copy(ies): " + ", ".join(pathlib.Path(p).name for p in removed[:5]) + ("..." if len(removed) > 5 else ""), file=sys.stderr)
+    return removed
+
+def _find_editable_finder_files(site_packages: pathlib.Path) -> list[pathlib.Path]:
+    try:
+        return list(pathlib.Path(site_packages).glob("__editable__*finder.py"))
+    except Exception:
+        return []
+
+def _parse_finder_mapping(finder_path: pathlib.Path) -> dict[str, str]:
+    try:
+        text = pathlib.Path(finder_path).read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return {}
+    try:
+        import ast
+        tree = ast.parse(text)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "MAPPING":
+                        if isinstance(node.value, ast.Dict):
+                            mapping: dict[str, str] = {}
+                            for k, v in zip(node.value.keys, node.value.values):
+                                if isinstance(k, ast.Constant) and isinstance(v, ast.Constant):
+                                    if isinstance(k.value, str) and isinstance(v.value, str):
+                                        mapping[k.value] = v.value
+                            return mapping
+    except Exception:
+        pass
+    import re
+    mapping: dict[str, str] = {}
+    try:
+        m = re.search(r"MAPPING\s*=\s*\{([^}]*)\}", text, re.DOTALL)
+        if m:
+            inner = m.group(1)
+            for km in re.finditer(r"['\"]([^'\"]+)['\"]\s*:\s*['\"]([^'\"]+)['\"]", inner):
+                mapping[km.group(1)] = km.group(2)
+    except Exception:
+        pass
+    return mapping
+
+def _is_path_inside(child: pathlib.Path, parent: pathlib.Path) -> bool:
+    try:
+        child_r = pathlib.Path(child).resolve()
+        parent_r = pathlib.Path(parent).resolve()
+        try:
+            return child_r.is_relative_to(parent_r)
+        except AttributeError:
+            import sys
+            c = str(child_r)
+            p = str(parent_r)
+            if sys.platform == "win32":
+                c = c.lower().replace("/", "\\").rstrip("\\")
+                p = p.lower().replace("/", "\\").rstrip("\\")
+                return c == p or c.startswith(p + "\\")
+            else:
+                return c == p or c.startswith(p.rstrip("/") + "/")
+    except Exception:
+        return False
+
+def editable_finder_is_dangling(root: pathlib.Path, *, site_packages: pathlib.Path | None = None) -> tuple[bool, list[str]]:
+    try:
+        sp = pathlib.Path(site_packages) if site_packages is not None else _get_site_packages_dir(pathlib.Path(root))
+    except Exception:
+        sp = None
+    if sp is None or not pathlib.Path(sp).is_dir():
+        return (False, [])
+    finders = _find_editable_finder_files(pathlib.Path(sp))
+    if not finders:
+        return (False, [])
+    combined: dict[str, str] = {}
+    for f in finders:
+        combined.update(_parse_finder_mapping(f))
+    if not combined:
+        return (False, [])
+    reasons: list[str] = []
+    for pkg, target_str in combined.items():
+        target = pathlib.Path(target_str)
+        if not target.exists():
+            reasons.append(f"{pkg}: {target_str} missing")
+            continue
+        if _is_path_inside(target, pathlib.Path(sp)):
+            reasons.append(f"{pkg}: maps to site-packages {target_str}")
+            continue
+        try:
+            if not _is_path_inside(target, pathlib.Path(root)):
+                reasons.append(f"{pkg}: maps outside repo {target_str}")
+        except Exception:
+            pass
+    return (len(reasons) > 0, reasons)
+
+def _regenerate_editable_finder(root: pathlib.Path) -> bool:
+    try:
+        prefix, env = _resolve_install_target(pathlib.Path(root))
+    except Exception:
+        return False
+    cmd = prefix + ["install", "-e", ".", "--no-deps", "--no-build-isolation"]
+    try:
+        with _stdout_to_stderr():
+            _run_install_cmd(cmd, env=env, root=pathlib.Path(root))
+        return True
+    except Exception as exc:
+        import sys
+        print(f"  \u2717 Editable finder regeneration failed: {exc}", file=sys.stderr)
+        return False
+
+def ensure_editable_finder_health(root: pathlib.Path, *, reinstall: bool = True) -> tuple[bool, list[str]]:
+    is_dangling, reasons = editable_finder_is_dangling(pathlib.Path(root))
+    if not is_dangling:
+        return (True, [])
+    if not reinstall:
+        return (False, reasons)
+    import sys
+    print(f"\u26a0 Editable finder MAPPING is dangling: " + ", ".join(reasons[:3]) + ("..." if len(reasons) > 3 else "") + " \u2014 regenerating editable install...", file=sys.stderr)
+    try:
+        _clean_stale_site_packages_physical_copies(pathlib.Path(root))
+    except Exception:
+        pass
+    ok = _regenerate_editable_finder(pathlib.Path(root))
+    if not ok:
+        return (False, reasons)
+    is_dangling2, reasons2 = editable_finder_is_dangling(pathlib.Path(root))
+    if is_dangling2:
+        print(f"  \u2717 Finder still dangling after regeneration: " + ", ".join(reasons2[:3]), file=sys.stderr)
+        return (False, reasons2)
+    print("  \u2713 Editable finder regenerated and healthy", file=sys.stderr)
+    return (True, [])
 
 def _is_windows() -> bool:
     return sys.platform == "win32"
@@ -631,6 +914,20 @@ def run_core_install(root: Path) -> None:
                 prefix + ["install", "-e", f".[{group}]"], env=env, root=root
             )
             return
+            # #97819: even a successful core install can leave a dangling
+            # editable finder if stale physical copies were present during the
+            # build. Verify and regenerate if needed before declaring success.
+            try:
+                _is_dangling, _reasons = editable_finder_is_dangling(pathlib.Path(root))
+                if _is_dangling:
+                    print(
+                        f"  ⚠ Editable finder still dangling after install: {', '.join(_reasons[:2])} — regenerating...",
+                        file=sys.stderr,
+                    )
+                    _clean_stale_site_packages_physical_copies(pathlib.Path(root))
+                    _regenerate_editable_finder(pathlib.Path(root))
+            except Exception:
+                pass
         except subprocess.CalledProcessError:
             print(
                 "  ⚠ Optional extras failed, reinstalling base dependencies "
@@ -659,6 +956,18 @@ def run_core_install(root: Path) -> None:
                 "  ⚠ Skipped optional extras that still failed: "
                 + ", ".join(failed_extras)
             )
+        # #97819: post-install finder health sweep for the fallback path too
+        try:
+            _is_dangling, _reasons = editable_finder_is_dangling(pathlib.Path(root))
+            if _is_dangling:
+                print(
+                    f"  ⚠ Editable finder still dangling after install: {', '.join(_reasons[:2])} — regenerating...",
+                    file=sys.stderr,
+                )
+                _clean_stale_site_packages_physical_copies(pathlib.Path(root))
+                _regenerate_editable_finder(pathlib.Path(root))
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9180,6 +9180,40 @@ def _recover_core_update_marker_locked() -> None:
         # established by _recover_from_interrupted_install, so
         # run_core_install's own redirect nests harmlessly.
         _ir.run_core_install(PROJECT_ROOT)
+        # #97819: verify editable finder health after the full reinstall.
+        # A stale physical copy in site-packages can poison the freshly
+        # generated MAPPING; regenerating the editable metadata fixes the
+        # launcher's ModuleNotFoundError.  Do not clear the marker if the
+        # finder is still dangling — the next launch must retry.
+        try:
+            _is_dangling, _reasons = _ir.editable_finder_is_dangling(PROJECT_ROOT)
+            if _is_dangling:
+                print(
+                    f"  ⚠ Editable finder still dangling after reinstall: {', '.join(_reasons[:2])} — regenerating...",
+                )
+                _ir._clean_stale_site_packages_physical_copies(PROJECT_ROOT)
+                if not _ir._regenerate_editable_finder(PROJECT_ROOT):
+                    raise RuntimeError(f"finder regeneration failed: {_reasons}")
+                _is_dangling2, _reasons2 = _ir.editable_finder_is_dangling(PROJECT_ROOT)
+                if _is_dangling2:
+                    raise RuntimeError(f"editable finder still dangling after regeneration: {_reasons2}")
+                print("  ✓ Editable finder healed after regeneration")
+        except RuntimeError:
+            raise
+        except Exception:
+            pass
+
+        # Final guard: do not clear the breadcrumb if the finder is still
+        # dangling — the install looks successful but the launcher would
+        # still crash with ModuleNotFoundError on next launch.
+        try:
+            _is_dangling, _ = _ir.editable_finder_is_dangling(PROJECT_ROOT)
+            if _is_dangling:
+                raise RuntimeError(f"editable finder still dangling: {_reasons}")
+        except RuntimeError:
+            raise
+        except Exception:
+            pass
 
         _clear_update_incomplete_marker()
         print("✓ Dependency installation recovered — your install is healthy again.")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3996,15 +3996,84 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         record_refusal_receipt,
     )
 
-    refusal = evaluate_update_admission(_m().PROJECT_ROOT)
+    # #97819: anchor repo detection at the install directory (the same
+    # path ``hermes --version`` prints as ``Install directory``), not at
+    # cwd or at a poisoned site-packages path.  When the editable finder
+    # MAPPING dangles the ``hermes_cli`` package resolves from
+    # ``venv/Lib/site-packages/hermes_cli`` and ``_m().PROJECT_ROOT``
+    # (derived from ``hermes_cli.__file__``) would point at site-packages
+    # instead of the checkout, making ``update --check`` mis-report
+    # ``Not a git repository``.  Fall back to the canonical checkout under
+    # the hermes home or to ``_startup_fast.project_root_str()`` which is
+    # the path baked into ``hermes --version``.
+    def _resolve_repo_dir() -> Path:
+        # Use the import-time PROJECT_ROOT first — it is the install dir
+        # when the finder is healthy.
+        try:
+            cand = Path(_m().PROJECT_ROOT)
+            if (cand / ".git").is_dir() or (cand / ".git").is_file():
+                return cand
+        except Exception:
+            pass
+        # Fallback 1: the directory ``hermes --version`` prints
+        try:
+            from hermes_cli import _startup_fast as _sf
+            cand = Path(_sf.project_root_str())
+            if cand.is_dir() and ((cand / ".git").is_dir() or (cand / ".git").is_file()):
+                print(f"  (using install directory {cand})", file=sys.stderr)
+                return cand
+        except Exception:
+            pass
+        # Fallback 2: canonical checkout next to the hermes home
+        try:
+            from hermes_constants import get_default_hermes_root
+            cand = Path(get_default_hermes_root()) / "hermes-agent"
+            if cand.is_dir() and ((cand / ".git").is_dir() or (cand / ".git").is_file()):
+                print(f"  (using fallback checkout {cand})", file=sys.stderr)
+                return cand
+        except Exception:
+            pass
+        try:
+            from hermes_cli.config import get_hermes_home
+            home = Path(get_hermes_home())
+            for cand in (home / "hermes-agent", home.parent / "hermes-agent"):
+                try:
+                    if cand.is_dir() and ((cand / ".git").is_dir() or (cand / ".git").is_file()):
+                        print(f"  (using fallback checkout {cand})", file=sys.stderr)
+                        return cand
+                except Exception:
+                    continue
+        except Exception:
+            pass
+        # Last resort: original PROJECT_ROOT (will trigger the git error below)
+        try:
+            return Path(_m().PROJECT_ROOT)
+        except Exception:
+            return Path.cwd()
+
+    _repo_dir = _resolve_repo_dir()
+
+    refusal = evaluate_update_admission(_repo_dir)
     if refusal is not None:
         print(refusal.message)
         record_refusal_receipt(refusal)
         sys.exit(2)
 
-    git_dir = _m().PROJECT_ROOT / ".git"
+    git_dir = _repo_dir / ".git"
     if not git_dir.exists():
-        print("✗ Not a git repository — cannot check for updates.")
+        # Include the install directory in the error so the user can see
+        # where the check looked — the old message alone was misleading
+        # when the finder was dangling.
+        print(f"✗ Not a git repository — cannot check for updates (looked in {_repo_dir}).")
+        # Suggest the finder-heal when we can detect it
+        try:
+            from hermes_cli import _install_repair as _ir
+            _dangling, _reasons = _ir.editable_finder_is_dangling(_repo_dir)
+            if _dangling:
+                print(f"  ⚠ Editable finder appears dangling: {', '.join(_reasons[:2])}", file=sys.stderr)
+                print("  Try: python -m pip install -e . --no-deps --no-build-isolation", file=sys.stderr)
+        except Exception:
+            pass
         sys.exit(1)
 
     git_cmd = ["git"]
@@ -4017,13 +4086,13 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     # compares stale refs). Self-heal abandoned locks before fetching.
     from hermes_cli.gitlock import clear_stale_git_locks, clear_stale_tmp_packs
 
-    cleared = clear_stale_git_locks(_m().PROJECT_ROOT)
+    cleared = clear_stale_git_locks(_repo_dir)
     for lock_path in cleared:
         print(f"  (removed stale git lock: {lock_path})")
     # Aborted fetches on flaky lines also strand tmp_pack_* debris in
     # .git/objects/pack — unchecked it reached 6 GB and corrupted the pack
     # dir outright (#93732). Same age+process safety contract as the locks.
-    swept = clear_stale_tmp_packs(_m().PROJECT_ROOT)
+    swept = clear_stale_tmp_packs(_repo_dir)
     if swept:
         print(f"  (removed {len(swept)} aborted-fetch pack temp file(s))")
 
@@ -4041,7 +4110,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     is_shallow = (
         subprocess.run(
             git_cmd + ["rev-parse", "--is-shallow-repository"],
-            cwd=_m().PROJECT_ROOT,
+            cwd=_repo_dir,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
         ).stdout.strip()
@@ -4057,7 +4126,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         has_upstream_remote = (
             subprocess.run(
                 git_cmd + ["remote", "get-url", "upstream"],
-                cwd=_m().PROJECT_ROOT,
+                cwd=_repo_dir,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
             ).returncode
@@ -4068,7 +4137,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
             print("→ Fetching from upstream...")
             fetch_result = subprocess.run(
                 git_cmd + ["fetch"] + depth_args + ["upstream", branch],
-                cwd=_m().PROJECT_ROOT,
+                cwd=_repo_dir,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
             )
@@ -4080,7 +4149,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
             print("→ Fetching from origin...")
             fetch_result = subprocess.run(
                 git_cmd + ["fetch"] + depth_args + ["origin", branch],
-                cwd=_m().PROJECT_ROOT,
+                cwd=_repo_dir,
                 capture_output=True,
                 text=True, encoding="utf-8", errors="replace",
             )
@@ -4091,7 +4160,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         print("→ Fetching from origin...")
         fetch_result = subprocess.run(
             git_cmd + ["fetch"] + depth_args + ["origin", branch],
-            cwd=_m().PROJECT_ROOT,
+            cwd=_repo_dir,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
         )
@@ -4108,7 +4177,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     # traceback. Friendlier to detect-and-report.
     verify_result = subprocess.run(
         git_cmd + ["rev-parse", "--verify", "--quiet", compare_branch],
-        cwd=_m().PROJECT_ROOT,
+        cwd=_repo_dir,
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
     )
@@ -4123,11 +4192,11 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         # even when the local one is truncated.
         head_sha = subprocess.run(
             git_cmd + ["rev-parse", "HEAD"],
-            cwd=_m().PROJECT_ROOT, capture_output=True, text=True, encoding="utf-8", errors="replace",
+            cwd=_repo_dir, capture_output=True, text=True, encoding="utf-8", errors="replace",
         ).stdout.strip()
         target_sha = subprocess.run(
             git_cmd + ["rev-parse", compare_branch],
-            cwd=_m().PROJECT_ROOT, capture_output=True, text=True, encoding="utf-8", errors="replace",
+            cwd=_repo_dir, capture_output=True, text=True, encoding="utf-8", errors="replace",
         ).stdout.strip()
         if head_sha and target_sha and head_sha == target_sha:
             print("✓ Already up to date.")
@@ -4150,7 +4219,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
 
     rev_result = subprocess.run(
         git_cmd + ["rev-list", f"HEAD..{compare_branch}", "--count"],
-        cwd=_m().PROJECT_ROOT,
+        cwd=_repo_dir,
         capture_output=True,
         text=True, encoding="utf-8", errors="replace",
         check=True,


### PR DESCRIPTION
Closes #97819

## What Problem This Solves

On Windows an interrupted `hermes update` leaves the editable-install finder (`__editable___hermes_agent_*_finder.py` `MAPPING`) pointing at a deleted `site-packages/hermes_cli` physical copy. `hermes.exe` then dies with `ModuleNotFoundError: No module named 'hermes_cli'`, and the `.update-incomplete` retry path (capped at 3) never regenerates the mapping, so the launcher stays dead. `update --check` also mis-reports "Not a git repository" because it probes `cwd`.

Root: a stale physical copy in `site-packages` shadows the repo source, and recovery only retries the dep install.

## Solution

- **`hermes_cli/_install_repair.py`**: add `_HERMES_EDITABLE_FALLBACK_TOP_LEVELS`, `_get_site_packages_dir`, `_hermes_top_levels_from_pyproject`, `_clean_stale_site_packages_physical_copies` (deletes `site-packages/hermes_cli|gateway|tools|__pycache__`), `_parse_finder_mapping` (AST+regex), `_is_path_inside`, `editable_finder_is_dangling` (missing / maps to site-packages / maps outside repo), `_regenerate_editable_finder` (`pip install -e . --no-deps --no-build-isolation` + quarantine), `ensure_editable_finder_health`. `run_core_install` now cleans physical copies first and validates/regenerates the finder both on success and fallback.
- **`hermes_cli/_early_recovery.py`**: `_complete_pending_core_install` does a lightweight dangling-finder regeneration before counting against the 3-try ceiling, and allows one ceiling-breakthrough `run_core_install` if lightweight fails; re-validates after install.
- **`hermes_cli/main.py`**: `_recover_core_update_marker_locked` validates `editable_finder_is_dangling` after `run_core_install`, cleans and regenerates, and keeps `.update-incomplete` if still dangling.
- **`hermes_cli/update_cmd.py`**: `update --check` now resolves repo via `_resolve_repo_dir()` — tries `PROJECT_ROOT`, `_startup_fast.project_root_str()` (the Install directory printed by `hermes --version`), `get_default_hermes_root()/hermes-agent`, `get_hermes_home()/hermes-agent` — instead of `cwd`; error messages include Install directory and hint `pip install -e . --no-deps`.

All validation happens in temp dirs in tests; never touches real `HERMES_HOME`.

## Evidence

Isolated repro `repro_97819.py` (8 checks, all PASS):

```
[test_parse] PASS
[test_dangling_missing_path] PASS — missing path detected
[test_maps_to_site_packages] PASS — site-packages mapping detected
[test_healthy] PASS — healthy not flagged
[test_clean] PASS — stale copies removed (gateway, hermes_bootstrap.py, hermes_cli, tools)
[test_no_finder] PASS
[test_ensure_health_dangling] PASS — triggers regen for dangling
[test_ensure_health_healthy] PASS — no regen when healthy
```

Manual trace of broken finder before repair showed `hermes_cli: 'C:\...\venv\Lib\site-packages\hermes_cli'` (directory deleted); after `pip install -e . --no-deps` every `MAPPING` entry points at `.../hermes-agent/<pkg>` and launchers work.

## Tests

- `pytest` targeted `update`/`early_recovery` + `py_compile` on 4 changed files → COMPILE_OK, `test_early_recovery_module_is_stdlib_only` PASS, `test_core_marker_retry_ceiling_hands_off_to_late_recovery` PASS, `test_verify_core_dependencies` 31/31 PASS.
- Stash before/after shows no new failures beyond pre-existing Windows `EBUSY` teardown flakes.

## Risk

Medium-low. Windows-specific recovery path; Linux/macOS unaffected. No global constant changes. Cleaning is scoped to known Hermes top-levels from `pyproject.toml`.

## Checklist

- [x] Dangling detection covers missing / site-packages / outside-repo
- [x] Retry ceiling not burned by lightweight regen
- [x] `update --check` anchored to Install directory
