### PR TITLE
fix(state): fail open on FTS5-index-only corruption instead of killing turns

### DIFF
--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -126,6 +126,27 @@ _PERSISTENCE_CAUSE_EXPLANATIONS: Dict[str, str] = {
         "3. Restore from a backup in ~/.hermes/backups/\n"
         "Then send your message again."
     ),
+    # SQLite scoped the corruption to the FTS index and the derived indexes could not be
+    # detached, so this write did not land; the message store itself is intact (#97794).
+    "fts_index": (
+        "the turn was stopped because the session search index (FTS5) "
+        "is corrupt and could not be detached, so this message was not "
+        "saved. The message store itself is not damaged: do not run "
+        "recovery tools or restore a backup. Run `hermes doctor --fix` "
+        "(or restart Hermes, which repairs the index on open), then "
+        "send your message again."
+    ),
+    # Unscoped corruption report, but a read-only quick_check found the canonical tables
+    # intact: the handle is still quarantined (restart), the recover/restore advice is not.
+    "corrupt_unconfirmed": (
+        "the turn was stopped because the state database reported a "
+        "corruption error, but a read-only verification pass found the "
+        "message tables intact. This process stopped writing to state.db "
+        "as a precaution: restart Hermes to resume. Unwritten messages "
+        "were diverted to sessions/<session_id>.jsonl. Do not run "
+        "recovery tools or restore a backup unless `hermes doctor` "
+        "confirms damage."
+    ),
     "disk": (
         "the turn was stopped because session storage could not "
         "be written (the transcript would have been lost on "

--- a/contributors/emails/zsulthan9@gmail.com
+++ b/contributors/emails/zsulthan9@gmail.com
@@ -1,0 +1,2 @@
+SulthanZahran1
+# PR #97843 fix(state): FTS5-index-only corruption fail-open

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -723,7 +723,8 @@ class GatewayNotificationsMixin:
         if not error:
             return
         from hermes_state import _default_db_path, classify_persistence_error, format_session_db_unavailable
-        if classify_persistence_error(error) == "corrupt":
+        cause = classify_persistence_error(error)
+        if cause == "corrupt":
             # Copy-pasteable, so name the real store (profiles / HERMES_HOME do not live under ~/.hermes).
             db_path = _default_db_path()
             message = (
@@ -740,6 +741,15 @@ class GatewayNotificationsMixin:
                 "vulnerable sqlite3 CLI can corrupt it further\n"
                 "3. Restore from a backup in ~/.hermes/backups/\n"
                 "Run `hermes doctor` for sanitized diagnostics."
+            )
+        elif cause in ("fts_index", "corrupt_unconfirmed"):
+            # Index-scoped (or unconfirmed) corruption: the message tables are not damaged, so
+            # the recover / restore advice above would be destructive on a healthy file (#97794).
+            message = (
+                "⚠️ Session database reported a corruption error confined to the search index "
+                "(FTS5); the message tables are not damaged. Messages may not be persisted until "
+                "it is repaired: run `hermes doctor --fix`, then restart the gateway. Do not run "
+                "recovery tools or restore a backup unless `hermes doctor` confirms damage."
             )
         else:
             message = (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1017,17 +1017,24 @@ class SessionDB(
     @classmethod
     def _is_structural_corruption_error(cls, exc: BaseException) -> bool:
         """Bare SQLITE_CORRUPT/NOTADB with no FTS provenance: canonical B-tree/schema/freelist damage,
-        never repairable from the live write path."""
+        never repairable from the live write path. The raw error carries no ``db_path``, so the
+        classifier never runs its canonical-table probe here: quarantine is decided on the
+        result code alone, exactly as before (#97940); the probe only refines the user-facing
+        cause of the quarantine error afterwards (#97794)."""
         return (
             isinstance(exc, sqlite3.DatabaseError)
             and not isinstance(exc, StateDbCorruptError)
             and not cls._is_fts_write_corruption_error(exc)
-            and classify_persistence_error(exc) == "corrupt"
+            and classify_persistence_error(exc) in ("corrupt", "corrupt_unconfirmed")
         )
 
     def _corrupt_error(self, prefix: str = "") -> "StateDbCorruptError":
-        """Build the quarantine error for this handle (message assembled once)."""
-        return StateDbCorruptError(f"{prefix}{_STATE_DB_CORRUPT_MSG} (cause: {self._db_corrupt_reason})")
+        """Build the quarantine error for this handle (message assembled once). ``db_path`` lets
+        ``classify_persistence_error`` verify the report against the file before it renders
+        whole-file recovery advice (#97794)."""
+        err = StateDbCorruptError(f"{prefix}{_STATE_DB_CORRUPT_MSG} (cause: {self._db_corrupt_reason})")
+        err.db_path = str(self.db_path)
+        return err
 
     def _halt_db_corrupt(self, exc: BaseException) -> None:
         """Quarantine this handle and raise; never run in-file repair here."""

--- a/hermes_state_errors.py
+++ b/hermes_state_errors.py
@@ -3,7 +3,9 @@ Shared by hermes_state and its mixins; string predicates match wrapped RPC
 strings as well as live sqlite3 exceptions."""
 
 import errno
+import re
 import sqlite3
+from pathlib import Path
 
 # Malformed schema: ``sqlite_master`` itself is inconsistent (typically a DUPLICATE
 # ``CREATE VIRTUAL TABLE messages_fts`` row). SQLite parses the whole schema while
@@ -74,8 +76,8 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
 
 # Every classify_persistence_error bucket; consumers enumerate this tuple.
 PERSISTENCE_ERROR_CAUSES = (
-    "locked", "compression", "compression_closed", "turn_lease", "corrupt", "replaced", "disk",
-    "unknown",
+    "locked", "compression", "compression_closed", "turn_lease", "corrupt", "corrupt_unconfirmed",
+    "fts_index", "replaced", "disk", "unknown",
 )
 
 
@@ -87,6 +89,72 @@ PERSISTENCE_ERROR_CAUSES = (
 _DB_CORRUPTION_MARKERS = (
     "malformed", "file is not a database", "not a database", "database corruption",
 )
+
+# SQLite result codes: the module constants exist on Python 3.11+, the numeric values are
+# stable across every SQLite release.
+SQLITE_CORRUPT = getattr(sqlite3, "SQLITE_CORRUPT", 11)
+SQLITE_NOTADB = getattr(sqlite3, "SQLITE_NOTADB", 26)
+SQLITE_CORRUPT_VTAB = getattr(sqlite3, "SQLITE_CORRUPT_VTAB", 267)
+
+# Every FTS object hangs off this prefix: the virtual tables and their _data/_idx/_content/
+# _docsize/_config shadow b-trees. FTS5 names the table in its own corruption reports.
+_FTS_OBJECT_RE = re.compile(r"\bmessages_fts\w*")
+
+
+def is_fts_scoped_corruption_error(exc_or_str) -> bool:
+    """Corruption SQLite itself attributes to the FTS index layer: the ONE provenance rule
+    shared by the write-repair gate (``SessionDB._is_fts_write_corruption_error``), the
+    gateway transcript retry and :func:`classify_persistence_error` (#96038, #97794).
+
+    A known result code outranks prose: ``SQLITE_CORRUPT_VTAB`` is FTS-scoped even with
+    the generic malformed-image text older SQLite builds emit, while bare ``SQLITE_CORRUPT``
+    / ``SQLITE_NOTADB`` carry no object scope and any other known code contradicts
+    FTS-looking prose, so both fail closed. Only without a code (Python < 3.11, RPC-wrapped
+    strings) does the text decide, and then only an ``fts5:`` corruption report or a
+    corruption marker that names a ``messages_fts*`` object counts.
+    """
+    if exc_or_str is None:
+        return False
+    code = getattr(exc_or_str, "sqlite_errorcode", None)
+    if code is not None:
+        return code == SQLITE_CORRUPT_VTAB
+    text = (exc_or_str if isinstance(exc_or_str, str) else str(exc_or_str)).lower()
+    if not _FTS_OBJECT_RE.search(text):
+        return False
+    if text.startswith("fts5:") and "corrupt" in text:
+        return True
+    return any(marker in text for marker in _DB_CORRUPTION_MARKERS)
+
+
+def _is_unscoped_corruption_code(code) -> bool:
+    """No code at all, or a corruption-class primary code that names no object."""
+    return code is None or (int(code) & 0xFF) in (SQLITE_CORRUPT, SQLITE_NOTADB)
+
+
+def verify_canonical_tables_healthy(db_path) -> bool:
+    """Read-only ``PRAGMA quick_check`` on a fresh connection; True only when every reported
+    problem names a ``messages_fts*`` object (or there is none).
+
+    Answers "is this corruption report confined to the derived index layer?" for errors whose
+    result code carries no scope (#97794: a healthy 22k-message store was declared structurally
+    corrupt on the strength of an FTS-layer error). quick_check walks every b-tree page, the
+    damage class behind a malformed-image error, and skips only the index-content cross-check
+    that never raises on a write; on a multi-GB store that is seconds instead of minutes. Any
+    probe failure (cannot open, locked, the check itself raising) returns False so callers keep
+    the conservative verdict.
+    """
+    try:
+        conn = sqlite3.connect(f"file:{Path(db_path)}?mode=ro", uri=True, timeout=1.0)
+    except sqlite3.Error:
+        return False
+    try:
+        rows = conn.execute("PRAGMA quick_check").fetchall()
+    except sqlite3.Error:
+        return False
+    finally:
+        conn.close()
+    problems = [str(row[0]) for row in rows if row and str(row[0]).lower() != "ok"]
+    return all(_FTS_OBJECT_RE.search(line.lower()) for line in problems)
 
 
 class CompressionSessionClosedError(RuntimeError):
@@ -195,12 +263,40 @@ _PERSISTENCE_CAUSE_BY_PHRASE = (
 )
 
 
+def _refine_corrupt_cause(exc_or_str) -> str:
+    """``corrupt`` unless the error carries the store's ``db_path`` (stamped by the SessionDB
+    quarantine), its result code is unscoped, and a read-only quick_check finds the canonical
+    tables intact: then ``corrupt_unconfirmed``. The quarantine itself is untouched (a live
+    handle that observed corruption must stop writing either way); only the guidance changes,
+    so a healthy file is never sent down the recover / restore path (#97794). Memoised on the
+    error object so the probe runs once per failure, not once per consumer."""
+    cached = getattr(exc_or_str, "_persistence_cause", None)
+    if cached is not None:
+        return cached
+    cause = "corrupt"
+    db_path = getattr(exc_or_str, "db_path", None)
+    if (
+        db_path
+        and _is_unscoped_corruption_code(getattr(exc_or_str, "sqlite_errorcode", None))
+        and verify_canonical_tables_healthy(db_path)
+    ):
+        cause = "corrupt_unconfirmed"
+    try:
+        exc_or_str._persistence_cause = cause
+    except (AttributeError, TypeError):  # plain strings
+        pass
+    return cause
+
+
 def classify_persistence_error(exc_or_str) -> str:
     """Coarse cause bucket (PERSISTENCE_ERROR_CAUSES) so the user's guidance
     matches: "locked" = busy, retry; "disk" = full/read-only/permissions;
     "compression" = a live lease refused the write; "compression_closed" = adopt
     the rotated session id; "turn_lease" = fencing, not storage; "corrupt" =
-    file damage (repair path, not disk space); "replaced" = stop writing."""
+    file damage (repair path, not disk space); "corrupt_unconfirmed" = corruption
+    reported but the canonical tables verify intact (restart, do not recover);
+    "fts_index" = SQLite scoped the corruption to the FTS index (the transcript
+    store is not damaged); "replaced" = stop writing."""
     if exc_or_str is None:
         return "unknown"
     # Lease refusals contain neither "locked" nor "busy": match by type first,
@@ -209,11 +305,15 @@ def classify_persistence_error(exc_or_str) -> str:
     # BEFORE the lock/disk buckets ("disk image is malformed" contains "disk").
     for exc_type, cause in _PERSISTENCE_CAUSE_BY_TYPE:
         if isinstance(exc_or_str, exc_type):
-            return cause
+            return _refine_corrupt_cause(exc_or_str) if cause == "corrupt" else cause
+    # Provenance before prose: an FTS-scoped result code (or, without one, an fts5 report
+    # naming messages_fts*) is index damage, never whole-file corruption (#97794).
+    if is_fts_scoped_corruption_error(exc_or_str):
+        return "fts_index"
     text = str(exc_or_str).lower()
     for markers, cause in _PERSISTENCE_CAUSE_BY_PHRASE:
         if any(marker in text for marker in markers):
-            return cause
+            return _refine_corrupt_cause(exc_or_str) if cause == "corrupt" else cause
     if is_disk_full_error(exc_or_str) or any(m in text for m in ("disk", "readonly", "read-only")):
         return "disk"
     return "unknown"

--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from hermes_constants import get_hermes_home
 from hermes_state_common import FTS_CJK_STALE_KEY, FTS_STALE_KEY, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS
+from hermes_state_errors import is_fts_scoped_corruption_error
 
 # caplog tests pin the "hermes_state" logger name.
 logger = logging.getLogger("hermes_state")
@@ -299,13 +300,11 @@ class SessionFtsSetupMixin:
 
     @staticmethod
     def _is_fts_write_corruption_error(exc: sqlite3.DatabaseError) -> bool:
-        """Corruption SQLite identifies as FTS-scoped (SQLITE_CORRUPT_VTAB, or an
-        ``fts5:`` message on older builds); a bare malformed image is structural."""
-        error_code = getattr(exc, "sqlite_errorcode", None)
-        if error_code is not None:
-            return error_code == getattr(sqlite3, "SQLITE_CORRUPT_VTAB", 267)
-        msg = str(exc).lower()
-        return msg.startswith("fts5:") and "corrupt structure" in msg
+        """Corruption SQLite identifies as FTS-scoped (SQLITE_CORRUPT_VTAB, or an ``fts5:``
+        report naming ``messages_fts*`` on builds without result codes); a bare malformed
+        image is structural. One rule, shared with ``classify_persistence_error`` and the
+        gateway transcript retry: see :func:`hermes_state_errors.is_fts_scoped_corruption_error`."""
+        return is_fts_scoped_corruption_error(exc)
 
     def _enter_fts_fail_open(self, exc: sqlite3.DatabaseError) -> bool:
         """Detach corrupt FTS indexes so canonical writes can continue. Breadcrumb +

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -155,6 +155,37 @@ def test_explanation_persistence_corrupt_cause_never_says_free_space():
     assert "full disk" not in lower
 
 
+def test_explanation_persistence_fts_index_and_unconfirmed_never_advise_recovery():
+    """#97794: an FTS-scoped failure, or a corruption report the canonical-table probe
+    could not confirm, must never send the user down the recover / restore-backup path
+    on a healthy file — and must not claim the transcript was lost."""
+    for cause in ("fts_index", "corrupt_unconfirmed"):
+        out = AIAgent._format_turn_completion_explanation(
+            "session_persistence_failed", cause
+        )
+        lower = out.lower()
+        assert out.strip() != ""
+        assert "sessions recover" not in lower
+        assert ".recover" not in lower
+        # Negative advice ("do not ... restore a backup") is fine; instructions are not.
+        assert "recovery options" not in lower
+        assert "restore from a backup" not in lower and "backups/" not in lower
+        assert "would have been lost" not in lower
+        assert "free" not in lower  # never disk-space advice
+        assert "hermes doctor" in lower
+    fts = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "fts_index"
+    ).lower()
+    assert "search index" in fts and "not damaged" in fts
+    assert "send your message again" in fts  # the handle stays live
+    unconfirmed = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "corrupt_unconfirmed"
+    ).lower()
+    assert "intact" in unconfirmed
+    assert "restart" in unconfirmed  # the handle is quarantined: retrying cannot help
+    assert "diverted" in unconfirmed
+
+
 def test_explanation_persistence_replaced_cause_forbids_inplace_repair():
     out = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "replaced"
@@ -317,6 +348,7 @@ def test_persistence_error_causes_tuple_matches_classifier():
         "Session 'abc' is being compressed by another writer",
         "Session turn lease lost; refusing transcript write for 'abc'",
         "database disk image is malformed",
+        'fts5: corrupt structure record for table "messages_fts"',
         "FATAL: state.db was replaced underneath the gateway",
         "database or disk is full",
         "something else entirely",
@@ -324,6 +356,113 @@ def test_persistence_error_causes_tuple_matches_classifier():
     )
     for probe in probes:
         assert classify_persistence_error(probe) in PERSISTENCE_ERROR_CAUSES
+
+
+def test_classify_persistence_error_fts_provenance_order():
+    """Result code first, prose only without one — the #96038 rule the write-repair gate
+    already enforces, now shared with the classifier so there is one definition of
+    "provably FTS-only" (#97794 review)."""
+    import sqlite3
+
+    from hermes_state import SessionDB, classify_persistence_error
+    from hermes_state_errors import SQLITE_CORRUPT_VTAB, is_fts_scoped_corruption_error
+
+    def _err(text, code=None, cls=sqlite3.DatabaseError):
+        exc = cls(text)
+        if code is not None:
+            exc.sqlite_errorcode = code
+        return exc
+
+    # Tier 1 — a known result code decides. SQLITE_CORRUPT_VTAB is FTS-scoped even with the
+    # generic text older SQLite builds emit; bare SQLITE_CORRUPT / SQLITE_NOTADB are unscoped.
+    vtab = _err("database disk image is malformed", SQLITE_CORRUPT_VTAB)
+    assert classify_persistence_error(vtab) == "fts_index"
+    assert SessionDB._is_fts_write_corruption_error(vtab)  # same verdict as the write gate
+    assert classify_persistence_error(
+        _err("database disk image is malformed", sqlite3.SQLITE_CORRUPT)
+    ) == "corrupt"
+    assert classify_persistence_error(
+        _err("file is not a database", sqlite3.SQLITE_NOTADB)
+    ) == "corrupt"
+    # A contradictory known code outranks FTS-looking prose (the #96038 regression shape).
+    contradictory = _err(
+        'fts5: corrupt structure record for table "messages_fts"',
+        sqlite3.SQLITE_CONSTRAINT_TRIGGER,
+        sqlite3.IntegrityError,
+    )
+    assert not is_fts_scoped_corruption_error(contradictory)
+    assert classify_persistence_error(contradictory) != "fts_index"
+    assert not SessionDB._is_fts_write_corruption_error(contradictory)
+
+    # Tier 2 — no code (Python < 3.11, RPC-wrapped strings): the report must name a
+    # messages_fts* object. Both shapes from #97794's evidence logs qualify.
+    assert classify_persistence_error(
+        _err('fts5: corrupt structure record for table "messages_fts"')
+    ) == "fts_index"
+    assert classify_persistence_error(
+        'fts5: corruption found reading blob 2061584302081 from table "messages_fts"'
+    ) == "fts_index"
+    assert classify_persistence_error(
+        'fts5: corrupt structure record for table "messages_fts_trigram"'
+    ) == "fts_index"
+    assert classify_persistence_error(
+        "malformed inverted index for FTS5 table main.messages_fts"
+    ) == "fts_index"
+    # Generic markers without provenance stay conservative; fts5 text without corruption,
+    # or an FTS name without a corruption marker, is not corruption at all.
+    assert classify_persistence_error("database disk image is malformed") == "corrupt"
+    assert classify_persistence_error('fts5: syntax error near "x"') == "unknown"
+    assert classify_persistence_error("no such table: messages_fts") == "unknown"
+
+
+def test_classify_persistence_error_quarantine_verified_healthy_is_unconfirmed(
+    tmp_path, monkeypatch
+):
+    """Tier 3 — the canonical-table probe. A quarantine error carrying the store's db_path,
+    an unscoped code, and a clean read-only quick_check classifies as
+    ``corrupt_unconfirmed``; a scoped/contradictory code, a missing path, or an unreadable
+    file keeps ``corrupt``. The probe runs once per error object."""
+    import sqlite3
+
+    import hermes_state_errors
+    from hermes_state import SessionDB, StateDbCorruptError, classify_persistence_error
+
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+
+    calls = []
+    real_probe = hermes_state_errors.verify_canonical_tables_healthy
+
+    def _counting_probe(path):
+        calls.append(path)
+        return real_probe(path)
+
+    monkeypatch.setattr(hermes_state_errors, "verify_canonical_tables_healthy", _counting_probe)
+
+    err = StateDbCorruptError("database disk image is malformed (quarantined)")
+    err.db_path = str(db_path)
+    err.sqlite_errorcode = sqlite3.SQLITE_NOTADB
+    assert classify_persistence_error(err) == "corrupt_unconfirmed"
+    assert classify_persistence_error(err) == "corrupt_unconfirmed"
+    assert len(calls) == 1  # memoised on the error object
+
+    # No code at all (a fail-fast re-raise on the quarantined handle) still verifies.
+    bare = StateDbCorruptError("quarantined")
+    bare.db_path = str(db_path)
+    assert classify_persistence_error(bare) == "corrupt_unconfirmed"
+
+    # A contradictory known code never probes.
+    contradictory = StateDbCorruptError("quarantined")
+    contradictory.db_path = str(db_path)
+    contradictory.sqlite_errorcode = sqlite3.SQLITE_CONSTRAINT_TRIGGER
+    assert classify_persistence_error(contradictory) == "corrupt"
+
+    # Missing path / unreadable file: conservative.
+    assert classify_persistence_error(StateDbCorruptError("quarantined")) == "corrupt"
+    missing = StateDbCorruptError("quarantined")
+    missing.db_path = str(tmp_path / "missing.db")
+    assert classify_persistence_error(missing) == "corrupt"
+    assert len(calls) == 3  # first err, bare, missing — never the contradictory one
 
 
 # --------------------------------------------------------------------------

--- a/tests/state/test_fts_index_fail_open.py
+++ b/tests/state/test_fts_index_fail_open.py
@@ -1,0 +1,225 @@
+"""Regression tests for #97794: an FTS5-index-only failure must not kill the turn, and a
+corruption report on a healthy file must not be rendered as whole-file damage.
+
+The write path already fails open on provenance-proven FTS corruption (detach the derived
+indexes, retry the canonical write) and quarantines the handle on unscoped corruption
+(#97940 / #90837). These tests pin the contract at the boundaries the issue was filed
+against — the agent flush whose failure ends the turn, and the cause that drives the
+user-facing guidance:
+
+* the flush succeeds after an FTS-only stomp and the exact user message is durable in
+  ``messages`` (the turn proceeds);
+* an FTS-scoped error that still escapes (detach refused) classifies as ``fts_index`` and
+  never quarantines the handle;
+* an unscoped corruption report on a file whose canonical tables verify intact keeps the
+  quarantine but classifies as ``corrupt_unconfirmed`` (restart, not recover / restore);
+* real canonical b-tree damage keeps the ``corrupt`` verdict.
+"""
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import SessionDB, StateDbCorruptError, classify_persistence_error
+from run_agent import AIAgent
+
+
+def _flush_agent(db, session_id):
+    """Bind the real flush methods onto a stand-in over a live SessionDB."""
+    agent = SimpleNamespace(
+        _session_db=db,
+        _session_db_created=True,
+        _persist_disabled=False,
+        session_id=session_id,
+        _session_persist_lock=None,
+        _flushed_db_message_ids=set(),
+        _flushed_db_message_session_id=None,
+        _last_flushed_db_idx=0,
+        _db_flush_scan_prefix=None,
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _pending_cli_user_message=None,
+        _active_session_turn_lease_holder=None,
+        _last_persistence_error_cause=None,
+        _compression_adoption_failed=False,
+    )
+    agent._ensure_db_session = lambda: None
+    agent._flush_messages_to_session_db = (
+        AIAgent._flush_messages_to_session_db.__get__(agent, AIAgent)
+    )
+    agent._flush_messages_to_session_db_unlocked = (
+        AIAgent._flush_messages_to_session_db_unlocked.__get__(agent, AIAgent)
+    )
+    return agent
+
+
+def _seed(db, rows=60):
+    if not db._fts_enabled:
+        pytest.skip("FTS5 unavailable in this build")
+    db.create_session("s1", source="cli")
+    for i in range(rows):
+        db.append_message("s1", "user", f"seed row {i} " + "z" * 200)
+
+
+def _stomp_fts_shadow(db_path):
+    """Overwrite the messages_fts shadow b-tree blocks: FTS5 raises SQLITE_CORRUPT_VTAB on the
+    next MATCH / sync-trigger insert while every canonical row stays intact."""
+    raw = sqlite3.connect(str(db_path))
+    raw.execute("UPDATE messages_fts_data SET block = X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'")
+    raw.commit()
+    raw.close()
+
+
+def _flip_canonical_root_page(db_path):
+    """Physically damage the ``messages`` root page so SQLite raises bare SQLITE_CORRUPT."""
+    raw = sqlite3.connect(str(db_path))
+    raw.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    page_size = raw.execute("PRAGMA page_size").fetchone()[0]
+    root = raw.execute(
+        "SELECT rootpage FROM sqlite_master WHERE type='table' AND name='messages'"
+    ).fetchone()[0]
+    raw.close()
+    with open(db_path, "r+b") as f:
+        f.seek((root - 1) * page_size)
+        f.write(b"\xff" * 64)
+
+
+def _contents(db_path):
+    raw = sqlite3.connect(str(db_path))
+    try:
+        return [r[0] for r in raw.execute("SELECT content FROM messages ORDER BY id").fetchall()]
+    finally:
+        raw.close()
+
+
+class _NotADbConn:
+    """Connection proxy whose every execute reports unscoped SQLITE_NOTADB — the exact error
+    shape from #97794's logs, on a file whose canonical tables are intact."""
+
+    def __init__(self, real_conn):
+        self._real = real_conn
+
+    def execute(self, *args, **kwargs):
+        exc = sqlite3.DatabaseError("file is not a database")
+        exc.sqlite_errorcode = sqlite3.SQLITE_NOTADB
+        exc.sqlite_errorname = "SQLITE_NOTADB"
+        raise exc
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_turn_flush_survives_fts_only_corruption(tmp_path):
+    """The turn's transcript write succeeds after an FTS-only stomp: the flush reports
+    success (the turn proceeds, no ``session_persistence_failed``) and the exact user
+    message is durable in ``messages``. The derived indexes are detached, the handle is
+    not quarantined."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        _seed(db)
+        _stomp_fts_shadow(db_path)
+        agent = _flush_agent(db, "s1")
+
+        ok = agent._flush_messages_to_session_db(
+            [{"role": "user", "content": "lands after stomp"}], []
+        )
+
+        assert ok is True
+        assert agent._last_persistence_error_cause is None
+        assert _contents(db_path)[-1] == "lands after stomp"
+        assert db._db_corrupt is False
+        # Builds whose sync trigger walks the stomped structure record detach the derived
+        # indexes; builds that defer the read pass the insert through untouched. Either way
+        # the canonical write landed, which is the contract.
+        assert db._fts_stale in (True, False)
+        assert db.get_session("s1") is not None
+    finally:
+        db.close()
+
+
+def test_escaped_fts_only_error_is_index_scoped_not_quarantined(tmp_path, monkeypatch):
+    """When the detach itself is refused the FTS-scoped error escapes to the agent. It must
+    classify as ``fts_index`` (guidance names the index, not the file) and must not
+    quarantine the handle or touch the derived indexes."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        _seed(db)
+        _stomp_fts_shadow(db_path)
+        monkeypatch.setattr(db, "_enter_fts_fail_open", lambda exc: False)
+        agent = _flush_agent(db, "s1")
+
+        ok = agent._flush_messages_to_session_db(
+            [{"role": "user", "content": "refused detach"}], []
+        )
+        if ok is True:
+            pytest.skip("this SQLite build defers FTS shadow corruption past the insert trigger")
+
+        assert ok is False
+        assert agent._last_persistence_error_cause == "fts_index"
+        assert db._db_corrupt is False
+        assert db._fts_stale is False
+        assert "refused detach" not in _contents(db_path)
+    finally:
+        db.close()
+
+
+def test_unscoped_corruption_on_healthy_file_is_unconfirmed(tmp_path, monkeypatch):
+    """#97794's exact shape: a bare 'file is not a database' on a store whose canonical tables
+    verify intact. The quarantine still trips (a live handle that observed corruption must
+    stop writing) and the batch is still diverted, but the cause is ``corrupt_unconfirmed``
+    so the user is told to restart, not to run recovery on a healthy file."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    real_conn = db._conn
+    try:
+        _seed(db, rows=5)
+        db._conn = _NotADbConn(real_conn)
+        agent = _flush_agent(db, "s1")
+
+        ok = agent._flush_messages_to_session_db(
+            [{"role": "user", "content": "diverted on unconfirmed corruption"}], []
+        )
+
+        assert ok is False
+        assert db._db_corrupt is True
+        assert agent._last_persistence_error_cause == "corrupt_unconfirmed"
+        jsonl = tmp_path / "sessions" / "s1.jsonl"
+        assert jsonl.is_file()
+        assert "diverted on unconfirmed corruption" in jsonl.read_text(encoding="utf-8")
+        # Fail-fast writes on the quarantined handle carry the same verified verdict.
+        with pytest.raises(StateDbCorruptError) as caught:
+            db.append_message("s1", "user", "after quarantine")
+        assert classify_persistence_error(caught.value) == "corrupt_unconfirmed"
+    finally:
+        db._conn = real_conn
+        db.close()
+
+
+def test_unscoped_corruption_on_damaged_file_stays_corrupt(tmp_path, monkeypatch):
+    """The probe must never downgrade real canonical damage: byte-flip the ``messages`` root
+    page and the quarantined error keeps the ``corrupt`` verdict (recover / restore guidance)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    seed = SessionDB(db_path=db_path)
+    try:
+        _seed(seed, rows=200)
+    finally:
+        seed.close()
+    _flip_canonical_root_page(db_path)
+
+    db = SessionDB(db_path=db_path)
+    try:
+        agent = _flush_agent(db, "s1")
+        ok = agent._flush_messages_to_session_db(
+            [{"role": "user", "content": "after real damage"}], []
+        )
+        assert ok is False
+        assert db._db_corrupt is True
+        assert agent._last_persistence_error_cause == "corrupt"
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

A healthy `state.db` was reported to the user as **structural corruption** with `.recover` / restore-a-backup advice because `classify_persistence_error` only had one bucket, `corrupt`, for every corruption marker — including the ones FTS5 raises about its own shadow tables (#97794). The reporter's evidence: `PRAGMA integrity_check` → `ok`, 22,835 messages intact, and a turn killed with the destructive banner anyway.

Since #99652 (salvaged #96038 + #97940), current main already **fails open on the write path** for provenance-proven FTS corruption (detach the derived indexes, retry the canonical write, the turn proceeds) and **quarantines** the handle on unscoped corruption. What was still wrong was the *cause the user is shown afterwards*, and that is what this PR fixes. It is rebuilt on current main; nothing from the original head survives except the intent.

1. **One shared provenance rule** — `hermes_state_errors.is_fts_scoped_corruption_error`. A known result code outranks prose: `SQLITE_CORRUPT_VTAB` is FTS-scoped; bare `SQLITE_CORRUPT` / `SQLITE_NOTADB` are unscoped; any other known code (e.g. `SQLITE_CONSTRAINT_TRIGGER`) contradicts FTS-looking text and fails closed. Only without a code (Python < 3.11, RPC-wrapped strings) does the text decide, and then only an `fts5:` corruption report or a corruption marker that names a `messages_fts*` object. `SessionDB._is_fts_write_corruption_error` — and through it the gateway transcript retry — now delegates to it, so the write-repair gate and the persistence classifier can no longer drift (review P1 #2).
2. **New cause `fts_index`** — returned from that rule before any phrase match. An FTS-scoped error that still escapes the write path (the detach was refused) is never rendered as file damage. On main today it classifies as `unknown` (fts5 text carries no marker) or `corrupt` (generic text + `SQLITE_CORRUPT_VTAB` on older SQLite).
3. **New cause `corrupt_unconfirmed`** — the canonical-table probe (review tier 3). The quarantine error now carries the store's `db_path`; when its result code is unscoped, the classifier runs a read-only `PRAGMA quick_check` on a fresh connection and refines the cause only if every reported problem names a `messages_fts*` object (or there is none). **The quarantine decision is untouched** (#97940 / #90837 — the handle still stops writing, the batch is still diverted to JSONL); only the guidance changes from *recover / restore* to *restart, do not recover unless doctor confirms damage*. Any probe failure keeps `corrupt`. `quick_check` rather than `integrity_check`: it walks every b-tree page (the damage class behind a malformed-image error) and skips only the index-content cross-check, which never raises on a write — seconds instead of minutes on a multi-GB store. The verdict is memoised on the error object so the probe runs once per failure, not once per consumer.
4. **Honest wording** at both user-facing boundaries. `fts_index`: *this message was not saved, the store is not damaged, run `hermes doctor --fix` or restart, then send again* (the handle is live). `corrupt_unconfirmed`: *verification found the message tables intact, this process stopped writing as a precaution, restart, unwritten messages were diverted to `sessions/<id>.jsonl`* (the handle is quarantined, so "send again" would be wrong). The gateway startup broadcast gets the same non-destructive text for both.

### What this PR deliberately does not do

- It does not weaken the quarantine on unscoped corruption, and it does not run the probe inside `_execute_write`'s decision — that would have flipped six maintainer tests that pin "bare `SQLITE_CORRUPT` on a live handle quarantines" and reopened #97940.
- It does not add search-path LIKE degradation or `db_path` annotation on `append_message`: main already degrades search to LIKE after fail-open (`_match_rows` / `_search_messages_impl`), and the original annotation would have been dead code behind the quarantine's typed error.
- Reconciling #97841 (@Finn763): same target, string-only classifier (`messages_fts` / `fts5` substrings before any result code), which #96038 showed is unsafe. Its tool-level `_discover` LIKE fallback is not carried over on purpose: swallowing *every* exception there would mask structural corruption as "no results". No unique behaviour or test was carried across, so there is nothing to attribute; I'd suggest closing #97841 in favour of this one.

## Related Issue

Fixes #97794

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_errors.py`: `is_fts_scoped_corruption_error`, `verify_canonical_tables_healthy`, `_refine_corrupt_cause`; `PERSISTENCE_ERROR_CAUSES` += `corrupt_unconfirmed`, `fts_index`; `classify_persistence_error` evidence order: type → provenance → phrase → probe
- `hermes_state_fts.py`: `_is_fts_write_corruption_error` delegates to the shared rule
- `hermes_state.py`: `_corrupt_error` stamps `db_path`; `_is_structural_corruption_error` docstring + explicit tuple (raw errors never carry a path, so quarantine is still decided on the result code alone)
- `agent/turn_explainers.py`, `gateway/run_notifications.py`: wording for the two causes
- `tests/state/test_fts_index_fail_open.py` (new, 4 tests): turn-boundary flush succeeds and the exact user message is durable in `messages` after an FTS-only stomp (review P1 #1's requested regression); escaped FTS error → `fts_index`, no quarantine; bare `SQLITE_NOTADB` on a healthy file → `corrupt_unconfirmed` with quarantine + JSONL divert intact, fail-fast re-raise carries the same verdict; real byte-flip damage to the `messages` root page → `corrupt`
- `tests/run_agent/test_turn_completion_explainer.py` (+3 tests): provenance matrix incl. the contradictory-code case and the same verdict from the write gate; probe tier (memoised, never runs on a contradictory code, conservative on missing path / unreadable file); wording for both causes

## How to Test

1. `scripts/run_tests.sh tests/state/test_fts_index_fail_open.py tests/run_agent/test_turn_completion_explainer.py tests/state/test_fts_runtime_rebuild.py tests/hermes_state/test_state_db_corrupt_quarantine.py -q` — 4 files, 87 passed, 0 failed, 1 skipped.
2. Broader affected suites (state, quarantine, NOTADB fail-closed, gateway session / corrupt fallback / normalize, malformed repair, flush divert, compression adoption, salvage gate, session_search tool): 274 passed, 1 skipped; the 2 failures are `tests/gateway/test_session.py::TestSenderPrefixWithBackfill::*` and fail identically on clean `origin/main`.
3. Sabotage (the 5 source files reverted to `origin/main`, tests kept): 5 failed, 26 passed. The two new tests that also pass on main are deliberate contract pins — `test_turn_flush_survives_fts_only_corruption` (main already fails open for proven FTS corruption; this is the turn-boundary proof the review asked for) and `test_unscoped_corruption_on_damaged_file_stays_corrupt` (the probe must never downgrade real damage).
4. `ruff check` clean on every changed file; `git diff --check` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs (#97841 duplicate target — reconciled above; #96038 landed via #99652 and this composes on top of it; #88604/#88587 are the doctor-side presentation boundary and stay distinct)
- [x] My PR contains **only** changes related to this fix
- [x] Affected suites pass; pre-existing failures confirmed on clean main
- [x] I've added tests for my changes
- [x] Tested on: Linux (CachyOS), Python 3.11.15, SQLite 3.53.1

### Documentation & Housekeeping

- [x] N/A — no config keys or schemas changed; the classifier, probe and shared rule carry docstrings explaining the evidence order and the quarantine contract

## For New Skills

N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/state/test_fts_index_fail_open.py tests/run_agent/test_turn_completion_explainer.py tests/state/test_fts_runtime_rebuild.py tests/hermes_state/test_state_db_corrupt_quarantine.py -q
=== Summary: 4 files, 87 tests passed, 0 failed, 1 skipped (100% complete) in 7.2s (32 workers) ===

$ python -m pytest <14 affected files> -q
2 failed, 274 passed, 1 skipped   # both failures pre-existing on origin/main (TestSenderPrefixWithBackfill)

$ # sabotage: git checkout origin/main -- <5 source files>; pytest <2 new/changed test files>
5 failed, 26 passed
```
