### PR TITLE
fix(cron): fire on_session_finalize when a cron job finishes

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6880,6 +6880,33 @@ def run_job(
                 )
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)
+            # Fire on_session_finalize for this cron run.
+            #
+            # end_session() above closes the DB row; it does NOT notify plugin
+            # lifecycle hooks. gateway/run.py finalizes on shutdown and expiry,
+            # tui_gateway in _finalize_session — run_job had no equivalent, so
+            # every cron run emitted a start with no matching end. Measured
+            # 2026-08-29 against a plugin that posts session boundaries: 51/51
+            # cron sessions opened and never closed.
+            #
+            # Uses _final_cron_session_id, not _cron_session_id: compression can
+            # rotate the live agent onto a continuation mid-run, and the raw id
+            # captured before AIAgent started would name a session the hook
+            # cannot resolve. Ordered before close() so a hook may still read
+            # session state, and wrapped so a misbehaving plugin cannot skip the
+            # SQLite teardown below (fd leak — #10200).
+            try:
+                from hermes_cli import lifecycle
+
+                lifecycle.finalize_session(
+                    session_id=_final_cron_session_id,
+                    platform="cron",
+                    reason="cron_complete",
+                )
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug(
+                    "Job '%s': session finalize hooks failed: %s", job_id, e
+                )
             try:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:

--- a/tests/cron/test_cron_session_finalize.py
+++ b/tests/cron/test_cron_session_finalize.py
@@ -1,0 +1,180 @@
+"""Regression tests: a cron run must notify session lifecycle hooks.
+
+``run_job`` closes its SQLite session row via ``end_session``, but that call
+does not reach plugin lifecycle observers. Before this was fixed, every cron
+run emitted ``on_session_start`` with no matching ``on_session_finalize``:
+measured against a plugin that posts session boundaries to an external store,
+51/51 cron sessions were opened and never closed, while the CLI and gateway
+paths matched every day.
+
+The three properties pinned here:
+
+1. ``run_job`` calls ``lifecycle.finalize_session`` for its cron session.
+2. It passes the *resolved* session id. Compression can rotate the live agent
+   onto a continuation mid-run, so the raw id captured before ``AIAgent``
+   started would name a session the hook cannot resolve.
+3. A plugin that raises cannot skip the SQLite teardown that follows — that
+   teardown is what stops a long-lived gateway from leaking one fd per job
+   until it hits EMFILE.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import cron.scheduler as cron_scheduler
+from hermes_cli import lifecycle
+
+
+class _RecordingSessionDB:
+    """SessionDB stub that records teardown order for assertions."""
+
+    instances: list["_RecordingSessionDB"] = []
+
+    def __init__(self, *args, **kwargs):
+        self.ended: tuple | None = None
+        self.closed = False
+        self.compression_tip: str | None = None
+        _RecordingSessionDB.instances.append(self)
+
+    def get_compression_tip(self, _session_id):
+        return self.compression_tip
+
+    def set_session_title(self, *args, **kwargs):
+        pass
+
+    def get_next_title_in_lineage(self, base):
+        return base
+
+    def end_session(self, session_id, reason):
+        self.ended = (session_id, reason)
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeCronAgent:
+    def __init__(self, *args, **kwargs):
+        self.session_id = kwargs.get("session_id")
+
+    def run_conversation(self, _prompt):
+        return {
+            "completed": True,
+            "failed": False,
+            "final_response": "done",
+            "turn_exit_reason": "",
+        }
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def cron_env(monkeypatch, tmp_path):
+    """Wire run_job to in-memory doubles: no network, no real SessionDB."""
+    _RecordingSessionDB.instances.clear()
+    monkeypatch.setenv("HERMES_MODEL", "test-model")
+    monkeypatch.setattr("hermes_state.SessionDB", _RecordingSessionDB)
+    monkeypatch.setattr("run_agent.AIAgent", _FakeCronAgent)
+    monkeypatch.setattr(
+        "hermes_constants.resolve_reasoning_config", lambda *_a, **_kw: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "test-key",
+            "base_url": None,
+            "provider": "test-provider",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        },
+    )
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: [])
+    monkeypatch.setattr(cron_scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(cron_scheduler, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(
+        cron_scheduler, "_guard_job_credential_exfil", lambda _job: None
+    )
+    return tmp_path
+
+
+def _job(job_id: str) -> dict:
+    return {
+        "id": job_id,
+        "name": f"Job {job_id}",
+        "prompt": "Run safely",
+        "schedule_display": "manual",
+    }
+
+
+def test_run_job_fires_session_finalize(cron_env, monkeypatch):
+    """A completed cron run notifies on_session_finalize for its session."""
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        lifecycle, "finalize_session", lambda **kw: calls.append(kw) or []
+    )
+
+    success, _output, _final, error = cron_scheduler.run_job(_job("finalize-basic"))
+
+    assert success is True
+    assert error is None
+    assert len(calls) == 1
+    assert calls[0]["session_id"].startswith("cron_finalize-basic_")
+    assert calls[0]["platform"] == "cron"
+    assert calls[0]["reason"]
+
+    db = _RecordingSessionDB.instances[-1]
+    # The hook is an addition, not a replacement: the DB row still closes.
+    assert db.ended is not None
+    assert db.ended[0] == calls[0]["session_id"]
+    assert db.closed is True
+
+
+def test_run_job_finalizes_compression_continuation(cron_env, monkeypatch):
+    """When compression rotates the session, the continuation id is reported.
+
+    The raw ``cron_<job>_<ts>`` id is assigned before AIAgent starts. If a
+    long run is compressed onto a continuation, finalizing the stale id would
+    hand observers a session that no longer exists.
+    """
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        lifecycle, "finalize_session", lambda **kw: calls.append(kw) or []
+    )
+
+    original_init = _RecordingSessionDB.__init__
+
+    def _init_with_tip(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.compression_tip = "cron_rotated_continuation"
+
+    monkeypatch.setattr(_RecordingSessionDB, "__init__", _init_with_tip)
+
+    success, _output, _final, _error = cron_scheduler.run_job(_job("finalize-rot"))
+
+    assert success is True
+    assert len(calls) == 1
+    assert calls[0]["session_id"] == "cron_rotated_continuation"
+    assert _RecordingSessionDB.instances[-1].ended[0] == "cron_rotated_continuation"
+
+
+def test_finalize_hook_failure_does_not_skip_sqlite_teardown(cron_env, monkeypatch):
+    """A raising plugin cannot take the job down or leak the SQLite handle."""
+    calls: list[dict] = []
+
+    def _boom(**kwargs):
+        calls.append(kwargs)
+        raise RuntimeError("plugin exploded")
+
+    monkeypatch.setattr(lifecycle, "finalize_session", _boom)
+
+    success, _output, _final, error = cron_scheduler.run_job(_job("finalize-boom"))
+
+    assert len(calls) == 1
+    assert success is True
+    assert error is None
+
+    db = _RecordingSessionDB.instances[-1]
+    assert db.ended is not None
+    assert db.closed is True


### PR DESCRIPTION
## What does this PR do?

`cron/scheduler.py:run_job()` opens a cron session through `AIAgent` — which
emits `on_session_start` — and closes the SQLite row with `end_session()`, but
never notifies plugin lifecycle observers. Every cron run therefore emitted a
session start with no matching end.

Measured on a live install against a plugin that posts session boundaries to an
external store:

| source | sessions with a matching end |
|---|---|
| cli | 3/3 every day since 24 Aug |
| telegram | 17/26 (the 9 without still had `ended_at = NULL` — genuinely open) |
| **cron** | **0/51** |

The `cli` and `telegram` numbers are what makes this a `run_job` bug rather than
a hook bug: the same plugin fires correctly on every other path. Probing the
hook directly returned `200 /session/end`, so nothing downstream was broken — it
was simply never called.

Why this approach: `end_session()` already exists two lines above and is the
right place for the DB row, but it is a `SessionDB` method with no knowledge of
plugins. `lifecycle.finalize_session()` is the existing seam every other path
uses (`gateway/run.py` on shutdown and expiry, `tui_gateway._finalize_session`),
so this adds the missing call rather than inventing a mechanism.

## Related Issue

Sibling call path to #79533, which fixes the same missing-end symptom in
one-shot cleanup (`os._exit` skipping `atexit`). That PR does not touch
`cron/scheduler.py`, and cron does not route through `run_oneshot` — it has its
own `run_job`. The two are independent and can land in either order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`cron/scheduler.py`** (+27): call `lifecycle.finalize_session()` in
  `run_job`'s session teardown.
  - Passes `_final_cron_session_id`, not the raw `_cron_session_id` captured
    before `AIAgent` started. Compression can rotate the agent onto a
    continuation mid-run, and the stale id would name a session observers
    cannot resolve — `run_job` already computes the resolved id for
    `end_session`, so this reuses it.
  - Ordered before `_session_db.close()` so a hook can still read session state.
  - Wrapped in `try/except (Exception, KeyboardInterrupt)` so a raising plugin
    cannot skip the SQLite teardown below — that teardown is what stops a
    long-lived gateway from leaking one fd per job until EMFILE (#10200).
- **`tests/cron/test_cron_session_finalize.py`** (+180, new): three regression
  tests driving `run_job` end to end.

## How to Test

Reproduction on `main`, with any plugin implementing `on_session_finalize`:

1. Register a plugin that logs `on_session_start` and `on_session_finalize`.
2. Run any agent-backed cron job (`no_agent` jobs never create a session, and a
   `monitor_script` job whose hash is unchanged is suppressed before the agent
   starts — neither will reproduce this).
3. Observe a start with no matching finalize.

Proof the fix works, from the same install after applying it — a real cron run,
not a test double:

```
15:17:44  OK 200 /session/start  cron_0d4c6cbe4057_20260829_151742
15:17:46  OK 200 /session/end    cron_0d4c6cbe4057_20260829_151742
```

Automated:

```bash
pytest tests/cron/test_cron_session_finalize.py -q     # 3 passed
scripts/run_tests.sh tests/cron/ -q                    # 1036 passed, 0 failed
```

Each of the three tests was verified to **fail** with the finalize call removed
from `run_job`, so they cannot pass vacuously:

```
FAILED test_run_job_fires_session_finalize
FAILED test_run_job_finalizes_compression_continuation
FAILED test_finalize_hook_failure_does_not_skip_sqlite_teardown
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — found #79533 on the one-shot path and deliberately scoped this to `cron/scheduler.py` so the two do not conflict
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Apple silicon), Python 3.11

> Note on the full-suite checkbox, since "all tests pass" needs qualifying:
> the whole tree on this branch is **39590 passed / 203 failed**. To attribute
> those, I re-ran the same 68 failing files against a clean `origin/main`
> worktree with no patch applied: **201 of 203 fail identically there**, so they
> are pre-existing. The 2-test delta was one file,
> `tests/tools/test_mcp_tool_issue_948.py`, which passes 3/3 in isolation on
> *both* the patched branch and clean `main` — flaky under `-j 56`, and an MCP
> test with no path to `cron/scheduler.py`. `tests/cron/` itself is
> **1036 passed / 0 failed**.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the change is an internal call with an explanatory comment
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific calls; pure Python control flow
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Session-boundary counts from the affected install before the fix — 369 starts
against 71 ends, with cron and subagent contributing zero ends:

```
/session/start  369
/session/end     71

by source:  cli 3/3 daily · telegram 17/26 · cron 0/51 · subagent 0/12
```
