### PR TITLE
fix(auth): key global-auth-store and OAuth-heal caches on content digest, not mtime

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1836,9 +1836,17 @@ _OAUTH_TOKEN_FIELDS = (
 )
 
 _oauth_heal_notices: List[str] = []
-# provider -> (profile auth.json path, auth.json mtime_ns, singleton mtime_ns)
-# of the last store verified fork-free; lets load_pool() skip the locked scan.
-_oauth_heal_clean_marks: Dict[str, Tuple[str, Optional[int], Optional[int]]] = {}
+# provider -> (profile auth.json path, auth.json content digest, singleton
+# content digest) of the last store verified fork-free; lets load_pool() skip
+# the locked scan. Content-digest-keyed, not mtime-keyed: this cache guards
+# whether a credential fork needs healing, and an external metadata-preserving
+# copy (dotfile sync, backup/restore) can replace a forked auth.json's bytes
+# while restoring its original mtime, which a stat-only key would never
+# detect — the mark would keep saying "clean" and the auto-heal (whose whole
+# purpose is fixing exactly this kind of forked grant) would never re-scan
+# (same class of bug as _global_auth_store_cache above and the Vertex SA
+# credential cache — see agent/vertex_adapter.py's _read_sa_file).
+_oauth_heal_clean_marks: Dict[str, Tuple[str, Optional[str], Optional[str]]] = {}
 
 
 def consume_oauth_heal_notices() -> List[str]:
@@ -2000,14 +2008,15 @@ def _heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str,
 
     # Hot-path short-circuit: load_pool() runs per model call. Once this
     # profile's store was verified clean for *provider_id*, skip the locked
-    # read-modify-write until the profile's own files change (mtime key).
-    def _stamp(p: Optional[Path]) -> Optional[int]:
+    # read-modify-write until the profile's own files change (content-digest
+    # key — see the type comment above for why not mtime).
+    def _digest(p: Optional[Path]) -> Optional[str]:
         try:
-            return p.stat().st_mtime_ns if p is not None else None
+            return hashlib.sha256(p.read_bytes()).hexdigest() if p is not None else None
         except OSError:
             return None
 
-    fingerprint = (str(profile_path), _stamp(profile_path), _stamp(profile_singleton))
+    fingerprint = (str(profile_path), _digest(profile_path), _digest(profile_singleton))
     if _oauth_heal_clean_marks.get(provider_id) == fingerprint:
         return None
     if fingerprint[1] is None and fingerprint[2] is None:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1179,14 +1179,21 @@ def _load_global_auth_store() -> Dict[str, Any]:
     Returns an empty dict when no global fallback exists (classic mode,
     or the global auth.json is absent). Never raises on missing file.
 
-    Memoised keyed on the global auth file's path + mtime (same pattern as
-    ``_nous_auth_status_cache``): read_credential_pool() -> load_pool() runs
-    this once per provider row in the /model picker, and the path resolution
-    (``_global_auth_file_path()`` -> ``get_default_hermes_root()``) + JSON
-    parse cost ~105us+ per call even when nothing changed. The global
-    store only changes when the user authenticates at global scope (writes
-    always go through _save_auth_store, which touches the file), so the mtime
-    key keeps the memo freshness-correct. Callers must treat the returned
+    Memoised keyed on the global auth file's path + content digest (same
+    pattern as ``_nous_auth_status_cache`` for the TTL idea, and the same
+    stat-vs-digest fix already applied to the Vertex SA credential cache —
+    see ``agent/vertex_adapter.py._read_sa_file``): read_credential_pool() ->
+    load_pool() runs this once per provider row in the /model picker, and the
+    path resolution (``_global_auth_file_path()`` -> ``get_default_hermes_root()``)
+    + JSON parse cost ~105us+ per call even when nothing changed. A
+    (path, mtime_ns) signature is the right idiom for a config cache, but
+    this one guards credential identity: an external metadata-preserving
+    copy of auth.json (dotfile sync, backup/restore) can replace the file's
+    bytes while restoring its original mtime, which a stat-only key would
+    never detect — the cache would keep serving stale (or entirely
+    different) global credentials indefinitely. Hashing the content closes
+    that gap at the cost of one extra read on a cache PROBE, which is noise
+    next to the JSON parse it's memoising. Callers must treat the returned
     store as read-only (all current callers do — .get / dict() / list()
     copies only).
     """
@@ -1197,13 +1204,13 @@ def _load_global_auth_store() -> Dict[str, Any]:
         return {}
     try:
         resolved_path = str(global_path.resolve(strict=False))
-        mtime_ns = global_path.stat().st_mtime_ns
-        cache_key: Optional[Tuple[str, int]] = (resolved_path, mtime_ns)
+        digest = hashlib.sha256(global_path.read_bytes()).hexdigest()
+        cache_key: Optional[Tuple[str, str]] = (resolved_path, digest)
     except Exception:
         cache_key = None
     if cache_key is not None and _global_auth_store_cache is not None:
-        cached_path, cached_mtime, cached_store = _global_auth_store_cache
-        if cached_path == cache_key[0] and cached_mtime == cache_key[1]:
+        cached_path, cached_digest, cached_store = _global_auth_store_cache
+        if cached_path == cache_key[0] and cached_digest == cache_key[1]:
             return cached_store
     if os.environ.get("PYTEST_CURRENT_TEST"):
         real_home_env = os.environ.get("HOME", "")
@@ -7426,10 +7433,15 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
 _NOUS_AUTH_STATUS_CACHE_TTL = 15.0  # seconds
 _nous_auth_status_cache: Optional[Tuple[float, str, Optional[float], Dict[str, Any]]] = None
 
-# mtime-keyed memo for _load_global_auth_store(): (path, mtime_ns, store).
+# content-digest-keyed memo for _load_global_auth_store(): (path, sha256, store).
 # Same invalidation contract as _nous_auth_status_cache — the global auth
-# file changes only when a global-scope auth write touches it.
-_global_auth_store_cache: Optional[Tuple[str, int, Dict[str, Any]]] = None
+# file changes only when a global-scope auth write touches it. Keyed on
+# content hash rather than mtime: this cache guards credential identity, and
+# an external metadata-preserving copy (dotfile sync, backup/restore) can
+# replace the file's bytes while restoring its mtime, which a stat-only key
+# would miss indefinitely (same class of bug fixed for the Vertex SA
+# credential cache — see agent/vertex_adapter.py's _read_sa_file).
+_global_auth_store_cache: Optional[Tuple[str, str, Dict[str, Any]]] = None
 
 
 def _auth_file_cache_key() -> Tuple[str, Optional[float]]:

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -348,6 +348,40 @@ def test_heal_is_idempotent_and_logs_once(fleet, caplog):
     assert sum("consolidated forked" in r.message for r in caplog.records) == 1
 
 
+def test_clean_mark_is_not_fooled_by_a_metadata_preserving_replace(fleet):
+    """The clean-mark cache is keyed on content digest, not mtime: a tool
+    that replaces a profile's auth.json bytes while preserving its mtime
+    (dotfile sync, backup/restore, rsync -a) must not leave a just-restored
+    fork sitting unhealed forever because the mark still says 'clean'."""
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    kid = _fork(fleet, "kid")
+    fleet["use"](kid)
+    # First call heals the existing fork; second finds nothing left to do
+    # and records the clean mark (mirrors test_heal_is_idempotent_and_logs_once).
+    assert heal_forked_single_use_oauth_grants("anthropic") is not None
+    assert fleet["rows"](kid) is None
+    assert heal_forked_single_use_oauth_grants("anthropic") is None
+
+    kid_auth = kid / "auth.json"
+    marked_stat = kid_auth.stat()
+
+    # External metadata-preserving replace: a fork reappears in kid's
+    # auth.json (e.g. a backup taken before this profile was healed gets
+    # restored), but the file's mtime is set back to the exact value the
+    # clean mark observed.
+    root_store = json.loads((fleet["root"] / "auth.json").read_text())
+    kid_auth.write_text(json.dumps(root_store))
+    os.utime(kid_auth, ns=(marked_stat.st_atime_ns, marked_stat.st_mtime_ns))
+    assert kid_auth.stat().st_mtime_ns == marked_stat.st_mtime_ns  # sanity
+
+    # Bytes changed (a real fork is back) even though mtime didn't — the
+    # digest-keyed mark must miss and the fork must be detected and healed,
+    # not silently left forked because the stale mark said "clean".
+    assert heal_forked_single_use_oauth_grants("anthropic") is not None
+    assert fleet["rows"](kid) is None
+
+
 def test_heal_never_deletes_the_only_surviving_copy(fleet):
     """Root lost its grant (user ran `hermes auth remove` at root); the profile's
     copy is the only one left — and an independent second account stays put."""

--- a/tests/hermes_cli/test_global_auth_store_memo.py
+++ b/tests/hermes_cli/test_global_auth_store_memo.py
@@ -3,10 +3,16 @@
 read_credential_pool() -> load_pool() runs _load_global_auth_store() once per
 provider row in the /model picker, and the global-store JSON read + parse
 cost ~60-100us+ per call even when nothing changed. The memo keyed on the
-global auth file's path+mtime makes repeat reads a dict lookup. The store
-only changes when the user authenticates at global scope (writes always go
-through _save_auth_store, which touches the file), so the mtime key keeps
-the memo freshness-correct.
+global auth file's path+content-digest makes repeat reads a dict lookup.
+
+Keyed on content digest rather than mtime: a (path, mtime_ns) signature is
+the right idiom for a config cache, but this one guards credential
+identity, and an external metadata-preserving copy of auth.json (dotfile
+sync, backup/restore) can replace the file's bytes while restoring its
+original mtime — a stat-only key would serve stale (or entirely different)
+global credentials indefinitely. See the fix that applied the same
+stat-vs-digest correction to the Vertex SA credential cache
+(agent/vertex_adapter.py._read_sa_file) for the reasoning this mirrors.
 """
 
 from __future__ import annotations
@@ -81,8 +87,8 @@ class TestLoadGlobalAuthStoreMemo:
         )
         assert first.get("providers", {}).get("openai") == {"api_key": "sk-x"}
 
-    def test_mtime_change_re_reads_once(self, tmp_path, monkeypatch):
-        """A store file change on disk invalidates the memo."""
+    def test_content_change_re_reads_once(self, tmp_path, monkeypatch):
+        """A store file content change on disk invalidates the memo."""
         global_path = _make_global_store(tmp_path)
         monkeypatch.setattr(
             auth_mod, "_global_auth_file_path", lambda: global_path
@@ -99,10 +105,47 @@ class TestLoadGlobalAuthStoreMemo:
         auth_mod._load_global_auth_store()
         assert reads["n"] == 1
 
-        # Bump the file mtime -> memo invalidates -> re-read once.
-        os.utime(global_path, (1_700_000_000, 1_700_000_000))
-        auth_mod._load_global_auth_store()
-        assert reads["n"] == 2, "mtime change must force exactly one re-read"
+        # Real content change (a fresh auth write) -> memo invalidates -> one re-read.
+        global_path.write_text(
+            json.dumps({"version": 1, "providers": {"openai": {"api_key": "sk-NEW"}}}),
+            encoding="utf-8",
+        )
+        second = auth_mod._load_global_auth_store()
+        assert reads["n"] == 2, "content change must force exactly one re-read"
+        assert second.get("providers", {}).get("openai") == {"api_key": "sk-NEW"}
+
+    def test_metadata_preserving_replace_is_not_served_stale(self, tmp_path, monkeypatch):
+        """A content change that PRESERVES the original mtime (e.g. rsync -a,
+        a dotfile-sync tool, or a backup/restore that restores timestamps)
+        must still invalidate the memo — a (path, mtime_ns) key would miss
+        this indefinitely and keep serving the old global credentials."""
+        global_path = _make_global_store(tmp_path)
+        monkeypatch.setattr(
+            auth_mod, "_global_auth_file_path", lambda: global_path
+        )
+
+        first = auth_mod._load_global_auth_store()
+        assert first.get("providers", {}).get("openai") == {"api_key": "sk-x"}
+        original_stat = global_path.stat()
+
+        # Replace the content, then restore the ORIGINAL mtime/atime exactly
+        # — simulates a metadata-preserving external copy landing different
+        # bytes at the same path with the same stat signature.
+        global_path.write_text(
+            json.dumps({"version": 1, "providers": {"openai": {"api_key": "sk-DIFFERENT"}}}),
+            encoding="utf-8",
+        )
+        os.utime(
+            global_path,
+            ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+        )
+        assert global_path.stat().st_mtime_ns == original_stat.st_mtime_ns
+
+        second = auth_mod._load_global_auth_store()
+        assert second.get("providers", {}).get("openai") == {"api_key": "sk-DIFFERENT"}, (
+            "memo served stale credentials after a metadata-preserving "
+            "content replace — the cache key did not detect the change"
+        )
 
     def test_absent_global_store_returns_empty_without_error(self, tmp_path, monkeypatch):
         """No global fallback (classic mode) returns {} and stays cheap."""


### PR DESCRIPTION
## Summary

`_load_global_auth_store()` (`hermes_cli/auth.py`) memoises the parsed global-root `auth.json` keyed on `(path, mtime_ns)`. That's the right idiom for a config cache, but this cache guards **credential identity**: an external metadata-preserving copy of the file — a dotfile-sync tool, a backup/restore, anything using `rsync -a` or equivalent — can replace its bytes while restoring the original mtime. A stat-only key never detects that, so the memo keeps serving stale (or entirely different) global credentials for the life of the process, with no TTL to self-heal it.

This is the exact same anti-pattern the Vertex SA credential cache had before `#97701` (merged earlier in this same window) fixed it — same review reasoning, quoted from that fix's own docstring: *"the stat idiom is right for config caches... wrong for a credential cache (guards identity)."* That fix never got applied to this cache.

Reproduced empirically against upstream/main before writing the fix: an atomic-replace with the original `mtime_ns` restored serves stale (and here, entirely different) credential data indefinitely.

Reachability: `_load_global_auth_store()` feeds `read_credential_pool()`/`load_pool()` and xAI OAuth state resolution — normal production paths, not an opt-in/plugin route.

## Fix

Rekey the memo on `(path, sha256-of-content)` instead of `(path, mtime_ns)`, mirroring `agent/vertex_adapter.py`'s `_read_sa_file()` pattern exactly.

## Test plan

- [x] Updated `tests/hermes_cli/test_global_auth_store_memo.py`: the old `test_mtime_change_re_reads_once` only bumped mtime without changing content — under the new key that correctly does NOT force a re-read (nothing changed), so it's rewritten as `test_content_change_re_reads_once`, which changes real content and asserts a re-read.
- [x] Added `test_metadata_preserving_replace_is_not_served_stale` — the direct regression test for this bug: replace the file's content, restore its exact original mtime/atime via `os.utime`, and assert the *new* content is served (not the stale cached one).
- [x] Mutation-verified: stashed the fix, confirmed the new regression test fails against the original mtime-only code — stale `sk-x` served instead of the replaced `sk-DIFFERENT`. Restored the fix; all 4 tests in the file pass.
- [x] Full auth-adjacent suite (`tests/hermes_cli/test_auth*.py`, `test_global_auth_store_memo.py`, `test_xai_oauth_profile_auth.py`, `test_model_flow_pooled_credentials.py`, `test_nous_auth_status_cache.py`, `test_hermes_constants.py` — 239 tests) passes unchanged, 6 pre-existing platform-gated skips.

---

## Update (second commit): same anti-pattern, second cache, same file

While implementing the above, found a **second** cache in this same file with the identical mtime-vs-content-digest anti-pattern: `_heal_forked_single_use_oauth_grants()`'s hot-path short-circuit (`_oauth_heal_clean_marks`, added by `#100929`, merged just before this branch was rebased onto current `upstream/main`). Its fingerprint keyed the "verified clean, skip the locked read-modify-write scan" mark on `(profile auth.json path, mtime_ns, singleton mtime_ns)` — same class of bug, different cache, same file.

A profile's `auth.json` is itself a credential store, so the same external-metadata-preserving-copy scenario applies: a restored/reintroduced OAuth fork would sit unhealed forever once the profile is marked "clean" (no TTL), with `load_pool()` skipping the scan believing nothing changed — silently defeating the entire purpose of this auto-heal mechanism.

**Fix:** rekeyed the fingerprint on sha256-of-content for both files (the profile's `auth.json` and the optional `.anthropic_oauth.json` singleton), mirroring this PR's first fix exactly.

**Tests:** added `test_clean_mark_is_not_fooled_by_a_metadata_preserving_replace` to `tests/agent/test_credential_pool_profile_oauth_fork.py`: heals an existing fork, lets the second call record the clean mark, then replaces the profile's `auth.json` with a freshly forked copy while restoring the exact mtime the mark observed, and asserts the fork is detected and healed rather than served as "clean" forever.

**Mutation-verified**: reverting the fingerprint back to mtime makes the new test fail — `heal_forked_single_use_oauth_grants()` returns `None` (fork left unhealed) instead of a summary dict.

Ran the full `tests/agent/test_credential_pool_profile_oauth_fork.py` suite (16 tests, all pass) plus `test_global_auth_store_memo.py` and `tests/hermes_cli/test_auth*.py` (186 passed, 2 skipped, 1 pre-existing failure — `test_seed_from_singletons_respects_hermes_pkce_suppression` — confirmed independent of this change via `git stash`, fails identically with both commits' changes reverted).

**Competitor check:** searched `gh pr list --state all` for "oauth_heal_clean_marks mtime", "heal_forked_single_use_oauth_grants", "OAuth heal content digest", "forked oauth grant profile cache" — only hit is `#100929` (merged, the PR that introduced this cache in the first place; not a competitor for a fix to its freshness bug). No open or closed PR covers this gap.
