### PR TITLE
fix(update): retarget dangling editable finder after interrupted install

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -150,7 +150,18 @@ def _should_skip_external_secret_sources() -> bool:
 
 
 def _project_root() -> Path:
-    return Path(__file__).resolve().parent.parent
+    here = Path(__file__).resolve().parent.parent
+    if (here / "pyproject.toml").is_file():
+        return here
+    try:
+        import hermes_editable_heal as _heal
+
+        resolved = _heal.resolve_project_root(hint=here)
+        if resolved:
+            return Path(resolved)
+    except Exception:
+        pass
+    return here
 
 
 def _pid_is_running(pid: int) -> bool:
@@ -478,6 +489,18 @@ def recover_if_needed(
         if core_marker.exists():
             if _marker_owner_is_live(core_marker):
                 return
+            # Cheap first: retarget a dangling editable finder before (or
+            # instead of) another dependency reinstall. The console script
+            # dies on ModuleNotFoundError when MAPPING points at deleted
+            # site-packages copies; if we got this far, cwd or a partial
+            # mapping let hermes_cli import — heal so the next launcher
+            # start works (#97819).
+            try:
+                import hermes_editable_heal as _heal
+
+                _heal.heal(project_root=root)
+            except Exception:
+                pass
             completed = _complete_pending_core_install(root, core_marker)
             if completed and "update" in args:
                 _UPDATE_RETRY_RECOVERED = True
@@ -617,6 +640,20 @@ def _complete_pending_core_install(root: Path, core_marker: Path) -> bool:
             attempts = 0
 
         if attempts >= _EARLY_CORE_INSTALL_MAX_ATTEMPTS:
+            # Retry cap is for the *installer*. A dangling finder is a
+            # local file rewrite and must still run after the cap — that
+            # is the failure the reporter hit (#97819).
+            try:
+                import hermes_editable_heal as _heal
+
+                if _heal.heal(project_root=root):
+                    print(
+                        "  ✓ Regenerated editable finder mapping against the "
+                        "source checkout (interrupted-update recovery).",
+                        file=sys.stderr,
+                    )
+            except Exception:
+                pass
             print(
                 "⚠ Pending interrupted-update install has already failed "
                 f"{attempts} times in the early pass — leaving it for the "

--- a/hermes_cli/_install_repair.py
+++ b/hermes_cli/_install_repair.py
@@ -594,6 +594,16 @@ def _load_installable_optional_extras(root: Path, group: str) -> list[str]:
     return referenced
 
 
+def _heal_editable_finder_after_install(root: Path) -> None:
+    """Recompute the editable finder so it never points at site-packages."""
+    try:
+        import hermes_editable_heal as _heal
+
+        _heal.heal(project_root=root)
+    except Exception:
+        pass
+
+
 def run_core_install(root: Path) -> None:
     """Full core ``.[all]`` editable reinstall — the recovery install.
 
@@ -630,6 +640,7 @@ def run_core_install(root: Path) -> None:
             _run_install_cmd(
                 prefix + ["install", "-e", f".[{group}]"], env=env, root=root
             )
+            _heal_editable_finder_after_install(root)
             return
         except subprocess.CalledProcessError:
             print(
@@ -659,6 +670,7 @@ def run_core_install(root: Path) -> None:
                 "  ⚠ Skipped optional extras that still failed: "
                 + ", ".join(failed_extras)
             )
+        _heal_editable_finder_after_install(root)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/_startup_fast.py
+++ b/hermes_cli/_startup_fast.py
@@ -46,7 +46,20 @@ __all__ = [
 
 def project_root_str() -> str:
     """Repo root as a str — the single source for main.py's PROJECT_ROOT."""
-    return os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir))
+    here = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir))
+    if os.path.isfile(os.path.join(here, "pyproject.toml")):
+        return here
+    # Stale editable mapping can import hermes_cli from site-packages. Prefer
+    # the checkout recorded on the editable dist-info (#97819).
+    try:
+        import hermes_editable_heal as _heal
+
+        resolved = _heal.resolve_project_root(hint=here)
+        if resolved:
+            return resolved
+    except Exception:
+        pass
+    return here
 
 
 def ensure_project_root_on_path() -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9150,6 +9150,13 @@ def _recover_core_update_marker_locked() -> None:
         "finishing dependency installation now..."
     )
 
+    try:
+        import hermes_editable_heal as _heal
+
+        _heal.heal(project_root=PROJECT_ROOT)
+    except Exception:
+        pass
+
     # Windows: a normal ``hermes.exe`` launch always has the launcher as an
     # ancestor. Full editable reinstall uses quarantine so the live shim can
     # still be replaced. Package-only import repair may help as first aid but
@@ -10132,9 +10139,18 @@ def _install_python_dependencies_with_optional_fallback(
             strict_quarantine=True,
         )
 
+    def _heal_editable_finder() -> None:
+        try:
+            import hermes_editable_heal as _heal
+
+            _heal.heal(project_root=PROJECT_ROOT)
+        except Exception:
+            pass
+
     try:
         _install(["install", "-e", f".[{group}]"])
         _verify_console_scripts_installed(install_cmd_prefix, env=env)
+        _heal_editable_finder()
         return
     except subprocess.CalledProcessError:
         print(
@@ -10173,6 +10189,7 @@ def _install_python_dependencies_with_optional_fallback(
     # downstream.
     _verify_core_dependencies_installed(install_cmd_prefix, env=env, group=group)
     _verify_console_scripts_installed(install_cmd_prefix, env=env)
+    _heal_editable_finder()
 
 
 def _load_console_script_names() -> list[str]:

--- a/hermes_editable_heal.py
+++ b/hermes_editable_heal.py
@@ -1,0 +1,390 @@
+"""Heal a dangling setuptools editable finder after an interrupted update.
+
+Stdlib-only. Safe to import on a half-broken venv.
+
+An interrupted ``hermes update`` can uninstall physical copies of first-party
+packages from site-packages while leaving ``__editable___*_finder.py`` mapping
+those names at the now-deleted paths. The ``hermes`` console script then dies
+with ``ModuleNotFoundError: No module named 'hermes_cli'`` before
+``hermes_cli._early_recovery`` can run (#97819).
+
+This module:
+
+- Retargets ``MAPPING`` / ``NAMESPACES`` at the git checkout recorded in
+  ``hermes_agent-*.dist-info/direct_url.json`` (or an explicit project root).
+- Never accepts a first-party mapping that lives *inside* site-packages.
+- Drops a physical ``__hermes_editable_heal.pth`` sidecar next to the
+  generated finder so the next interpreter start heals *before* the
+  console script imports ``hermes_cli.main``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+FINDER_GLOB = "__editable___hermes_agent_*_finder.py"
+DIST_INFO_GLOB = "hermes_agent-*.dist-info"
+HOOK_MODULE = "__hermes_editable_heal.py"
+HOOK_PTH = "__hermes_editable_heal.pth"
+CANONICAL_MODULE = "hermes_editable_heal.py"
+# Thin sidecar: never a copy of this file. Loaded by the .pth before the
+# console script imports hermes_cli. Loads the canonical module by path so a
+# dangling finder cannot hide it, then calls heal() once.
+_THIN_HOOK = """\
+from pathlib import Path
+import importlib.util
+
+def _run() -> None:
+    src = Path(__file__).resolve().parent / "hermes_editable_heal.py"
+    if not src.is_file():
+        return
+    spec = importlib.util.spec_from_file_location(
+        "_hermes_editable_heal_impl", src
+    )
+    if spec is None or spec.loader is None:
+        return
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.heal()
+
+try:
+    _run()
+except Exception:
+    pass
+"""
+_PTH_LINE = "import __hermes_editable_heal\n"
+
+_ASSIGN_RE = re.compile(
+    r"^(?P<name>MAPPING|NAMESPACES)(?P<ann>:[^=]+)? = (?P<value>.+)$",
+    re.MULTILINE,
+)
+
+
+def _unique_existing(paths: list[Path]) -> list[Path]:
+    seen: set[str] = set()
+    out: list[Path] = []
+    for path in paths:
+        try:
+            key = str(path.resolve())
+        except OSError:
+            key = str(path)
+        if key in seen or not path.is_dir():
+            continue
+        seen.add(key)
+        out.append(path)
+    return out
+
+
+def site_packages_dirs(
+    project_root: Path | None = None,
+    *,
+    extra: Path | None = None,
+) -> list[Path]:
+    """Likely site-packages dirs for this install.
+
+    When *project_root* is set, only that project's ``venv`` / ``.venv``
+    (plus *extra*) are scanned — never the running interpreter's prefix.
+    A test or recovery call must not rewrite some other checkout's finder.
+    When neither is set (startup ``.pth`` hook), scan ``sys.prefix`` only.
+    """
+    found: list[Path] = []
+    if extra is not None:
+        found.append(Path(extra))
+    if project_root is not None:
+        root = Path(project_root)
+        for name in ("venv", ".venv"):
+            venv = root / name
+            found.extend(venv.glob("lib/python*/site-packages"))
+            found.append(venv / "Lib" / "site-packages")
+        return _unique_existing(found)
+    if extra is None:
+        prefix = Path(sys.prefix)
+        found.extend(prefix.glob("lib/python*/site-packages"))
+        found.append(prefix / "Lib" / "site-packages")
+    return _unique_existing(found)
+
+
+def _file_url_to_path(url: str) -> Path | None:
+    if not url.startswith("file:"):
+        return None
+    rest = url[5:]
+    if rest.startswith("///"):
+        rest = rest[2:]  # file:///X -> /X  (POSIX) or /C:/... (Windows)
+    elif rest.startswith("//"):
+        rest = rest[1:]
+    if rest.startswith("/") and len(rest) >= 3 and rest[2] == ":":
+        rest = rest[1:]  # /C:/Users/... -> C:/Users/...
+    try:
+        from urllib.parse import unquote
+
+        rest = unquote(rest)
+    except Exception:
+        pass
+    path = Path(rest)
+    return path if path.exists() else path
+
+
+def read_editable_project_root(site_packages: Path) -> Path | None:
+    """Repo root from the editable install's ``direct_url.json``, if present."""
+    for info in site_packages.glob(f"{DIST_INFO_GLOB}/direct_url.json"):
+        try:
+            data = json.loads(info.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        dir_info = data.get("dir_info") or {}
+        if isinstance(dir_info, dict) and dir_info.get("editable") is False:
+            continue
+        path = _file_url_to_path(str(data.get("url") or ""))
+        if path is None:
+            continue
+        if (path / "pyproject.toml").is_file():
+            return path.resolve()
+    return None
+
+
+def resolve_project_root(
+    hint: str | Path | None = None,
+    *,
+    site_packages: Path | None = None,
+) -> str | None:
+    """Best checkout root when ``hermes_cli`` was imported from site-packages."""
+    if hint is not None:
+        hinted = Path(hint)
+        if (hinted / "pyproject.toml").is_file():
+            return str(hinted.resolve())
+        from_hint = read_editable_project_root(hinted)
+        if from_hint is not None:
+            return str(from_hint)
+    dirs = [site_packages] if site_packages is not None else site_packages_dirs()
+    for sp in dirs:
+        if sp is None:
+            continue
+        root = read_editable_project_root(Path(sp))
+        if root is not None:
+            return str(root)
+    return None
+
+
+def _is_under(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _repo_target(repo_root: Path, name: str) -> Path | None:
+    pkg = repo_root / name
+    if pkg.is_dir():
+        return pkg
+    module = repo_root / f"{name}.py"
+    if module.is_file():
+        return repo_root / name
+    return None
+
+
+def _target_is_stale(target: Path, site_packages: Path) -> bool:
+    if not target.exists():
+        return True
+    return _is_under(target, site_packages)
+
+
+def retarget_mapping(
+    mapping: dict,
+    repo_root: Path,
+    site_packages: Path,
+) -> tuple[dict, bool]:
+    """Rewrite finder MAPPING values that are missing or inside site-packages."""
+    changed = False
+    out: dict = {}
+    for name, raw in mapping.items():
+        dest = Path(str(raw))
+        replacement = _repo_target(repo_root, str(name))
+        if replacement is not None and _target_is_stale(dest, site_packages):
+            out[name] = str(replacement)
+            changed = True
+        else:
+            out[name] = raw
+    return out, changed
+
+
+def retarget_namespaces(
+    namespaces: dict,
+    repo_root: Path,
+    site_packages: Path,
+) -> tuple[dict, bool]:
+    changed = False
+    out: dict = {}
+    for name, raw_paths in namespaces.items():
+        paths = list(raw_paths) if isinstance(raw_paths, (list, tuple)) else [raw_paths]
+        new_paths: list[str] = []
+        for raw in paths:
+            dest = Path(str(raw))
+            if not _target_is_stale(dest, site_packages):
+                new_paths.append(str(raw))
+                continue
+            # tools.wakewords -> repo_root / tools / wakewords
+            rel = Path(*str(name).split("."))
+            candidate = repo_root / rel
+            if candidate.exists():
+                new_paths.append(str(candidate))
+                changed = True
+            else:
+                new_paths.append(str(raw))
+        out[name] = new_paths
+    return out, changed
+
+
+def _replace_assignment(source: str, name: str, value: object) -> str:
+    def _sub(match: re.Match[str]) -> str:
+        if match.group("name") != name:
+            return match.group(0)
+        ann = match.group("ann") or ""
+        return f"{name}{ann} = {repr(value)}"
+
+    new, count = _ASSIGN_RE.subn(_sub, source)
+    if count == 0:
+        raise ValueError(f"could not find {name} assignment in finder")
+    return new
+
+
+def rewrite_finder_file(
+    finder_path: Path,
+    *,
+    mapping: dict | None = None,
+    namespaces: dict | None = None,
+) -> None:
+    text = finder_path.read_text(encoding="utf-8")
+    if mapping is not None:
+        text = _replace_assignment(text, "MAPPING", mapping)
+    if namespaces is not None:
+        text = _replace_assignment(text, "NAMESPACES", namespaces)
+    finder_path.write_text(text, encoding="utf-8")
+
+
+def _apply_to_loaded_finder(mapping: dict, namespaces: dict | None) -> None:
+    for mod in list(sys.modules.values()):
+        mapping_obj = getattr(mod, "MAPPING", None)
+        if not isinstance(mapping_obj, dict):
+            continue
+        name = getattr(mod, "__name__", "")
+        file = getattr(mod, "__file__", "") or ""
+        if "editable" not in name and "editable" not in file.replace("\\", "/"):
+            continue
+        mapping_obj.clear()
+        mapping_obj.update(mapping)
+        if namespaces is not None:
+            ns = getattr(mod, "NAMESPACES", None)
+            if isinstance(ns, dict):
+                ns.clear()
+                ns.update(namespaces)
+
+
+def heal_finder(
+    finder_path: Path,
+    repo_root: Path,
+    site_packages: Path,
+) -> bool:
+    """Rewrite one finder file. Returns True when the on-disk mapping changed."""
+    ns: dict = {}
+    mapping: dict = {}
+    try:
+        source = finder_path.read_text(encoding="utf-8")
+        # Exec just the two assignments in an isolated dict — the file is
+        # generated by setuptools and is data, not a trust boundary we invent.
+        isolated: dict = {}
+        code = "\n".join(
+            f"{m.group('name')} = {m.group('value')}" for m in _ASSIGN_RE.finditer(source)
+        )
+        exec(code, {}, isolated)  # noqa: S102 — parser for generated finder
+        mapping = isolated.get("MAPPING") or {}
+        ns = isolated.get("NAMESPACES") or {}
+    except Exception:
+        return False
+    if not isinstance(mapping, dict):
+        return False
+
+    new_mapping, map_changed = retarget_mapping(mapping, repo_root, site_packages)
+    new_ns, ns_changed = retarget_namespaces(
+        ns if isinstance(ns, dict) else {}, repo_root, site_packages
+    )
+    if not map_changed and not ns_changed:
+        _apply_to_loaded_finder(new_mapping, new_ns if isinstance(ns, dict) else None)
+        return False
+    try:
+        rewrite_finder_file(
+            finder_path,
+            mapping=new_mapping,
+            namespaces=new_ns if ns_changed or map_changed else None,
+        )
+    except (OSError, ValueError):
+        return False
+    _apply_to_loaded_finder(new_mapping, new_ns)
+    return True
+
+
+def _write_if_changed(path: Path, text: str) -> None:
+    try:
+        if path.is_file() and path.read_text(encoding="utf-8") == text:
+            return
+    except OSError:
+        pass
+    path.write_text(text, encoding="utf-8")
+
+
+def _canonical_source() -> str:
+    """Source of hermes_editable_heal.py — never the thin sidecar."""
+    here = Path(__file__).resolve()
+    if here.name == HOOK_MODULE:
+        sibling = here.parent / CANONICAL_MODULE
+        return sibling.read_text(encoding="utf-8")
+    return here.read_text(encoding="utf-8")
+
+
+def install_startup_hook(site_packages: Path) -> None:
+    """Write an idempotent .pth hook that heals before console-script import.
+
+    The sidecar is a fixed thin loader. It must not be a growing copy of this
+    module: ``heal()`` runs on every interpreter start and would otherwise
+    append another ``try: heal()`` footer each launch.
+    """
+    _write_if_changed(site_packages / CANONICAL_MODULE, _canonical_source())
+    _write_if_changed(site_packages / HOOK_MODULE, _THIN_HOOK)
+    _write_if_changed(site_packages / HOOK_PTH, _PTH_LINE)
+
+
+def heal(
+    project_root: Path | str | None = None,
+    site_packages: Path | str | None = None,
+) -> bool:
+    """Heal every hermes-agent editable finder we can see. Never raises."""
+    try:
+        extra = Path(site_packages) if site_packages is not None else None
+        if extra is None:
+            here = Path(__file__).resolve().parent
+            if any(here.glob(FINDER_GLOB)):
+                extra = here
+        root = Path(project_root) if project_root is not None else None
+        if root is not None and not (root / "pyproject.toml").is_file():
+            root = None
+        dirs = site_packages_dirs(root, extra=extra)
+        healed = False
+        for sp in dirs:
+            repo = root or read_editable_project_root(sp)
+            if repo is None:
+                continue
+            for finder in sp.glob(FINDER_GLOB):
+                if heal_finder(finder, repo, sp):
+                    healed = True
+            try:
+                install_startup_hook(sp)
+            except OSError:
+                pass
+        return healed
+    except Exception:
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -448,6 +448,7 @@ py-modules = [
   "toolset_distributions",
   "cli",
   "hermes_bootstrap",
+  "hermes_editable_heal",
   "hermes_constants",
   "hermes_state",
   "hermes_state_common",

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -111,7 +111,10 @@ def test_early_recovery_module_is_stdlib_only(tmp_path):
             import builtins
             import sys
 
-            STDLIB = set(sys.stdlib_module_names) | {"hermes_cli"}
+            STDLIB = set(sys.stdlib_module_names) | {
+                "hermes_cli",
+                "hermes_editable_heal",
+            }
             real_import = builtins.__import__
 
             def guard(name, *args, **kwargs):

--- a/tests/hermes_cli/test_editable_finder_heal.py
+++ b/tests/hermes_cli/test_editable_finder_heal.py
@@ -1,0 +1,222 @@
+"""Heal dangling setuptools editable finder mappings (#97819)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import hermes_editable_heal as heal
+from hermes_cli import _early_recovery as er
+
+
+def _write_finder(site: Path, mapping: dict, namespaces: dict | None = None) -> Path:
+    site.mkdir(parents=True, exist_ok=True)
+    path = site / "__editable___hermes_agent_0_20_6_finder.py"
+    ns = namespaces if namespaces is not None else {}
+    path.write_text(
+        "from __future__ import annotations\n"
+        f"MAPPING: dict[str, str] = {mapping!r}\n"
+        f"NAMESPACES: dict[str, list[str]] = {ns!r}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_direct_url(site: Path, repo: Path) -> None:
+    info = site / "hermes_agent-0.20.6.dist-info"
+    info.mkdir(parents=True, exist_ok=True)
+    (info / "direct_url.json").write_text(
+        json.dumps({"url": repo.resolve().as_uri(), "dir_info": {"editable": True}}),
+        encoding="utf-8",
+    )
+
+
+def test_retarget_missing_and_site_packages_paths(tmp_path):
+    repo = tmp_path / "hermes-agent"
+    (repo / "hermes_cli").mkdir(parents=True)
+    (repo / "hermes_cli" / "__init__.py").write_text("", encoding="utf-8")
+    (repo / "hermes_bootstrap.py").write_text("", encoding="utf-8")
+    site = tmp_path / "venv" / "lib" / "python3.11" / "site-packages"
+    deleted = site / "hermes_cli"
+    mapping = {
+        "hermes_cli": str(deleted),
+        "hermes_bootstrap": str(site / "hermes_bootstrap"),
+    }
+    new, changed = heal.retarget_mapping(mapping, repo, site)
+    assert changed
+    assert new["hermes_cli"] == str(repo / "hermes_cli")
+    assert new["hermes_bootstrap"] == str(repo / "hermes_bootstrap")
+
+
+def test_heal_finder_rewrites_file_and_installs_hook(tmp_path):
+    repo = tmp_path / "hermes-agent"
+    (repo / "hermes_cli").mkdir(parents=True)
+    (repo / "hermes_cli" / "__init__.py").write_text("", encoding="utf-8")
+    (repo / "pyproject.toml").write_text("[project]\nname='hermes-agent'\n", encoding="utf-8")
+    site = tmp_path / "venv" / "lib" / "python3.11" / "site-packages"
+    finder = _write_finder(
+        site,
+        {"hermes_cli": str(site / "hermes_cli")},
+        {"hermes_cli.data": [str(site / "hermes_cli" / "data")]},
+    )
+    (repo / "hermes_cli" / "data").mkdir()
+    _write_direct_url(site, repo)
+
+    assert heal.heal(project_root=repo, site_packages=site)
+
+    text = finder.read_text(encoding="utf-8")
+    assert str(repo / "hermes_cli") in text
+    assert str(site / "hermes_cli") not in text
+    assert (site / heal.HOOK_PTH).is_file()
+    assert (site / heal.HOOK_MODULE).is_file()
+    assert (site / heal.HOOK_PTH).read_text(encoding="utf-8") == heal._PTH_LINE
+    hook = (site / heal.HOOK_MODULE).read_text(encoding="utf-8")
+    assert hook == heal._THIN_HOOK
+    assert "try:\n    heal()" not in hook
+
+
+def test_resolve_project_root_from_direct_url(tmp_path):
+    repo = tmp_path / "src"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    site = tmp_path / "site-packages"
+    _write_direct_url(site, repo)
+    assert heal.resolve_project_root(hint=site, site_packages=site) == str(
+        repo.resolve()
+    )
+
+
+def test_project_root_hint_that_is_site_packages_uses_direct_url(tmp_path):
+    from hermes_cli import _startup_fast
+
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    site = tmp_path / "site-packages"
+    site.mkdir()
+    _write_direct_url(site, repo)
+    assert heal.resolve_project_root(hint=site) == str(repo.resolve())
+    # In-tree hermes_cli still resolves to this checkout.
+    assert (Path(_startup_fast.project_root_str()) / "pyproject.toml").is_file()
+
+
+def test_exhausted_early_recovery_still_heals_finder(tmp_path, monkeypatch):
+    repo = tmp_path / "hermes-agent"
+    (repo / "hermes_cli").mkdir(parents=True)
+    (repo / "hermes_cli" / "__init__.py").write_text("", encoding="utf-8")
+    (repo / "pyproject.toml").write_text("[project]\nname='hermes-agent'\n", encoding="utf-8")
+    venv_site = repo / "venv" / "lib" / "python3.11" / "site-packages"
+    finder = _write_finder(venv_site, {"hermes_cli": str(venv_site / "hermes_cli")})
+    _write_direct_url(venv_site, repo)
+    marker = repo / ".update-incomplete"
+    marker.write_text(
+        json.dumps({"attempts": er._EARLY_CORE_INSTALL_MAX_ATTEMPTS}),
+        encoding="utf-8",
+    )
+
+    from hermes_cli import _install_repair as ir
+
+    monkeypatch.setattr(
+        ir,
+        "run_core_install",
+        lambda _r: (_ for _ in ()).throw(
+            AssertionError("install must NOT run past the attempts ceiling")
+        ),
+    )
+
+    er.recover_if_needed(project_root=repo, argv=[])
+
+    text = finder.read_text(encoding="utf-8")
+    assert str(repo / "hermes_cli") in text
+    assert marker.exists()
+
+
+def test_startup_hook_is_idempotent_across_repeated_heal(tmp_path):
+    repo = tmp_path / "hermes-agent"
+    (repo / "hermes_cli").mkdir(parents=True)
+    (repo / "hermes_cli" / "__init__.py").write_text("", encoding="utf-8")
+    (repo / "pyproject.toml").write_text("[project]\nname='hermes-agent'\n", encoding="utf-8")
+    site = repo / "venv" / "lib" / "python3.11" / "site-packages"
+    _write_finder(site, {"hermes_cli": str(site / "hermes_cli")})
+    _write_direct_url(site, repo)
+
+    assert heal.heal(project_root=repo, site_packages=site)
+    hook_path = site / heal.HOOK_MODULE
+    first = hook_path.read_text(encoding="utf-8")
+    assert first == heal._THIN_HOOK
+
+    # Same as the sidecar running heal() again on the next interpreter start.
+    for _ in range(5):
+        heal.heal(project_root=repo, site_packages=site)
+    assert hook_path.read_text(encoding="utf-8") == first
+    assert (site / "hermes_editable_heal.py").read_text(
+        encoding="utf-8"
+    ) == Path(heal.__file__).read_text(encoding="utf-8")
+
+
+def test_pth_hook_heals_before_console_script_import(tmp_path):
+    """The dead-launcher path: import hermes_cli with only site-packages on path."""
+    import os
+    import subprocess
+    import sys
+
+    repo = tmp_path / "hermes-agent"
+    pkg = repo / "hermes_cli"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("marker = 'from-repo'\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text("[project]\nname='hermes-agent'\n", encoding="utf-8")
+    site = tmp_path / "site-packages"
+    finder = _write_finder(site, {"hermes_cli": str(site / "hermes_cli")})
+    finder.write_text(
+        finder.read_text(encoding="utf-8")
+        + "\nimport sys\n"
+        + "class _F:\n"
+        + "    @classmethod\n"
+        + "    def find_spec(cls, fullname, path=None, target=None):\n"
+        + "        if fullname not in MAPPING:\n"
+        + "            return None\n"
+        + "        from importlib.util import spec_from_file_location\n"
+        + "        from pathlib import Path\n"
+        + "        loc = Path(MAPPING[fullname])\n"
+        + "        init = loc / '__init__.py'\n"
+        + "        if init.is_file():\n"
+        + "            return spec_from_file_location(fullname, init)\n"
+        + "        return None\n"
+        + "def install():\n"
+        + "    if not any(f is _F for f in sys.meta_path):\n"
+        + "        sys.meta_path.append(_F)\n",
+        encoding="utf-8",
+    )
+    (site / "__editable__.hermes_agent-0.20.6.pth").write_text(
+        "import __editable___hermes_agent_0_20_6_finder; "
+        "__editable___hermes_agent_0_20_6_finder.install()\n",
+        encoding="utf-8",
+    )
+    _write_direct_url(site, repo)
+    heal.install_startup_hook(site)
+    assert str(site / "hermes_cli") in finder.read_text(encoding="utf-8")
+
+    cwd = tmp_path / "not-the-repo"
+    cwd.mkdir()
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "import site\n"
+        f"site.addsitedir({str(site)!r})\n"
+        "import hermes_cli\n"
+        "print(hermes_cli.marker)\n"
+        "print(hermes_cli.__file__)\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PYTHONNOUSERSITE": "1"}
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, str(probe)],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "from-repo" in result.stdout
+    assert "hermes-agent" in result.stdout.replace("\\", "/")


### PR DESCRIPTION
## What does this PR do?

An interrupted `hermes update` can uninstall physical copies of first-party packages from site-packages while leaving the setuptools editable finder mapping those names at the deleted paths. The `hermes` console script then dies with `ModuleNotFoundError: No module named 'hermes_cli'` before launch-time recovery can run. `update --check` can also treat site-packages as the project root and report "Not a git repository".

This adds a stdlib healer that retargets `MAPPING` / `NAMESPACES` at the checkout recorded in `hermes_agent-*.dist-info/direct_url.json`. It refuses any first-party mapping that lives inside site-packages. After every editable reinstall (update and interrupted-install recovery, including after the early-pass retry cap), the healer rewrites the finder and installs a thin `__hermes_editable_heal.pth` hook so the next interpreter start repairs the mapping *before* `from hermes_cli.main import main`. The hook is a fixed-size loader (it does not grow on each launch). `hermes --version` / `update --check` resolve `PROJECT_ROOT` from that checkout when `hermes_cli` was imported from site-packages.

## Related Issue

Fixes #97819

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_editable_heal.py` — stdlib healer; idempotent `.pth` sidecar
- `pyproject.toml` — register `hermes_editable_heal` as a top-level py-module
- `hermes_cli/_install_repair.py` / `hermes_cli/main.py` — heal after editable `.[all]` / fallback installs
- `hermes_cli/_early_recovery.py` — heal on `.update-incomplete` (including exhausted retries); resolve project root via `direct_url.json`
- `hermes_cli/_startup_fast.py` — `project_root_str()` prefers the checkout over site-packages
- `tests/hermes_cli/test_editable_finder_heal.py` — retarget, hook idempotence, pre-import heal, exhausted-recovery heal

## How to Test

1. Create an isolated venv and `uv pip install -e <checkout> --no-deps`. Confirm `venv/bin/hermes --version` works from a directory that is not the checkout.
2. Rewrite `__editable___hermes_agent_*_finder.py` so `hermes_cli` maps to `<venv>/…/site-packages/hermes_cli`, delete that directory, and remove `__hermes_editable_heal.pth` if present. From `/tmp`, run `venv/bin/hermes --version` — expect `ModuleNotFoundError: No module named 'hermes_cli'`.
3. Install the healer hook into that site-packages (or run `heal()` / complete an editable reinstall). Leave the dangling mapping on disk. The same `hermes --version` from `/tmp` should succeed and print `Install directory:` as the git checkout. A second launch must not grow `__hermes_editable_heal.py`.
4. `python -m pytest tests/hermes_cli/test_editable_finder_heal.py tests/hermes_cli/test_early_recovery.py tests/hermes_cli/test_startup_fast_guards.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.5), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```

```
