### PR TITLE
fix(desktop): allow drive_preview on visible session tiles

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -64,7 +64,12 @@ describe('handleDesktopBridgeEvent preview.act visibility', () => {
     handleDesktopBridgeEvent(actCtx('runtime-tile', false))
     await vi.waitFor(() => expect(request).toHaveBeenCalled())
 
-    const [, params] = request.mock.calls[0] as [string, { text: string }]
-    expect(params.text).not.toContain('only takes actions in the session the user is looking at')
+    expect(request).toHaveBeenCalledWith(
+      'preview.act.respond',
+      expect.objectContaining({
+        request_id: 'req-97848',
+        text: expect.not.stringContaining('only takes actions in the session the user is looking at')
+      })
+    )
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/app/chat/right-rail/preview-act', () => ({
+  actOnActivePreview: vi.fn(async () => ({ success: true, typed: 'hello' }))
+}))
+
+import { $gateway } from '@/store/gateway'
+import { $activeSessionId } from '@/store/session'
+import { $sessionTiles, clearAllSessionStates } from '@/store/session-states'
+
+import { handleDesktopBridgeEvent } from './desktop-bridge'
+import type { GatewayEventContext } from './types'
+
+function actCtx(sessionId: string, isActiveEvent: boolean): GatewayEventContext {
+  return {
+    deps: {} as GatewayEventContext['deps'],
+    event: { session_id: sessionId, type: 'preview.act.request' },
+    explicitSid: sessionId,
+    fromActiveSource: () => true,
+    isActiveEvent,
+    occurredAt: Date.now() / 1000,
+    payload: { action: 'type', ref: 'inp-prompt', request_id: 'req-97848', text: 'hello' },
+    scheduleConfigRefresh: () => undefined,
+    sessionId
+  }
+}
+
+describe('handleDesktopBridgeEvent preview.act visibility', () => {
+  const request = vi.fn(async () => ({}))
+
+  beforeEach(() => {
+    clearAllSessionStates()
+    $activeSessionId.set(null)
+    $sessionTiles.set([])
+    request.mockClear()
+    $gateway.set({ request } as never)
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $activeSessionId.set(null)
+    $sessionTiles.set([])
+    $gateway.set(null)
+  })
+
+  it('rejects a hidden background session', async () => {
+    $activeSessionId.set('runtime-primary')
+    handleDesktopBridgeEvent(actCtx('runtime-hidden', false))
+    await vi.waitFor(() => expect(request).toHaveBeenCalled())
+
+    expect(request).toHaveBeenCalledWith(
+      'preview.act.respond',
+      expect.objectContaining({
+        request_id: 'req-97848',
+        text: expect.stringContaining('only takes actions in the session the user is looking at')
+      })
+    )
+  })
+
+  it('allows a visible session tile that is not the primary active session', async () => {
+    $activeSessionId.set('runtime-primary')
+    $sessionTiles.set([{ runtimeId: 'runtime-tile', storedSessionId: 'stored-tile' }])
+
+    handleDesktopBridgeEvent(actCtx('runtime-tile', false))
+    await vi.waitFor(() => expect(request).toHaveBeenCalled())
+
+    const [, params] = request.mock.calls[0] as [string, { text: string }]
+    expect(params.text).not.toContain('only takes actions in the session the user is looking at')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -3,6 +3,7 @@ import { writeAgentTerminalChunk } from '@/app/right-sidebar/terminal/agent-term
 import { readActiveTerminal } from '@/app/right-sidebar/terminal/buffer'
 import { closeAgentTerminalByProc } from '@/app/right-sidebar/terminal/terminals'
 import type { PreviewActAction } from '@/lib/preview-act/act-in-page'
+import { sessionIsOnScreen } from '@/lib/preview-visibility'
 import type { TourAction, TourStep } from '@/lib/tour'
 import { $gateway } from '@/store/gateway'
 import { applyDesktopLayoutPreset, revealDesktopPane } from '@/store/pane-focus'
@@ -45,7 +46,7 @@ const loadPreviewEngine = () => {
  *  (terminal/preview/window), agent terminal streaming, pane reveal, and
  *  message reactions. */
 export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
-  const { event, payload, isActiveEvent } = ctx
+  const { event, payload, isActiveEvent, sessionId } = ctx
 
   if (event.type === 'terminal.read.request') {
     // read_terminal tool: serialize the renderer's xterm buffer and answer
@@ -89,10 +90,13 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
   if (event.type === 'preview.act.request') {
     // drive_preview tool: click/type/scroll/press inside the guest page, or
     // drive the pane's history. Dynamic import keeps the injected engine off
-    // the boot path. Active session only: a background turn must never reach
-    // into the page the user is working in (desktop AGENTS.md: offer, don't
-    // hijack).
+    // the boot path. Visible session only (focused runtime, primary, or an
+    // on-screen tile) — same predicate as preview.open/close. A hidden
+    // background turn must never reach into the page the user is working in
+    // (desktop AGENTS.md: offer, don't hijack). `isActiveEvent` is the
+    // primary-session flag and is too narrow for a focused tile.
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
+    const previewVisible = !!sessionId && sessionIsOnScreen(sessionId)
 
     if (requestId) {
       const answer = (result: unknown) =>
@@ -101,7 +105,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
           text: result ? JSON.stringify(result) : ''
         })
 
-      if (isActiveEvent) {
+      if (previewVisible) {
         void loadPreviewEngine()
           .then(run =>
             run({

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 import { gatewayEventCompletedFileDiff } from '@/lib/gateway-events'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { reachablePreviewUrl } from '@/lib/preview-reach'
+import { sessionIsOnScreen } from '@/lib/preview-visibility'
 import {
   $previewTabs,
   beginPreviewServerRestart,
@@ -13,8 +14,8 @@ import {
   progressPreviewServerRestart,
   requestPreviewReload
 } from '@/store/preview'
-import { $activeSessionId, $currentCwd } from '@/store/session'
-import { $focusedRuntimeId, $sessionTiles } from '@/store/session-states'
+import { $currentCwd } from '@/store/session'
+import { $focusedRuntimeId } from '@/store/session-states'
 import type { RpcEvent } from '@/types/hermes'
 
 type EventHandler = (event: RpcEvent) => void
@@ -27,14 +28,6 @@ interface PreviewRoutingOptions {
 
 function asRecord(payload: unknown): Record<string, unknown> {
   return payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {}
-}
-
-function sessionIsOnScreen(sessionId: string): boolean {
-  return (
-    sessionId === $focusedRuntimeId.get() ||
-    sessionId === $activeSessionId.get() ||
-    $sessionTiles.get().some(tile => tile.runtimeId === sessionId)
-  )
 }
 
 export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestGateway }: PreviewRoutingOptions) {

--- a/apps/desktop/src/lib/preview-visibility.test.ts
+++ b/apps/desktop/src/lib/preview-visibility.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $activeSessionId } from '@/store/session'
+import { $sessionTiles, clearAllSessionStates } from '@/store/session-states'
+
+import { sessionIsOnScreen } from './preview-visibility'
+
+describe('sessionIsOnScreen', () => {
+  beforeEach(() => {
+    clearAllSessionStates()
+    $activeSessionId.set(null)
+    $sessionTiles.set([])
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $activeSessionId.set(null)
+    $sessionTiles.set([])
+  })
+
+  it('is true for the primary active session', () => {
+    $activeSessionId.set('runtime-primary')
+
+    expect(sessionIsOnScreen('runtime-primary')).toBe(true)
+    expect(sessionIsOnScreen('runtime-hidden')).toBe(false)
+  })
+
+  it('is true for a visible session tile that is not the primary', () => {
+    $activeSessionId.set('runtime-primary')
+    $sessionTiles.set([{ runtimeId: 'runtime-tile', storedSessionId: 'stored-tile' }])
+
+    expect(sessionIsOnScreen('runtime-tile')).toBe(true)
+    expect(sessionIsOnScreen('runtime-primary')).toBe(true)
+    expect(sessionIsOnScreen('runtime-background')).toBe(false)
+  })
+
+  it('is false for an empty session id', () => {
+    $activeSessionId.set('runtime-primary')
+
+    expect(sessionIsOnScreen('')).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/preview-visibility.ts
+++ b/apps/desktop/src/lib/preview-visibility.ts
@@ -1,0 +1,18 @@
+import { $activeSessionId } from '@/store/session'
+import { $focusedRuntimeId, $sessionTiles } from '@/store/session-states'
+
+/** A session the user can see: focused runtime, primary active chat, or an
+ *  open session tile. Preview open/close/act share this so a focused tile
+ *  can drive the in-app browser without the primary-only `isActiveEvent`
+ *  gate rejecting the turn. Hidden background sessions stay blocked. */
+export function sessionIsOnScreen(sessionId: string): boolean {
+  if (!sessionId) {
+    return false
+  }
+
+  return (
+    sessionId === $focusedRuntimeId.get() ||
+    sessionId === $activeSessionId.get() ||
+    $sessionTiles.get().some(tile => tile.runtimeId === sessionId)
+  )
+}


### PR DESCRIPTION
## What does this PR do?

`drive_preview` was gated on `isActiveEvent` (routed session === primary `$activeSessionId`). Preview open/close already treat a session as visible when it is the focused runtime, the primary session, or an on-screen session tile. That mismatch rejected click/type in a focused tile even while the in-app browser was in front of the user, while `action="elements"` / read still succeeded.

This change extracts `sessionIsOnScreen` and uses it for preview act as well as open/close, so a visible tile can drive the page and a hidden background session still cannot.

## Related Issue

Fixes #97848

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/preview-visibility.ts` — shared `sessionIsOnScreen` (focused runtime, primary active, or tile `runtimeId`)
- `apps/desktop/src/app/session/hooks/use-preview-routing.ts` — preview open/close use the shared helper
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts` — `preview.act.request` uses `sessionIsOnScreen` instead of `isActiveEvent`
- Tests: `preview-visibility.test.ts`, `desktop-bridge.test.ts`

## How to Test

1. Open Hermes Desktop with two sessions on screen (primary chat plus a session tile), and open a page in the in-app browser from the tile session.
2. From the tile session, ask the agent to list elements and type into a visible field via `drive_preview`.
3. Confirm the action runs instead of `The in-app browser only takes actions in the session the user is looking at.`
4. From a session that is not on screen, confirm the same action is still rejected.
5. From `apps/desktop`: `npx vitest run src/lib/preview-visibility.test.ts src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```

```
