### PR TITLE
feat(whatsapp): per-channel system prompt (channel_prompt) for WhatsApp adapters

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2099,6 +2099,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if body:
                 rich_sent_store.record(chat_id, wamid, body)
 
+        # Per-channel ephemeral prompt (mirrors Telegram/Slack adapters).
+        # See https://github.com/NousResearch/hermes-agent/pull/47218
+        from gateway.platforms.base import resolve_channel_prompt
+        _channel_prompt = resolve_channel_prompt(self.config.extra, chat_id)
+
         return MessageEvent(
             text=body,
             message_type=message_type,
@@ -2110,4 +2115,5 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             reply_to_is_own_message=reply_to_is_own,
             media_urls=media_urls,
             media_types=media_types,
+            channel_prompt=_channel_prompt,
         )

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1630,12 +1630,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # with ``[owner reply] `` here so the marker survives any downstream
             # failure (e.g. handover-rule errors that bypass silent_ingest).
             # Gated by ``WHATSAPP_FORWARD_OWNER_MESSAGES`` at the bridge layer;
-            # metadata + text tagging are unconditional when the flag is present
             # so a future producer can set it without adapter changes.
             if data.get("fromOwner"):
                 metadata["whatsapp_from_owner"] = True
                 if not body.startswith(_OWNER_REPLY_PREFIX):
                     body = f"{_OWNER_REPLY_PREFIX}{body}"
+
+            # Per-channel ephemeral prompt (mirrors Telegram/Slack adapters).
+            from gateway.platforms.base import resolve_channel_prompt
+            _chat_id = data.get("chatId", "")
+            _channel_prompt = resolve_channel_prompt(self.config.extra, _chat_id)
 
             return MessageEvent(
                 text=body,
@@ -1646,6 +1650,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 media_urls=cached_urls,
                 media_types=media_types,
                 metadata=metadata,
+                channel_prompt=_channel_prompt,
                 reply_to_message_id=reply_to_message_id,
                 reply_to_text=reply_to_text,
                 reply_to_author_id=reply_to_author_id,


### PR DESCRIPTION
Add per-channel ephemeral system prompts (channel_prompt) to the WhatsApp adapters, mirroring the pattern already implemented for Discord/Feishu/Telegram/Slack.

## What
- `gateway/platforms/whatsapp_cloud.py`: resolve `channel_prompt` via `resolve_channel_prompt(config.extra, chat_id)` and pass to `MessageEvent`.
- `plugins/platforms/whatsapp/adapter.py` (Baileys): same, keyed off `chatId`.

## Why
WhatApp was the only major platform adapter without channel-prompt support. The legacy `channel_prompts` config path is explicitly supported by upstream (`gateway/run.py` applies `event.channel_prompt`).

## Related
- #47218, #22209, #29883 (earlier similar efforts — this one rebased onto current main)
- `resolve_channel_prompt` exists in `gateway/platforms/base.py`