### PR TITLE
fix(peer): keep remote DM turns alive over SSE

### DIFF
--- a/hermes_cli/subcommands/peer.py
+++ b/hermes_cli/subcommands/peer.py
@@ -11,8 +11,8 @@ bot on THIS machine a transport to message bots on THAT machine:
     hermes peer status spark run_abc123
 
 ``dm`` resolves the remote agent's canonical "Bot Chat" session (by title,
-creating it when missing), runs ONE synchronous agent turn over the peer's
-existing ``POST /api/sessions/{id}/chat`` endpoint, and prints the reply on
+creating it when missing), runs ONE agent turn over the peer's existing
+``POST /api/sessions/{id}/chat/stream`` endpoint, and prints the reply on
 stdout — the exact cross-machine twin of the local
 ``hermes -p <bot> chat --in ~ -c "Bot Chat" ...`` bot-messaging command, so
 the Bot Mode protocol composes over it unchanged.
@@ -121,6 +121,52 @@ def _request(
         raise RuntimeError("Peer returned a non-object JSON response")
     return parsed
 
+
+def _request_chat_stream(url: str, key: str, message: str) -> dict:
+    """Run one peer chat turn and project its terminal SSE event."""
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"message": message}).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "User-Agent": "hermes-peer-dm",
+        },
+    )
+    completed = None
+    event = ""
+    data_lines: list[str] = []
+
+    with urllib.request.urlopen(req, timeout=DM_TIMEOUT_S) as resp:  # noqa: S310 — user-registered peer URL
+        for raw_line in resp:
+            line = raw_line.decode("utf-8", "replace").rstrip("\r\n")
+            if line.startswith("event:"):
+                event = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[len("data:") :].lstrip())
+            elif not line:
+                if event in {"assistant.completed", "error"}:
+                    payload_text = "\n".join(data_lines)
+                    try:
+                        payload = json.loads(payload_text)
+                    except ValueError as exc:
+                        raise RuntimeError(f"Peer returned invalid {event} event: {payload_text[:200]}") from exc
+                    if not isinstance(payload, dict):
+                        raise RuntimeError(f"Peer returned a non-object {event} event")
+                    if event == "error":
+                        raise RuntimeError(str(payload.get("message") or "Peer chat failed"))
+                    completed = payload
+                event = ""
+                data_lines = []
+
+    if completed is None:
+        raise RuntimeError("Peer chat stream ended without a completed assistant response")
+    return {
+        "session_id": completed.get("session_id"),
+        "message": {"role": "assistant", "content": completed.get("content") or ""},
+    }
 
 def _base_url(peer: dict, profile: str | None) -> str:
     url = str(peer.get("url") or "").rstrip("/")
@@ -409,12 +455,14 @@ def cmd_peer(args) -> int:
 
         try:
             session_id = _ensure_bot_chat(base, key)
-            result = _request(
-                f"{base}/api/sessions/{urllib.parse.quote(session_id, safe='')}/chat",
+            # The buffered /chat route cannot send its HTTP status until the
+            # whole agent turn finishes. The streaming twin prepares headers
+            # immediately and emits keepalives, so long peer turns remain
+            # reachable through clients and network paths with idle timeouts.
+            result = _request_chat_stream(
+                f"{base}/api/sessions/{urllib.parse.quote(session_id, safe='')}/chat/stream",
                 key,
-                method="POST",
-                body={"message": message},
-                timeout=DM_TIMEOUT_S,
+                message,
             )
         except urllib.error.HTTPError as exc:
             print(f"Peer '{peer_name}' rejected the request (HTTP {exc.code}): {_http_error_detail(exc)}", file=sys.stderr)

--- a/tests/hermes_cli/test_peer_cmd.py
+++ b/tests/hermes_cli/test_peer_cmd.py
@@ -2,6 +2,7 @@
 
 import json
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from types import SimpleNamespace
 
@@ -94,6 +95,7 @@ class _FakePeer(BaseHTTPRequestHandler):
     chats: list = []
     runs: list = []
     run_idempotency_keys: list = []
+    chat_paths: list = []
     auth_seen: list = []
 
     def _json(self, payload, status=200):
@@ -142,16 +144,28 @@ class _FakePeer(BaseHTTPRequestHandler):
             # (verified live Aug 2026 — a flat fake hid a parser bug).
             return self._json({"object": "hermes.session", "session": {"id": "bc_1", "title": body.get("title")}}, 201)
 
-        if self.path.startswith("/api/sessions/") and self.path.endswith("/chat"):
+        if self.path.startswith("/api/sessions/") and self.path.endswith("/chat/stream"):
             type(self).chats.append(body.get("message"))
-            return self._json({
-                "object": "hermes.session.chat.completion",
-                "session_id": "bc_1",
-                "message": {
-                    "role": "assistant",
-                    "content": "reply from the other machine",
-                },
-            })
+            type(self).chat_paths.append(self.path)
+            payload = json.dumps(
+                {"session_id": "bc_1", "content": "reply from the other machine"}
+            )
+            keepalive = b": keepalive\n\n"
+            events = f"event: assistant.completed\ndata: {payload}\n\nevent: done\ndata: {{}}\n\n".encode()
+            wire = keepalive + events
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(wire)))
+            self.end_headers()
+            self.wfile.write(keepalive)
+            self.wfile.flush()
+            time.sleep(0.05)
+            self.wfile.write(events)
+            self.wfile.flush()
+            return
+
+        if self.path.startswith("/api/sessions/") and self.path.endswith("/chat"):
+            return self._json({"error": {"message": "buffered chat route must not be used"}}, 500)
 
         if self.path == "/v1/runs":
             type(self).runs.append(body)
@@ -178,6 +192,7 @@ def fake_peer_server():
     _FakePeer.chats = []
     _FakePeer.runs = []
     _FakePeer.run_idempotency_keys = []
+    _FakePeer.chat_paths = []
     _FakePeer.auth_seen = []
     server = HTTPServer(("127.0.0.1", 0), _FakePeer)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -208,6 +223,7 @@ def test_dm_creates_bot_chat_then_chats(monkeypatch, capsys, fake_peer_server):
     # One Bot Chat was created (none existed), then the chat turn ran on it.
     assert _FakePeer.sessions == ["bc_1"]
     assert _FakePeer.chats == ["Message from 🤖 dixie (@dixie): disk status?"]
+    assert _FakePeer.chat_paths == ["/api/sessions/bc_1/chat/stream"]
     # Every request carried the peer key.
     assert all(a == "Bearer secret-key-123456" for a in _FakePeer.auth_seen)
 


### PR DESCRIPTION
## Summary

- Route `hermes peer dm` agent turns through the existing `/api/sessions/{id}/chat/stream` endpoint.
- Parse the terminal `assistant.completed` SSE event into the existing CLI result shape.
- Preserve the existing peer authentication, Bot Chat lookup/creation, JSON output, and error handling.
- Add a loopback regression test that emits an SSE keepalive and completion event and rejects the buffered `/chat` route.

Fixes #97769

## Why

The buffered `/chat` endpoint does not send its HTTP response until the full agent turn finishes. The SSE endpoint prepares headers before the turn and emits keepalives, avoiding idle/status-line timeouts observed when `hermes peer dm` talks to a Windows gateway.

## Tests

- `PYTHONPATH=. uv run --no-project --with pytest pytest --confcutdir=tests/hermes_cli tests/hermes_cli/test_peer_cmd.py -q`
  - 14 passed
- `uv run --no-project --with ruff ruff check hermes_cli/subcommands/peer.py tests/hermes_cli/test_peer_cmd.py`
  - All checks passed
- `uv run --no-project python -m py_compile hermes_cli/subcommands/peer.py tests/hermes_cli/test_peer_cmd.py`
  - Passed
- `git diff --check`
  - Passed

The focused regression test was also run against the old buffered route and failed 4 tests, confirming the test detects the regression.