### PR TITLE
fix(qqbot): notify gateway when the listen loop gives up instead of going zombie

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -251,6 +251,7 @@ class QQAdapter(BasePlatformAdapter):
         self._http_client: Optional[httpx.AsyncClient] = None
         self._listen_task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
+        self._fatal_notify_task: Optional[asyncio.Task] = None
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
@@ -515,6 +516,49 @@ class QQAdapter(BasePlatformAdapter):
         )
         logger.info("[%s] WebSocket connected to %s", self._log_tag, gateway_url)
 
+    async def _notify_fatal_error_guarded(self) -> None:
+        """Best-effort fatal-error notification — never raises.
+
+        Runs on its own task; an escaping exception would surface only as
+        "Task exception was never retrieved" at GC time and the gateway
+        would silently never learn about the dead adapter.
+        """
+        try:
+            await self._notify_fatal_error()
+        except Exception:  # noqa: BLE001 - notification is best-effort
+            logger.debug("[%s] fatal-error notify failed", self._log_tag, exc_info=True)
+
+    def _notify_fatal_error_detached(self) -> None:
+        """Schedule gateway notification of a fatal error without awaiting it.
+
+        The gateway's fatal-error handler calls ``adapter.disconnect()``,
+        which awaits ``self._listen_task`` — awaiting this very task from
+        inside the listen loop itself would deadlock, so the notification
+        runs on its own task. A strong reference is kept so the task is not
+        garbage-collected mid-notification.
+        """
+        try:
+            self._fatal_notify_task = asyncio.create_task(
+                self._notify_fatal_error_guarded()
+            )
+        except RuntimeError:
+            # No running event loop (e.g. interpreter shutdown) — nothing to notify.
+            pass
+
+    def _give_up_and_notify(self, code: str, message: str, *, retryable: bool) -> None:
+        """Terminal listen-loop exit: set a fatal error and notify the gateway.
+
+        The gateway handler disconnects this zombie adapter and requeues the
+        platform for background reconnection (retryable) or marks it fatal
+        (non-retryable). Callers must ``return`` immediately after this.
+
+        ``_set_fatal_error`` runs before ``_mark_disconnected`` so the latter
+        sees ``has_fatal_error`` and skips its redundant status write.
+        """
+        self._set_fatal_error(code, message, retryable=retryable)
+        self._mark_disconnected()
+        self._notify_fatal_error_detached()
+
     async def _listen_loop(self) -> None:
         """Read WebSocket events and reconnect on errors.
 
@@ -565,7 +609,12 @@ class QQAdapter(BasePlatformAdapter):
                             "Check: 1) AppID/Secret correct 2) Bot permissions on QQ Open Platform",
                             self._log_tag,
                         )
-                        self._set_fatal_error(
+                        # This branch returns before the shared
+                        # _fail_pending("Connection closed") below, so fail
+                        # pending response futures here — a handler-less
+                        # (standalone) adapter would otherwise never settle them.
+                        self._fail_pending("Too many quick disconnects")
+                        self._give_up_and_notify(
                             "qq_quick_disconnect",
                             "Too many quick disconnects — check bot permissions",
                             retryable=True,
@@ -604,8 +653,15 @@ class QQAdapter(BasePlatformAdapter):
                     logger.error(
                         "[%s] Bot is %s. Check QQ Open Platform.", self._log_tag, desc
                     )
-                    self._set_fatal_error(
-                        f"qq_{desc}", f"Bot is {desc}", retryable=False
+                    # Slugify the code (desc contains spaces/slashes/hyphens
+                    # and mixed case) so runtime-status error_code stays
+                    # machine-friendly.
+                    code_slug = (
+                        desc.replace(" ", "_").replace("/", "_")
+                        .replace("-", "_").lower()
+                    )
+                    self._give_up_and_notify(
+                        f"qq_{code_slug}", f"Bot is {desc}", retryable=False
                     )
                     return
 
@@ -617,7 +673,12 @@ class QQAdapter(BasePlatformAdapter):
                         RATE_LIMIT_DELAY,
                     )
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
-                        self._mark_disconnected()
+                        logger.error("[%s] Max reconnect attempts reached (rate limited)", self._log_tag)
+                        self._give_up_and_notify(
+                            "qq_max_reconnect",
+                            f"QQBot gave up reconnecting after {MAX_RECONNECT_ATTEMPTS} attempts (rate-limited)",
+                            retryable=True,
+                        )
                         return
                     await asyncio.sleep(RATE_LIMIT_DELAY)
                     if await self._reconnect(backoff_idx):
@@ -672,7 +733,11 @@ class QQAdapter(BasePlatformAdapter):
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                         logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
-                        self._mark_disconnected()
+                        self._give_up_and_notify(
+                            "qq_max_reconnect",
+                            f"QQBot gave up reconnecting after {MAX_RECONNECT_ATTEMPTS} attempts (last close code {code})",
+                            retryable=True,
+                        )
                         return
 
             except Exception as exc:
@@ -684,7 +749,11 @@ class QQAdapter(BasePlatformAdapter):
 
                 if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                     logger.error("[%s] Max reconnect attempts reached", self._log_tag)
-                    self._mark_disconnected()
+                    self._give_up_and_notify(
+                        "qq_max_reconnect",
+                        f"QQBot gave up reconnecting after {MAX_RECONNECT_ATTEMPTS} attempts: {exc}",
+                        retryable=True,
+                    )
                     return
 
                 if await self._reconnect(backoff_idx):

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1271,3 +1271,222 @@ class TestReadEventsClosedWsGuard:
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
 
+
+class TestListenLoopFatalNotify:
+    """Regression: terminal listen-loop exits must notify the gateway.
+
+    The listen loop used to exit silently after exhausting reconnect
+    attempts (and set fatal errors without notifying on quick-disconnect /
+    fatal close codes), leaving a zombie adapter installed in the gateway
+    with is_connected=False forever — only a gateway restart could recover
+    the platform. Every terminal exit must now notify so the gateway can
+    requeue the platform for background reconnection.
+    """
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @staticmethod
+    async def _fail_reconnect(self, backoff_idx):
+        await asyncio.sleep(0)
+        return False
+
+    async def _run_listen_loop(self, adapter, exc):
+        notified = []
+
+        async def handler(a):
+            notified.append(a)
+            # The gateway's handler disconnects the adapter — this must not
+            # deadlock even though the notification fires from inside the
+            # adapter's own listen-loop task tree.
+            await a.disconnect()
+
+        adapter.set_fatal_error_handler(handler)
+        adapter._running = True  # normally set by connect()
+        adapter._listen_task = asyncio.get_running_loop().create_task(
+            adapter._listen_loop()
+        )
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        with mock.patch.object(QQAdapter, "_read_events", side_effect=exc), \
+             mock.patch.object(QQAdapter, "_reconnect", new=self._fail_reconnect):
+            await asyncio.wait_for(adapter._listen_task, timeout=15)
+        assert adapter._fatal_notify_task is not None
+        await asyncio.wait_for(adapter._fatal_notify_task, timeout=15)
+        return adapter, notified
+
+    @pytest.mark.asyncio
+    async def test_max_reconnect_notifies_gateway(self):
+        """Exhausted reconnects → retryable fatal error + gateway notified."""
+        adapter, notified = await self._run_listen_loop(
+            self._make_adapter(), RuntimeError("boom"))
+        assert adapter.fatal_error_code == "qq_max_reconnect"
+        assert adapter.fatal_error_retryable is True
+        assert notified == [adapter]
+        assert adapter.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_fatal_close_code_notifies_gateway(self):
+        """Banned (4915) → non-retryable fatal error + gateway notified."""
+        from gateway.platforms.qqbot.adapter import QQCloseError
+        adapter, notified = await self._run_listen_loop(
+            self._make_adapter(), QQCloseError(4915, "banned"))
+        assert adapter.fatal_error_retryable is False
+        assert "banned" in (adapter.fatal_error_message or "")
+        assert notified == [adapter]
+
+    @pytest.mark.asyncio
+    async def test_quick_disconnect_notifies_and_fails_pending(self):
+        """3 rapid disconnects → retryable fatal, notified, pending futures
+        failed. This branch returns before the shared
+        _fail_pending("Connection closed"), so it must settle pending
+        responses itself."""
+        from gateway.platforms.qqbot.adapter import QQAdapter, QQCloseError
+        adapter = self._make_adapter()
+        notified = []
+
+        async def handler(a):
+            notified.append(a)
+            await a.disconnect()
+
+        adapter.set_fatal_error_handler(handler)
+        adapter._running = True
+        # Inject the pending future only on the 3rd disconnect — earlier
+        # iterations fall through to the shared
+        # _fail_pending("Connection closed"), which would settle it before
+        # the terminal exit and mask a deletion of the branch-local
+        # _fail_pending. Asserting the exception message proves which call
+        # settled the future.
+        pending_fut = asyncio.get_running_loop().create_future()
+        calls = {"n": 0}
+
+        def rapid_close():
+            calls["n"] += 1
+            if calls["n"] >= 3:
+                adapter._pending_responses["req-1"] = pending_fut
+            raise QQCloseError(4009, "Session timed out")
+
+        adapter._listen_task = asyncio.get_running_loop().create_task(
+            adapter._listen_loop()
+        )
+        with mock.patch.object(QQAdapter, "_read_events", side_effect=rapid_close), \
+             mock.patch.object(QQAdapter, "_reconnect", new=self._fail_reconnect):
+            await asyncio.wait_for(adapter._listen_task, timeout=15)
+        assert adapter._fatal_notify_task is not None
+        await asyncio.wait_for(adapter._fatal_notify_task, timeout=15)
+
+        assert adapter.fatal_error_code == "qq_quick_disconnect"
+        assert adapter.fatal_error_retryable is True
+        assert notified == [adapter]
+        # The future must be settled by the branch-local _fail_pending — its
+        # message is what distinguishes it from the shared "Connection closed".
+        assert pending_fut.done()
+        assert isinstance(pending_fut.exception(), RuntimeError)
+        assert str(pending_fut.exception()) == "Too many quick disconnects"
+
+    @pytest.mark.asyncio
+    async def test_notify_handler_exception_is_swallowed(self):
+        """A raising gateway handler must not leave an unawaited task error."""
+        adapter = self._make_adapter()
+
+        async def bad_handler(a):
+            raise RuntimeError("gateway bug")
+
+        adapter.set_fatal_error_handler(bad_handler)
+        adapter._set_fatal_error("qq_test", "boom", retryable=True)
+        adapter._notify_fatal_error_detached()
+        # Completes without raising (no "Task exception was never retrieved").
+        await asyncio.wait_for(adapter._fatal_notify_task, timeout=15)
+
+
+class TestQQBotGatewayHandoffEndToEnd:
+    """End-to-end proof that a QQBot retryable fatal error travels through
+    the *real* ``GatewayRunner._handle_adapter_fatal_error`` path and lands
+    in ``runner._failed_platforms``, where the reconnect watcher picks it up.
+
+    The adapter-side tests above stop at the handler being called; this one
+    drives a minimal QQ-shaped adapter with the exact retryable-fatal shape
+    the real QQAdapter emits (both exhaustion families), installs it into a
+    real GatewayRunner, and observes the queue outcome with no mocks on the
+    notify chain. Only ``runner.stop`` is mocked so we don't need the full
+    gateway lifecycle — mirroring
+    ``tests/gateway/test_runner_fatal_adapter.py``. Adapted from #72673
+    (@cadezhou), with error codes adjusted to this PR's naming.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error_code,error_message",
+        [
+            ("qq_max_reconnect", "QQBot gave up reconnecting after 100 attempts"),
+            (
+                "qq_quick_disconnect",
+                "Too many quick disconnects — check bot permissions",
+            ),
+        ],
+    )
+    async def test_qqbot_retryable_fatal_reaches_gateway_reconnect_queue(
+        self, tmp_path, error_code, error_message
+    ):
+        from unittest.mock import AsyncMock
+
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.platforms.base import BasePlatformAdapter
+        from gateway.run import GatewayRunner
+
+        class _QQFakeAdapter(BasePlatformAdapter):
+            """Minimal QQ-shaped adapter — mirrors the retryable-fatal shape
+            emitted by both ``qq_max_reconnect`` and ``qq_quick_disconnect``
+            in the real QQAdapter.
+            """
+
+            def __init__(self):
+                super().__init__(
+                    PlatformConfig(
+                        enabled=True,
+                        extra={"app_id": "a", "client_secret": "b"},
+                    ),
+                    Platform.QQBOT,
+                )
+
+            async def connect(self, *, is_reconnect: bool = False) -> bool:
+                return True
+
+            async def disconnect(self) -> None:
+                self._mark_disconnected()
+
+            async def send(self, chat_id, content, reply_to=None, metadata=None):
+                raise NotImplementedError
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id}
+
+        config = GatewayConfig(
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=True,
+                    extra={"app_id": "a", "client_secret": "b"},
+                )
+            },
+            sessions_dir=tmp_path / "sessions",
+        )
+        runner = GatewayRunner(config)
+        adapter = _QQFakeAdapter()
+        adapter._set_fatal_error(error_code, error_message, retryable=True)
+
+        runner.adapters = {Platform.QQBOT: adapter}
+        runner.delivery_router.adapters = runner.adapters
+        # We don't need a full gateway lifecycle for this assertion — just
+        # prevent the runner from tearing itself down as a side effect.
+        runner.stop = AsyncMock()
+
+        await runner._handle_adapter_fatal_error(adapter)
+
+        # Gateway must remove the fatal adapter and queue it for background
+        # reconnection — this is exactly what silent death used to skip.
+        assert Platform.QQBOT not in runner.adapters
+        assert Platform.QQBOT in runner._failed_platforms
+        assert runner._failed_platforms[Platform.QQBOT]["attempts"] == 0
+        # Gateway stays alive — the watcher owns retry from here.
+        runner.stop.assert_not_awaited()
+


### PR DESCRIPTION
## Problem

After a network outage longer than the reconnect budget (backoff 2s→5s→10s→30s→60s × 100 attempts, roughly 1–2h of continuous failure), the QQBot platform adapter becomes a permanent zombie:

- `_listen_loop` exhausts `MAX_RECONNECT_ATTEMPTS` and exits via `_mark_disconnected(); return` — **without setting a fatal error and without notifying the gateway**
- The `_failed_platforms` reconnect watcher only covers platforms that failed at gateway **startup**; nothing polls installed adapters post-startup, and the zombie stays installed in `self.adapters` with `is_connected=False` forever
- Inbound events are gone (no WebSocket); every send waits 15s in `_wait_for_reconnection()` then fails with `Not connected`
- Only a gateway restart recovers the platform

Real-world instance: a DNS outage on 2026-08-19 (~2h, `[Errno 8]`) left a production gateway's qqbot dead for 10 days while Telegram self-healed via the watcher. Gateway logs show the exact sequence: `Reconnect failed: Failed to get QQ Bot access token` ×100 → `Max reconnect attempts reached` → silence.

The same silent-death pattern existed in three more exits:

- **quick-disconnect** (×3 rapid disconnects) and **fatal close codes** (banned/offline/etc.) did call `_set_fatal_error()` but never notified — nothing reads the flag of an installed adapter, so it was equally zombie
- **4008 rate-limit exhaustion** also exited via bare `_mark_disconnected(); return`

## Fix

Every terminal `_listen_loop` exit now goes through `_give_up_and_notify(code, message, retryable=)`:

1. `_set_fatal_error(...)` — error code + retryable flag, `_running=False`
2. `_mark_disconnected()` — `is_connected=False` (ordering matters: it skips its redundant status write once `has_fatal_error` is set)
3. `_notify_fatal_error_detached()` — schedules the gateway's `_handle_adapter_fatal_error` on its own task

The gateway handler then disconnects the zombie and requeues the platform for background reconnection (retryable: max-reconnect ×3, quick-disconnect) or marks it fatal (non-retryable: banned/offline/…) — the exact contract every other adapter already uses; the qqbot listen loop was the one place that never called it.

**Why detached?** The gateway handler calls `adapter.disconnect()`, which awaits `self._listen_task`. Awaiting that from inside the listen loop itself would deadlock (task awaiting itself). The detached task runs the notification after the listen loop has already returned, so the cancel/await in `disconnect()` completes instantly. The wrapper is exception-guarded (best-effort notify) so a gateway-side bug cannot leave an unawaited-task error, and a strong reference on the adapter prevents mid-flight GC.

Two secondary fixes folded in:

- The quick-disconnect exit returns before the shared `_fail_pending("Connection closed")` — it now fails pending response futures itself (defensive parity with sibling adapters)
- Fatal close-code error codes are slugified (`qq_invalid_opcode`, `qq_offline_sandbox_only`) since they now persist in runtime-status `error_code` fields

## Behavior matrix

| Exit | Error code | Retryable | Gateway action |
|---|---|---|---|
| Max reconnect ×3 (generic / QQCloseError / rate-limit) | `qq_max_reconnect` | ✅ | disconnect + requeue, auto-recover when network returns |
| Quick-disconnect ×3 | `qq_quick_disconnect` | ✅ | requeue; recovers once credentials/permissions are fixed |
| Fatal close codes (4001/4002/4010–4014/4914/4915) | `qq_<desc>` (slugified) | ❌ | mark fatal — retrying a banned bot is pointless |

## Tests

4 regression tests in `TestListenLoopFatalNotify` (full suite: 67 passed):

- max-reconnect exhaustion → retryable fatal + handler notified, with the handler calling `adapter.disconnect()` — a regression to inline notification would deadlock/timeout here
- fatal close code (4915) → non-retryable + notified
- quick-disconnect → pending futures settled (future injected late + message asserted, so the assertion discriminates the branch-local `_fail_pending` from the shared one; verified by mutation test)
- raising gateway handler → exception swallowed, no unawaited task error

## Notes

- No gateway-side changes needed — the reconnect watcher, stale-instance guard, and shutdown-race handling (`shutdown_event` check) already exist upstream; this PR just makes qqbot use them
- Reconnect parameters unchanged — the budget is reasonable; only the death behavior after exhausting it was wrong
- No linked issue: searched open PRs/issues for qqbot reconnect/zombie/not-connected, nothing matches
