### PR TITLE
feat(browser): support Dia as a real-profile Chromium browser

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -558,7 +558,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   timezone: 'IANA timezone identifier. Blank uses the system timezone.',
   browser: {
     useRealProfile:
-      "Local browsing uses your real logins. Hermes copies your default browser's profile (cookies, logins, preferences) into a managed snapshot and drives it with its packaged Chromium — your live profile is never opened directly, and the copy is refreshed from it on each run. Also lets the agent open a local real-profile session on request even when a cloud browser backend is configured. Only Chromium browsers (Chrome, Edge, Brave, Brave Origin, Chromium) are supported; a non-Chromium default fails with a clear message. Off by default."
+      "Local browsing uses your real logins. Hermes copies your default browser's profile (cookies, logins, preferences) into a managed snapshot and drives it with its packaged Chromium — your live profile is never opened directly, and the copy is refreshed from it on each run. Also lets the agent open a local real-profile session on request even when a cloud browser backend is configured. Only Chromium browsers (Chrome, Dia, Edge, Brave, Brave Origin, Chromium) are supported; a non-Chromium default fails with a clear message. Off by default."
   },
   agent: {
     imageInputMode: 'Controls how image attachments are sent to the model.',

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -96,6 +96,11 @@ _BROWSERS = (
         ("/usr/bin/brave-origin", "/opt/brave.com/brave-origin/brave-origin",
          "/opt/brave.com/brave-origin-nightly/brave-origin"),
         "BraveSoftware/Brave-Origin", linux_exec=("brave-origin",)),
+    # Dia (The Browser Company): Chromium core, macOS-only. Windows is announced but has no
+    # public build, so the Windows/Linux fields stay empty and resolution fails closed there.
+    _Browser(
+        "dia", "/Applications/Dia.app/Contents/MacOS/Dia",
+        ("Dia", "User Data"), (), (), (), (), (), ""),
     _Browser(
         "edge", "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
         ("Microsoft Edge",), ("msedge.exe", "msedge"),
@@ -160,7 +165,8 @@ _LINUX_SNAP_PROFILE_PARTS = {
 # must not be read as ``com.google.chrome``, nor ``com.brave.browser.origin`` (Homebrew
 # cask id for Brave Origin) as plain ``com.brave.browser``.
 _DARWIN_BUNDLE_MAP = (
-    ("com.google.chrome", "chrome"), ("com.microsoft.edgemac", "edge"),
+    ("com.google.chrome", "chrome"), ("company.thebrowser.dia", "dia"),
+    ("com.microsoft.edgemac", "edge"),
     ("com.brave.browser", "brave"), ("com.brave.browser.origin", "brave-origin"),
     ("org.chromium.chromium", "chromium"))
 
@@ -179,7 +185,8 @@ UNSUPPORTED_CHANNEL = "__unsupported_channel__"
 def real_profile_data_dir(browser: str, system: str | None = None) -> str | None:
     """Default user-data-dir for ``browser`` on ``system`` (None if unknown). Linux tries native
     ($XDG_CONFIG_HOME), snap and Flatpak — first existing wins, else native so the caller's
-    error names it. Darwin/Windows paths are not stat'ed."""
+    error names it. Darwin/Windows paths are not stat'ed. A browser with no build for
+    ``system`` (empty platform fields) is None, never a bare parent dir."""
     b = _BROWSER_BY_KEY.get(browser)
     if b is None:
         return None
@@ -188,8 +195,12 @@ def real_profile_data_dir(browser: str, system: str | None = None) -> str | None
     if system == "Darwin":
         return posixpath.join(home, "Library", "Application Support", *b.mac_support)
     if system == "Windows":
+        if not b.win_profile:
+            return None
         local = os.environ.get("LOCALAPPDATA") or ntpath.join(home, "AppData", "Local")
         return ntpath.join(local, *b.win_profile)
+    if not b.linux_config:
+        return None
     config = os.environ.get("XDG_CONFIG_HOME") or posixpath.join(home, ".config")
     linux_parts = b.linux_config.split("/")
     candidates = [posixpath.join(config, *linux_parts)]

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -404,7 +404,7 @@ DEFAULT_CONFIG = {
         # prefs copied and re-synced per fresh session) driven by Hermes' packaged Chromium. The
         # snapshot dir sidesteps Chrome 136+'s default-profile debugging block and never contends
         # with the running browser. Turning off deletes ~/.hermes/browser-profile/ so credentials
-        # don't outlive consent. Chromium-family only (Chrome, Edge, Brave, Brave Origin, Chromium);
+        # don't outlive consent. Chromium-family only (Chrome, Dia, Edge, Brave, Brave Origin, Chromium);
         # Firefox etc. fails closed. Also gates the browser_exec `local` argument (real-profile
         # local session even under a cloud backend). Desktop Settings -> Browser.
         "use_real_profile": False,

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -96,6 +96,7 @@ class TestDetectDefaultDarwin:
         "bundle,expected",
         [
             ("com.google.Chrome", "chrome"),
+            ("company.thebrowser.Dia", "dia"),
             ("com.brave.Browser", "brave"),
             ("com.brave.Browser.origin", "brave-origin"),
             ("com.microsoft.edgemac", "edge"),
@@ -176,3 +177,23 @@ class TestLinuxProfileDir:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("XDG_CONFIG_HOME", "/home/t/.config")
         assert bc.real_profile_data_dir("edge", "Linux") == "/home/t/.config/microsoft-edge"
+
+
+class TestMacOnlyBrowser:
+    """Dia ships on macOS only. Elsewhere it must resolve to nothing, not to LOCALAPPDATA
+    or ~/.config themselves (snapshotting a parent dir is the wrong-principal bug)."""
+
+    def test_darwin_profile_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert bc.real_profile_data_dir("dia", "Darwin") == str(
+            tmp_path / "Library" / "Application Support" / "Dia" / "User Data")
+
+    @pytest.mark.parametrize("system", ["Windows", "Linux"])
+    def test_no_profile_dir_off_mac(self, system, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+        assert bc.real_profile_data_dir("dia", system) is None
+
+    @pytest.mark.parametrize("system", ["Windows", "Linux"])
+    def test_no_executable_off_mac(self, system):
+        assert bc.chromium_executable("dia", system) is None

--- a/tools/browser_tool_real_profile.py
+++ b/tools/browser_tool_real_profile.py
@@ -128,12 +128,12 @@ def _real_profile_unsupported_reason(browser) -> Optional[str]:
     """
     from hermes_cli.browser_connect import UNSUPPORTED_CHANNEL
     if browser is None:
-        return (_RP + "your default browser is not a supported Chromium browser (Chrome, Edge, Brave, "
+        return (_RP + "your default browser is not a supported Chromium browser (Chrome, Dia, Edge, Brave, "
                 "Brave Origin, Chromium). Real-profile browsing requires a Chromium default; set one or turn the toggle off.")
     if browser == UNSUPPORTED_CHANNEL:
         return (_RP + "your default browser is a pre-release Chromium channel (Beta / Dev / Canary), which "
                 "real-profile browsing does not support. Set your default to a "
-                "stable Chrome / Edge / Brave / Brave Origin / Chromium, or turn the toggle off.")
+                "stable Chrome / Dia / Edge / Brave / Brave Origin / Chromium, or turn the toggle off.")
     return None
 
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -242,8 +242,8 @@ losing unsaved tabs), then retries. If the profile is still locked after that
 to fully quit the browser — it won't loop or kill again on its own.
 :::
 
-- **Supported browsers:** Chrome, Edge, Brave, Brave Origin, Chromium (whichever is your OS
-  default). A non-Chromium default (e.g. Firefox) fails closed with a clear
+- **Supported browsers:** Chrome, Edge, Brave, Brave Origin, Chromium, and Dia on
+  macOS (whichever is your OS default). A non-Chromium default (e.g. Firefox) fails closed with a clear
   message rather than guessing.
 - **Works on any backend.** On a local backend it's automatic once the toggle
   is on. Under a **cloud** browser backend, the agent can still open a


### PR DESCRIPTION
## Summary

Dia (The Browser Company) is a Chromium browser, but real-profile browsing rejected it as non-Chromium. On a machine where Dia is the OS default, `browser.use_real_profile: true` fails every time with:

> browser.use_real_profile is on, but your default browser is not a supported Chromium browser (Chrome, Edge, Brave, Chromium).

It turned out to be missing detection, not a missing capability. I verified Dia speaks CDP with nothing stripped **before** writing any code:

```bash
open -na /Applications/Dia.app --args --remote-debugging-port=9333 \
  --user-data-dir=/tmp/dia-cdp-test --no-first-run
curl -s http://127.0.0.1:9333/json/version
```
```json
{ "Browser": "Chrome/152.0.7977.65", "Protocol-Version": "1.3" }
```

Its profile is at `~/Library/Application Support/Dia/User Data` in the standard Chromium layout (`Local State` + `Default/`), so the existing snapshot path needs no changes at all.

## What changed

Dia is registered at the five sites in `browser_connect.py` that already enumerate supported browsers:

| Site | Addition |
|---|---|
| `_DARWIN_APPS` | `/Applications/Dia.app/Contents/MacOS/Dia` |
| `_CHROMIUM_BROWSERS` | `"dia"` |
| `_DARWIN_BUNDLE_MAP` | `("company.thebrowser.dia", "dia")` |
| `_real_profile_relparts` | `("Dia", "User Data")` |
| `chromium_executable` (Darwin) | Dia binary path |

The four user-facing strings that enumerate supported browsers are updated alongside (tool error messages, config comment, docs, desktop settings copy). Leaving them stale would tell users Dia is unsupported while it demonstrably works.

macOS-only, matching where Dia ships. Linux/Windows tables are untouched.

## Test plan

- [x] `tests/hermes_cli/test_browser_connect_default_chromium.py` — **31 passed**
- [x] New bundle-map case is **mutation-verified**: with the `_DARWIN_BUNDLE_MAP` entry removed, `test_bundle_map[company.thebrowser.Dia-dia]` fails while the other four still pass. It guards the mapping rather than restating it.
- [x] No regression: `chrome` / `brave` / `edge` / `chromium` profile paths and detection are byte-identical before and after.
- [x] End-to-end against real imports — `detect_default_chromium()` returns `dia`, `real_profile_data_dir("dia")` resolves to a directory that exists and contains `Default/`.

The 18 errors from the wider `-k 'browser_connect or real_profile'` selection are a missing `fastapi` in my test sandbox, and reproduce identically on unmodified `main`. Unrelated to this change.

## Note for maintainers (separate, pre-existing issue)

While testing this I hit a bug that is **not** Dia-specific and is **not** addressed here, but is worth a look:

`snapshot_real_profile()` → `_mirror_profile_auth()` hangs on `Web Data` when the source browser is **running**. `Cookies`, `Login Data` and `Login Data For Account` all mirror fine, but `Web Data` stays 0 bytes indefinitely — sqlite's online-backup restarts its pass whenever the source is written, and a live browser writes that DB continuously, so it never converges.

The fast lock probe intentionally no-ops on POSIX ("copy-while-running still works"), which holds for the other DBs but not this one. Quitting the browser first makes the snapshot complete in seconds. Happy to open a separate issue if useful.
