### PR TITLE
fix(kanban): never auto-reclaim inline-owned running cards

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4478,6 +4478,23 @@ def release_stale_claims(
     API traffic. ``enforce_max_runtime`` and ``detect_crashed_workers``
     remain the upper bounds for genuinely wedged or dead workers.
 
+    Inline ownership guard: only tasks with a dispatcher-spawned worker
+    (``worker_pid`` set, i.e. status='running' with a real subprocess)
+    are reclaim candidates in the TTL and heartbeat-staleness passes. A
+    ``running`` task whose ``worker_pid`` is NULL is held by an INLINE
+    owner — a CLI ``kanban claim`` or a gateway/admin session, not the
+    dispatcher. Auto-reclaim must never release such a claim: doing so
+    requeues the card to ``ready`` and the dispatcher spawns a duplicate
+    worker beside the inline owner, producing the nudge-loop / double-
+    owner / protocol-violation crash cascade (see the hardening task on
+    inline-owner vs dispatched-worker ownership). A legitimate inline
+    claim always carries both ``claim_lock`` and ``claim_expires``, so it
+    is also structurally excluded from orphan reconciliation (which only
+    touches cards missing either field). The inline owner manages its own
+    lifecycle via ``heartbeat_claim`` and ``complete_task`` /
+    ``block_task``; a genuinely dead inline session is recovered by
+    operator ``reclaim_task``, never by auto-reclaim.
+
     Returns the number of stale claims actually reclaimed (live-pid
     extensions don't count). Safe to call often.
     """
@@ -4488,7 +4505,8 @@ def release_stale_claims(
         "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
-        "  AND claim_expires < ?",
+        "  AND claim_expires < ? "
+        "  AND worker_pid IS NOT NULL",
         (now,),
     ).fetchall()
     for row in stale:
@@ -7349,7 +7367,7 @@ def detect_stale_running(
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
-        "WHERE t.status = 'running'"
+        "WHERE t.status = 'running' AND t.worker_pid IS NOT NULL"
     ).fetchall()
 
     for row in rows:

--- a/tests/hermes_cli/test_kanban_inline_ownership.py
+++ b/tests/hermes_cli/test_kanban_inline_ownership.py
@@ -1,0 +1,99 @@
+"""Kanban inline-owner vs dispatched-worker ownership hardening.
+
+Regression coverage for the nudge-loop / double-owner bug: an INLINE owner
+(a ``kanban claim`` / gateway session) holds a card as ``running`` with
+``worker_pid NULL``. The dispatcher's auto-reclaim passes must NEVER release
+such a claim — releasing it requeues the card to ``ready`` and the dispatcher
+spawns a duplicate worker beside the inline owner (the protocol-violation /
+crash cascade observed on the control-plane migration).
+
+Auto-reclaim (TTL / heartbeat-stale / orphan reconciliation) only ever applies
+to dispatcher-spawned workers, i.e. ``status='running' AND worker_pid IS NOT
+NULL``. A genuinely dead dispatcher worker (worker_pid set) MUST still be
+reclaimed, so crash recovery is preserved.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture()
+def kanban_home(tmp_path, monkeypatch):
+    import os
+    from pathlib import Path
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _claim(conn, tt, *, worker_pid, expired=True):
+    """Claim a fresh card however the caller wants (inline vs dispatched)."""
+    host = kb._claimer_id().split(":", 1)[0]
+    if worker_pid is None:
+        # Inline owner: CLI/gateway claim, no dispatcher subprocess.
+        kb.claim_task(conn, tt, claimer=f"{host}:inline-session")
+    else:
+        # Dispatcher-spawned worker.
+        kb.claim_task(conn, tt, claimer=kb._claimer_id())
+        kb._set_worker_pid(conn, tt, worker_pid)
+    if expired:
+        old = int(time.time()) - 3600
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (old, tt),
+        )
+
+
+def _dispatch_spawn(conn):
+    spawned = []
+
+    def _spawn(task, ws, **kw):
+        spawned.append(task.id)
+        return 9999
+
+    kb.dispatch_once(
+        conn,
+        spawn_fn=_spawn,
+        max_spawn=4,
+        failure_limit=2,
+        reconcile_orphans=True,
+    )
+    return spawned
+
+
+def test_inline_owned_card_not_reclaimed(kanban_home, monkeypatch):
+    """An inline-owned card (worker_pid NULL) is NEVER auto-reclaimed to ready."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    with kb.connect() as conn:
+        tt = kb.create_task(conn, title="inline", assignee="developer")
+        _claim(conn, tt, worker_pid=None)
+
+        assert kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None) == 0
+        assert kb.detect_stale_running(conn, stale_timeout_seconds=30) == []
+        assert kb.reconcile_orphaned_running(conn) == []
+
+        assert kb.get_task(conn, tt).status == "running", \
+            "inline-owned card must stay running (dispatcher stayed out)"
+        # And a full dispatcher tick must NOT spawn a duplicate.
+        assert _dispatch_spawn(conn) == []
+
+
+def test_dispatcher_worker_still_reclaimed(kanban_home, monkeypatch):
+    """A dead dispatcher-spawned worker (worker_pid set) MUST still be reclaimed."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    with kb.connect() as conn:
+        tt = kb.create_task(conn, title="dispatched", assignee="developer")
+        _claim(conn, tt, worker_pid=12345)
+
+        assert kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None) >= 1
+        assert kb.get_task(conn, tt).status == "ready", \
+            "dead dispatcher worker reclaim -> crash recovery preserved"


### PR DESCRIPTION
Fixes the inline-owner vs dispatched-worker double-owner / nudge-loop / crash cascade.

## Root cause
An INLINE owner (CLI `kanban claim` / gateway session) holds a card `running` with `worker_pid=NULL`. The TTL (`release_stale_claims`) and heartbeat-staleness (`detect_stale_running`) reclaim passes treated it like any expired claim and requeued it to `ready`, where the dispatcher immediately spawned a duplicate worker beside the inline owner → `protocol_violation` loop → `pid not alive` crashes → `failure_limit` / `gave_up`.

## Change
- `release_stale_claims` and `detect_stale_running` now only consider `worker_pid IS NOT NULL` (dispatcher-spawned workers). Inline-owned cards are never auto-reclaimed.
- `detect_crashed_workers`/`enforce_max_runtime` already filtered `worker_pid IS NOT NULL`; `reconcile_orphaned_running` is structurally safe (a valid inline claim always carries both claim_lock and claim_expires).
- Operator `reclaim_task` remains the only recovery for a genuinely dead inline session.

## Preserves
- Dead dispatcher workers are still reclaimed → crash recovery intact (regression test).
- `HERMES_DELEGATED_CHILD_CONTEXT` guard untouched.
- ONE CARD → ONE EXECUTOR.

## Tests
- New `tests/hermes_cli/test_kanban_inline_ownership.py` (2 tests).
- 96 existing kanban DB/gateway/tools/worker-runs tests pass.