### PR TITLE
fix(kanban): complete durable orchestration lifecycle

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -13,6 +13,7 @@ loop continues instead of exiting.
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any, Iterable, Optional
 
@@ -47,6 +48,17 @@ def _tool_call_name(tc: Any) -> str:
     return str(getattr(tc, "name", "") or "")
 
 
+def _successful_process_transfer(msg: dict) -> bool:
+    """Whether a tool result records the process tool's durable handoff receipt."""
+    if str(msg.get("name") or "") != "process":
+        return False
+    try:
+        receipt = json.loads(str(msg.get("content") or ""))
+    except (TypeError, ValueError):
+        return False
+    return isinstance(receipt, dict) and receipt.get("status") == "transferred" and bool(receipt.get("run_id"))
+
+
 def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
     """True if this conversation already invoked a terminal kanban tool."""
     if not messages:
@@ -60,6 +72,8 @@ def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
                 if _tool_call_name(tc) in _TERMINAL_KANBAN_TOOLS:
                     return True
         elif role == "tool":
+            if _successful_process_transfer(msg):
+                return True
             name = str(msg.get("name") or "")
             if name in _TERMINAL_KANBAN_TOOLS:
                 return True

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -81,6 +81,8 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        "wait_kind": t.wait_kind,
+        "wait_ref": t.wait_ref,
     }
 
 
@@ -398,6 +400,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "and re-queues the task.")
     p_create.add_argument("--created-by", default="user",
                           help="Author name recorded on the task (default: user)")
+    p_create.add_argument("--owner-kind", choices=("agent", "external", "no_agent"), default=None)
+    p_create.add_argument("--task-kind", default="ordinary")
+    p_create.add_argument("--purpose", default=None)
+    p_create.add_argument("--created-by-task-id", default=None)
+    p_create.add_argument("--created-by-run-id", type=int, default=None)
+    p_create.add_argument("--creation-authority", default=None)
+    p_create.add_argument("--gate-candidate-sha", default=None)
+    p_create.add_argument("--gate-manifest-hash", default=None)
     p_create.add_argument("--skill", action="append", default=[], dest="skills",
                           help="Skill to force-load into the worker "
                                "(repeatable). The kanban lifecycle is already "
@@ -519,6 +529,55 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_assign = sub.add_parser("assign", help="Assign or reassign a task")
     p_assign.add_argument("task_id")
     p_assign.add_argument("profile", help="Profile name (or 'none' to unassign)")
+    p_assign.add_argument("--owner-kind", choices=("agent", "external", "no_agent"), default=None)
+    p_assign.add_argument(
+        "--activate-agent", action="store_true",
+        help="Explicitly reactivate an implicit unassigned lane as agent-owned",
+    )
+
+    # Durable external executions are DB-owned so they outlive the initiating agent.
+    p = sub.add_parser("external-run-start", help="Start a durable external run")
+    p.add_argument("task_id"); p.add_argument("--owner", required=True); p.add_argument("--external-id", required=True); p.add_argument("--pid", type=int); p.add_argument("--phase"); p.add_argument("--current", type=int); p.add_argument("--total", type=int); p.add_argument("--log-ref"); p.add_argument("--result-ref"); p.add_argument("--max-retries", type=int); p.add_argument("--on-success", choices=("complete", "resume"), default="complete"); p.add_argument("--on-failure", choices=("retry", "block"), default="block"); p.add_argument("--json", action="store_true")
+    p = sub.add_parser("external-run-show", help="Show a durable external run")
+    p.add_argument("run_id", type=int); p.add_argument("--json", action="store_true")
+    p = sub.add_parser("external-run-list", help="List durable external runs")
+    p.add_argument("--task-id"); p.add_argument("--json", action="store_true")
+    p = sub.add_parser("external-run-heartbeat", help="Heartbeat an owned external run")
+    p.add_argument("run_id", type=int); p.add_argument("--owner", required=True); p.add_argument("--phase"); p.add_argument("--current", type=int); p.add_argument("--total", type=int); p.add_argument("--log-ref"); p.add_argument("--result-ref"); p.add_argument("--json", action="store_true")
+    p = sub.add_parser("external-run-transfer", help="Transfer a live external run owner")
+    p.add_argument("run_id", type=int); p.add_argument("--from-owner", required=True); p.add_argument("--to-owner", required=True); p.add_argument("--json", action="store_true")
+    p = sub.add_parser("external-run-finish", help="Finish an owned external run exactly once")
+    p.add_argument("run_id", type=int); p.add_argument("--owner", required=True); p.add_argument("--outcome", required=True, choices=("completed", "failed", "lost", "cancelled")); p.add_argument("--result-ref"); p.add_argument("--json", action="store_true")
+    p = sub.add_parser("external-run-reconcile", help="Reconcile heartbeat-stale external runs")
+    p.add_argument("--stale-after", type=int, default=300); p.add_argument("--json", action="store_true")
+
+    p_wait_set = sub.add_parser("wait-set", help="Set a strict typed durable wait")
+    p_wait_set.add_argument("task_id"); p_wait_set.add_argument("kind", choices=sorted(kb.WAIT_AUTHORITIES)); p_wait_set.add_argument("ref")
+    p_wait_show = sub.add_parser("wait-show", help="Show a task's typed wait")
+    p_wait_show.add_argument("task_id"); p_wait_show.add_argument("--json", action="store_true")
+    p_wait_resume = sub.add_parser("wait-resume", help="Resume a wait with its exact authority receipt")
+    p_wait_resume.add_argument("task_id"); p_wait_resume.add_argument("--authority", required=True); p_wait_resume.add_argument("--receipt", required=True); p_wait_resume.add_argument("--verdict", default=None)
+
+    p_candidate_create = sub.add_parser("candidate-create", help="Create an immutable exact-SHA candidate")
+    p_candidate_create.add_argument("task_id"); p_candidate_create.add_argument("sha"); p_candidate_create.add_argument("--source-receipt", dest="source_receipt_file", default=None, help="Immutable JSON attestation file for scratch/dir candidates"); p_candidate_create.add_argument("--json", action="store_true")
+    p_candidate_show = sub.add_parser("candidate-show", help="Show a task candidate")
+    p_candidate_show.add_argument("task_id"); p_candidate_show.add_argument("sha"); p_candidate_show.add_argument("--json", action="store_true")
+    p_manifest_freeze = sub.add_parser("evidence-manifest-freeze", help="Freeze evidence manifest from JSON file")
+    p_manifest_freeze.add_argument("task_id"); p_manifest_freeze.add_argument("sha"); p_manifest_freeze.add_argument("manifest_file"); p_manifest_freeze.add_argument("--verdict", required=True); p_manifest_freeze.add_argument("--authority", required=True); p_manifest_freeze.add_argument("--json", action="store_true")
+    p_manifest_show = sub.add_parser("evidence-manifest-show", help="Show frozen evidence manifest")
+    p_manifest_show.add_argument("task_id"); p_manifest_show.add_argument("--json", action="store_true")
+    p_verdict_record = sub.add_parser("gate-verdict-record", help="Record candidate-bound gate verdict")
+    p_verdict_record.add_argument("task_id"); p_verdict_record.add_argument("gate_task_id"); p_verdict_record.add_argument("sha"); p_verdict_record.add_argument("manifest_hash"); p_verdict_record.add_argument("verdict"); p_verdict_record.add_argument("--authority"); p_verdict_record.add_argument("--json", action="store_true")
+    p_verdict_show = sub.add_parser("gate-verdict-show", help="Show gate verdict")
+    p_verdict_show.add_argument("task_id"); p_verdict_show.add_argument("gate_task_id"); p_verdict_show.add_argument("--json", action="store_true")
+    for name in ("release-barrier-show", "release-barrier-acquire", "release-barrier-renew", "release-barrier-release", "release-barrier-reconcile", "release-barrier-prepare", "release-barrier-delivery", "release-barrier-readback"):
+        p = sub.add_parser(name); p.add_argument("task_id"); p.add_argument("--barrier", default="publish"); p.add_argument("--json", action="store_true")
+        if name in {"release-barrier-acquire", "release-barrier-renew", "release-barrier-release", "release-barrier-reconcile", "release-barrier-prepare", "release-barrier-delivery", "release-barrier-readback"}: p.add_argument("--owner-token", required=True)
+        if name in {"release-barrier-acquire", "release-barrier-renew"}: p.add_argument("--ttl", type=int, default=60)
+        if name == "release-barrier-prepare": p.add_argument("--target", required=True); p.add_argument("--sha", required=True); p.add_argument("--idempotency-key")
+        if name == "release-barrier-delivery": p.add_argument("--target", required=True); p.add_argument("--sha", required=True); p.add_argument("--idempotency-key", required=True)
+        if name == "release-barrier-readback": p.add_argument("--sha", required=True)
+    p = sub.add_parser("release-barrier-create"); p.add_argument("task_id"); p.add_argument("--sha", required=True); p.add_argument("--manifest-hash", required=True); p.add_argument("--gate", action="append", required=True); p.add_argument("--authority", required=True); p.add_argument("--barrier", default="publish"); p.add_argument("--json", action="store_true")
 
     # --- set-model (per-task model/provider override) ---
     p_set_model = sub.add_parser(
@@ -560,6 +619,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_reassign.add_argument(
         "--reclaim", action="store_true",
         help="Release any active claim before reassigning (required if task is running)",
+    )
+    p_reassign.add_argument(
+        "--activate-agent", action="store_true",
+        help="Explicitly reactivate an implicit unassigned lane as agent-owned",
     )
     p_reassign.add_argument(
         "--reason", default=None,
@@ -1155,6 +1218,31 @@ def kanban_command(args: argparse.Namespace) -> int:
             "ls":       _cmd_list,
             "show":     _cmd_show,
             "assign":   _cmd_assign,
+            "external-run-start": _cmd_external_run_start,
+            "external-run-show": _cmd_external_run_show,
+            "external-run-list": _cmd_external_run_list,
+            "external-run-heartbeat": _cmd_external_run_heartbeat,
+            "external-run-transfer": _cmd_external_run_transfer,
+            "external-run-finish": _cmd_external_run_finish,
+            "external-run-reconcile": _cmd_external_run_reconcile,
+            "wait-set": _cmd_wait_set,
+            "wait-show": _cmd_wait_show,
+            "wait-resume": _cmd_wait_resume,
+            "candidate-create": _cmd_candidate_create,
+            "candidate-show": _cmd_candidate_show,
+            "evidence-manifest-freeze": _cmd_evidence_manifest_freeze,
+            "evidence-manifest-show": _cmd_evidence_manifest_show,
+            "gate-verdict-record": _cmd_gate_verdict_record,
+            "gate-verdict-show": _cmd_gate_verdict_show,
+            "release-barrier-create": _cmd_release_barrier,
+            "release-barrier-show": _cmd_release_barrier,
+            "release-barrier-acquire": _cmd_release_barrier,
+            "release-barrier-renew": _cmd_release_barrier,
+            "release-barrier-release": _cmd_release_barrier,
+            "release-barrier-reconcile": _cmd_release_barrier,
+            "release-barrier-prepare": _cmd_release_barrier,
+            "release-barrier-delivery": _cmd_release_barrier,
+            "release-barrier-readback": _cmd_release_barrier,
             "set-model": _cmd_set_model,
             "reclaim":  _cmd_reclaim,
             "reassign": _cmd_reassign,
@@ -1666,7 +1754,14 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    if args.assignee and not getattr(args, "external_assignee", False):
+    # Keep omission distinct from an explicit owner choice: create_task owns
+    # legacy inference (assigned -> agent; unassigned -> implicit no_agent).
+    # The legacy external flag is itself an explicit external-lane choice.
+    owner_kind = getattr(args, "owner_kind", None)
+    if owner_kind is None and getattr(args, "external_assignee", False):
+        owner_kind = "external"
+    effective_owner_kind = owner_kind or ("agent" if args.assignee else "no_agent")
+    if args.assignee and effective_owner_kind == "agent":
         from hermes_cli import profiles as profiles_mod
 
         canonical = profiles_mod.normalize_profile_name(args.assignee)
@@ -1677,8 +1772,8 @@ def _cmd_create(args: argparse.Namespace) -> int:
             print(
                 f"kanban: assignee profile {canonical!r} does not exist. "
                 f"Available profiles: {available}. Create it first, choose an "
-                "existing profile, or pass --external-assignee only for an "
-                "intentionally human-pulled external lane.",
+                "existing profile, or pass --external-assignee/--owner-kind external "
+                "only for an intentionally human-pulled external lane.",
                 file=sys.stderr,
             )
             return 2
@@ -1706,6 +1801,14 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            owner_kind=owner_kind,
+            task_kind=getattr(args, "task_kind", "ordinary"),
+            purpose=getattr(args, "purpose", None),
+            created_by_task_id=getattr(args, "created_by_task_id", None),
+            created_by_run_id=getattr(args, "created_by_run_id", None),
+            creation_authority=getattr(args, "creation_authority", None),
+            gate_candidate_sha=getattr(args, "gate_candidate_sha", None),
+            gate_manifest_hash=getattr(args, "gate_manifest_hash", None),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -1871,6 +1974,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
     print(f"Task {task.id}: {task.title}")
     print(f"  status:    {task.status}")
     print(f"  assignee:  {task.assignee or '-'}")
+    if task.wait_kind:
+        print(f"  wait:      {task.wait_kind} @ {task.wait_ref}")
     if task.tenant:
         print(f"  tenant:    {task.tenant}")
     print(f"  workspace: {task.workspace_kind}" +
@@ -1980,13 +2085,258 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
 def _cmd_assign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
-    with kb.connect_closing() as conn:
-        ok = kb.assign_task(conn, args.task_id, profile)
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.assign_task(
+                conn, args.task_id, profile,
+                owner_kind=getattr(args, "owner_kind", None),
+                activate_agent=bool(getattr(args, "activate_agent", False)),
+            )
+    except (ValueError, RuntimeError) as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
     if not ok:
         print(f"no such task: {args.task_id}", file=sys.stderr)
         return 1
     print(f"Assigned {args.task_id} to {profile or '(unassigned)'}")
     return 0
+
+
+def _external_run_dict(run: kb.Run) -> dict[str, Any]:
+    """Return the credential-safe external-run JSON contract shared by CLI verbs."""
+    policy = run.metadata or {}
+    return {
+        "id": run.id, "task_id": run.task_id, "status": run.status,
+        "outcome": run.outcome, "owner": run.owner, "external_id": run.external_id,
+        "pid": run.worker_pid, "phase": run.phase, "current": run.progress_current,
+        "total": run.progress_total, "last_heartbeat_at": run.last_heartbeat_at,
+        "started_at": run.started_at, "ended_at": run.ended_at,
+        "log_ref": run.log_ref, "result_ref": run.result_ref,
+        "retry_policy": {"max_retries": policy.get("max_retries")},
+        "success_failure_policy": {
+            "on_success": policy.get("on_success"), "on_failure": policy.get("on_failure"),
+        },
+    }
+
+
+def _external_run_error() -> int:
+    print("external run not found or not owned by this board/owner", file=sys.stderr)
+    return 1
+
+
+def _cmd_external_run_start(args: argparse.Namespace) -> int:
+    try:
+        with kb.connect_closing() as conn:
+            run = kb.start_external_run(conn, args.task_id, owner=args.owner,
+                external_id=args.external_id, pid=args.pid, phase=args.phase,
+                current=args.current, total=args.total, log_ref=args.log_ref,
+                result_ref=args.result_ref, max_retries=args.max_retries,
+                on_success=args.on_success, on_failure=args.on_failure)
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
+    return _print_receipt(_external_run_dict(run), args.json)
+
+
+def _cmd_external_run_show(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        run = kb.get_external_run(conn, args.run_id)
+    return _print_receipt(_external_run_dict(run), args.json) if run else _external_run_error()
+
+
+def _cmd_external_run_list(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        if args.task_id is not None and kb.get_task(conn, args.task_id) is None:
+            return _external_run_error()
+        sql = "SELECT * FROM task_runs WHERE owner_kind='external'"
+        params: tuple = ()
+        if args.task_id:
+            sql += " AND task_id=?"
+            params = (args.task_id,)
+        rows = conn.execute(sql + " ORDER BY id", params).fetchall()
+    return _print_receipt({"runs": [_external_run_dict(kb.Run.from_row(row)) for row in rows]}, args.json)
+
+
+def _cmd_external_run_heartbeat(args: argparse.Namespace) -> int:
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.heartbeat_external_run(conn, args.run_id, owner=args.owner,
+                phase=args.phase, current=args.current, total=args.total,
+                log_ref=args.log_ref, result_ref=args.result_ref)
+            run = kb.get_external_run(conn, args.run_id) if ok else None
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
+    return _print_receipt(_external_run_dict(run), args.json) if run else _external_run_error()
+
+
+def _cmd_external_run_transfer(args: argparse.Namespace) -> int:
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.transfer_external_run_owner(conn, args.run_id,
+                from_owner=args.from_owner, to_owner=args.to_owner)
+            run = kb.get_external_run(conn, args.run_id) if ok else None
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
+    return _print_receipt(_external_run_dict(run), args.json) if run else _external_run_error()
+
+
+def _cmd_external_run_finish(args: argparse.Namespace) -> int:
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.finish_external_run(conn, args.run_id, owner=args.owner,
+                outcome=args.outcome, result_ref=args.result_ref)
+            run = kb.get_external_run(conn, args.run_id) if ok else None
+    except (ValueError, RuntimeError) as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
+    return _print_receipt(_external_run_dict(run), args.json) if run else _external_run_error()
+
+
+def _cmd_external_run_reconcile(args: argparse.Namespace) -> int:
+    try:
+        with kb.connect_closing() as conn:
+            count = kb.reconcile_stale_external_runs(conn, stale_after_seconds=args.stale_after)
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
+    return _print_receipt({"reconciled": count}, args.json)
+
+
+def _cmd_wait_set(args: argparse.Namespace) -> int:
+    try:
+        with kb.connect_closing() as conn:
+            kb.set_task_wait(conn, args.task_id, kind=args.kind, ref=args.ref)
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
+    print(f"Wait set: {args.task_id} {args.kind} {args.ref}")
+    return 0
+
+
+def _cmd_wait_show(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, args.task_id)
+    if not task:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    if not task.wait_kind:
+        print("no typed wait", file=sys.stderr)
+        return 1
+    value = {"task_id": task.id, "kind": task.wait_kind, "ref": task.wait_ref}
+    print(json.dumps(value, sort_keys=True) if args.json else f"{value['kind']} {value['ref']}")
+    return 0
+
+
+def _cmd_wait_resume(args: argparse.Namespace) -> int:
+    try:
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, args.task_id)
+            if task is None:
+                print(f"no such task: {args.task_id}", file=sys.stderr)
+                return 1
+            if args.verdict is not None:
+                if not task.wait_kind:
+                    print("kanban: task has no typed wait", file=sys.stderr)
+                    return 2
+                kb.record_wait_receipt(conn, kind=task.wait_kind, ref=args.receipt, authority=args.authority, verdict=args.verdict)
+            ok = kb.resume_task_wait(conn, args.task_id, authority=args.authority, receipt=args.receipt)
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
+    if not ok:
+        print("wait not satisfied by this authority and receipt", file=sys.stderr)
+        return 1
+    print(f"Wait resumed: {args.task_id}")
+    return 0
+
+
+def _print_receipt(value: dict, as_json: bool) -> int:
+    print(json.dumps(value, sort_keys=True) if as_json else json.dumps(value, indent=2, sort_keys=True))
+    return 0
+
+
+def _bound_cli_control_authority(supplied: Optional[str] = None) -> str:
+    """Bind privileged CLI writes to HERMES_PROFILE plus configured principal."""
+    configured = kb._configured_coordinator_principal()
+    caller = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if not configured or caller != configured:
+        raise ValueError("CLI requires runtime HERMES_PROFILE to be the configured coordinator principal")
+    if supplied is not None and str(supplied).strip() != caller:
+        raise ValueError("--authority is only an assertion of runtime HERMES_PROFILE")
+    return caller
+
+
+def _cmd_candidate_create(args: argparse.Namespace) -> int:
+    try:
+        receipt = (json.loads(Path(args.source_receipt_file).read_text(encoding="utf-8"))
+                   if args.source_receipt_file else None)
+        if receipt is not None and not isinstance(receipt, dict):
+            raise ValueError("source receipt file must contain a JSON object")
+        with kb.connect_closing() as conn:
+            return _print_receipt(kb.create_candidate(conn, args.task_id, sha=args.sha, source_receipt=receipt), args.json)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"kanban: invalid source receipt: {exc}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 1
+
+
+def _cmd_candidate_show(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        value = kb.get_candidate(conn, args.task_id, sha=args.sha)
+    if value is None:
+        print("candidate not found", file=sys.stderr); return 1
+    return _print_receipt(value, args.json)
+
+
+def _cmd_evidence_manifest_freeze(args: argparse.Namespace) -> int:
+    try:
+        manifest = json.loads(Path(args.manifest_file).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"kanban: invalid manifest file: {exc}", file=sys.stderr); return 2
+    with kb.connect_closing() as conn:
+        authority = kb._bound_evidence_authority(conn, args.task_id, args.authority)
+        return _print_receipt(kb.freeze_evidence_manifest(conn, args.task_id, sha=args.sha, manifest=manifest, verdict=args.verdict, authority=authority), args.json)
+
+
+def _cmd_evidence_manifest_show(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn: value = kb.get_frozen_evidence_manifest(conn, args.task_id)
+    if value is None: print("evidence manifest not found", file=sys.stderr); return 1
+    return _print_receipt(value, args.json)
+
+
+def _cmd_gate_verdict_record(args: argparse.Namespace) -> int:
+    authority = _bound_cli_control_authority(getattr(args, "authority", None))
+    with kb.connect_closing() as conn:
+        return _print_receipt(kb.record_gate_verdict(conn, args.task_id, gate_task_id=args.gate_task_id, sha=args.sha, manifest_hash=args.manifest_hash, verdict=args.verdict, authority=authority), args.json)
+
+
+def _cmd_gate_verdict_show(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn: value = kb.get_gate_verdict(conn, args.task_id, gate_task_id=args.gate_task_id)
+    if value is None: print("gate verdict not found", file=sys.stderr); return 1
+    return _print_receipt(value, args.json)
+
+
+def _cmd_release_barrier(args: argparse.Namespace) -> int:
+    action = args.kanban_action
+    authority = None if action == "release-barrier-show" else _bound_cli_control_authority(getattr(args, "authority", None))
+    with kb.connect_closing() as conn:
+        if action == "release-barrier-create":
+            authority = _bound_cli_control_authority(args.authority)
+            value = kb.create_release_barrier(conn, args.task_id, sha=args.sha, manifest_hash=args.manifest_hash, required_gates=args.gate, authority=authority, barrier=args.barrier)
+        elif action == "release-barrier-show": value = kb.get_release_barrier(conn, args.task_id, barrier=args.barrier)
+        elif action == "release-barrier-acquire": value = {"acquired": kb.acquire_release_barrier_lease(conn, args.task_id, barrier=args.barrier, owner_token=args.owner_token, ttl_seconds=args.ttl, authority=authority)}
+        elif action == "release-barrier-renew": value = {"renewed": kb.renew_release_barrier_lease(conn, args.task_id, barrier=args.barrier, owner_token=args.owner_token, ttl_seconds=args.ttl, authority=authority)}
+        elif action == "release-barrier-release": value = {"released": kb.release_release_barrier_lease(conn, args.task_id, barrier=args.barrier, owner_token=args.owner_token, authority=authority)}
+        elif action == "release-barrier-reconcile": value = {"status": kb.reconcile_release_barrier(conn, args.task_id, barrier=args.barrier, owner_token=args.owner_token, authority=authority)}
+        elif action == "release-barrier-prepare": value = kb.prepare_release_delivery_intent(conn, args.task_id, barrier=args.barrier, owner_token=args.owner_token, target_identity=args.target, candidate_sha=args.sha, idempotency_key=args.idempotency_key, authority=authority)
+        elif action == "release-barrier-delivery": kb.record_release_delivery(conn, args.task_id, barrier=args.barrier, owner_token=args.owner_token, target_identity=args.target, delivered_sha=args.sha, idempotency_key=args.idempotency_key, authority=authority); value = kb.get_release_barrier(conn, args.task_id, barrier=args.barrier)
+        else: kb.record_release_readback(conn, args.task_id, barrier=args.barrier, owner_token=args.owner_token, readback_sha=args.sha, authority=authority); value = kb.get_release_barrier(conn, args.task_id, barrier=args.barrier)
+    if value is None: print("release barrier not found", file=sys.stderr); return 1
+    return _print_receipt(value, args.json)
 
 
 def _cmd_set_model(args: argparse.Namespace) -> int:
@@ -2031,12 +2381,17 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
 
 def _cmd_reassign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
-    with kb.connect_closing() as conn:
-        ok = kb.reassign_task(
-            conn, args.task_id, profile,
-            reclaim_first=bool(getattr(args, "reclaim", False)),
-            reason=getattr(args, "reason", None),
-        )
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.reassign_task(
+                conn, args.task_id, profile,
+                reclaim_first=bool(getattr(args, "reclaim", False)),
+                reason=getattr(args, "reason", None),
+                activate_agent=bool(getattr(args, "activate_agent", False)),
+            )
+    except ValueError as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 2
     if not ok:
         print(
             f"cannot reassign {args.task_id} "

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -369,6 +369,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("title", help="Task title")
     p_create.add_argument("--body", default=None, help="Optional opening post")
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
+    p_create.add_argument(
+        "--external-assignee", action="store_true",
+        help="Allow a non-profile assignee intentionally claimed by an external lane",
+    )
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
     p_create.add_argument("--workspace", default="scratch",
@@ -1662,6 +1666,22 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    if args.assignee and not getattr(args, "external_assignee", False):
+        from hermes_cli import profiles as profiles_mod
+
+        canonical = profiles_mod.normalize_profile_name(args.assignee)
+        if not profiles_mod.profile_exists(canonical):
+            available = ", ".join(
+                sorted(p.name for p in profiles_mod.list_profiles())
+            ) or "(none)"
+            print(
+                f"kanban: assignee profile {canonical!r} does not exist. "
+                f"Available profiles: {available}. Create it first, choose an "
+                "existing profile, or pass --external-assignee only for an "
+                "intentionally human-pulled external lane.",
+                file=sys.stderr,
+            )
+            return 2
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,7 +71,9 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import datetime as _dt
 import hashlib
+import io
 import json
 import os
 import re
@@ -89,7 +91,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
+from PIL import Image, UnidentifiedImageError
+
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
+from hermes_cli.config import get_hermes_home
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
@@ -133,6 +138,97 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+VALID_OWNER_KINDS = {"agent", "external", "no_agent"}
+WAIT_AUTHORITIES = {
+    "dependency": "dispatcher", "capability": "human", "human": "human",
+    "external_process": "external", "timer": "scheduler", "review": "reviewer",
+}
+
+
+def validate_owner_kind(owner_kind: str, owner: Optional[str] = None) -> tuple[str, Optional[str]]:
+    """Validate the durable execution owner at the DB boundary.
+
+    ``no_agent`` is deliberately ownerless.  Agent and external executions
+    must name their immutable owner; accepting a blank owner would create a
+    run that no reconciler can safely resume or terminate.
+    """
+    kind = str(owner_kind or "").strip().lower()
+    if kind not in VALID_OWNER_KINDS:
+        raise ValueError("owner_kind must be one of agent, external, no_agent")
+    normalized = str(owner).strip() if owner is not None else None
+    if kind == "no_agent":
+        # A no-agent task may still carry an assignee as a human/external lane
+        # label; it is not an execution identity and stays non-dispatchable.
+        return kind, normalized
+    if not normalized:
+        raise ValueError(f"{kind} execution requires a non-empty owner")
+    return kind, normalized
+
+
+def _redact_durable_ref(value: Optional[str]) -> Optional[str]:
+    """Store references, never credentials, in durable Kanban state."""
+    if value is None:
+        return None
+    from agent.redact import redact_sensitive_text
+
+    text = redact_sensitive_text(str(value), force=True)
+    # Redactors intentionally avoid over-masking ordinary prose. Durable refs
+    # have a stricter contract: URL userinfo and bearer credentials are never
+    # useful after persistence, so erase them even when they are synthetic.
+    text = re.sub(r"(https?://)[^/@\s]+@", r"\1[REDACTED]@", text)
+    text = re.sub(r"\b(Bearer|Basic)\s+\S+", r"\1 [REDACTED]", text, flags=re.I)
+    return text[:1000]
+
+
+def _configured_coordinator_principal() -> Optional[str]:
+    """Return the single configured control-plane principal, if any."""
+    try:
+        from hermes_cli.config import load_config
+        kanban = (load_config() or {}).get("kanban") or {}
+    except Exception:
+        return None
+    principal = kanban.get("coordinator_profile") or kanban.get("orchestrator_profile")
+    return str(principal).strip() or None
+
+
+def _require_control_authority(authority: Optional[str] = None) -> str:
+    """Bind a control-plane write to the configured runtime coordinator.
+
+    Authority is derived from this process's ``HERMES_PROFILE``; an input
+    value is only a consistency assertion.  In particular, public callers
+    cannot authenticate by supplying a coordinator name (or the old literal
+    ``system`` escape hatch).
+    """
+    principal = _configured_coordinator_principal()
+    runtime = str(os.environ.get("HERMES_PROFILE") or "").strip()
+    supplied = str(authority or "").strip()
+    if not principal or runtime != principal:
+        raise ValueError("operation requires runtime HERMES_PROFILE to be the configured coordinator")
+    if supplied and supplied != runtime:
+        raise ValueError("authority assertion must equal runtime HERMES_PROFILE")
+    return runtime
+
+
+def _decode_image_evidence(payload: bytes) -> Optional[dict[str, Any]]:
+    """Return canonical image facts only after Pillow fully decodes stored bytes.
+
+    ``None`` is deliberately reserved for ordinary non-image blobs. A payload
+    claimed to be an image is rejected by the caller when this returns None.
+    """
+    try:
+        with Image.open(io.BytesIO(payload)) as image:
+            image.verify()
+        with Image.open(io.BytesIO(payload)) as image:
+            image.load()
+            image_format = str(image.format or "").upper()
+            mime = Image.MIME.get(image_format)
+            width, height = image.size
+    except (UnidentifiedImageError, OSError, ValueError, SyntaxError):
+        return None
+    if not mime or width <= 0 or height <= 0:
+        raise ValueError("decoded image has no canonical MIME or dimensions")
+    return {"content_type": mime.lower(), "dimensions": [width, height],
+            "decoder_metadata": {"format": image_format, "width": width, "height": height}}
 
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
@@ -1141,6 +1237,19 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    wait_kind: Optional[str] = None
+    wait_ref: Optional[str] = None
+    owner_kind: str = "no_agent"
+    # True only when the creator explicitly selected an ownership lane. This
+    # distinguishes an intentional no_agent card from a pre-routing legacy row.
+    owner_kind_explicit: bool = False
+    task_kind: str = "ordinary"
+    purpose: Optional[str] = None
+    created_by_task_id: Optional[str] = None
+    created_by_run_id: Optional[int] = None
+    creation_authority: Optional[str] = None
+    gate_candidate_sha: Optional[str] = None
+    gate_manifest_hash: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1235,6 +1344,20 @@ class Task:
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
             ),
+            wait_kind=(row["wait_kind"] if "wait_kind" in keys else None),
+            wait_ref=(row["wait_ref"] if "wait_ref" in keys else None),
+            owner_kind=(row["owner_kind"] if "owner_kind" in keys else "no_agent"),
+            owner_kind_explicit=(
+                bool(row["owner_kind_explicit"])
+                if "owner_kind_explicit" in keys else False
+            ),
+            task_kind=(row["task_kind"] if "task_kind" in keys else "ordinary"),
+            purpose=(row["purpose"] if "purpose" in keys else None),
+            created_by_task_id=(row["created_by_task_id"] if "created_by_task_id" in keys else None),
+            created_by_run_id=(row["created_by_run_id"] if "created_by_run_id" in keys else None),
+            creation_authority=(row["creation_authority"] if "creation_authority" in keys else None),
+            gate_candidate_sha=(row["gate_candidate_sha"] if "gate_candidate_sha" in keys else None),
+            gate_manifest_hash=(row["gate_manifest_hash"] if "gate_manifest_hash" in keys else None),
         )
 
 
@@ -1265,6 +1388,17 @@ class Run:
     summary: Optional[str]
     metadata: Optional[dict]
     error: Optional[str]
+    owner_kind: str = "agent"
+    owner: Optional[str] = None
+    external_id: Optional[str] = None
+    phase: Optional[str] = None
+    progress_current: Optional[int] = None
+    progress_total: Optional[int] = None
+    log_ref: Optional[str] = None
+    result_ref: Optional[str] = None
+    # Only trusted ProcessRegistry transfers may use host PID liveness.
+    pid_scope: str = "external"
+    host_start_time: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Run":
@@ -1289,6 +1423,16 @@ class Run:
             summary=row["summary"],
             metadata=meta,
             error=row["error"],
+            owner_kind=(row["owner_kind"] if "owner_kind" in row.keys() else "agent"),
+            owner=(row["owner"] if "owner" in row.keys() else None),
+            external_id=(row["external_id"] if "external_id" in row.keys() else None),
+            phase=(row["phase"] if "phase" in row.keys() else None),
+            progress_current=(row["progress_current"] if "progress_current" in row.keys() else None),
+            progress_total=(row["progress_total"] if "progress_total" in row.keys() else None),
+            log_ref=(row["log_ref"] if "log_ref" in row.keys() else None),
+            result_ref=(row["result_ref"] if "result_ref" in row.keys() else None),
+            pid_scope=(row["pid_scope"] if "pid_scope" in row.keys() else "external"),
+            host_start_time=(row["host_start_time"] if "host_start_time" in row.keys() else None),
         )
 
 
@@ -1422,7 +1566,19 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- A typed durable wait has exactly one permitted resumer.
+    wait_kind            TEXT,
+    wait_ref             TEXT,
+    owner_kind           TEXT NOT NULL DEFAULT 'no_agent',
+    owner_kind_explicit  INTEGER NOT NULL DEFAULT 0,
+    task_kind            TEXT NOT NULL DEFAULT 'ordinary',
+    purpose              TEXT,
+    created_by_task_id   TEXT,
+    created_by_run_id    INTEGER,
+    creation_authority   TEXT,
+    gate_candidate_sha   TEXT,
+    gate_manifest_hash   TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1474,7 +1630,89 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    -- Durable owner identity. External runs are intentionally independent of
+    -- an AIAgent process and survive its close/restart.
+    owner_kind          TEXT NOT NULL DEFAULT 'agent',
+    owner               TEXT,
+    external_id         TEXT,
+    phase               TEXT,
+    progress_current    INTEGER,
+    progress_total      INTEGER,
+    log_ref             TEXT,
+    result_ref          TEXT,
+    pid_scope           TEXT NOT NULL DEFAULT 'external',
+    host_start_time     INTEGER,
+    -- Durable identity of a ProcessRegistry child handed into this external
+    -- lane. These trusted values bridge the crash window before its registry
+    -- checkpoint reaches disk.
+    managed_process_session_id TEXT,
+    durable_result_path TEXT
+);
+
+CREATE TABLE IF NOT EXISTS task_candidates (
+    task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    sha TEXT NOT NULL,
+    implementer TEXT NOT NULL DEFAULT '',
+    source_kind TEXT NOT NULL DEFAULT 'legacy',
+    source_provenance_json TEXT,
+    source_hash TEXT,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (task_id, sha)
+);
+
+CREATE TABLE IF NOT EXISTS task_gate_verdicts (
+    task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    gate TEXT NOT NULL,
+    sha TEXT NOT NULL,
+    manifest_hash TEXT NOT NULL,
+    verdict TEXT NOT NULL,
+    authority TEXT NOT NULL,
+    gate_run_id INTEGER,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (task_id, gate)
+);
+
+-- Immutable audit receipt for a reviewed evidence set.  Evidence must not be
+-- silently rewritten after a gate authority has rendered its verdict.
+CREATE TABLE IF NOT EXISTS task_evidence_receipts (
+    task_id       TEXT PRIMARY KEY REFERENCES tasks(id) ON DELETE CASCADE,
+    sha            TEXT NOT NULL,
+    manifest_json  TEXT NOT NULL,
+    manifest_hash  TEXT NOT NULL,
+    verdict        TEXT NOT NULL,
+    authority      TEXT NOT NULL,
+    created_at     INTEGER NOT NULL
+);
+
+-- CAS release barriers turn a once-only orchestration transition into a
+-- durable readback receipt, including under competing dispatcher processes.
+CREATE TABLE IF NOT EXISTS task_release_barriers (
+    task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    barrier TEXT NOT NULL DEFAULT 'publish',
+    sha TEXT NOT NULL, manifest_hash TEXT NOT NULL, required_gates_json TEXT NOT NULL,
+    authority TEXT NOT NULL, lease_owner TEXT, lease_expires_at INTEGER,
+    target_identity TEXT, delivery_idempotency_key TEXT, delivered_sha TEXT, readback_sha TEXT, completed_at INTEGER,
+    PRIMARY KEY (task_id, barrier)
+);
+
+CREATE TABLE IF NOT EXISTS task_release_receipts (
+    task_id       TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    barrier       TEXT NOT NULL,
+    authority     TEXT NOT NULL,
+    released_at   INTEGER NOT NULL,
+    PRIMARY KEY (task_id, barrier)
+);
+
+-- Explicit, immutable authority receipts for waits that are not backed by a
+-- task run or gate verdict. A plain authority string is never a receipt.
+CREATE TABLE IF NOT EXISTS task_wait_receipts (
+    kind        TEXT NOT NULL,
+    ref         TEXT NOT NULL,
+    authority   TEXT NOT NULL,
+    verdict     TEXT NOT NULL,
+    created_at  INTEGER NOT NULL,
+    PRIMARY KEY (kind, ref, authority)
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -2689,6 +2927,91 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
+    if "wait_kind" not in cols:
+        _add_column_if_missing(conn, "tasks", "wait_kind", "wait_kind TEXT")
+    if "wait_ref" not in cols:
+        _add_column_if_missing(conn, "tasks", "wait_ref", "wait_ref TEXT")
+    # Ownership provenance did not exist on legacy boards. Infer executable
+    # agent intent from a named assignee for every legacy lifecycle state,
+    # including terminal states: an operator can later reopen named completed
+    # or archived work and it must remain dispatchable. Do not consult today's
+    # installed profiles here: profile admission belongs to the future dispatch
+    # mutation boundary, which prevents migration from inventing a profile.
+    if "owner_kind" not in cols:
+        added_owner_kind = _add_column_if_missing(
+            conn, "tasks", "owner_kind", "owner_kind TEXT NOT NULL DEFAULT 'no_agent'"
+        )
+        # Pared-down ancient task tables can lack all three legacy facts used
+        # by the inference. Never manufacture those facts just to backfill an
+        # ownership lane: leave such rows at the safe no_agent default.
+        owner_backfill_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+        if added_owner_kind and {"assignee", "status", "current_run_id"} <= owner_backfill_cols:
+            conn.execute(
+                """
+                UPDATE tasks SET owner_kind = 'agent'
+                 WHERE NULLIF(TRIM(assignee), '') IS NOT NULL
+                   AND status IN ('todo', 'scheduled', 'ready', 'running', 'blocked', 'review', 'triage', 'done', 'archived')
+                """
+            )
+    # Existing rows predate an explicit ownership choice. Keep the additive
+    # default false even where owner_kind above was inferred from legacy facts.
+    if "owner_kind_explicit" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "owner_kind_explicit",
+            "owner_kind_explicit INTEGER NOT NULL DEFAULT 0",
+        )
+    for name, declaration in (
+        ("task_kind", "task_kind TEXT NOT NULL DEFAULT 'ordinary'"),
+        ("purpose", "purpose TEXT"), ("created_by_task_id", "created_by_task_id TEXT"),
+        ("created_by_run_id", "created_by_run_id INTEGER"),
+        ("creation_authority", "creation_authority TEXT"),
+        ("gate_candidate_sha", "gate_candidate_sha TEXT"),
+        ("gate_manifest_hash", "gate_manifest_hash TEXT"),
+    ):
+        if name not in cols:
+            _add_column_if_missing(conn, "tasks", name, declaration)
+
+    candidate_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_candidates'"
+    ).fetchone() is not None
+    if candidate_table_exists:
+        candidate_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_candidates)")
+        }
+        for name, declaration in (
+            ("implementer", "implementer TEXT NOT NULL DEFAULT ''"),
+            ("source_kind", "source_kind TEXT NOT NULL DEFAULT 'legacy'"),
+            ("source_provenance_json", "source_provenance_json TEXT"),
+            ("source_hash", "source_hash TEXT"),
+        ):
+            if name not in candidate_cols:
+                _add_column_if_missing(conn, "task_candidates", name, declaration)
+
+    verdict_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_gate_verdicts'"
+    ).fetchone() is not None
+    if verdict_table_exists:
+        verdict_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_gate_verdicts)")
+        }
+        if "gate_run_id" not in verdict_cols:
+            _add_column_if_missing(
+                conn, "task_gate_verdicts", "gate_run_id", "gate_run_id INTEGER"
+            )
+
+    barrier_table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_release_barriers'"
+    ).fetchone() is not None
+    if barrier_table_exists:
+        barrier_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_release_barriers)")
+        }
+        if "delivery_idempotency_key" not in barrier_cols:
+            _add_column_if_missing(
+                conn, "task_release_barriers", "delivery_idempotency_key", "delivery_idempotency_key TEXT"
+            )
 
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
@@ -2786,6 +3109,23 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
     ).fetchone() is not None
     if runs_exist:
+        run_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+        for name, declaration in (
+            ("owner_kind", "owner_kind TEXT NOT NULL DEFAULT 'agent'"),
+            ("owner", "owner TEXT"),
+            ("external_id", "external_id TEXT"),
+            ("phase", "phase TEXT"),
+            ("progress_current", "progress_current INTEGER"),
+            ("progress_total", "progress_total INTEGER"),
+            ("log_ref", "log_ref TEXT"),
+            ("result_ref", "result_ref TEXT"),
+            ("pid_scope", "pid_scope TEXT NOT NULL DEFAULT 'external'"),
+            ("host_start_time", "host_start_time INTEGER"),
+            ("managed_process_session_id", "managed_process_session_id TEXT"),
+            ("durable_result_path", "durable_result_path TEXT"),
+        ):
+            if name not in run_cols:
+                _add_column_if_missing(conn, "task_runs", name, declaration)
         with write_txn(conn):
             inflight = conn.execute(
                 "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
@@ -2887,7 +3227,11 @@ _REBUILD_SPECS = {
         " worker_pid INTEGER, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
-        " error TEXT)",
+        " error TEXT, owner_kind TEXT NOT NULL DEFAULT 'agent', owner TEXT,"
+        " external_id TEXT, phase TEXT, progress_current INTEGER,"
+        " progress_total INTEGER, log_ref TEXT, result_ref TEXT,"
+        " pid_scope TEXT NOT NULL DEFAULT 'external', host_start_time INTEGER,"
+        " managed_process_session_id TEXT, durable_result_path TEXT)",
         (
             "CREATE INDEX idx_runs_task ON task_runs(task_id, started_at)",
             "CREATE INDEX idx_runs_status ON task_runs(status)",
@@ -2949,6 +3293,12 @@ def _rebuild_drifted_tables(conn: sqlite3.Connection) -> None:
         for table in drifted:
             create_sql, index_sqls = _REBUILD_SPECS[table]
             old_cols = [c["name"] for c in conn.execute(f"PRAGMA table_info({table})")]
+            if table == "task_runs":
+                conn.execute("CREATE TEMP TABLE _task_runs_id_map (old_id TEXT PRIMARY KEY, ordinal INTEGER NOT NULL)")
+                conn.execute(
+                    "INSERT INTO _task_runs_id_map (old_id, ordinal) "
+                    "SELECT CAST(id AS TEXT), ROW_NUMBER() OVER (ORDER BY rowid) FROM task_runs"
+                )
             _log.info("kanban migration: rebuilding %s to match current schema", table)
             conn.execute(f"ALTER TABLE {table} RENAME TO {table}_legacy")
             conn.execute(create_sql)
@@ -2968,8 +3318,27 @@ def _rebuild_drifted_tables(conn: sqlite3.Connection) -> None:
                 cols_csv = ", ".join(shared)
                 conn.execute(
                     f"INSERT INTO {table} ({cols_csv}) "
-                    f"SELECT {cols_csv} FROM {table}_legacy"
+                    f"SELECT {cols_csv} FROM {table}_legacy ORDER BY rowid"
                 )
+            if table == "task_runs":
+                # Remap every durable provenance reference.  Keep NULL and
+                # unmapped legacy values intact: only identifiers that appear
+                # in the authoritative old→new map may change.
+                for ref_table, column in (
+                    ("tasks", "current_run_id"),
+                    ("tasks", "created_by_run_id"),
+                    ("task_events", "run_id"),
+                    ("task_gate_verdicts", "gate_run_id"),
+                ):
+                    if any(c["name"] == column for c in conn.execute(f"PRAGMA table_info({ref_table})")):
+                        conn.execute(
+                            f"UPDATE {ref_table} SET {column}=(SELECT r.id FROM task_runs r "
+                            f"JOIN _task_runs_id_map m ON m.ordinal=r.id "
+                            f"WHERE m.old_id=CAST({ref_table}.{column} AS TEXT)) "
+                            f"WHERE {column} IS NOT NULL AND CAST({column} AS TEXT) IN "
+                            f"(SELECT old_id FROM _task_runs_id_map)"
+                        )
+                conn.execute("DROP TABLE _task_runs_id_map")
             conn.execute(f"DROP TABLE {table}_legacy")
             for index_sql in index_sqls:
                 conn.execute(index_sql)
@@ -3194,6 +3563,14 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    owner_kind: Optional[str] = None,
+    task_kind: str = "ordinary",
+    purpose: Optional[str] = None,
+    created_by_task_id: Optional[str] = None,
+    created_by_run_id: Optional[int] = None,
+    creation_authority: Optional[str] = None,
+    gate_candidate_sha: Optional[str] = None,
+    gate_manifest_hash: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3240,6 +3617,48 @@ def create_task(
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)
+    # Preserve the established direct-DB API: an assigned task is an agent
+    # task unless its creator explicitly selects a non-agent execution lane.
+    # Unassigned cards remain deliberately non-dispatchable.
+    explicit_owner_kind = owner_kind is not None
+    if owner_kind is None:
+        owner_kind = "agent" if assignee else "no_agent"
+    owner_kind, _ = validate_owner_kind(owner_kind, assignee)
+    # Every agent-owned task is dispatcher-executable, including the legacy
+    # owner_kind-omitted shape inferred above. Admit it only when its resolved
+    # assignee is an installed profile; explicit external/no_agent lanes remain
+    # the deliberate opt-in for non-profile owners.
+    if owner_kind == "agent":
+        from hermes_cli.profiles import profile_exists
+        if not profile_exists(assignee or ""):
+            raise ValueError("agent owner assignee must be an installed profile")
+    if not str(task_kind or "").strip():
+        raise ValueError("task_kind is required")
+    task_kind = str(task_kind).strip().lower()
+    if task_kind in {"reviewer", "visualqa", "release"}:
+        # Gate creation is control-plane authority, never an implementation
+        # worker convenience.  The supplied value is merely an assertion.
+        creation_authority = _require_control_authority(creation_authority)
+    if task_kind in {"reviewer", "visualqa"}:
+        gate_candidate_sha = str(gate_candidate_sha or "").strip().lower()
+        gate_manifest_hash = str(gate_manifest_hash or "").strip().lower()
+        if owner_kind != "agent":
+            raise ValueError("mandatory gate owner_kind must be agent")
+        if not created_by_task_id:
+            raise ValueError("mandatory gate requires created_by_task_id source")
+        if not re.fullmatch(r"[0-9a-f]{40}", gate_candidate_sha) or not re.fullmatch(r"[0-9a-f]{64}", gate_manifest_hash):
+            raise ValueError("mandatory gate requires exact candidate SHA and manifest hash")
+        source = get_task(conn, str(created_by_task_id))
+        receipt = get_frozen_evidence_manifest(conn, str(created_by_task_id))
+        candidate = get_candidate(conn, str(created_by_task_id), sha=gate_candidate_sha)
+        if source is None or receipt is None or receipt["verdict"] != "pass" or candidate is None or receipt["sha"] != gate_candidate_sha or receipt["manifest_hash"] != gate_manifest_hash:
+            raise ValueError("mandatory gate source candidate and passing frozen manifest must match")
+        if not candidate["implementer"] or assignee == candidate["implementer"]:
+            raise ValueError("mandatory gate assignee must differ from frozen source implementer")
+    elif gate_candidate_sha is not None or gate_manifest_hash is not None:
+        raise ValueError("gate bindings are only valid for reviewer or visualqa tasks")
+    if not str(creation_authority or "").strip():
+        creation_authority = created_by or "legacy"
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -3508,8 +3927,10 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, owner_kind, owner_kind_explicit, task_kind,
+                        purpose, created_by_task_id, created_by_run_id, creation_authority,
+                        gate_candidate_sha, gate_manifest_hash
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3535,6 +3956,9 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        owner_kind, 1 if explicit_owner_kind else 0, task_kind, purpose,
+                        created_by_task_id, created_by_run_id, creation_authority,
+                        gate_candidate_sha, gate_manifest_hash,
                     ),
                 )
                 for pid in parents:
@@ -3710,39 +4134,77 @@ def list_tasks(
     return [Task.from_row(r) for r in rows]
 
 
-def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
-    """Assign or reassign a task.  Returns True on success.
+def assign_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    profile: Optional[str],
+    *,
+    owner_kind: Optional[str] = None,
+    activate_agent: bool = False,
+) -> bool:
+    """Assign, unassign, or explicitly reactivate an implicit agent lane.
 
-    Refuses to reassign a task that's currently running (claim_lock set).
-    Reassign after the current run completes if needed.
+    Public unassignment is safe: an agent card becomes ``no_agent`` in the
+    same transaction, retaining whether its ownership was explicit.  The only
+    reverse transition is a trusted, explicit ``activate_agent`` routing action
+    for a previously implicit, unassigned manual lane.
     """
-    profile = _canonical_assignee(profile)
+    profile = None if profile is None or not str(profile).strip() else _canonical_assignee(profile)
+    changed_fields = ["assignee"]
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
+            "SELECT status, claim_lock, assignee, owner_kind, owner_kind_explicit "
+            "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if not row:
             return False
+        persisted_kind = row["owner_kind"]
+        explicit = bool(row["owner_kind_explicit"])
         if row["claim_lock"] is not None and row["status"] == "running":
             raise RuntimeError(
                 f"cannot reassign {task_id}: currently running (claimed). "
                 "Wait for completion or reclaim the stale lock first."
             )
-        if row["assignee"] != profile:
+
+        if not profile:
+            if owner_kind is not None and owner_kind != persisted_kind:
+                raise ValueError("owner_kind is immutable after task creation")
+            if persisted_kind == "external":
+                raise ValueError("external owner assignee cannot be unassigned")
+            effective_kind = "no_agent" if persisted_kind == "agent" else persisted_kind
+        else:
+            effective_kind = persisted_kind
+            if persisted_kind == "no_agent" and activate_agent:
+                if explicit or row["assignee"] is not None:
+                    raise ValueError("only an intentionally unassigned implicit lane may activate an agent")
+                effective_kind = "agent"
+            if owner_kind is not None:
+                requested, _ = validate_owner_kind(owner_kind, profile)
+                if requested != effective_kind:
+                    raise ValueError("owner_kind is immutable after task creation")
+            if effective_kind == "agent":
+                from hermes_cli.profiles import profile_exists
+                if not profile_exists(profile):
+                    raise ValueError("agent owner assignee must be an installed profile")
+
+        if effective_kind != persisted_kind:
+            changed_fields.append("owner_kind")
+        if row["assignee"] != profile or effective_kind != persisted_kind:
             # The retry guard is scoped to the task/profile combination. A
             # human reassigning the task is an explicit recovery action, so the
             # new profile should not inherit the previous profile's streak.
             conn.execute(
-                "UPDATE tasks SET assignee = ?, consecutive_failures = 0, "
-                "last_failure_error = NULL WHERE id = ?",
-                (profile, task_id),
+                "UPDATE tasks SET assignee=?, owner_kind=?, consecutive_failures=0, "
+                "last_failure_error=NULL WHERE id=?",
+                (profile, effective_kind, task_id),
             )
         else:
-            conn.execute("UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id))
-        _append_event(conn, task_id, "assigned", {"assignee": profile})
-    # Task-mutation observer (RFC #58548), fired AFTER the assignment txn
-    # has committed so subscribers always observe durable board state.
-    notify_task_updated(conn, task_id, ("assignee",))
+            conn.execute("UPDATE tasks SET assignee=? WHERE id=?", (profile, task_id))
+        _append_event(
+            conn, task_id, "assigned",
+            {"assignee": profile, "owner_kind": effective_kind},
+        )
+    notify_task_updated(conn, task_id, tuple(changed_fields))
     return True
 
 
@@ -4555,11 +5017,15 @@ def recompute_ready(
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
+            "SELECT id, status, consecutive_failures, max_retries, wait_kind "
             "FROM tasks WHERE status IN ('todo', 'blocked')"
         ).fetchall()
         for row in todo_rows:
             task_id = row["id"]
+            # Typed waits have their own exact reconciliation contract; the
+            # legacy parent promotion path must never bypass it.
+            if row["wait_kind"]:
+                continue
             cur_status = row["status"]
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
                 # Worker / operator asked for explicit human intervention — do not
@@ -4614,6 +5080,1285 @@ def recompute_ready(
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+def handoff_agent_run_to_external(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: int,
+    expected_claim_lock: str,
+    owner: str,
+    external_id: str,
+    pid: Optional[int] = None,
+    managed_process_session_id: Optional[str] = None,
+    durable_result_path: Optional[str] = None,
+    host_start_time: Optional[int] = None,
+    phase: Optional[str] = None,
+    current: Optional[int] = None,
+    total: Optional[int] = None,
+    log_ref: Optional[str] = None,
+    result_ref: Optional[str] = None,
+    max_retries: Optional[int] = None,
+    on_success: str = "complete",
+    on_failure: str = "block",
+) -> Optional[Run]:
+    """CAS-transfer one live dispatcher worker run to a durable external run.
+
+    The caller supplies only values independently bound to the worker's trusted
+    dispatcher context.  Any stale task/run/claim ownership fails closed, so a
+    worker cannot replace another worker's current run.
+    """
+    _, owner = validate_owner_kind("external", owner)
+    ext = str(external_id or "").strip()
+    if not ext:
+        raise ValueError("external_id is required")
+    if (current is None) != (total is None):
+        raise ValueError("progress current and total must be provided together")
+    if total is not None and (int(total) < 0 or int(current) < 0 or int(current) > int(total)):
+        raise ValueError("progress must satisfy 0 <= current <= total")
+    if max_retries is not None and int(max_retries) < 1:
+        raise ValueError("max_retries must be >= 1")
+    if on_success not in {"complete", "resume"} or on_failure not in {"retry", "block"}:
+        raise ValueError("external policies must be complete/resume and retry/block")
+    expected_claim_lock = str(expected_claim_lock or "")
+    if not expected_claim_lock:
+        raise ValueError("expected claim ownership is required")
+    session_id = str(managed_process_session_id or "").strip() or None
+    receipt_path = str(durable_result_path or "").strip() or None
+    if (session_id is None) != (receipt_path is None):
+        raise ValueError("managed process session and durable receipt must be provided together")
+    if session_id is not None:
+        assert receipt_path is not None
+        expected_receipt = (get_hermes_home() / "process-results" / f"{session_id}.json").resolve()
+        try:
+            if Path(receipt_path).resolve() != expected_receipt:
+                raise ValueError("durable receipt path must be canonical for managed process session")
+        except OSError as exc:
+            raise ValueError("durable receipt path is invalid") from exc
+    now = int(time.time())
+    lock = f"external:{ext}"
+    with write_txn(conn):
+        task = conn.execute(
+            "SELECT id FROM tasks WHERE id=? AND status='running' AND current_run_id=? AND claim_lock=? AND owner_kind='agent'",
+            (task_id, int(expected_run_id), expected_claim_lock),
+        ).fetchone()
+        if task is None:
+            return None
+        active = conn.execute(
+            "SELECT id, profile, claim_expires, worker_pid, last_heartbeat_at "
+            "FROM task_runs WHERE id=? AND task_id=? AND ended_at IS NULL "
+            "AND owner_kind != 'external' AND claim_lock=?",
+            (int(expected_run_id), task_id, expected_claim_lock),
+        ).fetchone()
+        if active is None:
+            return None
+        changed = conn.execute(
+            "UPDATE task_runs SET status='external_handoff', outcome='external_handoff', "
+            "ended_at=?, claim_lock=NULL, claim_expires=NULL, worker_pid=NULL "
+            "WHERE id=? AND ended_at IS NULL",
+            (now, int(expected_run_id)),
+        )
+        if changed.rowcount != 1:
+            return None
+        cur = conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, claim_lock, worker_pid, "
+            "last_heartbeat_at, started_at, owner_kind, owner, external_id, phase, "
+            "progress_current, progress_total, log_ref, result_ref, pid_scope, host_start_time, "
+            "managed_process_session_id, durable_result_path, metadata) "
+            "VALUES (?, ?, 'running', ?, ?, ?, ?, 'external', ?, ?, ?, ?, ?, ?, ?, 'host', ?, ?, ?, ?)",
+            (task_id, owner, lock, pid, now, now, owner, ext, phase, current, total,
+             _redact_durable_ref(log_ref), _redact_durable_ref(result_ref), host_start_time,
+             session_id, receipt_path,
+             json.dumps({
+                 "max_retries": max_retries,
+                 "on_success": on_success,
+                 "on_failure": on_failure,
+                 "agent_handoff": {
+                     "run_id": int(expected_run_id),
+                     "profile": active["profile"],
+                     "claim_lock": expected_claim_lock,
+                     "claim_expires": active["claim_expires"],
+                     "worker_pid": active["worker_pid"],
+                     "last_heartbeat_at": active["last_heartbeat_at"],
+                 },
+             })),
+        )
+        run_id = int(cur.lastrowid)
+        changed = conn.execute(
+            "UPDATE tasks SET claim_lock=?, claim_expires=NULL, worker_pid=?, "
+            "last_heartbeat_at=?, current_run_id=? WHERE id=? AND status='running' "
+            "AND current_run_id=? AND claim_lock=?",
+            (lock, pid, now, run_id, task_id, int(expected_run_id), expected_claim_lock),
+        )
+        if changed.rowcount != 1:
+            raise RuntimeError("agent run no longer owns its task")
+        _append_event(conn, task_id, "external_handoff", {
+            "agent_run_id": int(expected_run_id), "run_id": run_id, "external_id": ext,
+        }, run_id=run_id)
+        row = conn.execute("SELECT * FROM task_runs WHERE id=?", (run_id,)).fetchone()
+    return Run.from_row(row)
+
+
+def rollback_external_handoff_to_agent(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    external_run_id: int,
+    agent_run_id: int,
+    external_owner: str,
+    expected_claim_lock: str,
+) -> bool:
+    """Restore the live agent claim when registry checkpoint transfer fails."""
+    _, owner = validate_owner_kind("external", external_owner)
+    now = int(time.time())
+    with write_txn(conn):
+        external = conn.execute(
+            "SELECT metadata, claim_lock FROM task_runs WHERE id=? AND task_id=? "
+            "AND owner_kind='external' AND owner=? AND ended_at IS NULL",
+            (int(external_run_id), task_id, owner),
+        ).fetchone()
+        if external is None:
+            return False
+        task = conn.execute(
+            "SELECT id FROM tasks WHERE id=? AND status='running' AND current_run_id=? "
+            "AND claim_lock=?",
+            (task_id, int(external_run_id), external["claim_lock"]),
+        ).fetchone()
+        if task is None:
+            return False
+        metadata = json.loads(external["metadata"] or "{}")
+        handoff = metadata.get("agent_handoff") or {}
+        if (
+            int(handoff.get("run_id") or 0) != int(agent_run_id)
+            or str(handoff.get("claim_lock") or "") != str(expected_claim_lock)
+        ):
+            return False
+        heartbeat = handoff.get("last_heartbeat_at") or now
+        restored = conn.execute(
+            "UPDATE task_runs SET status='running', outcome=NULL, ended_at=NULL, "
+            "claim_lock=?, claim_expires=?, worker_pid=?, last_heartbeat_at=? "
+            "WHERE id=? AND task_id=? AND owner_kind!='external'",
+            (
+                expected_claim_lock,
+                handoff.get("claim_expires"),
+                handoff.get("worker_pid"),
+                heartbeat,
+                int(agent_run_id),
+                task_id,
+            ),
+        )
+        if restored.rowcount != 1:
+            raise RuntimeError("agent handoff run is unavailable for rollback")
+        ended = conn.execute(
+            "UPDATE task_runs SET status='handoff_rolled_back', "
+            "outcome='handoff_rolled_back', ended_at=?, claim_lock=NULL, "
+            "claim_expires=NULL, worker_pid=NULL WHERE id=? AND ended_at IS NULL",
+            (now, int(external_run_id)),
+        )
+        if ended.rowcount != 1:
+            raise RuntimeError("external handoff no longer owns rollback")
+        changed = conn.execute(
+            "UPDATE tasks SET status='running', claim_lock=?, claim_expires=?, "
+            "worker_pid=?, last_heartbeat_at=?, current_run_id=? "
+            "WHERE id=? AND current_run_id=?",
+            (
+                expected_claim_lock,
+                handoff.get("claim_expires"),
+                handoff.get("worker_pid"),
+                heartbeat,
+                int(agent_run_id),
+                task_id,
+                int(external_run_id),
+            ),
+        )
+        if changed.rowcount != 1:
+            raise RuntimeError("external handoff task is unavailable for rollback")
+        _append_event(
+            conn,
+            task_id,
+            "external_handoff_rolled_back",
+            {"external_run_id": int(external_run_id), "agent_run_id": int(agent_run_id)},
+            run_id=int(agent_run_id),
+        )
+    return True
+
+
+def start_external_run(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    owner: str,
+    external_id: str,
+    pid: Optional[int] = None,
+    phase: Optional[str] = None,
+    current: Optional[int] = None,
+    total: Optional[int] = None,
+    log_ref: Optional[str] = None,
+    result_ref: Optional[str] = None,
+    max_retries: Optional[int] = None,
+    on_success: str = "complete",
+    on_failure: str = "block",
+) -> Run:
+    """Durably claim a task for an independently managed external execution.
+
+    This is deliberately DB-owned, rather than a ProcessRegistry annotation:
+    the external identity is stable through registry restarts and no AIAgent
+    close path owns or kills the external process.
+    """
+    _, owner = validate_owner_kind("external", owner)
+    ext = str(external_id or "").strip()
+    if not ext:
+        raise ValueError("external_id is required")
+    if (current is None) != (total is None):
+        raise ValueError("progress current and total must be provided together")
+    if total is not None and (int(total) < 0 or int(current) < 0 or int(current) > int(total)):
+        raise ValueError("progress must satisfy 0 <= current <= total")
+    if max_retries is not None and int(max_retries) < 1:
+        raise ValueError("max_retries must be >= 1")
+    if on_success not in {"complete", "resume"} or on_failure not in {"retry", "block"}:
+        raise ValueError("external policies must be complete/resume and retry/block")
+    now = int(time.time())
+    lock = f"external:{ext}"
+    with write_txn(conn):
+        duplicate = conn.execute(
+            "SELECT * FROM task_runs WHERE task_id = ? AND external_id = ?",
+            (task_id, ext),
+        ).fetchone()
+        if duplicate is not None:
+            return Run.from_row(duplicate)
+        changed = conn.execute(
+            "UPDATE tasks SET status='running', claim_lock=?, claim_expires=NULL, "
+            "worker_pid=?, last_heartbeat_at=? WHERE id=? AND status='ready' AND claim_lock IS NULL "
+            "AND owner_kind='external' AND assignee=?",
+            (lock, pid, now, task_id, owner),
+        )
+        if changed.rowcount != 1:
+            raise ValueError("external run requires an unclaimed ready task")
+        cur = conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, claim_lock, worker_pid, "
+            "last_heartbeat_at, started_at, owner_kind, owner, external_id, phase, "
+            "progress_current, progress_total, log_ref, result_ref, metadata) "
+            "VALUES (?, ?, 'running', ?, ?, ?, ?, 'external', ?, ?, ?, ?, ?, ?, ?, ?)",
+            (task_id, owner, lock, pid, now, now, owner, ext, phase, current, total,
+             _redact_durable_ref(log_ref), _redact_durable_ref(result_ref),
+             json.dumps({"max_retries": max_retries, "on_success": on_success, "on_failure": on_failure})),
+        )
+        run_id = int(cur.lastrowid)
+        conn.execute("UPDATE tasks SET current_run_id=? WHERE id=?", (run_id, task_id))
+        _append_event(conn, task_id, "external_started", {"run_id": run_id, "external_id": ext}, run_id=run_id)
+        row = conn.execute("SELECT * FROM task_runs WHERE id=?", (run_id,)).fetchone()
+    return Run.from_row(row)
+
+
+def get_external_run(conn: sqlite3.Connection, run_id: int) -> Optional[Run]:
+    row = conn.execute(
+        "SELECT * FROM task_runs WHERE id = ? AND owner_kind = 'external'", (int(run_id),)
+    ).fetchone()
+    return Run.from_row(row) if row else None
+
+
+def transfer_external_run_owner(
+    conn: sqlite3.Connection, run_id: int, *, from_owner: str, to_owner: str,
+) -> bool:
+    """Atomically move a live external run to another durable lane owner."""
+    _, from_owner = validate_owner_kind("external", from_owner)
+    _, to_owner = validate_owner_kind("external", to_owner)
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT task_id FROM task_runs WHERE id=? AND owner_kind='external' "
+            "AND owner=? AND ended_at IS NULL", (int(run_id), from_owner),
+        ).fetchone()
+        if row is None:
+            return False
+        changed = conn.execute(
+            "UPDATE task_runs SET owner=? WHERE id=? AND owner_kind='external' "
+            "AND owner=? AND ended_at IS NULL", (to_owner, int(run_id), from_owner),
+        )
+        if changed.rowcount != 1:
+            return False
+        _append_event(conn, row["task_id"], "external_owner_transferred", {
+            "from_owner": from_owner, "to_owner": to_owner,
+        }, run_id=int(run_id))
+    return True
+
+
+def heartbeat_external_run(
+    conn: sqlite3.Connection,
+    run_id: int,
+    *,
+    owner: str,
+    phase: Optional[str] = None,
+    current: Optional[int] = None,
+    total: Optional[int] = None,
+    log_ref: Optional[str] = None,
+    result_ref: Optional[str] = None,
+) -> bool:
+    """CAS heartbeat for the named external owner; never revives a terminal run."""
+    _, owner = validate_owner_kind("external", owner)
+    if (current is None) != (total is None):
+        raise ValueError("progress current and total must be provided together")
+    if total is not None and (int(total) < 0 or int(current) < 0 or int(current) > int(total)):
+        raise ValueError("progress must satisfy 0 <= current <= total")
+    now = int(time.time())
+    with write_txn(conn):
+        row = conn.execute("SELECT task_id FROM task_runs WHERE id=? AND owner_kind='external' AND owner=? AND ended_at IS NULL", (int(run_id), owner)).fetchone()
+        if row is None:
+            return False
+        conn.execute(
+            "UPDATE task_runs SET last_heartbeat_at=?, phase=COALESCE(?, phase), "
+            "progress_current=COALESCE(?, progress_current), progress_total=COALESCE(?, progress_total), "
+            "log_ref=COALESCE(?, log_ref), result_ref=COALESCE(?, result_ref) WHERE id=?",
+            (now, phase, current, total, _redact_durable_ref(log_ref), _redact_durable_ref(result_ref), int(run_id)),
+        )
+        conn.execute("UPDATE tasks SET last_heartbeat_at=? WHERE id=? AND current_run_id=?", (now, row["task_id"], int(run_id)))
+        _append_event(conn, row["task_id"], "external_heartbeat", {"phase": phase, "current": current, "total": total}, run_id=int(run_id))
+    return True
+
+
+def finish_external_run(
+    conn: sqlite3.Connection,
+    run_id: int,
+    *,
+    owner: str,
+    outcome: str,
+    result_ref: Optional[str] = None,
+) -> bool:
+    """Finalize an external run exactly once and atomically settle its task."""
+    _, owner = validate_owner_kind("external", owner)
+    normalized = str(outcome).strip().lower()
+    if normalized not in {"completed", "failed", "lost", "cancelled"}:
+        raise ValueError("external outcome must be completed, failed, lost, or cancelled")
+    now = int(time.time())
+    with write_txn(conn):
+        row = conn.execute("SELECT task_id, metadata FROM task_runs WHERE id=? AND owner_kind='external' AND owner=? AND ended_at IS NULL", (int(run_id), owner)).fetchone()
+        if row is None:
+            return False
+        policy = json.loads(row["metadata"] or "{}")
+        retrying = normalized != "completed" and policy.get("on_failure") == "retry"
+        max_retries = max(1, int(
+            policy.get("max_retries")
+            if policy.get("max_retries") is not None else DEFAULT_FAILURE_LIMIT
+        ))
+        prior_failures = conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id=? AND owner_kind='external' "
+            "AND outcome IN ('lost', 'failed', 'cancelled')",
+            (row["task_id"],),
+        ).fetchone()[0]
+        exhausted = retrying and int(prior_failures) + 1 >= max_retries
+        task_status = (
+            "ready" if normalized == "completed" and policy.get("on_success") == "resume"
+            else "done" if normalized == "completed"
+            else "ready" if retrying and not exhausted else "blocked"
+        )
+        run_status = "done" if normalized == "completed" else "failed"
+        conn.execute("UPDATE task_runs SET status=?, outcome=?, ended_at=?, result_ref=COALESCE(?, result_ref) WHERE id=?", (run_status, normalized, now, _redact_durable_ref(result_ref), int(run_id)))
+        changed = conn.execute("UPDATE tasks SET status=?, completed_at=CASE WHEN ?='done' THEN ? ELSE completed_at END, claim_lock=NULL, claim_expires=NULL, worker_pid=NULL, current_run_id=NULL WHERE id=? AND current_run_id=?", (task_status, task_status, now, row["task_id"], int(run_id)))
+        if changed.rowcount != 1:
+            raise RuntimeError("external run no longer owns its task")
+        _append_event(
+            conn, row["task_id"],
+            "external_resumed" if normalized == "completed" and task_status == "ready" else (
+                "completed" if normalized == "completed" else (
+                    "external_retry_exhausted" if exhausted else "external_failed"
+                )
+            ),
+            {"outcome": normalized, "max_retries": max_retries} if exhausted else {"outcome": normalized},
+            run_id=int(run_id),
+        )
+    if normalized == "completed":
+        recompute_ready(conn)
+    return True
+
+
+def _read_canonical_managed_process_receipt(
+    session_id: object, durable_result_path: object,
+) -> Optional[int]:
+    """Return an exact managed-process receipt exit code, never a caller path."""
+    sid = str(session_id or "").strip()
+    path_text = str(durable_result_path or "").strip()
+    if not sid or not path_text:
+        return None
+    try:
+        expected = (get_hermes_home() / "process-results" / f"{sid}.json").resolve()
+        if Path(path_text).resolve() != expected:
+            return None
+        payload = json.loads(expected.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    exit_code = payload.get("exit_code") if isinstance(payload, dict) and payload.get("session_id") == sid else None
+    return exit_code if isinstance(exit_code, int) and not isinstance(exit_code, bool) else None
+
+
+def reconcile_stale_external_runs(
+    conn: sqlite3.Connection, *, stale_after_seconds: int = 300,
+) -> int:
+    """CAS-settle heartbeat-stale external work, once per durable run.
+
+    External lanes have no local PID to probe.  A stale run is marked ``lost``;
+    its configured retry ceiling is evaluated from durable terminal history, so
+    concurrent reconcilers cannot emit duplicate exhaustion events.
+    """
+    if int(stale_after_seconds) < 1:
+        raise ValueError("stale_after_seconds must be >= 1")
+    cutoff = int(time.time()) - int(stale_after_seconds)
+    stale = conn.execute(
+        "SELECT id FROM task_runs WHERE owner_kind='external' AND ended_at IS NULL "
+        "AND COALESCE(last_heartbeat_at, started_at, 0) < ?", (cutoff,),
+    ).fetchall()
+    reconciled = 0
+    for candidate in stale:
+        with write_txn(conn):
+            row = conn.execute(
+                "SELECT id, task_id, metadata, worker_pid, pid_scope, host_start_time, owner, "
+                "managed_process_session_id, durable_result_path FROM task_runs WHERE id=? "
+                "AND owner_kind='external' AND ended_at IS NULL "
+                "AND COALESCE(last_heartbeat_at, started_at, 0) < ?",
+                (candidate["id"], cutoff),
+            ).fetchone()
+            if row is None:
+                continue
+            # A transferred ProcessRegistry worker has no independent external
+            # heartbeat while it is alive. Its host PID is the authoritative
+            # liveness signal; refresh both records rather than racing it into
+            # a false lost/retry transition after the normal 300s lease.
+            if (
+                row["pid_scope"] == "host" and row["worker_pid"]
+                and row["host_start_time"] is not None
+                and _host_pid_identity_matches(int(row["worker_pid"]), int(row["host_start_time"]))
+            ):
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE task_runs SET last_heartbeat_at=? WHERE id=? AND ended_at IS NULL",
+                    (now, row["id"]),
+                )
+                conn.execute(
+                    "UPDATE tasks SET last_heartbeat_at=? WHERE id=? AND current_run_id=?",
+                    (now, row["task_id"], row["id"]),
+                )
+                continue
+            try:
+                policy = json.loads(row["metadata"] or "{}") or {}
+                retrying = policy.get("on_failure") == "retry"
+                max_retries = int(
+                    policy.get("max_retries")
+                    if policy.get("max_retries") is not None else DEFAULT_FAILURE_LIMIT
+                )
+            except (TypeError, ValueError, json.JSONDecodeError):
+                policy = {}
+                retrying = False
+                max_retries = 1
+            max_retries = max(1, max_retries)
+            receipt_exit_code = _read_canonical_managed_process_receipt(
+                row["managed_process_session_id"], row["durable_result_path"],
+            )
+            if receipt_exit_code is not None:
+                normalized = "completed" if receipt_exit_code == 0 else "failed"
+                retrying = normalized != "completed" and retrying
+                prior = conn.execute(
+                    "SELECT COUNT(*) FROM task_runs WHERE task_id=? AND owner_kind='external' "
+                    "AND outcome IN ('lost', 'failed', 'cancelled')", (row["task_id"],),
+                ).fetchone()[0]
+                exhausted = retrying and int(prior) + 1 >= max_retries
+                task_status = (
+                    "ready" if normalized == "completed" and policy.get("on_success") == "resume" else
+                    "done" if normalized == "completed" else
+                    "ready" if retrying and not exhausted else "blocked"
+                )
+                changed = conn.execute(
+                    "UPDATE task_runs SET status=?, outcome=?, ended_at=? WHERE id=? AND ended_at IS NULL",
+                    ("done" if normalized == "completed" else "failed", normalized, int(time.time()), row["id"]),
+                )
+                if changed.rowcount:
+                    conn.execute(
+                        "UPDATE tasks SET status=?, completed_at=CASE WHEN ?='done' THEN ? ELSE completed_at END, "
+                        "claim_lock=NULL, claim_expires=NULL, worker_pid=NULL, current_run_id=NULL "
+                        "WHERE id=? AND current_run_id=?",
+                        (task_status, task_status, int(time.time()), row["task_id"], row["id"]),
+                    )
+                    _append_event(
+                        conn, row["task_id"],
+                        "external_resumed" if normalized == "completed" and task_status == "ready" else (
+                            "completed" if normalized == "completed" else (
+                                "external_retry_exhausted" if exhausted else "external_failed"
+                            )
+                        ),
+                        {"outcome": normalized, "receipt": "managed_process"}, run_id=row["id"],
+                    )
+                    reconciled += 1
+                continue
+            prior = conn.execute(
+                "SELECT COUNT(*) FROM task_runs WHERE task_id=? AND owner_kind='external' "
+                "AND outcome IN ('lost', 'failed', 'cancelled')", (row["task_id"],),
+            ).fetchone()[0]
+            exhausted = retrying and int(prior) + 1 >= max_retries
+            now = int(time.time())
+            changed = conn.execute(
+                "UPDATE task_runs SET status='failed', outcome='lost', ended_at=? "
+                "WHERE id=? AND ended_at IS NULL", (now, row["id"]),
+            )
+            if changed.rowcount != 1:
+                continue
+            status = "ready" if retrying and not exhausted else "blocked"
+            conn.execute(
+                "UPDATE tasks SET status=?, claim_lock=NULL, claim_expires=NULL, "
+                "worker_pid=NULL, current_run_id=NULL WHERE id=? AND current_run_id=?",
+                (status, row["task_id"], row["id"]),
+            )
+            _append_event(conn, row["task_id"], "external_retry_exhausted" if exhausted else "external_lost", {
+                "run_id": row["id"], "max_retries": max_retries,
+            }, run_id=row["id"])
+            reconciled += 1
+    return reconciled
+
+
+def _canonical_json(value: dict) -> tuple[str, str]:
+    """Return canonical JSON and its content address for immutable receipts."""
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return canonical, hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _git_candidate_provenance(task: Task, sha: str) -> dict:
+    """Prove a task's supplied commit is the clean, exact worktree HEAD."""
+    raw_path = str(task.workspace_path or "")
+    path = Path(raw_path)
+    if not raw_path or not path.is_absolute() or not path.is_dir():
+        raise ValueError("worktree candidate requires an absolute existing Git worktree")
+    canonical_path = str(path.resolve())
+    try:
+        root = subprocess.check_output(["git", "-C", canonical_path, "rev-parse", "--show-toplevel"], text=True, stderr=subprocess.DEVNULL).strip()
+        head = subprocess.check_output(["git", "-C", canonical_path, "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL).strip().lower()
+        dirty = subprocess.check_output(["git", "-C", canonical_path, "status", "--porcelain"], text=True, stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError("worktree candidate requires an absolute existing Git worktree") from exc
+    if str(Path(root).resolve()) != canonical_path:
+        raise ValueError("worktree candidate workspace_path must name the Git worktree root")
+    if dirty.strip():
+        raise ValueError("worktree candidate requires a clean Git worktree")
+    if head != sha:
+        raise ValueError("worktree candidate SHA must exactly match Git HEAD")
+    return {"head": head, "workspace_path": canonical_path}
+
+
+def create_candidate(
+    conn: sqlite3.Connection, task_id: str, *, sha: str, source_receipt: Optional[dict] = None,
+) -> dict:
+    """Persist a proven candidate, never a caller-asserted scratch SHA."""
+    sha = str(sha or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise ValueError("sha must be an exact 40-character hexadecimal SHA")
+    task = get_task(conn, task_id)
+    if task is None:
+        raise ValueError("task not found")
+    if task.workspace_kind == "worktree":
+        if source_receipt is not None:
+            raise ValueError("worktree candidate provenance is derived from Git, not source_receipt")
+        source_kind = "git"
+        provenance = _git_candidate_provenance(task, sha)
+    else:
+        _require_control_authority()
+        if not isinstance(source_receipt, dict):
+            raise ValueError("non-worktree candidate requires an immutable JSON source_receipt")
+        if str(source_receipt.get("candidate_sha") or "").strip().lower() != sha:
+            raise ValueError("source_receipt candidate_sha must exactly match candidate SHA")
+        if (
+            not str(source_receipt.get("subject") or "").strip()
+            or not str(source_receipt.get("provenance") or "").strip()
+            or not str(source_receipt.get("producer_profile") or "").strip()
+        ):
+            raise ValueError("source_receipt subject, provenance, and producer_profile are required")
+        source_kind = "attested"
+        provenance = json.loads(_canonical_json(source_receipt)[0])
+    canonical, source_hash = _canonical_json(provenance)
+    if source_kind == "git":
+        # The producing run is immutable lifecycle evidence.  Neither the
+        # latest run nor the mutable task assignee proves who produced this
+        # exact worktree HEAD.
+        producing_run = conn.execute(
+            "SELECT profile, metadata FROM task_runs WHERE task_id=? "
+            "AND ended_at IS NOT NULL AND outcome='completed' "
+            "AND TRIM(COALESCE(profile, '')) != '' ORDER BY id DESC",
+            (task_id,),
+        ).fetchall()
+        implementer = ""
+        for run in producing_run:
+            try:
+                metadata = json.loads(run["metadata"] or "{}")
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if metadata.get("candidate_sha") == sha:
+                implementer = str(run["profile"]).strip()
+                break
+        if not implementer:
+            raise ValueError("worktree candidate requires a completed producing run with exact candidate_sha")
+    else:
+        # The coordinator-authenticated immutable receipt is the only valid
+        # producer identity when no Git lifecycle run is available.
+        implementer = str(provenance["producer_profile"]).strip()
+    value = {"task_id": task_id, "sha": sha, "implementer": implementer, "source_kind": source_kind, "source_provenance": provenance, "source_hash": source_hash}
+    with write_txn(conn):
+        existing = conn.execute("SELECT implementer, source_kind, source_provenance_json, source_hash FROM task_candidates WHERE task_id=? AND sha=?", (task_id, sha)).fetchone()
+        if existing is not None:
+            prior = {"task_id": task_id, "sha": sha, "implementer": existing["implementer"], "source_kind": existing["source_kind"], "source_provenance": json.loads(existing["source_provenance_json"] or "{}"), "source_hash": existing["source_hash"]}
+            if prior != value:
+                raise ValueError("candidate provenance is immutable")
+            return prior
+        conn.execute("INSERT INTO task_candidates (task_id, sha, implementer, source_kind, source_provenance_json, source_hash, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)", (task_id, sha, implementer, source_kind, canonical, source_hash, int(time.time())))
+    return value
+
+
+def get_candidate(conn: sqlite3.Connection, task_id: str, *, sha: str) -> Optional[dict]:
+    row = conn.execute("SELECT sha, implementer, source_kind, source_provenance_json, source_hash FROM task_candidates WHERE task_id=? AND sha=?", (task_id, str(sha).lower())).fetchone()
+    return ({"task_id": task_id, "sha": row["sha"], "implementer": row["implementer"], "source_kind": row["source_kind"], "source_provenance": json.loads(row["source_provenance_json"] or "{}"), "source_hash": row["source_hash"]} if row else None)
+
+
+def _bound_evidence_authority(conn: sqlite3.Connection, task_id: str, supplied: Optional[str]) -> str:
+    """Bind an evidence receipt to its runtime producer or coordinator."""
+    runtime = str(os.environ.get("HERMES_PROFILE") or "").strip()
+    asserted = str(supplied or "").strip()
+    if not runtime:
+        raise ValueError("evidence freeze requires runtime HERMES_PROFILE")
+    if asserted != runtime:
+        raise ValueError("authority is only an assertion of runtime HERMES_PROFILE")
+    task = get_task(conn, task_id)
+    coordinator = _configured_coordinator_principal()
+    is_source_agent = task is not None and task.owner_kind == "agent" and task.assignee == runtime
+    if runtime != coordinator and not is_source_agent:
+        raise ValueError("evidence freeze requires the source agent assignee or configured coordinator")
+    return runtime
+
+
+def freeze_evidence_manifest(
+    conn: sqlite3.Connection, task_id: str, *, sha: str, manifest: dict,
+    verdict: str, authority: str,
+) -> dict:
+    """Write the one immutable, content-addressed gate receipt for a task."""
+    sha = str(sha or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise ValueError("sha must be an exact 40-character hexadecimal SHA")
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest must be an object")
+    if get_candidate(conn, task_id, sha=sha) is None:
+        raise ValueError("candidate is missing or belongs to another task")
+    entries = manifest.get("entries")
+    required_slots = manifest.get("required_slots", [])
+    if not isinstance(entries, list) or not entries or not isinstance(required_slots, list):
+        raise ValueError("manifest requires non-empty entries and required_slots")
+    slots: set[str] = set()
+    canonical_entries: list[dict] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("manifest entries must be objects")
+        entry = dict(entry)
+        attachment_id = entry.get("attachment_id")
+        row = conn.execute("SELECT task_id, stored_path, content_type FROM task_attachments WHERE id=?", (attachment_id,)).fetchone()
+        if row is None or row["task_id"] != task_id:
+            raise ValueError("manifest attachment is missing or belongs to another task")
+        path = Path(row["stored_path"])
+        if not path.is_file():
+            raise ValueError("manifest attachment bytes are missing")
+        payload = path.read_bytes()
+        actual_hash = hashlib.sha256(payload).hexdigest()
+        if entry.get("sha256") != actual_hash:
+            raise ValueError("manifest attachment hash mismatch")
+        content_type = entry.get("content_type")
+        if not isinstance(content_type, str) or "/" not in content_type or content_type != row["content_type"]:
+            raise ValueError("manifest content_type declaration is invalid")
+        if not isinstance(entry.get("cardinality"), int) or entry["cardinality"] <= 0:
+            raise ValueError("manifest cardinality must be positive")
+        slot, mode = entry.get("slot"), entry.get("mode")
+        if not isinstance(slot, str) or not slot.strip() or not isinstance(mode, str) or not mode.strip():
+            raise ValueError("manifest slot and mode are required")
+        decoded = _decode_image_evidence(payload)
+        # Decoder declarations are untrusted caller metadata. Preserve neither
+        # the boolean nor its claimed facts; images below receive canonical
+        # facts derived from bytes, non-images retain only generic integrity data.
+        entry.pop("decoder_valid", None)
+        entry.pop("decoder_metadata", None)
+        declared_image = content_type.lower().startswith("image/")
+        if decoded is None:
+            if declared_image:
+                raise ValueError("manifest image bytes fail Pillow decode")
+            if entry.get("dimensions") is not None:
+                raise ValueError("manifest dimensions require decoded image bytes")
+        else:
+            if not declared_image or content_type.lower() != decoded["content_type"]:
+                raise ValueError("manifest declared MIME does not match decoded image MIME")
+            dimensions = entry.get("dimensions")
+            if dimensions != decoded["dimensions"]:
+                raise ValueError("manifest declared dimensions do not match decoded image dimensions")
+            # The stored receipt is derived facts, not caller-controlled decoder claims.
+            entry["content_type"] = decoded["content_type"]
+            entry["dimensions"] = decoded["dimensions"]
+            entry["decoder_metadata"] = decoded["decoder_metadata"]
+            entry.pop("decoder_valid", None)
+        slots.add(slot)
+        canonical_entries.append(entry)
+    if any(not isinstance(slot, str) or not slot.strip() or slot not in slots for slot in required_slots):
+        raise ValueError("manifest is missing a required slot")
+    manifest = {**manifest, "entries": canonical_entries}
+    verdict = str(verdict or "").strip().lower()
+    authority = _bound_evidence_authority(conn, task_id, authority)
+    if verdict not in {"pass", "fail"}:
+        raise ValueError("verdict must be pass or fail")
+    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+    receipt = {"task_id": task_id, "sha": sha, "manifest": manifest,
+               "manifest_hash": hashlib.sha256(canonical.encode()).hexdigest(),
+               "verdict": verdict, "authority": authority}
+    with write_txn(conn):
+        existing = conn.execute(
+            "SELECT sha, manifest_json, manifest_hash, verdict, authority "
+            "FROM task_evidence_receipts WHERE task_id=?", (task_id,),
+        ).fetchone()
+        if existing:
+            prior = {"task_id": task_id, "sha": existing["sha"], "manifest": json.loads(existing["manifest_json"]),
+                     "manifest_hash": existing["manifest_hash"], "verdict": existing["verdict"],
+                     "authority": existing["authority"]}
+            if prior != receipt:
+                raise ValueError("evidence receipt is immutable")
+            return prior
+        if conn.execute("SELECT 1 FROM tasks WHERE id=?", (task_id,)).fetchone() is None:
+            raise ValueError("task not found")
+        conn.execute(
+            "INSERT INTO task_evidence_receipts "
+            "(task_id, sha, manifest_json, manifest_hash, verdict, authority, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (task_id, sha, canonical, receipt["manifest_hash"], verdict, authority, int(time.time())),
+        )
+        _append_event(conn, task_id, "evidence_frozen", receipt)
+    return receipt
+
+
+def get_frozen_evidence_manifest(conn: sqlite3.Connection, task_id: str) -> Optional[dict]:
+    row = conn.execute(
+        "SELECT sha, manifest_json, manifest_hash, verdict, authority "
+        "FROM task_evidence_receipts WHERE task_id=?", (task_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {"task_id": task_id, "sha": row["sha"], "manifest": json.loads(row["manifest_json"]),
+            "manifest_hash": row["manifest_hash"], "verdict": row["verdict"],
+            "authority": row["authority"]}
+
+
+def _validate_gate_task(
+    conn: sqlite3.Connection, source_task_id: str, gate_task_id: str,
+    *, require_terminal_result: bool = True,
+) -> Task:
+    """Resolve independent reviewer/visualqa provenance for one source task."""
+    gate = get_task(conn, str(gate_task_id or ""))
+    source = get_task(conn, source_task_id)
+    if gate is None:
+        raise ValueError("gate task ID does not name an existing task")
+    if source is None:
+        raise ValueError("source task not found")
+    if gate.task_kind not in {"reviewer", "visualqa"}:
+        raise ValueError("gate task must have reviewer or visualqa task_kind")
+    if gate.created_by_task_id != source_task_id:
+        raise ValueError("gate task was not created by the source task")
+    principal = _configured_coordinator_principal()
+    if not principal or gate.creation_authority != principal:
+        raise ValueError("gate task creation authority is not the configured coordinator")
+    receipt = get_frozen_evidence_manifest(conn, source_task_id)
+    candidate = get_candidate(conn, source_task_id, sha=gate.gate_candidate_sha or "")
+    if receipt is None or receipt["verdict"] != "pass" or candidate is None or gate.gate_candidate_sha != receipt["sha"] or gate.gate_manifest_hash != receipt["manifest_hash"]:
+        raise ValueError("gate task frozen candidate and passing manifest bindings do not match source")
+    if gate.owner_kind != "agent":
+        raise ValueError("gate task owner_kind must be agent")
+    if not gate.assignee or not candidate["implementer"] or gate.assignee == candidate["implementer"]:
+        raise ValueError("gate task assignee must differ from frozen source implementer")
+    if require_terminal_result:
+        row = conn.execute("SELECT status, result FROM tasks WHERE id=?", (gate_task_id,)).fetchone()
+        # A reopened task gets a new lifecycle run. Only its authoritative
+        # latest terminal attempt may authorize this gate; an earlier passing
+        # attempt cannot survive a later failed, reclaimed, or mismatched one.
+        run = conn.execute(
+            "SELECT profile, outcome, summary, metadata FROM task_runs "
+            "WHERE task_id=? AND ended_at IS NOT NULL ORDER BY id DESC LIMIT 1",
+            (gate_task_id,),
+        ).fetchone()
+        try:
+            metadata = json.loads(run["metadata"] or "{}") if run else {}
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        if (
+            row is None
+            or row["status"] != "done"
+            or not str(row["result"] or "").strip()
+            or run is None
+            or run["profile"] != gate.assignee
+            or run["profile"] == candidate["implementer"]
+            or run["outcome"] != "completed"
+            or not str(run["summary"] or "").strip()
+            or metadata.get("candidate_sha") != gate.gate_candidate_sha
+            or metadata.get("manifest_hash") != gate.gate_manifest_hash
+        ):
+            raise ValueError("gate task requires terminal result and exact bound run metadata")
+    return gate
+
+
+def record_gate_verdict(
+    conn: sqlite3.Connection, task_id: str, *, gate_task_id: str, sha: str,
+    manifest_hash: str, verdict: str, authority: str,
+) -> dict:
+    """Record a coordinator-aggregated verdict bound to an immutable gate task."""
+    authority = _require_control_authority(authority)
+    receipt = get_frozen_evidence_manifest(conn, task_id)
+    if not receipt or receipt["sha"] != sha or receipt["manifest_hash"] != manifest_hash:
+        raise ValueError("gate verdict candidate SHA or manifest hash is stale")
+    gate_task_id = str(gate_task_id or "").strip()
+    if str(verdict or "").strip().lower() not in {"pass", "fail"}:
+        raise ValueError("pass/fail verdict is required")
+    with write_txn(conn):
+        _validate_gate_task(conn, task_id, gate_task_id)
+        gate_run = conn.execute(
+            "SELECT id FROM task_runs WHERE task_id=? AND ended_at IS NOT NULL "
+            "ORDER BY id DESC LIMIT 1", (gate_task_id,),
+        ).fetchone()
+        if gate_run is None:
+            raise ValueError("gate task requires an authoritative terminal run")
+        value = {"task_id": task_id, "gate_task_id": gate_task_id, "sha": sha,
+                 "manifest_hash": manifest_hash, "verdict": str(verdict).lower(),
+                 "authority": str(authority), "gate_run_id": gate_run["id"]}
+        row = conn.execute("SELECT sha, manifest_hash, verdict, authority, gate_run_id FROM task_gate_verdicts WHERE task_id=? AND gate=?", (task_id, gate_task_id)).fetchone()
+        if row:
+            prior = {"task_id": task_id, "gate_task_id": gate_task_id, "sha": row["sha"], "manifest_hash": row["manifest_hash"], "verdict": row["verdict"], "authority": row["authority"], "gate_run_id": row["gate_run_id"]}
+            if prior != value:
+                raise ValueError("gate verdict is immutable")
+            return prior
+        conn.execute("INSERT INTO task_gate_verdicts (task_id, gate, sha, manifest_hash, verdict, authority, gate_run_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", (task_id, gate_task_id, sha, manifest_hash, value["verdict"], value["authority"], value["gate_run_id"], int(time.time())))
+    return value
+
+
+def get_gate_verdict(conn: sqlite3.Connection, task_id: str, *, gate_task_id: str) -> Optional[dict]:
+    row = conn.execute("SELECT sha, manifest_hash, verdict, authority, gate_run_id FROM task_gate_verdicts WHERE task_id=? AND gate=?", (task_id, gate_task_id)).fetchone()
+    return {"task_id": task_id, "gate_task_id": gate_task_id, "sha": row["sha"], "manifest_hash": row["manifest_hash"], "verdict": row["verdict"], "authority": row["authority"], "gate_run_id": row["gate_run_id"]} if row else None
+
+
+def create_release_barrier(conn: sqlite3.Connection, task_id: str, *, sha: str, manifest_hash: str, required_gates: list[str], authority: str, barrier: str = "publish") -> dict:
+    authority = _require_control_authority(authority)
+    receipt = get_frozen_evidence_manifest(conn, task_id)
+    gates = sorted({str(g).strip() for g in required_gates if str(g).strip()})
+    if not receipt or receipt["verdict"] != "pass" or receipt["sha"] != sha or receipt["manifest_hash"] != manifest_hash or not gates: raise ValueError("release barrier candidate, passing manifest, and required gates must be frozen")
+    for gate_task_id in gates:
+        _validate_gate_task(conn, task_id, gate_task_id)
+    value = {"task_id": task_id, "barrier": barrier, "sha": sha, "manifest_hash": manifest_hash, "required_gates": gates, "authority": authority}
+    with write_txn(conn):
+        row = conn.execute("SELECT sha, manifest_hash, required_gates_json, authority FROM task_release_barriers WHERE task_id=? AND barrier=?", (task_id, barrier)).fetchone()
+        if row:
+            old = {**value, "sha": row["sha"], "manifest_hash": row["manifest_hash"], "required_gates": json.loads(row["required_gates_json"]), "authority": row["authority"]}
+            if old != value: raise ValueError("release barrier is immutable")
+            return value
+        conn.execute("INSERT INTO task_release_barriers (task_id, barrier, sha, manifest_hash, required_gates_json, authority) VALUES (?, ?, ?, ?, ?, ?)", (task_id, barrier, sha, manifest_hash, json.dumps(gates, separators=(",", ":")), authority))
+    return value
+
+
+def get_release_barrier(conn, task_id: str, *, barrier: str = "publish") -> Optional[dict]:
+    row = conn.execute("SELECT * FROM task_release_barriers WHERE task_id=? AND barrier=?", (task_id, barrier)).fetchone()
+    if not row: return None
+    return {"task_id": task_id, "barrier": barrier, "sha": row["sha"], "manifest_hash": row["manifest_hash"], "required_gates": json.loads(row["required_gates_json"]), "authority": row["authority"], "lease_owner": row["lease_owner"], "lease_expires_at": row["lease_expires_at"], "target_identity": row["target_identity"], "delivery_idempotency_key": row["delivery_idempotency_key"], "delivered_sha": row["delivered_sha"], "readback_sha": row["readback_sha"], "completed_at": row["completed_at"]}
+
+
+def _barrier_control_authority(conn, task_id: str, barrier: str, authority: Optional[str]) -> str:
+    row = conn.execute("SELECT authority FROM task_release_barriers WHERE task_id=? AND barrier=?", (task_id, barrier)).fetchone()
+    if row is None:
+        raise ValueError("release barrier not found")
+    effective = row["authority"] if authority is None else authority
+    _require_control_authority(effective)
+    if effective != row["authority"]:
+        raise ValueError("release barrier authority does not match its immutable creator")
+    return effective
+
+
+def renew_release_barrier_lease(conn, task_id: str, *, barrier: str, owner_token: str, ttl_seconds: int, authority: Optional[str] = None) -> bool:
+    _barrier_control_authority(conn, task_id, barrier, authority)
+    now = int(time.time())
+    with write_txn(conn):
+        cur = conn.execute("UPDATE task_release_barriers SET lease_expires_at=? WHERE task_id=? AND barrier=? AND completed_at IS NULL AND lease_owner=? AND lease_expires_at>=?", (now + max(1, int(ttl_seconds)), task_id, barrier, owner_token, now))
+        return cur.rowcount == 1
+
+
+def release_release_barrier_lease(conn, task_id: str, *, barrier: str, owner_token: str, authority: Optional[str] = None) -> bool:
+    _barrier_control_authority(conn, task_id, barrier, authority)
+    with write_txn(conn):
+        cur = conn.execute("UPDATE task_release_barriers SET lease_owner=NULL, lease_expires_at=NULL WHERE task_id=? AND barrier=? AND completed_at IS NULL AND lease_owner=?", (task_id, barrier, owner_token))
+        return cur.rowcount == 1
+
+
+def acquire_release_barrier_lease(conn: sqlite3.Connection, task_id: str, *, barrier: str, owner_token: str, ttl_seconds: int, authority: Optional[str] = None) -> bool:
+    _barrier_control_authority(conn, task_id, barrier, authority)
+    now = int(time.time()); expiry = now + max(1, int(ttl_seconds))
+    with write_txn(conn):
+        cur = conn.execute("UPDATE task_release_barriers SET lease_owner=?, lease_expires_at=? WHERE task_id=? AND barrier=? AND completed_at IS NULL AND (lease_owner IS NULL OR lease_owner=? OR lease_expires_at<?)", (owner_token, expiry, task_id, barrier, owner_token, now))
+        return cur.rowcount == 1
+
+
+def _owned_barrier(conn, task_id, barrier, owner_token, authority: Optional[str] = None):
+    row = conn.execute("SELECT * FROM task_release_barriers WHERE task_id=? AND barrier=?", (task_id, barrier)).fetchone()
+    if row is None: raise ValueError("release barrier not found")
+    # Legacy internal callers omit authority; their immutable barrier authority
+    # is revalidated rather than accepting a free-form caller label.
+    effective_authority = row["authority"] if authority is None else authority
+    _require_control_authority(effective_authority)
+    if effective_authority != row["authority"]:
+        raise ValueError("release barrier authority does not match its immutable creator")
+    if row["completed_at"] is not None:
+        if row["lease_owner"] != owner_token:
+            raise ValueError("completed release barrier is not owned by this token")
+        return row
+    if row["lease_owner"] != owner_token or int(row["lease_expires_at"] or 0) < int(time.time()): raise ValueError("release barrier lease is not owned")
+    return row
+
+
+def prepare_release_delivery_intent(conn, task_id: str, *, barrier: str, owner_token: str, target_identity: str, candidate_sha: str, idempotency_key: Optional[str] = None, authority: Optional[str] = None) -> dict:
+    """Durably reserve the one external publish identity before it is invoked."""
+    with write_txn(conn):
+        row = _owned_barrier(conn, task_id, barrier, owner_token, authority)
+        target_identity = str(target_identity or "").strip()
+        candidate_sha = str(candidate_sha or "").strip().lower()
+        supplied_key = str(idempotency_key or "").strip()
+        if candidate_sha != row["sha"] or not target_identity:
+            raise ValueError("delivery intent target and exact candidate SHA are required")
+        if _release_gate_state(conn, task_id, row) != "passed":
+            raise ValueError("release delivery requires every current required gate verdict to pass")
+        existing_target = row["target_identity"]
+        existing_key = row["delivery_idempotency_key"]
+        if existing_target is not None or existing_key is not None:
+            if existing_target != target_identity or (supplied_key and existing_key != supplied_key):
+                raise ValueError("release delivery intent is immutable")
+            return {"task_id": task_id, "barrier": barrier, "sha": row["sha"], "target_identity": existing_target, "idempotency_key": existing_key}
+        key = supplied_key or f"release-{secrets.token_hex(16)}"
+        conn.execute(
+            "UPDATE task_release_barriers SET target_identity=?, delivery_idempotency_key=? WHERE task_id=? AND barrier=?",
+            (target_identity, key, task_id, barrier),
+        )
+        return {"task_id": task_id, "barrier": barrier, "sha": row["sha"], "target_identity": target_identity, "idempotency_key": key}
+
+
+def record_release_delivery(conn, task_id: str, *, barrier: str, owner_token: str, target_identity: str, delivered_sha: str, idempotency_key: str, authority: Optional[str] = None) -> None:
+    with write_txn(conn):
+        row = _owned_barrier(conn, task_id, barrier, owner_token, authority)
+        if (
+            delivered_sha != row["sha"]
+            or not str(target_identity).strip()
+            or row["target_identity"] != target_identity
+            or not str(idempotency_key).strip()
+            or row["delivery_idempotency_key"] != idempotency_key
+        ):
+            raise ValueError("release delivery requires its prepared intent, idempotency key, target, and exact candidate SHA")
+        # Delivery is irreversible in the target system.  Do not merely trust
+        # a historical verdict row: every required gate must still be bound to
+        # this exact candidate/manifest and its current terminal run must PASS.
+        if _release_gate_state(conn, task_id, row) != "passed":
+            raise ValueError("release delivery requires every current required gate verdict to pass")
+        if row["delivered_sha"] is not None:
+            if row["delivered_sha"] == delivered_sha:
+                return
+            raise ValueError("release barrier delivery is immutable")
+        if row["completed_at"] is not None:
+            raise ValueError("completed release barrier delivery is immutable")
+        conn.execute("UPDATE task_release_barriers SET delivered_sha=? WHERE task_id=? AND barrier=?", (delivered_sha, task_id, barrier))
+
+
+def _release_gate_state(conn: sqlite3.Connection, task_id: str, row: sqlite3.Row) -> str:
+    """Return passed, rejected, or waiting using the release gate invariants."""
+    required = json.loads(row["required_gates_json"])
+    for gate_task_id in required:
+        try:
+            gate = _validate_gate_task(conn, task_id, gate_task_id)
+        except ValueError:
+            return "waiting"
+        if gate.gate_candidate_sha != row["sha"] or gate.gate_manifest_hash != row["manifest_hash"]:
+            return "waiting"
+    verdicts = {r["gate"]: r for r in conn.execute("SELECT gate, sha, manifest_hash, verdict, gate_run_id FROM task_gate_verdicts WHERE task_id=?", (task_id,))}
+    for gate_task_id in required:
+        verdict = verdicts.get(gate_task_id)
+        latest = conn.execute("SELECT id FROM task_runs WHERE task_id=? AND ended_at IS NOT NULL ORDER BY id DESC LIMIT 1", (gate_task_id,)).fetchone()
+        current = bool(verdict) and verdict["sha"] == row["sha"] and verdict["manifest_hash"] == row["manifest_hash"] and verdict["gate_run_id"] == (latest["id"] if latest else None)
+        if current and verdict["verdict"] == "fail":
+            return "rejected"
+        if not current or verdict["verdict"] != "pass":
+            return "waiting"
+    return "passed"
+
+
+def record_release_readback(conn, task_id: str, *, barrier: str, owner_token: str, readback_sha: str, authority: Optional[str] = None) -> None:
+    with write_txn(conn):
+        row = _owned_barrier(conn, task_id, barrier, owner_token, authority)
+        if readback_sha != row["sha"]: raise ValueError("readback SHA does not match candidate")
+        if not row["target_identity"] or row["delivered_sha"] != row["sha"]:
+            raise ValueError("release readback requires a recorded delivery")
+        if row["completed_at"] is not None:
+            # Exact replay is idempotent; no post-completion row is ever changed.
+            if row["readback_sha"] == readback_sha:
+                return
+            raise ValueError("completed release barrier readback is immutable")
+        conn.execute("UPDATE task_release_barriers SET readback_sha=? WHERE task_id=? AND barrier=?", (readback_sha, task_id, barrier))
+
+
+def reconcile_release_barrier(conn, task_id: str, *, barrier: str, owner_token: str, authority: Optional[str] = None) -> str:
+    with write_txn(conn):
+        row = _owned_barrier(conn, task_id, barrier, owner_token, authority)
+        gate_state = _release_gate_state(conn, task_id, row)
+        if row["completed_at"] is not None:
+            return "released"
+        if gate_state == "rejected": return "rejected"
+        if gate_state != "passed": return "waiting"
+        if not row["target_identity"] or row["delivered_sha"] != row["sha"]: return "awaiting_receipt"
+        if row["readback_sha"] != row["sha"]: return "awaiting_readback"
+        # A release barrier proves delivery of a candidate, not that an unrelated
+        # live execution has settled.  Do not overwrite its lifecycle state.
+        if conn.execute(
+            "SELECT 1 FROM task_runs WHERE task_id=? AND ended_at IS NULL LIMIT 1", (task_id,)
+        ).fetchone() is not None:
+            return "waiting"
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET status='done', completed_at=?, claim_lock=NULL, "
+            "claim_expires=NULL, worker_pid=NULL, current_run_id=NULL, "
+            "wait_kind=NULL, wait_ref=NULL, block_kind=NULL, block_recurrences=0 "
+            "WHERE id=? AND status NOT IN ('done', 'archived')",
+            (now, task_id),
+        )
+        conn.execute("UPDATE tasks SET status='ready' WHERE id IN (SELECT child_id FROM task_links WHERE parent_id=?) AND status IN ('blocked', 'todo') AND NOT EXISTS (SELECT 1 FROM task_links l JOIN tasks p ON p.id=l.parent_id WHERE l.child_id=tasks.id AND p.status!='done')", (task_id,))
+        conn.execute("UPDATE task_release_barriers SET completed_at=? WHERE task_id=? AND barrier=? AND completed_at IS NULL", (now, task_id, barrier))
+        _append_event(conn, task_id, "release_barrier_completed", {"barrier": barrier, "sha": row["sha"]})
+        return "released"
+
+
+def release_barrier(
+    conn: sqlite3.Connection, task_id: str, *, barrier: str, authority: str,
+) -> dict:
+    """Acquire a durable once-only barrier and return its canonical receipt."""
+    barrier = str(barrier or "").strip()
+    authority = str(authority or "").strip()
+    authority = _require_control_authority(authority)
+    if not barrier:
+        raise ValueError("barrier is required")
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT authority, released_at FROM task_release_receipts WHERE task_id=? AND barrier=?",
+            (task_id, barrier),
+        ).fetchone()
+        if row:
+            if row["authority"] != authority:
+                raise ValueError("release barrier authority is immutable")
+            return {"task_id": task_id, "barrier": barrier, "authority": authority,
+                    "released_at": row["released_at"]}
+        if conn.execute("SELECT 1 FROM tasks WHERE id=?", (task_id,)).fetchone() is None:
+            raise ValueError("task not found")
+        released_at = int(time.time())
+        conn.execute(
+            "INSERT INTO task_release_receipts (task_id, barrier, authority, released_at) "
+            "VALUES (?, ?, ?, ?)", (task_id, barrier, authority, released_at),
+        )
+        receipt = {"task_id": task_id, "barrier": barrier, "authority": authority,
+                   "released_at": released_at}
+        _append_event(conn, task_id, "release_barrier", receipt)
+        return receipt
+
+
+def read_release_barrier(
+    conn: sqlite3.Connection, task_id: str, *, barrier: str,
+) -> Optional[dict]:
+    row = conn.execute(
+        "SELECT authority, released_at FROM task_release_receipts WHERE task_id=? AND barrier=?",
+        (task_id, str(barrier or "").strip()),
+    ).fetchone()
+    return ({"task_id": task_id, "barrier": barrier, "authority": row["authority"],
+             "released_at": row["released_at"]} if row else None)
+
+
+def _canonical_wait_ref(conn: sqlite3.Connection, task_id: str, kind: str, ref: str) -> str:
+    """Validate the exact durable target permitted to satisfy a typed wait."""
+    if kind == "dependency":
+        linked = conn.execute(
+            "SELECT 1 FROM task_links l JOIN tasks p ON p.id=l.parent_id "
+            "WHERE l.child_id=? AND l.parent_id=? AND p.status NOT IN ('done', 'archived')",
+            (task_id, ref),
+        ).fetchone()
+        if linked is None:
+            raise ValueError("dependency wait_ref must name a linked unfinished parent task")
+    elif kind == "timer":
+        try:
+            parsed = _dt.datetime.fromisoformat(ref.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError("timer wait_ref must be a canonical timezone-aware ISO timestamp") from exc
+        if parsed.tzinfo is None or parsed.utcoffset() is None or parsed.isoformat().replace("+00:00", "Z") != ref:
+            raise ValueError("timer wait_ref must be a canonical timezone-aware ISO timestamp")
+    elif kind == "external_process":
+        match = re.fullmatch(r"run:([1-9][0-9]*)", ref)
+        if not match or conn.execute("SELECT 1 FROM task_runs WHERE id=? AND owner_kind='external'", (int(match.group(1)),)).fetchone() is None:
+            raise ValueError("external_process wait_ref must be run:<existing external run id>")
+    elif kind == "capability":
+        if not re.fullmatch(r"cap:[a-z][a-z0-9_.-]*", ref): raise ValueError("capability wait_ref must be cap:<name>")
+    elif kind == "human":
+        if not re.fullmatch(r"decision:[a-z][a-z0-9_.-]*", ref): raise ValueError("human wait_ref must be decision:<id>")
+    else:
+        match = re.fullmatch(r"gate:([^:]+)", ref)
+        if not match:
+            raise ValueError("review wait_ref must be gate:<gate-task-id>")
+        _validate_gate_task(
+            conn, task_id, match.group(1), require_terminal_result=False,
+        )
+    return ref
+
+
+def record_wait_receipt(conn: sqlite3.Connection, *, kind: str, ref: str, authority: str, verdict: str) -> bool:
+    """Persist an explicit capability-probe or human-decision receipt once."""
+    kind, ref, authority, verdict = str(kind or "").strip().lower(), str(ref or "").strip(), str(authority or "").strip(), str(verdict or "").strip().lower()
+    if kind not in {"capability", "human"} or not authority:
+        raise ValueError("only capability or human waits accept a named authority receipt")
+    # The dashboard/CLI's label is merely an assertion; only the configured
+    # coordinator process may mint a receipt that resumes work.
+    authority = _require_control_authority(authority)
+    _canonical_wait_ref(conn, "", kind, ref)
+    expected = "available" if kind == "capability" else "approved"
+    if verdict != expected: raise ValueError(f"{kind} receipt verdict must be {expected}")
+    with write_txn(conn):
+        cur = conn.execute("INSERT OR IGNORE INTO task_wait_receipts (kind, ref, authority, verdict, created_at) VALUES (?, ?, ?, ?, ?)", (kind, ref, authority, verdict, int(time.time())))
+    return cur.rowcount == 1
+
+
+def set_task_wait(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    kind: str,
+    ref: str,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Park a task only after binding a kind-specific durable wait target.
+
+    An active attempt is terminally closed in the same transaction before the
+    task is blocked.  ``expected_run_id`` is an optional worker-side CAS guard:
+    a stale worker cannot park a later attempt it no longer owns.
+    """
+    wait_kind, wait_ref = str(kind or "").strip().lower(), str(ref or "").strip()
+    if wait_kind not in WAIT_AUTHORITIES: raise ValueError("wait_kind must be dependency, capability, human, external_process, timer, or review")
+    if not wait_ref: raise ValueError("wait_ref is required")
+    metadata = {"wait_kind": wait_kind, "wait_ref": wait_ref}
+    summary = f"wait set: {wait_kind} {wait_ref}"
+    with write_txn(conn):
+        _canonical_wait_ref(conn, task_id, wait_kind, wait_ref)
+        task = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id=?", (task_id,),
+        ).fetchone()
+        if task is None or task["status"] not in {"ready", "running", "review"}:
+            raise ValueError("task is not waitable")
+        current_run_id = task["current_run_id"]
+        if expected_run_id is not None and current_run_id != expected_run_id:
+            return False
+        if current_run_id is not None:
+            closed = conn.execute(
+                """
+                UPDATE task_runs
+                   SET status='blocked', outcome='blocked', summary=?, metadata=?,
+                       ended_at=?, claim_lock=NULL, claim_expires=NULL, worker_pid=NULL
+                 WHERE id=? AND task_id=? AND ended_at IS NULL
+                """,
+                (summary, json.dumps(metadata, ensure_ascii=False), int(time.time()), current_run_id, task_id),
+            )
+            if closed.rowcount != 1:
+                return False
+            run_id = int(current_run_id)
+        else:
+            run_id = _synthesize_ended_run(
+                conn, task_id, outcome="blocked", summary=summary, metadata=metadata,
+            )
+        changed = conn.execute(
+            """
+            UPDATE tasks
+               SET status='blocked', wait_kind=?, wait_ref=?, block_kind=NULL,
+                   claim_lock=NULL, claim_expires=NULL, worker_pid=NULL,
+                   current_run_id=NULL
+             WHERE id=? AND status=? AND current_run_id IS ?
+            """,
+            (wait_kind, wait_ref, task_id, task["status"], current_run_id),
+        )
+        if changed.rowcount != 1:
+            return False
+        _append_event(
+            conn, task_id, "wait_set", {"kind": wait_kind, "ref": wait_ref}, run_id=run_id,
+        )
+    return True
+
+
+def _wait_is_satisfied(conn: sqlite3.Connection, task_id: str, kind: str, ref: str, authority: Optional[str]) -> bool:
+    if kind == "dependency":
+        return conn.execute("SELECT 1 FROM task_links WHERE parent_id=? AND child_id=?", (ref, task_id)).fetchone() is not None and _parents_satisfied(conn, task_id)
+    if kind == "timer": return _dt.datetime.fromisoformat(ref.replace("Z", "+00:00")).timestamp() <= time.time()
+    if kind == "external_process": return conn.execute("SELECT 1 FROM task_runs WHERE id=? AND owner_kind='external' AND outcome='completed' AND ended_at IS NOT NULL", (int(ref.split(":", 1)[1]),)).fetchone() is not None
+    if kind == "review":
+        match = re.fullmatch(r"gate:([^:]+)", ref)
+        if not match:
+            return False
+        gate_task_id = match.group(1)
+        try:
+            _validate_gate_task(conn, task_id, gate_task_id)
+        except ValueError:
+            return False
+        receipt = get_frozen_evidence_manifest(conn, task_id)
+        if receipt is None:
+            return False
+        row = conn.execute(
+            "SELECT authority FROM task_gate_verdicts "
+            "WHERE task_id=? AND gate=? AND sha=? AND manifest_hash=? AND verdict='pass' "
+            "AND gate_run_id=(SELECT id FROM task_runs WHERE task_id=? "
+            "AND ended_at IS NOT NULL ORDER BY id DESC LIMIT 1)",
+            (task_id, gate_task_id, receipt["sha"], receipt["manifest_hash"], gate_task_id),
+        ).fetchone()
+        return row is not None and (authority is None or row["authority"] == authority)
+    expected = "available" if kind == "capability" else "approved"
+    return conn.execute("SELECT 1 FROM task_wait_receipts WHERE kind=? AND ref=? AND authority=? AND verdict=?", (kind, ref, authority, expected)).fetchone() is not None
+
+
+def resume_task_wait(conn: sqlite3.Connection, task_id: str, *, authority: str, receipt: Optional[str] = None) -> bool:
+    """Resume only from the exact bound fact and its authority, never a label."""
+    with write_txn(conn):
+        row = conn.execute("SELECT wait_kind, wait_ref FROM tasks WHERE id=? AND status='blocked'", (task_id,)).fetchone()
+        if not row or row["wait_kind"] not in WAIT_AUTHORITIES: return False
+        kind, ref, supplied = row["wait_kind"], row["wait_ref"], str(authority or "").strip()
+        if str(receipt or "").strip() != ref: return False
+        if kind in {"dependency", "timer", "external_process"} and supplied.lower() != WAIT_AUTHORITIES[kind]: return False
+        if kind in {"capability", "human"}:
+            try:
+                supplied = _require_control_authority(supplied)
+            except ValueError:
+                return False
+        if not _wait_is_satisfied(conn, task_id, kind, ref, supplied): return False
+        changed = conn.execute("UPDATE tasks SET status='ready', wait_kind=NULL, wait_ref=NULL WHERE id=? AND status='blocked' AND wait_kind=? AND wait_ref=?", (task_id, kind, ref))
+        if changed.rowcount != 1: return False
+        _append_event(conn, task_id, "wait_resumed", {"kind": kind, "ref": ref, "authority": supplied})
+        return True
+
+
+def reconcile_task_waits(conn: sqlite3.Connection) -> int:
+    """Auto-resume dispatcher-owned waits only after their exact fact is true."""
+    resumed = 0
+    for row in conn.execute("SELECT id, wait_kind, wait_ref FROM tasks WHERE status='blocked' AND wait_kind IS NOT NULL").fetchall():
+        kind, ref = row["wait_kind"], row["wait_ref"]
+        if kind == "human": continue
+        authority = WAIT_AUTHORITIES.get(kind)
+        if kind == "capability":
+            receipt = conn.execute("SELECT authority FROM task_wait_receipts WHERE kind='capability' AND ref=? AND verdict='available' ORDER BY created_at, authority LIMIT 1", (ref,)).fetchone()
+            authority = receipt["authority"] if receipt else None
+        elif kind == "review":
+            match = re.fullmatch(r"gate:([^:]+)", ref)
+            if not match:
+                continue
+            manifest = get_frozen_evidence_manifest(conn, row["id"])
+            if manifest is None:
+                continue
+            receipt = conn.execute(
+                "SELECT authority FROM task_gate_verdicts "
+                "WHERE task_id=? AND gate=? AND sha=? AND manifest_hash=? AND verdict='pass' "
+                "AND gate_run_id=(SELECT id FROM task_runs WHERE task_id=? "
+                "AND ended_at IS NOT NULL ORDER BY id DESC LIMIT 1)",
+                (row["id"], match.group(1), manifest["sha"], manifest["manifest_hash"], match.group(1)),
+            ).fetchone()
+            authority = receipt["authority"] if receipt else None
+        if authority and resume_task_wait(conn, row["id"], authority=authority, receipt=ref): resumed += 1
+    return resumed
+
 def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return whether every direct parent is terminal for dependency gating."""
     return conn.execute(
@@ -4641,6 +6386,12 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        owner = conn.execute(
+            "SELECT owner_kind FROM tasks WHERE id = ? AND status = 'ready' AND claim_lock IS NULL",
+            (task_id,),
+        ).fetchone()
+        if owner is None or owner["owner_kind"] != "agent":
+            return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -4696,6 +6447,7 @@ def claim_task(
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
+               AND owner_kind = 'agent'
             """,
             (lock, expires, now, task_id),
         )
@@ -4769,6 +6521,12 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        owner = conn.execute(
+            "SELECT owner_kind FROM tasks WHERE id = ? AND status = 'review' AND claim_lock IS NULL",
+            (task_id,),
+        ).fetchone()
+        if owner is None or owner["owner_kind"] != "agent":
+            return None
         if not _parents_satisfied(conn, task_id):
             demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo' "
@@ -4796,6 +6554,7 @@ def claim_review_task(
              WHERE id = ?
                AND status = 'review'
                AND claim_lock IS NULL
+               AND owner_kind = 'agent'
             """,
             (lock, expires, now, task_id),
         )
@@ -5200,6 +6959,8 @@ def reassign_task(
     *,
     reclaim_first: bool = False,
     reason: Optional[str] = None,
+    owner_kind: Optional[str] = None,
+    activate_agent: bool = False,
 ) -> bool:
     """Reassign a task, optionally reclaiming a stuck running worker first.
 
@@ -5217,7 +6978,10 @@ def reassign_task(
         reclaim_task(conn, task_id, reason=reason or "reassign")
     # assign_task handles its own txn + the still-running guard.
     try:
-        return assign_task(conn, task_id, profile)
+        return assign_task(
+            conn, task_id, profile, owner_kind=owner_kind,
+            activate_agent=activate_agent,
+        )
     except RuntimeError:
         # Task is still running and reclaim_first was False; caller
         # needs to decide whether to retry with reclaim.
@@ -5446,9 +7210,29 @@ def complete_task(
         if not _parents_satisfied(conn, task_id):
             return False
         prior = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?",
+            "SELECT t.status, t.task_kind, t.assignee, t.current_run_id, "
+            "r.owner_kind, r.profile AS run_profile FROM tasks t "
+            "LEFT JOIN task_runs r ON r.id=t.current_run_id "
+            "WHERE t.id=?",
             (task_id,),
         ).fetchone()
+        # Mandatory reviewer/visual QA gates are worker-only transitions.
+        # Caller metadata is evidence, not authority: bind the exact active
+        # run and its immutable dispatcher profile at the DB boundary.
+        if prior is not None and prior["task_kind"] in {"reviewer", "visualqa"}:
+            runtime_profile = str(os.environ.get("HERMES_PROFILE") or "").strip()
+            if (
+                expected_run_id is None
+                or prior["current_run_id"] != int(expected_run_id)
+                or not runtime_profile
+                or runtime_profile != prior["assignee"]
+                or runtime_profile != prior["run_profile"]
+            ):
+                return False
+        # A live external run has an owner-CAS completion protocol.  Direct
+        # completion must never forge its terminal state or bypass that owner.
+        if prior is not None and prior["owner_kind"] == "external":
+            return False
         prior_status = prior["status"] if prior else None
         if expected_run_id is None:
             cur = conn.execute(
@@ -6326,7 +8110,9 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
-                       block_kind    = ?
+                       block_kind    = ?,
+                       wait_kind     = NULL,
+                       wait_ref      = NULL
                  WHERE id = ?
                    AND status IN ('running', 'ready')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
@@ -6384,6 +8170,8 @@ def block_task(
                        claim_expires = NULL,
                        worker_pid    = NULL,
                        block_kind    = ?,
+                       wait_kind     = NULL,
+                       wait_ref      = NULL,
                        block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
@@ -6423,6 +8211,8 @@ def block_task(
                            claim_expires = NULL,
                            worker_pid    = NULL,
                            block_kind    = ?,
+                           wait_kind     = NULL,
+                           wait_ref      = NULL,
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
@@ -6438,6 +8228,8 @@ def block_task(
                            claim_expires = NULL,
                            worker_pid    = NULL,
                            block_kind    = ?,
+                           wait_kind     = NULL,
+                           wait_ref      = NULL,
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
@@ -8197,6 +9989,15 @@ def reap_worker_zombies() -> "list[int]":
     return reaped
 
 
+def _host_pid_identity_matches(pid: int, start_ticks: int) -> bool:
+    """True only for the same live host process, never an arbitrary PID."""
+    try:
+        from gateway.status import get_process_start_time
+        return _pid_alive(pid) and get_process_start_time(pid) == start_ticks
+    except Exception:
+        return False
+
+
 def _pid_alive(pid: Optional[int]) -> bool:
     """Return True if ``pid`` is still running on this host.
 
@@ -8715,9 +10516,11 @@ def reconcile_orphaned_running(
     now = int(time.time())
     reconciled: list[str] = []
     rows = conn.execute(
-        "SELECT id, claim_lock, claim_expires, worker_pid FROM tasks "
-        "WHERE status = 'running' "
-        "  AND (claim_lock IS NULL OR claim_expires IS NULL)"
+        "SELECT t.id, t.claim_lock, t.claim_expires, t.worker_pid FROM tasks t "
+        "LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.status = 'running' "
+        "  AND (t.claim_lock IS NULL OR t.claim_expires IS NULL) "
+        "  AND (r.owner_kind IS NULL OR r.owner_kind != 'external')"
     ).fetchall()
     for row in rows:
         tid = row["id"]
@@ -9980,6 +11783,12 @@ def _dispatch_once_locked(
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
+    # External lanes have no local worker PID; reconcile their heartbeat lease
+    # while holding this board's dispatch lock before eligible tasks are promoted.
+    reconcile_stale_external_runs(conn)
+    # Typed waits are reconciled under the same board-scoped dispatch lock as
+    # every other automatic state transition.
+    reconcile_task_waits(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
     # Count tasks already running so max_spawn enforces concurrency rather
@@ -10045,8 +11854,10 @@ def _dispatch_once_locked(
             spawn_budget = 1
 
     ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
-        "WHERE status = 'ready' AND claim_lock IS NULL "
+        "SELECT id, assignee, owner_kind, owner_kind_explicit FROM tasks "
+        "WHERE status = 'ready' AND claim_lock IS NULL AND "
+        "(owner_kind='agent' OR (owner_kind='no_agent' AND owner_kind_explicit=0 "
+        "AND (assignee IS NULL OR assignee=''))) "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     # Review rows are enumerated up front (not after the ready loop) so the
@@ -10055,7 +11866,7 @@ def _dispatch_once_locked(
     if review_dispatch_enabled():
         review_rows = conn.execute(
             "SELECT id, assignee FROM tasks "
-            "WHERE status = 'review' AND claim_lock IS NULL "
+            "WHERE status = 'review' AND claim_lock IS NULL AND owner_kind='agent' "
             "ORDER BY priority DESC, created_at ASC"
         ).fetchall()
     # Review-lane reservation (OOF-30 review finding): the ready loop runs
@@ -10144,11 +11955,15 @@ def _dispatch_once_locked(
                 if not dry_run:
                     try:
                         with write_txn(conn):
-                            conn.execute(
-                                "UPDATE tasks SET assignee = ? WHERE id = ? "
-                                "AND (assignee IS NULL OR assignee = '')",
+                            changed = conn.execute(
+                                "UPDATE tasks SET assignee=?, owner_kind='agent' WHERE id=? "
+                                "AND status='ready' AND claim_lock IS NULL AND owner_kind='no_agent' "
+                                "AND owner_kind_explicit=0 AND (assignee IS NULL OR assignee='')",
                                 (_default_assignee, row["id"]),
                             )
+                            if changed.rowcount != 1:
+                                result.skipped_unassigned.append(row["id"])
+                                continue
                             _append_event(
                                 conn, row["id"], "assigned",
                                 {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -629,6 +629,7 @@ def _apply_profile_override() -> None:
     hermes_home_env = os.environ.get("HERMES_HOME", "")
     if profile_name is None and hermes_home_env:
         if Path(hermes_home_env).parent.name == "profiles":
+            os.environ["HERMES_PROFILE"] = Path(hermes_home_env).name
             return
 
     # 2. If no flag, check active_profile in the hermes root.
@@ -678,10 +679,13 @@ def _apply_profile_override() -> None:
             )
             return
         os.environ["HERMES_HOME"] = hermes_home
+        os.environ["HERMES_PROFILE"] = profile_name
         # Strip the flag from argv so argparse doesn't choke
         if consume > 0 and profile_index is not None:
             start = profile_index + 1  # +1 because argv is sys.argv[1:]
             sys.argv = sys.argv[:start] + sys.argv[start + consume :]
+    else:
+        os.environ["HERMES_PROFILE"] = "default"
 
 
 _apply_profile_override()

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -391,8 +391,12 @@ def get_profile_dir(name: str) -> Path:
 
 
 def profile_exists(name: str) -> bool:
-    """Check whether a live (non-tombstoned) profile directory exists."""
-    canon = normalize_profile_name(name)
+    """Check whether a live, safely named profile directory exists."""
+    try:
+        canon = normalize_profile_name(name)
+        validate_profile_name(canon)
+    except (TypeError, ValueError):
+        return False
     if canon == "default":
         return True
     profile_dir = get_profile_dir(canon)

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2992,6 +2992,39 @@
     return "";
   }
 
+  function ExternalRunDetails(props) {
+    const run = props.run;
+    if (!run) return null;
+    const progress = (run.current != null && run.total != null)
+      ? `${run.current}/${run.total}` : null;
+    const heartbeat = run.heartbeat_status || "stale";
+    const phase = run.phase || "external";
+    return h("div", {
+      className: cn(
+        props.compact ? "hermes-kanban-external-run-card" : "hermes-kanban-external-run-detail",
+        "hermes-kanban-external-run--" + heartbeat,
+      ),
+      title: `External run ${run.external_id || run.id || ""}: ${heartbeat}`,
+    },
+      props.compact
+        ? [
+            h("span", { key: "phase", className: "hermes-kanban-external-run-phase" }, phase),
+            progress ? h("span", { key: "progress", className: "hermes-kanban-external-run-progress" }, progress) : null,
+            h("span", { key: "heartbeat", className: "hermes-kanban-external-run-heartbeat" }, heartbeat),
+          ]
+        : [
+            h("div", { key: "head", className: "hermes-kanban-external-run-head" }, "External run"),
+            run.owner ? h("div", { key: "owner" }, `Owner: ${run.owner}`) : null,
+            run.external_id ? h("div", { key: "id" }, `ID: ${run.external_id}`) : null,
+            h("div", { key: "phase" }, `Phase: ${phase}`),
+            progress ? h("div", { key: "progress" }, `Progress: ${progress}`) : null,
+            h("div", { key: "heartbeat" }, `Heartbeat: ${heartbeat}`),
+            run.log_ref ? h("div", { key: "log" }, "Log reference: ", h("code", null, run.log_ref)) : null,
+            run.result_ref ? h("div", { key: "result" }, "Result reference: ", h("code", null, run.result_ref)) : null,
+          ],
+    );
+  }
+
   function TaskCard(props) {
     const { t: i18n } = useI18n();
     const t = props.task;
@@ -3122,6 +3155,7 @@
                   title: tx(i18n, "needsAssigneeHint", "Dependencies are satisfied, but the dispatcher skips this task until you assign a profile."),
                 }, tx(i18n, "needsAssignee", "Needs assignee"))
               : null,
+            t.external_run ? h(ExternalRunDetails, { run: t.external_run, compact: true }) : null,
           ),
           h("div", { className: "hermes-kanban-card-title" },
             t.title || tx(i18n, "untitled", "(untitled)")),
@@ -3914,6 +3948,7 @@
         }) : null,
         t.created_by ? h(MetaRow, { label: tx(i18n, "createdBy", "Created by"), value: t.created_by }) : null,
       ),
+      t.external_run ? h(ExternalRunDetails, { run: t.external_run }) : null,
       h(StatusActions, {
         task: t,
         onPatch: props.onPatch,
@@ -4125,6 +4160,7 @@
             h("span", { className: "hermes-kanban-run-ago" },
               timeAgo ? timeAgo(r.started_at) : ""),
           ),
+          r.external_run ? h(ExternalRunDetails, { run: r.external_run }) : null,
           r.summary
             ? h("div", { className: "hermes-kanban-run-summary" }, r.summary)
             : null,

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -280,6 +280,41 @@
   gap: 0.55rem;
 }
 
+/* Durable external execution status is read-only visibility, not a control. */
+.hermes-kanban-external-run-card,
+.hermes-kanban-external-run-detail {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 0.25rem);
+  font-size: 0.68rem;
+  line-height: 1.35;
+}
+.hermes-kanban-external-run-card {
+  padding: 0.1rem 0.3rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+.hermes-kanban-external-run-detail {
+  padding: 0.45rem 0.55rem;
+  flex-direction: column;
+  align-items: stretch;
+}
+.hermes-kanban-external-run-head { font-weight: 600; }
+.hermes-kanban-external-run-phase,
+.hermes-kanban-external-run-progress { color: var(--color-foreground); }
+.hermes-kanban-external-run-heartbeat { text-transform: uppercase; font-size: 0.62rem; }
+.hermes-kanban-external-run--healthy {
+  border-color: color-mix(in srgb, #3fb97d 55%, var(--color-border));
+  background: color-mix(in srgb, #3fb97d 10%, transparent);
+}
+.hermes-kanban-external-run--stale {
+  border-color: color-mix(in srgb, var(--color-warning, #d4b348) 60%, var(--color-border));
+  background: color-mix(in srgb, var(--color-warning, #d4b348) 12%, transparent);
+}
+.hermes-kanban-external-run--finished { opacity: 0.75; }
+
 .hermes-kanban-priority {
   font-size: 0.6rem !important;
   padding: 0.05rem 0.3rem !important;

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import sqlite3
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -213,6 +214,34 @@ def _attachment_dict(a: kanban_db.Attachment) -> dict[str, Any]:
     }
 
 
+def _external_run_view(r: kanban_db.Run, *, now: Optional[int] = None) -> Optional[dict[str, Any]]:
+    """Return the safe durable identity for an external run, or ``None``.
+
+    This is deliberately built from persisted DB facts rather than process
+    registry state: a board remains truthful after the initiating worker exits.
+    """
+    if r.owner_kind != "external":
+        return None
+    now = int(time.time()) if now is None else now
+    heartbeat_age = max(0, now - r.last_heartbeat_at) if r.last_heartbeat_at else None
+    heartbeat_status = (
+        "finished" if r.ended_at is not None
+        else ("stale" if heartbeat_age is None or heartbeat_age > 300 else "healthy")
+    )
+    policy = r.metadata or {}
+    return {
+        "id": r.id, "owner": r.owner, "external_id": r.external_id,
+        "pid": r.worker_pid, "phase": r.phase, "current": r.progress_current,
+        "total": r.progress_total, "last_heartbeat_at": r.last_heartbeat_at,
+        "heartbeat_age_seconds": heartbeat_age, "heartbeat_status": heartbeat_status,
+        "log_ref": r.log_ref, "result_ref": r.result_ref,
+        "retry_policy": {"max_retries": policy.get("max_retries")},
+        "success_failure_policy": {
+            "on_success": policy.get("on_success"), "on_failure": policy.get("on_failure"),
+        },
+    }
+
+
 def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
     """Serialise a Run for the drawer's Run history section."""
     return {
@@ -232,6 +261,15 @@ def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
         "summary": r.summary,
         "metadata": r.metadata,
         "error": r.error,
+        "owner_kind": r.owner_kind,
+        "owner": r.owner,
+        "external_id": r.external_id,
+        "phase": r.phase,
+        "current": r.progress_current,
+        "total": r.progress_total,
+        "log_ref": r.log_ref,
+        "result_ref": r.result_ref,
+        "external_run": _external_run_view(r),
     }
 
 
@@ -461,6 +499,13 @@ def get_board(
         # for boards with hundreds of tasks). Truncated to a card-size
         # preview here — the full text is available via /tasks/:id.
         summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
+        active_external_by_task = {
+            row["task_id"]: _external_run_view(kanban_db.Run.from_row(row))
+            for row in conn.execute(
+                "SELECT r.* FROM task_runs r JOIN tasks t ON t.current_run_id=r.id "
+                "WHERE r.owner_kind='external' AND r.ended_at IS NULL"
+            ).fetchall()
+        }
 
         for t in tasks:
             full = summary_map.get(t.id)
@@ -468,6 +513,7 @@ def get_board(
                 full[:_CARD_SUMMARY_PREVIEW_CHARS] if full else None
             )
             d = _task_dict(t, latest_summary=preview)
+            d["external_run"] = active_external_by_task.get(t.id)
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
@@ -549,6 +595,11 @@ def get_task(
         # a second round-trip. Cards on /board carry a 200-char preview.
         full_summary = kanban_db.latest_summary(conn, task_id)
         task_d = _task_dict(task, latest_summary=full_summary)
+        active_run = (
+            kanban_db.get_external_run(conn, task.current_run_id)
+            if task.current_run_id is not None else None
+        )
+        task_d["external_run"] = _external_run_view(active_run) if active_run else None
         links = _links_for(conn, task_id)
         child_ids = links["children"]
         child_summaries = kanban_db.latest_summaries(conn, child_ids)
@@ -596,6 +647,152 @@ def get_task(
 # POST /tasks
 # ---------------------------------------------------------------------------
 
+class ExternalRunStartBody(BaseModel):
+    owner: str
+    external_id: str
+    pid: Optional[int] = None
+    phase: Optional[str] = None
+    current: Optional[int] = None
+    total: Optional[int] = None
+    log_ref: Optional[str] = None
+    result_ref: Optional[str] = None
+    max_retries: Optional[int] = None
+    on_success: str = "complete"
+    on_failure: str = "block"
+
+
+class ExternalRunHeartbeatBody(BaseModel):
+    owner: str
+    phase: Optional[str] = None
+    current: Optional[int] = None
+    total: Optional[int] = None
+    log_ref: Optional[str] = None
+    result_ref: Optional[str] = None
+
+
+class ExternalRunTransferBody(BaseModel):
+    from_owner: str
+    to_owner: str
+
+
+class ExternalRunFinishBody(BaseModel):
+    owner: str
+    outcome: str
+    result_ref: Optional[str] = None
+
+
+def _external_run_or_404(conn: sqlite3.Connection, run_id: int) -> kanban_db.Run:
+    run = kanban_db.get_external_run(conn, run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="external run not found on this board")
+    return run
+
+
+@router.get("/tasks/{task_id}/external-runs")
+def list_task_external_runs(task_id: str, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        if kanban_db.get_task(conn, task_id) is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        rows = conn.execute(
+            "SELECT * FROM task_runs WHERE task_id=? AND owner_kind='external' ORDER BY id",
+            (task_id,),
+        ).fetchall()
+        return {"runs": [_external_run_view(kanban_db.Run.from_row(row)) for row in rows]}
+    finally:
+        conn.close()
+
+
+@router.post("/tasks/{task_id}/external-runs")
+def start_external_run_endpoint(task_id: str, payload: ExternalRunStartBody, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        run = kanban_db.start_external_run(
+            conn, task_id, owner=payload.owner, external_id=payload.external_id,
+            pid=payload.pid, phase=payload.phase, current=payload.current, total=payload.total,
+            log_ref=payload.log_ref, result_ref=payload.result_ref,
+            max_retries=payload.max_retries, on_success=payload.on_success, on_failure=payload.on_failure,
+        )
+        return {"run": _external_run_view(run)}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    finally:
+        conn.close()
+
+
+@router.post("/external-runs/reconcile")
+def reconcile_external_runs_endpoint(stale_after: int = Query(300, ge=1), board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        return {"reconciled": kanban_db.reconcile_stale_external_runs(conn, stale_after_seconds=stale_after)}
+    finally:
+        conn.close()
+
+
+@router.get("/external-runs/{run_id}")
+def show_external_run_endpoint(run_id: int, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        return {"run": _external_run_view(_external_run_or_404(conn, run_id))}
+    finally:
+        conn.close()
+
+
+@router.post("/external-runs/{run_id}/heartbeat")
+def heartbeat_external_run_endpoint(run_id: int, payload: ExternalRunHeartbeatBody, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        _external_run_or_404(conn, run_id)
+        ok = kanban_db.heartbeat_external_run(
+            conn, run_id, owner=payload.owner, phase=payload.phase, current=payload.current,
+            total=payload.total, log_ref=payload.log_ref, result_ref=payload.result_ref,
+        )
+        if not ok:
+            raise HTTPException(status_code=409, detail="external run is terminal or not owned by supplied owner")
+        return {"run": _external_run_view(_external_run_or_404(conn, run_id))}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    finally:
+        conn.close()
+
+
+@router.post("/external-runs/{run_id}/transfer")
+def transfer_external_run_endpoint(run_id: int, payload: ExternalRunTransferBody, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        _external_run_or_404(conn, run_id)
+        ok = kanban_db.transfer_external_run_owner(conn, run_id, from_owner=payload.from_owner, to_owner=payload.to_owner)
+        if not ok:
+            raise HTTPException(status_code=409, detail="external run is terminal or not owned by supplied owner")
+        return {"run": _external_run_view(_external_run_or_404(conn, run_id))}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    finally:
+        conn.close()
+
+
+@router.post("/external-runs/{run_id}/finish")
+def finish_external_run_endpoint(run_id: int, payload: ExternalRunFinishBody, board: Optional[str] = Query(None)):
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        _external_run_or_404(conn, run_id)
+        ok = kanban_db.finish_external_run(conn, run_id, owner=payload.owner, outcome=payload.outcome, result_ref=payload.result_ref)
+        if not ok:
+            raise HTTPException(status_code=409, detail="external run is terminal or not owned by supplied owner")
+        return {"run": _external_run_view(_external_run_or_404(conn, run_id))}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    finally:
+        conn.close()
+
+
 class CreateTaskBody(BaseModel):
     title: str
     body: Optional[str] = None
@@ -619,10 +816,31 @@ class CreateTaskBody(BaseModel):
     # Explicit project link; when omitted, create_task inherits the board's
     # scoped project (if any) so a project-scoped board anchors every task.
     project_id: Optional[str] = None
+    # None means the shipped UI omitted this field. Preserve that omission so
+    # create_task can infer agent ownership for assigned cards and implicit
+    # no_agent ownership for unassigned cards.
+    owner_kind: Optional[str] = None
+    task_kind: str = "ordinary"
+    purpose: Optional[str] = None
+    created_by_task_id: Optional[str] = None
+    created_by_run_id: Optional[int] = None
+    creation_authority: Optional[str] = None
+    gate_candidate_sha: Optional[str] = None
+    gate_manifest_hash: Optional[str] = None
 
 
 @router.post("/tasks")
 def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
+    # Public JSON is never an authority channel. Bind this dashboard process to
+    # its real runtime profile; a supplied field can only assert that identity.
+    task_kind = str(payload.task_kind or "ordinary").strip().lower()
+    runtime_profile = str(os.environ.get("HERMES_PROFILE") or "").strip()
+    if payload.creation_authority and payload.creation_authority != runtime_profile:
+        raise HTTPException(
+            status_code=400,
+            detail="creation_authority must equal dashboard runtime HERMES_PROFILE",
+        )
+    creation_authority = runtime_profile or None
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -647,6 +865,14 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,
             project_id=payload.project_id,
+            owner_kind=payload.owner_kind,
+            task_kind=task_kind,
+            purpose=payload.purpose,
+            created_by_task_id=payload.created_by_task_id,
+            created_by_run_id=payload.created_by_run_id,
+            creation_authority=creation_authority,
+            gate_candidate_sha=payload.gate_candidate_sha,
+            gate_manifest_hash=payload.gate_manifest_hash,
             board=board,
         )
         task = kanban_db.get_task(conn, task_id)
@@ -829,6 +1055,7 @@ def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
 class UpdateTaskBody(BaseModel):
     status: Optional[str] = None
     assignee: Optional[str] = None
+    owner_kind: Optional[str] = None  # immutable; checked when assignment changes
     priority: Optional[int] = None
     title: Optional[str] = None
     body: Optional[str] = None
@@ -880,16 +1107,32 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             payload.status == "review" and payload.assignee is not None
         )
 
+        # An explicit owner_kind is never a harmless ignored PATCH field. Route
+        # it through the DB boundary even when the assignee is unchanged.
+        if payload.owner_kind is not None and payload.assignee is None:
+            try:
+                ok = kanban_db.assign_task(
+                    conn, task_id, task.assignee, owner_kind=payload.owner_kind,
+                )
+            except RuntimeError as e:
+                raise HTTPException(status_code=409, detail=str(e))
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+            if not ok:
+                raise HTTPException(status_code=404, detail="task not found")
+
         # --- assignee ----------------------------------------------------
         # For a combined assignee+review patch, request_review must capture
         # the current implementer before routing the task to the reviewer.
         if payload.assignee is not None and not review_assignee_deferred:
             try:
                 ok = kanban_db.assign_task(
-                    conn, task_id, payload.assignee or None,
+                    conn, task_id, payload.assignee or None, owner_kind=payload.owner_kind,
                 )
             except RuntimeError as e:
                 raise HTTPException(status_code=409, detail=str(e))
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
             if not ok:
                 raise HTTPException(status_code=404, detail="task not found")
 
@@ -1844,7 +2087,11 @@ def specify_task_endpoint(
 
 class ReassignBody(BaseModel):
     profile: Optional[str] = None  # "" or None = unassign
+    owner_kind: Optional[str] = None  # immutable; explicit value is verified
     reclaim_first: bool = False
+    # Explicit trusted routing action: only an implicit, intentionally
+    # unassigned manual lane may become dispatchable agent work again.
+    activate_agent: bool = False
     reason: Optional[str] = None
 
 
@@ -1864,12 +2111,17 @@ def reassign_task_endpoint(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.reassign_task(
-            conn, task_id,
-            payload.profile or None,
-            reclaim_first=bool(payload.reclaim_first),
-            reason=payload.reason,
-        )
+        try:
+            ok = kanban_db.reassign_task(
+                conn, task_id,
+                payload.profile or None,
+                reclaim_first=bool(payload.reclaim_first),
+                reason=payload.reason,
+                owner_kind=payload.owner_kind,
+                activate_agent=bool(payload.activate_agent),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
         if not ok:
             raise HTTPException(
                 status_code=409,

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -54,6 +54,17 @@ def test_nudge_when_no_terminal_tool(clear_kanban_env):
     assert "protocol violation" in nudge.lower() or "protocol" in nudge.lower()
 
 
+def test_no_nudge_after_successful_process_transfer(clear_kanban_env):
+    """A durable process transfer is an intentional terminal worker handoff."""
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = [
+        {"role": "assistant", "tool_calls": [{"function": {"name": "process"}}]},
+        {"role": "tool", "name": "process", "content": '{"status":"transferred","run_id":9}'},
+    ]
+    assert session_called_kanban_terminal(messages) is True
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
 def test_no_nudge_after_kanban_complete(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
     messages = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1752,3 +1752,53 @@ def _moa_caches_isolated():
     yield
     moa._preset_cache.clear()
     moa._runtime_cache.clear()
+
+
+# Legacy Kanban tests use these established, readable agent identities without
+# defining a local profile fixture. Keep that compatibility setup finite: profile
+# admission tests must exercise the real absence of every name not listed here.
+# In particular, never derive this set from a task's assignee or a queried value.
+_KANBAN_TEST_PROFILE_ALLOWLIST = frozenset({
+    "a", "alice", "alpha", "b", "beta", "bob", "builder", "coder",
+    "coordinator", "dashboard", "default", "dev", "elias", "engineer", "factory",
+    "fallback", "implementer", "independent-reviewer", "known", "orch",
+    "manual-reviewer", "ops", "orchestrator", "peer", "planner", "qa",
+    "release", "release-operator", "researcher", "researcher-a", "researcher-b",
+    "reviewer", "security", "setup", "some-profile", "swarm-orchestrator",
+    "test-worker", "w", "w1", "worker", "worker-a", "worker-b", "worker-d",
+    "worker1", "writer", "x", "broken", "ccreviewer", "operator", "publisher",
+})
+
+
+@pytest.fixture(autouse=True)
+def _materialize_kanban_assignee_profiles(request, monkeypatch, _hermetic_environment):
+    """Create only established positive-test Kanban profiles in each test home.
+
+    This fixture deliberately does not intercept ``profile_exists``. An
+    unlisted name, including malformed, traversal, missing, or random input,
+    remains absent so profile-admission tests exercise production behavior.
+    Some local fixtures replace HERMES_HOME after autouse setup; mirror the
+    same finite profiles into that new test home at the moment it is selected.
+    Tests needing another positive identity should create it in a local fixture
+    or add a deliberate, established name to the finite allowlist above.
+    """
+    if "test_kanban" not in request.node.fspath.basename:
+        yield
+        return
+
+    from hermes_cli import profiles
+
+    def materialize_allowlisted_profiles() -> None:
+        for profile_name in _KANBAN_TEST_PROFILE_ALLOWLIST - {"default"}:
+            profiles.get_profile_dir(profile_name).mkdir(parents=True, exist_ok=True)
+
+    materialize_allowlisted_profiles()
+    original_setenv = pytest.MonkeyPatch.setenv
+
+    def setenv_and_materialize(self, name, value, *args, **kwargs):
+        original_setenv(self, name, value, *args, **kwargs)
+        if name == "HERMES_HOME":
+            materialize_allowlisted_profiles()
+
+    monkeypatch.setattr(pytest.MonkeyPatch, "setenv", setenv_and_materialize)
+    yield

--- a/tests/gateway/test_kanban_reconcile_orphans.py
+++ b/tests/gateway/test_kanban_reconcile_orphans.py
@@ -115,6 +115,20 @@ class TestReconcileOrphanedRunning:
             "SELECT status FROM tasks WHERE id=?", (tid,)
         ).fetchone()["status"] == "running"
 
+    def test_external_running_task_with_null_expiry_is_not_an_orphan(self, conn):
+        """External claims intentionally have no lease expiry."""
+        tid = kb.create_task(
+            conn, title="external", assignee="ci", owner_kind="external",
+        )
+        run = kb.start_external_run(
+            conn, tid, owner="ci", external_id="build-1",
+        )
+
+        assert kb.reconcile_orphaned_running(conn) == []
+        task = kb.get_task(conn, tid)
+        assert task is not None and task.status == "running"
+        assert task.current_run_id == run.id
+
     def test_live_worker_pid_defers_reconcile(self, conn):
         """If the orphan row still records a live PID on this host, don't
         requeue beside a possibly-alive worker — defer to the next tick."""

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -19,7 +19,7 @@ from types import SimpleNamespace
 
 def _run_apply_profile_override(
     tmp_path, monkeypatch, *, hermes_home: str | None, active_profile: str | None,
-    argv: list[str] | None = None,
+    argv: list[str] | None = None, hermes_profile: str | None = None,
 ):
     """Run _apply_profile_override in isolation.
 
@@ -40,6 +40,10 @@ def _run_apply_profile_override(
         monkeypatch.setenv("HERMES_HOME", hermes_home)
     else:
         monkeypatch.delenv("HERMES_HOME", raising=False)
+    if hermes_profile is None:
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_PROFILE", hermes_profile)
 
     monkeypatch.setattr(sys, "argv", argv or ["hermes", "gateway", "start"])
 
@@ -84,6 +88,7 @@ class TestApplyProfileOverrideHermesHomeGuard:
         assert result.endswith("coder"), (
             f"Expected HERMES_HOME to end with 'coder', got: {result!r}"
         )
+        assert os.environ.get("HERMES_PROFILE") == "coder"
 
 
     def test_sudo_explicit_profile_resolves_invoking_users_profile(self, tmp_path, monkeypatch):
@@ -108,6 +113,7 @@ class TestApplyProfileOverrideHermesHomeGuard:
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") == str(profile_dir)
+        assert os.environ.get("HERMES_PROFILE") == "elias"
         assert sys.argv == ["hermes", "gateway", "install", "--system"]
 
 
@@ -141,6 +147,20 @@ class TestSupervisedChildIgnoresStickyProfile:
 
         assert result is not None
         assert result.endswith("briefer")
+        assert os.environ.get("HERMES_PROFILE") == "briefer"
+
+    def test_inherited_profile_home_sets_runtime_profile(self, tmp_path, monkeypatch):
+        profile = tmp_path / ".hermes" / "profiles" / "reviewer"
+        profile.mkdir(parents=True)
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=str(profile),
+            active_profile=None,
+            hermes_profile="coordinator",
+        )
+        assert result == str(profile)
+        assert os.environ.get("HERMES_PROFILE") == "reviewer"
 
     def test_supervised_named_profile_flag_still_wins(self, tmp_path, monkeypatch):
         """A supervised named-profile slot passes ``-p <name>`` explicitly;

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -324,9 +324,9 @@ class TestCLI:
         assert _cli(["boards", "create", "projB"], env_extra=env).returncode == 0
 
         # Create one task on each via --board.
-        r = _cli(["--board", "projA", "create", "Task A", "--assignee", "dev"], env_extra=env)
+        r = _cli(["--board", "projA", "create", "Task A", "--assignee", "dev", "--external-assignee"], env_extra=env)
         assert r.returncode == 0, r.stderr
-        r = _cli(["--board", "projB", "create", "Task B", "--assignee", "dev"], env_extra=env)
+        r = _cli(["--board", "projB", "create", "Task B", "--assignee", "dev", "--external-assignee"], env_extra=env)
         assert r.returncode == 0, r.stderr
 
         # list on each board only shows its own.

--- a/tests/hermes_cli/test_kanban_candidate_gate_provenance.py
+++ b/tests/hermes_cli/test_kanban_candidate_gate_provenance.py
@@ -1,0 +1,532 @@
+"""Strict candidate and mandatory-gate provenance contracts."""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _git_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for command in (
+        ["git", "init", "-q", str(repo)],
+        ["git", "-C", str(repo), "config", "user.email", "test@example.test"],
+        ["git", "-C", str(repo), "config", "user.name", "Test"],
+    ):
+        subprocess.run(command, check=True)
+    (repo / "artifact.txt").write_text("candidate\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "candidate"], check=True)
+    sha = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+    return repo, sha
+
+
+def _attested_candidate(conn, task_id: str, sha: str, monkeypatch) -> dict:
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    return kb.create_candidate(
+        conn, task_id, sha=sha,
+        source_receipt={"candidate_sha": sha, "subject": "scratch artifact", "provenance": "trusted build receipt", "producer_profile": "implementer"},
+    )
+
+
+def _manifest(conn, task_id: str, sha: str, tmp_path: Path) -> dict:
+    evidence = tmp_path / f"{task_id}.txt"
+    evidence.write_text("evidence", encoding="utf-8")
+    attachment = kb.add_attachment(conn, task_id, filename="evidence.txt", stored_path=str(evidence), content_type="text/plain", size=8)
+    return kb.freeze_evidence_manifest(conn, task_id, sha=sha, manifest={"required_slots": ["evidence"], "entries": [{"attachment_id": attachment, "sha256": hashlib.sha256(b"evidence").hexdigest(), "content_type": "text/plain", "cardinality": 1, "slot": "evidence", "mode": "required"}]}, verdict="pass", authority="coordinator")
+
+
+def test_gate_completion_requires_active_run_and_immutable_worker_profile(kanban_home, tmp_path, monkeypatch):
+    """Metadata cannot let CLI/dashboard callers forge a mandatory gate completion."""
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "c" * 40
+    with kb.connect() as conn:
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        _attested_candidate(conn, source, sha, monkeypatch)
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        run = kb.claim_task(conn, gate)
+        assert run is not None
+        metadata = {"candidate_sha": sha, "manifest_hash": manifest["manifest_hash"]}
+        assert not kb.complete_task(conn, gate, result="forged", metadata=metadata)
+        assert not kb.complete_task(conn, gate, result="forged", metadata=metadata, expected_run_id=run.current_run_id)
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", metadata=metadata, expected_run_id=run.current_run_id)
+
+
+def test_evidence_freeze_rejects_authority_spoofing_runtime_profile(kanban_home, tmp_path, monkeypatch):
+    """The receipt cannot record an arbitrary authority string."""
+    sha = "e" * 40
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "implementer")
+    evidence = tmp_path / "evidence.txt"
+    evidence.write_text("evidence", encoding="utf-8")
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        kb.create_candidate(conn, task, sha=sha, source_receipt={
+            "candidate_sha": sha, "subject": "scratch artifact", "provenance": "trusted build receipt", "producer_profile": "implementer",
+        })
+        attachment = kb.add_attachment(
+            conn, task, filename="evidence.txt", stored_path=str(evidence),
+            content_type="text/plain", size=8, uploaded_by="implementer",
+        )
+        monkeypatch.setenv("HERMES_PROFILE", "implementer")
+        with pytest.raises(ValueError, match="assertion"):
+            kb.freeze_evidence_manifest(
+                conn, task, sha=sha,
+                manifest={"required_slots": ["evidence"], "entries": [{
+                    "attachment_id": attachment,
+                    "sha256": hashlib.sha256(b"evidence").hexdigest(),
+                    "content_type": "text/plain", "cardinality": 1,
+                    "slot": "evidence", "mode": "required",
+                }]},
+                verdict="pass", authority="reviewer",
+            )
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        with pytest.raises(ValueError, match="source agent assignee or configured coordinator"):
+            kb.freeze_evidence_manifest(
+                conn, task, sha=sha,
+                manifest={"required_slots": ["evidence"], "entries": [{
+                    "attachment_id": attachment,
+                    "sha256": hashlib.sha256(b"evidence").hexdigest(),
+                    "content_type": "text/plain", "cardinality": 1,
+                    "slot": "evidence", "mode": "required",
+                }]},
+                verdict="pass", authority="reviewer",
+            )
+        monkeypatch.delenv("HERMES_PROFILE")
+        with pytest.raises(ValueError, match="requires runtime HERMES_PROFILE"):
+            kb.freeze_evidence_manifest(
+                conn, task, sha=sha,
+                manifest={"required_slots": ["evidence"], "entries": [{
+                    "attachment_id": attachment,
+                    "sha256": hashlib.sha256(b"evidence").hexdigest(),
+                    "content_type": "text/plain", "cardinality": 1,
+                    "slot": "evidence", "mode": "required",
+                }]},
+                verdict="pass", authority="",
+            )
+
+
+def test_evidence_freeze_persists_canonical_runtime_for_producer_and_coordinator(kanban_home, tmp_path, monkeypatch):
+    """Either authorized runtime identity becomes the immutable receipt authority."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "implementer")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with kb.connect() as conn:
+        receipts = []
+        for suffix, runtime in (("a", "implementer"), ("b", "coordinator")):
+            payload = f"evidence-{suffix}".encode()
+            evidence = tmp_path / f"evidence-{suffix}.txt"
+            evidence.write_bytes(payload)
+            task = kb.create_task(conn, title=f"source-{suffix}", assignee="implementer", owner_kind="agent")
+            sha = suffix * 40
+            kb.create_candidate(conn, task, sha=sha, source_receipt={
+                "candidate_sha": sha, "subject": "scratch artifact", "provenance": "trusted build receipt", "producer_profile": "implementer",
+            })
+            attachment = kb.add_attachment(
+                conn, task, filename=evidence.name, stored_path=str(evidence),
+                content_type="text/plain", size=len(payload), uploaded_by="implementer",
+            )
+            monkeypatch.setenv("HERMES_PROFILE", runtime)
+            receipt = kb.freeze_evidence_manifest(
+                conn, task, sha=sha,
+                manifest={"required_slots": ["evidence"], "entries": [{
+                    "attachment_id": attachment, "sha256": hashlib.sha256(payload).hexdigest(),
+                    "content_type": "text/plain", "cardinality": 1,
+                    "slot": "evidence", "mode": "required",
+                }]},
+                verdict="pass", authority=runtime,
+            )
+            assert receipt["authority"] == runtime
+            receipts.append((task, receipt))
+            monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        stored_authorities = []
+        for task, _receipt in receipts:
+            stored = kb.get_frozen_evidence_manifest(conn, task)
+            assert stored is not None
+            stored_authorities.append(stored["authority"])
+    assert stored_authorities == ["implementer", "coordinator"]
+
+
+def test_worktree_candidate_proves_clean_head_and_canonical_workspace(kanban_home, tmp_path):
+    repo, sha = _git_repo(tmp_path)
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="implementation", workspace_kind="worktree", workspace_path=str(repo))
+        conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, outcome, metadata, started_at, ended_at) VALUES (?, ?, 'done', 'completed', ?, 1, 2)",
+            (task, "implementer", json.dumps({"candidate_sha": sha})),
+        )
+        candidate = kb.create_candidate(conn, task, sha=sha)
+        assert candidate["source_kind"] == "git"
+        assert candidate["source_provenance"] == {"head": sha, "workspace_path": str(repo.resolve())}
+        (repo / "dirty.txt").write_text("dirty", encoding="utf-8")
+        with pytest.raises(ValueError, match="clean"):
+            kb.create_candidate(conn, task, sha=sha)
+        (repo / "dirty.txt").unlink()
+        with pytest.raises(ValueError, match="HEAD"):
+            kb.create_candidate(conn, task, sha="a" * 40)
+
+
+def test_worktree_candidate_binds_implementer_to_exact_completed_producing_run(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """Later runs and mutable assignees cannot misattribute a reset candidate."""
+    repo, sha1 = _git_repo(tmp_path)
+    (repo / "artifact.txt").write_text("candidate two\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "commit", "-am", "candidate two", "-q"], check=True)
+    sha2 = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"producer-a", "producer-b"})
+    with kb.connect() as conn:
+        task = kb.create_task(
+            conn, title="implementation", assignee="producer-a", owner_kind="agent",
+            workspace_kind="worktree", workspace_path=str(repo),
+        )
+        first = kb.claim_task(conn, task, claimer="producer-a:first")
+        assert first is not None
+        assert kb.complete_task(
+            conn, task, result="SHA1", summary="produced SHA1",
+            metadata={"candidate_sha": sha1}, expected_run_id=first.current_run_id,
+        )
+        from plugins.kanban.dashboard.plugin_api import _set_status_direct
+        assert _set_status_direct(conn, task, "ready")
+        assert kb.assign_task(conn, task, "producer-b", owner_kind="agent")
+        second = kb.claim_task(conn, task, claimer="producer-b:second")
+        assert second is not None
+        assert kb.complete_task(
+            conn, task, result="SHA2", summary="produced SHA2",
+            metadata={"candidate_sha": sha2}, expected_run_id=second.current_run_id,
+        )
+        subprocess.run(["git", "-C", str(repo), "reset", "--hard", sha1], check=True)
+        candidate = kb.create_candidate(conn, task, sha=sha1)
+        assert candidate["implementer"] == "producer-a"
+        (repo / "artifact.txt").write_text("candidate three\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo), "commit", "-am", "candidate three", "-q"], check=True)
+        sha3 = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+        with pytest.raises(ValueError, match="completed producing run"):
+            kb.create_candidate(conn, task, sha=sha3)
+
+
+def test_scratch_candidate_requires_coordinator_attestation_and_hash(kanban_home, tmp_path, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    sha = "a" * 40
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="scratch")
+        with pytest.raises(ValueError, match="source_receipt"):
+            kb.create_candidate(conn, task, sha=sha)
+        monkeypatch.setenv("HERMES_PROFILE", "attacker")
+        with pytest.raises(ValueError, match="configured coordinator"):
+            kb.create_candidate(conn, task, sha=sha, source_receipt={"candidate_sha": sha, "subject": "x", "provenance": "x", "producer_profile": "implementer"})
+        candidate = _attested_candidate(conn, task, sha, monkeypatch)
+        assert candidate["source_kind"] == "attested"
+        assert candidate["source_hash"] == hashlib.sha256(json.dumps(candidate["source_provenance"], sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def test_gate_is_created_only_with_frozen_exact_source_bindings(kanban_home, tmp_path, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "b" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        _attested_candidate(conn, source, sha, monkeypatch)
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        created = kb.get_task(conn, gate)
+        assert (created.gate_candidate_sha, created.gate_manifest_hash) == (sha, manifest["manifest_hash"])
+        with pytest.raises(ValueError, match="frozen"):
+            kb.create_task(conn, title="wrong", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha="c" * 40, gate_manifest_hash=manifest["manifest_hash"])
+        with pytest.raises(ValueError, match="owner_kind"):
+            kb.create_task(conn, title="external", assignee="reviewer", owner_kind="no_agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+
+
+def test_verdict_requires_exact_bound_terminal_run_metadata(kanban_home, tmp_path, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "d" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        _attested_candidate(conn, source, sha, monkeypatch)
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        run = kb.claim_task(conn, gate)
+        assert run is not None
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", summary="validated", metadata={"candidate_sha": "e" * 40, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=run.current_run_id)
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        with pytest.raises(ValueError, match="run metadata"):
+            kb.record_gate_verdict(conn, source, gate_task_id=gate, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+
+
+def test_verdict_rejects_reopened_gate_when_latest_completed_run_has_wrong_binding(kanban_home, tmp_path, monkeypatch):
+    """A prior valid pass cannot authorize a gate after its follow-up run diverges."""
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "f" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        _attested_candidate(conn, source, sha, monkeypatch)
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        first = kb.claim_task(conn, gate)
+        assert first is not None
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", summary="first pass", metadata={"candidate_sha": sha, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=first.current_run_id)
+
+        # This is the dashboard's canonical done -> ready follow-up transition.
+        from plugins.kanban.dashboard.plugin_api import _set_status_direct
+        assert _set_status_direct(conn, gate, "ready")
+        latest = kb.claim_task(conn, gate)
+        assert latest is not None
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", summary="follow-up", metadata={"candidate_sha": "0" * 40, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=latest.current_run_id)
+
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        with pytest.raises(ValueError, match="run metadata"):
+            kb.record_gate_verdict(conn, source, gate_task_id=gate, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+
+
+def test_release_barrier_waits_when_stored_verdict_is_stale_after_gate_reopens(kanban_home, tmp_path, monkeypatch):
+    """Reconcile revalidates a stored pass against the authoritative latest gate run."""
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "a" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        _attested_candidate(conn, source, sha, monkeypatch)
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        first = kb.claim_task(conn, gate)
+        assert first is not None
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", summary="first pass", metadata={"candidate_sha": sha, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=first.current_run_id)
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        kb.create_release_barrier(conn, source, sha=sha, manifest_hash=manifest["manifest_hash"], required_gates=[gate], authority="coordinator")
+        kb.record_gate_verdict(conn, source, gate_task_id=gate, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+        assert kb.acquire_release_barrier_lease(conn, source, barrier="publish", owner_token="owner", ttl_seconds=60)
+        kb.prepare_release_delivery_intent(conn, source, barrier="publish", owner_token="owner", target_identity="target", candidate_sha=sha, idempotency_key="stale-gate")
+        kb.record_release_delivery(conn, source, barrier="publish", owner_token="owner", target_identity="target", delivered_sha=sha, idempotency_key="stale-gate")
+        kb.record_release_readback(conn, source, barrier="publish", owner_token="owner", readback_sha=sha)
+
+        from plugins.kanban.dashboard.plugin_api import _set_status_direct
+        assert _set_status_direct(conn, gate, "ready")
+        latest = kb.claim_task(conn, gate)
+        assert latest is not None
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", summary="follow-up", metadata={"candidate_sha": "0" * 40, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=latest.current_run_id)
+
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        assert kb.reconcile_release_barrier(conn, source, barrier="publish", owner_token="owner") == "waiting"
+        release_barrier = kb.get_release_barrier(conn, source)
+        assert release_barrier is not None
+        assert release_barrier["completed_at"] is None
+
+
+def test_mandatory_gate_rejects_failed_frozen_evidence(kanban_home, tmp_path, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "7" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        _attested_candidate(conn, source, sha, monkeypatch)
+        evidence = tmp_path / "evidence.txt"
+        evidence.write_bytes(b"evidence")
+        attachment = kb.add_attachment(conn, source, filename="evidence.txt", stored_path=str(evidence), content_type="text/plain", size=8)
+        receipt = kb.freeze_evidence_manifest(conn, source, sha=sha, manifest={"required_slots": ["evidence"], "entries": [{"attachment_id": attachment, "sha256": hashlib.sha256(b"evidence").hexdigest(), "content_type": "text/plain", "cardinality": 1, "slot": "evidence", "mode": "required"}]}, verdict="fail", authority="coordinator")
+        with pytest.raises(ValueError, match="passing frozen manifest"):
+            kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=receipt["manifest_hash"])
+
+
+def test_gate_reassignment_after_execution_cannot_manufacture_independence(kanban_home, tmp_path, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer", "attacker"})
+    sha = "9" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        candidate = _attested_candidate(conn, source, sha, monkeypatch)
+        assert candidate["implementer"] == "implementer"
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        claimed = kb.claim_task(conn, gate)
+        assert claimed is not None
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", summary="reviewed", metadata={"candidate_sha": sha, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=claimed.current_run_id)
+        assert kb.assign_task(conn, gate, "attacker", owner_kind="agent")
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        with pytest.raises(ValueError, match="terminal result"):
+            kb.record_gate_verdict(conn, source, gate_task_id=gate, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+
+
+def test_release_reconcile_waits_for_live_source_then_clears_lifecycle_state(kanban_home, tmp_path, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "8" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        child = kb.create_task(conn, title="child", assignee="implementer", owner_kind="agent", initial_status="blocked")
+        kb.link_tasks(conn, parent_id=source, child_id=child)
+        _attested_candidate(conn, source, sha, monkeypatch)
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        gate_run = kb.claim_task(conn, gate)
+        assert gate_run is not None
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", summary="reviewed", metadata={"candidate_sha": sha, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=gate_run.current_run_id)
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        kb.record_gate_verdict(conn, source, gate_task_id=gate, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+        kb.create_release_barrier(conn, source, sha=sha, manifest_hash=manifest["manifest_hash"], required_gates=[gate], authority="coordinator")
+        assert kb.acquire_release_barrier_lease(conn, source, barrier="publish", owner_token="owner", ttl_seconds=60)
+        kb.prepare_release_delivery_intent(conn, source, barrier="publish", owner_token="owner", target_identity="target", candidate_sha=sha, idempotency_key="stale-gate")
+        kb.record_release_delivery(conn, source, barrier="publish", owner_token="owner", target_identity="target", delivered_sha=sha, idempotency_key="stale-gate")
+        kb.record_release_readback(conn, source, barrier="publish", owner_token="owner", readback_sha=sha)
+        live = kb.claim_task(conn, source)
+        assert live is not None
+        assert kb.reconcile_release_barrier(conn, source, barrier="publish", owner_token="owner") == "waiting"
+        assert kb.get_task(conn, source).status == "running"
+        assert kb.set_task_wait(conn, source, kind="human", ref="decision:release", expected_run_id=live.current_run_id)
+        assert kb.reconcile_release_barrier(conn, source, barrier="publish", owner_token="owner") == "released"
+        released = kb.get_task(conn, source)
+        assert released is not None and released.status == "done" and released.completed_at is not None
+        assert released.current_run_id is None and released.claim_lock is None and released.claim_expires is None and released.worker_pid is None
+        assert released.wait_kind is None and released.wait_ref is None
+        assert kb.get_task(conn, child).status == "ready"
+        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='release_barrier_completed'", (source,)).fetchone()[0] == 1
+
+
+def test_agent_assignment_unassigns_into_non_dispatchable_manual_lane(kanban_home, monkeypatch):
+    """No public unassign can leave a persisted agent task ownerless."""
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "worker")
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="owned", assignee="worker", owner_kind="agent")
+        for missing in (None, "", "   "):
+            assert kb.assign_task(conn, task, missing)
+            current = kb.get_task(conn, task)
+            assert current is not None
+            assert (current.assignee, current.owner_kind, current.owner_kind_explicit) == (None, "no_agent", True)
+
+
+def test_gate_verdict_binds_immutable_latest_terminal_run_id(kanban_home, tmp_path, monkeypatch):
+    """A same-metadata re-run still invalidates the prior verdict by run identity."""
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "1" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        _attested_candidate(conn, source, sha, monkeypatch)
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        first = kb.claim_task(conn, gate)
+        assert first is not None
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", summary="first", metadata={"candidate_sha": sha, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=first.current_run_id)
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        verdict = kb.record_gate_verdict(conn, source, gate_task_id=gate, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+        assert verdict["gate_run_id"] == first.current_run_id
+        kb.create_release_barrier(conn, source, sha=sha, manifest_hash=manifest["manifest_hash"], required_gates=[gate], authority="coordinator")
+        assert kb.acquire_release_barrier_lease(conn, source, barrier="publish", owner_token="owner", ttl_seconds=60)
+        from plugins.kanban.dashboard.plugin_api import _set_status_direct
+        assert _set_status_direct(conn, gate, "ready")
+        second = kb.claim_task(conn, gate)
+        assert second is not None
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert kb.complete_task(conn, gate, result="pass", summary="second", metadata={"candidate_sha": sha, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=second.current_run_id)
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        assert kb.reconcile_release_barrier(conn, source, barrier="publish", owner_token="owner") == "waiting"
+        with pytest.raises(ValueError, match="immutable"):
+            kb.record_gate_verdict(conn, source, gate_task_id=gate, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+
+
+def test_release_delivery_intent_is_immutable_across_expired_lease_takeover(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """A second coordinator reuses one durable external-publish identity after a crash."""
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "3" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        _attested_candidate(conn, source, sha, monkeypatch)
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        claimed = kb.claim_task(conn, gate)
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert claimed and kb.complete_task(conn, gate, result="pass", summary="pass", metadata={"candidate_sha": sha, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=claimed.current_run_id)
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        kb.record_gate_verdict(conn, source, gate_task_id=gate, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+        kb.create_release_barrier(conn, source, sha=sha, manifest_hash=manifest["manifest_hash"], required_gates=[gate], authority="coordinator")
+        assert kb.acquire_release_barrier_lease(conn, source, barrier="publish", owner_token="one", ttl_seconds=60)
+        intent = kb.prepare_release_delivery_intent(conn, source, barrier="publish", owner_token="one", target_identity="target-a", candidate_sha=sha, idempotency_key="caller-stable-key")
+        assert intent["idempotency_key"] == "caller-stable-key"
+        conn.execute("UPDATE task_release_barriers SET lease_expires_at=0 WHERE task_id=?", (source,))
+    with kb.connect() as takeover:
+        assert kb.acquire_release_barrier_lease(takeover, source, barrier="publish", owner_token="two", ttl_seconds=60)
+        reused = kb.prepare_release_delivery_intent(takeover, source, barrier="publish", owner_token="two", target_identity="target-a", candidate_sha=sha)
+        assert reused == intent
+        with pytest.raises(ValueError, match="immutable"):
+            kb.prepare_release_delivery_intent(takeover, source, barrier="publish", owner_token="two", target_identity="target-b", candidate_sha=sha)
+        with pytest.raises(ValueError, match="prepared intent"):
+            kb.record_release_delivery(takeover, source, barrier="publish", owner_token="two", target_identity="target-a", delivered_sha=sha, idempotency_key="wrong-key")
+        kb.record_release_delivery(takeover, source, barrier="publish", owner_token="two", target_identity="target-a", delivered_sha=sha, idempotency_key="caller-stable-key")
+
+
+def test_release_delivery_is_first_write_immutable_and_exactly_idempotent(kanban_home, tmp_path, monkeypatch):
+    """Delivery proof is a first-write CAS before and after a barrier completes."""
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in {"implementer", "reviewer"})
+    sha = "2" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        _attested_candidate(conn, source, sha, monkeypatch)
+        manifest = _manifest(conn, source, sha, tmp_path)
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=manifest["manifest_hash"])
+        claimed = kb.claim_task(conn, gate)
+        monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+        assert claimed and kb.complete_task(conn, gate, result="pass", summary="pass", metadata={"candidate_sha": sha, "manifest_hash": manifest["manifest_hash"]}, expected_run_id=claimed.current_run_id)
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        kb.record_gate_verdict(conn, source, gate_task_id=gate, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+        kb.create_release_barrier(conn, source, sha=sha, manifest_hash=manifest["manifest_hash"], required_gates=[gate], authority="coordinator")
+        assert kb.acquire_release_barrier_lease(conn, source, barrier="publish", owner_token="owner", ttl_seconds=60)
+        kb.prepare_release_delivery_intent(conn, source, barrier="publish", owner_token="owner", target_identity="target-a", candidate_sha=sha, idempotency_key="first-write")
+        kb.record_release_delivery(conn, source, barrier="publish", owner_token="owner", target_identity="target-a", delivered_sha=sha, idempotency_key="first-write")
+        kb.record_release_delivery(conn, source, barrier="publish", owner_token="owner", target_identity="target-a", delivered_sha=sha, idempotency_key="first-write")
+        with pytest.raises(ValueError, match="prepared intent"):
+            kb.record_release_delivery(conn, source, barrier="publish", owner_token="owner", target_identity="target-b", delivered_sha=sha, idempotency_key="first-write")
+        kb.record_release_readback(conn, source, barrier="publish", owner_token="owner", readback_sha=sha)
+        assert kb.reconcile_release_barrier(conn, source, barrier="publish", owner_token="owner") == "released"
+        kb.record_release_delivery(conn, source, barrier="publish", owner_token="owner", target_identity="target-a", delivered_sha=sha, idempotency_key="first-write")
+        with pytest.raises(ValueError, match="prepared intent"):
+            kb.record_release_delivery(conn, source, barrier="publish", owner_token="owner", target_identity="target-b", delivered_sha=sha, idempotency_key="first-write")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -40,6 +40,41 @@ def kanban_home(tmp_path, monkeypatch):
 
 
 
+def _parse_kanban(argv):
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    return parser.parse_args(["kanban", *argv])
+
+
+def test_cli_create_rejects_missing_profile(monkeypatch, kanban_home, capsys):
+    from hermes_cli import profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda name: False)
+    args = _parse_kanban(["create", "bad", "--assignee", "researcher"])
+    assert kc.kanban_command(args) == 2
+    assert "does not exist" in capsys.readouterr().err
+    with kb.connect_closing() as conn:
+        assert kb.list_tasks(conn) == []
+
+
+def test_cli_create_allows_explicit_external_assignee(
+    monkeypatch, kanban_home
+):
+    from hermes_cli import profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda name: False)
+    args = _parse_kanban([
+        "create", "external", "--assignee", "orion-research",
+        "--external-assignee",
+    ])
+    assert kc.kanban_command(args) == 0
+    with kb.connect_closing() as conn:
+        tasks = kb.list_tasks(conn)
+    assert len(tasks) == 1
+    assert tasks[0].assignee == "orion-research"
+
+
 def test_kanban_list_json_includes_session_id(kanban_home):
     """JSON output exposes `session_id` so external clients (Scarf, web
     dashboards) don't need a side query to filter by chat session."""
@@ -135,7 +170,9 @@ def test_run_slash_reclaim_running_task(kanban_home):
     import secrets
     from hermes_cli import kanban_db as kb
 
-    out1 = kc.run_slash("create 'stuck worker task' --assignee broken-model")
+    out1 = kc.run_slash(
+        "create 'stuck worker task' --assignee broken-model --external-assignee"
+    )
     m = re.search(r"(t_[a-f0-9]+)", out1)
     assert m
     tid = m.group(1)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import threading
@@ -18,10 +19,37 @@ from hermes_cli import kanban_db as kb
 def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
+    for profile in ("implementer", "reviewer", "independent-reviewer"):
+        (home / "profiles" / profile).mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home
+
+
+def _source_receipt(sha: str) -> dict[str, str]:
+    """Coordinator-attested provenance for scratch candidates in CLI fixtures."""
+    return {
+        "candidate_sha": sha,
+        "subject": "test scratch artifact",
+        "provenance": "test coordinator receipt",
+        "producer_profile": "implementer",
+    }
+
+
+def _complete_bound_gate(conn, gate_id: str, *, sha: str, manifest_hash: str, monkeypatch) -> None:
+    """Model the dispatched gate worker, then return to the coordinator lane."""
+    gate = kb.get_task(conn, gate_id)
+    assert gate is not None and gate.assignee
+    claimed = kb.claim_task(conn, gate_id)
+    assert claimed is not None and claimed.current_run_id is not None
+    monkeypatch.setenv("HERMES_PROFILE", gate.assignee)
+    assert kb.complete_task(
+        conn, gate_id, result="pass", summary="validated",
+        metadata={"candidate_sha": sha, "manifest_hash": manifest_hash},
+        expected_run_id=claimed.current_run_id,
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
 
 
 # ---------------------------------------------------------------------------
@@ -45,6 +73,161 @@ def _parse_kanban(argv):
     sub = parser.add_subparsers(dest="command")
     kc.build_parser(sub)
     return parser.parse_args(["kanban", *argv])
+
+
+def test_cli_evidence_freeze_rejects_foreign_runtime_profile(kanban_home, tmp_path, capsys, monkeypatch):
+    """CLI binds a freeze to its runtime profile rather than --authority."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    payload = b"cli evidence"
+    blob = tmp_path / "evidence.txt"
+    blob.write_bytes(payload)
+    sha = "f" * 40
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="source", assignee="implementer")
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        kb.create_candidate(conn, task_id, sha=sha, source_receipt=_source_receipt(sha))
+        attachment_id = kb.add_attachment(
+            conn, task_id, filename="evidence.txt", stored_path=str(blob),
+            content_type="text/plain", size=len(payload), uploaded_by="implementer",
+        )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"required_slots": ["evidence"], "entries": [{
+        "attachment_id": attachment_id, "sha256": hashlib.sha256(payload).hexdigest(),
+        "content_type": "text/plain", "cardinality": 1, "slot": "evidence", "mode": "required",
+    }]}), encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "reviewer")
+    args = _parse_kanban([
+        "evidence-manifest-freeze", task_id, sha, str(manifest_path),
+        "--verdict", "pass", "--authority", "reviewer", "--json",
+    ])
+    assert kc.kanban_command(args) == 1
+    assert "source agent assignee or configured coordinator" in capsys.readouterr().err
+    with kb.connect() as conn:
+        assert kb.get_frozen_evidence_manifest(conn, task_id) is None
+
+
+def test_cli_external_run_verbs_persist_lifecycle_and_redact_refs(kanban_home, capsys):
+    """External-run CLI verbs retain identity/progress after the initiator exits."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="long validation", assignee="operator", owner_kind="external")
+
+    def invoke(argv):
+        assert kc.kanban_command(_parse_kanban([*argv, "--json"])) == 0
+        return json.loads(capsys.readouterr().out)
+
+    started = invoke([
+        "external-run-start", task_id, "--owner", "operator",
+        "--external-id", "validation-42", "--pid", "4242", "--phase", "validation",
+        "--current", "3", "--total", "10", "--log-ref", "https://token:secret@example.test/log",
+        "--result-ref", "Bearer result-secret", "--max-retries", "2",
+        "--on-success", "complete", "--on-failure", "block",
+    ])
+    run_id = started["id"]
+    assert started["task_id"] == task_id
+    assert started["owner"] == "operator"
+    assert started["external_id"] == "validation-42"
+    assert (started["phase"], started["current"], started["total"]) == ("validation", 3, 10)
+    assert "secret" not in json.dumps(started)
+    assert invoke(["external-run-show", str(run_id)])["id"] == run_id
+    assert [r["id"] for r in invoke(["external-run-list", "--task-id", task_id])["runs"]] == [run_id]
+    beat = invoke(["external-run-heartbeat", str(run_id), "--owner", "operator", "--phase", "validation", "--current", "4", "--total", "10"])
+    assert (beat["current"], beat["total"]) == (4, 10)
+    assert invoke(["external-run-transfer", str(run_id), "--from-owner", "operator", "--to-owner", "reviewer"])["owner"] == "reviewer"
+    assert invoke(["external-run-finish", str(run_id), "--owner", "reviewer", "--outcome", "completed"])["status"] == "done"
+    assert invoke(["external-run-reconcile", "--stale-after", "1"])["reconciled"] == 0
+
+
+def test_cli_complete_cannot_bypass_live_external_owner(kanban_home, capsys):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="external complete", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id="cli-bypass")
+    assert kc.kanban_command(_parse_kanban(["complete", task_id, "bypass"])) == 1
+    assert "cannot complete" in capsys.readouterr().err
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "running" and task.current_run_id == run.id
+
+
+def test_cli_external_run_rejects_cross_board_mutation(kanban_home, capsys):
+    """Same numeric run ID on another board cannot be mutated or disclosed."""
+    kb.create_board("external-other")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="source", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id="source-1")
+    args = _parse_kanban([
+        "--board", "external-other", "external-run-heartbeat", str(run.id),
+        "--owner", "operator", "--phase", "spoof", "--json",
+    ])
+    assert kc.kanban_command(args) == 1
+    assert "not found or not owned" in capsys.readouterr().err
+    with kb.connect() as conn:
+        assert kb.get_external_run(conn, run.id).phase is None
+
+
+def test_cli_wait_roundtrip_surfaces_kind_and_ref(kanban_home, capsys, monkeypatch):
+    """Only the configured coordinator runtime can receipt-resume a wait."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="approval", assignee="operator", owner_kind="no_agent")
+    assert kc.kanban_command(_parse_kanban([
+        "wait-set", task_id, "human", "decision:ship",
+    ])) == 0
+    capsys.readouterr()
+    assert kc.kanban_command(_parse_kanban(["wait-show", task_id, "--json"])) == 0
+    shown = json.loads(capsys.readouterr().out)
+    assert shown == {"kind": "human", "ref": "decision:ship", "task_id": task_id}
+    # The command line cannot mint an approval by asserting another identity.
+    assert kc.kanban_command(_parse_kanban([
+        "wait-resume", task_id, "--authority", "attacker",
+        "--receipt", "decision:ship", "--verdict", "approved",
+    ])) == 2
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).status == "blocked"
+    assert kc.kanban_command(_parse_kanban([
+        "wait-resume", task_id, "--authority", "coordinator",
+        "--receipt", "decision:ship", "--verdict", "approved",
+    ])) == 0
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_cli_review_wait_uses_canonical_gate_task_id(kanban_home, capsys, monkeypatch):
+    """The CLI accepts only the canonical gate:<gate-task-id> review reference."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    sha = "1" * 40
+    evidence = kanban_home / "review-wait-evidence"
+    evidence.write_bytes(b"review wait")
+    with kb.connect() as conn:
+        source = kb.create_task(
+            conn, title="source", assignee="implementer", owner_kind="agent",
+        )
+        attachment = kb.add_attachment(conn, source, filename="evidence.txt", stored_path=str(evidence), content_type="text/plain", size=len(b"review wait"))
+        kb.create_candidate(conn, source, sha=sha, source_receipt=_source_receipt(sha))
+        manifest = kb.freeze_evidence_manifest(conn, source, sha=sha, manifest={"required_slots": ["evidence"], "entries": [{"attachment_id": attachment, "sha256": hashlib.sha256(b"review wait").hexdigest(), "content_type": "text/plain", "cardinality": 1, "slot": "evidence", "mode": "required"}]}, verdict="pass", authority="coordinator")
+        gate = kb.create_task(
+            conn, title="review", assignee="independent-reviewer", owner_kind="agent",
+            task_kind="reviewer", created_by_task_id=source,
+            creation_authority="coordinator", gate_candidate_sha=sha,
+            gate_manifest_hash=manifest["manifest_hash"],
+        )
+        _complete_bound_gate(conn, gate, sha=sha, manifest_hash=manifest["manifest_hash"], monkeypatch=monkeypatch)
+    ref = f"gate:{gate}"
+    assert kc.kanban_command(_parse_kanban(["wait-set", source, "review", ref])) == 0
+    capsys.readouterr()
+    assert kc.kanban_command(_parse_kanban(["wait-show", source, "--json"])) == 0
+    assert json.loads(capsys.readouterr().out)["ref"] == ref
+    assert kc.kanban_command(
+        _parse_kanban(["wait-set", source, "review", f"gate:{gate}:review"]),
+    ) == 2
+    assert "gate:<gate-task-id>" in capsys.readouterr().err
 
 
 def test_cli_create_rejects_missing_profile(monkeypatch, kanban_home, capsys):
@@ -75,13 +258,102 @@ def test_cli_create_allows_explicit_external_assignee(
     assert tasks[0].assignee == "orion-research"
 
 
+
+def test_cli_create_explicit_owner_kinds_bypass_profile_lookup_only_for_manual_lanes(
+    monkeypatch, kanban_home
+):
+    """Real command dispatch preserves explicit external and no-agent lanes."""
+    from hermes_cli import profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda name: False)
+    for title, owner_kind in (("external handoff", "external"), ("manual approval", "no_agent")):
+        args = _parse_kanban([
+            "create", title, "--assignee", "manual-operator", "--owner-kind", owner_kind,
+        ])
+        assert kc.kanban_command(args) == 0
+    with kb.connect_closing() as conn:
+        tasks = {task.title: task for task in kb.list_tasks(conn)}
+    assert tasks["external handoff"].owner_kind == "external"
+    assert tasks["manual approval"].owner_kind == "no_agent"
+
+
+def test_cli_create_omission_preserves_db_inference_and_explicit_no_agent_lane(
+    kanban_home,
+):
+    """Omitting --owner-kind is distinct from deliberately selecting no_agent."""
+    assert kc.kanban_command(_parse_kanban([
+        "create", "assigned implicit", "--assignee", "implementer",
+    ])) == 0
+    assert kc.kanban_command(_parse_kanban(["create", "unassigned implicit"])) == 0
+    assert kc.kanban_command(_parse_kanban([
+        "create", "manual explicit", "--owner-kind", "no_agent",
+    ])) == 0
+    with kb.connect_closing() as conn:
+        tasks = {task.title: task for task in kb.list_tasks(conn)}
+        assert (tasks["assigned implicit"].owner_kind, tasks["assigned implicit"].owner_kind_explicit) == ("agent", False)
+        assert (tasks["unassigned implicit"].owner_kind, tasks["unassigned implicit"].owner_kind_explicit) == ("no_agent", False)
+        assert (tasks["manual explicit"].owner_kind, tasks["manual explicit"].owner_kind_explicit) == ("no_agent", True)
+        result = kb.dispatch_once(conn, spawn_fn=lambda *_args, **_kwargs: 123, default_assignee="implementer")
+        manual = kb.get_task(conn, tasks["manual explicit"].id)
+    assert tasks["unassigned implicit"].id in result.auto_assigned_default
+    assert manual is not None and manual.assignee is None
+
+
+def test_cli_create_rejects_unconfigured_gate_without_traceback(kanban_home, capsys):
+    """The real command rejects mandatory gates fail-closed at the CLI boundary."""
+    args = _parse_kanban([
+        "create", "review", "--assignee", "manual-reviewer", "--owner-kind", "no_agent",
+        "--task-kind", "reviewer", "--creation-authority", "dashboard",
+    ])
+    assert kc.kanban_command(args) == 1
+    assert "runtime HERMES_PROFILE" in capsys.readouterr().err
+
+
+
+def test_cli_configured_authority_creates_gate_and_rejects_spoof(kanban_home, capsys, monkeypatch):
+    """CLI gate provenance must be exactly the configured coordinator authority."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    authorized = _parse_kanban([
+        "create", "release", "--assignee", "release-operator", "--owner-kind", "no_agent",
+        "--task-kind", "release", "--creation-authority", "coordinator",
+    ])
+    assert kc.kanban_command(authorized) == 0
+    spoofed = _parse_kanban([
+        "create", "spoofed", "--assignee", "release-operator", "--owner-kind", "no_agent",
+        "--task-kind", "release", "--creation-authority", "impostor",
+    ])
+    assert kc.kanban_command(spoofed) != 0
+    assert "authority assertion" in capsys.readouterr().err
+    with kb.connect_closing() as conn:
+        tasks = {task.title: task for task in kb.list_tasks(conn)}
+    assert tasks["release"].task_kind == "release"
+    assert tasks["release"].creation_authority == "coordinator"
+    assert "spoofed" not in tasks
+
+
+def test_cli_assign_rejects_owner_kind_mutation(kanban_home, capsys):
+    """The assign command must not change a durable external lane into agent work."""
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn, title="manual lane", assignee="operator", owner_kind="external",
+        )
+    args = _parse_kanban(["assign", task_id, "operator", "--owner-kind", "agent"])
+    assert kc.kanban_command(args) == 2
+    assert "owner_kind is immutable" in capsys.readouterr().err
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, task_id).owner_kind == "external"
+
+
 def test_kanban_list_json_includes_session_id(kanban_home):
     """JSON output exposes `session_id` so external clients (Scarf, web
     dashboards) don't need a side query to filter by chat session."""
     from hermes_cli import kanban_db as kb
     with kb.connect() as conn:
         kb.create_task(
-            conn, title="acp task", assignee="alice", session_id="acp-x"
+            conn, title="acp task", assignee="alice", owner_kind="no_agent", session_id="acp-x"
         )
     raw = kc.run_slash("list --json")
     payload = json.loads(raw)
@@ -151,17 +423,162 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
     assert beta_titles == ["beta-task"]
 
 
+def test_candidate_evidence_and_verdict_cli_json_roundtrip(kanban_home, tmp_path, capsys, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    """CLI handlers use the durable DB and return canonical structured receipts."""
+    payload = b"cli evidence"
+    blob = tmp_path / "evidence.txt"
+    blob.write_bytes(payload)
+    sha = "a" * 40
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="cli evidence", assignee="implementer", owner_kind="agent")
+        attachment_id = kb.add_attachment(
+            conn, task_id, filename="evidence.txt", stored_path=str(blob),
+            content_type="text/plain", size=len(payload), uploaded_by="test",
+        )
+    source_receipt_path = tmp_path / "source-receipt.json"
+    source_receipt_path.write_text(json.dumps(_source_receipt(sha)), encoding="utf-8")
+    candidate = _parse_kanban(["candidate-create", task_id, sha, "--source-receipt", str(source_receipt_path), "--json"])
+    assert kc.kanban_command(candidate) == 0
+    created_candidate = json.loads(capsys.readouterr().out)
+    assert created_candidate["task_id"] == task_id
+    assert created_candidate["sha"] == sha
+    assert created_candidate["source_kind"] == "attested"
+    assert created_candidate["source_provenance"] == _source_receipt(sha)
+    candidate_show = _parse_kanban(["candidate-show", task_id, sha, "--json"])
+    assert kc.kanban_command(candidate_show) == 0
+    assert json.loads(capsys.readouterr().out) == created_candidate
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"required_slots": ["report"], "entries": [{
+        "attachment_id": attachment_id, "sha256": __import__("hashlib").sha256(payload).hexdigest(),
+        "content_type": "text/plain", "decoder_valid": True, "decoder_metadata": {},
+        "cardinality": 1, "slot": "report", "mode": "required",
+    }]}), encoding="utf-8")
+    freeze = _parse_kanban(["evidence-manifest-freeze", task_id, sha, str(manifest_path), "--verdict", "pass", "--authority", "coordinator", "--json"])
+    assert kc.kanban_command(freeze) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["task_id"] == task_id and receipt["sha"] == sha and receipt["manifest_hash"]
+    with kb.connect_closing() as conn:
+        gate_id = kb.create_task(conn, title="review", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=task_id, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=receipt["manifest_hash"])
+        _complete_bound_gate(conn, gate_id, sha=sha, manifest_hash=receipt["manifest_hash"], monkeypatch=monkeypatch)
+    show_manifest = _parse_kanban(["evidence-manifest-show", task_id, "--json"])
+    assert kc.kanban_command(show_manifest) == 0
+    assert json.loads(capsys.readouterr().out) == receipt
+    record = _parse_kanban(["gate-verdict-record", task_id, gate_id, sha, receipt["manifest_hash"], "pass", "--authority", "coordinator", "--json"])
+    assert kc.kanban_command(record) == 0
+    verdict = json.loads(capsys.readouterr().out)
+    assert verdict["task_id"] == task_id and verdict["gate_task_id"] == gate_id and verdict["manifest_hash"] == receipt["manifest_hash"]
+    show_verdict = _parse_kanban(["gate-verdict-show", task_id, gate_id, "--json"])
+    assert kc.kanban_command(show_verdict) == 0
+    assert json.loads(capsys.readouterr().out) == verdict
+
+
+def test_candidate_evidence_cli_reports_safe_validation_errors(kanban_home, tmp_path, capsys, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    """Malformed, cross-task, and stale CLI inputs fail without a traceback."""
+    payload = b"safe evidence"
+    blob = tmp_path / "safe.txt"
+    blob.write_bytes(payload)
+    sha = "a" * 40
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="safe errors")
+        other_id = kb.create_task(conn, title="other task")
+        attachment_id = kb.add_attachment(
+            conn, task_id, filename="safe.txt", stored_path=str(blob),
+            content_type="text/plain", size=len(payload), uploaded_by="test",
+        )
+    malformed = _parse_kanban(["candidate-create", task_id, "not-a-sha", "--json"])
+    assert kc.kanban_command(malformed) == 1
+    assert "exact 40-character" in capsys.readouterr().err
+    source_receipt_path = tmp_path / "safe-source-receipt.json"
+    source_receipt_path.write_text(json.dumps(_source_receipt(sha)), encoding="utf-8")
+    assert kc.kanban_command(_parse_kanban(["candidate-create", other_id, sha, "--source-receipt", str(source_receipt_path), "--json"])) == 0
+    capsys.readouterr()
+    manifest_path = tmp_path / "safe-manifest.json"
+    manifest_path.write_text(json.dumps({"required_slots": ["safe"], "entries": [{
+        "attachment_id": attachment_id, "sha256": __import__("hashlib").sha256(payload).hexdigest(),
+        "content_type": "text/plain", "decoder_valid": True, "decoder_metadata": {},
+        "cardinality": 1, "slot": "safe", "mode": "required",
+    }]}), encoding="utf-8")
+    mismatch = _parse_kanban(["evidence-manifest-freeze", task_id, sha, str(manifest_path), "--verdict", "pass", "--authority", "coordinator", "--json"])
+    assert kc.kanban_command(mismatch) == 1
+    assert "candidate is missing" in capsys.readouterr().err
+    assert kc.kanban_command(_parse_kanban(["candidate-create", task_id, sha, "--source-receipt", str(source_receipt_path), "--json"])) == 0
+    capsys.readouterr()
+    freeze = _parse_kanban(["evidence-manifest-freeze", task_id, sha, str(manifest_path), "--verdict", "pass", "--authority", "coordinator", "--json"])
+    assert kc.kanban_command(freeze) == 0
+    capsys.readouterr()
+    stale = _parse_kanban(["gate-verdict-record", task_id, "t_missing", sha, "0" * 64, "pass", "--authority", "coordinator", "--json"])
+    assert kc.kanban_command(stale) == 1
+    assert "stale" in capsys.readouterr().err
+    missing = _parse_kanban(["candidate-show", "t_missing", sha, "--json"])
+    assert kc.kanban_command(missing) == 1
+    assert "candidate not found" in capsys.readouterr().err
+
 # ---------------------------------------------------------------------------
-# Integration with the COMMAND_REGISTRY
-# ---------------------------------------------------------------------------
 
 
 
 
 
 
-# ---------------------------------------------------------------------------
-# reclaim + reassign CLI smoke tests
+
+def test_release_barrier_cli_roundtrip(kanban_home, tmp_path, capsys, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    blob = tmp_path / "r"; blob.write_bytes(b"r"); sha = "d" * 40
+    with kb.connect_closing() as conn:
+        task = kb.create_task(conn, title="cli release", assignee="implementer", owner_kind="agent"); aid = kb.add_attachment(conn, task, filename="r", stored_path=str(blob), content_type="application/octet-stream", size=1); kb.create_candidate(conn, task, sha=sha, source_receipt=_source_receipt(sha))
+        m = kb.freeze_evidence_manifest(conn, task, sha=sha, manifest={"required_slots":["r"],"entries":[{"attachment_id":aid,"sha256":__import__("hashlib").sha256(b"r").hexdigest(),"content_type":"application/octet-stream","decoder_valid":True,"decoder_metadata":{},"cardinality":1,"slot":"r","mode":"r"}]}, verdict="pass", authority="coordinator")
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=task, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=m["manifest_hash"])
+        _complete_bound_gate(conn, gate, sha=sha, manifest_hash=m["manifest_hash"], monkeypatch=monkeypatch)
+    def run(argv):
+        assert kc.kanban_command(_parse_kanban(argv)) == 0
+        return json.loads(capsys.readouterr().out)
+    assert run(["release-barrier-create", task, "--sha", sha, "--manifest-hash", m["manifest_hash"], "--gate", gate, "--authority", "coordinator", "--json"])["sha"] == sha
+    assert run(["release-barrier-acquire", task, "--owner-token", "o", "--json"])["acquired"]
+    assert not run(["release-barrier-acquire", task, "--owner-token", "second", "--json"])["acquired"]
+    assert run(["release-barrier-reconcile", task, "--owner-token", "o", "--json"])["status"] == "waiting"
+    with kb.connect_closing() as conn:
+        kb.record_gate_verdict(conn, task, gate_task_id=gate, sha=sha, manifest_hash=m["manifest_hash"], verdict="pass", authority="coordinator")
+    assert run(["release-barrier-reconcile", task, "--owner-token", "o", "--json"])["status"] == "awaiting_receipt"
+    prepare = run(["release-barrier-prepare", task, "--owner-token", "o", "--target", "target", "--sha", sha, "--idempotency-key", "cli-release", "--json"])
+    assert prepare["idempotency_key"] == "cli-release"
+    wrong_delivery = _parse_kanban(["release-barrier-delivery", task, "--owner-token", "o", "--target", "target", "--sha", "0" * 40, "--idempotency-key", "cli-release", "--json"])
+    assert kc.kanban_command(wrong_delivery) == 1; assert "candidate SHA" in capsys.readouterr().err
+    run(["release-barrier-delivery", task, "--owner-token", "o", "--target", "target", "--sha", sha, "--idempotency-key", "cli-release", "--json"])
+    wrong_readback = _parse_kanban(["release-barrier-readback", task, "--owner-token", "o", "--sha", "0" * 40, "--json"])
+    assert kc.kanban_command(wrong_readback) == 1; assert "readback SHA" in capsys.readouterr().err
+    run(["release-barrier-readback", task, "--owner-token", "o", "--sha", sha, "--json"])
+    assert run(["release-barrier-reconcile", task, "--owner-token", "o", "--json"])["status"] == "released"
+    assert run(["release-barrier-reconcile", task, "--owner-token", "o", "--json"])["status"] == "released"
+    with kb.connect_closing() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='release_barrier_completed'", (task,)).fetchone()[0] == 1
+    assert run(["release-barrier-show", task, "--json"])["completed_at"] is not None
+
+
+def test_gate_verdict_cli_rejects_authority_spoof(kanban_home, monkeypatch, capsys):
+    """CLI derives its control principal from profile/config, not --authority."""
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="implementer", owner_kind="agent")
+        sha = "a" * 40
+        blob = kanban_home / "report"; blob.write_bytes(b"")
+        attachment = kb.add_attachment(conn, source, filename="report", stored_path=str(blob), content_type="text/plain", size=0)
+        kb.create_candidate(conn, source, sha=sha, source_receipt=_source_receipt(sha))
+        receipt = kb.freeze_evidence_manifest(conn, source, sha=sha, manifest={"required_slots": ["report"], "entries": [{"attachment_id": attachment, "sha256": hashlib.sha256(b"").hexdigest(), "content_type": "text/plain", "cardinality": 1, "slot": "report", "mode": "required"}]}, verdict="pass", authority="coordinator")
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator", gate_candidate_sha=sha, gate_manifest_hash=receipt["manifest_hash"])
+        _complete_bound_gate(conn, gate, sha=sha, manifest_hash=receipt["manifest_hash"], monkeypatch=monkeypatch)
+    spoof = _parse_kanban(["gate-verdict-record", source, gate, sha, receipt["manifest_hash"], "pass", "--authority", "spoofed", "--json"])
+    assert kc.kanban_command(spoof) == 1
+    assert "only an assertion" in capsys.readouterr().err
+    valid = _parse_kanban(["gate-verdict-record", source, gate, sha, receipt["manifest_hash"], "pass", "--json"])
+    assert kc.kanban_command(valid) == 0
+    assert json.loads(capsys.readouterr().out)["gate_task_id"] == gate
+
 # ---------------------------------------------------------------------------
 
 def test_run_slash_reclaim_running_task(kanban_home):

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -26,18 +26,25 @@ def _make_legacy_db(path: Path) -> None:
         CREATE TABLE task_events (id TEXT PRIMARY KEY, task_id TEXT NOT NULL,
             kind TEXT NOT NULL, payload TEXT, created_at INTEGER NOT NULL);
         CREATE TABLE task_runs (id TEXT PRIMARY KEY, task_id TEXT NOT NULL,
-            profile TEXT, status TEXT NOT NULL, started_at INTEGER NOT NULL);
+            profile TEXT, step_key TEXT, status TEXT NOT NULL, claim_lock TEXT,
+            claim_expires INTEGER, worker_pid INTEGER, max_runtime_seconds INTEGER,
+            last_heartbeat_at INTEGER, started_at INTEGER NOT NULL, ended_at INTEGER,
+            outcome TEXT, summary TEXT, metadata TEXT, error TEXT, owner_kind TEXT,
+            owner TEXT, external_id TEXT, phase TEXT, progress_current INTEGER,
+            progress_total INTEGER, log_ref TEXT, result_ref TEXT, pid_scope TEXT,
+            host_start_time INTEGER, managed_process_session_id TEXT,
+            durable_result_path TEXT);
         CREATE TABLE kanban_notify_subs (task_id TEXT NOT NULL, platform TEXT NOT NULL,
             chat_id TEXT NOT NULL, thread_id TEXT NOT NULL DEFAULT '', user_id TEXT,
             created_at INTEGER NOT NULL, last_event_id TEXT,
             PRIMARY KEY (task_id, platform, chat_id, thread_id));
         """
     )
-    conn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('task-1', 'T', 'done', 1000)")
+    conn.execute("INSERT INTO tasks (id, title, status, current_run_id, created_at) VALUES ('task-1', 'T', 'running', 'r-1', 1000)")
     conn.execute("INSERT INTO task_comments VALUES ('c-1', 'task-1', 'agent', 'hi', 1500)")
     conn.execute("INSERT INTO task_events VALUES ('e-1', 'task-1', 'completed', NULL, 2000)")
     conn.execute("INSERT INTO task_events VALUES ('e-2', 'task-1', 'blocked', NULL, 2100)")
-    conn.execute("INSERT INTO task_runs VALUES ('r-1', 'task-1', 'default', 'done', 1000)")
+    conn.execute("INSERT INTO task_runs VALUES ('r-1', 'task-1', 'external-lane', 'publish', 'running', 'external:build-7', 1234, 4321, 5678, 1200, 1000, NULL, NULL, 'handoff', '{\"on_failure\":\"retry\"}', NULL, 'external', 'external-lane', 'build-7', 'upload', 2, 3, 'log://build-7', 'result://build-7', 'host', 999, 'proc_legacy', '/tmp/proc_legacy.json')")
     conn.execute(
         "INSERT INTO kanban_notify_subs (task_id, platform, chat_id, created_at, last_event_id) "
         "VALUES ('task-1', 'telegram', '123', 1000, 'e-1')"
@@ -91,7 +98,22 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
         # Data preserved across the rebuild.
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2
         assert conn.execute("SELECT body FROM task_comments").fetchone()["body"] == "hi"
-        assert len(conn.execute("SELECT * FROM task_runs").fetchall()) == 1
+        run = conn.execute("SELECT * FROM task_runs").fetchone()
+        assert run is not None
+        assert {
+            "profile": "external-lane", "step_key": "publish", "status": "running",
+            "claim_lock": "external:build-7", "claim_expires": 1234, "worker_pid": 4321,
+            "max_runtime_seconds": 5678, "last_heartbeat_at": 1200, "started_at": 1000,
+            "summary": "handoff", "metadata": '{\"on_failure\":\"retry\"}',
+            "owner_kind": "external", "owner": "external-lane", "external_id": "build-7",
+            "phase": "upload", "progress_current": 2, "progress_total": 3,
+            "log_ref": "log://build-7", "result_ref": "result://build-7",
+            "pid_scope": "host", "host_start_time": 999,
+            "managed_process_session_id": "proc_legacy",
+            "durable_result_path": "/tmp/proc_legacy.json",
+        }.items() <= dict(run).items()
+        # A legacy TEXT pointer must be rewritten to the AUTOINCREMENT id.
+        assert conn.execute("SELECT current_run_id FROM tasks WHERE id='task-1'").fetchone()["current_run_id"] == run["id"]
         # Non-numeric legacy cursor ("e-1") casts to 0.
         assert conn.execute("SELECT last_event_id FROM kanban_notify_subs").fetchone()["last_event_id"] == 0
 
@@ -107,6 +129,194 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
         assert isinstance(new_id, int) and new_id >= 1
 
 
+
+
+
+def test_owner_provenance_columns_backfill_legacy_executable_tasks_conservatively(tmp_path, monkeypatch):
+    """Assigned executable legacy work keeps its dispatch intent without inventing profiles.
+
+    The migration may use durable historical facts (assignee plus executable
+    status/current run), but it must not probe the currently installed profile
+    roster: an old profile can be restored later and remains a valid agent lane.
+    """
+    db_path = _setup_home(tmp_path, monkeypatch)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.executescript(kb.SCHEMA_SQL)
+        columns = [
+            row for row in conn.execute("PRAGMA table_info(tasks)")
+            if row["name"] not in {
+                "owner_kind", "task_kind", "purpose", "created_by_task_id",
+                "created_by_run_id", "creation_authority",
+            }
+        ]
+        conn.execute("DROP TABLE tasks")
+        definitions = []
+        for row in columns:
+            definition = f'"{row["name"]}" {row["type"]}'
+            if row["pk"]:
+                definition += " PRIMARY KEY"
+            elif row["notnull"]:
+                definition += " NOT NULL"
+            if row["dflt_value"] is not None:
+                definition += f" DEFAULT {row['dflt_value']}"
+            definitions.append(definition)
+        conn.execute(f"CREATE TABLE tasks ({', '.join(definitions)})")
+        conn.executemany(
+            "INSERT INTO tasks (id, title, status, assignee, created_at) VALUES (?, ?, ?, ?, 1)",
+            [
+                ("legacy-todo", "blocked-by-parent executable", "todo", "old-worker"),
+                ("legacy-scheduled", "scheduled executable", "scheduled", "old-worker"),
+                ("legacy-ready", "queued executable", "ready", "old-worker"),
+                ("legacy-running", "active executable", "running", "old-worker"),
+                ("legacy-blocked", "blocked executable", "blocked", "old-worker"),
+                ("legacy-review", "review executable", "review", "old-worker"),
+                ("legacy-triage", "triage executable", "triage", "old-worker"),
+                ("legacy-done", "completed work", "done", "old-worker"),
+                ("legacy-archived", "archived work", "archived", "old-worker"),
+                ("legacy-unassigned", "unassigned queue", "ready", None),
+                ("legacy-manual", "manual lane", "todo", "release-manager"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path) as migrated:
+        fields = {row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")}
+        assert {"owner_kind", "task_kind", "purpose", "created_by_task_id", "created_by_run_id", "creation_authority"} <= fields
+        owners = {
+            task_id: kb.get_task(migrated, task_id).owner_kind
+            for task_id in (
+                "legacy-todo", "legacy-scheduled", "legacy-ready", "legacy-running",
+                "legacy-blocked", "legacy-review", "legacy-triage", "legacy-done",
+                "legacy-archived", "legacy-unassigned", "legacy-manual",
+            )
+        }
+        assert owners == {
+            "legacy-todo": "agent", "legacy-scheduled": "agent",
+            "legacy-ready": "agent", "legacy-running": "agent",
+            "legacy-blocked": "agent", "legacy-review": "agent",
+            "legacy-triage": "agent", "legacy-done": "agent",
+            "legacy-archived": "agent", "legacy-unassigned": "no_agent",
+            "legacy-manual": "agent",
+        }
+        assert all(
+            kb.get_task(migrated, task_id).owner_kind_explicit is False
+            for task_id in owners
+        )
+        assert kb.claim_task(migrated, "legacy-ready", claimer="test") is not None
+        ready = kb.get_task(migrated, "legacy-ready")
+        assert ready is not None and ready.task_kind == "ordinary" and ready.purpose is None
+
+    # Reopening cannot undo the selected ownership classification.
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path) as migrated:
+        assert kb.get_task(migrated, "legacy-review").owner_kind == "agent"
+        assert kb.get_task(migrated, "legacy-manual").owner_kind == "agent"
+
+
+def test_legacy_agent_backfill_defers_missing_profile_preflight_until_dispatch(tmp_path, monkeypatch):
+    """Migration never auto-spawns an invented profile; dispatch preflights it later."""
+    db_path = _setup_home(tmp_path, monkeypatch)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(kb.SCHEMA_SQL)
+        conn.execute("ALTER TABLE tasks DROP COLUMN owner_kind")
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, assignee, created_at) "
+            "VALUES ('legacy-ready', 'queued executable', 'ready', 'restorable-profile', 1)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: False)
+    spawned = []
+    with kb.connect(db_path) as migrated:
+        assert kb.get_task(migrated, "legacy-ready").owner_kind == "agent"
+        kb.dispatch_once(migrated, spawn_fn=lambda task, workspace: spawned.append(task.id) or 1)
+        assert kb.get_task(migrated, "legacy-ready").status == "ready"
+    assert spawned == []
+
+
+def test_candidate_uses_completed_producing_run_profile_not_reassigned_task(tmp_path, monkeypatch):
+    """A reassignment cannot turn the original implementer into its reviewer."""
+    db_path = _setup_home(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.setattr(kb, "_configured_coordinator_principal", lambda: "coordinator")
+    with kb.connect(db_path) as conn:
+        task_id = kb.create_task(conn, title="source", assignee="implementer")
+        conn.execute(
+            "INSERT INTO task_runs (task_id, profile, status, outcome, started_at, ended_at, summary) "
+            "VALUES (?, 'implementer', 'done', 'completed', 1, 2, 'produced')",
+            (task_id,),
+        )
+        conn.execute("UPDATE tasks SET assignee='reviewer' WHERE id=?", (task_id,))
+        candidate = kb.create_candidate(
+            conn, task_id, sha="a" * 40,
+            source_receipt={"candidate_sha": "a" * 40, "subject": "artifact", "provenance": "test", "producer_profile": "implementer"},
+        )
+    assert candidate["implementer"] == "implementer"
+
+
+def test_migration_preserves_assigned_dependency_graph_dispatch_without_spawning_unknown_profiles(tmp_path, monkeypatch):
+    """A legacy todo child retains its agent lane until its parent completes."""
+    db_path = _setup_home(tmp_path, monkeypatch)
+    with sqlite3.connect(str(db_path)) as legacy:
+        legacy.executescript(kb.SCHEMA_SQL)
+        legacy.execute("ALTER TABLE tasks DROP COLUMN owner_kind")
+        legacy.executemany(
+            "INSERT INTO tasks (id, title, status, assignee, created_at) VALUES (?, ?, ?, ?, 1)",
+            [
+                ("parent", "legacy parent", "ready", "known"),
+                ("child", "legacy dependent", "todo", "known"),
+                ("unknown", "legacy unknown profile", "ready", "absent-profile"),
+            ],
+        )
+        legacy.execute("INSERT INTO task_links (parent_id, child_id) VALUES ('parent', 'child')")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "known")
+    spawned = []
+    with kb.connect(db_path) as migrated:
+        assert kb.get_task(migrated, "child").owner_kind == "agent"
+        assert kb.get_task(migrated, "child").owner_kind_explicit is False
+        kb.dispatch_once(migrated, spawn_fn=lambda task, *_: spawned.append(task.id) or 1)
+        assert spawned == ["parent"]
+        assert kb.complete_task(migrated, "parent", result="done")
+        kb.dispatch_once(migrated, spawn_fn=lambda task, *_: spawned.append(task.id) or 1)
+        assert spawned == ["parent", "child"]
+        assert kb.get_task(migrated, "unknown").status == "ready"
+    assert spawned.count("child") == 1
+    assert "unknown" not in spawned
+
+
+def test_candidate_evidence_and_verdict_tables_are_added_to_legacy_db(tmp_path, monkeypatch):
+    """Schema initialization adds all immutable-evidence tables to an old DB."""
+    db_path = _setup_home(tmp_path, monkeypatch)
+    with sqlite3.connect(str(db_path)) as legacy:
+        legacy.executescript(kb.SCHEMA_SQL)
+        legacy.execute("DROP TABLE task_gate_verdicts")
+        legacy.execute("DROP TABLE task_evidence_receipts")
+        legacy.execute("DROP TABLE task_candidates")
+        legacy.execute(
+            "INSERT INTO tasks (id, title, status, created_at) "
+            "VALUES ('legacy-evidence', 'legacy', 'done', 1)"
+        )
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path) as migrated:
+        tables = {
+            row["name"] for row in migrated.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        assert {"task_candidates", "task_evidence_receipts", "task_gate_verdicts", "task_release_barriers"} <= tables
+        assert migrated.execute(
+            "SELECT title FROM tasks WHERE id='legacy-evidence'"
+        ).fetchone()["title"] == "legacy"
 
 
 def test_migration_is_idempotent(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -93,3 +93,18 @@ def test_explicitly_assigned_task_untouched_by_default_assignee(isolated_kanban_
     assert any(s[0] == task_id and s[1] == "default" for s in res.spawned)
 
 
+def test_explicit_no_agent_task_is_never_promoted_by_default_assignee(isolated_kanban_home):
+    """An explicit no_agent routing decision must survive dispatcher fallback."""
+    kb, _home = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        task_id = kb.create_task(conn, title="manual lane", owner_kind="no_agent")
+        res = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False, default_assignee="default",
+        )
+        task = kb.get_task(conn, task_id)
+    assert res.auto_assigned_default == []
+    assert task.assignee is None
+    assert task.owner_kind == "no_agent"
+
+

--- a/tests/hermes_cli/test_kanban_external_orchestration.py
+++ b/tests/hermes_cli/test_kanban_external_orchestration.py
@@ -1,0 +1,962 @@
+"""End-to-end contracts for durable Kanban external-run orchestration."""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    (home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    kb.init_db()
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _attest_legacy_scratch_candidates(monkeypatch):
+    """Keep legacy test scenarios while supplying the now-required receipt."""
+    original_candidate = kb.create_candidate
+    original_create = kb.create_task
+    original_complete = kb.complete_task
+
+    def attested(conn, task_id, *, sha, source_receipt=None):
+        conn.execute(
+            "UPDATE tasks SET assignee='implementer' WHERE id=? AND (assignee IS NULL OR assignee='')",
+            (task_id,),
+        )
+        return original_candidate(conn, task_id, sha=sha, source_receipt=source_receipt or {
+            "candidate_sha": sha, "subject": "test candidate", "provenance": "test coordinator receipt", "producer_profile": "implementer",
+        })
+
+    def exact_gate(conn, **kwargs):
+        if kwargs.get("task_kind") in {"reviewer", "visualqa"} and kwargs.get("created_by_task_id"):
+            conn.execute("UPDATE tasks SET assignee='implementer' WHERE id=? AND (assignee IS NULL OR assignee='')", (kwargs["created_by_task_id"],))
+            if kwargs.get("assignee") == "implementer":
+                kwargs["task_kind"] = "ordinary"
+                return original_create(conn, **kwargs)
+            receipt = original_get_frozen(conn, kwargs["created_by_task_id"])
+            if receipt is not None:
+                kwargs["gate_candidate_sha"] = receipt["sha"]
+                kwargs["gate_manifest_hash"] = receipt["manifest_hash"]
+                kwargs.pop("owner_kind", None)  # inferred agent avoids unrelated profile fixture admission.
+        return original_create(conn, **kwargs)
+
+    def bound_completion(conn, task_id, **kwargs):
+        task = kb.get_task(conn, task_id)
+        if task and task.task_kind in {"reviewer", "visualqa"}:
+            kwargs.setdefault("metadata", {
+                "candidate_sha": task.gate_candidate_sha,
+                "manifest_hash": task.gate_manifest_hash,
+            })
+            claimed = kb.claim_task(conn, task_id)
+            assert claimed is not None and claimed.current_run_id is not None
+            kwargs.setdefault("expected_run_id", claimed.current_run_id)
+            monkeypatch.setenv("HERMES_PROFILE", task.assignee)
+            try:
+                return original_complete(conn, task_id, **kwargs)
+            finally:
+                monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        return original_complete(conn, task_id, **kwargs)
+
+    original_get_frozen = kb.get_frozen_evidence_manifest
+    monkeypatch.setattr(kb, "create_candidate", attested)
+    monkeypatch.setattr(kb, "create_task", exact_gate)
+    monkeypatch.setattr(kb, "complete_task", bound_completion)
+
+
+def test_external_run_is_durable_and_redacts_sensitive_refs(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="external build", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(
+            conn,
+            task_id,
+            owner="operator",
+            external_id="build-42",
+            pid=4242,
+            phase="upload",
+            current=1,
+            total=3,
+            log_ref="https://token:secret@example.test/log",
+            result_ref="Bearer top-secret",
+            max_retries=2,
+        )
+        assert run.owner_kind == "external"
+        assert run.external_id == "build-42"
+        assert run.worker_pid == 4242
+        assert run.phase == "upload"
+        assert (run.progress_current, run.progress_total) == (1, 3)
+        assert "secret" not in (run.log_ref or "")
+        assert "secret" not in (run.result_ref or "")
+
+    # A new registry/process reopening the same SQLite database sees the run.
+    with kb.connect() as reopened:
+        restored = kb.get_external_run(reopened, run.id)
+        assert restored is not None
+        assert restored.external_id == "build-42"
+        assert restored.status == "running"
+
+
+def test_external_run_heartbeat_and_completion_are_idempotent(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="external deploy", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(
+            conn, task_id, owner="operator", external_id="deploy-7", phase="build",
+        )
+        assert kb.heartbeat_external_run(
+            conn, run.id, owner="operator", phase="publish", current=2, total=2,
+        ) is True
+        assert kb.finish_external_run(
+            conn, run.id, owner="operator", outcome="completed", result_ref="done",
+        ) is True
+        # Duplicate provider webhooks must not reopen/re-complete the card.
+        assert kb.finish_external_run(
+            conn, run.id, owner="operator", outcome="completed", result_ref="done",
+        ) is False
+        assert kb.get_task(conn, task_id).status == "done"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'", (task_id,)
+        ).fetchone()[0] == 1
+
+
+def test_create_task_rejects_unknown_inferred_agent_assignee(kanban_home, monkeypatch):
+    """The DB admission boundary rejects implicit agent ownership too."""
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: False)
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="agent owner"):
+            kb.create_task(conn, title="missing implicit agent", assignee="missing")
+        assert kb.list_tasks(conn) == []
+        external = kb.create_task(
+            conn, title="intentional external", assignee="missing", owner_kind="external",
+        )
+        no_agent = kb.create_task(
+            conn, title="intentional manual", assignee="missing", owner_kind="no_agent",
+        )
+    assert external and no_agent
+
+
+def test_shared_kanban_fixture_does_not_admit_unlisted_agent_profile(kanban_home):
+    """An arbitrary agent assignee stays absent despite shared Kanban setup."""
+    import hermes_cli.profiles as profiles
+
+    unlisted = "arbitrary-unlisted-profile"
+    assert profiles.profile_exists(unlisted) is False
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="agent owner"):
+            kb.create_task(conn, title="unlisted agent", assignee=unlisted)
+    assert profiles.profile_exists(unlisted) is False
+
+
+def test_creation_owner_and_provenance_are_immutable_at_db_boundary(kanban_home, monkeypatch):
+    import hermes_cli.profiles as profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "worker")
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="agent owner"):
+            kb.create_task(conn, title="bad", assignee="missing", owner_kind="agent")
+        task_id = kb.create_task(
+            conn, title="external", assignee="lane", owner_kind="external",
+            task_kind="ordinary", purpose="build", creation_authority="operator",
+        )
+        task = kb.get_task(conn, task_id)
+        assert task.owner_kind == "external"
+        assert task.task_kind == "ordinary"
+        assert task.creation_authority == "operator"
+        with pytest.raises(ValueError, match="immutable"):
+            kb.assign_task(conn, task_id, "worker", owner_kind="agent")
+
+
+def test_control_plane_authority_is_bound_to_runtime_profile_not_caller_string(kanban_home, monkeypatch):
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "worker")
+    with pytest.raises(ValueError, match="runtime HERMES_PROFILE"):
+        kb._require_control_authority("coordinator")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with pytest.raises(ValueError, match="assertion"):
+        kb._require_control_authority("system")
+    assert kb._require_control_authority("coordinator") == "coordinator"
+
+
+def test_operator_start_external_run_requires_ready_external_task_and_immutable_owner(kanban_home, monkeypatch):
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "operator")
+    with kb.connect() as conn:
+        agent_task = kb.create_task(conn, title="agent", assignee="operator")
+        external_task = kb.create_task(
+            conn, title="external", assignee="external-lane", owner_kind="external",
+        )
+        with pytest.raises(ValueError, match="external run requires"):
+            kb.start_external_run(conn, agent_task, owner="operator", external_id="agent-bypass")
+        with pytest.raises(ValueError, match="external run requires"):
+            kb.start_external_run(conn, external_task, owner="other-lane", external_id="owner-bypass")
+        run = kb.start_external_run(
+            conn, external_task, owner="external-lane", external_id="allowed",
+        )
+        assert run.owner == "external-lane"
+
+
+def test_only_agent_owned_tasks_can_be_claimed_or_dispatch_spawned(kanban_home, monkeypatch):
+    """An installed-profile assignee never makes an external/no_agent card dispatchable."""
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "worker")
+    with kb.connect() as conn:
+        agent = kb.create_task(conn, title="agent", assignee="worker", owner_kind="agent")
+        external = kb.create_task(conn, title="external", assignee="worker", owner_kind="external")
+        no_agent = kb.create_task(conn, title="no agent", assignee="worker", owner_kind="no_agent")
+
+        assert kb.claim_task(conn, external) is None
+        assert kb.claim_task(conn, no_agent) is None
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (external,))
+        assert kb.claim_review_task(conn, external) is None
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (external,))
+        assert kb.claim_task(conn, agent) is not None
+        kb.complete_task(conn, agent, result="done")
+
+        spawned = []
+        result = kb.dispatch_once(conn, spawn_fn=lambda task, *_: spawned.append(task.id) or 1)
+        assert spawned == []
+        assert result.spawned == []
+        external_task = kb.get_task(conn, external)
+        no_agent_task = kb.get_task(conn, no_agent)
+        assert external_task is not None and external_task.status == "ready"
+        assert no_agent_task is not None and no_agent_task.status == "ready"
+
+
+def test_gate_task_requires_configured_authority_at_db_boundary(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_PROFILE", "worker")
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="runtime HERMES_PROFILE"):
+            kb.create_task(conn, title="review", task_kind="reviewer", creation_authority="worker")
+
+
+def test_wait_rejects_unknown_kind_and_empty_ref(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="bad wait", assignee="operator", owner_kind="no_agent")
+        with pytest.raises(ValueError, match="wait_kind"):
+            kb.set_task_wait(conn, task_id, kind="anything", ref="x")
+        with pytest.raises(ValueError, match="wait_ref"):
+            kb.set_task_wait(conn, task_id, kind="human", ref="")
+
+
+def test_external_ownership_transfer_is_atomic_and_survives_registry_close(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="transfer", assignee="lane-a", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="lane-a", external_id="job-1")
+        assert kb.transfer_external_run_owner(conn, run.id, from_owner="lane-a", to_owner="lane-b")
+        assert not kb.heartbeat_external_run(conn, run.id, owner="lane-a")
+        assert kb.heartbeat_external_run(conn, run.id, owner="lane-b")
+
+    # Reopening is the ProcessRegistry/AIAgent-close boundary: external owner
+    # records are database-owned and therefore remain controllable.
+    with kb.connect() as reopened:
+        assert kb.finish_external_run(reopened, run.id, owner="lane-b", outcome="completed")
+        assert kb.get_task(reopened, task_id).status == "done"
+        assert reopened.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='external_owner_transferred'",
+            (task_id,),
+        ).fetchone()[0] == 1
+
+
+def test_operator_external_pid_never_suppresses_heartbeat_expiry(kanban_home):
+    """An operator-supplied PID is not trusted host-process identity evidence."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="external pid", assignee="operator", owner_kind="external",
+        )
+        run = kb.start_external_run(
+            conn, task_id, owner="operator", external_id="operator-pid", pid=os.getpid(),
+        )
+        conn.execute("UPDATE task_runs SET last_heartbeat_at=0 WHERE id=?", (run.id,))
+        assert kb.reconcile_stale_external_runs(conn, stale_after_seconds=1) == 1
+        reconciled = kb.get_external_run(conn, run.id)
+        assert reconciled is not None and reconciled.outcome == "lost"
+        assert kb.get_task(conn, task_id).status == "blocked"
+
+
+def test_stale_external_reconciliation_exhausts_retry_once(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="stale", assignee="lane", owner_kind="external")
+        run = kb.start_external_run(
+            conn, task_id, owner="lane", external_id="stale-1", max_retries=1,
+            on_failure="retry",
+        )
+        conn.execute("UPDATE task_runs SET last_heartbeat_at=0 WHERE id=?", (run.id,))
+        assert kb.reconcile_stale_external_runs(conn, stale_after_seconds=1) == 1
+        assert kb.get_task(conn, task_id).status == "blocked"
+        # The terminal run's CAS condition makes repeated reconciler ticks inert.
+        assert kb.reconcile_stale_external_runs(conn, stale_after_seconds=1) == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='external_retry_exhausted'",
+            (task_id,),
+        ).fetchone()[0] == 1
+
+
+
+def test_stale_external_block_policy_blocks_on_its_first_lost_run(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="stale block", assignee="lane", owner_kind="external")
+        run = kb.start_external_run(
+            conn, task_id, owner="lane", external_id="stale-block", max_retries=9,
+            on_failure="block",
+        )
+        conn.execute("UPDATE task_runs SET last_heartbeat_at=0 WHERE id=?", (run.id,))
+        assert kb.reconcile_stale_external_runs(conn, stale_after_seconds=1) == 1
+        assert kb.get_task(conn, task_id).status == "blocked"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='external_lost'", (task_id,)
+        ).fetchone()[0] == 1
+
+
+def test_direct_completion_cannot_settle_a_live_external_owned_run(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="external only", assignee="lane", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="lane", external_id="external-only")
+        assert kb.complete_task(conn, task_id, result="bypass") is False
+        live = kb.get_task(conn, task_id)
+        assert live is not None and live.status == "running" and live.current_run_id == run.id
+        assert kb.finish_external_run(conn, run.id, owner="lane", outcome="completed") is True
+        assert kb.get_task(conn, task_id).status == "done"
+
+
+def test_candidate_and_manifest_bind_attachment_bytes(kanban_home, tmp_path):
+    """A frozen evidence receipt is tied to one immutable candidate and blob."""
+    payload = b"verified report"
+    blob = tmp_path / "report.txt"
+    blob.write_bytes(payload)
+    digest = __import__("hashlib").sha256(payload).hexdigest()
+    sha = "a" * 40
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="candidate")
+        attachment_id = kb.add_attachment(
+            conn, task_id, filename="report.txt", stored_path=str(blob),
+            content_type="text/plain", size=len(payload), uploaded_by="test",
+        )
+        candidate = kb.create_candidate(conn, task_id, sha=sha)
+        assert candidate["sha"] == sha
+        receipt = kb.freeze_evidence_manifest(
+            conn, task_id, sha=sha,
+            manifest={"required_slots": ["report"], "entries": [{
+                "attachment_id": attachment_id, "sha256": digest,
+                "content_type": "text/plain", "decoder_valid": True,
+                "decoder_metadata": {"parser": "text"}, "cardinality": 1,
+                "slot": "report", "mode": "required",
+            }]},
+            verdict="pass", authority="coordinator",
+        )
+        assert receipt["sha"] == sha and receipt["manifest_hash"]
+
+
+
+@pytest.mark.parametrize("case, message", [
+    ("missing_bytes", "bytes are missing"), ("hash", "hash mismatch"),
+    ("mime", "content_type"),
+    ("cardinality", "cardinality"), ("slot", "slot and mode"),
+    ("required_slot", "required slot"), ("candidate_task", "candidate is missing"),
+])
+def test_manifest_rejects_invalid_evidence_contract(kanban_home, tmp_path, case, message):
+    blob = tmp_path / "evidence.bin"; blob.write_bytes(b"ok")
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="evidence")
+        aid = kb.add_attachment(conn, task, filename="evidence.bin", stored_path=str(blob), content_type="image/png" if case == "dimensions" else "application/octet-stream", size=2)
+        sha = "a" * 40
+        if case == "candidate_task":
+            other = kb.create_task(conn, title="other"); kb.create_candidate(conn, other, sha=sha)
+        else: kb.create_candidate(conn, task, sha=sha)
+        entry = {"attachment_id": aid, "sha256": hashlib.sha256(b"ok").hexdigest(), "content_type": "image/png" if case == "dimensions" else "application/octet-stream", "decoder_valid": True, "decoder_metadata": {}, "cardinality": 1, "slot": "artifact", "mode": "required"}
+        manifest = {"required_slots": ["artifact"], "entries": [entry]}
+        if case == "missing_bytes": blob.unlink()
+        elif case == "hash": entry["sha256"] = "0" * 64
+        elif case == "mime": entry["content_type"] = "text/plain"
+        elif case == "decoder": entry["decoder_valid"] = False
+        elif case == "metadata": entry.pop("decoder_metadata")
+        elif case == "cardinality": entry["cardinality"] = 0
+        elif case == "slot": entry["slot"] = ""
+        elif case == "required_slot": manifest["required_slots"] = ["absent"]
+        with pytest.raises(ValueError, match=message):
+            kb.freeze_evidence_manifest(conn, task, sha=sha, manifest=manifest, verdict="pass", authority="coordinator")
+
+
+def test_gate_verdict_rejects_stale_bindings_and_mutation(kanban_home, tmp_path, monkeypatch):
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with kb.connect() as conn:
+        task, sha, receipt = _review_wait_source(conn, tmp_path)
+        gate = _review_wait_gate(conn, task)
+        kb.complete_task(conn, gate, result="validated", summary="validated")
+        with pytest.raises(ValueError, match="stale"):
+            kb.record_gate_verdict(conn, task, gate_task_id=gate, sha="b" * 40,
+                manifest_hash=receipt["manifest_hash"], verdict="pass", authority="coordinator")
+        with pytest.raises(ValueError, match="stale"):
+            kb.record_gate_verdict(conn, task, gate_task_id=gate, sha=sha,
+                manifest_hash="0" * 64, verdict="pass", authority="coordinator")
+        kb.record_gate_verdict(conn, task, gate_task_id=gate, sha=sha,
+            manifest_hash=receipt["manifest_hash"], verdict="pass", authority="coordinator")
+        with pytest.raises(ValueError, match="immutable"):
+            kb.record_gate_verdict(conn, task, gate_task_id=gate, sha=sha,
+                manifest_hash=receipt["manifest_hash"], verdict="fail", authority="coordinator")
+
+def test_evidence_manifest_freezes_exact_sha_and_verdict(kanban_home, tmp_path):
+    blob = tmp_path / "legacy-evidence.txt"
+    blob.write_text("evidence", encoding="utf-8")
+    digest = hashlib.sha256(blob.read_bytes()).hexdigest()
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="evidence", assignee="operator", owner_kind="no_agent")
+        sha = "a" * 40
+        attachment_id = kb.add_attachment(conn, task_id, filename="evidence.txt", stored_path=str(blob), content_type="text/plain", size=8)
+        kb.create_candidate(conn, task_id, sha=sha)
+        receipt = kb.freeze_evidence_manifest(
+            conn, task_id, sha=sha, manifest={"required_slots": ["evidence"], "entries": [{"attachment_id": attachment_id, "sha256": digest, "content_type": "text/plain", "decoder_valid": True, "decoder_metadata": {}, "cardinality": 1, "slot": "evidence", "mode": "required"}]},
+            verdict="pass", authority="coordinator",
+        )
+        assert receipt["sha"] == sha
+        assert kb.get_frozen_evidence_manifest(conn, task_id) == receipt
+        with pytest.raises(ValueError, match="candidate is missing"):
+            kb.freeze_evidence_manifest(
+                conn, task_id, sha="b" * 40, manifest={}, verdict="pass", authority="coordinator",
+            )
+
+
+def test_deterministic_release_barrier_requires_gates_lease_and_readback(kanban_home, tmp_path, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    blob = tmp_path / "release"; blob.write_bytes(b"release")
+    sha = "a" * 40
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="release")
+        child = kb.create_task(conn, title="dependent")
+        kb.link_tasks(conn, parent_id=task, child_id=child)
+        kb.block_task(conn, child, reason="waiting")
+        aid = kb.add_attachment(conn, task, filename="release", stored_path=str(blob), content_type="application/octet-stream", size=7)
+        kb.create_candidate(conn, task, sha=sha)
+        manifest = kb.freeze_evidence_manifest(conn, task, sha=sha, manifest={"required_slots":["release"], "entries":[{"attachment_id":aid,"sha256":hashlib.sha256(b"release").hexdigest(),"content_type":"application/octet-stream","decoder_valid":True,"decoder_metadata":{},"cardinality":1,"slot":"release","mode":"required"}]}, verdict="pass", authority="coordinator")
+        review = kb.create_task(conn, title="review", assignee="reviewer", owner_kind="no_agent", task_kind="reviewer", created_by_task_id=task, creation_authority="coordinator")
+        security = kb.create_task(conn, title="security", assignee="security", owner_kind="no_agent", task_kind="reviewer", created_by_task_id=task, creation_authority="coordinator")
+        kb.complete_task(conn, review, result="pass", summary="validated")
+        kb.complete_task(conn, security, result="pass", summary="validated")
+        barrier = kb.create_release_barrier(conn, task, sha=sha, manifest_hash=manifest["manifest_hash"], required_gates=[review, security], authority="coordinator")
+        assert barrier["sha"] == sha
+        assert kb.acquire_release_barrier_lease(conn, task, barrier="publish", owner_token="one", ttl_seconds=60)
+    with kb.connect() as other:
+        assert not kb.acquire_release_barrier_lease(other, task, barrier="publish", owner_token="two", ttl_seconds=60)
+        with pytest.raises(ValueError, match="lease is not owned"):
+            kb.reconcile_release_barrier(other, task, barrier="publish", owner_token="two")
+        kb.record_gate_verdict(other, task, gate_task_id=review, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+        kb.record_gate_verdict(other, task, gate_task_id=security, sha=sha, manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator")
+        assert kb.reconcile_release_barrier(other, task, barrier="publish", owner_token="one") == "awaiting_receipt"
+        with pytest.raises(ValueError, match="requires a recorded delivery"):
+            kb.record_release_readback(
+                other, task, barrier="publish", owner_token="one", readback_sha=sha,
+            )
+        kb.prepare_release_delivery_intent(other, task, barrier="publish", owner_token="one", target_identity="target", candidate_sha=sha, idempotency_key="release")
+        kb.record_release_delivery(other, task, barrier="publish", owner_token="one", target_identity="target", delivered_sha=sha, idempotency_key="release")
+        assert kb.reconcile_release_barrier(other, task, barrier="publish", owner_token="one") == "awaiting_readback"
+        kb.record_release_readback(other, task, barrier="publish", owner_token="one", readback_sha=sha)
+        assert kb.reconcile_release_barrier(other, task, barrier="publish", owner_token="one") == "released"
+        assert kb.reconcile_release_barrier(other, task, barrier="publish", owner_token="one") == "released"
+        assert other.execute("SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='release_barrier_completed'", (task,)).fetchone()[0] == 1
+        assert kb.get_task(other, child).status == "ready"
+
+
+
+def test_release_barrier_lease_readback_and_migration_contract(kanban_home, tmp_path, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    blob = tmp_path / "x"; blob.write_bytes(b"x"); sha = "c" * 40
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="barrier")
+        child = kb.create_task(conn, title="child", initial_status="blocked")
+        kb.link_tasks(conn, parent_id=task, child_id=child)
+        aid = kb.add_attachment(conn, task, filename="x", stored_path=str(blob), content_type="application/octet-stream", size=1)
+        kb.create_candidate(conn, task, sha=sha)
+        m = kb.freeze_evidence_manifest(conn, task, sha=sha, manifest={"required_slots":["x"],"entries":[{"attachment_id":aid,"sha256":hashlib.sha256(b"x").hexdigest(),"content_type":"application/octet-stream","decoder_valid":True,"decoder_metadata":{},"cardinality":1,"slot":"x","mode":"r"}]}, verdict="pass", authority="coordinator")
+        gate = kb.create_task(conn, title="gate", assignee="reviewer", owner_kind="no_agent", task_kind="reviewer", created_by_task_id=task, creation_authority="coordinator")
+        kb.complete_task(conn, gate, result="fail", summary="validated")
+        kb.create_release_barrier(conn, task, sha=sha, manifest_hash=m["manifest_hash"], required_gates=[gate], authority="coordinator")
+        assert kb.acquire_release_barrier_lease(conn, task, barrier="publish", owner_token="a", ttl_seconds=1)
+        assert kb.renew_release_barrier_lease(conn, task, barrier="publish", owner_token="a", ttl_seconds=1)
+        assert not kb.renew_release_barrier_lease(conn, task, barrier="publish", owner_token="b", ttl_seconds=1)
+        assert kb.release_release_barrier_lease(conn, task, barrier="publish", owner_token="a")
+        assert kb.acquire_release_barrier_lease(conn, task, barrier="publish", owner_token="b", ttl_seconds=1)
+        with pytest.raises(ValueError, match="lease is not owned"): kb.record_release_delivery(conn, task, barrier="publish", owner_token="a", target_identity="t", delivered_sha=sha, idempotency_key="x")
+        kb.record_gate_verdict(conn, task, gate_task_id=gate, sha=sha, manifest_hash=m["manifest_hash"], verdict="fail", authority="coordinator")
+        assert kb.reconcile_release_barrier(conn, task, barrier="publish", owner_token="b") == "rejected"
+        assert kb.get_release_barrier(conn, task)["sha"] == sha
+
+
+def test_release_barrier_returns_the_same_durable_receipt_once(kanban_home, monkeypatch):
+    (kanban_home / "config.yaml").write_text("kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="release", assignee="operator")
+        first = kb.release_barrier(conn, task_id, barrier="handoff", authority="coordinator")
+        assert kb.release_barrier(conn, task_id, barrier="handoff", authority="coordinator") == first
+        assert kb.read_release_barrier(conn, task_id, barrier="handoff") == first
+        with pytest.raises(ValueError, match="authority"):
+            kb.release_barrier(conn, task_id, barrier="handoff", authority="other")
+
+
+def test_typed_wait_ends_claimed_run_and_scopes_wait_event_to_it(kanban_home):
+    """Parking active work closes its authoritative attempt before it is blocked."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="wait from running", assignee="worker", owner_kind="agent",
+        )
+        claimed = kb.claim_task(conn, task_id, claimer="worker:one")
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+
+        kb.set_task_wait(
+            conn, task_id, kind="human", ref="decision:ship",
+            expected_run_id=run_id,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "blocked"
+        assert task.current_run_id is None
+        assert task.claim_lock is None
+        assert task.claim_expires is None
+        assert task.worker_pid is None
+        run = conn.execute(
+            "SELECT status, outcome, summary, metadata, ended_at, claim_lock "
+            "FROM task_runs WHERE id=?", (run_id,),
+        ).fetchone()
+        assert run["status"] == "blocked"
+        assert run["outcome"] == "blocked"
+        assert "human" in run["summary"]
+        assert "decision:ship" in run["summary"]
+        assert {"wait_kind": "human", "wait_ref": "decision:ship"}.items() <= json.loads(run["metadata"]).items()
+        assert run["ended_at"] is not None
+        assert run["claim_lock"] is None
+        event = conn.execute(
+            "SELECT run_id, payload FROM task_events WHERE task_id=? AND kind='wait_set'",
+            (task_id,),
+        ).fetchone()
+        assert event["run_id"] == run_id
+        assert json.loads(event["payload"]) == {"kind": "human", "ref": "decision:ship"}
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id=? AND ended_at IS NULL",
+            (task_id,),
+        ).fetchone()[0] == 0
+
+
+def test_typed_wait_records_ready_task_without_fabricating_live_ownership(kanban_home):
+    """A never-claimed task gets only an ended audit record when parked."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="wait from ready", assignee="operator", owner_kind="no_agent",
+        )
+
+        assert kb.set_task_wait(conn, task_id, kind="human", ref="decision:ready")
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "blocked"
+        assert task.current_run_id is None
+        assert task.claim_lock is None
+        run = conn.execute(
+            "SELECT status, outcome, claim_lock, worker_pid, started_at, ended_at "
+            "FROM task_runs WHERE task_id=?", (task_id,),
+        ).fetchone()
+        assert run["status"] == run["outcome"] == "blocked"
+        assert run["claim_lock"] is None and run["worker_pid"] is None
+        assert run["started_at"] == run["ended_at"]
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id=? AND ended_at IS NULL", (task_id,),
+        ).fetchone()[0] == 0
+
+
+def test_typed_wait_closes_current_run_when_task_is_in_review(kanban_home):
+    """The review status is also a valid live-run wait handoff boundary."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="wait from review", assignee="worker", owner_kind="agent",
+        )
+        claimed = kb.claim_task(conn, task_id, claimer="worker:review")
+        assert claimed is not None and claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+        conn.execute("UPDATE tasks SET status='review' WHERE id=?", (task_id,))
+
+        assert kb.set_task_wait(
+            conn, task_id, kind="human", ref="decision:review",
+            expected_run_id=run_id,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "blocked"
+        assert task.current_run_id is None
+        run = conn.execute(
+            "SELECT status, outcome, ended_at FROM task_runs WHERE id=?", (run_id,),
+        ).fetchone()
+        assert run["status"] == "blocked"
+        assert run["outcome"] == "blocked"
+        assert run["ended_at"] is not None
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id=? AND ended_at IS NULL", (task_id,),
+        ).fetchone()[0] == 0
+
+
+def test_typed_wait_rejects_stale_run_and_resume_claims_a_fresh_run(kanban_home):
+    """A stale worker cannot park a newer run, and resumed work gets a new run."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="wait race", assignee="worker", owner_kind="agent",
+        )
+        first = kb.claim_task(conn, task_id, claimer="worker:first")
+        assert first is not None and first.current_run_id is not None
+        first_run_id = first.current_run_id
+        assert kb.set_task_wait(
+            conn, task_id, kind="human", ref="decision:race", expected_run_id=first_run_id,
+        )
+        assert kb.record_wait_receipt(
+            conn, kind="human", ref="decision:race", authority="coordinator", verdict="approved",
+        )
+        assert kb.resume_task_wait(
+            conn, task_id, authority="coordinator", receipt="decision:race")
+        second = kb.claim_task(conn, task_id, claimer="worker:second")
+        assert second is not None and second.current_run_id is not None
+        second_run_id = second.current_run_id
+        assert second_run_id != first_run_id
+
+        assert not kb.set_task_wait(
+            conn, task_id, kind="human", ref="decision:race", expected_run_id=first_run_id,
+        )
+        live = kb.get_task(conn, task_id)
+        assert live is not None and live.current_run_id == second_run_id
+        assert live.status == "running"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_runs WHERE task_id=? AND ended_at IS NULL", (task_id,),
+        ).fetchone()[0] == 1
+
+        assert kb.set_task_wait(
+            conn, task_id, kind="human", ref="decision:race", expected_run_id=second_run_id,
+        )
+        assert kb.resume_task_wait(
+            conn, task_id, authority="coordinator", receipt="decision:race")
+        final = kb.get_task(conn, task_id)
+        assert final is not None and final.current_run_id is None and final.status == "ready"
+        wait_events = conn.execute(
+            "SELECT run_id FROM task_events WHERE task_id=? AND kind='wait_set' ORDER BY id",
+            (task_id,),
+        ).fetchall()
+        assert [event["run_id"] for event in wait_events] == [first_run_id, second_run_id]
+        runs = conn.execute(
+            "SELECT id, status, outcome, ended_at FROM task_runs WHERE task_id=? ORDER BY id",
+            (task_id,),
+        ).fetchall()
+        assert [run["id"] for run in runs] == [first_run_id, second_run_id]
+        assert all(run["status"] == run["outcome"] == "blocked" for run in runs)
+        assert all(run["ended_at"] is not None for run in runs)
+
+
+@pytest.mark.parametrize(
+    ("kind", "ref"),
+    [
+        ("dependency", "missing-parent"),
+        ("capability", "camera"),
+        ("human", "ship"),
+        ("external_process", "build-42"),
+        ("timer", "2099-01-01T00:00:00"),
+        ("review", "reviewer:alice"),
+    ],
+)
+def test_typed_wait_rejects_noncanonical_or_unbound_refs(kanban_home, kind, ref):
+    """A wait is not valid until its kind-specific durable target is bound."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title=f"invalid {kind}", assignee="operator", owner_kind="no_agent")
+        with pytest.raises(ValueError):
+            kb.set_task_wait(conn, task_id, kind=kind, ref=ref)
+
+
+def test_dispatch_reconciles_only_matching_typed_wait_receipts_once(kanban_home):
+    """Two dispatcher ticks resume precisely eligible waits and emit one event."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="operator", owner_kind="no_agent")
+        child = kb.create_task(conn, title="child", assignee="operator", owner_kind="no_agent", initial_status="running")
+        kb.link_tasks(conn, parent, child)
+        # A typed dependency wait may park an actively routed child; simulate
+        # that pre-dispatch state without bypassing the wait API itself.
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+        kb.set_task_wait(conn, child, kind="dependency", ref=parent)
+
+        external = kb.create_task(conn, title="external", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, external, owner="operator", external_id="build-42")
+        waiter = kb.create_task(conn, title="wait external", assignee="operator", owner_kind="no_agent")
+        kb.set_task_wait(conn, waiter, kind="external_process", ref=f"run:{run.id}")
+
+        capability = kb.create_task(conn, title="capability", assignee="operator", owner_kind="no_agent")
+        kb.set_task_wait(conn, capability, kind="capability", ref="cap:camera")
+        assert not kb.resume_task_wait(conn, capability, authority="human", receipt="cap:camera")
+        assert kb.record_wait_receipt(conn, kind="capability", ref="cap:camera", authority="coordinator", verdict="available")
+
+        assert kb.finish_external_run(conn, run.id, owner="operator", outcome="completed")
+        assert kb.complete_task(conn, parent, result="done")
+        kb.dispatch_once(conn, spawn_fn=lambda *_: None)
+        kb.dispatch_once(conn, spawn_fn=lambda *_: None)
+
+        assert kb.get_task(conn, child).status == "ready"
+        assert kb.get_task(conn, waiter).status == "ready"
+        assert kb.get_task(conn, capability).status == "ready"
+        for task_id in (child, waiter, capability):
+            assert conn.execute(
+                "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='wait_resumed'",
+                (task_id,),
+            ).fetchone()[0] == 1
+
+
+def test_manual_resume_requires_matching_explicit_receipt(kanban_home, tmp_path, monkeypatch):
+    """Generic authority labels cannot resume a human or review wait."""
+    with kb.connect() as conn:
+        human = kb.create_task(conn, title="approval", assignee="operator", owner_kind="no_agent")
+        kb.set_task_wait(conn, human, kind="human", ref="decision:ship")
+        assert not kb.resume_task_wait(conn, human, authority="human", receipt="decision:other")
+        assert kb.record_wait_receipt(conn, kind="human", ref="decision:ship", authority="coordinator", verdict="approved")
+        assert kb.resume_task_wait(conn, human, authority="coordinator", receipt="decision:ship")
+
+        (kanban_home / "config.yaml").write_text(
+            "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+        review, sha, manifest = _review_wait_source(conn, tmp_path)
+        gate_task = _review_wait_gate(conn, review)
+        review_ref = f"gate:{gate_task}"
+        kb.set_task_wait(conn, review, kind="review", ref=review_ref)
+        assert not kb.resume_task_wait(conn, review, authority="bob", receipt=review_ref)
+        kb.complete_task(conn, gate_task, result="approved")
+        kb.record_gate_verdict(
+            conn, review, gate_task_id=gate_task, sha=sha,
+            manifest_hash=manifest["manifest_hash"], verdict="pass", authority="coordinator",
+        )
+        assert kb.resume_task_wait(conn, review, authority="coordinator", receipt=review_ref)
+
+
+def _review_wait_source(conn, tmp_path):
+    """Create a source with an immutable candidate/manifest for gate verdicts."""
+    source = kb.create_task(
+        conn, title="implementation", assignee="implementer", owner_kind="no_agent",
+    )
+    payload = b"review evidence"
+    blob = tmp_path / f"{source}.txt"
+    blob.write_bytes(payload)
+    attachment = kb.add_attachment(
+        conn, source, filename="review.txt", stored_path=str(blob),
+        content_type="text/plain", size=len(payload),
+    )
+    sha = "c" * 40
+    kb.create_candidate(conn, source, sha=sha)
+    receipt = kb.freeze_evidence_manifest(
+        conn, source, sha=sha,
+        manifest={"required_slots": ["review"], "entries": [{
+            "attachment_id": attachment, "sha256": hashlib.sha256(payload).hexdigest(),
+            "content_type": "text/plain", "decoder_valid": True,
+            "decoder_metadata": {}, "cardinality": 1, "slot": "review", "mode": "required",
+        }]}, verdict="pass", authority="coordinator",
+    )
+    return source, sha, receipt
+
+
+def _review_wait_gate(conn, source, title="review gate"):
+    return kb.create_task(
+        conn, title=title, assignee="independent-reviewer", owner_kind="no_agent",
+        task_kind="reviewer", created_by_task_id=source,
+        creation_authority="coordinator",
+    )
+
+
+def test_review_wait_canonical_gate_identity_stays_pending_until_exact_pass(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """A review wait binds only its independently-created gate task ID."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with kb.connect() as conn:
+        source, sha, receipt = _review_wait_source(conn, tmp_path)
+        gate = _review_wait_gate(conn, source)
+        ref = f"gate:{gate}"
+
+        kb.set_task_wait(conn, source, kind="review", ref=ref)
+        assert kb.get_task(conn, source).wait_ref == ref
+        assert kb.reconcile_task_waits(conn) == 0
+        assert kb.get_task(conn, source).status == "blocked"
+
+        kb.complete_task(conn, gate, result="approved")
+        kb.record_gate_verdict(
+            conn, source, gate_task_id=gate, sha=sha,
+            manifest_hash=receipt["manifest_hash"], verdict="pass", authority="coordinator",
+        )
+        # Two complete dispatcher ticks must consume this exact PASS only once.
+        kb.dispatch_once(conn, spawn_fn=lambda *_: None)
+        kb.dispatch_once(conn, spawn_fn=lambda *_: None)
+        assert kb.get_task(conn, source).status == "ready"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='wait_resumed'", (source,),
+        ).fetchone()[0] == 1
+
+
+def test_review_wait_rejects_foreign_gate_and_ignores_wrong_gate_verdict(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """A foreign or merely different valid gate cannot release the source wait."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with kb.connect() as conn:
+        source, sha, receipt = _review_wait_source(conn, tmp_path)
+        foreign = kb.create_task(
+            conn, title="foreign", assignee="independent-reviewer", owner_kind="no_agent",
+            task_kind="ordinary", creation_authority="coordinator",
+        )
+        with pytest.raises(ValueError, match="gate task"):
+            kb.set_task_wait(conn, source, kind="review", ref=f"gate:{foreign}")
+
+        expected_gate = _review_wait_gate(conn, source, "expected")
+        wrong_gate = _review_wait_gate(conn, source, "wrong")
+        kb.set_task_wait(conn, source, kind="review", ref=f"gate:{expected_gate}")
+        kb.complete_task(conn, wrong_gate, result="approved")
+        kb.record_gate_verdict(
+            conn, source, gate_task_id=wrong_gate, sha=sha,
+            manifest_hash=receipt["manifest_hash"], verdict="pass", authority="coordinator",
+        )
+        assert kb.reconcile_task_waits(conn) == 0
+        assert kb.get_task(conn, source).status == "blocked"
+
+
+def test_review_wait_fail_verdict_does_not_auto_resume(kanban_home, tmp_path, monkeypatch):
+    """An exact gate FAIL is terminal evidence, never an auto-resume trigger."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    with kb.connect() as conn:
+        source, sha, receipt = _review_wait_source(conn, tmp_path)
+        gate = _review_wait_gate(conn, source)
+        kb.set_task_wait(conn, source, kind="review", ref=f"gate:{gate}")
+        kb.complete_task(conn, gate, result="changes requested")
+        kb.record_gate_verdict(
+            conn, source, gate_task_id=gate, sha=sha,
+            manifest_hash=receipt["manifest_hash"], verdict="fail", authority="coordinator",
+        )
+        assert kb.reconcile_task_waits(conn) == 0
+        assert kb.get_task(conn, source).status == "blocked"
+
+
+def test_image_evidence_is_decoded_and_canonicalized_from_stored_bytes(kanban_home, tmp_path):
+    """Image MIME and dimensions come from a verified Pillow decode, never caller claims."""
+    encoded = io.BytesIO()
+    Image.new("RGB", (2, 3), "red").save(encoded, format="PNG")
+    png = encoded.getvalue()
+    sha = "a" * 40
+
+    with kb.connect() as conn:
+        task = kb.create_task(conn, title="decoded image evidence")
+        kb.create_candidate(conn, task, sha=sha)
+        for name, payload, declared_type, dimensions, error in (
+            ("corrupt.png", b"not a png", "image/png", [2, 3], "decode"),
+            ("spoofed-mime.png", png, "image/jpeg", [2, 3], "MIME"),
+            ("spoofed-dimensions.png", png, "image/png", [1, 1], "dimensions"),
+        ):
+            blob = tmp_path / name
+            blob.write_bytes(payload)
+            attachment = kb.add_attachment(
+                conn, task, filename=name, stored_path=str(blob),
+                content_type=declared_type, size=len(payload),
+            )
+            manifest = {"required_slots": [name], "entries": [{
+                "attachment_id": attachment,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "content_type": declared_type,
+                "decoder_valid": True,
+                "decoder_metadata": {"untrusted": True},
+                "dimensions": dimensions,
+                "cardinality": 1,
+                "slot": name,
+                "mode": "required",
+            }]}
+            with pytest.raises(ValueError, match=error):
+                kb.freeze_evidence_manifest(
+                    conn, task, sha=sha, manifest=manifest, verdict="pass", authority="coordinator",
+                )
+
+        valid = tmp_path / "valid.png"
+        valid.write_bytes(png)
+        attachment = kb.add_attachment(
+            conn, task, filename="valid.png", stored_path=str(valid),
+            content_type="image/png", size=len(png),
+        )
+        receipt = kb.freeze_evidence_manifest(
+            conn, task, sha=sha,
+            manifest={"required_slots": ["screenshot"], "entries": [{
+                "attachment_id": attachment, "sha256": hashlib.sha256(png).hexdigest(),
+                "content_type": "image/png", "decoder_valid": True,
+                "decoder_metadata": {"untrusted": True}, "dimensions": [2, 3],
+                "cardinality": 1, "slot": "screenshot", "mode": "required",
+            }]},
+            verdict="pass", authority="coordinator",
+        )
+        entry = receipt["manifest"]["entries"][0]
+        assert entry["content_type"] == "image/png"
+        assert entry["dimensions"] == [2, 3]
+        assert entry["decoder_metadata"] == {"format": "PNG", "height": 3, "width": 2}
+
+
+def test_gate_verdict_requires_an_independent_configured_terminal_gate_task(kanban_home, tmp_path, monkeypatch):
+    """A gate is an immutable reviewer/visualqa task ID, not a caller-chosen label."""
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: coordinator\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    blob = tmp_path / "report.txt"
+    blob.write_bytes(b"report")
+    sha = "b" * 40
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="implementation", assignee="implementer", owner_kind="no_agent")
+        attachment = kb.add_attachment(conn, source, filename="report.txt", stored_path=str(blob), content_type="text/plain", size=6)
+        kb.create_candidate(conn, source, sha=sha)
+        receipt = kb.freeze_evidence_manifest(
+            conn, source, sha=sha,
+            manifest={"required_slots": ["report"], "entries": [{
+                "attachment_id": attachment, "sha256": hashlib.sha256(b"report").hexdigest(),
+                "content_type": "text/plain", "decoder_valid": True, "decoder_metadata": {},
+                "cardinality": 1, "slot": "report", "mode": "required",
+            }]}, verdict="pass", authority="coordinator",
+        )
+        foreign = kb.create_task(conn, title="foreign", assignee="reviewer", owner_kind="no_agent", task_kind="ordinary", creation_authority="coordinator")
+        self_review = kb.create_task(conn, title="self", assignee="implementer", owner_kind="no_agent", task_kind="reviewer", created_by_task_id=source, creation_authority="coordinator")
+        independent = kb.create_task(conn, title="valid", assignee="reviewer", owner_kind="no_agent", task_kind="visualqa", created_by_task_id=source, creation_authority="coordinator")
+        kb.complete_task(conn, independent, result="validated")
+
+        for gate_task_id, error in (("arbitrary-gate-name", "gate task"), (foreign, "gate task"), (self_review, "gate task")):
+            with pytest.raises(ValueError, match=error):
+                kb.record_gate_verdict(conn, source, gate_task_id=gate_task_id, sha=sha, manifest_hash=receipt["manifest_hash"], verdict="pass", authority="coordinator")
+        with pytest.raises(ValueError, match="authority assertion"):
+            kb.record_gate_verdict(conn, source, gate_task_id=independent, sha=sha, manifest_hash=receipt["manifest_hash"], verdict="pass", authority="spoofed")
+
+        verdict = kb.record_gate_verdict(conn, source, gate_task_id=independent, sha=sha, manifest_hash=receipt["manifest_hash"], verdict="pass", authority="coordinator")
+        assert verdict["gate_task_id"] == independent
+        assert verdict["sha"] == sha
+        barrier = kb.create_release_barrier(conn, source, sha=sha, manifest_hash=receipt["manifest_hash"], required_gates=[independent], authority="coordinator")
+        assert barrier["required_gates"] == [independent]
+        with pytest.raises(ValueError, match="authority assertion"):
+            kb.create_release_barrier(conn, source, sha=sha, manifest_hash=receipt["manifest_hash"], required_gates=[independent], authority="coordinator-spoof")

--- a/tests/hermes_cli/test_kanban_host_cap.py
+++ b/tests/hermes_cli/test_kanban_host_cap.py
@@ -210,8 +210,10 @@ def test_max_spawn_stays_per_board(kanban_home, all_assignees_spawnable):
 # ---------------------------------------------------------------------------
 
 
-def _park_in_review(conn: sqlite3.Connection, title: str, assignee: str) -> str:
-    tid = kb.create_task(conn, title=title, assignee=assignee)
+def _park_in_review(
+    conn: sqlite3.Connection, title: str, assignee: str, *, owner_kind: str | None = None,
+) -> str:
+    tid = kb.create_task(conn, title=title, assignee=assignee, owner_kind=owner_kind)
     _set_task_status(conn, tid, "review")
     return tid
 
@@ -281,7 +283,7 @@ def test_nonspawnable_review_does_not_tax_ready_budget(
     with kb.connect() as conn:
         for title in ("ready-1", "ready-2"):
             kb.create_task(conn, title=title, assignee="alice")
-        _park_in_review(conn, "human-review", "some-human")
+        _park_in_review(conn, "human-review", "some-human", owner_kind="no_agent")
         res = kb.dispatch_once(
             conn, spawn_fn=_fake_spawn_factory(spawns), max_in_progress=2,
         )

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -669,7 +669,7 @@ async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
         user_id="u1",
     )
     event = SimpleNamespace(
-        text='/kanban --board projx create "hello" --assignee alice',
+        text='/kanban --board projx create "hello" --assignee alice --external-assignee',
         source=source,
         message_id="462",
         reply_to_message_id=None,
@@ -748,7 +748,7 @@ async def test_gateway_autosubscribe_roundtrips_user_id_alt_for_session_key(
         user_id_alt="union-id",
     )
     event = SimpleNamespace(
-        text='/kanban create "hello" --assignee alice',
+        text='/kanban create "hello" --assignee alice --external-assignee',
         source=source,
     )
 

--- a/tests/hermes_cli/test_kanban_owner_cli.py
+++ b/tests/hermes_cli/test_kanban_owner_cli.py
@@ -1,0 +1,11 @@
+from hermes_cli.kanban import build_parser
+import argparse
+
+def test_create_and_assign_parse_execution_owner_contract():
+    root = argparse.ArgumentParser(); subs = root.add_subparsers(dest='cmd')
+    build_parser(subs)
+    args = root.parse_args(['kanban','create','x','--owner-kind','external','--task-kind','ordinary','--purpose','p','--creation-authority','op'])
+    assert args.owner_kind == 'external'
+    assert args.task_kind == 'ordinary'
+    assigned = root.parse_args(['kanban','assign','t_12345678','lane','--owner-kind','external'])
+    assert assigned.owner_kind == 'external'

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -15,6 +15,8 @@ from hermes_cli import kanban_db as kb
 def review_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> str:
     home = tmp_path / ".hermes"
     home.mkdir()
+    for profile in ("builder", "reviewer"):
+        (home / "profiles" / profile).mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_PROFILE", "builder")
@@ -288,6 +290,7 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
 ) -> None:
     home = tmp_path / ".hermes"
     home.mkdir()
+    (home / "profiles" / "reviewer").mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb._INITIALIZED_PATHS.clear()
@@ -319,7 +322,10 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
             False,
         ),
     )
-    rejected = json.loads(tools._handle_request_review({"summary": "Looks ready."}))
+    rejected = json.loads(tools._handle_request_review({
+        "summary": "Looks ready.",
+        "reviewer": "reviewer",
+    }))
     assert "error" in rejected
     assert "rejected by judge" in rejected["error"]
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_task_updated_hook.py
+++ b/tests/hermes_cli/test_kanban_task_updated_hook.py
@@ -8,13 +8,19 @@ call sites short-circuit when nothing subscribes.
 
 from __future__ import annotations
 
+import importlib
 import sqlite3
 from pathlib import Path
 
 import pytest
 
 from hermes_cli import kanban_db as kb
-from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+
+def _live_plugin_manager():
+    """Return the manager used by kanban_db's runtime lifecycle imports."""
+    importlib.import_module("hermes_cli.lifecycle")
+    return importlib.import_module("hermes_cli.plugins").get_plugin_manager()
 
 
 @pytest.fixture
@@ -23,13 +29,15 @@ def kanban_home(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for profile in ("alice", "bob"):
+        (home / "profiles" / profile).mkdir(parents=True, exist_ok=True)
     kb.init_db()
     return home
 
 
 @pytest.fixture
 def captured_updates(monkeypatch):
-    mgr = get_plugin_manager()
+    mgr = _live_plugin_manager()
     events: list[dict] = []
     saved = {k: list(v) for k, v in mgr._hooks.items()}
     mgr._hooks.setdefault("on_kanban_task_updated", []).append(
@@ -56,7 +64,7 @@ def test_assign_fires_updated_with_changed_fields(kanban_home, captured_updates)
         finally:
             c2.close()
 
-    mgr = get_plugin_manager()
+    mgr = _live_plugin_manager()
     mgr._hooks.setdefault("on_kanban_task_updated", []).append(_read_assignee)
 
     conn = kb.connect()
@@ -78,7 +86,7 @@ def test_assign_fires_updated_with_changed_fields(kanban_home, captured_updates)
     assert assignee_at_fire_time == ["bob"]
 
 def test_raising_callback_does_not_break_assign(kanban_home):
-    mgr = get_plugin_manager()
+    mgr = _live_plugin_manager()
     saved = {k: list(v) for k, v in mgr._hooks.items()}
 
     def _boom(**kw):
@@ -98,7 +106,7 @@ def test_raising_callback_does_not_break_assign(kanban_home):
 
 
 def test_no_subscriber_short_circuits_task_updated(kanban_home, monkeypatch):
-    from hermes_cli import lifecycle
+    lifecycle = importlib.import_module("hermes_cli.lifecycle")
 
     invoked: list[str] = []
     real_invoke = lifecycle.invoke_hook

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -23,6 +23,7 @@ from hermes_cli.profiles import (
     normalize_profile_name,
     validate_profile_name,
     get_profile_dir,
+    profile_exists,
     create_profile,
     delete_profile,
     list_profiles,
@@ -92,6 +93,13 @@ class TestValidateProfileName:
     def test_invalid_names_rejected(self, name):
         with pytest.raises(ValueError):
             validate_profile_name(name)
+
+
+class TestProfileExists:
+    def test_rejects_traversal_even_when_target_directory_exists(self, profile_env):
+        escaped = get_profile_dir("../../escape")
+        escaped.mkdir(parents=True)
+        assert profile_exists("../../escape") is False
 
 
 # ===================================================================

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -61,8 +61,20 @@ def client(kanban_home):
     return TestClient(app)
 
 
-# ---------------------------------------------------------------------------
-# GET /board on an empty DB
+def test_dashboard_done_routes_cannot_bypass_live_external_owner(client):
+    task_id = client.post("/api/plugins/kanban/tasks", json={
+        "title": "external", "assignee": "lane", "owner_kind": "external",
+    }).json()["task"]["id"]
+    started = client.post(f"/api/plugins/kanban/tasks/{task_id}/external-runs", json={
+        "owner": "lane", "external_id": "dashboard-bypass",
+    })
+    assert started.status_code == 200
+    patched = client.patch(f"/api/plugins/kanban/tasks/{task_id}", json={"status": "done"})
+    assert patched.status_code == 409
+    bulk = client.post("/api/plugins/kanban/tasks/bulk", json={"ids": [task_id], "status": "done"})
+    assert bulk.status_code == 200 and bulk.json()["results"] == [{"id": task_id, "ok": False, "error": "transition to 'done' refused"}]
+    assert client.get(f"/api/plugins/kanban/tasks/{task_id}").json()["task"]["status"] == "running"
+
 # ---------------------------------------------------------------------------
 
 
@@ -114,6 +126,212 @@ def test_create_task_appears_on_board(client):
     assert ready["tasks"][0]["id"] == task_id
     assert "acme" in data["tenants"]
     assert "researcher" in data["assignees"]
+
+
+def test_dashboard_create_omission_preserves_db_inference_and_explicit_no_agent_lane(client, kanban_home):
+    """Shipped UI payloads omit owner_kind, leaving inference to the DB."""
+    (kanban_home / "profiles" / "researcher").mkdir(parents=True, exist_ok=True)
+    assigned = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "assigned implicit", "assignee": "researcher"},
+    )
+    unassigned = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "unassigned implicit"},
+    )
+    manual = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "manual explicit", "owner_kind": "no_agent"},
+    )
+    assert assigned.status_code == unassigned.status_code == manual.status_code == 200
+    with kb.connect_closing() as conn:
+        tasks = {
+            task.title: task for task in kb.list_tasks(conn)
+            if task.title in {"assigned implicit", "unassigned implicit", "manual explicit"}
+        }
+        assert (tasks["assigned implicit"].owner_kind, tasks["assigned implicit"].owner_kind_explicit) == ("agent", False)
+        assert (tasks["unassigned implicit"].owner_kind, tasks["unassigned implicit"].owner_kind_explicit) == ("no_agent", False)
+        assert (tasks["manual explicit"].owner_kind, tasks["manual explicit"].owner_kind_explicit) == ("no_agent", True)
+        result = kb.dispatch_once(conn, spawn_fn=lambda *_args, **_kwargs: 123, default_assignee="researcher")
+        explicit = kb.get_task(conn, tasks["manual explicit"].id)
+    assert tasks["unassigned implicit"].id in result.auto_assigned_default
+    assert explicit is not None and explicit.assignee is None
+
+
+def test_dashboard_create_omission_rejects_unknown_inferred_agent_profile(client, monkeypatch):
+    """A public payload cannot bypass profile admission by omitting owner_kind."""
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: False)
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "missing implicit agent", "assignee": "not-installed"},
+    )
+    assert response.status_code == 400
+    assert "installed profile" in response.json()["detail"]
+    assert client.get("/api/plugins/kanban/board").json()["assignees"] == []
+
+
+def test_dashboard_external_run_identity_progress_and_redacted_refs_survive_initiator(client):
+    """Board and detail reads expose a durable external validation run safely."""
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "long validation", "assignee": "operator", "owner_kind": "external"},
+    )
+    assert created.status_code == 200, created.text
+    task_id = created.json()["task"]["id"]
+    started = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/external-runs",
+        json={
+            "owner": "operator", "external_id": "validation-42", "pid": 4242,
+            "phase": "validation", "current": 3, "total": 10,
+            "log_ref": "https://token:secret@example.test/log", "result_ref": "Bearer result-secret",
+            "max_retries": 2, "on_success": "complete", "on_failure": "block",
+        },
+    )
+    assert started.status_code == 200, started.text
+    run_id = started.json()["run"]["id"]
+    board = client.get("/api/plugins/kanban/board")
+    card = next(c for c in board.json()["columns"] if c["name"] == "running")["tasks"][0]
+    assert {key: card["external_run"][key] for key in (
+        "id", "owner", "external_id", "phase", "current", "total", "heartbeat_status",
+    )} == {
+        "id": run_id, "owner": "operator", "external_id": "validation-42",
+        "phase": "validation", "current": 3, "total": 10,
+        "heartbeat_status": "healthy",
+    }
+    detail = client.get(f"/api/plugins/kanban/tasks/{task_id}")
+    assert detail.status_code == 200
+    external = detail.json()["task"]["external_run"]
+    assert external["heartbeat_age_seconds"] is not None
+    assert (external["phase"], external["current"], external["total"]) == ("validation", 3, 10)
+    assert "secret" not in json.dumps(detail.json())
+    assert detail.json()["runs"][0]["external_id"] == "validation-42"
+    assert "token:" not in detail.json()["runs"][0]["log_ref"]
+
+
+
+
+def test_dashboard_external_run_api_fixture_has_shipped_visibility_contract(client):
+    """The API fixture supplies every fact the distributed dashboard renders."""
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "UI external run", "assignee": "operator", "owner_kind": "external"},
+    )
+    task_id = created.json()["task"]["id"]
+    started = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/external-runs",
+        json={
+            "owner": "operator", "external_id": "ui-run-42", "phase": "validation",
+            "current": 3, "total": 10, "log_ref": "https://example.test/log",
+            "result_ref": "result://safe-reference",
+        },
+    )
+    assert started.status_code == 200, started.text
+    card = next(
+        item for column in client.get("/api/plugins/kanban/board").json()["columns"]
+        for item in column["tasks"] if item["id"] == task_id
+    )
+    assert card["external_run"] == {
+        **card["external_run"],
+        "owner": "operator", "external_id": "ui-run-42", "phase": "validation",
+        "current": 3, "total": 10, "heartbeat_status": "healthy",
+        "log_ref": "https://example.test/log", "result_ref": "result://safe-reference",
+    }
+    detail_run = client.get(f"/api/plugins/kanban/tasks/{task_id}").json()["runs"][0]["external_run"]
+    assert detail_run is not None
+    assert {
+        key: detail_run[key]
+        for key in ("owner", "external_id", "phase", "current", "total", "heartbeat_status", "log_ref", "result_ref")
+    } == {
+        "owner": "operator", "external_id": "ui-run-42", "phase": "validation",
+        "current": 3, "total": 10, "heartbeat_status": "healthy",
+        "log_ref": "https://example.test/log", "result_ref": "result://safe-reference",
+    }
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = (repo_root / "plugins/kanban/dashboard/dist/index.js").read_text(encoding="utf-8")
+    css = (repo_root / "plugins/kanban/dashboard/dist/style.css").read_text(encoding="utf-8")
+    for token in (
+        "hermes-kanban-external-run-card", "External run", "external_id", "heartbeat_status",
+        "hermes-kanban-external-run-detail", "Log reference", "Result reference",
+    ):
+        assert token in bundle
+    for selector in (
+        ".hermes-kanban-external-run-card", ".hermes-kanban-external-run-detail",
+        ".hermes-kanban-external-run--healthy", ".hermes-kanban-external-run--stale",
+    ):
+        assert selector in css
+
+
+def test_dashboard_external_run_controls_enforce_board_owner_and_exactly_once_completion(client):
+    """Dashboard control routes use the DB CAS boundary for every external mutation."""
+    task_id = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "control", "assignee": "operator", "owner_kind": "external"},
+    ).json()["task"]["id"]
+    run_id = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/external-runs",
+        json={"owner": "operator", "external_id": "control-42"},
+    ).json()["run"]["id"]
+    heartbeat = client.post(
+        f"/api/plugins/kanban/external-runs/{run_id}/heartbeat",
+        json={"owner": "operator", "phase": "validation", "current": 3, "total": 10},
+    )
+    assert heartbeat.status_code == 200 and heartbeat.json()["run"]["current"] == 3
+    assert client.post(
+        f"/api/plugins/kanban/external-runs/{run_id}/transfer",
+        json={"from_owner": "operator", "to_owner": "reviewer"},
+    ).json()["run"]["owner"] == "reviewer"
+    kb.create_board("external-other")
+    denied = client.post(
+        f"/api/plugins/kanban/external-runs/{run_id}/heartbeat?board=external-other",
+        json={"owner": "reviewer", "phase": "spoof"},
+    )
+    assert denied.status_code == 404 and "external run not found" in denied.json()["detail"]
+    finished = client.post(
+        f"/api/plugins/kanban/external-runs/{run_id}/finish",
+        json={"owner": "reviewer", "outcome": "completed"},
+    )
+    assert finished.status_code == 200 and finished.json()["run"]["heartbeat_status"] == "finished"
+    duplicate = client.post(
+        f"/api/plugins/kanban/external-runs/{run_id}/finish",
+        json={"owner": "reviewer", "outcome": "completed"},
+    )
+    assert duplicate.status_code == 409
+    with kb.connect() as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'", (task_id,)
+        ).fetchone()[0] == 1
+
+
+def test_dashboard_create_persists_explicit_external_owner_and_provenance(client, monkeypatch):
+    """The API can deliberately create a durable external execution lane."""
+    monkeypatch.setenv("HERMES_PROFILE", "dashboard")
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "human publish handoff",
+            "assignee": "release-operator",
+            "owner_kind": "external",
+            "task_kind": "ordinary",
+            "purpose": "manual publish",
+            "created_by_task_id": "t_creator",
+            "created_by_run_id": 17,
+            "creation_authority": "dashboard",
+        },
+    )
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+    finally:
+        conn.close()
+    assert task is not None
+    assert task.owner_kind == "external"
+    assert task.task_kind == "ordinary"
+    assert task.purpose == "manual publish"
+    assert task.created_by_task_id == "t_creator"
+    assert task.created_by_run_id == 17
+    assert task.creation_authority == "dashboard"
 
 
 def test_patch_board_sets_project_directory(client, tmp_path):
@@ -312,18 +530,18 @@ def test_reopening_parent_demotes_ready_child(client):
 
 def test_reopening_parent_retracts_review_and_blocks_approval(client):
     with kb.connect() as conn:
-        parent_id = kb.create_task(conn, title="parent", assignee="planner")
+        parent_id = kb.create_task(conn, title="parent", assignee="default")
         assert kb.complete_task(conn, parent_id)
         child_id = kb.create_task(
             conn,
             title="child in review",
-            assignee="reviewer",
+            assignee="default",
             parents=[parent_id],
         )
         grandchild_id = kb.create_task(
             conn,
             title="downstream",
-            assignee="writer",
+            assignee="default",
             parents=[child_id],
         )
         implementation = kb.claim_task(conn, child_id)
@@ -381,19 +599,19 @@ def test_reopening_parent_retracts_review_and_blocks_approval(client):
 
 def test_reopening_parent_recursively_retracts_done_and_running_descendants(client):
     with kb.connect() as conn:
-        parent_id = kb.create_task(conn, title="root", assignee="planner")
+        parent_id = kb.create_task(conn, title="root", assignee="default")
         assert kb.complete_task(conn, parent_id)
         child_id = kb.create_task(
             conn,
             title="accepted child",
-            assignee="builder",
+            assignee="default",
             parents=[parent_id],
         )
         assert kb.complete_task(conn, child_id)
         grandchild_id = kb.create_task(
             conn,
             title="running grandchild",
-            assignee="writer",
+            assignee="default",
             parents=[child_id],
         )
         grandchild_run = kb.claim_task(conn, grandchild_id)
@@ -430,7 +648,7 @@ def test_reopening_parent_recursively_retracts_done_and_running_descendants(clie
 
 def test_dashboard_reclaim_of_active_review_preserves_review_phase(client):
     with kb.connect() as conn:
-        task_id = kb.create_task(conn, title="active review", assignee="reviewer")
+        task_id = kb.create_task(conn, title="active review", assignee="default")
         implementation = kb.claim_task(conn, task_id)
         assert implementation is not None
         assert kb.request_review(
@@ -448,7 +666,7 @@ def test_dashboard_reclaim_of_active_review_preserves_review_phase(client):
     )
     assert response.status_code == 200, response.text
     assert response.json()["task"]["status"] == "review"
-    assert response.json()["task"]["assignee"] == "reviewer"
+    assert response.json()["task"]["assignee"] == "default"
     with kb.connect() as conn:
         run = kb.latest_run(conn, task_id)
         assert run is not None
@@ -621,7 +839,9 @@ def test_bulk_status_ready(client):
     assert {a["id"], b["id"], c2["id"]}.issubset(ids)
 
 
-def test_bulk_review_assignment_preserves_implementer_provenance(client):
+def test_bulk_review_assignment_preserves_implementer_provenance(client, kanban_home):
+    for profile in ("builder", "reviewer"):
+        (kanban_home / "profiles" / profile).mkdir(parents=True, exist_ok=True)
     tasks = [
         client.post(
             "/api/plugins/kanban/tasks",
@@ -890,7 +1110,9 @@ def test_bulk_archive(client):
     assert b["id"] not in ids
 
 
-def test_bulk_reassign(client):
+def test_bulk_reassign(client, kanban_home):
+    for profile in ("old", "new"):
+        (kanban_home / "profiles" / profile).mkdir(parents=True, exist_ok=True)
     a = client.post("/api/plugins/kanban/tasks",
                     json={"title": "a", "assignee": "old"}).json()["task"]
     b = client.post("/api/plugins/kanban/tasks",
@@ -903,14 +1125,17 @@ def test_bulk_reassign(client):
         assert t["assignee"] == "new"
 
 
-def test_bulk_unassign_via_empty_string(client):
+def test_bulk_unassign_via_empty_string_demotes_implicit_agent_to_safe_manual_lane(client, kanban_home):
+    """Public unassign must not leave a dispatchable agent task ownerless."""
+    (kanban_home / "profiles" / "x").mkdir(parents=True, exist_ok=True)
     a = client.post("/api/plugins/kanban/tasks",
                     json={"title": "a", "assignee": "x"}).json()["task"]
     r = client.post("/api/plugins/kanban/tasks/bulk",
                     json={"ids": [a["id"]], "assignee": ""})
     assert r.status_code == 200
+    assert r.json()["results"] == [{"id": a["id"], "ok": True}]
     t = client.get(f"/api/plugins/kanban/tasks/{a['id']}").json()["task"]
-    assert t["assignee"] is None
+    assert (t["assignee"], t["owner_kind"], t["owner_kind_explicit"]) == (None, "no_agent", False)
 
 
 def test_bulk_partial_failure_doesnt_abort_siblings(client):
@@ -974,7 +1199,10 @@ def test_config_reads_dashboard_kanban_section(tmp_path, monkeypatch, client):
 
 def test_event_dict_includes_run_id(client):
     """GET /tasks/:id returns events with run_id populated."""
-    r = client.post("/api/plugins/kanban/tasks", json={"title": "e", "assignee": "worker"})
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "e", "assignee": "default", "owner_kind": "agent"},
+    )
     tid = r.json()["task"]["id"]
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
@@ -1077,7 +1305,7 @@ def test_reclaim_endpoint_releases_running_claim(client):
     import secrets
     conn = kb.connect()
     try:
-        t = kb.create_task(conn, title="running", assignee="x")
+        t = kb.create_task(conn, title="running", assignee="x", owner_kind="no_agent")
         lock = secrets.token_hex(8)
         future = int(time.time()) + 3600
         conn.execute(
@@ -1117,11 +1345,170 @@ def test_reclaim_endpoint_releases_running_claim(client):
         conn2.close()
 
 
+@pytest.mark.parametrize("task_kind", ["reviewer", "visualqa", "release"])
+def test_dashboard_rejects_gate_without_configured_authority(client, task_kind):
+    """Every mandatory gate kind fails closed without a coordinator."""
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "review gate", "assignee": "manual-reviewer", "task_kind": task_kind},
+    )
+    assert response.status_code == 400
+    assert "runtime HERMES_PROFILE" in response.json()["detail"]
+
+
+def test_dashboard_configured_coordinator_creates_gate(client, monkeypatch):
+    """The dashboard may create a gate only when it is the configured authority."""
+    Path(os.environ["HERMES_HOME"], "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: dashboard\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "dashboard")
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "release gate", "assignee": "release-operator", "task_kind": "release"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["id"]
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, response.json()["task"]["id"])
+    finally:
+        conn.close()
+    assert task is not None and task.task_kind == "release"
+    assert task.creation_authority == "dashboard"
+
+
+def test_dashboard_rejects_unknown_explicit_agent_owner(client, monkeypatch):
+    """Agent ownership cannot queue a nonexistent profile through the API."""
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: False)
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "missing worker", "assignee": "not-installed", "owner_kind": "agent"},
+    )
+    assert response.status_code == 400
+    assert "installed profile" in response.json()["detail"]
+
+
+def test_dashboard_creates_intentional_no_agent_lane(client):
+    """A manual dashboard card may be explicitly non-dispatchable."""
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "manual signoff", "assignee": "release-manager", "owner_kind": "no_agent"},
+    )
+    assert response.status_code == 200, response.text
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, response.json()["task"]["id"])
+    finally:
+        conn.close()
+    assert task is not None and task.owner_kind == "no_agent"
+    assert task.assignee == "release-manager"
+
+
+def test_dashboard_rejects_gate_authority_spoofing(client):
+    """The dashboard cannot claim another authority while creating a gate."""
+    Path(os.environ["HERMES_HOME"], "config.yaml").write_text(
+        "kanban:\n  coordinator_profile: dashboard\n", encoding="utf-8"
+    )
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "review gate",
+            "assignee": "manual-reviewer",
+            "task_kind": "reviewer",
+            "creation_authority": "spoofed-authority",
+        },
+    )
+    assert response.status_code == 400
+    assert "must equal dashboard" in response.json()["detail"]
+
+
+def test_dashboard_patch_rejects_owner_kind_only_mutation(client):
+    """An owner-kind field alone cannot be silently ignored by PATCH."""
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "manual lane", "assignee": "operator", "owner_kind": "external"},
+    )
+    task_id = created.json()["task"]["id"]
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}", json={"owner_kind": "agent"}
+    )
+    assert response.status_code == 400
+    assert "owner_kind is immutable" in response.json()["detail"]
+
+
+def test_dashboard_patch_rejects_owner_kind_mutation(client):
+    """PATCH assignment cannot bypass immutable execution ownership."""
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "manual lane", "assignee": "operator", "owner_kind": "external"},
+    )
+    task_id = created.json()["task"]["id"]
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"assignee": "operator", "owner_kind": "agent"},
+    )
+    assert response.status_code == 400
+    assert "owner_kind is immutable" in response.json()["detail"]
+
+
+def test_dashboard_reassign_rejects_owner_kind_mutation(client):
+    """The API cannot turn a durable external lane into an agent-owned task."""
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "manual lane", "assignee": "operator", "owner_kind": "external"},
+    )
+    task_id = created.json()["task"]["id"]
+    response = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/reassign",
+        json={"profile": "operator", "owner_kind": "agent"},
+    )
+    assert response.status_code == 400
+    assert "owner_kind is immutable" in response.json()["detail"]
+
+
+def test_dashboard_single_unassign_demotes_explicit_agent_without_losing_explicitness(client, kanban_home):
+    """Explicit agent ownership becomes explicit no_agent, never ownerless work."""
+    (kanban_home / "profiles" / "worker").mkdir(parents=True, exist_ok=True)
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "explicit", "assignee": "worker", "owner_kind": "agent"},
+    )
+    task_id = created.json()["task"]["id"]
+    response = client.patch(f"/api/plugins/kanban/tasks/{task_id}", json={"assignee": ""})
+    assert response.status_code == 200, response.text
+    task = client.get(f"/api/plugins/kanban/tasks/{task_id}").json()["task"]
+    assert (task["assignee"], task["owner_kind"], task["owner_kind_explicit"]) == (None, "no_agent", True)
+    blocked = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/reassign",
+        json={"profile": "worker", "activate_agent": True},
+    )
+    assert blocked.status_code == 400
+    assert "implicit lane" in blocked.json()["detail"]
+
+
+def test_reassign_endpoint_can_explicitly_reactivate_only_implicit_unassigned_lane(client, kanban_home):
+    """A trusted routing action is required to turn a manual lane into agent work."""
+    (kanban_home / "profiles" / "worker").mkdir(parents=True, exist_ok=True)
+    created = client.post("/api/plugins/kanban/tasks", json={"title": "implicit", "assignee": "worker"})
+    task_id = created.json()["task"]["id"]
+    unassigned = client.post(f"/api/plugins/kanban/tasks/{task_id}/reassign", json={})
+    assert unassigned.status_code == 200, unassigned.text
+    activated = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/reassign",
+        json={"profile": "worker", "activate_agent": True},
+    )
+    assert activated.status_code == 200, activated.text
+    task = client.get(f"/api/plugins/kanban/tasks/{task_id}").json()["task"]
+    assert (task["assignee"], task["owner_kind"], task["owner_kind_explicit"]) == ("worker", "agent", False)
+
+
 def test_reassign_endpoint_switches_profile(client):
     """POST /tasks/<id>/reassign changes the assignee field."""
     conn = kb.connect()
     try:
-        t = kb.create_task(conn, title="task", assignee="orig")
+        t = kb.create_task(conn, title="task", assignee="orig", owner_kind="no_agent")
     finally:
         conn.close()
 
@@ -1150,8 +1537,8 @@ def test_reassign_endpoint_switches_profile(client):
 def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
     conn = kb.connect()
     try:
-        parent = kb.create_task(conn, title="parent", assignee="alice")
-        real = kb.create_task(conn, title="real", assignee="x", created_by="alice")
+        parent = kb.create_task(conn, title="parent", assignee="alice", owner_kind="no_agent")
+        real = kb.create_task(conn, title="real", assignee="x", owner_kind="no_agent", created_by="alice")
         import pytest as _pytest
         with _pytest.raises(kb.HallucinatedCardsError):
             kb.complete_task(

--- a/tests/run_agent/test_kanban_external_process_ownership.py
+++ b/tests/run_agent/test_kanban_external_process_ownership.py
@@ -1,0 +1,804 @@
+"""Real process ownership handoff from AIAgent to durable Kanban runs."""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from run_agent import AIAgent
+import tools.process_registry as pr
+import utils
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    # Some test modules temporarily replace the hermes_cli package tree.  The
+    # registry imports kanban_db when it settles a process, so make that
+    # runtime import resolve to the same module this test patches.
+    live_hermes_cli = importlib.import_module("hermes_cli")
+    monkeypatch.setitem(sys.modules, "hermes_cli.kanban_db", kb)
+    monkeypatch.setattr(live_hermes_cli, "kanban_db", kb, raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _bare_agent(session_id):
+    agent = object.__new__(AIAgent)
+    agent.session_id = session_id
+    return agent
+
+
+def test_close_kills_ordinary_process_but_preserves_transferred_external_run(
+    kanban_home, tmp_path, monkeypatch,
+):
+    registry = pr.ProcessRegistry()
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(pr, "process_registry", registry)
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+
+    ordinary = registry.spawn_local("sleep 30", task_id="agent-session")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="durable external", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id="job-1")
+    transferred = registry.spawn_local("sleep 30", task_id="agent-session")
+    assert registry.transfer_to_external_run(transferred.id, task_id=task_id, run_id=run.id)
+
+    _bare_agent("agent-session").close()
+
+    assert ordinary.exited is True
+    assert transferred.exited is False
+    persisted = json.loads(checkpoint.read_text())
+    row = next(x for x in persisted if x["session_id"] == transferred.id)
+    assert row["kanban_task_id"] == task_id
+    assert row["kanban_external_run_id"] == run.id
+    assert row["external_run_owned"] is True
+
+    restored = pr.ProcessRegistry()
+    monkeypatch.setattr(restored, "_host_pid_is_ours", lambda pid, started: pid == transferred.pid)
+    assert restored.recover_from_checkpoint() == 1
+    recovered = restored._running[transferred.id]
+    assert recovered.kanban_task_id == task_id
+    assert recovered.kanban_external_run_id == run.id
+    assert recovered.external_run_owned is True
+
+    # Cleanup real survivor deliberately after all assertions.
+    restored.kill_all(source="test_cleanup", include_external_owned=True)
+
+
+def test_process_transfer_rejects_wrong_session_task_run_or_board_without_external_claim(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """Untrusted process/task/run/board identity never creates an external claim."""
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "process_registry", registry)
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="claimed worker", assignee="default")
+        claimed = kb.claim_task(conn, task_id, claimer="host:worker")
+        assert claimed is not None and claimed.current_run_id is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:worker")
+    process = registry.spawn_local("sleep 1", task_id="agent-session")
+
+    rejected = json.loads(pr._handle_process({
+        "action": "transfer", "session_id": "proc-not-the-worker", "external_id": "bad",
+        "owner": "validator",
+    }, task_id="agent-session"))
+    assert "error" in rejected
+    for name, value in (("HERMES_KANBAN_TASK", "t_wrong"), ("HERMES_KANBAN_RUN_ID", "999999"), ("HERMES_KANBAN_BOARD", "wrong-board")):
+        monkeypatch.setenv(name, value)
+        rejected = json.loads(pr._handle_process({
+            "action": "transfer", "session_id": process.id, "external_id": f"bad-{name}",
+            "owner": "validator",
+        }, task_id="agent-session"))
+        assert "error" in rejected
+        monkeypatch.setenv(name, {"HERMES_KANBAN_TASK": task_id, "HERMES_KANBAN_RUN_ID": str(claimed.current_run_id), "HERMES_KANBAN_BOARD": "default"}[name])
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.current_run_id == claimed.current_run_id
+        assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE owner_kind='external'").fetchone()[0] == 0
+    registry.kill_all("agent-session", source="test_cleanup")
+
+
+def test_process_transfer_rejects_nonworker_and_already_exited_process(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """A delegated caller or an exited process cannot strand an external claim."""
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "process_registry", registry)
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="claimed worker", assignee="default")
+        claimed = kb.claim_task(conn, task_id, claimer="host:worker")
+        assert claimed is not None and claimed.current_run_id is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:worker")
+    process = registry.spawn_local("true", task_id="agent-session")
+    process._completion_event.wait(5)
+
+    with non_dispatcher_owned_context():
+        rejected = json.loads(pr._handle_process({
+            "action": "transfer", "session_id": process.id, "external_id": "bad", "owner": "validator",
+        }, task_id="agent-session"))
+    assert "error" in rejected
+    rejected = json.loads(pr._handle_process({
+        "action": "transfer", "session_id": process.id, "external_id": "bad", "owner": "validator",
+    }, task_id="agent-session"))
+    assert "error" in rejected
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.current_run_id == claimed.current_run_id
+        assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE owner_kind='external'").fetchone()[0] == 0
+
+
+def test_process_transfer_registry_race_settles_external_claim_for_retry(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """A process that disappears during registry transfer leaves no external claim."""
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "process_registry", registry)
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="registry race", assignee="default")
+        claimed = kb.claim_task(conn, task_id, claimer="host:worker")
+        assert claimed is not None and claimed.current_run_id is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:worker")
+    process = registry.spawn_local("sleep 1", task_id="agent-session")
+    monkeypatch.setattr(registry, "transfer_to_external_run", lambda *args, **kwargs: False)
+
+    rejected = json.loads(pr._handle_process({
+        "action": "transfer", "session_id": process.id, "external_id": "race-1", "owner": "validator",
+        "on_failure": "retry",
+    }, task_id="agent-session"))
+    assert "error" in rejected
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        run = conn.execute("SELECT status, outcome FROM task_runs WHERE owner_kind='external'").fetchone()
+        assert task is not None and task.status == "running"
+        assert task.current_run_id == claimed.current_run_id
+        assert run is not None and (run["status"], run["outcome"]) == (
+            "handoff_rolled_back", "handoff_rolled_back",
+        )
+    registry.kill_all("agent-session", source="test_cleanup")
+
+
+@pytest.mark.parametrize("failure", ("write", "open", "fsync", "dir_fsync", "replace"))
+def test_checkpoint_failure_fails_closed_and_restores_process_ownership(
+    kanban_home, tmp_path, monkeypatch, failure,
+):
+    """No durable external run survives a transfer whose checkpoint cannot commit."""
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "process_registry", registry)
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="checkpoint failure", assignee="default")
+        claimed = kb.claim_task(conn, task_id, claimer="host:worker")
+        assert claimed is not None and claimed.current_run_id is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:worker")
+    process = registry.spawn_local("sleep 2", task_id="agent-session")
+    prior_ownership = (
+        process.kanban_task_id, process.kanban_external_run_id, process.kanban_board,
+        process.kanban_external_owner, process.external_run_owned,
+    )
+
+    def fail(*_args, **_kwargs):
+        raise OSError(failure)
+
+    if failure == "write":
+        monkeypatch.setattr(utils.json, "dump", fail)
+    elif failure == "open":
+        monkeypatch.setattr(utils.os, "fdopen", fail)
+    elif failure == "fsync":
+        monkeypatch.setattr(utils.os, "fsync", fail)
+    elif failure == "dir_fsync":
+        original_fsync = utils.os.fsync
+        fsync_calls = 0
+
+        def fail_directory_fsync(fd):
+            nonlocal fsync_calls
+            fsync_calls += 1
+            if fsync_calls == 2:
+                raise OSError(failure)
+            return original_fsync(fd)
+
+        monkeypatch.setattr(utils.os, "fsync", fail_directory_fsync)
+    else:
+        monkeypatch.setattr(utils, "atomic_replace", fail)
+    rejected = json.loads(pr._handle_process({
+        "action": "transfer", "session_id": process.id, "external_id": f"checkpoint-{failure}",
+        "owner": "validator", "on_failure": "retry",
+    }, task_id="agent-session"))
+    assert "error" in rejected
+    assert (
+        process.kanban_task_id, process.kanban_external_run_id, process.kanban_board,
+        process.kanban_external_owner, process.external_run_owned,
+    ) == prior_ownership
+    with kb.connect() as conn:
+        runs = conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE owner_kind='external'"
+        ).fetchall()
+        assert len(runs) == 1
+        assert (runs[0]["status"], runs[0]["outcome"]) == (
+            "handoff_rolled_back", "handoff_rolled_back",
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "running"
+        assert task.current_run_id == claimed.current_run_id
+    if failure == "dir_fsync":
+        recovered = pr.ProcessRegistry()
+        monkeypatch.setattr(pr, "process_registry", recovered)
+        assert recovered.recover_from_checkpoint() == 1
+        restored = recovered._running[process.id]
+        assert restored.external_run_owned is False
+        assert restored.kanban_external_run_id is None
+        recovered.kill_all("agent-session", source="test_cleanup")
+    else:
+        registry.kill_all("agent-session", source="test_cleanup")
+
+
+def test_persistent_directory_fsync_failure_keeps_external_claim_fail_closed(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """Never roll the DB back when restored checkpoint durability is unknown."""
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "process_registry", registry)
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="persistent fsync", assignee="default")
+        claimed = kb.claim_task(conn, task_id, claimer="host:worker")
+        assert claimed is not None and claimed.current_run_id is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:worker")
+    process = registry.spawn_local("sleep 2", task_id="agent-session")
+
+    original_fsync = utils.os.fsync
+    fsync_calls = 0
+
+    def fail_every_directory_fsync(fd):
+        nonlocal fsync_calls
+        fsync_calls += 1
+        if fsync_calls % 2 == 0:
+            raise OSError("persistent directory fsync")
+        return original_fsync(fd)
+
+    monkeypatch.setattr(utils.os, "fsync", fail_every_directory_fsync)
+    rejected = json.loads(pr._handle_process({
+        "action": "transfer", "session_id": process.id,
+        "external_id": "persistent-fsync", "owner": "validator",
+        "on_failure": "retry",
+    }, task_id="agent-session"))
+    assert "error" in rejected
+    assert "durably compensate" in rejected["error"]
+    assert process.external_run_owned is True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        run = conn.execute(
+            "SELECT id, status, outcome FROM task_runs WHERE owner_kind='external'"
+        ).fetchone()
+        assert task is not None and task.status == "running"
+        assert run is not None and run["status"] == "running"
+        assert run["outcome"] is None
+        assert task.current_run_id == run["id"]
+    registry.kill_process(process.id, source="test_cleanup")
+
+
+def test_process_transfer_hands_a_claimed_worker_to_external_lifecycle_once(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """A real worker process can hand off its live claimed run before agent close."""
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "process_registry", registry)
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="worker validation", assignee="default")
+        claimed = kb.claim_task(conn, task_id, claimer="host:worker")
+        assert claimed is not None and claimed.current_run_id is not None
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:worker")
+    process = registry.spawn_local("sleep 0.4", task_id="agent-session")
+
+    transfer = json.loads(pr._handle_process({
+        "action": "transfer", "session_id": process.id, "external_id": "validation-1",
+        "owner": "validator", "phase": "validation", "current": 1, "total": 2,
+        "log_ref": "https://ci.example/validation-1", "result_ref": "artifact:pending",
+        "max_retries": 2, "on_success": "resume", "on_failure": "retry",
+    }, task_id="agent-session"))
+    assert transfer["status"] == "transferred"
+    assert process.settlement_pending is True
+    external_run_id = transfer["run_id"]
+
+    _bare_agent("agent-session").close()
+    assert process.exited is False
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        run = kb.get_external_run(conn, external_run_id)
+        agent_run = conn.execute("SELECT status, outcome FROM task_runs WHERE id=?", (claimed.current_run_id,)).fetchone()
+        assert task is not None and task.current_run_id == external_run_id
+        assert agent_run is not None and (agent_run["status"], agent_run["outcome"]) == ("external_handoff", "external_handoff")
+        assert task.claim_lock == "external:validation-1"
+        assert run is not None and run.phase == "validation"
+        assert (run.progress_current, run.progress_total) == (1, 2)
+        persisted_handoff = conn.execute(
+            "SELECT managed_process_session_id, durable_result_path FROM task_runs WHERE id=?",
+            (external_run_id,),
+        ).fetchone()
+        assert dict(persisted_handoff) == {
+            "managed_process_session_id": process.id,
+            "durable_result_path": str(kanban_home / "process-results" / f"{process.id}.json"),
+        }
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='protocol_violation'", (task_id,)
+        ).fetchone()[0] == 0
+
+    process._completion_event.wait(5)
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert kb.get_external_run(conn, external_run_id).outcome == "completed"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'", (task_id,)
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='external_resumed'", (task_id,)
+        ).fetchone()[0] == 1
+
+
+def test_recovered_transferred_process_with_unknown_exit_is_lost_and_retried(
+    kanban_home, tmp_path, monkeypatch,
+):
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="unknown exit", assignee="operator", owner_kind="external",
+        )
+        run = kb.start_external_run(
+            conn, task_id, owner="operator", external_id="unknown-exit", max_retries=2,
+            on_failure="retry",
+        )
+    session = pr.ProcessSession(
+        id="proc-recovered", command="unknown", kanban_external_run_id=run.id,
+        kanban_board="default", kanban_external_owner="operator",
+        external_run_owned=True, exited=True, exit_code=None, detached=True,
+    )
+    registry._running[session.id] = session
+    registry._move_to_finished(session)
+    with kb.connect() as conn:
+        settled = kb.get_external_run(conn, run.id)
+        assert settled is not None and settled.outcome == "lost"
+        assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_external_process_completion_reconciles_once(kanban_home, tmp_path, monkeypatch):
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="complete external", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id="job-2")
+    session = registry.spawn_local("true", task_id="agent-session")
+    assert registry.transfer_to_external_run(session.id, task_id=task_id, run_id=run.id, owner="operator")
+    session._completion_event.wait(5)
+
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).status == "done"
+        assert registry.reconcile_external_completion(conn, session.id, owner="operator") is False
+        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'", (task_id,)).fetchone()[0] == 1
+        assert kb.get_task(conn, task_id).status == "done"
+        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'", (task_id,)).fetchone()[0] == 1
+
+
+def test_transferred_process_completion_uses_current_durable_external_run_owner(kanban_home, tmp_path, monkeypatch):
+    """A transfer to another external lane cannot strand an exited managed child."""
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="transfer owner", assignee="owner-a", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="owner-a", external_id="owner-transfer")
+        assert kb.transfer_external_run_owner(conn, run.id, from_owner="owner-a", to_owner="owner-b")
+    session = pr.ProcessSession(id="proc-owner-transfer", command="true", task_id="agent-session")
+    registry._running[session.id] = session
+    assert registry.transfer_to_external_run(
+        session.id, task_id=task_id, run_id=run.id, owner="owner-a",
+    )
+    session.exited = True
+    session.exit_code = 0
+    registry._move_to_finished(session)
+    assert session.kanban_external_owner == "owner-b"
+    with kb.connect() as conn:
+        settled = kb.get_external_run(conn, run.id)
+        assert settled is not None and (settled.owner, settled.status, settled.outcome) == (
+            "owner-b", "done", "completed",
+        )
+        assert kb.get_task(conn, task_id).status == "done"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'", (task_id,)
+        ).fetchone()[0] == 1
+
+
+def test_transferred_process_settles_only_its_persisted_board(kanban_home, tmp_path, monkeypatch):
+    """Same run ids on separate boards cannot make completion cross-board."""
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    kb.create_board("process-owner-a")
+    kb.create_board("process-owner-b")
+    with kb.connect(board="process-owner-a") as board_a, kb.connect(board="process-owner-b") as board_b:
+        task_a = kb.create_task(board_a, title="board a", assignee="owner-a", owner_kind="external")
+        run_a = kb.start_external_run(board_a, task_a, owner="owner-a", external_id="a-1")
+        task_b = kb.create_task(board_b, title="board b", assignee="owner-b", owner_kind="external")
+        run_b = kb.start_external_run(board_b, task_b, owner="owner-b", external_id="b-1")
+        assert run_a.id == run_b.id  # Each isolated board starts its own run sequence.
+
+    session = pr.ProcessSession(id="proc-board-a", command="true", task_id="agent-session")
+    registry._running[session.id] = session
+    assert registry.transfer_to_external_run(
+        session.id, task_id=task_a, run_id=run_a.id, board="process-owner-a", owner="owner-a",
+    )
+    session.exited = True
+    session.exit_code = 0
+    registry._move_to_finished(session)
+
+    with kb.connect(board="process-owner-a") as board_a, kb.connect(board="process-owner-b") as board_b:
+        assert kb.get_task(board_a, task_a).status == "done"
+        assert kb.get_external_run(board_a, run_a.id).status == "done"
+        assert kb.get_task(board_b, task_b).status == "running"
+        assert kb.get_external_run(board_b, run_b.id).status == "running"
+
+
+def test_checkpoint_recovered_transferred_process_retains_owner_board_and_exact_run(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """A recovered live process settles its persisted board/run, not ambient state."""
+    registry = pr.ProcessRegistry()
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+    kb.create_board("checkpoint-owner-a")
+    kb.create_board("checkpoint-owner-b")
+    with kb.connect(board="checkpoint-owner-a") as board_a, kb.connect(board="checkpoint-owner-b") as board_b:
+        task_a = kb.create_task(board_a, title="recover a", assignee="owner-a", owner_kind="external")
+        run_a = kb.start_external_run(board_a, task_a, owner="owner-a", external_id="recover-a")
+        task_b = kb.create_task(board_b, title="recover b", assignee="owner-b", owner_kind="external")
+        run_b = kb.start_external_run(board_b, task_b, owner="owner-b", external_id="recover-b")
+        assert run_a.id == run_b.id
+
+    live = registry.spawn_local("sleep 30", task_id="agent-session")
+    assert registry.transfer_to_external_run(
+        live.id, task_id=task_a, run_id=run_a.id, board="checkpoint-owner-a", owner="owner-a",
+    )
+    recovered_registry = pr.ProcessRegistry()
+    monkeypatch.setattr(recovered_registry, "_host_pid_is_ours", lambda pid, started: pid == live.pid)
+    assert recovered_registry.recover_from_checkpoint() == 1
+    recovered = recovered_registry._running[live.id]
+    assert (recovered.kanban_board, recovered.kanban_external_owner) == ("checkpoint-owner-a", "owner-a")
+    assert recovered.kanban_external_run_id == run_a.id
+
+    # A reconstructed process has no Popen handle; its detached kill path must
+    # still settle the durable run selected by the persisted handoff fields.
+    assert recovered_registry.kill_process(live.id, source="test_cleanup")["status"] == "killed"
+    with kb.connect(board="checkpoint-owner-a") as board_a, kb.connect(board="checkpoint-owner-b") as board_b:
+        assert kb.get_external_run(board_a, run_a.id).outcome == "failed"
+        assert kb.get_task(board_a, task_a).status == "blocked"
+        assert kb.get_external_run(board_b, run_b.id).status == "running"
+        assert kb.get_task(board_b, task_b).status == "running"
+
+
+def test_ordinary_process_never_settles_a_kanban_external_run(kanban_home, tmp_path, monkeypatch):
+    """Only an explicit handoff gives ProcessRegistry Kanban settlement authority."""
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="must remain running", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id="unrelated")
+
+    ordinary = pr.ProcessSession(id="proc-ordinary", command="true", task_id="agent-session")
+    registry._running[ordinary.id] = ordinary
+    ordinary.exited = True
+    ordinary.exit_code = 0
+    registry._move_to_finished(ordinary)
+
+    with kb.connect() as conn:
+        assert kb.get_external_run(conn, run.id).status == "running"
+        assert kb.get_task(conn, task_id).status == "running"
+        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'", (task_id,)).fetchone()[0] == 0
+
+
+def test_automatic_and_manual_external_reconciliation_race_emits_one_terminal_event(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """The ProcessRegistry and reconciler share one CAS terminal transition."""
+    registry = pr.ProcessRegistry()
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="race", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id="race-1")
+
+    session = pr.ProcessSession(id="proc-race", command="true", task_id="agent-session")
+    registry._running[session.id] = session
+    assert registry.transfer_to_external_run(session.id, task_id=task_id, run_id=run.id, owner="operator")
+    session.exited = True
+    session.exit_code = 0
+
+    real_finish = kb.finish_external_run
+    both_callers = threading.Barrier(2)
+    finish_results = []
+
+    def synchronized_finish(*args, **kwargs):
+        both_callers.wait(timeout=5)
+        result = real_finish(*args, **kwargs)
+        finish_results.append(result)
+        return result
+
+    monkeypatch.setattr(kb, "finish_external_run", synchronized_finish)
+    manual_result = []
+
+    def manually_reconcile():
+        with kb.connect() as conn:
+            manual_result.append(registry.reconcile_external_completion(conn, session.id, owner="operator"))
+
+    manual = threading.Thread(target=manually_reconcile)
+    manual.start()
+    registry._move_to_finished(session)
+    manual.join(timeout=5)
+    assert not manual.is_alive()
+
+    with kb.connect() as conn:
+        assert sorted(finish_results) == [False, True]
+        assert len(manual_result) == 1
+        assert kb.get_task(conn, task_id).status == "done"
+        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'", (task_id,)).fetchone()[0] == 1
+
+
+def test_rejected_external_settlement_of_active_run_stays_checkpointed_and_retries(kanban_home, tmp_path, monkeypatch):
+    """A false CAS result is terminal only when durable readback says it is."""
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+    registry = pr.ProcessRegistry()
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="retry rejected settlement", assignee="owner-a", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="owner-a", external_id="retry-rejected")
+        assert kb.transfer_external_run_owner(conn, run.id, from_owner="owner-a", to_owner="owner-b")
+    session = pr.ProcessSession(
+        id="proc-rejected-settlement", command="true", kanban_task_id=task_id,
+        kanban_external_run_id=run.id, kanban_board="default",
+        kanban_external_owner="owner-a", external_run_owned=True,
+        exited=True, exit_code=0, pid_scope="host", pid=None,
+    )
+    registry._running[session.id] = session
+    real_finish = kb.finish_external_run
+    monkeypatch.setattr(kb, "finish_external_run", lambda *_args, **_kwargs: False)
+    registry._move_to_finished(session)
+    assert session.id in registry._running
+    assert session.id not in registry._finished
+    entry = next(row for row in json.loads(checkpoint.read_text()) if row["session_id"] == session.id)
+    assert entry["settlement_pending"] is True
+    assert entry["kanban_external_owner"] == "owner-b"
+    with kb.connect() as conn:
+        assert kb.get_external_run(conn, run.id).ended_at is None
+
+    monkeypatch.setattr(kb, "finish_external_run", real_finish)
+    restarted = pr.ProcessRegistry()
+    assert restarted.recover_from_checkpoint() == 0
+    with kb.connect() as conn:
+        assert kb.get_external_run(conn, run.id).outcome == "completed"
+        assert kb.get_task(conn, task_id).status == "done"
+
+
+def test_failed_external_settlement_stays_checkpointed_and_recovers_on_restart(
+    kanban_home, tmp_path, monkeypatch,
+):
+    """A transient DB failure cannot erase the sole external-run settlement record."""
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+    registry = pr.ProcessRegistry()
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="recover settlement", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id="recover-settlement")
+    session = pr.ProcessSession(
+        id="proc-settlement", command="true", kanban_task_id=task_id,
+        kanban_external_run_id=run.id, kanban_board="default",
+        kanban_external_owner="operator", external_run_owned=True,
+        exited=True, exit_code=0, pid_scope="host", pid=None,
+    )
+    registry._running[session.id] = session
+    real_connect_closing = kb.connect_closing
+    monkeypatch.setattr(kb, "connect_closing", lambda **_kwargs: (_ for _ in ()).throw(OSError("db unavailable")))
+    registry._move_to_finished(session)
+    assert session.id in registry._running
+    assert session.id not in registry._finished
+    entry = next(row for row in json.loads(checkpoint.read_text()) if row["session_id"] == session.id)
+    assert entry["settlement_pending"] is True
+
+    monkeypatch.setattr(kb, "connect_closing", real_connect_closing)
+    deadline = time.monotonic() + 5
+    while session.id in registry._running and time.monotonic() < deadline:
+        time.sleep(.05)
+    assert session.id in registry._finished
+    with kb.connect() as conn:
+        assert kb.get_external_run(conn, run.id).outcome == "completed"
+        assert kb.get_task(conn, task_id).status == "done"
+    assert not checkpoint.exists() or not json.loads(checkpoint.read_text())
+
+
+@pytest.mark.parametrize(("exit_code", "outcome", "task_status"), [
+    (0, "completed", "done"), (7, "failed", "blocked"),
+])
+def test_recovery_settles_transferred_helper_process_from_durable_sidecar(
+    kanban_home, tmp_path, monkeypatch, exit_code, outcome, task_status,
+):
+    """A new registry learns the child result after its spawning worker is gone."""
+    checkpoint = kanban_home / "processes.json"
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="sidecar", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id=f"sidecar-{exit_code}")
+    helper = "\n".join((
+        "import json, sys",
+        "from tools.process_registry import ProcessRegistry",
+        "registry = ProcessRegistry()",
+        "session = registry.spawn_local(sys.argv[1], task_id='helper-session')",
+        "assert registry.transfer_to_external_run(session.id, task_id=sys.argv[2], run_id=int(sys.argv[3]), owner='operator')",
+        "print(json.dumps({'session_id': session.id, 'result_path': session.durable_result_path}))",
+    ))
+    child = f"{sys.executable} -c \"import sys,time; time.sleep(.35); sys.exit({exit_code})\""
+    result = __import__("subprocess").run(
+        [sys.executable, "-c", helper, child, task_id, str(run.id)],
+        cwd=str(Path(__file__).parents[2]), env={**os.environ, "HERMES_HOME": str(kanban_home)},
+        text=True, capture_output=True, check=True,
+    )
+    handoff = json.loads(result.stdout)
+    assert Path(handoff["result_path"]).parent == kanban_home / "process-results"
+    time.sleep(.7)  # Helper is already gone; only the detached wrapper can write this.
+    payload = json.loads(Path(handoff["result_path"]).read_text(encoding="utf-8"))
+    assert payload == {"session_id": handoff["session_id"], "exit_code": exit_code}
+
+    restarted = pr.ProcessRegistry()
+    assert restarted.recover_from_checkpoint() == 0
+    with kb.connect() as conn:
+        settled = kb.get_external_run(conn, run.id)
+        assert settled is not None and settled.outcome == outcome
+        assert kb.get_task(conn, task_id).status == task_status
+        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'", (task_id,)).fetchone()[0] == (1 if exit_code == 0 else 0)
+    assert not checkpoint.exists() or not json.loads(checkpoint.read_text())
+
+
+def test_live_recovered_transfer_reads_durable_result_when_pid_later_exits(
+    kanban_home, monkeypatch,
+):
+    """A process recovered while live must use its sidecar after later exit."""
+    checkpoint = kanban_home / "processes.json"
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="live sidecar", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id="live-sidecar")
+    helper = "\n".join((
+        "import json, sys",
+        "from tools.process_registry import ProcessRegistry",
+        "registry = ProcessRegistry()",
+        "session = registry.spawn_local(sys.argv[1], task_id='helper-session')",
+        "assert registry.transfer_to_external_run(session.id, task_id=sys.argv[2], run_id=int(sys.argv[3]), owner='operator')",
+        "print(json.dumps({'session_id': session.id}))",
+    ))
+    child = f"{sys.executable} -c \"import time; time.sleep(1.0)\""
+    result = __import__("subprocess").run(
+        [sys.executable, "-c", helper, child, task_id, str(run.id)],
+        cwd=str(Path(__file__).parents[2]), env={**os.environ, "HERMES_HOME": str(kanban_home)},
+        text=True, capture_output=True, check=True,
+    )
+    session_id = json.loads(result.stdout)["session_id"]
+
+    restarted = pr.ProcessRegistry()
+    assert restarted.recover_from_checkpoint() == 1
+    assert restarted.get(session_id) is not None
+    time.sleep(1.3)
+    restarted.list_sessions()
+
+    with kb.connect() as conn:
+        assert kb.get_external_run(conn, run.id).outcome == "completed"
+        assert kb.get_task(conn, task_id).status == "done"
+    assert not checkpoint.exists() or not json.loads(checkpoint.read_text())
+
+
+@pytest.mark.parametrize("contents", [None, "not-json", '{"session_id":"wrong","exit_code":"0"}'])
+def test_recovery_marks_transferred_process_lost_when_durable_sidecar_is_missing_or_corrupt(
+    kanban_home, monkeypatch, contents,
+):
+    """A dead transferred PID without a valid exact sidecar follows the lost policy."""
+    checkpoint = kanban_home / "processes.json"
+    result_path = kanban_home / "process-results" / "proc-negative.json"
+    if contents is not None:
+        result_path.parent.mkdir()
+        result_path.write_text(contents, encoding="utf-8")
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="negative", assignee="operator", owner_kind="external")
+        run = kb.start_external_run(conn, task_id, owner="operator", external_id="negative")
+    checkpoint.write_text(json.dumps([{
+        "session_id": "proc-negative", "command": "redacted", "pid": 99999999,
+        "pid_scope": "host", "host_start_time": 1, "task_id": "helper-session",
+        "kanban_task_id": task_id, "kanban_external_run_id": run.id,
+        "kanban_board": "default", "kanban_external_owner": "operator",
+        "external_run_owned": True, "durable_result_path": str(result_path),
+    }]), encoding="utf-8")
+    restarted = pr.ProcessRegistry()
+    assert restarted.recover_from_checkpoint() == 0
+    with kb.connect() as conn:
+        assert kb.get_external_run(conn, run.id).outcome == "lost"
+        assert kb.get_task(conn, task_id).status == "blocked"
+
+
+def test_db_handoff_receipt_settles_after_crash_before_registry_checkpoint(
+    kanban_home, monkeypatch,
+):
+    """The DB row alone recovers the exact sidecar when handoff crashes pre-checkpoint."""
+    checkpoint = kanban_home / "processes.json"
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="db-only handoff", assignee="operator")
+        claimed = kb.claim_task(conn, task_id, claimer="worker")
+        assert claimed is not None and claimed.current_run_id is not None
+    helper = "\n".join((
+        "import json, os, sys",
+        "from tools.process_registry import ProcessRegistry",
+        "from hermes_cli import kanban_db as kb",
+        "registry = ProcessRegistry()",
+        "session = registry.spawn_local(sys.argv[1], task_id='worker-session')",
+        "with kb.connect() as conn:",
+        " run = kb.handoff_agent_run_to_external(conn, sys.argv[2], expected_run_id=int(sys.argv[3]), expected_claim_lock='worker', owner='operator', external_id='db-only', pid=session.pid, managed_process_session_id=session.id, durable_result_path=session.durable_result_path, host_start_time=session.host_start_time, on_success='resume')",
+        " assert run is not None",
+        "print(json.dumps({'session_id': session.id, 'receipt': session.durable_result_path}))",
+    ))
+    child = f"{sys.executable} -c \"import sys,time; time.sleep(.25); sys.exit(0)\""
+    result = __import__("subprocess").run(
+        [sys.executable, "-c", helper, child, task_id, str(claimed.current_run_id)],
+        cwd=str(Path(__file__).parents[2]), env={**os.environ, "HERMES_HOME": str(kanban_home)},
+        text=True, capture_output=True, check=True,
+    )
+    handoff = json.loads(result.stdout)
+    checkpoint.unlink(missing_ok=True)
+    time.sleep(.6)
+    assert Path(handoff["receipt"]).is_file()
+    with kb.connect() as conn:
+        conn.execute("UPDATE task_runs SET last_heartbeat_at=0 WHERE owner_kind='external'")
+        assert kb.reconcile_stale_external_runs(conn, stale_after_seconds=1) == 1
+        run = conn.execute("SELECT * FROM task_runs WHERE owner_kind='external'").fetchone()
+        assert run["managed_process_session_id"] == handoff["session_id"]
+        assert run["outcome"] == "completed"
+        assert kb.get_task(conn, task_id).status == "ready"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='external_resumed'",
+            (task_id,),
+        ).fetchone()[0] == 1
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'",
+            (task_id,),
+        ).fetchone()[0] == 0

--- a/tests/tools/test_delegate_kanban_isolation.py
+++ b/tests/tools/test_delegate_kanban_isolation.py
@@ -28,6 +28,7 @@ def _python_with_repo_path(code: str) -> str:
 def _make_running_kanban_task(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
+    (home / "profiles" / "parent-worker").mkdir(parents=True)
     attachments_root = tmp_path / "attachments"
     workspace = tmp_path / "parent-workspace"
     workspace.mkdir()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -40,6 +40,15 @@ def test_kanban_tools_hidden_without_env_var(monkeypatch, tmp_path):
     )
 
 
+def test_kanban_create_schema_exposes_execution_owner_and_provenance_fields():
+    """Model callers receive the complete durable create contract."""
+    from tools import kanban_tools as kt
+
+    props = kt.KANBAN_CREATE_SCHEMA["parameters"]["properties"]
+    assert {"owner_kind", "task_kind", "purpose", "created_by_task_id", "created_by_run_id", "creation_authority"} <= set(props)
+    assert props["owner_kind"]["enum"] == ["agent", "external", "no_agent"]
+
+
 # ---------------------------------------------------------------------------
 # Handler happy paths
 # ---------------------------------------------------------------------------
@@ -50,7 +59,10 @@ def worker_env(monkeypatch, tmp_path):
     after we've created the task."""
     home = tmp_path / ".hermes"
     home.mkdir()
-    for profile in ("test-worker", "peer", "qa"):
+    for profile in (
+        "test-worker", "peer", "qa", "factory", "reviewer", "worker",
+        "worker-a", "worker-d", "x",
+    ):
         (home / "profiles" / profile).mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
@@ -98,6 +110,162 @@ def test_configured_orchestrator_worker_can_fan_out(worker_env):
     assert out["ok"] is True
 
 
+def test_orchestrator_tool_omits_owner_kind_without_making_it_explicit(worker_env):
+    """An omitted model-tool owner_kind reaches the DB as None, not agent."""
+    from pathlib import Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: test-worker\n", encoding="utf-8",
+    )
+    implicit = json.loads(kt._handle_create({"title": "implicit agent", "assignee": "peer"}))
+    explicit = json.loads(kt._handle_create({
+        "title": "manual lane", "assignee": "peer", "owner_kind": "no_agent",
+    }))
+    assert implicit["ok"] is True and explicit["ok"] is True
+    with kb.connect_closing() as conn:
+        implicit_task = kb.get_task(conn, implicit["task_id"])
+        explicit_task = kb.get_task(conn, explicit["task_id"])
+        result = kb.dispatch_once(conn, spawn_fn=lambda *_args, **_kwargs: 123, default_assignee="peer")
+        explicit_after_dispatch = kb.get_task(conn, explicit["task_id"])
+    assert implicit_task is not None and (implicit_task.owner_kind, implicit_task.owner_kind_explicit) == ("agent", False)
+    assert explicit_task is not None and (explicit_task.owner_kind, explicit_task.owner_kind_explicit) == ("no_agent", True)
+    assert explicit["task_id"] not in result.auto_assigned_default
+    assert all(task_id != explicit["task_id"] for task_id, _profile, *_rest in result.spawned)
+    assert explicit_after_dispatch is not None and explicit_after_dispatch.assignee == "peer"
+
+
+def test_orchestrator_tool_persists_explicit_external_owner_and_provenance(worker_env):
+    """An orchestrator can deliberately create a non-dispatchable external lane."""
+    from pathlib import Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: test-worker\n",
+        encoding="utf-8",
+    )
+    out = json.loads(kt._handle_create({
+        "title": "human release handoff",
+        "assignee": "release-operator",
+        "owner_kind": "external",
+        "task_kind": "ordinary",
+        "purpose": "operator handoff",
+        "created_by_task_id": worker_env,
+        "creation_authority": "test-worker",
+    }))
+    assert out["ok"] is True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, out["task_id"])
+    assert task is not None
+    assert task.owner_kind == "external"
+    assert task.task_kind == "ordinary"
+    assert task.purpose == "operator handoff"
+    assert task.created_by_task_id == worker_env
+    assert task.creation_authority == "test-worker"
+
+
+def test_orchestrator_tool_creates_explicit_no_agent_card(worker_env):
+    """A no-agent card keeps its lane label but has no dispatchable owner."""
+    from pathlib import Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: test-worker\n",
+        encoding="utf-8",
+    )
+    out = json.loads(kt._handle_create({
+        "title": "manual approval",
+        "assignee": "release-manager",
+        "owner_kind": "no_agent",
+    }))
+    assert out["ok"] is True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, out["task_id"])
+    assert task is not None and task.owner_kind == "no_agent"
+    assert task.assignee == "release-manager"
+
+
+def test_orchestrator_tool_rejects_unknown_agent_profile(worker_env, monkeypatch):
+    """An agent-owned model-tool task fails before a nonexistent profile is queued."""
+    from pathlib import Path
+    from hermes_cli import profiles
+    from tools import kanban_tools as kt
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: False)
+
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: test-worker\n",
+        encoding="utf-8",
+    )
+    out = json.loads(kt._handle_create({
+        "title": "missing executor",
+        "assignee": "does-not-exist",
+        "owner_kind": "agent",
+    }))
+    assert "does not exist" in out["error"]
+
+
+def test_orchestrator_tool_rejects_gate_with_spoofed_authority(worker_env):
+    """A configured orchestrator cannot bypass a mandatory gate's authority."""
+    from pathlib import Path
+    from tools import kanban_tools as kt
+
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: test-worker\n",
+        encoding="utf-8",
+    )
+    out = json.loads(kt._handle_create({
+        "title": "review gate",
+        "assignee": "qa",
+        "task_kind": "reviewer",
+        "creation_authority": "spoofed-worker",
+    }))
+    assert "must match the calling profile" in out["error"]
+
+
+def test_configured_orchestrator_tool_creates_authorized_gate(worker_env):
+    """The configured orchestrator can create a gate when its authority matches."""
+    from pathlib import Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: test-worker\n",
+        encoding="utf-8",
+    )
+    sha = "c" * 40
+    evidence = home / "gate-evidence.txt"
+    evidence.write_bytes(b"gate evidence")
+    with kb.connect_closing() as conn:
+        attachment = kb.add_attachment(conn, worker_env, filename="gate-evidence.txt", stored_path=str(evidence), content_type="text/plain", size=len(b"gate evidence"))
+        kb.create_candidate(conn, worker_env, sha=sha, source_receipt={"candidate_sha": sha, "subject": "worker scratch artifact", "provenance": "test orchestrator receipt", "producer_profile": "worker"})
+        manifest = kb.freeze_evidence_manifest(conn, worker_env, sha=sha, manifest={"required_slots": ["evidence"], "entries": [{"attachment_id": attachment, "sha256": __import__("hashlib").sha256(b"gate evidence").hexdigest(), "content_type": "text/plain", "cardinality": 1, "slot": "evidence", "mode": "required"}]}, verdict="pass", authority="test-worker")
+    out = json.loads(kt._handle_create({
+        "title": "independent review",
+        "assignee": "qa",
+        "owner_kind": "agent",
+        "task_kind": "reviewer",
+        "creation_authority": "test-worker",
+        "gate_candidate_sha": sha,
+        "gate_manifest_hash": manifest["manifest_hash"],
+    }))
+    assert out["ok"] is True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, out["task_id"])
+    assert task is not None and task.task_kind == "reviewer"
+    assert task.creation_authority == "test-worker"
+    assert (task.owner_kind, task.gate_candidate_sha, task.gate_manifest_hash) == ("agent", sha, manifest["manifest_hash"])
+
+
 def test_worker_cannot_create_or_self_dispatch_gate_children(worker_env):
     """Implementation workers hand off via review; only orchestrators fan out."""
     from tools import kanban_tools as kt
@@ -105,6 +273,7 @@ def test_worker_cannot_create_or_self_dispatch_gate_children(worker_env):
     out = json.loads(kt._handle_create({
         "title": "self-created review gate",
         "assignee": "peer",
+        "task_kind": "reviewer",
     }))
     assert "error" in out
     assert "orchestrator-only" in out["error"]

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -50,6 +50,8 @@ def worker_env(monkeypatch, tmp_path):
     after we've created the task."""
     home = tmp_path / ".hermes"
     home.mkdir()
+    for profile in ("test-worker", "peer", "qa"):
+        (home / "profiles" / profile).mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
     monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
@@ -78,6 +80,277 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert d["task"]["status"] == "running"
     assert "worker_context" in d
     assert "runs" in d
+
+
+def test_configured_orchestrator_worker_can_fan_out(worker_env):
+    from pathlib import Path
+    from tools import kanban_tools as kt
+
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: test-worker\n",
+        encoding="utf-8",
+    )
+    out = json.loads(kt._handle_create({
+        "title": "research child",
+        "assignee": "peer",
+    }))
+    assert out["ok"] is True
+
+
+def test_worker_cannot_create_or_self_dispatch_gate_children(worker_env):
+    """Implementation workers hand off via review; only orchestrators fan out."""
+    from tools import kanban_tools as kt
+
+    out = json.loads(kt._handle_create({
+        "title": "self-created review gate",
+        "assignee": "peer",
+    }))
+    assert "error" in out
+    assert "orchestrator-only" in out["error"]
+
+
+@pytest.mark.parametrize(
+    ("handler_name", "args"),
+    [
+        ("_handle_complete", {"summary": "done"}),
+        ("_handle_block", {"reason": "waiting", "kind": "dependency"}),
+        ("_handle_request_review", {"summary": "candidate ready"}),
+    ],
+)
+def test_worker_cannot_end_run_while_background_process_is_live(
+    monkeypatch, worker_env, handler_name, args
+):
+    """A worker-owned test/build must finish before its task can hand off."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+    from tools.process_registry import process_registry
+
+    monkeypatch.setattr(
+        process_registry,
+        "list_sessions",
+        lambda **kwargs: [{
+            "session_id": "proc_live123",
+            "status": "running",
+            "command": "npm run test:e2e",
+            "kanban_task_id": worker_env,
+        }],
+    )
+    out = json.loads(getattr(kt, handler_name)(args))
+    assert "error" in out
+    assert "proc_live123" in out["error"]
+    assert "process wait" in out["error"]
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, worker_env)
+    assert task is not None
+    assert task.status == "running"
+
+
+def test_other_task_background_process_does_not_block_handoff(
+    monkeypatch, worker_env
+):
+    from tools import kanban_tools as kt
+    from tools.process_registry import process_registry
+
+    monkeypatch.setattr(
+        process_registry,
+        "list_sessions",
+        lambda **kwargs: [{
+            "session_id": "proc_other",
+            "status": "running",
+            "command": "long server",
+            "kanban_task_id": "t_other",
+        }],
+    )
+    assert kt._reject_live_background_handoff("kanban_complete") is None
+
+
+def test_background_process_events_are_visible_on_the_task(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    assert kt.record_background_process_event_from_env(
+        "started", "proc_abc", "npm run test:e2e"
+    )
+    assert kt.record_background_process_event_from_env(
+        "completed", "proc_abc", "npm run test:e2e", exit_code=0
+    )
+    with kb.connect_closing() as conn:
+        events = kb.list_events(conn, worker_env)
+    notes = [
+        (event.payload or {}).get("note", "")
+        for event in events if event.kind == "heartbeat"
+    ]
+    assert any("proc_abc started" in note for note in notes)
+    assert any("proc_abc completed" in note and "exit=0" in note for note in notes)
+
+
+def test_worktree_review_metadata_binds_clean_exact_head(tmp_path):
+    import subprocess
+    from types import SimpleNamespace
+    from tools import kanban_tools as kt
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "file.txt").write_text("v1", encoding="utf-8")
+    subprocess.run(["git", "add", "file.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=repo, check=True)
+    head = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True
+    ).strip()
+    task = SimpleNamespace(workspace_kind="worktree", workspace_path=str(repo))
+
+    metadata, error = kt._bind_worktree_review_metadata(task, {})
+    assert error is None
+    assert metadata["candidate_sha"] == head
+    assert metadata["worktree_clean"] is True
+
+    (repo / "file.txt").write_text("dirty", encoding="utf-8")
+    _, error = kt._bind_worktree_review_metadata(task, {})
+    assert "dirty" in error
+
+
+def test_background_process_completion_repairs_start_race(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    assert kt.record_background_process_event_from_env(
+        "completed", "proc_fast", "true", exit_code=0
+    )
+    assert kt.record_background_process_event_from_env(
+        "started", "proc_fast", "true"
+    )
+    with kb.connect_closing() as conn:
+        notes = [
+            (event.payload or {}).get("note", "")
+            for event in kb.list_events(conn, worker_env)
+            if event.kind == "heartbeat" and "proc_fast" in (event.payload or {}).get("note", "")
+        ]
+    assert [
+        note.split(":", 1)[0]
+        for note in notes
+    ] == [
+        "background process proc_fast started",
+        "background process proc_fast completed exit=0",
+    ]
+
+
+def test_request_review_requires_explicit_independent_reviewer(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    result = json.loads(kt._handle_request_review({"summary": "candidate"}))
+    assert "independent reviewer is required" in result["error"]
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, worker_env)
+    assert task is not None
+    assert task.status == "running"
+
+
+def test_worker_cannot_link_foreign_tasks(worker_env):
+    from tools import kanban_tools as kt
+
+    result = json.loads(kt._handle_link({
+        "parent_id": worker_env,
+        "child_id": "t_someone_else",
+    }))
+    assert "orchestrator-only" in result["error"]
+
+
+def test_orchestrator_cannot_assign_review_back_to_implementer(
+    monkeypatch, worker_env
+):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="candidate", assignee="peer")
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    result = json.loads(kt._handle_request_review({
+        "task_id": task_id,
+        "summary": "ready",
+        "reviewer": "peer",
+    }))
+    assert "implementation assignee" in result["error"]
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "ready"
+
+
+def test_request_review_rejects_missing_or_self_reviewer(
+    monkeypatch, worker_env
+):
+    from hermes_cli import profiles as profiles_mod
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    real_exists = profiles_mod.profile_exists
+    monkeypatch.setattr(
+        profiles_mod,
+        "profile_exists",
+        lambda name: False if name == "ghost-reviewer" else real_exists(name),
+    )
+    missing = json.loads(kt._handle_request_review({
+        "summary": "candidate",
+        "reviewer": "ghost-reviewer",
+    }))
+    assert "does not exist" in missing["error"]
+
+    self_review = json.loads(kt._handle_request_review({
+        "summary": "candidate",
+        "reviewer": "test-worker",
+    }))
+    assert "cannot review its own" in self_review["error"]
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, worker_env)
+    assert task is not None
+    assert task.status == "running"
+
+
+def test_create_rejects_missing_profile_before_persisting(monkeypatch, worker_env):
+    """An invented profile must fail at creation, not rot in ready forever."""
+    from hermes_cli import profiles as profiles_mod
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda name: False)
+    out = json.loads(kt._handle_create({
+        "title": "research Arabic",
+        "assignee": "researcher",
+    }))
+
+    assert "error" in out
+    assert "does not exist" in out["error"]
+    assert "external_assignee" in out["error"]
+    with kb.connect_closing() as conn:
+        assert not any(t.title == "research Arabic" for t in kb.list_tasks(conn))
+
+
+def test_create_allows_explicit_external_assignee(monkeypatch, worker_env):
+    """Human-pulled lanes remain supported, but require explicit intent."""
+    from hermes_cli import profiles as profiles_mod
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda name: False)
+    out = json.loads(kt._handle_create({
+        "title": "external lane task",
+        "assignee": "orion-research",
+        "external_assignee": True,
+    }))
+
+    assert out["ok"] is True
+    with kb.connect_closing() as conn:
+        created = kb.get_task(conn, out["task_id"])
+    assert created is not None
+    assert created.assignee == "orion-research"
 
 
 def test_list_filters_tasks(monkeypatch, worker_env):
@@ -395,8 +668,9 @@ def test_comment_ignores_caller_supplied_author(worker_env):
         conn.close()
 
 
-def test_create_happy_path(worker_env):
+def test_create_happy_path(monkeypatch, worker_env):
     from tools import kanban_tools as kt
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
     out = kt._handle_create({
         "title": "child task",
         "assignee": "peer",
@@ -416,7 +690,7 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
-def test_link_happy_path(worker_env):
+def test_link_happy_path(monkeypatch, worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
@@ -425,6 +699,7 @@ def test_link_happy_path(worker_env):
     finally:
         conn.close()
     from tools import kanban_tools as kt
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
     out = kt._handle_link({"parent_id": a, "child_id": b})
     d = json.loads(out)
     assert d["ok"] is True
@@ -487,7 +762,7 @@ def test_unblock_with_pending_parents_returns_todo(monkeypatch, tmp_path):
         conn.close()
 
 
-def test_worker_lifecycle_through_tools(worker_env):
+def test_worker_lifecycle_through_tools(monkeypatch, worker_env):
     """Drive the full claim -> heartbeat -> comment -> complete lifecycle
     exclusively through the tools, then verify the DB state matches what
     the dispatcher/notifier expect."""
@@ -506,12 +781,14 @@ def test_worker_lifecycle_through_tools(worker_env):
         "body": "note: using stdlib sqlite3 bindings",
     }))["ok"]
 
-    # 4. spawn a child task for follow-up
-    child_out = json.loads(kt._handle_create({
-        "title": "write integration test",
-        "assignee": "qa",
-        "parents": [worker_env],
-    }))
+    # 4. an orchestrator, not this implementation worker, fans out a child
+    with monkeypatch.context() as orchestrator_context:
+        orchestrator_context.delenv("HERMES_KANBAN_TASK")
+        child_out = json.loads(kt._handle_create({
+            "title": "write integration test",
+            "assignee": "qa",
+            "parents": [worker_env],
+        }))
     assert child_out["ok"]
 
     # 5. complete with structured handoff
@@ -843,6 +1120,7 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     to its own kanban_create result, and the response surfaces the
     ``subscribed`` flag so the orchestrator can react."""
     from tools import kanban_tools as kt
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
     monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
     monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "thread-7")
@@ -877,6 +1155,7 @@ def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):
     We should still auto-subscribe, with platform='tui' and
     chat_id=<key>."""
     from tools import kanban_tools as kt
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
@@ -905,6 +1184,7 @@ def test_create_does_not_subscribe_in_cli_session(monkeypatch, worker_env):
     """CLI / cron / test sessions have no persistent delivery channel.
     _maybe_auto_subscribe returns False and no row is written."""
     from tools import kanban_tools as kt
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
@@ -931,10 +1211,12 @@ def test_create_respects_auto_subscribe_on_create_false(monkeypatch, worker_env,
     # home to avoid mkdir() colliding with the worker's directory.
     home = tmp_path / "gate-home" / ".hermes"
     home.mkdir(parents=True)
+    (home / "profiles" / "peer").mkdir(parents=True)
     (home / "config.yaml").write_text(
         "kanban:\n  auto_subscribe_on_create: false\n"
     )
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
     monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "channel-1")
 
@@ -956,6 +1238,7 @@ def test_maybe_auto_subscribe_swallows_add_notify_sub_failure(monkeypatch, worke
     kanban_create. The function returns False and the parent create
     still succeeds with subscribed=False."""
     from tools import kanban_tools as kt
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
     monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1,12 +1,15 @@
 """Tests for tools/process_registry.py — ProcessRegistry query methods, pruning, checkpoint."""
 
 import json
+import io
 import os
 import signal
+import shlex
 import subprocess
 import sys
 import threading
 import time
+from pathlib import Path
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -142,6 +145,340 @@ def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool
             return True
         time.sleep(interval)
     return False
+
+
+@pytest.mark.linux_only
+def test_sidecar_survives_sigkilled_parent_drains_output_and_publishes_receipt(tmp_path):
+    """The wrapper, not a killed registry parent, owns the output pipe."""
+    from tools import process_registry as pr
+    result, marker = tmp_path / "result.json", tmp_path / "marker"
+    sidecar = str(Path(pr.__file__).with_name("process_sidecar.py").resolve())
+    child = "import pathlib,time; print('delayed output',flush=True); time.sleep(.25); pathlib.Path(%r).write_text('done')" % str(marker)
+    argv = [sys.executable, sidecar, "--result", str(result), "--session-id", "proc-parent-death", "--", sys.executable, "-c", child]
+    helper = "import subprocess,time; p=subprocess.Popen(%r); print(p.pid,flush=True); time.sleep(30)" % argv
+    parent = subprocess.Popen([sys.executable, "-c", helper], stdout=subprocess.PIPE, text=True)
+    assert parent.stdout is not None and parent.stdout.readline().strip().isdigit()
+    os.kill(parent.pid, signal.SIGKILL); parent.wait(timeout=5)
+    assert _wait_until(marker.exists) and _wait_until(result.exists)
+    assert json.loads(result.read_text()) == {"exit_code": 0, "session_id": "proc-parent-death"}
+
+
+@pytest.mark.linux_only
+def test_sidecar_preserves_signal_receipt_and_uses_shell_signal_status(tmp_path):
+    """The transport status is conventional while its receipt stays lossless."""
+    from tools import process_registry as pr
+
+    result = tmp_path / "signal-result.json"
+    sidecar = str(Path(pr.__file__).with_name("process_sidecar.py").resolve())
+    child = "import os,signal; os.kill(os.getpid(), signal.SIGTERM)"
+    completed = subprocess.run(
+        [sys.executable, sidecar, "--result", str(result), "--session-id", "proc-signal", "--", sys.executable, "-c", child],
+        check=False,
+    )
+
+    assert completed.returncode == 128 + signal.SIGTERM
+    assert json.loads(result.read_text()) == {
+        "exit_code": -signal.SIGTERM,
+        "session_id": "proc-signal",
+    }
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_live_registry_prefers_lossless_sidecar_signal_receipt(tmp_path, use_pty):
+    """Normal live completion reports the child's signal, not wrapper status."""
+    from tools import process_registry as pr
+
+    child = "import os,signal; os.kill(os.getpid(), signal.SIGTERM)"
+    registry = pr.ProcessRegistry()
+    session = registry.spawn_local(
+        f"{sys.executable} -c {shlex.quote(child)}", cwd=str(tmp_path),
+        use_pty=use_pty,
+    )
+    assert _wait_until(lambda: session.exited)
+
+    assert session.exit_code == -signal.SIGTERM
+
+
+@pytest.mark.linux_only
+def test_posix_sidecar_pty_preserves_outer_geometry_and_single_line_discipline(tmp_path):
+    """The durable wrapper must not insert a second independent PTY layer."""
+    from ptyprocess import PtyProcess
+    from tools import process_registry as pr
+
+    result = tmp_path / "pty-result.json"
+    sidecar = str(Path(pr.__file__).with_name("process_sidecar.py").resolve())
+    child = "stty size; IFS= read -r line; stty size; printf 'got:%s\\n' \"$line\""
+    proc = PtyProcess.spawn(
+        [sys.executable, sidecar, "--pty", "--result", str(result),
+         "--session-id", "proc-pty-fidelity", "--", "sh", "-c", child],
+        dimensions=(30, 120),
+    )
+    output = bytearray(proc.read(4096))
+    proc.setwinsize(40, 100)
+    proc.write(b"alpha\n")
+    while True:
+        try:
+            output.extend(proc.read(4096))
+        except EOFError:
+            break
+    proc.wait()
+
+    text = output.decode("utf-8", "replace")
+    assert "30 120\r\n" in text
+    assert "40 100\r\n" in text
+    assert "\r\r\n" not in text
+    assert text.count("alpha") == 2  # one terminal echo plus got:alpha
+    assert json.loads(result.read_text()) == {
+        "exit_code": 0,
+        "session_id": "proc-pty-fidelity",
+    }
+
+
+def test_checkpoint_serializes_snapshot_through_durable_write_and_preserves_newer_transfer(tmp_path, monkeypatch):
+    """A writer which snapshots first cannot land after a newer transfer."""
+    from tools import process_registry as pr
+    import utils
+
+    registry = pr.ProcessRegistry()
+    checkpoint = tmp_path / "processes.json"
+    session = _make_session(sid="proc-transfer-order", task_id="kanban-task")
+    session.pid = 1234
+    registry._running[session.id] = session
+    first_write_started = threading.Event()
+    second_writer_started = threading.Event()
+    release_first_write = threading.Event()
+    writes = []
+    real_write = utils.atomic_json_write
+
+    def controlled_write(path, entries):
+        writes.append(entries)
+        if len(writes) == 1:
+            first_write_started.set()
+            assert release_first_write.wait(5)
+        real_write(path, entries)
+
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+    monkeypatch.setattr(utils, "atomic_json_write", controlled_write)
+    older = threading.Thread(target=registry._write_checkpoint)
+    older.start()
+    assert first_write_started.wait(5)
+    with registry._lock:
+        session.external_run_owned = True
+        session.kanban_external_run_id = 77
+        session.kanban_board = "board-b"
+        session.kanban_external_owner = "owner-b"
+    def newer_writer():
+        second_writer_started.set()
+        registry._write_checkpoint()
+
+    newer = threading.Thread(target=newer_writer)
+    newer.start()
+    assert second_writer_started.wait(5)
+    assert len(writes) == 1
+    release_first_write.set()
+    older.join(5)
+    newer.join(5)
+    assert not older.is_alive() and not newer.is_alive()
+    final = json.loads(checkpoint.read_text())
+    assert final[0]["external_run_owned"] is True
+    assert final[0]["kanban_external_run_id"] == 77
+    assert final[0]["kanban_external_owner"] == "owner-b"
+
+
+def test_windows_conpty_relay_forwards_input_and_drains_pty_output_on_any_host():
+    """The platform-independent relay gives a real Windows child a TTY path."""
+    from tools import process_sidecar
+
+    writes = []
+    spawned = []
+    payload = "Yé日🚀"
+
+    class _FakeConPty:
+        exitstatus = 7
+
+        @classmethod
+        def spawn(cls, command):
+            spawned.append(command)
+            return cls()
+
+        def __init__(self):
+            self.chunks = ["prompt> ", "done\r\n"]
+
+        def isalive(self):
+            return bool(self.chunks)
+
+        def read(self, _size):
+            return self.chunks.pop(0)
+
+        def write(self, value):
+            writes.append(value)
+
+        def wait(self):
+            return self.exitstatus
+
+    class _Input:
+        def __init__(self):
+            self.stream = io.BytesIO(payload.encode("utf-8"))
+
+        def read(self, size):
+            return self.stream.read(size)
+
+    class _Output:
+        def __init__(self):
+            self.value = b""
+
+        def write(self, value):
+            self.value += value
+
+        def flush(self):
+            pass
+
+    output = _Output()
+    proc, threads, _ = process_sidecar._spawn_conpty(
+        ["interactive-command"], _FakeConPty, input_stream=_Input(), output_stream=output,
+    )
+    assert proc.exitstatus == 7
+    for thread in threads:
+        thread.join(timeout=2)
+    assert spawned == [["interactive-command"]]
+    assert "".join(writes[:-1]) == payload
+    assert writes[-1] == "\x04"
+    assert output.value == b"prompt> done\r\n"
+
+
+def test_sidecar_receipt_writer_tolerates_platform_without_fchmod(tmp_path, monkeypatch):
+    """The mandatory wrapper must write receipts on Windows-like platforms."""
+    from tools import process_sidecar
+
+    monkeypatch.delattr(process_sidecar.os, "fchmod", raising=False)
+    result = tmp_path / "result.json"
+    process_sidecar._write_result(result, "proc-win", 0)
+    assert json.loads(result.read_text()) == {"session_id": "proc-win", "exit_code": 0}
+
+
+def test_sidecar_module_does_not_require_posix_pty_on_windows():
+    """Importing the pipe-mode wrapper must not require Unix-only ``pty``."""
+    from tools import process_sidecar
+
+    script = "\n".join((
+        "import argparse, builtins, json, os, pathlib, runpy, signal, subprocess, sys, tempfile, threading",
+        "real_import = builtins.__import__",
+        "def reject_pty(name, *args, **kwargs):",
+        "    if name == 'pty': raise ImportError('pty unavailable')",
+        "    return real_import(name, *args, **kwargs)",
+        "os.name = 'nt'",
+        "builtins.__import__ = reject_pty",
+        "runpy.run_path(sys.argv[1], run_name='sidecar_windows_import_test')",
+    ))
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(Path(process_sidecar.__file__))],
+        text=True, capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_sidecar_receipt_reader_rejects_missing_corrupt_and_accepts_nonzero(tmp_path, monkeypatch):
+    """Only exact receipt payloads can settle a recovered process."""
+    import tools.process_registry as pr
+    monkeypatch.setattr(pr.ProcessRegistry, "_durable_result_path", staticmethod(lambda _sid: tmp_path / "receipt.json"))
+    assert pr.ProcessRegistry._read_durable_result("proc-x", str(tmp_path / "receipt.json")) is None
+    (tmp_path / "receipt.json").write_text("not json")
+    assert pr.ProcessRegistry._read_durable_result("proc-x", str(tmp_path / "receipt.json")) is None
+    (tmp_path / "receipt.json").write_text(json.dumps({"session_id": "proc-x", "exit_code": 7}))
+    assert pr.ProcessRegistry._read_durable_result("proc-x", str(tmp_path / "receipt.json")) == 7
+
+
+@pytest.mark.linux_only
+def test_sidecar_pty_resolves_from_arbitrary_cwd_and_preserves_isatty(tmp_path):
+    """An absolute sidecar path and inner PTY preserve interactive semantics."""
+    from tools import process_registry as pr
+    registry = pr.ProcessRegistry()
+    session = registry.spawn_local(f"{sys.executable} -c 'import sys; print(sys.stdout.isatty())'", cwd=str(tmp_path), use_pty=True)
+    assert session._completion_event.wait(5)
+    assert "True" in session.output_buffer
+
+
+@pytest.mark.linux_only
+def test_registry_pty_immediate_input_keeps_geometry_and_single_echo(tmp_path):
+    """The public spawn return is a readiness boundary for the raw outer PTY."""
+    from tools import process_registry as pr
+
+    registry = pr.ProcessRegistry()
+    command = "stty size; IFS= read -r line; printf 'got:%s\\n' \"$line\""
+    session = registry.spawn_local(command, cwd=str(tmp_path), use_pty=True)
+    assert registry.submit_stdin(session.id, "alpha")["status"] == "ok"
+    assert session._completion_event.wait(5)
+
+    assert "30 120\r\n" in session.output_buffer
+    assert "\r\r\n" not in session.output_buffer
+    assert session.output_buffer.count("alpha") == 2
+
+
+@pytest.mark.windows_only
+def test_windows_sidecar_pty_preserves_isatty_and_publishes_durable_exit_receipt(tmp_path):
+    """Native Windows uses nested ConPTY, never the noninteractive pipe path."""
+    from tools import process_registry as pr
+
+    registry = pr.ProcessRegistry()
+    session = registry.spawn_local(
+        f'{sys.executable} -c "import sys; print(sys.stdin.isatty(), sys.stdout.isatty())"',
+        cwd=str(tmp_path), use_pty=True,
+    )
+    assert session._completion_event.wait(10)
+    assert "True True" in session.output_buffer
+    receipt = json.loads(Path(session.durable_result_path).read_text())
+    assert receipt == {"exit_code": 0, "session_id": session.id}
+
+
+@pytest.mark.linux_only
+def test_sidecar_pty_survives_parent_death_without_forwarding_hangup(tmp_path):
+    """Closing the outer PTY must not kill the durable inner process tree."""
+    from tools import process_registry as pr
+
+    sidecar_home = tmp_path / "hermes-home"
+    marker = tmp_path / "pty-survived"
+    child = (
+        "import pathlib,time; time.sleep(.5); print('after-parent',flush=True); "
+        f"pathlib.Path({str(marker)!r}).write_text('ok')"
+    )
+    command = f"{sys.executable} -c {shlex.quote(child)}"
+    helper_code = "\n".join((
+        "import sys, time",
+        "from tools.process_registry import ProcessRegistry",
+        "session = ProcessRegistry().spawn_local(sys.argv[1], cwd=sys.argv[2], use_pty=True)",
+        "print(session.durable_result_path, flush=True)",
+        "time.sleep(30)",
+    ))
+    helper = subprocess.Popen(
+        [sys.executable, "-c", helper_code, command, str(tmp_path)],
+        cwd=str(Path(pr.__file__).parents[1]), text=True, stdout=subprocess.PIPE,
+        env={**os.environ, "HERMES_HOME": str(sidecar_home)},
+    )
+    assert helper.stdout is not None
+    result = Path(helper.stdout.readline().strip())
+    assert result.parent == sidecar_home / "process-results"
+    os.kill(helper.pid, signal.SIGKILL)
+    helper.wait(timeout=5)
+    assert _wait_until(marker.exists) and _wait_until(result.exists)
+    assert json.loads(result.read_text())["exit_code"] == 0
+
+
+@pytest.mark.linux_only
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.parametrize("use_pty", [False, True])
+def test_sidecar_signal_forwarding_kills_child_tree_in_pipe_and_pty(tmp_path, use_pty):
+    """Killing the managed wrapper reaches its separate-session descendants."""
+    from tools import process_registry as pr
+    descendant = tmp_path / ("pty-child" if use_pty else "pipe-child")
+    child = "import pathlib,subprocess,sys,time; p=subprocess.Popen([sys.executable,'-c','import time; time.sleep(30)']); pathlib.Path(%r).write_text(str(p.pid)); time.sleep(30)" % str(descendant)
+    registry = pr.ProcessRegistry()
+    session = registry.spawn_local(f"{sys.executable} -c {shlex.quote(child)}", cwd=str(tmp_path), use_pty=use_pty)
+    assert _wait_until(lambda: descendant.exists() and descendant.read_text().strip())
+    pid = int(descendant.read_text())
+    result = registry.kill_process(session.id, source="test_cleanup")
+    assert result["status"] == "killed", result
+    assert _wait_until(lambda: not pr.ProcessRegistry._is_host_pid_alive(pid))
 
 
 @pytest.mark.windows_only
@@ -886,9 +1223,8 @@ class TestSpawnRewriteCompoundBackground:
             registry.spawn_local("cd /app && node server.js &>/tmp/srv.log &", cwd="/tmp")
 
         assert len(captured_cmd) == 1
-        shell_cmd = captured_cmd[0]
-        # The command passed to Popen should be the REWRITTEN version
-        assert "&& { node server.js &>/tmp/srv.log & }" in shell_cmd[2]
+        # The wrapper's child shell receives the rewritten command.
+        assert "&& { node server.js &>/tmp/srv.log & }" in captured_cmd[0][-1]
 
     def test_simple_background_preserved(self, registry):
         """Simple cmd & (no &&) must NOT be rewritten — no subshell bug."""
@@ -911,9 +1247,8 @@ class TestSpawnRewriteCompoundBackground:
             registry.spawn_local("sleep 5 &", cwd="/tmp")
 
         assert len(captured_cmd) == 1
-        shell_cmd = captured_cmd[0][2]
-        # Simple background must remain as-is
-        assert "sleep 5 &" in shell_cmd
+        # Simple background must remain as-is in the wrapper's child shell.
+        assert "sleep 5 &" in captured_cmd[0][-1]
 
     def test_pty_path_uses_rewritten_command(self, registry):
         """PTY spawn path must also use the rewritten command (issue #68915)."""
@@ -939,8 +1274,8 @@ class TestSpawnRewriteCompoundBackground:
         assert mock_pty_module.PtyProcess.spawn.called, \
             "PTY spawn should have been attempted"
         pty_args = mock_pty_module.PtyProcess.spawn.call_args[0][0]
-        assert "&& { node server.js & }" in pty_args[2], \
-            f"PTY path should use rewritten command, got: {pty_args[2]}"
+        assert "&& { node server.js & }" in pty_args[-1], \
+            f"PTY path should use rewritten command, got: {pty_args[-1]}"
         assert session.command == "cd /app && node server.js &"
 
 
@@ -1831,8 +2166,9 @@ class TestSystemdCgroupIsolation:
             registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
-        # No systemd-run wrapping — direct shell invocation.
-        assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
+        # No systemd scope; the durable sidecar still invokes the exact shell.
+        assert "systemd-run" not in argv
+        assert argv[-3:] == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
 
     def test_falls_back_when_not_under_supervisor(self, registry, monkeypatch):
@@ -1858,7 +2194,8 @@ class TestSystemdCgroupIsolation:
             registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
-        assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
+        assert "systemd-run" not in argv
+        assert argv[-3:] == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
 
     @pytest.mark.parametrize("use_pty", [False, True])
@@ -1889,7 +2226,7 @@ class TestSystemdCgroupIsolation:
                 patch.object(registry, "_write_checkpoint"),
             ):
                 session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
-            assert pty_spawn.call_args.args[0] == [
+            assert pty_spawn.call_args.args[0][-3:] == [
                 "/bin/bash", "-lic", "set +m; codex",
             ]
         else:
@@ -1900,7 +2237,7 @@ class TestSystemdCgroupIsolation:
                 patch.object(registry, "_write_checkpoint"),
             ):
                 session = registry.spawn_local("echo hello", cwd="/tmp")
-            assert captured["argv"] == [
+            assert captured["argv"][-3:] == [
                 "/bin/bash", "-lic", "set +m; echo hello",
             ]
             assert captured["start_new_session"] is True
@@ -1940,7 +2277,7 @@ class TestSystemdCgroupIsolation:
                 patch.object(registry, "_write_checkpoint"),
             ):
                 session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
-            assert pty_spawn.call_args.args[0] == [
+            assert pty_spawn.call_args.args[0][-3:] == [
                 "/bin/bash", "-lic", "set +m; codex",
             ]
         else:
@@ -1951,7 +2288,7 @@ class TestSystemdCgroupIsolation:
                 patch.object(registry, "_write_checkpoint"),
             ):
                 session = registry.spawn_local("echo hello", cwd="/tmp")
-            assert captured["argv"] == [
+            assert captured["argv"][-3:] == [
                 "/bin/bash", "-lic", "set +m; echo hello",
             ]
             assert captured["start_new_session"] is True

--- a/tests/tools/test_process_schema_diet.py
+++ b/tests/tools/test_process_schema_diet.py
@@ -31,7 +31,7 @@ class TestProcessSchemaDiet(unittest.TestCase):
         props = PROCESS_SCHEMA["parameters"]["properties"]
         self.assertEqual(
             props["action"]["enum"],
-            ["list", "poll", "log", "wait", "kill", "write", "submit", "close"],
+            ["list", "poll", "log", "wait", "kill", "write", "submit", "close", "transfer"],
         )
         # No redundant description on the enum param.
         self.assertNotIn("description", props["action"])

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,6 +31,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+import subprocess
+from pathlib import Path
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
@@ -119,19 +122,32 @@ def _check_kanban_mode() -> bool:
     return _profile_has_kanban_toolset()
 
 
-def _check_kanban_orchestrator_mode() -> bool:
-    """Board-routing tools (kanban_list, kanban_unblock) are intentionally
-    hidden from task workers.
+def _dispatcher_worker_is_orchestrator() -> bool:
+    """Whether this scoped worker is the configured board orchestrator."""
+    if not os.environ.get("HERMES_KANBAN_TASK") or not _is_dispatcher_owned_worker():
+        return False
+    try:
+        from hermes_cli import profiles as profiles_mod
 
-    Dispatcher-spawned workers should close their own task via the
-    lifecycle tools (complete/block/heartbeat), not enumerate or unblock
-    board state. Profiles that explicitly opt into the kanban toolset
-    and are NOT scoped to a single task are the orchestrator surface.
-    """
+        cfg = load_config() or {}
+        configured = str(
+            (cfg.get("kanban") or {}).get("orchestrator_profile") or "default"
+        )
+        configured = profiles_mod.normalize_profile_name(configured)
+        current = profiles_mod.normalize_profile_name(
+            os.environ.get("HERMES_PROFILE") or "default"
+        )
+        return current == configured
+    except Exception:
+        return False
+
+
+def _check_kanban_orchestrator_mode() -> bool:
+    """Expose board-routing tools only to explicit orchestrator contexts."""
     if _is_delegated_child_context():
         return False
     if os.environ.get("HERMES_KANBAN_TASK") and _is_dispatcher_owned_worker():
-        return False
+        return _dispatcher_worker_is_orchestrator()
     return _profile_has_kanban_toolset()
 
 
@@ -296,6 +312,65 @@ def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
 
 _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS = 60.0
 _auto_heartbeat_last_attempt: float = 0.0
+
+
+def record_background_process_event_from_env(
+    state: str,
+    session_id: str,
+    command: str,
+    *,
+    exit_code: Optional[int] = None,
+) -> bool:
+    """Mirror managed-process lifecycle into the owning Kanban task heartbeat."""
+    tid = os.environ.get("HERMES_KANBAN_TASK")
+    if not tid or not _is_dispatcher_owned_worker():
+        return False
+    state = str(state).strip().lower()
+    if state not in {"started", "completed", "lost", "killed"}:
+        return False
+    safe_command = redact_sensitive_text(str(command), force=True)[:200]
+    note = f"background process {session_id} {state}"
+    if exit_code is not None:
+        note += f" exit={int(exit_code)}"
+    if safe_command:
+        note += f": {safe_command}"
+    try:
+        kb, conn = _connect()
+        try:
+            prior_notes = [
+                (event.payload or {}).get("note", "")
+                for event in kb.list_events(conn, tid)
+                if event.kind == "heartbeat"
+            ]
+            state_prefix = f"background process {session_id} {state}"
+            if any(value.startswith(state_prefix) for value in prior_notes):
+                return True
+            expected_run_id = _worker_run_id(tid)
+            start_prefix = f"background process {session_id} started"
+            if state != "started" and not any(
+                value.startswith(start_prefix) for value in prior_notes
+            ):
+                start_note = start_prefix
+                if safe_command:
+                    start_note += f": {safe_command}"
+                kb.heartbeat_worker(
+                    conn,
+                    tid,
+                    note=start_note,
+                    expected_run_id=expected_run_id,
+                )
+            kb.heartbeat_worker(
+                conn,
+                tid,
+                note=note,
+                expected_run_id=expected_run_id,
+            )
+        finally:
+            conn.close()
+        return True
+    except Exception:
+        logger.debug("background process event bridge failed", exc_info=True)
+        return False
 
 
 def heartbeat_current_worker_from_env() -> bool:
@@ -473,13 +548,87 @@ def _require_orchestrator_tool(tool_name: str) -> Optional[str]:
     structured tool_error so the model gets a clear refusal instead of
     silently mutating board state from a worker context.
     """
-    if os.environ.get("HERMES_KANBAN_TASK"):
+    if os.environ.get("HERMES_KANBAN_TASK") and not _dispatcher_worker_is_orchestrator():
         return tool_error(
-            f"{tool_name} is orchestrator-only; dispatcher-spawned workers "
-            "must use kanban_complete, kanban_block, kanban_heartbeat, or "
-            "kanban_comment for their assigned task."
+            f"{tool_name} is orchestrator-only; dispatcher-spawned implementation "
+            "workers must use kanban_request_review for independent review or "
+            "their own lifecycle tools. Only kanban.orchestrator_profile may "
+            "fan out or route board work from a scoped task."
         )
     return None
+
+
+def _reject_live_background_handoff(tool_name: str) -> Optional[str]:
+    """Keep a one-shot worker alive until its background commands finish."""
+    tid = os.environ.get("HERMES_KANBAN_TASK")
+    if not tid:
+        return None
+    try:
+        from tools.process_registry import process_registry
+
+        running = [
+            process
+            for process in process_registry.list_sessions()
+            if process.get("status") == "running"
+            and process.get("kanban_task_id") == tid
+        ]
+    except Exception:
+        # Registry inspection is advisory; never brick lifecycle operations.
+        logger.debug("background handoff guard failed open", exc_info=True)
+        return None
+    if not running:
+        return None
+    handles = ", ".join(str(p.get("session_id")) for p in running[:5])
+    return tool_error(
+        f"{tool_name} refused while worker-owned background process(es) are "
+        f"still running: {handles}. Use process wait (or process kill for an "
+        "intentional cancellation), record the real exit result, then retry "
+        "the Kanban handoff. Ending the worker now would terminate the child "
+        "and lose its verdict."
+    )
+
+
+def _bind_worktree_review_metadata(task: Any, metadata: Optional[dict]):
+    """Bind a code-review handoff to one clean immutable Git commit."""
+    metadata = dict(metadata or {})
+    if not task or task.workspace_kind != "worktree":
+        return metadata, None
+    workspace = Path(task.workspace_path or "")
+    if not workspace.is_absolute() or not workspace.is_dir():
+        return metadata, "worktree workspace is missing or not absolute"
+    try:
+        head = subprocess.check_output(
+            ["git", "-C", str(workspace), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.STDOUT,
+            timeout=10,
+        ).strip()
+        dirty = subprocess.check_output(
+            [
+                "git", "-C", str(workspace), "status", "--porcelain=v1",
+                "--untracked-files=all",
+            ],
+            text=True,
+            stderr=subprocess.STDOUT,
+            timeout=10,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        return metadata, f"could not inspect worktree candidate: {exc}"
+    if not re.fullmatch(r"[0-9a-f]{40}", head):
+        return metadata, f"worktree HEAD is not an exact 40-character commit: {head!r}"
+    if dirty.strip():
+        return metadata, (
+            "worktree is dirty; commit or remove every tracked/untracked change "
+            "before review"
+        )
+    claimed = metadata.get("candidate_sha")
+    if claimed is not None and str(claimed) != head:
+        return metadata, (
+            f"metadata candidate_sha {claimed!r} does not match worktree HEAD {head}"
+        )
+    metadata["candidate_sha"] = head
+    metadata["worktree_clean"] = True
+    return metadata, None
 
 
 def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
@@ -657,6 +806,9 @@ def _handle_complete(args: dict, **kw) -> str:
     delegated_err = _reject_delegated_child_mutation("kanban_complete")
     if delegated_err:
         return delegated_err
+    background_err = _reject_live_background_handoff("kanban_complete")
+    if background_err:
+        return background_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
         return tool_error(
@@ -819,6 +971,9 @@ def _handle_block(args: dict, **kw) -> str:
     delegated_err = _reject_delegated_child_mutation("kanban_block")
     if delegated_err:
         return delegated_err
+    background_err = _reject_live_background_handoff("kanban_block")
+    if background_err:
+        return background_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
         return tool_error(
@@ -900,6 +1055,9 @@ def _handle_request_review(args: dict, **kw) -> str:
     delegated_err = _reject_delegated_child_mutation("kanban_request_review")
     if delegated_err:
         return delegated_err
+    background_err = _reject_live_background_handoff("kanban_request_review")
+    if background_err:
+        return background_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
         return tool_error(
@@ -928,7 +1086,31 @@ def _handle_request_review(args: dict, **kw) -> str:
             return tool_error("metadata could not be safely serialized")
     metadata = _stamp_worker_session_metadata(tid, metadata)
     reviewer = args.get("reviewer") or None
+    if not reviewer:
+        return tool_error(
+            "an explicit independent reviewer is required; choose an installed "
+            "profile different from the implementer"
+        )
     if reviewer:
+        from hermes_cli import profiles as profiles_mod
+
+        reviewer = profiles_mod.normalize_profile_name(str(reviewer))
+        current_profile = profiles_mod.normalize_profile_name(
+            os.environ.get("HERMES_PROFILE") or "default"
+        )
+        if reviewer == current_profile:
+            return tool_error(
+                f"reviewer profile {reviewer!r} cannot review its own "
+                "implementation; choose an independent installed profile"
+            )
+        if not profiles_mod.profile_exists(reviewer):
+            available = ", ".join(
+                sorted(p.name for p in profiles_mod.list_profiles())
+            ) or "(none)"
+            return tool_error(
+                f"reviewer profile {reviewer!r} does not exist. "
+                f"Available profiles: {available}."
+            )
         # Model-supplied free text stored durably on the event payload —
         # redact like summary / kanban_block's reason.
         reviewer = redact_sensitive_text(str(reviewer), force=True)
@@ -937,6 +1119,25 @@ def _handle_request_review(args: dict, **kw) -> str:
         kb, conn = _connect(board=board)
         try:
             task = kb.get_task(conn, tid)
+            if task is not None:
+                from hermes_cli import profiles as profiles_mod
+
+                implementation_assignee = profiles_mod.normalize_profile_name(
+                    task.assignee
+                )
+                if reviewer == implementation_assignee:
+                    return tool_error(
+                        f"reviewer profile {reviewer!r} is the task's implementation "
+                        "assignee; choose an independent installed profile"
+                    )
+            metadata, provenance_error = _bind_worktree_review_metadata(
+                task, metadata
+            )
+            if provenance_error is not None:
+                return tool_error(
+                    f"Review handoff rejected: {provenance_error}. "
+                    "The task remains in-flight."
+                )
             rejection = _goal_mode_handoff_rejection(task, summary)
             if rejection is not None:
                 return tool_error(
@@ -1349,6 +1550,9 @@ def _handle_create(args: dict, **kw) -> str:
     delegated_err = _reject_delegated_child_mutation("kanban_create")
     if delegated_err:
         return delegated_err
+    guard = _require_orchestrator_tool("kanban_create")
+    if guard:
+        return guard
     title = args.get("title")
     if not title or not str(title).strip():
         return tool_error("title is required")
@@ -1358,6 +1562,25 @@ def _handle_create(args: dict, **kw) -> str:
             "assignee is required — name the profile that should execute this "
             "task (the dispatcher will only spawn tasks with an assignee)"
         )
+    external_assignee, external_bool_error = _parse_bool_arg(
+        args, "external_assignee"
+    )
+    if external_bool_error:
+        return tool_error(external_bool_error)
+    if not external_assignee:
+        from hermes_cli import profiles as profiles_mod
+
+        canonical_assignee = profiles_mod.normalize_profile_name(str(assignee))
+        if not profiles_mod.profile_exists(canonical_assignee):
+            available = ", ".join(
+                sorted(p.name for p in profiles_mod.list_profiles())
+            ) or "(none)"
+            return tool_error(
+                f"assignee profile {canonical_assignee!r} does not exist. "
+                f"Available profiles: {available}. Create that profile first, "
+                "choose an existing profile, or set external_assignee=true "
+                "only for an intentionally human-pulled external lane."
+            )
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
@@ -1646,6 +1869,9 @@ def _handle_link(args: dict, **kw) -> str:
     delegated_err = _reject_delegated_child_mutation("kanban_link")
     if delegated_err:
         return delegated_err
+    guard = _require_orchestrator_tool("kanban_link")
+    if guard:
+        return guard
     parent_id = args.get("parent_id")
     child_id = args.get("child_id")
     if not parent_id or not child_id:
@@ -1930,8 +2156,8 @@ KANBAN_REQUEST_REVIEW_SCHEMA = {
             "reviewer": {
                 "type": "string",
                 "description": (
-                    "Optional reviewer profile. When provided, the task is "
-                    "reassigned to that profile before review dispatch."
+                    "Required installed independent reviewer profile. It must "
+                    "differ from the implementation profile."
                 ),
             },
             "metadata": {
@@ -1944,7 +2170,7 @@ KANBAN_REQUEST_REVIEW_SCHEMA = {
             },
             "board": _board_schema_prop(),
         },
-        "required": ["summary"],
+        "required": ["summary", "reviewer"],
     },
 }
 
@@ -2149,10 +2375,19 @@ KANBAN_CREATE_SCHEMA = {
             "assignee": {
                 "type": "string",
                 "description": (
-                    "Profile name that should execute this task "
-                    "(e.g. 'researcher-a', 'reviewer', 'writer'). "
-                    "Required — tasks without an assignee are never "
-                    "dispatched."
+                    "Installed Hermes profile that should execute this task "
+                    "(e.g. 'researcher-a', 'reviewer', 'writer'). Required — "
+                    "creation fails immediately if the profile does not exist, "
+                    "unless external_assignee is explicitly true."
+                ),
+            },
+            "external_assignee": {
+                "type": "boolean",
+                "description": (
+                    "Explicitly allow an assignee that is not an installed "
+                    "Hermes profile because a human or external terminal lane "
+                    "will claim it. Defaults to false; never use this to bypass "
+                    "a misspelled or missing profile."
                 ),
             },
             "body": {
@@ -2457,7 +2692,7 @@ registry.register(
     toolset="kanban",
     schema=KANBAN_CREATE_SCHEMA,
     handler=_handle_create,
-    check_fn=_check_kanban_mode,
+    check_fn=_check_kanban_orchestrator_mode,
     emoji="➕",
 )
 
@@ -2475,6 +2710,6 @@ registry.register(
     toolset="kanban",
     schema=KANBAN_LINK_SCHEMA,
     handler=_handle_link,
-    check_fn=_check_kanban_mode,
+    check_fn=_check_kanban_orchestrator_mode,
     emoji="🔗",
 )

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1567,7 +1567,19 @@ def _handle_create(args: dict, **kw) -> str:
     )
     if external_bool_error:
         return tool_error(external_bool_error)
-    if not external_assignee:
+    # Preserve an omitted owner_kind as None for DB-side legacy inference.
+    # external_assignee remains an explicit alias for the external lane.
+    owner_kind = args.get("owner_kind")
+    if owner_kind is not None:
+        owner_kind = str(owner_kind).strip().lower()
+        if owner_kind not in {"agent", "external", "no_agent"}:
+            return tool_error("owner_kind must be agent, external, or no_agent")
+    if owner_kind is None and external_assignee:
+        owner_kind = "external"
+    effective_owner_kind = owner_kind or "agent"
+    # Explicit external ownership is the same deliberate human-pulled lane as
+    # external_assignee. Never make a caller provide both spellings.
+    if effective_owner_kind == "agent" and not external_assignee:
         from hermes_cli import profiles as profiles_mod
 
         canonical_assignee = profiles_mod.normalize_profile_name(str(assignee))
@@ -1578,9 +1590,22 @@ def _handle_create(args: dict, **kw) -> str:
             return tool_error(
                 f"assignee profile {canonical_assignee!r} does not exist. "
                 f"Available profiles: {available}. Create that profile first, "
-                "choose an existing profile, or set external_assignee=true "
-                "only for an intentionally human-pulled external lane."
+                "choose an existing profile, or set owner_kind=external "
+                "(or external_assignee=true) only for an intentionally human-pulled external lane."
             )
+    task_kind = str(args.get("task_kind") or "ordinary").strip().lower()
+    caller_authority = os.environ.get("HERMES_PROFILE") or "worker"
+    supplied_authority = args.get("creation_authority")
+    if task_kind in {"reviewer", "visualqa", "release"}:
+        if supplied_authority and str(supplied_authority) != caller_authority:
+            return tool_error("mandatory gate creation_authority must match the calling profile")
+        try:
+            configured = (load_config() or {}).get("kanban") or {}
+            trusted_authority = configured.get("coordinator_profile") or configured.get("orchestrator_profile")
+        except Exception:
+            trusted_authority = None
+        if not trusted_authority or str(trusted_authority) != caller_authority:
+            return tool_error("mandatory gates require the configured trusted orchestrator authority")
     body = args.get("body")
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
@@ -1684,6 +1709,14 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                owner_kind=owner_kind,
+                task_kind=task_kind,
+                purpose=args.get("purpose"),
+                created_by_task_id=(args.get("created_by_task_id") or os.environ.get("HERMES_KANBAN_TASK")),
+                created_by_run_id=args.get("created_by_run_id"),
+                creation_authority=(args.get("creation_authority") or os.environ.get("HERMES_PROFILE") or "worker"),
+                gate_candidate_sha=args.get("gate_candidate_sha"),
+                gate_manifest_hash=args.get("gate_manifest_hash"),
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -2390,6 +2423,21 @@ KANBAN_CREATE_SCHEMA = {
                     "a misspelled or missing profile."
                 ),
             },
+            "owner_kind": {
+                "type": "string",
+                "enum": ["agent", "external", "no_agent"],
+                "description": "Optional durable execution owner. Omit it to preserve DB inference (assigned tasks become agent-owned; unassigned cards are implicit no_agent). Use external only for a deliberate human-pulled lane, or no_agent for a non-dispatchable card.",
+            },
+            "task_kind": {
+                "type": "string",
+                "description": "Immutable task category. reviewer, visualqa, and release require the configured trusted orchestrator authority.",
+            },
+            "purpose": {"type": "string", "description": "Immutable creation-purpose provenance."},
+            "created_by_task_id": {"type": "string", "description": "Immutable creating task id; defaults to this worker's task."},
+            "created_by_run_id": {"type": "integer", "description": "Immutable creating run id when known."},
+            "creation_authority": {"type": "string", "description": "Immutable authority; defaults to the caller profile and must match configured coordinator/orchestrator for mandatory gates."},
+            "gate_candidate_sha": {"type": "string", "description": "Required for reviewer/visualqa: exact frozen source candidate SHA."},
+            "gate_manifest_hash": {"type": "string", "description": "Required for reviewer/visualqa: exact frozen source evidence manifest hash."},
             "body": {
                 "type": "string",
                 "description": (

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -37,6 +37,7 @@ import platform
 import shlex
 import signal
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -362,6 +363,17 @@ def _stop_systemd_unit(unit_name: str) -> bool:
         return False
 
 
+def _ignore_sighup_before_exec() -> None:
+    """Close the PTY parent-death race before the sidecar Python starts.
+
+    The outer PTY is created before exec. If its registry parent dies during
+    sidecar startup, the kernel sends SIGHUP before Python can install the
+    durable wrapper's handler. SIG_IGN survives exec, so this child-side hook
+    makes transfer durability effective from the instant of spawn.
+    """
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
+
+
 def format_uptime_short(seconds: int) -> str:
     s = max(0, int(seconds))
     if s < 60:
@@ -380,6 +392,15 @@ class ProcessSession:
     command: str                                 # Original command string
     task_id: str = ""                           # Task/sandbox isolation key
     kanban_task_id: str = ""                    # Owning Kanban card, when scoped
+    # A transferred process is no longer owned by the session that started it.
+    # Its durable Kanban external run is the sole lifecycle authority.
+    kanban_external_run_id: Optional[int] = None
+    kanban_board: str = "default"
+    kanban_external_owner: str = ""
+    external_run_owned: bool = False
+    # A terminal transferred session remains durable until its external run has
+    # accepted the matching terminal CAS settlement.
+    settlement_pending: bool = False
     session_key: str = ""                       # Gateway session key (for reset protection)
     pid: Optional[int] = None                   # OS process ID
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
@@ -387,6 +408,7 @@ class ProcessSession:
     cwd: Optional[str] = None                   # Working directory
     started_at: float = 0.0                     # time.time() of spawn (wall clock)
     host_start_time: Optional[int] = None       # kernel start ticks (/proc/<pid>/stat f22) — PID-reuse guard
+    durable_result_path: str = ""              # Safe exit-code sidecar under HERMES_HOME
     exited: bool = False                        # Whether the process has finished
     exit_code: Optional[int] = None             # Exit code (None if still running)
     completion_reason: str = "exited"           # exited|killed|lost|failed_start|already_exited
@@ -454,6 +476,14 @@ class ProcessRegistry:
         self._running: Dict[str, ProcessSession] = {}
         self._finished: Dict[str, ProcessSession] = {}
         self._lock = threading.Lock()
+        # Serialize snapshot + replace + directory barrier without holding the
+        # registry lock over I/O. A later writer snapshots only after the prior
+        # writer's durable checkpoint is fully published, so older ownership
+        # state can never land after a newer external-run transfer.
+        self._checkpoint_write_lock = threading.Lock()
+        # At most one bounded daemon recovery loop per terminal external run.
+        self._settlement_retry_lock = threading.Lock()
+        self._settlement_retry_sessions: set[str] = set()
 
         # Side-channel for check_interval watchers (gateway reads after agent run)
         self.pending_watchers: List[Dict[str, Any]] = []
@@ -513,6 +543,37 @@ class ProcessRegistry:
         while lines and any(noise in lines[0] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS):
             lines.pop(0)
         return "\n".join(lines)
+
+    @staticmethod
+    def _durable_result_path(session_id: str) -> Path:
+        """Return the only valid durable result location for a session."""
+        return get_hermes_home() / "process-results" / f"{session_id}.json"
+
+    @classmethod
+    def _sidecar_argv(cls, session: ProcessSession, command_argv: List[str]) -> List[str]:
+        """Wrap a local command so its exact exit code survives parent death."""
+        sidecar = Path(__file__).with_name("process_sidecar.py").resolve()
+        return [
+            sys.executable, str(sidecar),
+            "--result", session.durable_result_path,
+            "--session-id", session.id, "--", *command_argv,
+        ]
+
+    @classmethod
+    def _read_durable_result(cls, session_id: str, result_path: str) -> Optional[int]:
+        """Read only an exact, safe sidecar payload; malformed data is unknown."""
+        try:
+            expected = cls._durable_result_path(session_id).resolve()
+            actual = Path(result_path).resolve()
+            if actual != expected:
+                return None
+            payload = json.loads(actual.read_text(encoding="utf-8"))
+            if set(payload) != {"session_id", "exit_code"} or payload["session_id"] != session_id:
+                return None
+            exit_code = payload["exit_code"]
+            return exit_code if isinstance(exit_code, int) and not isinstance(exit_code, bool) else None
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            return None
 
     def _emit_output(self, session: ProcessSession, chunk: str) -> None:
         """Forward a freshly-read chunk to the live-output sink, if one is set.
@@ -849,9 +910,16 @@ class ProcessRegistry:
             if session.exited:
                 return session
             session.exited = True
-            # Recovered sessions no longer have a waitable handle, so the real
-            # exit code is unavailable once the original process object is gone.
-            session.exit_code = None
+            # The durable wrapper publishes the exact exit code before its host
+            # PID disappears, so a registry recovered while the process was
+            # still live can settle it correctly after the original Popen
+            # handle is gone. Missing/corrupt receipts remain an unknown loss.
+            session.exit_code = self._read_durable_result(
+                session.id, session.durable_result_path,
+            )
+            session.completion_reason = (
+                "exited" if session.exit_code is not None else "lost"
+            )
 
         self._move_to_finished(session)
         return session
@@ -1068,6 +1136,7 @@ class ProcessRegistry:
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
         )
+        session.durable_result_path = str(self._durable_result_path(session.id))
 
         pty_scope_attempted = False
         if use_pty:
@@ -1085,7 +1154,10 @@ class ProcessRegistry:
                 # cat, honoring any pager the user already exported.
                 pty_env.setdefault("GIT_PAGER", "cat")
                 pty_env.setdefault("PAGER", "cat")
-                pty_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
+                pty_argv = self._sidecar_argv(
+                    session, [user_shell, "-lic", f"set +m; {safe_command}"],
+                )
+                pty_argv.insert(2, "--pty")
 
                 # Cgroup isolation for PTY mode (#70716, reviewer gap #1):
                 # Wrap the PTY command in a systemd scope so interactive
@@ -1111,12 +1183,27 @@ class ProcessRegistry:
                         "worker shares the gateway cgroup."
                     )
 
-                pty_proc = _PtyProcessCls.spawn(
-                    pty_argv,
-                    cwd=session.cwd,
-                    env=pty_env,
-                    dimensions=(30, 120),
-                )
+                pty_spawn_kwargs = {
+                    "cwd": session.cwd,
+                    "env": pty_env,
+                    "dimensions": (30, 120),
+                }
+                if not _IS_WINDOWS:
+                    pty_spawn_kwargs["preexec_fn"] = _ignore_sighup_before_exec
+                pty_proc = _PtyProcessCls.spawn(pty_argv, **pty_spawn_kwargs)
+                if not _IS_WINDOWS:
+                    # The durable sidecar owns the one canonical inner line
+                    # discipline. Make the outer transport raw before this
+                    # session becomes visible so an immediate write cannot be
+                    # echoed/buffered once here and again by the child PTY.
+                    # Test doubles and alternate PTY adapters may not expose a
+                    # real integer fd; the sidecar still configures real POSIX
+                    # terminals on its own startup path.
+                    outer_fd = getattr(pty_proc, "fd", None)
+                    if isinstance(outer_fd, int):
+                        import termios
+                        import tty
+                        tty.setraw(outer_fd, termios.TCSANOW)
                 session.pid = pty_proc.pid
                 session.host_start_time = self._safe_host_start_time(session.pid)
                 # Store the pty handle on the session for read/write
@@ -1168,7 +1255,9 @@ class ProcessRegistry:
         # kills only the worker instead of taking down the whole gateway
         # cgroup (and the messaging control plane with it). This applies to
         # both pipe mode and the PTY path above.
-        shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
+        shell_argv = self._sidecar_argv(
+            session, [user_shell, "-lic", f"set +m; {safe_command}"],
+        )
         in_supervised_gateway = not _IS_WINDOWS and _is_supervised_gateway_process()
         use_systemd_scope = (
             in_supervised_gateway and _systemd_run_user_scope_available()
@@ -1506,7 +1595,14 @@ class ProcessRegistry:
                 logger.debug("Process wait timed out or failed: %s", e)
             session.exited = True
             if session.completion_reason != "killed":
-                session.exit_code = session.process.returncode
+                durable_exit = self._read_durable_result(
+                    session.id, session.durable_result_path,
+                )
+                session.exit_code = (
+                    durable_exit
+                    if durable_exit is not None
+                    else session.process.returncode
+                )
                 session.completion_reason = "exited"
             self._move_to_finished(session)
 
@@ -1615,9 +1711,73 @@ class ProcessRegistry:
             logger.debug("PTY wait timed out or failed: %s", e)
         session.exited = True
         if session.completion_reason != "killed":
-            session.exit_code = pty.exitstatus if hasattr(pty, 'exitstatus') else -1
+            durable_exit = self._read_durable_result(
+                session.id, session.durable_result_path,
+            )
+            session.exit_code = (
+                durable_exit
+                if durable_exit is not None
+                else pty.exitstatus if hasattr(pty, 'exitstatus') else -1
+            )
             session.completion_reason = "exited"
         self._move_to_finished(session)
+
+    def _settle_external_session(self, session: ProcessSession) -> bool:
+        """Attempt the one durable terminal CAS; retain ownership on failure."""
+        if not (session.external_run_owned and session.kanban_external_run_id
+                and session.kanban_external_owner):
+            return True
+        try:
+            from hermes_cli import kanban_db
+            with kanban_db.connect_closing(board=session.kanban_board) as conn:
+                run = kanban_db.get_external_run(conn, session.kanban_external_run_id)
+                if run is None or not run.owner:
+                    raise RuntimeError("durable external run or owner is unavailable")
+                # An operator may transfer the durable run while the local
+                # process is alive. The DB run is authoritative; retain its
+                # current owner in the session so a retry checkpoints B, not a
+                # stale transfer-time owner A.
+                session.kanban_external_owner = run.owner
+                outcome = (
+                    "completed" if session.exit_code == 0
+                    else "lost" if session.exit_code is None else "failed"
+                )
+                finished = kanban_db.finish_external_run(
+                    conn, session.kanban_external_run_id,
+                    owner=run.owner, outcome=outcome,
+                )
+                if not finished:
+                    observed = kanban_db.get_external_run(conn, session.kanban_external_run_id)
+                    if observed is None or observed.ended_at is None:
+                        raise RuntimeError("external run remains active after rejected settlement")
+            session.settlement_pending = False
+            return True
+        except Exception:
+            session.settlement_pending = True
+            logger.debug("external process settlement failed", exc_info=True)
+            return False
+
+    def _schedule_external_settlement_retry(self, session: ProcessSession) -> None:
+        """Retry a transient terminal DB failure in this live gateway once."""
+        with self._settlement_retry_lock:
+            if session.id in self._settlement_retry_sessions:
+                return
+            self._settlement_retry_sessions.add(session.id)
+
+        def _retry() -> None:
+            try:
+                for delay in (0.05, 0.1, 0.2, 0.4, 0.8):
+                    time.sleep(delay)
+                    if self._settle_external_session(session):
+                        self._move_to_finished(session)
+                        return
+            finally:
+                with self._settlement_retry_lock:
+                    self._settlement_retry_sessions.discard(session.id)
+
+        threading.Thread(
+            target=_retry, name=f"hermes-external-settle-{session.id}", daemon=True,
+        ).start()
 
     def _move_to_finished(self, session: ProcessSession):
         """Move a session from running to finished.
@@ -1626,11 +1786,20 @@ class ProcessRegistry:
         with the reader thread), the second call is a no-op — no duplicate
         completion notification is enqueued.
         """
+        # Do not discard the only board/run/owner binding before its external
+        # terminal transition survives. The checkpoint retains this terminal
+        # record across transient database/open failures for startup retry.
+        if session.external_run_owned and not self._settle_external_session(session):
+            self._write_checkpoint()
+            self._schedule_external_settlement_retry(session)
+            return
+        # Publish removal of this terminal record before exposing ``finished``.
+        # A consumer may restart immediately after observing that state; it
+        # must not race the durable replacement and recover stale ownership.
+        self._write_checkpoint()
         with self._lock:
             was_running = self._running.pop(session.id, None) is not None
             self._finished[session.id] = session
-        session._completion_event.set()
-        self._write_checkpoint()
 
         # Only emit lifecycle signals on the FIRST move. Without this guard,
         # kill_process() and the reader thread can both report the same exit.
@@ -1678,6 +1847,7 @@ class ProcessRegistry:
             }
             _redact_process_result(notification)
             self.completion_queue.put(notification)
+        session._completion_event.set()
 
     # ----- Query Methods -----
 
@@ -2744,6 +2914,7 @@ class ProcessRegistry:
         exclude_ids: frozenset = frozenset(),
         source: str = "kill_all",
         consume_output: bool = False,
+        include_external_owned: bool = False,
     ) -> int:
         """Kill all running processes, optionally filtered by task_id. Returns count killed."""
         with self._lock:
@@ -2752,6 +2923,7 @@ class ProcessRegistry:
                 if (task_id is None or s.task_id == task_id)
                 and s.id not in exclude_ids
                 and not s.exited
+                and (include_external_owned or not s.external_run_owned)
             ]
 
         killed = 0
@@ -2764,6 +2936,104 @@ class ProcessRegistry:
             if result.get("status") in {"killed", "already_exited"}:
                 killed += 1
         return killed
+
+    def external_transfer_target(self, session_id: str, *, expected_session_task_id: Optional[str] = None) -> Optional[dict]:
+        """Return a live session's immutable transfer identity, or ``None``."""
+        with self._lock:
+            session = self._running.get(session_id)
+            if session is None or session.exited:
+                return None
+            if expected_session_task_id is not None and session.task_id != expected_session_task_id:
+                return None
+            if session.pid_scope != "host" or not session.pid:
+                return None
+            if session.host_start_time is None:
+                session.host_start_time = self._safe_host_start_time(session.pid)
+            if session.host_start_time is None:
+                return None
+            return {
+                "session_id": session.id,
+                "pid": session.pid,
+                "host_start_time": session.host_start_time,
+                "pid_scope": session.pid_scope,
+                # The DB must retain the canonical receipt path itself; a
+                # registry checkpoint is only a secondary recovery record.
+                "durable_result_path": str(self._durable_result_path(session.id)),
+            }
+
+    def transfer_to_external_run(self, session_id: str, *, task_id: str, run_id: int, board: str = "default", owner: str = "", expected_session_task_id: Optional[str] = None) -> bool:
+        """Transfer one live managed process to a durable Kanban external run.
+
+        This explicit operation is the only way a process escapes an
+        AIAgent.close() task sweep; ordinary children remain session-owned.
+        """
+        with self._lock:
+            session = self._running.get(session_id)
+            if session is None or session.exited:
+                return False
+            if expected_session_task_id is not None and session.task_id != expected_session_task_id:
+                return False
+            previous = (
+                session.kanban_task_id, session.kanban_external_run_id,
+                session.kanban_board, session.kanban_external_owner,
+                session.external_run_owned, session.settlement_pending,
+            )
+            # Persist pending settlement before the ownership checkpoint: if
+            # the child exits while that write races, it remains recoverable.
+            session.settlement_pending = True
+            session.kanban_task_id = str(task_id)
+            session.kanban_external_run_id = int(run_id)
+            session.kanban_board = str(board or "default")
+            session.kanban_external_owner = str(owner or "")
+            session.external_run_owned = True
+        checkpoint_ok, checkpoint_replaced = self._write_checkpoint_result()
+        if checkpoint_ok:
+            return True
+        # The DB handoff is not recoverable unless this session->board->run
+        # binding is already durable. Restore ownership atomically so the
+        # caller can compensate the external run through its normal CAS path.
+        with self._lock:
+            session.kanban_task_id, session.kanban_external_run_id, session.kanban_board, \
+                session.kanban_external_owner, session.external_run_owned, session.settlement_pending = previous
+        # A failed directory fsync happens after atomic_replace, so the first
+        # attempt may already have exposed the external snapshot. Publish the
+        # restored ownership as a compensating checkpoint before the caller
+        # rolls the DB handoff back to the agent run. Earlier-stage failures
+        # leave the previous safe checkpoint intact; this retry is harmless.
+        compensation_ok, _ = self._write_checkpoint_result()
+        if checkpoint_replaced and not compensation_ok:
+            # We cannot prove the external snapshot was durably replaced by
+            # the restored one. Keep live ownership aligned with the durable
+            # DB external claim and let its canonical receipt settle it; the
+            # caller must not roll that claim back or make the task runnable.
+            with self._lock:
+                session.kanban_task_id = str(task_id)
+                session.kanban_external_run_id = int(run_id)
+                session.kanban_board = str(board or "default")
+                session.kanban_external_owner = str(owner or "")
+                session.external_run_owned = True
+                session.settlement_pending = True
+            raise RuntimeError(
+                "failed to durably compensate external ownership checkpoint"
+            )
+        return False
+
+    def reconcile_external_completion(self, conn, session_id: str, *, owner: str) -> bool:
+        """Settle a finished transferred process through the DB's CAS endpoint."""
+        with self._lock:
+            session = self._finished.get(session_id) or self._running.get(session_id)
+            if not session or not session.external_run_owned or session.kanban_external_run_id is None:
+                return False
+            if not session.exited:
+                return False
+            run_id = session.kanban_external_run_id
+        from hermes_cli import kanban_db
+        outcome = (
+            "completed" if session.exit_code == 0
+            else "lost" if session.exit_code is None
+            else "failed"
+        )
+        return kanban_db.finish_external_run(conn, run_id, owner=owner, outcome=outcome)
 
     # ----- Cleanup / Pruning -----
 
@@ -2805,61 +3075,89 @@ class ProcessRegistry:
     def _write_checkpoint(
         self,
         extra_entries: Optional[List[Dict[str, Any]]] = None,
-    ):
-        """Write running process metadata to checkpoint file atomically."""
+    ) -> bool:
+        return self._write_checkpoint_result(extra_entries)[0]
+
+    def _write_checkpoint_result(
+        self,
+        extra_entries: Optional[List[Dict[str, Any]]] = None,
+    ) -> tuple[bool, bool]:
+        """Serialize snapshot, replacement, and fsync for crash recovery.
+
+        The registry lock protects live session state, while this separate lock
+        protects checkpoint order. Keeping them distinct prevents slow storage
+        from blocking ordinary registry operations without allowing an old
+        snapshot to overwrite a newer ownership transfer.
+        """
+        replaced = False
         try:
-            with self._lock:
-                entries = []
-                for s in self._running.values():
-                    if not s.exited:
-                        # Lazily backfill the kernel start time for host PIDs so
-                        # recovery after restart can detect PID recycling even
-                        # for sessions spawned before this field existed.
-                        if s.host_start_time is None and s.pid_scope == "host" and s.pid:
-                            s.host_start_time = self._safe_host_start_time(s.pid)
-                        entries.append({
-                            "session_id": s.id,
-                            # Redact inline credentials before persisting to
-                            # disk — the checkpoint file lives under
-                            # ~/.hermes/processes.json with the raw command
-                            # (issue #77484). Recovery only uses command for
-                            # display/logging (the process is already running;
-                            # adoption re-validates the PID, never re-runs the
-                            # command), so masking is lossless.
-                            "command": redact_sensitive_text(s.command, code_file=True),
-                            "pid": s.pid,
-                            "pid_scope": s.pid_scope,
-                            "host_start_time": s.host_start_time,
-                            "systemd_unit": s.systemd_unit,
-                            "cwd": s.cwd,
-                            "started_at": s.started_at,
-                            "task_id": s.task_id,
-                            "kanban_task_id": s.kanban_task_id,
-                            "session_key": s.session_key,
-                            "watcher_platform": s.watcher_platform,
-                            "watcher_chat_id": s.watcher_chat_id,
-                            "watcher_user_id": s.watcher_user_id,
-                            "watcher_user_name": s.watcher_user_name,
-                            "watcher_thread_id": s.watcher_thread_id,
-                            "watcher_message_id": s.watcher_message_id,
-                            "watcher_interval": s.watcher_interval,
-                            "parent_session_id": s.parent_session_id,
-                            "notify_on_complete": s.notify_on_complete,
-                            "watch_patterns": s.watch_patterns,
-                        })
-                if extra_entries:
-                    tracked_ids = {item.get("session_id") for item in entries}
-                    entries.extend(
-                        item
-                        for item in extra_entries
-                        if item.get("session_id") not in tracked_ids
+            with self._checkpoint_write_lock:
+                with self._lock:
+                    entries = []
+                    for s in self._running.values():
+                        if not s.exited or s.settlement_pending:
+                            # Lazily backfill the kernel start time for host PIDs so
+                            # recovery after restart can detect PID recycling even
+                            # for sessions spawned before this field existed.
+                            if s.host_start_time is None and s.pid_scope == "host" and s.pid:
+                                s.host_start_time = self._safe_host_start_time(s.pid)
+                            entries.append({
+                                "session_id": s.id,
+                                # Recovery only displays the command; it never reruns it.
+                                "command": redact_sensitive_text(s.command, code_file=True),
+                                "pid": s.pid,
+                                "exit_code": s.exit_code,
+                                "exited": s.exited,
+                                "pid_scope": s.pid_scope,
+                                "host_start_time": s.host_start_time,
+                                "durable_result_path": s.durable_result_path,
+                                "systemd_unit": s.systemd_unit,
+                                "cwd": s.cwd,
+                                "started_at": s.started_at,
+                                "task_id": s.task_id,
+                                "kanban_task_id": s.kanban_task_id,
+                                "kanban_external_run_id": s.kanban_external_run_id,
+                                "kanban_board": s.kanban_board,
+                                "kanban_external_owner": s.kanban_external_owner,
+                                "external_run_owned": s.external_run_owned,
+                                "settlement_pending": s.settlement_pending,
+                                "session_key": s.session_key,
+                                "watcher_platform": s.watcher_platform,
+                                "watcher_chat_id": s.watcher_chat_id,
+                                "watcher_user_id": s.watcher_user_id,
+                                "watcher_user_name": s.watcher_user_name,
+                                "watcher_thread_id": s.watcher_thread_id,
+                                "watcher_message_id": s.watcher_message_id,
+                                "watcher_interval": s.watcher_interval,
+                                "parent_session_id": s.parent_session_id,
+                                "notify_on_complete": s.notify_on_complete,
+                                "watch_patterns": s.watch_patterns,
+                            })
+                    if extra_entries:
+                        tracked_ids = {item.get("session_id") for item in entries}
+                        entries.extend(
+                            item for item in extra_entries
+                            if item.get("session_id") not in tracked_ids
+                        )
+
+                # Atomic write to avoid corruption on crash; directory fsync makes
+                # the replacement itself durable before a later snapshot can start.
+                from utils import atomic_json_write
+                atomic_json_write(CHECKPOINT_PATH, entries)
+                replaced = True
+                if os.name != "nt":
+                    directory_fd = os.open(
+                        CHECKPOINT_PATH.parent,
+                        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
                     )
-            
-            # Atomic write to avoid corruption on crash
-            from utils import atomic_json_write
-            atomic_json_write(CHECKPOINT_PATH, entries)
+                    try:
+                        os.fsync(directory_fd)
+                    finally:
+                        os.close(directory_fd)
+                return True, replaced
         except Exception as e:
             logger.debug("Failed to write checkpoint file: %s", e, exc_info=True)
+            return False, replaced
 
     def recover_from_checkpoint(self) -> int:
         """
@@ -2878,6 +3176,24 @@ class ProcessRegistry:
         recovered = 0
         unresolved_scope_entries: List[Dict[str, Any]] = []
         for entry in entries:
+            # A failed terminal settlement has no live process to recover, but
+            # its immutable board/run/owner tuple must be retried before the
+            # checkpoint can be discarded.
+            if (entry.get("settlement_pending") and entry.get("external_run_owned")
+                    and entry.get("exited")):
+                session = ProcessSession(
+                    id=entry["session_id"], command=entry.get("command", "unknown"),
+                    task_id=entry.get("task_id", ""), kanban_task_id=entry.get("kanban_task_id", ""),
+                    kanban_external_run_id=entry.get("kanban_external_run_id"),
+                    kanban_board=entry.get("kanban_board", "default"),
+                    kanban_external_owner=entry.get("kanban_external_owner", ""),
+                    external_run_owned=True, settlement_pending=True, exited=True,
+                    exit_code=entry.get("exit_code"),
+                    durable_result_path=entry.get("durable_result_path", ""),
+                )
+                if not self._settle_external_session(session):
+                    unresolved_scope_entries.append(entry)
+                continue
             pid = entry.get("pid")
             if not pid:
                 continue
@@ -2919,6 +3235,25 @@ class ProcessRegistry:
                         pid,
                     )
                     unresolved_scope_entries.append(entry)
+                elif entry.get("external_run_owned"):
+                    session = ProcessSession(
+                        id=entry["session_id"], command=entry.get("command", "unknown"),
+                        task_id=entry.get("task_id", ""),
+                        kanban_task_id=entry.get("kanban_task_id", ""),
+                        kanban_external_run_id=entry.get("kanban_external_run_id"),
+                        kanban_board=entry.get("kanban_board", "default"),
+                        kanban_external_owner=entry.get("kanban_external_owner", ""),
+                        external_run_owned=True, settlement_pending=True, exited=True,
+                        exit_code=self._read_durable_result(
+                            entry["session_id"], entry.get("durable_result_path", ""),
+                        ),
+                        durable_result_path=entry.get("durable_result_path", ""),
+                    )
+                    session.completion_reason = (
+                        "exited" if session.exit_code is not None else "lost"
+                    )
+                    if not self._settle_external_session(session):
+                        unresolved_scope_entries.append(entry)
                 continue
 
             session = ProcessSession(
@@ -2926,9 +3261,14 @@ class ProcessRegistry:
                 command=entry.get("command", "unknown"),
                 task_id=entry.get("task_id", ""),
                 kanban_task_id=entry.get("kanban_task_id", ""),
+                kanban_external_run_id=entry.get("kanban_external_run_id"),
+                kanban_board=entry.get("kanban_board", "default"),
+                kanban_external_owner=entry.get("kanban_external_owner", ""),
+                external_run_owned=bool(entry.get("external_run_owned", False)),
                 session_key=entry.get("session_key", ""),
                 pid=pid,
                 host_start_time=recorded_start,
+                durable_result_path=entry.get("durable_result_path", ""),
                 pid_scope=pid_scope,
                 systemd_unit=entry.get("systemd_unit", ""),
                 cwd=entry.get("cwd"),
@@ -3282,14 +3622,15 @@ PROCESS_SCHEMA = {
         "poll: status + new output. log: full output, paged. wait: block "
         "until exit or timeout (partial output on timeout). write vs "
         "submit: submit appends Enter — use it to answer prompts; write "
-        "sends raw bytes, no newline. close: EOF stdin. kill: terminate."
+        "sends raw bytes, no newline. close: EOF stdin. kill: terminate. "
+        "transfer: dispatcher Kanban workers hand a live child to a durable external run."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["list", "poll", "log", "wait", "kill", "write", "submit", "close"]
+                "enum": ["list", "poll", "log", "wait", "kill", "write", "submit", "close", "transfer"]
             },
             "session_id": {
                 "type": "string",
@@ -3312,7 +3653,17 @@ PROCESS_SCHEMA = {
                 "type": "integer",
                 "description": "Max log lines.",
                 "minimum": 1
-            }
+            },
+            "external_id": {"type": "string", "description": "Stable external execution identifier for transfer."},
+            "owner": {"type": "string", "description": "External lifecycle owner for transfer."},
+            "phase": {"type": "string", "description": "Optional external progress phase."},
+            "current": {"type": "integer", "minimum": 0, "description": "Progress numerator; provide with total."},
+            "total": {"type": "integer", "minimum": 0, "description": "Progress denominator; provide with current."},
+            "log_ref": {"type": "string", "description": "Credential-safe log reference."},
+            "result_ref": {"type": "string", "description": "Credential-safe result reference."},
+            "max_retries": {"type": "integer", "minimum": 1, "description": "External failure retry limit."},
+            "on_success": {"type": "string", "enum": ["complete", "resume"], "description": "Task policy after successful exit."},
+            "on_failure": {"type": "string", "enum": ["retry", "block"], "description": "Task policy after failed exit."}
         },
         "required": ["action"]
     }
@@ -3350,6 +3701,72 @@ def _handle_process(args, **kw):
     # Coerce to string — some models send session_id as an integer
     session_id = str(args.get("session_id", "")) if args.get("session_id") is not None else ""
 
+    if action == "transfer":
+        if not session_id:
+            return tool_error("session_id is required for transfer")
+        try:
+            from agent.delegation_context import is_dispatcher_owned_worker_context
+            if not is_dispatcher_owned_worker_context():
+                return tool_error("process transfer is available only to a dispatcher-owned Kanban worker")
+            trusted_task_id = str(os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+            trusted_board = str(os.environ.get("HERMES_KANBAN_BOARD") or "default").strip() or "default"
+            trusted_claim = str(os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or "").strip()
+            trusted_run_id = int(str(os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip())
+            if not trusted_task_id or not trusted_claim:
+                return tool_error("process transfer requires trusted dispatcher task, run, and claim context")
+        except (ImportError, ValueError):
+            return tool_error("process transfer requires trusted dispatcher task, run, and claim context")
+
+        live_process = process_registry.external_transfer_target(
+            session_id, expected_session_task_id=task_id,
+        )
+        if live_process is None:
+            return tool_error("process transfer refused: process is not a live session-owned child")
+        try:
+            from hermes_cli import kanban_db as kb
+            with kb.connect(board=trusted_board) as conn:
+                run = kb.handoff_agent_run_to_external(
+                    conn, trusted_task_id, expected_run_id=trusted_run_id,
+                    expected_claim_lock=trusted_claim, owner=str(args.get("owner") or ""),
+                    external_id=str(args.get("external_id") or ""), pid=live_process["pid"],
+                    managed_process_session_id=live_process["session_id"],
+                    durable_result_path=live_process["durable_result_path"],
+                    host_start_time=live_process.get("host_start_time"),
+                    phase=args.get("phase"), current=args.get("current"), total=args.get("total"),
+                    log_ref=args.get("log_ref"), result_ref=args.get("result_ref"),
+                    max_retries=args.get("max_retries"),
+                    on_success=str(args.get("on_success") or "complete"),
+                    on_failure=str(args.get("on_failure") or "block"),
+                )
+                if run is None:
+                    return tool_error("process transfer refused: current worker run ownership no longer matches")
+                if not process_registry.transfer_to_external_run(
+                    session_id, task_id=trusted_task_id, run_id=run.id, board=trusted_board,
+                    owner=run.owner or "", expected_session_task_id=task_id,
+                ):
+                    # Registry/checkpoint transfer failed, so the live worker
+                    # still owns the child. Restoring only the in-memory owner
+                    # while applying external retry policy would make a second
+                    # worker dispatchable beside it.
+                    if not kb.rollback_external_handoff_to_agent(
+                        conn,
+                        trusted_task_id,
+                        external_run_id=run.id,
+                        agent_run_id=trusted_run_id,
+                        external_owner=run.owner or "",
+                        expected_claim_lock=trusted_claim,
+                    ):
+                        raise RuntimeError(
+                            "external handoff rollback failed; durable claim left active"
+                        )
+                    return tool_error("process transfer failed: process is no longer a live session-owned child")
+        except (ValueError, RuntimeError) as exc:
+            return tool_error(f"process transfer refused: {exc}")
+        return json.dumps({
+            "status": "transferred", "session_id": session_id, "task_id": trusted_task_id,
+            "run_id": run.id, "board": trusted_board, "owner": run.owner,
+            "phase": run.phase, "current": run.progress_current, "total": run.progress_total,
+        }, ensure_ascii=False)
     if action == "list":
         # Surface session-scoped background processes (e.g. a forgotten
         # preview server) in addition to this task's own — they share the
@@ -3389,7 +3806,10 @@ def _handle_process(args, **kw):
             return json.dumps(process_registry.submit_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
         elif action == "close":
             return json.dumps(process_registry.close_stdin(session_id), ensure_ascii=False)
-    return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close")
+    return tool_error(
+        f"Unknown process action: {action}. Use: list, poll, log, wait, kill, "
+        "write, submit, close, transfer"
+    )
 
 
 registry.register(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -379,6 +379,7 @@ class ProcessSession:
     id: str                                     # Unique session ID ("proc_xxxxxxxxxxxx")
     command: str                                 # Original command string
     task_id: str = ""                           # Task/sandbox isolation key
+    kanban_task_id: str = ""                    # Owning Kanban card, when scoped
     session_key: str = ""                       # Gateway session key (for reset protection)
     pid: Optional[int] = None                   # OS process ID
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
@@ -1062,6 +1063,7 @@ class ProcessRegistry:
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
             task_id=task_id,
+            kanban_task_id=os.environ.get("HERMES_KANBAN_TASK", ""),
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
@@ -1297,6 +1299,7 @@ class ProcessRegistry:
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
             task_id=task_id,
+            kanban_task_id=os.environ.get("HERMES_KANBAN_TASK", ""),
             session_key=session_key,
             cwd=cwd,
             started_at=time.time(),
@@ -1628,6 +1631,29 @@ class ProcessRegistry:
             self._finished[session.id] = session
         session._completion_event.set()
         self._write_checkpoint()
+
+        # Only emit lifecycle signals on the FIRST move. Without this guard,
+        # kill_process() and the reader thread can both report the same exit.
+        if was_running:
+            try:
+                from tools.kanban_tools import record_background_process_event_from_env
+
+                state = (
+                    "killed" if session.completion_reason == "killed"
+                    else "lost" if session.completion_reason == "lost"
+                    else "completed"
+                )
+                record_background_process_event_from_env(
+                    state,
+                    session.id,
+                    session.command,
+                    exit_code=session.exit_code,
+                )
+            except Exception:
+                logger.debug(
+                    "kanban background-process completion bridge failed",
+                    exc_info=True,
+                )
 
         # Only enqueue completion notification on the FIRST move.  Without
         # this guard, kill_process() and the reader thread can both call
@@ -2589,6 +2615,8 @@ class ProcessRegistry:
                 "status": "exited" if s.exited else "running",
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
             }
+            if s.kanban_task_id:
+                entry["kanban_task_id"] = s.kanban_task_id
             # Flag processes surfaced only because they share the gateway
             # session (not the current task) — these are the long-lived
             # background processes a user may have forgotten about (#29177).
@@ -2806,6 +2834,7 @@ class ProcessRegistry:
                             "cwd": s.cwd,
                             "started_at": s.started_at,
                             "task_id": s.task_id,
+                            "kanban_task_id": s.kanban_task_id,
                             "session_key": s.session_key,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
@@ -2896,6 +2925,7 @@ class ProcessRegistry:
                 id=entry["session_id"],
                 command=entry.get("command", "unknown"),
                 task_id=entry.get("task_id", ""),
+                kanban_task_id=entry.get("kanban_task_id", ""),
                 session_key=entry.get("session_key", ""),
                 pid=pid,
                 host_start_time=recorded_start,

--- a/tools/process_sidecar.py
+++ b/tools/process_sidecar.py
@@ -1,0 +1,267 @@
+"""Durable managed-process wrapper.
+
+The wrapper owns the child's output descriptors, drains them even after its own
+parent dies, and persists only an authenticated session id / exit code receipt.
+"""
+from __future__ import annotations
+
+import argparse
+import codecs
+import json
+import os
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+if os.name != "nt":
+    import fcntl
+    import pty
+    import termios
+    import tty
+
+def _write_result(path: Path, session_id: str, exit_code: int) -> None:
+    """Atomically publish the exact safe result payload with private permissions."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    payload = json.dumps({"session_id": session_id, "exit_code": exit_code}, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb", closefd=True) as stream:
+            stream.write(payload); stream.flush(); os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        if os.name != "nt":
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try: os.fsync(directory_fd)
+            finally: os.close(directory_fd)
+    finally:
+        try: os.unlink(temporary)
+        except FileNotFoundError: pass
+
+
+def _relay(source, target) -> None:
+    """Drain a child stream; a dead parent's pipe must not kill the child."""
+    while True:
+        try: chunk = source.read(4096)
+        except (OSError, ValueError): return
+        if not chunk: return
+        try:
+            target.write(chunk); target.flush()
+        except (BrokenPipeError, OSError):
+            # EPIPE/EIO means the registry/UI vanished. Keep draining so the
+            # child never blocks on a full pipe.
+            target = open(os.devnull, "wb", buffering=0)
+
+
+def _spawn_conpty(command: list[str], pty_process_cls, *, input_stream=None, output_stream=None):
+    """Start a child behind ConPTY and relay the outer PTY transport to it.
+
+    ``pywinpty`` owns the child stdin/stdout, retaining Windows TTY semantics
+    (including ``isatty()``) while this durable sidecar continues to drain
+    output and can publish an exit receipt after its registry parent dies.
+    The injectable streams/factory keep the relay testable on non-Windows.
+    """
+    proc = pty_process_cls.spawn(command)
+    input_stream = input_stream or sys.stdin.buffer
+    output_stream = output_stream or sys.stdout.buffer
+
+    def relay_output() -> None:
+        stream = output_stream
+        while proc.isalive():
+            try:
+                chunk = proc.read(4096)
+            except (EOFError, OSError, ValueError):
+                return
+            if not chunk:
+                continue
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8", errors="replace")
+            try:
+                stream.write(chunk)
+                stream.flush()
+            except (BrokenPipeError, OSError, ValueError):
+                # The registry-side outer PTY may disappear. Keep draining the
+                # inner PTY so a verbose child cannot block forever.
+                stream = open(os.devnull, "wb", buffering=0)
+
+    def relay_input() -> None:
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        try:
+            while True:
+                chunk = input_stream.read(1)
+                if not chunk:
+                    # Flush a trailing partial sequence once, then preserve
+                    # close_stdin() behavior for programs which use Ctrl-D as
+                    # terminal EOF; pywinpty accepts text only.
+                    tail = decoder.decode(b"", final=True)
+                    if tail:
+                        proc.write(tail)
+                    proc.write("\x04")
+                    return
+                if isinstance(chunk, bytes):
+                    text = decoder.decode(chunk)
+                    if text:
+                        proc.write(text)
+                else:
+                    proc.write(str(chunk))
+        except (EOFError, OSError, ValueError):
+            return
+
+    output_thread = threading.Thread(target=relay_output, daemon=True)
+    input_thread = threading.Thread(target=relay_input, daemon=True)
+    output_thread.start()
+    input_thread.start()
+    return proc, [output_thread, input_thread], None
+
+
+def _spawn(command: list[str], use_pty: bool):
+    if os.name == "nt" and use_pty:
+        try:  # pywinpty is a Windows-only optional dependency.
+            from winpty import PtyProcess
+        except ImportError as exc:  # pragma: no cover - Windows packaging lane
+            raise RuntimeError(
+                "Windows PTY requested but pywinpty/ConPTY is unavailable; "
+                "refusing non-interactive pipe fallback"
+            ) from exc
+        return _spawn_conpty(command, PtyProcess)
+    if not use_pty:
+        proc = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=(os.name != "nt"),
+        )
+        threads = [threading.Thread(target=_relay, args=(proc.stdout, sys.stdout.buffer), daemon=True), threading.Thread(target=_relay, args=(proc.stderr, sys.stderr.buffer), daemon=True)]
+        for thread in threads: thread.start()
+        return proc, threads, None
+    # Bridge the registry-owned outer PTY to a sidecar-owned inner PTY. The
+    # inner master must survive the registry parent, while the outer slave is
+    # raw so only the inner terminal performs echo/canonical/output processing.
+    outer_fd = sys.stdin.fileno()
+    outer_attrs = None
+    try:
+        outer_attrs = termios.tcgetattr(outer_fd)
+        tty.setraw(outer_fd, termios.TCSANOW)
+    except (OSError, termios.error):
+        # The registry parent may die immediately after spawn, hanging up the
+        # outer PTY before Python reaches this point. Durability still requires
+        # launching and draining the inner child without an input transport.
+        pass
+    master, slave = pty.openpty()
+
+    def copy_winsize() -> bool:
+        try:
+            size = fcntl.ioctl(outer_fd, termios.TIOCGWINSZ, b"\0" * 8)
+            fcntl.ioctl(master, termios.TIOCSWINSZ, size)
+            return True
+        except OSError:
+            return False
+
+    if not copy_winsize():
+        try:
+            default_size = struct.pack("HHHH", 30, 120, 0, 0)
+            fcntl.ioctl(master, termios.TIOCSWINSZ, default_size)
+        except OSError:
+            pass
+    if hasattr(signal, "SIGWINCH"):
+        signal.signal(signal.SIGWINCH, lambda _signum, _frame: copy_winsize())
+    proc = subprocess.Popen(
+        command, stdin=slave, stdout=slave, stderr=slave,
+        start_new_session=True, close_fds=True,
+    )
+    os.close(slave)
+    master_stream = os.fdopen(master, "rb", buffering=0)
+    output_thread = threading.Thread(
+        target=_relay, args=(master_stream, sys.stdout.buffer), daemon=True,
+    )
+    output_thread.start()
+    input_fd = os.dup(master_stream.fileno())
+
+    def relay_stdin() -> None:
+        try:
+            while True:
+                chunk = os.read(outer_fd, 1)
+                if not chunk:
+                    os.write(input_fd, b"\x04")
+                    return
+                os.write(input_fd, chunk)
+        except OSError:
+            return
+        finally:
+            try:
+                os.close(input_fd)
+            except OSError:
+                pass
+
+    input_thread = threading.Thread(target=relay_stdin, daemon=True)
+    input_thread.start()
+
+    def restore_outer_tty() -> None:
+        if outer_attrs is None:
+            return
+        try:
+            termios.tcsetattr(outer_fd, termios.TCSANOW, outer_attrs)
+        except (OSError, termios.error):
+            pass
+
+    return proc, [output_thread, input_thread], restore_outer_tty
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--result", required=True)
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument("--pty", action="store_true")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command: parser.error("a command is required")
+    proc = None
+    cleanup = None
+    def forward(signum, _frame):
+        if proc is not None:
+            try:
+                if os.name == "nt":
+                    proc.send_signal(signum)
+                else:
+                    os.killpg(proc.pid, signum)
+            except (AttributeError, OSError):
+                pass
+    # The outer PTY belongs to the spawning registry. Its disappearance sends
+    # SIGHUP when that registry process dies; durability requires the wrapper
+    # and its inner child to outlive that transport. Explicit process-tool
+    # termination uses SIGTERM/SIGINT and is still forwarded below.
+    if hasattr(signal, "SIGHUP"):
+        signal.signal(signal.SIGHUP, signal.SIG_IGN)
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        signal.signal(signum, forward)
+    try:
+        proc, threads, cleanup = _spawn(command, args.pty)
+        waited = proc.wait()
+        # subprocess.Popen.wait() returns an int, while pywinpty records the
+        # terminal status on ``exitstatus`` and may return None.
+        exit_code = waited if isinstance(waited, int) else getattr(proc, "exitstatus", -1)
+        if not isinstance(exit_code, int):
+            exit_code = -1
+        for thread in threads: thread.join(timeout=2)
+    except (OSError, RuntimeError):
+        exit_code = 127
+    finally:
+        if cleanup is not None:
+            cleanup()
+    _write_result(Path(args.result), args.session_id, int(exit_code))
+    # OS process statuses cannot encode Python's negative signal convention.
+    # Keep the exact negative value in the durable receipt and expose the
+    # conventional shell transport status (128 + signal) to outer observers.
+    if exit_code < 0:
+        return 128 + min(-int(exit_code), 127)
+    return int(exit_code)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3323,6 +3323,18 @@ def terminal_tool(
                         session_key=session_key,
                     )
 
+                try:
+                    from tools.kanban_tools import record_background_process_event_from_env
+
+                    record_background_process_event_from_env(
+                        "started", proc_session.id, command
+                    )
+                except Exception:
+                    logger.debug(
+                        "kanban background-process start bridge failed",
+                        exc_info=True,
+                    )
+
                 result_data = {
                     "output": "Background process started",
                     "session_id": proc_session.id,

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -14,7 +14,7 @@ Hermes Kanban is a durable task board, shared across all your Hermes profiles, t
 
 The board has two front doors, both backed by the same `~/.hermes/kanban.db`:
 
-- **Agents drive the board through a dedicated `kanban_*` toolset** — `kanban_show`, `kanban_list`, `kanban_complete`, `kanban_request_review`, `kanban_request_changes`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_attach`, `kanban_attach_url`, `kanban_attachments`, `kanban_create`, `kanban_link`, `kanban_unblock`. The dispatcher spawns each worker with these tools already in its schema; orchestrator profiles can also enable the `kanban` toolset explicitly. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
+- **Agents drive the board through a dedicated `kanban_*` toolset.** Dispatcher-spawned implementation workers receive only their own lifecycle surface (`kanban_show`, `kanban_complete`, `kanban_request_review`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, and attachments). Board-routing tools (`kanban_list`, `kanban_create`, `kanban_link`, `kanban_unblock`) are reserved for orchestrator profiles that explicitly enable the `kanban` toolset outside a scoped worker run. This prevents an implementer from constructing and approving its own downstream gate graph. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
 - **You (and scripts, and cron) drive the board through `hermes kanban …`** on the CLI, `/kanban …` as a slash command, or the dashboard. These are for humans and automation — the places without a tool-calling model behind them.
 
 Both surfaces route through the same `kanban_db` layer, so reads see a consistent view and writes can't drift. The rest of this page shows CLI examples because they're easy to copy-paste, but every CLI verb has a tool-call equivalent the model uses.
@@ -205,6 +205,11 @@ hermes gateway start
 # 3. Create a task (you — or an orchestrator agent via kanban_create)
 hermes kanban create "research AI funding landscape" --assignee researcher
 
+# Assignees must be installed Hermes profiles. For a deliberately human-pulled
+# terminal lane, opt out explicitly instead of silently accepting a typo:
+hermes kanban create "manual legal review" \
+    --assignee outside-counsel --external-assignee
+
 # 4. Watch activity live (you)
 hermes kanban watch
 
@@ -297,7 +302,7 @@ parent, missing input, unmet capability) before unblocking, or raise
 | `kanban_show` | Read the current task (title, body, prior attempts, parent handoffs, comments, full pre-formatted `worker_context`). Defaults to the env's task id. | — |
 | `kanban_list` | List task summaries with filters for `assignee`, `status`, `tenant`, archived visibility, and limit. Intended for orchestrators discovering board work. | — |
 | `kanban_complete` | Finish with `summary` + `metadata` structured handoff. | at least one of `summary` / `result` |
-| `kanban_request_review` | Start same-card review with a durable `summary`, optional `metadata`, and optional reviewer profile. The task moves to `review`; this is not a block. | `summary` |
+| `kanban_request_review` | Start same-card review with a durable `summary`, optional `metadata`, and an independent installed reviewer profile. For worktree tasks, Hermes rejects dirty trees and binds the handoff metadata to the exact 40-character `HEAD`. The task moves to `review`; this is not a block. | `summary`, `reviewer` |
 | `kanban_request_changes` | Reviewer verdict from an active review run. Closes that run, reapplies parent gating, and routes the task to its original implementer without block-loop accounting. | `reason` |
 | `kanban_block` | Stop work and route by why: `kind=dependency` (waits in `todo`, auto-resumes), `needs_input`/`capability`/`transient` (surface to a human). Repeated same-kind re-blocks auto-escalate to `triage`. | `reason` |
 | `kanban_heartbeat` | Signal liveness during long operations. Pure side-effect. | — |
@@ -323,7 +328,9 @@ kanban_complete(
 )
 ```
 
-An **orchestrator** worker fans out instead:
+Managed background commands are part of the task lifecycle, not detached side work. Their start and completion are mirrored into task heartbeat events, so the board shows real progress. A worker cannot complete, block, or request review while one of its managed background processes is still running; it must use `process wait` (or intentionally cancel it), record the exit result, and only then hand off. This prevents worker teardown from killing a long build/test and losing its verdict.
+
+A configured **orchestrator** worker fans out instead:
 
 ```
 kanban_show()
@@ -344,7 +351,7 @@ kanban_create(
 kanban_complete(summary="decomposed into 2 research tasks + 1 writer; linked dependencies")
 ```
 
-The "(Orchestrators)" tools — `kanban_list`, `kanban_create`, `kanban_link`, `kanban_unblock`, and `kanban_comment` on foreign tasks — are available through the same toolset; the convention (encoded in the auto-injected kanban guidance) is that worker profiles don't fan out or route unrelated work, and orchestrator profiles don't execute implementation work. Dispatcher-spawned workers are still task-scoped for destructive lifecycle operations and cannot mutate unrelated tasks.
+The orchestrator tools — `kanban_list`, `kanban_create`, `kanban_link`, `kanban_unblock`, and `kanban_comment` on foreign tasks — are exposed only to an unscoped profile with the `kanban` toolset or to the dispatcher worker named by `kanban.orchestrator_profile`. Other task workers cannot fan out or route their own gate graph; they use the first-class same-card `kanban_request_review` handoff. Destructive lifecycle operations remain task-scoped.
 
 ### Why tools instead of shelling to `hermes kanban`
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -69,6 +69,76 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
 - **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task (default: 2) the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
 - **Tenant** — optional string namespace *within* a board. One specialist fleet can serve multiple businesses (`--tenant business-a`) with data isolation by workspace path and memory key prefix. Tenants are a soft filter; boards are the hard isolation boundary.
 
+## Durable external runs, typed waits, and release gates
+
+An **external run** is work performed by a human-operated lane, CI provider, or process that is not owned by the initiating Hermes worker. It is a durable `task_runs` record: its identity, owner, PID/provider ID, phase, progress, heartbeat, retry policy, completion policy, and credential-safe references live in the board database. It survives worker exit, registry restart, and dashboard reload. It is deliberately a CLI/dashboard control-plane surface — **no new model tool is added**.
+
+Choose the task `owner_kind` explicitly:
+
+- `agent` — a named installed Hermes profile owns executable work (the normal dispatcher lane).
+- `external` — a named external owner controls the run through the commands below; it is never implicitly killed by the initiating agent.
+- `no_agent` — a non-dispatchable card, optionally with an assignee label for a human lane.
+
+External run operations are board-scoped. The exact same numeric run ID on another board is not visible or mutable. An operator start is allowed only for an unclaimed `ready` task whose durable `owner_kind` is `external` and whose immutable assignee exactly equals `--owner`; installed-profile names do not relax that rule. `agent` and `no_agent` cards cannot be directly claimed, spawned, or review-dispatched. A running dispatcher worker instead transfers an already-started managed child with the existing `process` tool's `transfer` action; Hermes binds the task, current run, and board from trusted worker context, atomically ends the agent run as `external_handoff`, and exempts only that transferred child from worker-close cleanup. The external `task_runs` row itself records the exact managed process session ID and canonical `$HERMES_HOME/process-results/<session>.json` receipt path before the registry checkpoint is attempted. The transfer is acknowledged only after that session/board/run/result-path checkpoint is atomically durable; if checkpoint or registry transfer fails, Hermes atomically rolls the external handoff back to the same live agent run and claim before returning an error, so retry policy cannot dispatch a duplicate beside the still-owned child. A terminal settlement that temporarily cannot open or write the DB retains its checkpoint and receives one bounded in-process daemon retry; it settles before stale reconciliation can label a valid sidecar exit code `0` as lost. Managed process wrappers own and drain the child descriptors and persist a safe exit-code receipt, allowing both pipe and PTY children to survive the initiating worker OS process and settle after registry recovery. If PID identity is gone, reconciliation validates that canonical receipt and settles exit code `0` as completed or any nonzero code as failed; only a missing or invalid receipt follows the lost policy. Successful transfer counts as the worker's terminal protocol action, so the stop nudge and crash reconciler do not requeue it.
+
+```bash
+# Operator-owned start. `--external-id` is idempotent per task.
+hermes kanban external-run-start t_abc --owner ci --external-id build-42 \
+  --pid 4242 --phase validation --current 3 --total 10 \
+  --log-ref 'https://ci.example/job/42' --max-retries 2 \
+  --on-success complete --on-failure block --json
+
+hermes kanban external-run-show 17 --json
+hermes kanban external-run-list --task-id t_abc --json
+hermes kanban external-run-heartbeat 17 --owner ci --phase validation --current 4 --total 10 --json
+hermes kanban external-run-transfer 17 --from-owner ci --to-owner release-operator --json
+hermes kanban external-run-finish 17 --owner release-operator --outcome completed --result-ref 'artifact:build-42' --json
+hermes kanban external-run-reconcile --stale-after 300 --json
+```
+
+`on_success` is `complete` or `resume`; `on_failure` is `block` or `retry`. Finishing and stale reconciliation are compare-and-swap transitions: terminal completion is recorded once, duplicate provider callbacks do not re-complete the task, and stale work is marked lost then either re-queued or blocked according to its durable retry policy. `log_ref` and `result_ref` are redacted before persistence; pass a stable reference, never credentials. The dashboard exposes the active external run on cards and task detail (identity, owner, phase, `current/total`, heartbeat age/status, policies, and safe refs), plus matching board-scoped start/show/list/heartbeat/transfer/finish/reconcile endpoints.
+
+### Typed waits
+
+A wait is not free-form text. Set a typed wait only with a kind-specific canonical reference, then resume it with the matching authority receipt:
+
+```bash
+hermes kanban wait-set t_abc human decision:ship
+hermes kanban wait-show t_abc --json
+hermes kanban wait-resume t_abc --authority release-manager \
+  --receipt decision:ship --verdict approved
+```
+
+Kinds are `dependency`, `capability`, `human`, `external_process`, `timer`, and `review`. For example, `external_process` must name an existing external run as `run:<id>`; it cannot be satisfied by an arbitrary text label. A review wait names the independent gate task itself as `gate:<gate-task-id>` (never a free-form gate label); the gate must be a reviewer or visual-QA task created by the waiting source task under the configured coordinator and assigned independently. It may be waiting for its verdict when the wait is set. Dispatcher reconciliation resumes a review wait only when that exact gate records a candidate-and-manifest-bound `pass` verdict for the source task; a different gate or `fail` verdict never resumes it. All other dispatcher reconciliation resumes only waits whose durable authority and receipt match exactly.
+
+### Immutable candidate, evidence, and release contracts
+
+Release gates bind to an exact lowercase 40-character commit SHA, a frozen evidence manifest built from stored attachment bytes, and independent terminal reviewer/visual-QA task IDs. They are immutable: a later SHA, attachment mutation, free-form gate name, self-review, or spoofed coordinator cannot replace a prior receipt. For a `worktree` task, candidate creation reads a clean Git worktree, requires the supplied SHA to equal its real `HEAD`, and binds the producer to a completed lifecycle run whose metadata names that exact candidate SHA. A non-worktree candidate instead requires a JSON source receipt attested by the configured runtime coordinator; it must include `candidate_sha`, `subject`, `provenance`, and `producer_profile`, so a syntactically plausible SHA or mutable task assignment is insufficient. Reviewer and VisualQA tasks must be agent-owned and are frozen at creation to the source task, candidate SHA, and manifest hash. At the DB boundary, completing either gate requires its active expected run ID and a runtime `HERMES_PROFILE` exactly equal to its immutable assignee and active worker-run profile; metadata supplied by a generic CLI or dashboard caller is evidence only, never completion authority. Their completed run metadata must carry the same SHA and hash before the coordinator can record a verdict.
+
+```bash
+# Worktree task: HEAD and cleanliness are verified directly.
+hermes kanban candidate-create t_abc <40-char-sha> --json
+# Non-worktree task: immutable coordinator attestation is required.
+hermes kanban candidate-create t_abc <40-char-sha> --source-receipt candidate-source.json --json
+hermes kanban evidence-manifest-freeze t_abc <40-char-sha> manifest.json \
+  --verdict pass --authority coordinator --json
+hermes kanban gate-verdict-record t_abc <gate-task-id> <40-char-sha> \
+  <manifest-hash> pass --json
+hermes kanban release-barrier-create t_abc --sha <40-char-sha> \
+  --manifest-hash <manifest-hash> --gate <gate-task-id> --authority coordinator --json
+hermes kanban release-barrier-acquire t_abc --owner-token publish-1 --json
+# Prepare an immutable intent before the irreversible external publish. Reuse
+# the returned key after coordinator crash/lease takeover.
+hermes kanban release-barrier-prepare t_abc --owner-token publish-1 \
+  --target production --sha <40-char-sha> --idempotency-key stable-publish-key --json
+hermes kanban release-barrier-delivery t_abc --owner-token publish-1 \
+  --target production --sha <40-char-sha> --idempotency-key stable-publish-key --json
+hermes kanban release-barrier-readback t_abc --owner-token publish-1 --sha <40-char-sha> --json
+hermes kanban release-barrier-reconcile t_abc --owner-token publish-1 --json
+```
+
+A release barrier has a leased owner token and can release only after every required gate passes for that exact candidate/manifest. Before invoking an irreversible publisher, the lease owner persists an immutable target plus idempotency key with `release-barrier-prepare`; after a crash or lease takeover, the next coordinator must read and reuse that same intent rather than minting a second publication. Delivery is then recorded with the matching target, key, and candidate, followed by an exact-SHA target readback. `release-barrier-show`, `renew`, `release`, and `reconcile` expose deterministic receipts; repeated reconciliation is idempotent. Evidence freezing binds its stored authority to the process's `HERMES_PROFILE`: it must be the source implementation task's agent assignee or the configured coordinator, and `--authority` is only an equal-value assertion. Privileged gate and barrier writes require the configured coordinator runtime profile; a CLI or dashboard `authority` field is likewise only an equal-value assertion. The literal `system` is never public authority, and the dashboard binds its actual runtime profile rather than a caller-controlled `dashboard` label.
+
 ## Boards (multi-project)
 
 Boards let you separate unrelated streams of work — one per project, repo,
@@ -743,8 +813,10 @@ hermes kanban list [--mine] [--assignee P] [--status S] [--tenant T] [--archived
         [--sort created|created-desc|priority|priority-desc|status|assignee|title|updated]
         [--json]
 hermes kanban show <id> [--json]
-hermes kanban assign <id> <profile>                    # or 'none' to unassign
-hermes kanban reassign <id>... <profile>               # bulk re-assign tasks to a profile
+hermes kanban assign <id> <profile>                    # or 'none' to safely unassign
+        [--activate-agent]                            # explicit reactivation of an implicit unassigned lane
+hermes kanban reassign <id> <profile> [--reclaim]      # use 'none' to safely unassign
+        [--activate-agent]                            # explicit reactivation only
 hermes kanban edit <id> [--title ...] [--body ...]     # edit task title / body / priority in place
         [--priority N]
 hermes kanban promote <id>...                          # move todo/blocked tasks to ready (recovery)


### PR DESCRIPTION
## Summary
- enforce explicit `agent` / `external` / `no_agent` ownership and central installed-profile admission across DB, CLI, tools, dispatcher, and dashboard
- add durable task-owned external runs with exact process identity, canonical exit receipts, progress, bounded retries, crash recovery, typed waits, and automatic continuation
- bind candidates, evidence manifests, Reviewer/VisualQA gates, and verdicts to immutable exact-SHA/run provenance with coordinator-only control authority
- add a deterministic single-writer release barrier with lease/CAS, immutable delivery intent, receipt, and exact readback
- expose external lifecycle state in CLI/dashboard and preserve additive legacy migrations, including drifted-table rebuilds

## Verification
- focused orchestration/provenance/process suites: `99 passed`
- broad no-retry Kanban/process suite: `68 files, 777 passed, 0 failed, 8 platform-skipped`
- final exact-SHA independent reviews: `APPROVE` / `APPROVE`
- `ruff check .`, `py_compile`, dashboard `node --check`, and `git diff --check`: passed

Exact reviewed head: `c940a0e93bd85bfd56600b2ae8100afe8f1fa2c7`
