### PR TITLE
feat(kanban): govern specialist discovery approvals

### DIFF
--- a/agent/profile_benchmark.py
+++ b/agent/profile_benchmark.py
@@ -1,0 +1,787 @@
+"""Local, receipt-bound specialist-candidate benchmark and promotion gates.
+
+This module is deliberately not a model adapter.  A caller may provide a
+synthetic/local score and verification observation, but no provider, network,
+or scorer callback is accepted here.  Every promotion gate consequently fails
+closed when the designated independent scorer is unavailable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+from gateway.candidate_profile_requests import CandidateLifecycleSnapshot, CandidateProfileRequests
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature
+from hermes_cli import kanban_db
+
+
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
+_MAX_RECEIPT_LIFETIME_SECONDS = 86_400
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _hash(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _require_hash(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not _HASH_RE.fullmatch(value):
+        raise ValueError(f"{field} must be a SHA-256 hex digest")
+    return value
+
+
+def _require_identity(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not _IDENTITY_RE.fullmatch(value):
+        raise ValueError(f"{field} must be a bounded canonical identity")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenBenchmarkCaseSet:
+    """A task-specific case identity set frozen before any score is recorded."""
+
+    case_ids: tuple[str, ...]
+    non_production: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.non_production:
+            raise ValueError("benchmark cases must be explicitly non-production")
+        if not isinstance(self.case_ids, tuple) or not self.case_ids or len(self.case_ids) > 32:
+            raise ValueError("case_ids must be a non-empty bounded tuple")
+        canonical = tuple(sorted(set(self.case_ids)))
+        if any(not isinstance(case, str) or not _HASH_RE.fullmatch(case) for case in canonical):
+            raise ValueError("benchmark case identities must be opaque SHA-256 digests")
+        object.__setattr__(self, "case_ids", canonical)
+
+    @property
+    def case_set_hash(self) -> str:
+        return _hash({"case_ids": self.case_ids, "non_production": self.non_production})
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateProposal:
+    """Opaque proposal identity and the declared, immutable candidate scope."""
+
+    candidate_id: str
+    proposal_author: str
+    sol_reviewer: str
+    proposal_hash: str
+    signature_hash: str
+    permissions_hash: str
+
+    def __post_init__(self) -> None:
+        _require_identity(self.candidate_id, field="candidate_id")
+        _require_identity(self.proposal_author, field="proposal_author")
+        _require_identity(self.sol_reviewer, field="sol_reviewer")
+        for field in ("proposal_hash", "signature_hash", "permissions_hash"):
+            _require_hash(getattr(self, field), field=field)
+
+    @property
+    def input_hash(self) -> str:
+        return _hash(
+            {
+                "candidate_id": self.candidate_id,
+                "permissions_hash": self.permissions_hash,
+                "proposal_hash": self.proposal_hash,
+                "signature_hash": self.signature_hash,
+                "sol_reviewer": self.sol_reviewer,
+            }
+        )
+
+
+BenchmarkStatus = Literal["passed", "failed", "unavailable", "rejected"]
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkReceipt:
+    """A bounded benchmark record that can be revalidated without a model call."""
+
+    candidate_id: str
+    proposal_input_hash: str
+    case_set_hash: str
+    scorer_model: str
+    scores: tuple[int, ...]
+    pass_threshold: int
+    status: BenchmarkStatus
+    issued_at: int
+    expires_at: int
+    result_hash: str
+
+    def __post_init__(self) -> None:
+        _require_identity(self.candidate_id, field="candidate_id")
+        _require_identity(self.scorer_model, field="scorer_model")
+        for field in ("proposal_input_hash", "case_set_hash", "result_hash"):
+            _require_hash(getattr(self, field), field=field)
+        if not isinstance(self.scores, tuple) or any(
+            isinstance(score, bool) or not isinstance(score, int) or score < 0 or score > 100
+            for score in self.scores
+        ):
+            raise ValueError("scores must be bounded integer percentages")
+        if isinstance(self.pass_threshold, bool) or not isinstance(self.pass_threshold, int) or not 0 <= self.pass_threshold <= 100:
+            raise ValueError("pass_threshold must be an integer percentage")
+        if self.status not in {"passed", "failed", "unavailable", "rejected"}:
+            raise ValueError("benchmark status is invalid")
+        if any(isinstance(value, bool) or not isinstance(value, int) for value in (self.issued_at, self.expires_at)):
+            raise ValueError("receipt times must be integer timestamps")
+        if not self.issued_at <= self.expires_at <= self.issued_at + _MAX_RECEIPT_LIFETIME_SECONDS:
+            raise ValueError("receipt expiry is outside the bounded lifetime")
+        if self.result_hash != self.expected_result_hash:
+            raise ValueError("result_hash does not bind benchmark receipt contents")
+
+    @property
+    def expected_result_hash(self) -> str:
+        return _hash(
+            {
+                "candidate_id": self.candidate_id,
+                "case_set_hash": self.case_set_hash,
+                "expires_at": self.expires_at,
+                "issued_at": self.issued_at,
+                "pass_threshold": self.pass_threshold,
+                "proposal_input_hash": self.proposal_input_hash,
+                "scorer_model": self.scorer_model,
+                "scores": self.scores,
+                "status": self.status,
+            }
+        )
+
+
+VerificationStatus = Literal["verified", "failed", "unavailable", "rejected"]
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationReceipt:
+    """Independent result from one disposable, one-task local sandbox."""
+
+    candidate_id: str
+    benchmark_result_hash: str
+    verifier_identity: str
+    sandbox_id: str
+    sandbox_disposable: bool
+    sandbox_task_count: int
+    status: VerificationStatus
+    issued_at: int
+    expires_at: int
+    result_hash: str
+
+    def __post_init__(self) -> None:
+        for field in ("candidate_id", "verifier_identity", "sandbox_id"):
+            _require_identity(getattr(self, field), field=field)
+        _require_hash(self.benchmark_result_hash, field="benchmark_result_hash")
+        if not isinstance(self.sandbox_disposable, bool) or self.sandbox_task_count != 1:
+            raise ValueError("verification requires one disposable sandbox task")
+        if self.status not in {"verified", "failed", "unavailable", "rejected"}:
+            raise ValueError("verification status is invalid")
+        if any(isinstance(value, bool) or not isinstance(value, int) for value in (self.issued_at, self.expires_at)):
+            raise ValueError("receipt times must be integer timestamps")
+        if not self.issued_at <= self.expires_at <= self.issued_at + _MAX_RECEIPT_LIFETIME_SECONDS:
+            raise ValueError("receipt expiry is outside the bounded lifetime")
+        if self.result_hash != self.expected_result_hash:
+            raise ValueError("result_hash does not bind verification receipt contents")
+
+    @property
+    def expected_result_hash(self) -> str:
+        return _hash(
+            {
+                "benchmark_result_hash": self.benchmark_result_hash,
+                "candidate_id": self.candidate_id,
+                "expires_at": self.expires_at,
+                "issued_at": self.issued_at,
+                "sandbox_disposable": self.sandbox_disposable,
+                "sandbox_id": self.sandbox_id,
+                "sandbox_task_count": self.sandbox_task_count,
+                "status": self.status,
+                "verifier_identity": self.verifier_identity,
+            }
+        )
+
+
+CanaryStatus = Literal["passed", "rejected"]
+
+
+@dataclass(frozen=True, slots=True)
+class CanaryReceipt:
+    """A synthetic local-only no-send canary bound to a staged candidate.
+
+    This is intentionally an observation of durable local records.  It never
+    constructs a worker, dispatches a task, invokes a provider, or changes a
+    registry entry.  A separate active approval is still required afterwards.
+    """
+
+    candidate_id: str
+    promotion_proof_hash: str
+    verification_result_hash: str
+    mode: Literal["local-no-send"]
+    status: CanaryStatus
+    issued_at: int
+    result_hash: str
+
+    def __post_init__(self) -> None:
+        _require_identity(self.candidate_id, field="candidate_id")
+        for field in ("promotion_proof_hash", "verification_result_hash", "result_hash"):
+            _require_hash(getattr(self, field), field=field)
+        if self.mode != "local-no-send" or self.status not in {"passed", "rejected"}:
+            raise ValueError("canary must be a local no-send receipt with a valid status")
+        if isinstance(self.issued_at, bool) or not isinstance(self.issued_at, int):
+            raise ValueError("canary issued_at must be an integer timestamp")
+        if self.result_hash != self.expected_result_hash:
+            raise ValueError("result_hash does not bind canary receipt contents")
+
+    @property
+    def expected_result_hash(self) -> str:
+        return _hash(
+            {
+                "candidate_id": self.candidate_id,
+                "issued_at": self.issued_at,
+                "mode": self.mode,
+                "promotion_proof_hash": self.promotion_proof_hash,
+                "status": self.status,
+                "verification_result_hash": self.verification_result_hash,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorApproval:
+    """A separately recorded local operator decision; absence is not approval."""
+
+    candidate_id: str
+    approval_id: str
+    operator_identity: str
+    verification_result_hash: str
+    target_state: Literal["staged", "active"]
+    approved: bool
+    issued_at: int
+
+    def __post_init__(self) -> None:
+        for field in ("candidate_id", "approval_id", "operator_identity"):
+            _require_identity(getattr(self, field), field=field)
+        _require_hash(self.verification_result_hash, field="verification_result_hash")
+        if self.target_state not in {"staged", "active"}:
+            raise ValueError("operator approval target must be staged or active")
+        if not isinstance(self.approved, bool) or isinstance(self.issued_at, bool) or not isinstance(self.issued_at, int):
+            raise ValueError("operator approval fields are malformed")
+
+    @property
+    def approval_hash(self) -> str:
+        return _hash(
+            {
+                "approval_id": self.approval_id,
+                "approved": self.approved,
+                "candidate_id": self.candidate_id,
+                "issued_at": self.issued_at,
+                "operator_identity": self.operator_identity,
+                "target_state": self.target_state,
+                "verification_result_hash": self.verification_result_hash,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PromotionResult:
+    status: Literal["benchmarked", "sandbox", "verified", "staged", "active", "rejected"]
+    reason: str
+    snapshot: CandidateLifecycleSnapshot | None = None
+
+
+class CandidatePromotionGate:
+    """Validate only durable local evidence, then append a legal transition."""
+
+    def __init__(
+        self,
+        requests: CandidateProfileRequests,
+        registry: CapabilityRegistry,
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._requests = requests
+        self._registry = registry
+        self._clock = clock
+
+    def benchmark(
+        self,
+        proposal: CandidateProposal,
+        cases: FrozenBenchmarkCaseSet,
+        *,
+        scorer_model: str,
+        scores: tuple[int, ...] = (),
+        pass_threshold: int = 80,
+        scorer_available: bool = False,
+        receipt_lifetime_seconds: int = 3_600,
+    ) -> tuple[PromotionResult, BenchmarkReceipt]:
+        """Record only a local receipt; unavailable scorers cause no call or transition."""
+        now = int(self._clock())
+        status: BenchmarkStatus = "unavailable"
+        if not self._proposal_matches_candidate(proposal):
+            status = "rejected"
+        elif not self._independent_scorer(proposal, scorer_model):
+            status = "rejected"
+        elif not scorer_available:
+            status = "unavailable"
+        elif not scores or len(scores) != len(cases.case_ids):
+            status = "rejected"
+        elif min(scores) >= pass_threshold:
+            status = "passed"
+        else:
+            status = "failed"
+        receipt = self._benchmark_receipt(
+            proposal, cases, scorer_model, scores, pass_threshold, status, now, receipt_lifetime_seconds
+        )
+        if status != "passed":
+            return PromotionResult("rejected", f"benchmark {status}"), receipt
+        self._store_benchmark(receipt, proposal)
+        snapshot = self._append(proposal.candidate_id, "candidate", "benchmarked", "benchmark_passed", receipt.result_hash)
+        return self._transition_result("benchmarked", snapshot, "benchmark transition rejected"), receipt
+
+    def open_disposable_sandbox(
+        self, proposal: CandidateProposal, benchmark: BenchmarkReceipt, *, sandbox_id: str,
+        sandbox_disposable: bool = True, sandbox_task_count: int = 1,
+    ) -> PromotionResult:
+        if not self.valid_benchmark(benchmark, proposal, None):
+            return PromotionResult("rejected", "benchmark receipt is invalid")
+        if not sandbox_disposable or sandbox_task_count != 1:
+            return PromotionResult("rejected", "sandbox must be disposable and contain exactly one task")
+        try:
+            _require_identity(sandbox_id, field="sandbox_id")
+            with self._connection() as conn:
+                with kanban_db.write_txn(conn):
+                    conn.execute(
+                        "INSERT INTO specialist_sandbox_runs (sandbox_id, candidate_id, benchmark_result_hash, disposable, task_count, created_at) VALUES (?, ?, ?, 1, 1, ?)",
+                        (sandbox_id, proposal.candidate_id, benchmark.result_hash, int(self._clock())),
+                    )
+        except Exception as exc:
+            return PromotionResult("rejected", f"sandbox record unavailable: {type(exc).__name__}")
+        return PromotionResult("benchmarked", "durable disposable sandbox record created")
+
+    def verify(
+        self,
+        proposal: CandidateProposal,
+        benchmark: BenchmarkReceipt,
+        *,
+        verifier_identity: str,
+        sandbox_id: str,
+        verifier_available: bool = False,
+        receipt_lifetime_seconds: int = 3_600,
+    ) -> tuple[PromotionResult, VerificationReceipt]:
+        now = int(self._clock())
+        valid_benchmark = self.valid_benchmark(benchmark, proposal, None)
+        independent = self._independent_verifier(proposal, benchmark, verifier_identity)
+        status: VerificationStatus = "verified"
+        if not valid_benchmark or not independent or not self._has_disposable_sandbox(proposal.candidate_id, benchmark.result_hash, sandbox_id):
+            status = "rejected"
+        elif not verifier_available:
+            status = "unavailable"
+        receipt = self._verification_receipt(
+            proposal.candidate_id, benchmark.result_hash, verifier_identity, sandbox_id,
+            True, 1, status, now, receipt_lifetime_seconds,
+        )
+        if status != "verified":
+            return PromotionResult("rejected", f"verification {status}"), receipt
+        self._store_verification(receipt)
+        snapshot = self._append(proposal.candidate_id, "benchmarked", "verified", "sandbox_verified", receipt.result_hash)
+        return self._transition_result("verified", snapshot, "verification transition rejected"), receipt
+
+    def stage(
+        self,
+        proposal: CandidateProposal,
+        benchmark: BenchmarkReceipt,
+        verification: VerificationReceipt,
+        approval: OperatorApproval | None,
+    ) -> PromotionResult:
+        if not self.valid_benchmark(benchmark, proposal, None) or not self.valid_verification(verification, proposal, benchmark, None):
+            return PromotionResult("rejected", "benchmark or verification receipt is invalid")
+        if not self._valid_approval(approval, proposal, verification, "staged"):
+            return PromotionResult("rejected", "separate operator approval is required before staging")
+        if self._store_proof(proposal, "staged", None, benchmark, verification, approval) is None:
+            return PromotionResult("rejected", "durable staged-promotion proof is unavailable")
+        snapshot = self._append(proposal.candidate_id, "verified", "staged", "operator_approved", approval.approval_hash)
+        return self._transition_result("staged", snapshot, "staging transition rejected")
+
+    def run_local_no_send_canary(
+        self, proposal: CandidateProposal, verification: VerificationReceipt
+    ) -> tuple[PromotionResult, CanaryReceipt | None]:
+        """Persist one synthetic local-only canary for an already staged profile.
+
+        The implementation only reads and writes the local Kanban ledger.  In
+        particular it does not call a model/adaptor, create a profile, or emit
+        a task/message.  Repeating the same durable input safely reuses the
+        same immutable receipt.
+        """
+        now = int(self._clock())
+        current = self._requests.lifecycle_snapshot(proposal.candidate_id)
+        proof = self._staged_proof(proposal.candidate_id, verification.result_hash)
+        benchmark = self._benchmark_for(verification)
+        if (
+            current is None
+            or current.lifecycle_status != "staged"
+            or benchmark is None
+            or not self.valid_verification(verification, proposal, benchmark, None)
+            or proof is None
+        ):
+            return PromotionResult("rejected", "staged durable evidence is required before a no-send canary"), None
+        provisional = {
+            "candidate_id": proposal.candidate_id,
+            "promotion_proof_hash": proof,
+            "verification_result_hash": verification.result_hash,
+            "mode": "local-no-send",
+            "status": "passed",
+            "issued_at": now,
+        }
+        receipt = CanaryReceipt(**provisional, result_hash=_hash(provisional))
+        try:
+            with self._connection() as conn:
+                with kanban_db.write_txn(conn):
+                    conn.execute(
+                        """
+                        INSERT OR IGNORE INTO specialist_canary_receipts (
+                            result_hash, candidate_id, promotion_proof_hash,
+                            verification_result_hash, mode, status, issued_at, created_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            receipt.result_hash,
+                            receipt.candidate_id,
+                            receipt.promotion_proof_hash,
+                            receipt.verification_result_hash,
+                            receipt.mode,
+                            receipt.status,
+                            receipt.issued_at,
+                            now,
+                        ),
+                    )
+        except Exception as exc:
+            return PromotionResult("rejected", f"canary receipt unavailable: {type(exc).__name__}"), None
+        return PromotionResult("staged", "durable local no-send canary recorded", current), receipt
+
+    def activate(
+        self,
+        proposal: CandidateProposal,
+        signature: CapabilitySignature,
+        profile_id: str,
+        benchmark: BenchmarkReceipt,
+        verification: VerificationReceipt,
+        approval: OperatorApproval | None,
+        *,
+        expires_at: int | None = None,
+    ) -> PromotionResult:
+        if signature.signature_hash != proposal.signature_hash or signature.permissions_hash != proposal.permissions_hash:
+            return PromotionResult("rejected", "activation signature or permissions differ from the benchmarked candidate")
+        if not self.valid_benchmark(benchmark, proposal, None) or not self.valid_verification(verification, proposal, benchmark, None):
+            return PromotionResult("rejected", "benchmark or verification receipt is invalid")
+        if not self._valid_approval(approval, proposal, verification, "active"):
+            return PromotionResult("rejected", "separate operator approval is required before activation")
+        current = self._requests.lifecycle_snapshot(proposal.candidate_id)
+        if current is None or current.lifecycle_status != "staged":
+            return PromotionResult("rejected", "candidate must be staged before activation")
+        if not self._has_local_no_send_canary(proposal.candidate_id, verification.result_hash):
+            return PromotionResult("rejected", "durable local no-send canary is required before activation")
+        proof_hash = self._store_proof(proposal, "active", profile_id, benchmark, verification, approval)
+        if proof_hash is None:
+            return PromotionResult("rejected", "durable authorized promotion proof is unavailable")
+        try:
+            self._registry.add_active_from_durable_promotion(
+                profile_id=profile_id,
+                signature=signature,
+                candidate_id=proposal.candidate_id,
+                promotion_proof_hash=proof_hash,
+                expires_at=expires_at,
+                now=int(self._clock()),
+            )
+        except Exception as exc:
+            return PromotionResult("rejected", f"capability activation unavailable: {type(exc).__name__}")
+        snapshot = self._append(proposal.candidate_id, "staged", "active", "profile_activated", approval.approval_hash)
+        return self._transition_result("active", snapshot, "activation transition rejected")
+
+    def valid_benchmark(
+        self,
+        receipt: BenchmarkReceipt,
+        proposal: CandidateProposal,
+        cases: FrozenBenchmarkCaseSet | None,
+    ) -> bool:
+        now = int(self._clock())
+        return (
+            receipt.status == "passed"
+            and receipt.result_hash == receipt.expected_result_hash
+            and receipt.issued_at <= now < receipt.expires_at
+            and receipt.candidate_id == proposal.candidate_id
+            and receipt.proposal_input_hash == proposal.input_hash
+            and (cases is None or receipt.case_set_hash == cases.case_set_hash)
+            and self._independent_scorer(proposal, receipt.scorer_model)
+            and bool(receipt.scores)
+            and min(receipt.scores) >= receipt.pass_threshold
+            and self._proposal_matches_candidate(proposal)
+            and self._stored_benchmark_matches(receipt, proposal)
+        )
+
+    def valid_verification(
+        self,
+        receipt: VerificationReceipt,
+        proposal: CandidateProposal,
+        benchmark: BenchmarkReceipt,
+        cases: FrozenBenchmarkCaseSet | None,
+    ) -> bool:
+        now = int(self._clock())
+        return (
+            self.valid_benchmark(benchmark, proposal, cases)
+            and receipt.status == "verified"
+            and receipt.result_hash == receipt.expected_result_hash
+            and receipt.issued_at <= now < receipt.expires_at
+            and receipt.candidate_id == proposal.candidate_id
+            and receipt.benchmark_result_hash == benchmark.result_hash
+            and receipt.sandbox_disposable
+            and receipt.sandbox_task_count == 1
+            and self._has_disposable_sandbox(receipt.candidate_id, receipt.benchmark_result_hash, receipt.sandbox_id)
+            and self._independent_verifier(proposal, benchmark, receipt.verifier_identity)
+            and self._stored_verification_matches(receipt)
+        )
+
+    def _proposal_matches_candidate(self, proposal: CandidateProposal) -> bool:
+        snapshot = self._requests.lifecycle_snapshot(proposal.candidate_id)
+        return bool(
+            snapshot
+            and snapshot.lifecycle_status
+            in {"candidate", "benchmarked", "verified", "staged"}
+            and snapshot.signature_hash == proposal.signature_hash
+            and snapshot.permissions_hash == proposal.permissions_hash
+        )
+
+    @staticmethod
+    def _independent_scorer(proposal: CandidateProposal, scorer: str) -> bool:
+        try:
+            scorer = _require_identity(scorer, field="scorer_model")
+        except ValueError:
+            return False
+        return scorer not in {proposal.proposal_author, proposal.sol_reviewer}
+
+    @staticmethod
+    def _independent_verifier(proposal: CandidateProposal, benchmark: BenchmarkReceipt, verifier: str) -> bool:
+        try:
+            verifier = _require_identity(verifier, field="verifier_identity")
+        except ValueError:
+            return False
+        return verifier not in {proposal.proposal_author, proposal.sol_reviewer, benchmark.scorer_model}
+
+    def _append(self, candidate_id: str, expected: str, next_status: str, reason: str, receipt_hash: str) -> CandidateLifecycleSnapshot | None:
+        return self._requests.append_lifecycle_transition(
+            candidate_id,
+            expected_status=expected,
+            next_status=next_status,
+            reason_code=reason,
+            receipt_hash=receipt_hash,
+        )
+
+    @staticmethod
+    def _transition_result(status: Literal["benchmarked", "sandbox", "verified", "staged", "active"], snapshot: CandidateLifecycleSnapshot | None, reason: str) -> PromotionResult:
+        if snapshot is None or snapshot.lifecycle_status != status:
+            return PromotionResult("rejected", reason, snapshot)
+        return PromotionResult(status, "append-only lifecycle transition recorded", snapshot)
+
+    def record_operator_approval(
+        self, approval: OperatorApproval, *, authenticated_operator_identity: str | None = None
+    ) -> bool:
+        """Persist an approval only when the dashboard auth boundary attests it.
+
+        A caller-supplied identity is never sufficient.  The authenticated
+        dashboard route supplies the verified, allowlisted subject and binds it
+        to the approval's durable identity before this method can append a row.
+        """
+        if authenticated_operator_identity != approval.operator_identity:
+            return False
+        try:
+            _require_identity(authenticated_operator_identity, field="authenticated_operator_identity")
+        except ValueError:
+            return False
+        with self._connection() as conn:
+            with kanban_db.write_txn(conn):
+                conn.execute(
+                    "INSERT INTO specialist_operator_approvals (approval_hash, approval_id, candidate_id, target_state, operator_identity, verification_result_hash, approved, issued_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        approval.approval_hash,
+                        approval.approval_id,
+                        approval.candidate_id,
+                        approval.target_state,
+                        approval.operator_identity,
+                        approval.verification_result_hash,
+                        int(approval.approved),
+                        approval.issued_at,
+                        int(self._clock()),
+                    ),
+                )
+        return True
+
+    def _valid_approval(self, approval: OperatorApproval | None, proposal: CandidateProposal, verification: VerificationReceipt, target: str) -> bool:
+        if approval is None or not approval.approved or approval.target_state != target:
+            return False
+        if approval.candidate_id != proposal.candidate_id:
+            return False
+        if approval.verification_result_hash != verification.result_hash:
+            return False
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT approval_hash, operator_identity, approved FROM specialist_operator_approvals WHERE approval_hash = ? AND candidate_id = ? AND target_state = ?",
+                (approval.approval_hash, proposal.candidate_id, target),
+            ).fetchone()
+        return bool(
+            row
+            and row["operator_identity"] == approval.operator_identity
+            and bool(row["approved"])
+        )
+
+    def _connection(self):
+        return kanban_db.connect_closing(self._requests._db_path, board=self._requests._board)
+
+    def _store_benchmark(self, receipt: BenchmarkReceipt, proposal: CandidateProposal) -> None:
+        with self._connection() as conn:
+            with kanban_db.write_txn(conn):
+                conn.execute(
+                    "INSERT INTO specialist_benchmark_receipts (result_hash, candidate_id, proposal_input_hash, proposal_author, sol_reviewer, signature_hash, permissions_hash, case_set_hash, scorer_model, scores_json, pass_threshold, status, issued_at, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (receipt.result_hash, receipt.candidate_id, receipt.proposal_input_hash, proposal.proposal_author, proposal.sol_reviewer, proposal.signature_hash, proposal.permissions_hash, receipt.case_set_hash, receipt.scorer_model, _canonical_json(receipt.scores), receipt.pass_threshold, receipt.status, receipt.issued_at, receipt.expires_at, int(self._clock())),
+                )
+
+    def _store_verification(self, receipt: VerificationReceipt) -> None:
+        with self._connection() as conn:
+            with kanban_db.write_txn(conn):
+                conn.execute(
+                    "INSERT INTO specialist_verification_receipts (result_hash, candidate_id, benchmark_result_hash, verifier_identity, sandbox_id, status, issued_at, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (receipt.result_hash, receipt.candidate_id, receipt.benchmark_result_hash, receipt.verifier_identity, receipt.sandbox_id, receipt.status, receipt.issued_at, receipt.expires_at, int(self._clock())),
+                )
+
+    def _stored_benchmark_matches(self, receipt: BenchmarkReceipt, proposal: CandidateProposal) -> bool:
+        try:
+            with self._connection() as conn:
+                row = conn.execute("SELECT * FROM specialist_benchmark_receipts WHERE result_hash = ?", (receipt.result_hash,)).fetchone()
+            return bool(row and tuple(json.loads(row["scores_json"])) == receipt.scores and all(row[field] == value for field, value in (("candidate_id", receipt.candidate_id), ("proposal_input_hash", receipt.proposal_input_hash), ("proposal_author", proposal.proposal_author), ("sol_reviewer", proposal.sol_reviewer), ("signature_hash", proposal.signature_hash), ("permissions_hash", proposal.permissions_hash), ("case_set_hash", receipt.case_set_hash), ("scorer_model", receipt.scorer_model), ("pass_threshold", receipt.pass_threshold), ("status", receipt.status), ("issued_at", receipt.issued_at), ("expires_at", receipt.expires_at))))
+        except Exception:
+            return False
+
+    def _stored_verification_matches(self, receipt: VerificationReceipt) -> bool:
+        try:
+            with self._connection() as conn:
+                row = conn.execute("SELECT * FROM specialist_verification_receipts WHERE result_hash = ?", (receipt.result_hash,)).fetchone()
+            return bool(row and all(row[field] == value for field, value in (("candidate_id", receipt.candidate_id), ("benchmark_result_hash", receipt.benchmark_result_hash), ("verifier_identity", receipt.verifier_identity), ("sandbox_id", receipt.sandbox_id), ("status", receipt.status), ("issued_at", receipt.issued_at), ("expires_at", receipt.expires_at))))
+        except Exception:
+            return False
+
+    def _stored_approval_matches(self, approval: OperatorApproval) -> bool:
+        try:
+            with self._connection() as conn:
+                row = conn.execute("SELECT approval_hash FROM specialist_operator_approvals WHERE approval_hash = ? AND candidate_id = ? AND target_state = ? AND verification_result_hash = ? AND approved = 1", (approval.approval_hash, approval.candidate_id, approval.target_state, approval.verification_result_hash)).fetchone()
+            return row is not None
+        except Exception:
+            return False
+
+    def _has_disposable_sandbox(self, candidate_id: str, benchmark_hash: str, sandbox_id: str) -> bool:
+        try:
+            with self._connection() as conn:
+                row = conn.execute("SELECT 1 FROM specialist_sandbox_runs WHERE sandbox_id = ? AND candidate_id = ? AND benchmark_result_hash = ? AND disposable = 1 AND task_count = 1", (sandbox_id, candidate_id, benchmark_hash)).fetchone()
+            return row is not None
+        except Exception:
+            return False
+
+    def _staged_proof(self, candidate_id: str, verification_hash: str) -> str | None:
+        try:
+            with self._connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT proof_hash FROM specialist_promotion_proofs
+                    WHERE candidate_id = ? AND target_state = 'staged'
+                      AND verification_result_hash = ?
+                    ORDER BY id DESC LIMIT 1
+                    """,
+                    (candidate_id, verification_hash),
+                ).fetchone()
+            return row["proof_hash"] if row else None
+        except Exception:
+            return None
+
+    def _benchmark_for(self, verification: VerificationReceipt) -> BenchmarkReceipt | None:
+        """Reconstruct a stored benchmark for local canary validation only."""
+        try:
+            with self._connection() as conn:
+                row = conn.execute(
+                    "SELECT * FROM specialist_benchmark_receipts WHERE result_hash = ?",
+                    (verification.benchmark_result_hash,),
+                ).fetchone()
+            if row is None:
+                return None
+            scores = tuple(json.loads(row["scores_json"]))
+            return BenchmarkReceipt(
+                candidate_id=row["candidate_id"],
+                proposal_input_hash=row["proposal_input_hash"],
+                case_set_hash=row["case_set_hash"],
+                scorer_model=row["scorer_model"],
+                scores=scores,
+                pass_threshold=row["pass_threshold"],
+                status=row["status"],
+                issued_at=row["issued_at"],
+                expires_at=row["expires_at"],
+                result_hash=row["result_hash"],
+            )
+        except Exception:
+            return None
+
+    def _has_local_no_send_canary(self, candidate_id: str, verification_hash: str) -> bool:
+        try:
+            with self._connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT 1 FROM specialist_canary_receipts
+                    WHERE candidate_id = ? AND verification_result_hash = ?
+                      AND mode = 'local-no-send' AND status = 'passed'
+                    """,
+                    (candidate_id, verification_hash),
+                ).fetchone()
+            return row is not None
+        except Exception:
+            return False
+
+    def _store_proof(self, proposal: CandidateProposal, target: str, profile_id: str | None, benchmark: BenchmarkReceipt, verification: VerificationReceipt, approval: OperatorApproval) -> str | None:
+        proof_hash = _hash({"candidate_id": proposal.candidate_id, "target": target, "profile_id": profile_id, "signature_hash": proposal.signature_hash, "permissions_hash": proposal.permissions_hash, "benchmark": benchmark.result_hash, "verification": verification.result_hash, "approval": approval.approval_hash})
+        try:
+            with self._connection() as conn:
+                with kanban_db.write_txn(conn):
+                    conn.execute("INSERT INTO specialist_promotion_proofs (proof_hash, candidate_id, target_state, profile_id, signature_hash, permissions_hash, benchmark_result_hash, verification_result_hash, approval_hash, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", (proof_hash, proposal.candidate_id, target, profile_id, proposal.signature_hash, proposal.permissions_hash, benchmark.result_hash, verification.result_hash, approval.approval_hash, int(self._clock())))
+            return proof_hash
+        except Exception:
+            return None
+
+    @staticmethod
+    def _benchmark_receipt(
+        proposal: CandidateProposal,
+        cases: FrozenBenchmarkCaseSet,
+        scorer: str,
+        scores: tuple[int, ...],
+        threshold: int,
+        status: BenchmarkStatus,
+        issued_at: int,
+        lifetime: int,
+    ) -> BenchmarkReceipt:
+        expires_at = issued_at + max(1, min(lifetime, _MAX_RECEIPT_LIFETIME_SECONDS))
+        provisional = {
+            "candidate_id": proposal.candidate_id, "proposal_input_hash": proposal.input_hash,
+            "case_set_hash": cases.case_set_hash, "scorer_model": scorer, "scores": scores,
+            "pass_threshold": threshold, "status": status, "issued_at": issued_at, "expires_at": expires_at,
+        }
+        return BenchmarkReceipt(**provisional, result_hash=_hash(provisional))
+
+    @staticmethod
+    def _verification_receipt(
+        candidate_id: str, benchmark_hash: str, verifier: str, sandbox_id: str,
+        disposable: bool, task_count: int, status: VerificationStatus, issued_at: int, lifetime: int,
+    ) -> VerificationReceipt:
+        expires_at = issued_at + max(1, min(lifetime, _MAX_RECEIPT_LIFETIME_SECONDS))
+        provisional = {
+            "candidate_id": candidate_id, "benchmark_result_hash": benchmark_hash,
+            "verifier_identity": verifier, "sandbox_id": sandbox_id,
+            "sandbox_disposable": disposable, "sandbox_task_count": task_count,
+            "status": status, "issued_at": issued_at, "expires_at": expires_at,
+        }
+        return VerificationReceipt(**provisional, result_hash=_hash(provisional))

--- a/agent/profile_candidate_review.py
+++ b/agent/profile_candidate_review.py
@@ -1,0 +1,403 @@
+"""Inert, provider-neutral receipts for specialist-profile advisory proposals.
+
+Phase 0 deliberately authorizes no specialist advisory adapter.  This module
+therefore has no provider clients, subprocesses, network calls, registry
+writes, or candidate-lifecycle writes.  It only canonicalizes a bounded local
+request and returns an auditable ``advisory_unavailable`` receipt until a later
+operator-approved integration supplies a separately reviewed adapter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from gateway.candidate_profile_requests import (
+    DEFAULT_POLICY_DIGEST,
+    OpaqueEvidenceReference,
+    SanitizedTaskEnvelope,
+)
+from gateway.capability_registry import CapabilitySignature
+
+
+_MAX_ID_CHARS = 96
+_MAX_TEXT_CHARS = 4_096
+_MAX_ROLE_NAME_CHARS = 96
+_MAX_BENCHMARK_CASES = 16
+_MAX_LIMITATIONS = 16
+_MAX_PERMISSIONS = 16
+_MAX_TIMEOUT_SECONDS = 600
+_MAX_MODEL_CALLS = 1
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_CANDIDATE_ID_RE = re.compile(r"^cpr_[0-9a-f]{24}_[0-9a-f]{8}$")
+_ROLE_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,95}$")
+_SECRET_LIKE_RE = re.compile(
+    r"(?i)(?:\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password)\s*[:=]"
+    r"|\bauthorization\s*:\s*bearer\b|\bbearer\s+[a-z0-9._-]{8,}|-----BEGIN(?: [A-Z]+)? PRIVATE KEY-----)"
+)
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _hash(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _bounded_text(value: object, *, field: str, max_chars: int) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > max_chars:
+        raise ValueError(f"{field} must be a bounded non-empty string")
+    return value
+
+
+def _reject_secret_like(*values: str) -> None:
+    if any(_SECRET_LIKE_RE.search(value) for value in values):
+        raise ValueError("receipt-only advisory data cannot contain secret-like material")
+
+
+def _canonical_strings(value: object, *, field: str, max_items: int) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, tuple) or len(value) > max_items:
+        raise ValueError(f"{field} must be a bounded tuple of strings")
+    normalized = tuple(sorted(set(value)))
+    if any(not isinstance(item, str) or not item.strip() or len(item) > _MAX_TEXT_CHARS for item in normalized):
+        raise ValueError(f"{field} must contain bounded non-empty strings")
+    return normalized
+
+
+def _validated_evidence_refs(envelope: SanitizedTaskEnvelope) -> tuple[str, ...]:
+    if not isinstance(envelope, SanitizedTaskEnvelope) or not isinstance(envelope.evidence_refs, tuple):
+        raise TypeError("envelope must contain only a sanitized evidence-reference tuple")
+    refs = envelope.evidence_refs
+    if len(refs) > _MAX_BENCHMARK_CASES:
+        raise ValueError("envelope has too many evidence references")
+    if any(not isinstance(reference, OpaqueEvidenceReference) for reference in refs):
+        raise ValueError("envelope must contain opaque evidence references")
+    return tuple(sorted({reference.digest for reference in refs}))
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationCapability:
+    """A sanitized Phase-0 compatibility row, never dispatch authority."""
+
+    agent: str
+    supported_operation: str
+    authentication_owner: str
+    human_interaction_required: bool
+    egress_class: str
+    allowed: bool
+    evidence: str
+    failure_fallback: str
+
+    def __post_init__(self) -> None:
+        for field in (
+            "agent",
+            "supported_operation",
+            "authentication_owner",
+            "egress_class",
+            "evidence",
+            "failure_fallback",
+        ):
+            _bounded_text(getattr(self, field), field=field, max_chars=_MAX_TEXT_CHARS)
+        _reject_secret_like(
+            self.agent,
+            self.supported_operation,
+            self.authentication_owner,
+            self.egress_class,
+            self.evidence,
+            self.failure_fallback,
+        )
+        if not isinstance(self.human_interaction_required, bool) or not isinstance(self.allowed, bool):
+            raise TypeError("capability flags must be booleans")
+        if self.failure_fallback != "advisory_unavailable":
+            raise ValueError("advisory capability fallback must be advisory_unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisoryLimits:
+    """Finite budget supplied with a receipt-only advisory request."""
+
+    max_input_bytes: int
+    max_model_calls: int
+    timeout_seconds: int
+
+    def __post_init__(self) -> None:
+        for field, maximum in (
+            ("max_input_bytes", _MAX_TEXT_CHARS * 2),
+            ("max_model_calls", _MAX_MODEL_CALLS),
+            ("timeout_seconds", _MAX_TIMEOUT_SECONDS),
+        ):
+            value = getattr(self, field)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0 or value > maximum:
+                raise ValueError(f"{field} must be a positive bounded integer")
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisoryRequest:
+    """Only the bounded, opaque material a future advisory adapter could receive."""
+
+    candidate_request_id: str
+    signature: CapabilitySignature
+    envelope: SanitizedTaskEnvelope
+    limits: AdvisoryLimits
+    policy_digest: str = DEFAULT_POLICY_DIGEST
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.candidate_request_id, str) or not _CANDIDATE_ID_RE.fullmatch(self.candidate_request_id):
+            raise ValueError("candidate_request_id must be a canonical opaque candidate id")
+        if not isinstance(self.signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        _reject_secret_like(*self.signature.requested_permissions)
+        if not isinstance(self.limits, AdvisoryLimits):
+            raise TypeError("limits must be AdvisoryLimits")
+        if not isinstance(self.policy_digest, str) or self.policy_digest != DEFAULT_POLICY_DIGEST:
+            raise ValueError("policy_digest must match the fixed local candidate policy")
+        if self.encoded_size > self.limits.max_input_bytes:
+            raise ValueError("bounded advisory request exceeds max_input_bytes")
+
+    @property
+    def canonical_payload(self) -> dict[str, object]:
+        return {
+            "candidate_request_id": self.candidate_request_id,
+            "evidence_ref_hashes": _validated_evidence_refs(self.envelope),
+            "limits": {
+                "max_input_bytes": self.limits.max_input_bytes,
+                "max_model_calls": self.limits.max_model_calls,
+                "timeout_seconds": self.limits.timeout_seconds,
+            },
+            "permissions_hash": self.signature.permissions_hash,
+            "policy_digest": self.policy_digest,
+            "signature_hash": self.signature.signature_hash,
+        }
+
+    @property
+    def encoded_size(self) -> int:
+        return len(_canonical_json(self.canonical_payload).encode("utf-8"))
+
+    @property
+    def input_hash(self) -> str:
+        return _hash(self.canonical_payload)
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisoryProfileProposal:
+    """Untrusted advisory material; validation never promotes or persists it."""
+
+    role_name: str
+    soul_markdown: str
+    benchmark_cases: tuple[str, ...]
+    claimed_permissions: tuple[str, ...]
+    limitations: tuple[str, ...]
+    source_receipt_hash: str
+
+    def __post_init__(self) -> None:
+        if not _ROLE_NAME_RE.fullmatch(self.role_name):
+            raise ValueError("role_name must be a bounded lowercase role label")
+        _bounded_text(self.soul_markdown, field="soul_markdown", max_chars=_MAX_TEXT_CHARS)
+        object.__setattr__(self, "benchmark_cases", _canonical_strings(
+            self.benchmark_cases, field="benchmark_cases", max_items=_MAX_BENCHMARK_CASES
+        ))
+        object.__setattr__(self, "claimed_permissions", _canonical_strings(
+            self.claimed_permissions, field="claimed_permissions", max_items=_MAX_PERMISSIONS
+        ))
+        object.__setattr__(self, "limitations", _canonical_strings(
+            self.limitations, field="limitations", max_items=_MAX_LIMITATIONS
+        ))
+        if not isinstance(self.source_receipt_hash, str) or not _SHA256_RE.fullmatch(self.source_receipt_hash):
+            raise ValueError("source_receipt_hash must be a SHA-256 digest")
+
+
+ReceiptStatus = Literal[
+    "advisory_received",
+    "advisory_unavailable",
+    "advisory_timeout",
+    "advisory_malformed",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewReceipt:
+    """A local observation bound to exactly one candidate packet and budget."""
+
+    provider_label: str
+    candidate_request_id: str
+    input_hash: str
+    policy_digest: str
+    max_input_bytes: int
+    max_model_calls: int
+    timeout_seconds: int
+    elapsed_seconds: int
+    model_calls: int
+    status: ReceiptStatus
+    reason: str
+
+    def __post_init__(self) -> None:
+        _bounded_text(self.provider_label, field="provider_label", max_chars=64)
+        if not isinstance(self.candidate_request_id, str) or not _CANDIDATE_ID_RE.fullmatch(self.candidate_request_id):
+            raise ValueError("candidate_request_id must be a canonical opaque candidate id")
+        if not isinstance(self.input_hash, str) or not _SHA256_RE.fullmatch(self.input_hash):
+            raise ValueError("input_hash must be a SHA-256 digest")
+        if not isinstance(self.policy_digest, str) or not _SHA256_RE.fullmatch(self.policy_digest):
+            raise ValueError("policy_digest must be a SHA-256 digest")
+        for field in ("max_input_bytes", "max_model_calls", "timeout_seconds", "elapsed_seconds", "model_calls"):
+            value = getattr(self, field)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{field} must be a non-negative integer")
+        if self.status not in {
+            "advisory_received",
+            "advisory_unavailable",
+            "advisory_timeout",
+            "advisory_malformed",
+        }:
+            raise ValueError("receipt status is not an advisory-only status")
+        _bounded_text(self.reason, field="reason", max_chars=512)
+        _reject_secret_like(self.provider_label, self.reason)
+
+    @property
+    def source_receipt_hash(self) -> str:
+        return _hash({
+            "candidate_request_id": self.candidate_request_id,
+            "elapsed_seconds": self.elapsed_seconds,
+            "input_hash": self.input_hash,
+            "max_input_bytes": self.max_input_bytes,
+            "max_model_calls": self.max_model_calls,
+            "model_calls": self.model_calls,
+            "policy_digest": self.policy_digest,
+            "provider_label": self.provider_label,
+            "reason": self.reason,
+            "status": self.status,
+            "timeout_seconds": self.timeout_seconds,
+        })
+
+
+ReviewStatus = Literal["accepted", "advisory_unavailable", "rejected"]
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisoryReviewResult:
+    """The receipt-only outcome.  ``proposal`` is always ``None`` in Phase 0."""
+
+    status: ReviewStatus
+    receipt: ReviewReceipt
+    proposal: AdvisoryProfileProposal | None = None
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ProposalValidationResult:
+    status: Literal["accepted", "rejected"]
+    reason: str
+
+
+def _unavailable_receipt(capability: IntegrationCapability, request: AdvisoryRequest, *, reason: str) -> ReviewReceipt:
+    return ReviewReceipt(
+        provider_label=capability.agent,
+        candidate_request_id=request.candidate_request_id,
+        input_hash=request.input_hash,
+        policy_digest=request.policy_digest,
+        max_input_bytes=request.limits.max_input_bytes,
+        max_model_calls=request.limits.max_model_calls,
+        timeout_seconds=request.limits.timeout_seconds,
+        elapsed_seconds=0,
+        model_calls=0,
+        status="advisory_unavailable",
+        reason=reason,
+    )
+
+
+def review_with(capability: IntegrationCapability, request: AdvisoryRequest) -> AdvisoryReviewResult:
+    """Return an inert receipt without looking up or calling any provider.
+
+    An allowed compatibility row is intentionally insufficient: no external
+    adapter is wired by Phase 0, and this function must never substitute a
+    provider or transform the originating task into a failure.
+    """
+    if not isinstance(capability, IntegrationCapability):
+        raise TypeError("capability must be an IntegrationCapability")
+    if not isinstance(request, AdvisoryRequest):
+        raise TypeError("request must be an AdvisoryRequest")
+    reason = (
+        "integration capability is not currently allowed"
+        if not capability.allowed
+        else "no approved advisory adapter is wired"
+    )
+    receipt = _unavailable_receipt(capability, request, reason=reason)
+    return AdvisoryReviewResult(status="advisory_unavailable", receipt=receipt, reason=reason)
+
+
+def validate_receipt(
+    receipt: ReviewReceipt,
+    request: AdvisoryRequest,
+    capability: IntegrationCapability,
+) -> AdvisoryReviewResult:
+    """Validate a supplied local observation without accepting a provider output."""
+    if not isinstance(receipt, ReviewReceipt) or not isinstance(request, AdvisoryRequest):
+        raise TypeError("receipt and request must use the advisory receipt types")
+    if not isinstance(capability, IntegrationCapability):
+        raise TypeError("capability must be an IntegrationCapability")
+    if receipt.provider_label != capability.agent:
+        return AdvisoryReviewResult("rejected", receipt, reason="receipt provider does not match capability")
+    if receipt.candidate_request_id != request.candidate_request_id or receipt.input_hash != request.input_hash:
+        return AdvisoryReviewResult("rejected", receipt, reason="receipt candidate or input binding does not match request")
+    if receipt.policy_digest != request.policy_digest:
+        return AdvisoryReviewResult("rejected", receipt, reason="receipt policy digest does not match request")
+    if (
+        receipt.max_input_bytes != request.limits.max_input_bytes
+        or receipt.max_model_calls != request.limits.max_model_calls
+        or receipt.timeout_seconds != request.limits.timeout_seconds
+    ):
+        return AdvisoryReviewResult("rejected", receipt, reason="receipt budget does not match request")
+    if receipt.model_calls > receipt.max_model_calls:
+        return AdvisoryReviewResult("rejected", receipt, reason="receipt model calls exceed requested budget")
+    if receipt.elapsed_seconds > receipt.timeout_seconds:
+        return AdvisoryReviewResult("rejected", receipt, reason="receipt timeout exceeds requested budget")
+    if receipt.status == "advisory_timeout":
+        return AdvisoryReviewResult("rejected", receipt, reason="advisory timed out")
+    if receipt.status == "advisory_malformed":
+        return AdvisoryReviewResult("rejected", receipt, reason="advisory receipt is malformed")
+    if receipt.status == "advisory_received":
+        if not capability.allowed:
+            return AdvisoryReviewResult("rejected", receipt, reason="integration capability is not currently allowed")
+        # A Phase-0 compatibility row is descriptive, not an adapter grant.
+        # No implementation is allowed to inject an advisory result merely by
+        # setting ``allowed=True``; a later task must add a separately approved
+        # concrete adapter authority before this branch can ever accept data.
+        return AdvisoryReviewResult("rejected", receipt, reason="no advisory adapter is wired in Phase 0")
+    return AdvisoryReviewResult("advisory_unavailable", receipt, reason=receipt.reason)
+
+
+def validate_proposal(
+    proposal: AdvisoryProfileProposal,
+    request: AdvisoryRequest,
+    receipt: ReviewReceipt | None,
+    capability: IntegrationCapability,
+) -> ProposalValidationResult:
+    """Reject unsafe advisory text or permission expansion without persisting it."""
+    if not isinstance(proposal, AdvisoryProfileProposal) or not isinstance(request, AdvisoryRequest):
+        raise TypeError("proposal and request must use the advisory types")
+    if receipt is None:
+        return ProposalValidationResult("rejected", "proposal requires a bound advisory receipt")
+    if not isinstance(receipt, ReviewReceipt) or not isinstance(capability, IntegrationCapability):
+        return ProposalValidationResult("rejected", "proposal receipt or capability is malformed")
+    receipt_result = validate_receipt(receipt, request, capability)
+    if proposal.source_receipt_hash != receipt.source_receipt_hash:
+        return ProposalValidationResult("rejected", "proposal receipt binding does not match")
+    text = "\n".join(
+        (
+            proposal.role_name,
+            proposal.soul_markdown,
+            *proposal.benchmark_cases,
+            *proposal.claimed_permissions,
+            *proposal.limitations,
+        )
+    )
+    if _SECRET_LIKE_RE.search(text):
+        return ProposalValidationResult("rejected", "proposal contains secret-like material")
+    if not set(proposal.claimed_permissions) <= set(request.signature.requested_permissions):
+        return ProposalValidationResult("rejected", "proposal expands requested permissions")
+    if receipt_result.status != "accepted":
+        return ProposalValidationResult("rejected", f"proposal receipt rejected: {receipt_result.reason}")
+    return ProposalValidationResult("accepted", "proposal is bounded advisory input only")

--- a/docs/architecture/specialist_discovery_operations.md
+++ b/docs/architecture/specialist_discovery_operations.md
@@ -1,0 +1,106 @@
+# Specialist-discovery operations
+
+## Authority and boundaries
+
+Specialist discovery is a local Hermes orchestration feature.  It does not
+grant trading, runtime, acceptance, CI, PR, merge, deployment, credential, or
+provider authority.  A candidate is inert until every durable receipt is
+present: independent benchmark, one-task disposable sandbox, independent
+verification, staged operator approval, a local no-send canary, and a second
+active operator approval.
+
+Hermes now recognizes an approval only when it is submitted through the gated
+dashboard by an OAuth-authenticated session whose exact
+`<provider>:<user_id>` subject is in
+`kanban.specialist_operator_approvals.allowed_subjects`.  The allowlist is
+empty by default, and loopback dashboard session tokens are deliberately not
+an operator identity. `operator_identity` text supplied by a worker, model,
+or API body is not authority.
+
+Configure the intended operator before using this feature:
+
+```yaml
+kanban:
+  specialist_operator_approvals:
+    allowed_subjects:
+      - "portal:YOUR_AUTHENTICATED_USER_ID"
+```
+
+The authenticated dashboard can then POST the exact candidate ID, durable
+verification receipt hash, and target (`staged` or `active`) to
+`/api/plugins/kanban/specialist-approvals`. The server derives the operator
+identity from its verified session and records an append-only approval. A
+separate approval is required for each target state.
+
+The status read model is deliberately reconstructed from append-only SQLite
+records.  It never retries Codex, Claude, Sol, an advisory adapter, a
+benchmark, a sandbox, or a canary after restart.
+
+## Inspecting one candidate
+
+Use `gateway.status.specialist_discovery_status(candidate_id, db_path=...)`.
+It returns only opaque receipt hashes and stage/status rows for:
+
+- source task and candidate request;
+- benchmark, sandbox, verification, staged/active approvals, and no-send
+  canary;
+- active resolution, expiry, and rollback/revocation.
+
+`recovery_action` is `active_resolution` only for an unexpired, unrevoked
+durable profile.  Any missing, expired, revoked, malformed, or unavailable
+state returns `task_orchestrator` or `normal_triage`; it must not dispatch a
+generated profile.
+
+Recovery always opens an existing mutable Hermes SQLite ledger with a fresh
+`mode=ro` snapshot, so a committed WAL revocation is visible immediately even
+if the WAL appears between earlier filesystem observations and the read. It
+never mutates the database or WAL. SQLite may attach or create its `-shm`
+mapping while observing an active writer; that mapping is not lifecycle
+evidence. Any fresh-read failure is `normal_triage`, never a stale active
+resolution.
+
+## Synthetic manual no-send canary
+
+This is an operator-run local verification, not a provider or deployment
+operation. After the staged dashboard approval is durably recorded, use a new,
+synthetic diagnostic-only signature and opaque test-case hashes. Confirm all
+of the following before the active approval:
+
+1. The no-match handoff created exactly one candidate request and preserved
+   source idempotency.
+2. The original task was assigned to `task-orchestrator`; no generated profile
+   is active or dispatchable.
+3. The durable benchmark, disposable one-task sandbox, verification, and
+   staged approval are present.
+4. `run_local_no_send_canary` produced a `local-no-send` receipt.  It only
+   reads/writes local Kanban SQLite records: no provider/model/network call,
+   adapter fallback, task worker, notification send, external write, or
+   registry activation occurs.
+5. Registry activation still fails until the separately recorded active
+   operator approval is present.
+
+The canary never proves runtime, acceptance, trading, CI, merge, or deployment
+safety.
+
+## Expiry and rollback
+
+An elapsed profile expiry is rejected during lookup.  To roll back before
+expiry, call `CapabilityRegistry.revoke` with the exact local profile and
+capability signature; it appends an immutable revocation receipt.  Revoked
+profiles immediately stop resolving.  Subsequent specialist handoffs use
+their safe `task-orchestrator`/normal-triage fallback and may create only an
+inert candidate request.
+
+No receipt table is updated or deleted during recovery, expiry, or rollback.
+
+## Verification evidence
+
+The focused specialist-discovery suite was run locally with the Hermes project
+venv:
+
+```text
+pytest tests/gateway/test_capability_registry.py tests/gateway/test_candidate_profile_requests.py tests/gateway/test_specialist_routing.py tests/gateway/test_specialist_handoff_orchestration.py tests/agent/test_profile_candidate_review.py tests/agent/test_profile_benchmark.py tests/gateway/test_specialist_discovery_e2e.py -q
+```
+
+Result: `75 passed in 4.74s` (local diagnostic evidence only; no external
+adapter, provider, model, or live-trading action was invoked).

--- a/gateway/candidate_profile_requests.py
+++ b/gateway/candidate_profile_requests.py
@@ -1,0 +1,429 @@
+"""Local, inert candidate requests for missing specialist capabilities.
+
+This ledger deliberately has no provider, model, profile-creation, or dispatch
+dependency. A row is a bounded request for later human-governed review, never a
+profile that can receive work.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal
+
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature, RegistryResolution
+from hermes_cli import kanban_db
+
+
+CandidateRequestStatus = Literal["candidate", "duplicate", "cooldown", "rejected"]
+_LIFECYCLE_NONTERMINAL = frozenset({"candidate", "benchmarked", "verified", "staged", "active"})
+_LIFECYCLE_TERMINAL = frozenset({"rejected", "expired", "revoked"})
+_ALLOWED_LIFECYCLE_TRANSITIONS = {
+    "candidate": "benchmarked",
+    "benchmarked": "verified",
+    "verified": "staged",
+    "staged": "active",
+}
+_DEFAULT_COOLDOWN_SECONDS = 3_600
+_MAX_SOURCE_KEY_CHARS = 512
+_MAX_EVIDENCE_REFERENCES = 16
+_OPAQUE_REFERENCE_RE = re.compile(r"^[0-9a-f]{64}$")
+_REASON_CODE_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+_LOCAL_READ_ONLY_SCOPES: dict[str, tuple[frozenset[str], frozenset[str]]] = {
+    "financial-analysis": (
+        frozenset({"audit", "inspect", "read", "review", "validate"}),
+        frozenset({"financial-analysis:read"}),
+    ),
+    "market-data": (
+        frozenset({"audit", "inspect", "read", "review", "validate"}),
+        frozenset({"market-data:read"}),
+    ),
+    "repository-evidence": (
+        frozenset({"audit", "inspect", "read", "review", "validate"}),
+        frozenset({"repository-evidence:read"}),
+    ),
+    "research": (
+        frozenset({"audit", "read", "research", "review"}),
+        frozenset({"research:read"}),
+    ),
+}
+_POLICY = {
+    "external_egress": False,
+    "local_read_only_scopes": sorted(_LOCAL_READ_ONLY_SCOPES),
+    "profile_creation": False,
+    "requested_permissions": "explicit-local-read-only",
+    "sandbox_tasks": 1,
+}
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _hash(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+DEFAULT_POLICY_DIGEST = _hash(_POLICY)
+
+
+@dataclass(frozen=True, slots=True)
+class OpaqueEvidenceReference:
+    """A pre-hashed opaque evidence identity suitable for durable storage."""
+
+    digest: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.digest, str) or not _OPAQUE_REFERENCE_RE.fullmatch(self.digest):
+            raise ValueError("opaque evidence references must be SHA-256 hex digests")
+
+
+@dataclass(frozen=True, slots=True)
+class SanitizedTaskEnvelope:
+    """Only bounded opaque evidence digests may enter the candidate ledger."""
+
+    evidence_refs: tuple[OpaqueEvidenceReference, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateProfileRequest:
+    """Result of opening an inert candidate request, never a dispatch target."""
+
+    request_id: str
+    status: CandidateRequestStatus
+    profile_id: None
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateLifecycleSnapshot:
+    """The immutable scope and newest append-only state for one candidate."""
+
+    candidate_id: str
+    request_hash: str
+    signature_hash: str
+    permissions_hash: str
+    policy_digest: str
+    lifecycle_status: str
+
+
+def _capability_rejection_code(signature: CapabilitySignature) -> str | None:
+    scope = _LOCAL_READ_ONLY_SCOPES.get(signature.domain)
+    if scope is None or signature.evidence_class != "diagnostic-only":
+        return "unapproved_local_scope"
+    allowed_actions, allowed_permissions = scope
+    if not signature.actions or not set(signature.actions) <= allowed_actions:
+        return "non_read_only_action"
+    if not signature.requested_permissions or not set(signature.requested_permissions) <= allowed_permissions:
+        return "unapproved_permission"
+    return None
+
+
+def _result_reason(reason_code: str) -> str:
+    return {
+        "invalid_evidence_refs": "candidate requests store only sanitized evidence references",
+        "invalid_policy_digest": "candidate policy digest does not match the fixed local policy",
+        "non_read_only_action": "candidate requests require read-only actions",
+        "unapproved_local_scope": "candidate requests require an approved local read-only scope",
+        "unapproved_permission": "candidate requests require approved local read-only permissions",
+        "unresolved_scope": "candidate request requires a no-match or ambiguous local resolution",
+    }.get(reason_code, "candidate request rejected by fixed local policy")
+
+
+def _sanitize_evidence_refs(envelope: SanitizedTaskEnvelope | None) -> tuple[str, ...] | None:
+    if envelope is None:
+        return ()
+    if isinstance(envelope, SanitizedTaskEnvelope):
+        refs = envelope.evidence_refs
+    else:
+        return None
+    if not isinstance(refs, tuple) or len(refs) > _MAX_EVIDENCE_REFERENCES:
+        return None
+    normalized: list[str] = []
+    for reference in refs:
+        if not isinstance(reference, OpaqueEvidenceReference):
+            return None
+        normalized.append(reference.digest)
+    return tuple(sorted(set(normalized)))
+
+
+class CandidateProfileRequests:
+    """Open idempotent local candidate requests under a fixed least-privilege policy."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | None = None,
+        board: str | None = None,
+        cooldown_seconds: int = _DEFAULT_COOLDOWN_SECONDS,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if isinstance(cooldown_seconds, bool) or not isinstance(cooldown_seconds, int) or cooldown_seconds <= 0:
+            raise ValueError("cooldown_seconds must be a positive integer")
+        self._db_path = db_path
+        self._board = board
+        self._cooldown_seconds = cooldown_seconds
+        self._clock = clock
+
+    def open_or_reuse(
+        self,
+        signature: CapabilitySignature,
+        *,
+        source_key: str,
+        resolution: RegistryResolution | None = None,
+        envelope: SanitizedTaskEnvelope | None = None,
+        policy_digest: str = DEFAULT_POLICY_DIGEST,
+    ) -> CandidateProfileRequest:
+        """Create or reuse a request only after a concrete local no-match lookup.
+
+        ``resolution`` is retained temporarily for call-site compatibility but
+        is deliberately ignored. It is untrusted caller input and cannot
+        authorize candidate persistence; this method always resolves the
+        supplied signature against its own local Kanban-backed registry.
+        """
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        if not isinstance(source_key, str) or not source_key.strip() or len(source_key) > _MAX_SOURCE_KEY_CHARS:
+            raise ValueError("source_key must be a bounded non-empty string")
+        local_resolution = CapabilityRegistry(
+            db_path=self._db_path, board=self._board
+        ).resolve(signature)
+        if local_resolution.status not in {"no_match", "ambiguous"}:
+            return CandidateProfileRequest(
+                request_id="",
+                status="rejected",
+                profile_id=None,
+                reason="candidate request requires a local no-match or ambiguous resolution",
+            )
+        evidence_refs = _sanitize_evidence_refs(envelope)
+        reason_code = _capability_rejection_code(signature)
+        stored_policy_digest = DEFAULT_POLICY_DIGEST
+        if not isinstance(policy_digest, str) or policy_digest != DEFAULT_POLICY_DIGEST:
+            stored_policy_digest = _hash({"untrusted_policy_digest": policy_digest})
+            reason_code = "invalid_policy_digest"
+        if evidence_refs is None:
+            reason_code = "invalid_evidence_refs"
+
+        request_hash = _hash(
+            {
+                "policy_digest": stored_policy_digest,
+                "signature": {
+                    "actions": signature.actions,
+                    "domain": signature.domain,
+                    "evidence_class": signature.evidence_class,
+                    "requested_permissions": signature.requested_permissions,
+                },
+                "source_key": source_key,
+            }
+        )
+        return self._open_or_reuse_latest(
+            request_hash=request_hash,
+            signature=signature,
+            source_key=source_key,
+            policy_digest=stored_policy_digest,
+            evidence_ref_hashes=evidence_refs or (),
+            reason_code=reason_code,
+        )
+
+    def _open_or_reuse_latest(
+        self,
+        *,
+        request_hash: str,
+        signature: CapabilitySignature,
+        source_key: str,
+        policy_digest: str,
+        evidence_ref_hashes: tuple[str, ...],
+        reason_code: str | None,
+    ) -> CandidateProfileRequest:
+        now = int(self._clock())
+        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+            with kanban_db.write_txn(conn):
+                row = conn.execute(
+                    """
+                    SELECT request_id, lifecycle_status, cooldown_until
+                    FROM candidate_profile_requests
+                    WHERE request_hash = ?
+                    ORDER BY id DESC LIMIT 1
+                    """,
+                    (request_hash,),
+                ).fetchone()
+                if row is not None and row["lifecycle_status"] in _LIFECYCLE_TERMINAL:
+                    if isinstance(row["cooldown_until"], int) and now < row["cooldown_until"]:
+                        return CandidateProfileRequest(
+                            request_id=row["request_id"], status="cooldown", profile_id=None,
+                            reason="repeated terminal candidate request is in bounded cooldown",
+                        )
+                elif row is not None and row["lifecycle_status"] in _LIFECYCLE_NONTERMINAL:
+                    return CandidateProfileRequest(
+                        request_id=row["request_id"], status="duplicate", profile_id=None,
+                        reason="reused existing nonterminal inert candidate request",
+                    )
+                lifecycle_status = "rejected" if reason_code else "candidate"
+                cooldown_until = now + self._cooldown_seconds if reason_code else None
+                stored_reason_code = reason_code or "candidate_opened"
+                request_id = self._insert(
+                    conn, request_hash=request_hash, signature=signature, source_key=source_key,
+                    policy_digest=policy_digest, evidence_ref_hashes=evidence_ref_hashes,
+                    lifecycle_status=lifecycle_status, reason_code=stored_reason_code,
+                    cooldown_until=cooldown_until, now=now,
+                )
+        if reason_code:
+            return CandidateProfileRequest(
+                request_id=request_id, status="rejected", profile_id=None,
+                reason=_result_reason(reason_code),
+            )
+        return CandidateProfileRequest(
+            request_id=request_id, status="candidate", profile_id=None,
+            reason="local no-match queued for bounded inert candidate review",
+        )
+
+    def lifecycle_snapshot(self, candidate_id: str) -> CandidateLifecycleSnapshot | None:
+        """Read a candidate's latest state without treating a transition as mutable.
+
+        Lifecycle rows share the original request hash and are appended with a
+        derived request id.  The original candidate id remains the stable
+        receipt identity throughout promotion.
+        """
+        if not isinstance(candidate_id, str) or not candidate_id:
+            raise ValueError("candidate_id must be a non-empty string")
+        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+            original = conn.execute(
+                """
+                SELECT request_id, request_hash, signature_hash, permissions_hash, policy_digest
+                FROM candidate_profile_requests WHERE request_id = ?
+                """,
+                (candidate_id,),
+            ).fetchone()
+            if original is None:
+                return None
+            latest = conn.execute(
+                """
+                SELECT lifecycle_status FROM candidate_profile_requests
+                WHERE request_hash = ? ORDER BY id DESC LIMIT 1
+                """,
+                (original["request_hash"],),
+            ).fetchone()
+        if latest is None:
+            return None
+        return CandidateLifecycleSnapshot(
+            candidate_id=original["request_id"],
+            request_hash=original["request_hash"],
+            signature_hash=original["signature_hash"],
+            permissions_hash=original["permissions_hash"],
+            policy_digest=original["policy_digest"],
+            lifecycle_status=latest["lifecycle_status"],
+        )
+
+    def append_lifecycle_transition(
+        self,
+        candidate_id: str,
+        *,
+        expected_status: str,
+        next_status: str,
+        reason_code: str,
+        receipt_hash: str,
+    ) -> CandidateLifecycleSnapshot | None:
+        """Append one monotonic lifecycle observation, never update a candidate.
+
+        ``receipt_hash`` is intentionally opaque and only contributes to a
+        deterministic derived row id; it is not persisted as raw advisory or
+        benchmark content in the candidate ledger.
+        """
+        if _ALLOWED_LIFECYCLE_TRANSITIONS.get(expected_status) != next_status:
+            raise ValueError("candidate lifecycle transition is not permitted")
+        if not _REASON_CODE_RE.fullmatch(reason_code):
+            raise ValueError("reason_code must be a bounded canonical code")
+        if not _OPAQUE_REFERENCE_RE.fullmatch(receipt_hash):
+            raise ValueError("receipt_hash must be a SHA-256 hex digest")
+        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+            with kanban_db.write_txn(conn):
+                original = conn.execute(
+                    """
+                    SELECT request_id, request_hash, signature_hash, permissions_hash, source_key_hash,
+                           policy_digest, evidence_ref_hashes_json
+                    FROM candidate_profile_requests WHERE request_id = ?
+                    """,
+                    (candidate_id,),
+                ).fetchone()
+                if original is None:
+                    return None
+                latest = conn.execute(
+                    """
+                    SELECT lifecycle_status FROM candidate_profile_requests
+                    WHERE request_hash = ? ORDER BY id DESC LIMIT 1
+                    """,
+                    (original["request_hash"],),
+                ).fetchone()
+                if latest is None or latest["lifecycle_status"] != expected_status:
+                    return None
+                transition_id = (
+                    f"cpr_{original['request_hash'][:24]}_"
+                    f"{_hash((candidate_id, expected_status, next_status, receipt_hash))[:8]}"
+                )
+                conn.execute(
+                    """
+                    INSERT INTO candidate_profile_requests (
+                        request_id, request_hash, signature_hash, permissions_hash, source_key_hash,
+                        policy_digest, evidence_ref_hashes_json, lifecycle_status, reason_code,
+                        cooldown_until, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+                    """,
+                    (
+                        transition_id,
+                        original["request_hash"],
+                        original["signature_hash"],
+                        original["permissions_hash"],
+                        original["source_key_hash"],
+                        original["policy_digest"],
+                        original["evidence_ref_hashes_json"],
+                        next_status,
+                        reason_code,
+                        int(self._clock()),
+                    ),
+                )
+        return self.lifecycle_snapshot(candidate_id)
+
+    @staticmethod
+    def _insert(
+        conn: object,
+        *,
+        request_hash: str,
+        signature: CapabilitySignature,
+        source_key: str,
+        policy_digest: str,
+        evidence_ref_hashes: tuple[str, ...],
+        lifecycle_status: str,
+        reason_code: str,
+        cooldown_until: int | None,
+        now: int,
+    ) -> str:
+        if not _OPAQUE_REFERENCE_RE.fullmatch(request_hash):
+            raise ValueError("request_hash must be a SHA-256 hex digest")
+        if any(not _OPAQUE_REFERENCE_RE.fullmatch(value) for value in evidence_ref_hashes):
+            raise ValueError("evidence_ref_hashes must contain only SHA-256 hex digests")
+        if lifecycle_status not in _LIFECYCLE_NONTERMINAL | _LIFECYCLE_TERMINAL:
+            raise ValueError("lifecycle_status must be a declared candidate lifecycle state")
+        if not _OPAQUE_REFERENCE_RE.fullmatch(policy_digest):
+            policy_digest = _hash({"untrusted_policy_digest": policy_digest})
+        if not _REASON_CODE_RE.fullmatch(reason_code):
+            reason_code = "internal_rejection"
+        request_id = f"cpr_{request_hash[:24]}_{_hash((request_hash, lifecycle_status, now))[:8]}"
+        conn.execute(
+            """
+            INSERT INTO candidate_profile_requests (
+                request_id, request_hash, signature_hash, permissions_hash, source_key_hash,
+                policy_digest, evidence_ref_hashes_json, lifecycle_status, reason_code,
+                cooldown_until, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                request_id, request_hash, signature.signature_hash, signature.permissions_hash,
+                _hash(source_key), policy_digest, _canonical_json(evidence_ref_hashes),
+                lifecycle_status, reason_code, cooldown_until, now,
+            ),
+        )
+        return request_id

--- a/gateway/capability_registry.py
+++ b/gateway/capability_registry.py
@@ -1,0 +1,457 @@
+"""Local, fail-closed storage for specialist capability declarations.
+
+This module deliberately does not route, dispatch, or invoke model providers.
+It only persists locally verified declarations and resolves a supplied scope.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from hermes_cli import kanban_db
+
+
+_MAX_EXPIRY_TIMESTAMP = 253402300799  # 9999-12-31T23:59:59Z
+_RECEIPT_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+# Fixed baseline profiles are deployed configuration, not candidate output.
+# Keep their permitted diagnostic-only scope in this module so the registry can
+# validate registration without importing the router (which imports this
+# module).  Every generated profile must use durable-promotion evidence.
+_FIXED_BASELINE_SCOPES = {
+    "task-orchestrator": ("repository-evidence", ("audit", "inspect", "read", "review", "validate"), "repository-evidence:read"),
+    "burndown-patch-steward": ("repository-evidence", ("audit", "inspect", "read", "review", "validate"), "repository-evidence:read"),
+    "acceptance-gate-verifier": ("repository-evidence", ("audit", "inspect", "read", "review", "validate"), "repository-evidence:read"),
+    "paper-safety-guardian": ("financial-analysis", ("audit", "inspect", "read", "review", "validate"), "financial-analysis:read"),
+    "market-data-authority-auditor": ("market-data", ("audit", "inspect", "read", "review", "validate"), "market-data:read"),
+    "route-execution-boundary-auditor": ("repository-evidence", ("audit", "inspect", "read", "review", "validate"), "repository-evidence:read"),
+    "dependency-tooling-health-sentinel": ("repository-evidence", ("audit", "inspect", "read", "review", "validate"), "repository-evidence:read"),
+    "copilot-learning-steward": ("repository-evidence", ("audit", "inspect", "read", "review", "validate"), "repository-evidence:read"),
+    "mission-control-ux-auditor": ("repository-evidence", ("audit", "inspect", "read", "review", "validate"), "repository-evidence:read"),
+    "research-scout": ("research", ("audit", "read", "research", "review"), "research:read"),
+    "performance-sentinel": ("repository-evidence", ("audit", "inspect", "read", "review", "validate"), "repository-evidence:read"),
+}
+
+
+def _canonical_tokens(values: tuple[str, ...], *, field: str) -> tuple[str, ...]:
+    if isinstance(values, str):
+        raise TypeError(f"{field} must be a tuple of strings")
+    if any(not isinstance(value, str) or not value.strip() for value in values):
+        raise ValueError(f"{field} must contain only non-empty strings")
+    return tuple(sorted(set(values)))
+
+
+def _hash_payload(payload: object) -> str:
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilitySignature:
+    """Canonical scope that a specialist profile is allowed to advise on."""
+
+    domain: str
+    actions: tuple[str, ...]
+    evidence_class: str
+    requested_permissions: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.domain, str) or not self.domain.strip():
+            raise ValueError("domain must be a non-empty string")
+        if not isinstance(self.evidence_class, str) or not self.evidence_class.strip():
+            raise ValueError("evidence_class must be a non-empty string")
+        object.__setattr__(self, "actions", _canonical_tokens(self.actions, field="actions"))
+        object.__setattr__(
+            self,
+            "requested_permissions",
+            _canonical_tokens(self.requested_permissions, field="requested_permissions"),
+        )
+
+    @property
+    def signature_hash(self) -> str:
+        return _hash_payload(
+            {
+                "actions": self.actions,
+                "domain": self.domain,
+                "evidence_class": self.evidence_class,
+            }
+        )
+
+    @property
+    def permissions_hash(self) -> str:
+        return _hash_payload({"requested_permissions": self.requested_permissions})
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryResolution:
+    """A fail-closed registry result; only ``active_match`` has a profile."""
+
+    status: Literal["active_match", "no_match", "ambiguous", "unavailable"]
+    profile: str | None
+    reason: str
+
+
+def _expires_at_timestamp(expires_at: datetime | int | float | None) -> int | None:
+    if expires_at is None:
+        return None
+    if isinstance(expires_at, datetime):
+        if expires_at.tzinfo is None:
+            raise ValueError("expires_at datetime must be timezone-aware")
+        return int(expires_at.timestamp())
+    if isinstance(expires_at, bool) or not isinstance(expires_at, (int, float)):
+        raise TypeError("expires_at must be a timestamp or timezone-aware datetime")
+    return int(expires_at)
+
+
+def _is_unexpired_stored_timestamp(expires_at: object, *, now: int) -> bool:
+    """Return false for malformed SQLite expiry metadata rather than coercing it."""
+    if expires_at is None:
+        return True
+    if isinstance(expires_at, bool) or not isinstance(expires_at, int):
+        return False
+    return now < expires_at <= _MAX_EXPIRY_TIMESTAMP
+
+
+def _authenticated_operator_approval_authority_available() -> bool:
+    """Whether a separately verified operator-approval integration is wired.
+
+    Phase 0 has no such integration.  Keep this explicit predicate so a future
+    authenticated authority must change a narrow, reviewable boundary rather
+    than silently trusting the descriptive ``operator_identity`` field.
+    """
+    return False
+
+
+class CapabilityRegistry:
+    """Persist and resolve capability records in the local Kanban SQLite DB."""
+
+    def __init__(self, *, db_path: Path | None = None, board: str | None = None) -> None:
+        self._db_path = db_path
+        self._board = board
+
+    def register_fixed_baseline(
+        self,
+        *,
+        profile_id: str,
+        signature: CapabilitySignature,
+        expires_at: datetime | int | float | None = None,
+    ) -> None:
+        """Register one closed, configured baseline specialist declaration.
+
+        This is intentionally not a generic profile-registration API.  It
+        accepts only a profile and exact scope compiled into the fixed routing
+        baseline; generated profiles can only reach active state through
+        :meth:`add_active_from_durable_promotion`.
+        """
+        fixed_scope = _FIXED_BASELINE_SCOPES.get(profile_id)
+        if fixed_scope is None:
+            raise ValueError("profile_id is not a fixed baseline specialist")
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        domain, allowed_actions, permission = fixed_scope
+        if (
+            signature.domain != domain
+            or signature.evidence_class != "diagnostic-only"
+            or not signature.actions
+            or not set(signature.actions) <= set(allowed_actions)
+            or not signature.requested_permissions
+            or not set(signature.requested_permissions) <= {permission}
+        ):
+            raise ValueError("fixed baseline profile scope does not match its closed declaration")
+        self._append_active(
+            profile_id=profile_id,
+            signature=signature,
+            model_receipt_hash="",
+            verification_receipt_hash="",
+            expires_at=expires_at,
+        )
+
+    def add_active(self, **_: object) -> None:
+        """Reject the former public arbitrary-profile activation API."""
+        raise ValueError(
+            "direct arbitrary active profile registration is disabled; use fixed baseline or durable promotion"
+        )
+
+    def _append_active(
+        self,
+        *,
+        profile_id: str,
+        signature: CapabilitySignature,
+        model_receipt_hash: str,
+        verification_receipt_hash: str,
+        expires_at: datetime | int | float | None,
+    ) -> None:
+        """Internal persistence primitive reached only by closed gate paths."""
+
+        expires_at_timestamp = _expires_at_timestamp(expires_at)
+        created_at = int(time.time())
+        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+            with kanban_db.write_txn(conn):
+                conn.execute(
+                    """
+                    INSERT INTO capability_profiles (
+                        profile_id, signature_hash, permissions_hash,
+                        model_receipt_hash, verification_receipt_hash,
+                        domain, actions_json, evidence_class, requested_permissions_json,
+                        expires_at, status, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)
+                    """,
+                    (
+                        profile_id,
+                        signature.signature_hash,
+                        signature.permissions_hash,
+                        model_receipt_hash,
+                        verification_receipt_hash,
+                        signature.domain,
+                        json.dumps(signature.actions, separators=(",", ":")),
+                        signature.evidence_class,
+                        json.dumps(signature.requested_permissions, separators=(",", ":")),
+                        expires_at_timestamp,
+                        created_at,
+                    ),
+                )
+
+    def add_active_from_promotion(
+        self,
+        *,
+        profile_id: str,
+        signature: CapabilitySignature,
+        benchmark_receipt_hash: str,
+        verification_receipt_hash: str,
+        expires_at: datetime | int | float | None = None,
+    ) -> None:
+        """Disabled unsafe compatibility entry point.
+
+        Hash-shaped strings alone are not authorization.  The only promotion
+        entry point is :meth:`add_active_from_durable_promotion`, which reads
+        and validates immutable board-local proof, receipt, sandbox, and
+        approval rows before delegating to the fixed-profile append path.
+        """
+        del profile_id, signature, benchmark_receipt_hash, verification_receipt_hash, expires_at
+        raise ValueError("hash-only promotion is disabled; use durable promotion proof")
+
+    def add_active_from_durable_promotion(
+        self,
+        *,
+        profile_id: str,
+        signature: CapabilitySignature,
+        candidate_id: str,
+        promotion_proof_hash: str,
+        expires_at: datetime | int | float | None = None,
+        now: int | None = None,
+    ) -> None:
+        """Derive an active profile from a stored active-promotion proof only."""
+        if not isinstance(candidate_id, str) or not candidate_id:
+            raise ValueError("candidate_id must be a non-empty string")
+        if not isinstance(promotion_proof_hash, str) or not _RECEIPT_HASH_RE.fullmatch(promotion_proof_hash):
+            raise ValueError("promotion_proof_hash must be a SHA-256 hex digest")
+        # No authenticated, operator-controlled approval authority is wired in
+        # this integration.  Refuse even a durable-looking legacy proof rather
+        # than treating a historical identity string as authorization.
+        if not _authenticated_operator_approval_authority_available():
+            raise ValueError("authenticated operator approval authority is unavailable")
+        # The durable validation below is retained as the future gate once an
+        # authenticated approval authority is separately integrated.
+        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+            proof = conn.execute(
+                """
+                SELECT benchmark_result_hash, verification_result_hash, approval_hash
+                FROM specialist_promotion_proofs
+                WHERE proof_hash = ? AND candidate_id = ? AND target_state = 'active'
+                  AND profile_id = ? AND signature_hash = ? AND permissions_hash = ?
+                """,
+                (promotion_proof_hash, candidate_id, profile_id, signature.signature_hash, signature.permissions_hash),
+            ).fetchone()
+            if proof is None:
+                raise ValueError("no durable authorized active-promotion proof")
+            benchmark = conn.execute(
+                """
+                SELECT proposal_author, sol_reviewer, scorer_model, status, expires_at
+                FROM specialist_benchmark_receipts
+                WHERE result_hash = ? AND candidate_id = ?
+                """,
+                (proof["benchmark_result_hash"], candidate_id),
+            ).fetchone()
+            verification = conn.execute(
+                """
+                SELECT verifier_identity, sandbox_id, status, expires_at
+                FROM specialist_verification_receipts
+                WHERE result_hash = ? AND candidate_id = ? AND benchmark_result_hash = ?
+                """,
+                (proof["verification_result_hash"], candidate_id, proof["benchmark_result_hash"]),
+            ).fetchone()
+            now = int(time.time()) if now is None else now
+            if isinstance(now, bool) or not isinstance(now, int):
+                raise ValueError("now must be an integer timestamp")
+            if (
+                benchmark is None
+                or verification is None
+                or benchmark["status"] != "passed"
+                or verification["status"] != "verified"
+                or not _is_unexpired_stored_timestamp(benchmark["expires_at"], now=now)
+                or not _is_unexpired_stored_timestamp(verification["expires_at"], now=now)
+                or benchmark["scorer_model"] in {benchmark["proposal_author"], benchmark["sol_reviewer"]}
+                or verification["verifier_identity"]
+                in {benchmark["proposal_author"], benchmark["sol_reviewer"], benchmark["scorer_model"]}
+            ):
+                raise ValueError("durable benchmark or independent verification is invalid")
+            sandbox = conn.execute(
+                """
+                SELECT 1 FROM specialist_sandbox_runs
+                WHERE sandbox_id = ? AND candidate_id = ? AND benchmark_result_hash = ?
+                  AND disposable = 1 AND task_count = 1
+                """,
+                (verification["sandbox_id"], candidate_id, proof["benchmark_result_hash"]),
+            ).fetchone()
+            if sandbox is None:
+                raise ValueError("durable disposable sandbox record is missing")
+            approval = conn.execute(
+                """
+                SELECT 1 FROM specialist_operator_approvals
+                WHERE approval_hash = ? AND candidate_id = ? AND target_state = 'active'
+                  AND verification_result_hash = ? AND approved = 1
+                """,
+                (proof["approval_hash"], candidate_id, proof["verification_result_hash"]),
+            ).fetchone()
+            if approval is None:
+                raise ValueError("durable active approval is missing")
+            canary = conn.execute(
+                """
+                SELECT 1 FROM specialist_canary_receipts
+                WHERE candidate_id = ? AND verification_result_hash = ?
+                  AND mode = 'local-no-send' AND status = 'passed'
+                """,
+                (candidate_id, proof["verification_result_hash"]),
+            ).fetchone()
+            if canary is None:
+                raise ValueError("durable local no-send canary is missing")
+        self._append_active(
+            profile_id=profile_id,
+            signature=signature,
+            model_receipt_hash=proof["benchmark_result_hash"],
+            verification_receipt_hash=proof["verification_result_hash"],
+            expires_at=expires_at,
+        )
+
+    def revoke(
+        self,
+        *,
+        profile_id: str,
+        signature: CapabilitySignature,
+        reason_code: str,
+        now: int | None = None,
+    ) -> str:
+        """Append a local rollback receipt that immediately removes a profile.
+
+        Revocation is deliberately a separate immutable record rather than an
+        update to ``capability_profiles``.  It performs no dispatch, adapter,
+        model, or external action; callers must explicitly issue it.
+        """
+        if not isinstance(profile_id, str) or not profile_id.strip():
+            raise ValueError("profile_id must be a non-empty string")
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+        if not isinstance(reason_code, str) or not re.fullmatch(r"[a-z0-9_]{1,64}", reason_code):
+            raise ValueError("reason_code must be a bounded canonical code")
+        created_at = int(time.time()) if now is None else now
+        if isinstance(created_at, bool) or not isinstance(created_at, int):
+            raise ValueError("now must be an integer timestamp")
+        revocation_hash = _hash_payload(
+            {
+                "profile_id": profile_id,
+                "reason_code": reason_code,
+                "signature_hash": signature.signature_hash,
+            }
+        )
+        with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+            with kanban_db.write_txn(conn):
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO specialist_profile_revocations (
+                        revocation_hash, profile_id, signature_hash, reason_code, created_at
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (revocation_hash, profile_id, signature.signature_hash, reason_code, created_at),
+                )
+        return revocation_hash
+
+    def resolve(self, signature: CapabilitySignature) -> RegistryResolution:
+        """Resolve exactly one active, unexpired, non-expanding local profile."""
+        if not isinstance(signature, CapabilitySignature):
+            raise TypeError("signature must be a CapabilitySignature")
+
+        try:
+            now = int(time.time())
+            with kanban_db.connect_closing(self._db_path, board=self._board) as conn:
+                rows = conn.execute(
+                    """
+                    SELECT profile_id, signature_hash, permissions_hash, domain,
+                           actions_json, evidence_class, requested_permissions_json, expires_at
+                    FROM capability_profiles AS profiles
+                    WHERE status = 'active'
+                      AND signature_hash = ?
+                      AND evidence_class = ?
+                      AND NOT EXISTS (
+                          SELECT 1 FROM specialist_profile_revocations AS revocations
+                          WHERE revocations.profile_id = profiles.profile_id
+                            AND revocations.signature_hash = profiles.signature_hash
+                      )
+                    ORDER BY profile_id, id
+                    """,
+                    (signature.signature_hash, signature.evidence_class),
+                ).fetchall()
+        except Exception as exc:
+            return RegistryResolution(
+                status="unavailable",
+                profile=None,
+                reason=f"local capability registry unavailable: {type(exc).__name__}",
+            )
+
+        matches: list[str] = []
+        requested_permissions = set(signature.requested_permissions)
+        for row in rows:
+            if not _is_unexpired_stored_timestamp(row["expires_at"], now=now):
+                continue
+            try:
+                stored_signature = CapabilitySignature(
+                    domain=row["domain"],
+                    actions=tuple(json.loads(row["actions_json"])),
+                    evidence_class=row["evidence_class"],
+                    requested_permissions=tuple(json.loads(row["requested_permissions_json"])),
+                )
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if (
+                stored_signature.signature_hash != row["signature_hash"]
+                or stored_signature.permissions_hash != row["permissions_hash"]
+                or stored_signature.domain != signature.domain
+                or stored_signature.actions != signature.actions
+                or not set(stored_signature.requested_permissions) <= requested_permissions
+            ):
+                continue
+            matches.append(row["profile_id"])
+
+        if len(matches) == 1:
+            return RegistryResolution(
+                status="active_match",
+                profile=matches[0],
+                reason="exact active capability profile matched locally",
+            )
+        if len(matches) > 1:
+            return RegistryResolution(
+                status="ambiguous",
+                profile=None,
+                reason="multiple active capability profiles matched the requested scope",
+            )
+        return RegistryResolution(
+            status="no_match",
+            profile=None,
+            reason="no active unexpired profile matched the requested scope",
+        )

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1713,6 +1713,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.DISCORD and "specialist_routing" in platform_cfg:
+                    bridged["specialist_routing"] = platform_cfg["specialist_routing"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:

--- a/gateway/configured_board.py
+++ b/gateway/configured_board.py
@@ -1,0 +1,21 @@
+"""Canonical paths for explicitly configured gateway Kanban boards."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_BOARD_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def configured_board_db_path(board: object) -> Path:
+    """Resolve one explicit board without honoring the per-process DB override."""
+    if not isinstance(board, str) or not _BOARD_RE.fullmatch(board):
+        raise ValueError("an explicit valid Kanban board is required")
+
+    from hermes_cli import kanban_db as kb
+
+    if board == kb.DEFAULT_BOARD:
+        return kb.kanban_home().expanduser() / "kanban.db"
+    return kb.boards_root().expanduser() / board / "kanban.db"

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -263,7 +263,11 @@ class GatewayKanbanWatchersMixin:
         # but is not a block (see kanban_db.request_review); the task is not
         # archived, so the subscription stays alive and later review
         # cycles keep notifying.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested", "changes_requested")
+        TERMINAL_KINDS = (
+            "completed", "blocked", "gave_up", "crashed", "timed_out",
+            "status", "archived", "unblocked", "block_loop_detected",
+            "review_requested", "changes_requested", "decomposed",
+        )
         # Subscriptions are removed only when the task reaches the irreversible
         # archived status. ``done`` is reversible in review/controller flows,
         # so removing its subscription would silence a later reopen. We used
@@ -633,6 +637,14 @@ class GatewayKanbanWatchersMixin:
                             if ev.payload and ev.payload.get("status"):
                                 new_status = str(ev.payload["status"])
                             msg = f"🔄 {board_tag}{tag}Kanban {sub['task_id']} → {new_status}"
+                        elif kind == "decomposed":
+                            child_ids = ev.payload.get("child_ids") if ev.payload else []
+                            worker_count = len(child_ids) if isinstance(child_ids, list) else 0
+                            plural = "s" if worker_count != 1 else ""
+                            msg = (
+                                f"🧭 {board_tag}Kanban {sub['task_id']} planned "
+                                f"{worker_count} coordinated worker{plural}"
+                            )
                         elif kind == "review_requested":
                             # Implementation complete; task moved to the
                             # first-class review lane. Wake the origin thread.

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -118,6 +118,34 @@ async def _to_thread_process_service(func: Callable[..., Any], /, *args: Any) ->
     return await asyncio.to_thread(_run_in_fresh_context, func, *args)
 
 
+def _format_gave_up_notification(
+    *,
+    board_tag: str,
+    tag: str,
+    task_id: str,
+    payload: Optional[dict],
+) -> str:
+    """Render a truthful terminal notice for any circuit-breaker cause."""
+    payload = payload or {}
+    trigger = str(payload.get("trigger_outcome") or "")
+    error = str(payload.get("error") or "")[:200]
+    if trigger == "timed_out" and payload.get("budget_used") is not None:
+        used = payload["budget_used"]
+        maximum = payload.get("budget_max", "?")
+        return (
+            f"✖ {board_tag}{tag}Kanban {task_id} gave up: iteration budget "
+            f"exhausted ({used}/{maximum}) after repeated attempts"
+        )
+    if trigger == "spawn_failed":
+        reason = "after repeated spawn failures"
+    elif trigger:
+        reason = f"after repeated {trigger} failures"
+    else:
+        reason = "after repeated worker failures"
+    suffix = f"\n{error}" if error else ""
+    return f"✖ {board_tag}{tag}Kanban {task_id} gave up {reason}{suffix}"
+
+
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
 
@@ -612,12 +640,11 @@ class GatewayKanbanWatchersMixin:
                                 reason = f": {str(ev.payload['reason'])[:160]}"
                             msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
-                            err = ""
-                            if ev.payload and ev.payload.get("error"):
-                                err = f"\n{str(ev.payload['error'])[:200]}"
-                            msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                            msg = _format_gave_up_notification(
+                                board_tag=board_tag,
+                                tag=tag,
+                                task_id=sub["task_id"],
+                                payload=ev.payload,
                             )
                         elif kind == "crashed":
                             msg = (

--- a/gateway/lifecycle_ledger.py
+++ b/gateway/lifecycle_ledger.py
@@ -41,10 +41,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sqlite3
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, NamedTuple, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -330,3 +331,209 @@ def read_prior_exit_label(profile_home: Path) -> str:
     except Exception:
         pass
     return "unknown"
+
+
+# Specialist discovery uses the Kanban SQLite ledger rather than this process
+# sentinel.  The read model lives here because it has the same crucial
+# property: it is reconstructed from append-only durable evidence at startup,
+# rather than replaying a model/advisory operation after a restart.
+class SpecialistLifecycleRow(NamedTuple):
+    """One sanitized, durable specialist-discovery lifecycle observation."""
+
+    stage: str
+    status: str
+    receipt_hash: Optional[str] = None
+    expires_at: Optional[int] = None
+
+
+class SpecialistDiscoveryRecovery(NamedTuple):
+    """Read-only recovery/status result for one candidate request."""
+
+    candidate_id: str
+    rows: tuple[SpecialistLifecycleRow, ...]
+    recovery_action: str
+
+
+def _specialist_rows_query(conn: Any, candidate_id: str, now: int) -> tuple[SpecialistLifecycleRow, ...]:
+    """Read only the immutable receipts that belong to a candidate.
+
+    The function deliberately has no callback parameter.  A restart must
+    never cause an advisory, benchmark, sandbox, or canary to run again.
+    """
+    candidate = conn.execute(
+        """
+        SELECT request_hash, lifecycle_status FROM candidate_profile_requests
+        WHERE request_id = ?
+        """,
+        (candidate_id,),
+    ).fetchone()
+    if candidate is None:
+        return (SpecialistLifecycleRow("candidate_request", "missing"),)
+    latest_candidate = conn.execute(
+        """
+        SELECT lifecycle_status FROM candidate_profile_requests
+        WHERE request_hash = ? ORDER BY id DESC LIMIT 1
+        """,
+        (candidate["request_hash"],),
+    ).fetchone()
+    rows: list[SpecialistLifecycleRow] = [
+        SpecialistLifecycleRow(
+            "candidate_request",
+            latest_candidate["lifecycle_status"] if latest_candidate is not None else candidate["lifecycle_status"],
+            candidate_id,
+        )
+    ]
+    source_rows = conn.execute(
+        "SELECT body, status FROM tasks WHERE body LIKE ? ORDER BY created_at DESC",
+        (f'%"candidate_request_id": "{candidate_id}"%',),
+    ).fetchall()
+    source_status = "not_found"
+    for source in source_rows:
+        try:
+            payload = json.loads(source["body"] or "")
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict) and payload.get("candidate_request_id") == candidate_id:
+            source_status = str(source["status"])
+            break
+    rows.insert(0, SpecialistLifecycleRow("source_task", source_status))
+    latest_benchmark = conn.execute(
+        """
+        SELECT result_hash, status, expires_at FROM specialist_benchmark_receipts
+        WHERE candidate_id = ? ORDER BY id DESC LIMIT 1
+        """,
+        (candidate_id,),
+    ).fetchone()
+    if latest_benchmark is not None:
+        benchmark_status = latest_benchmark["status"]
+        if now >= latest_benchmark["expires_at"]:
+            benchmark_status = "expired"
+        rows.append(
+            SpecialistLifecycleRow(
+                "benchmark", benchmark_status, latest_benchmark["result_hash"], latest_benchmark["expires_at"]
+            )
+        )
+    sandbox = conn.execute(
+        """
+        SELECT benchmark_result_hash, disposable, task_count FROM specialist_sandbox_runs
+        WHERE candidate_id = ? ORDER BY id DESC LIMIT 1
+        """,
+        (candidate_id,),
+    ).fetchone()
+    if sandbox is not None:
+        status = "verified_shape" if sandbox["disposable"] == 1 and sandbox["task_count"] == 1 else "rejected"
+        rows.append(SpecialistLifecycleRow("sandbox", status, sandbox["benchmark_result_hash"]))
+    verification = conn.execute(
+        """
+        SELECT result_hash, status, expires_at FROM specialist_verification_receipts
+        WHERE candidate_id = ? ORDER BY id DESC LIMIT 1
+        """,
+        (candidate_id,),
+    ).fetchone()
+    if verification is not None:
+        verification_status = verification["status"]
+        if now >= verification["expires_at"]:
+            verification_status = "expired"
+        rows.append(
+            SpecialistLifecycleRow(
+                "verification", verification_status, verification["result_hash"], verification["expires_at"]
+            )
+        )
+    canary = conn.execute(
+        """
+        SELECT result_hash, status FROM specialist_canary_receipts
+        WHERE candidate_id = ? ORDER BY id DESC LIMIT 1
+        """,
+        (candidate_id,),
+    ).fetchone()
+    rows.append(
+        SpecialistLifecycleRow("canary", canary["status"] if canary is not None else "not_run", canary["result_hash"] if canary else None)
+    )
+    approvals = conn.execute(
+        """
+        SELECT target_state, approval_hash FROM specialist_operator_approvals
+        WHERE candidate_id = ? AND approved = 1 ORDER BY id
+        """,
+        (candidate_id,),
+    ).fetchall()
+    approved_targets = {row["target_state"] for row in approvals}
+    rows.append(SpecialistLifecycleRow("staged_approval", "approved" if "staged" in approved_targets else "missing"))
+    rows.append(SpecialistLifecycleRow("active_approval", "approved" if "active" in approved_targets else "missing"))
+    profile = conn.execute(
+        """
+        SELECT profile_id, signature_hash, expires_at FROM capability_profiles
+        WHERE model_receipt_hash IN (
+            SELECT result_hash FROM specialist_benchmark_receipts WHERE candidate_id = ?
+        ) AND verification_receipt_hash IN (
+            SELECT result_hash FROM specialist_verification_receipts WHERE candidate_id = ?
+        ) ORDER BY id DESC LIMIT 1
+        """,
+        (candidate_id, candidate_id),
+    ).fetchone()
+    if profile is not None:
+        revoked = conn.execute(
+            """
+            SELECT revocation_hash FROM specialist_profile_revocations
+            WHERE profile_id = ? AND signature_hash = ? ORDER BY id DESC LIMIT 1
+            """,
+            (profile["profile_id"], profile["signature_hash"]),
+        ).fetchone()
+        if revoked is not None:
+            rows.append(SpecialistLifecycleRow("rollback", "revoked", revoked["revocation_hash"]))
+            rows.append(SpecialistLifecycleRow("active_profile", "revoked"))
+        elif profile["expires_at"] is not None and now >= profile["expires_at"]:
+            rows.append(SpecialistLifecycleRow("expiry", "expired", expires_at=profile["expires_at"]))
+            rows.append(SpecialistLifecycleRow("active_profile", "expired", expires_at=profile["expires_at"]))
+        else:
+            rows.append(SpecialistLifecycleRow("active_profile", "active"))
+    else:
+        rows.append(SpecialistLifecycleRow("active_profile", "not_active"))
+    return tuple(rows)
+
+
+def recover_specialist_discovery(
+    candidate_id: str, *, db_path: Optional[Path] = None, board: Optional[str] = None, now: Optional[int] = None
+) -> SpecialistDiscoveryRecovery:
+    """Reconcile one candidate exclusively from append-only local evidence.
+
+    Recovery never retries advisory/benchmark work and never dispatches or
+    activates a profile.  Expired/revoked results explicitly direct the caller
+    to the normal task-orchestrator/triage fallback.
+    """
+    if not isinstance(candidate_id, str) or not candidate_id:
+        raise ValueError("candidate_id must be a non-empty string")
+    if now is None:
+        now = int(time.time())
+    if isinstance(now, bool) or not isinstance(now, int):
+        raise ValueError("now must be an integer timestamp")
+    try:
+        from hermes_cli import kanban_db
+
+        path = Path(db_path) if db_path is not None else kanban_db.kanban_db_path(board=board)
+        # `mode=ro` is critical here: the normal Kanban connect helper can
+        # initialize/migrate a DB and create WAL sidecars. Recovery must refuse
+        # a missing/uninitialized ledger rather than making evidence appear.
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        # Always use a fresh ``mode=ro`` snapshot for a mutable Hermes ledger.
+        # Choosing a mode from a prior WAL-path observation races a writer that
+        # commits a revocation immediately afterwards. SQLite may attach or
+        # create a ``-shm`` mapping while observing WAL state, but this reader
+        # never writes the main database or WAL. Any read failure is normal
+        # triage rather than a stale active resolution.
+        uri = f"{path.resolve().as_uri()}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = _specialist_rows_query(conn, candidate_id, now)
+        finally:
+            conn.close()
+    except Exception as exc:
+        return SpecialistDiscoveryRecovery(
+            candidate_id,
+            (SpecialistLifecycleRow("ledger", f"unavailable:{type(exc).__name__}"),),
+            "normal_triage",
+        )
+    active = next((row for row in rows if row.stage == "active_profile"), None)
+    action = "active_resolution" if active and active.status == "active" else "task_orchestrator"
+    return SpecialistDiscoveryRecovery(candidate_id, rows, action)

--- a/gateway/operator_approval_authority.py
+++ b/gateway/operator_approval_authority.py
@@ -1,0 +1,44 @@
+"""Authenticated dashboard identity boundary for specialist promotion.
+
+The legacy loopback dashboard token proves only that a caller knows a
+process-local bearer secret.  It cannot identify a human operator.  Promotion
+therefore accepts an identity only from the verified dashboard-auth session in
+gated mode and only when that identity appears in the operator's explicit
+allowlist.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def dashboard_session_subject(session: Any, *, auth_required: bool) -> str | None:
+    """Return the verified dashboard session's stable subject, if any."""
+    if not auth_required or session is None:
+        return None
+    provider = getattr(session, "provider", None)
+    user_id = getattr(session, "user_id", None)
+    if not isinstance(provider, str) or not provider.strip():
+        return None
+    if not isinstance(user_id, str) or not user_id.strip():
+        return None
+    return f"{provider.strip()}:{user_id.strip()}"
+
+
+def authenticated_operator_identity(
+    session: Any,
+    *,
+    auth_required: bool,
+    allowed_subjects: Iterable[str],
+) -> str | None:
+    """Return an allowlisted authenticated subject, otherwise fail closed."""
+    subject = dashboard_session_subject(session, auth_required=auth_required)
+    if subject is None:
+        return None
+    configured = {
+        value.strip()
+        for value in allowed_subjects
+        if isinstance(value, str) and value.strip()
+    }
+    return subject if subject in configured else None

--- a/gateway/specialist_handoff.py
+++ b/gateway/specialist_handoff.py
@@ -1,0 +1,118 @@
+"""Transactional, deterministic Kanban handoff for specialist routing."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+from gateway.configured_board import configured_board_db_path
+from gateway.specialist_routing import SpecialistRouteDecision
+
+
+_ORCHESTRATION_GOAL_MAX_TURNS = 12
+
+
+@dataclass(frozen=True)
+class HandoffSource:
+    """Trusted source fields needed to create a task notification route."""
+
+    platform: str
+    chat_id: str
+    chat_type: str
+    user_id: Optional[str]
+    message_id: str
+    guild_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    user_id_alt: Optional[str] = None
+    notifier_profile: Optional[str] = None
+    session_id: Optional[str] = None
+    delivery_metadata: Optional[dict] = None
+
+
+@dataclass(frozen=True)
+class HandoffResult:
+    ok: bool
+    task_id: Optional[str] = None
+    created: bool = False
+    reason: str = ""
+
+
+def _idempotency_key(source: HandoffSource) -> Optional[str]:
+    if not source.message_id or not source.platform or not source.chat_id:
+        return None
+    return "specialist-routing:" + ":".join(
+        (source.platform, source.guild_id or "", source.chat_id, source.thread_id or "", source.message_id)
+    )
+
+
+def _body(*, decision: SpecialistRouteDecision, source: HandoffSource, request: str, router_model: str) -> str:
+    return json.dumps(
+        {
+            "schema": "specialist_routing.v1",
+            "request": request[:4_000],
+            "profile": decision.profile,
+            "confidence": decision.confidence,
+            "reason": decision.reason,
+            "router_model": router_model or "configured_auxiliary",
+            "ingress": {
+                "platform": source.platform,
+                "guild_id": source.guild_id,
+                "chat_id": source.chat_id,
+                "thread_id": source.thread_id,
+                "message_id": source.message_id,
+                "user_id": source.user_id,
+            },
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+def create_specialist_handoff(*, decision: SpecialistRouteDecision, source: HandoffSource, request: str, router_model: str = "", board: Optional[str] = None) -> HandoffResult:
+    """Create a subscribed, durable triage root for specialist orchestration."""
+    if not decision.dispatches:
+        return HandoffResult(False, reason="non_dispatch_decision")
+    if not source.platform or not source.chat_id or not source.message_id:
+        return HandoffResult(False, reason="incomplete_source")
+    if not isinstance(request, str) or not request.strip():
+        return HandoffResult(False, reason="empty_request")
+    try:
+        from hermes_cli import kanban_db as kb
+        from hermes_cli.profiles import profile_exists
+
+        if not profile_exists(decision.profile):
+            return HandoffResult(False, reason="profile_unavailable")
+
+        key = _idempotency_key(source)
+        conn = kb.connect(db_path=configured_board_db_path(board), board=board)
+        try:
+            existing_id = None
+            if key:
+                row = conn.execute(
+                    "SELECT id FROM tasks WHERE idempotency_key = ? AND status != 'archived' ORDER BY created_at DESC LIMIT 1",
+                    (key,),
+                ).fetchone()
+                existing_id = row["id"] if row else None
+            with kb.write_txn(conn):
+                task_id = kb.create_task(
+                    conn, title=decision.title,
+                    body=_body(decision=decision, source=source, request=request, router_model=router_model),
+                    assignee=decision.profile, created_by="specialist-routing",
+                    idempotency_key=key, session_id=source.session_id, board=board,
+                    triage=True,
+                    goal_mode=True,
+                    goal_max_turns=_ORCHESTRATION_GOAL_MAX_TURNS,
+                )
+                kb.add_notify_sub(
+                    conn, task_id=task_id, platform=source.platform, chat_id=source.chat_id,
+                    chat_type=source.chat_type, thread_id=source.thread_id,
+                    user_id=source.user_id, user_id_alt=source.user_id_alt,
+                    notifier_profile=source.notifier_profile, delivery_mode="notify",
+                    delivery_metadata=source.delivery_metadata, allow_nested=True,
+                )
+            return HandoffResult(True, task_id=task_id, created=existing_id is None)
+        finally:
+            conn.close()
+    except Exception as exc:
+        return HandoffResult(False, reason=f"handoff_error:{type(exc).__name__}")

--- a/gateway/specialist_handoff.py
+++ b/gateway/specialist_handoff.py
@@ -3,11 +3,24 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+import hashlib
+from dataclasses import dataclass, replace
 from typing import Optional
 
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature, RegistryResolution
+from gateway.candidate_profile_requests import (
+    CandidateProfileRequest,
+    CandidateProfileRequests,
+    OpaqueEvidenceReference,
+    SanitizedTaskEnvelope,
+)
 from gateway.configured_board import configured_board_db_path
-from gateway.specialist_routing import SpecialistRouteDecision
+from gateway.specialist_routing import (
+    SPECIALIST_PROFILES,
+    SpecialistRouteDecision,
+    apply_registry_resolution,
+    resolve_registry,
+)
 
 
 _ORCHESTRATION_GOAL_MAX_TURNS = 12
@@ -36,6 +49,8 @@ class HandoffResult:
     task_id: Optional[str] = None
     created: bool = False
     reason: str = ""
+    candidate_request_id: Optional[str] = None
+    candidate_status: Optional[str] = None
 
 
 def _idempotency_key(source: HandoffSource) -> Optional[str]:
@@ -46,32 +61,128 @@ def _idempotency_key(source: HandoffSource) -> Optional[str]:
     )
 
 
-def _body(*, decision: SpecialistRouteDecision, source: HandoffSource, request: str, router_model: str) -> str:
-    return json.dumps(
-        {
-            "schema": "specialist_routing.v1",
-            "request": request[:4_000],
-            "profile": decision.profile,
-            "confidence": decision.confidence,
-            "reason": decision.reason,
-            "router_model": router_model or "configured_auxiliary",
-            "ingress": {
-                "platform": source.platform,
-                "guild_id": source.guild_id,
-                "chat_id": source.chat_id,
-                "thread_id": source.thread_id,
-                "message_id": source.message_id,
-                "user_id": source.user_id,
-            },
+def _body(
+    *,
+    decision: SpecialistRouteDecision,
+    source: HandoffSource,
+    request: str,
+    router_model: str,
+    candidate_request_id: str | None = None,
+) -> str:
+    payload = {
+        "schema": "specialist_routing.v1",
+        "request": request[:4_000],
+        "profile": decision.profile,
+        "confidence": decision.confidence,
+        "reason": decision.reason,
+        "router_model": router_model or "configured_auxiliary",
+        "ingress": {
+            "platform": source.platform,
+            "guild_id": source.guild_id,
+            "chat_id": source.chat_id,
+            "thread_id": source.thread_id,
+            "message_id": source.message_id,
+            "user_id": source.user_id,
         },
-        ensure_ascii=False,
-        sort_keys=True,
+    }
+    if candidate_request_id:
+        payload["candidate_request_id"] = candidate_request_id
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def _candidate_source_ref(source_key: str) -> OpaqueEvidenceReference:
+    """Return an opaque source reference; candidate storage never gets ingress IDs."""
+    return OpaqueEvidenceReference(
+        digest=hashlib.sha256(source_key.encode("utf-8")).hexdigest()
     )
 
 
-def create_specialist_handoff(*, decision: SpecialistRouteDecision, source: HandoffSource, request: str, router_model: str = "", board: Optional[str] = None) -> HandoffResult:
+def _candidate_fallback(
+    *,
+    decision: SpecialistRouteDecision,
+    signature: CapabilitySignature | None,
+    resolution: RegistryResolution | None,
+    source_key: str,
+    db_path: object,
+    candidate_requests: CandidateProfileRequests | None,
+) -> tuple[SpecialistRouteDecision, CandidateProfileRequest | None]:
+    """Queue a no-match locally and retain the source task's safe known owner."""
+    if resolution is None or resolution.status not in {"no_match", "ambiguous"}:
+        return decision, None
+
+    fallback = replace(decision, profile="task-orchestrator")
+    if signature is None:
+        return fallback, None
+    try:
+        requests = candidate_requests or CandidateProfileRequests(db_path=db_path)
+        result = requests.open_or_reuse(
+            signature,
+            source_key=source_key,
+            envelope=SanitizedTaskEnvelope(evidence_refs=(_candidate_source_ref(source_key),)),
+        )
+    except Exception:
+        # A candidate ledger is advisory and local-only. Its unavailability
+        # must never prevent the original task's existing triage fallback.
+        result = None
+    return fallback, result
+
+
+def _is_candidate_orchestration_fallback(
+    decision: SpecialistRouteDecision, resolution: RegistryResolution | None
+) -> bool:
+    """Allow an explicit missing-scope handoff to reach the inert Task-3 queue.
+
+    The supplied candidate name is never persisted as an assignee: the caller
+    immediately replaces it with ``task-orchestrator`` in ``_candidate_fallback``.
+    Without a no-match/ambiguous resolution, an unlisted profile remains a
+    no-dispatch decision.
+    """
+    return (
+        decision.dispatches
+        and decision.profile not in SPECIALIST_PROFILES
+        and resolution is not None
+        and resolution.status in {"no_match", "ambiguous"}
+    )
+
+
+def create_specialist_handoff(
+    *,
+    decision: SpecialistRouteDecision,
+    source: HandoffSource,
+    request: str,
+    router_model: str = "",
+    board: Optional[str] = None,
+    signature: CapabilitySignature | None = None,
+    registry: CapabilityRegistry | None = None,
+    candidate_requests: CandidateProfileRequests | None = None,
+) -> HandoffResult:
     """Create a subscribed, durable triage root for specialist orchestration."""
-    if not decision.dispatches:
+    effective_decision = decision
+    effective_resolution: RegistryResolution | None = None
+    if signature is not None and type(registry) is CapabilityRegistry:
+        effective_resolution = resolve_registry(signature, registry)
+        if not _is_candidate_orchestration_fallback(decision, effective_resolution):
+            effective_decision = apply_registry_resolution(
+                effective_resolution, fallback=decision
+            )
+    elif signature is not None:
+        # A capability signature without the concrete local registry has no
+        # authority to select a profile or create a candidate request. In
+        # particular, a caller-supplied duck-typed ``resolve()`` result cannot
+        # turn an invented profile into a dispatch target.
+        effective_decision = apply_registry_resolution(
+            resolve_registry(signature, None), fallback=decision
+        )
+    elif decision.dispatches and decision.profile not in SPECIALIST_PROFILES:
+        effective_decision = SpecialistRouteDecision(
+            kind=decision.kind,
+            profile=None,
+            confidence=decision.confidence,
+            reason=decision.reason,
+            title=decision.title,
+            audit_reason="inactive_profile",
+        )
+    if not effective_decision.dispatches:
         return HandoffResult(False, reason="non_dispatch_decision")
     if not source.platform or not source.chat_id or not source.message_id:
         return HandoffResult(False, reason="incomplete_source")
@@ -81,11 +192,19 @@ def create_specialist_handoff(*, decision: SpecialistRouteDecision, source: Hand
         from hermes_cli import kanban_db as kb
         from hermes_cli.profiles import profile_exists
 
-        if not profile_exists(decision.profile):
-            return HandoffResult(False, reason="profile_unavailable")
-
         key = _idempotency_key(source)
-        conn = kb.connect(db_path=configured_board_db_path(board), board=board)
+        db_path = configured_board_db_path(board)
+        effective_decision, candidate_result = _candidate_fallback(
+            decision=effective_decision,
+            signature=signature,
+            resolution=effective_resolution,
+            source_key=key or "",
+            db_path=db_path,
+            candidate_requests=candidate_requests,
+        )
+        if not profile_exists(effective_decision.profile):
+            return HandoffResult(False, reason="profile_unavailable")
+        conn = kb.connect(db_path=db_path, board=board)
         try:
             existing_id = None
             if key:
@@ -96,9 +215,15 @@ def create_specialist_handoff(*, decision: SpecialistRouteDecision, source: Hand
                 existing_id = row["id"] if row else None
             with kb.write_txn(conn):
                 task_id = kb.create_task(
-                    conn, title=decision.title,
-                    body=_body(decision=decision, source=source, request=request, router_model=router_model),
-                    assignee=decision.profile, created_by="specialist-routing",
+                    conn, title=effective_decision.title,
+                    body=_body(
+                        decision=effective_decision,
+                        source=source,
+                        request=request,
+                        router_model=router_model,
+                        candidate_request_id=candidate_result.request_id if candidate_result else None,
+                    ),
+                    assignee=effective_decision.profile, created_by="specialist-routing",
                     idempotency_key=key, session_id=source.session_id, board=board,
                     triage=True,
                     goal_mode=True,
@@ -111,7 +236,13 @@ def create_specialist_handoff(*, decision: SpecialistRouteDecision, source: Hand
                     notifier_profile=source.notifier_profile, delivery_mode="notify",
                     delivery_metadata=source.delivery_metadata, allow_nested=True,
                 )
-            return HandoffResult(True, task_id=task_id, created=existing_id is None)
+            return HandoffResult(
+                True,
+                task_id=task_id,
+                created=existing_id is None,
+                candidate_request_id=candidate_result.request_id if candidate_result else None,
+                candidate_status=candidate_result.status if candidate_result else None,
+            )
         finally:
             conn.close()
     except Exception as exc:

--- a/gateway/specialist_routing.py
+++ b/gateway/specialist_routing.py
@@ -1,0 +1,195 @@
+"""Fail-closed natural-language routing for guarded Kanban specialists.
+
+This module deliberately owns no Discord, database, or provider state. It
+turns a bounded auxiliary-model answer into a typed decision; the caller owns
+all side effects. Invalid answers always fall through to normal chat.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Awaitable, Callable, Optional
+
+
+DEFAULT_SPECIALIST_PROFILES: dict[str, str] = {
+    "task-orchestrator": "broad actionable work needing a plan, specialist handoffs, and final verification",
+    "patch-steward": "narrow corrective patches with focused regression evidence",
+    "acceptance-verifier": "acceptance evidence and release-gate verification",
+    "safety-reviewer": "security, privacy, and operational boundary review",
+    "data-quality-auditor": "data quality, freshness, and provenance review",
+    "execution-boundary-auditor": "side-effect and execution-boundary verification",
+    "dependency-health-sentinel": "dependency and development-tooling health",
+    "learning-steward": "governed learning and memory maintenance",
+    "ux-auditor": "operator experience and interface evidence",
+    "research-scout": "read-only research and evidence gathering",
+    "performance-sentinel": "performance and latency diagnostics",
+}
+
+_RESPONSE_FIELDS = frozenset({"kind", "profile", "confidence", "reason", "title"})
+_MAX_REQUEST_CHARS = 4_000
+_MAX_REASON_CHARS = 500
+_MAX_TITLE_CHARS = 160
+
+
+class RouteKind(str, Enum):
+    SPECIALIST = "specialist"
+    GENERAL = "general"
+    CLARIFY = "clarify"
+
+
+@dataclass(frozen=True)
+class SpecialistRouteDecision:
+    """One fail-closed classifier decision suitable for gateway audit logs."""
+
+    kind: RouteKind
+    profile: Optional[str] = None
+    confidence: Optional[float] = None
+    reason: str = ""
+    title: str = ""
+    audit_reason: str = ""
+
+    @property
+    def dispatches(self) -> bool:
+        return self.kind is RouteKind.SPECIALIST and self.profile is not None
+
+
+def _general(audit_reason: str) -> SpecialistRouteDecision:
+    return SpecialistRouteDecision(kind=RouteKind.GENERAL, audit_reason=audit_reason)
+
+
+def _profiles(value: Optional[dict[str, str]]) -> dict[str, str]:
+    return dict(value or DEFAULT_SPECIALIST_PROFILES)
+
+
+def build_classifier_messages(
+    request: str, *, profiles: Optional[dict[str, str]] = None
+) -> list[dict[str, str]]:
+    """Build a cache-independent, tool-free JSON-only auxiliary request."""
+    routes = "\n".join(
+        f"- {name}: {description}" for name, description in _profiles(profiles).items()
+    )
+    system = (
+        "Classify whether the authorized user's message is a bounded task for one "
+        "specialist route. Do not use tools and do not answer the request. Return exactly "
+        "one JSON object with only these fields: kind, profile, confidence, reason, "
+        "title. kind must be specialist, general, or clarify. Use specialist only "
+        "when exactly one listed profile clearly owns an actionable task. Route broad "
+        "multi-step work with no narrower owner to task-orchestrator. Keep ordinary "
+        "conversation, questions, and requests lacking an actionable outcome as general. "
+        "For specialist, title "
+        "must be a short non-empty task title. For general or clarify "
+        "set profile to null, confidence to 0, and title to an empty string. "
+        "Do not infer missing scope or turn ordinary conversation into a task.\n\n"
+        f"Available specialists:\n{routes}"
+    )
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": request[:_MAX_REQUEST_CHARS]},
+    ]
+
+
+def parse_specialist_response(
+    raw: str,
+    *,
+    threshold: float = 0.80,
+    fallback_title: str = "",
+    profiles: Optional[dict[str, str]] = None,
+) -> SpecialistRouteDecision:
+    """Validate an untrusted classifier answer without repair or coercion."""
+    if not isinstance(raw, str):
+        return _general("invalid_classifier_output")
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return _general("malformed_json")
+    if not isinstance(value, dict):
+        return _general("invalid_classifier_output")
+    if set(value) != _RESPONSE_FIELDS:
+        return _general("unexpected_fields")
+
+    kind_value = value.get("kind")
+    try:
+        kind = RouteKind(kind_value)
+    except (TypeError, ValueError):
+        return _general("invalid_kind")
+
+    profile = value.get("profile")
+    confidence = value.get("confidence")
+    reason = value.get("reason")
+    title = value.get("title")
+    if not isinstance(reason, str) or not reason.strip() or len(reason) > _MAX_REASON_CHARS:
+        return _general("invalid_reason")
+    if not isinstance(title, str) or len(title) > _MAX_TITLE_CHARS:
+        return _general("invalid_title")
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+        return _general("invalid_confidence")
+    confidence = float(confidence)
+    if not math.isfinite(confidence) or not 0.0 <= confidence <= 1.0:
+        return _general("invalid_confidence")
+
+    if kind is RouteKind.SPECIALIST:
+        if not isinstance(profile, str) or profile not in _profiles(profiles):
+            return _general("unknown_profile")
+        if not title.strip():
+            title = " ".join(fallback_title.split())[:_MAX_TITLE_CHARS]
+            if not title:
+                return _general("invalid_title")
+        if confidence < threshold:
+            return _general("low_confidence")
+        return SpecialistRouteDecision(
+            kind=kind,
+            profile=profile,
+            confidence=confidence,
+            reason=reason.strip(),
+            title=title.strip(),
+            audit_reason="specialist",
+        )
+
+    if profile is not None or confidence != 0.0 or title:
+        return _general("inconsistent_non_specialist")
+    return SpecialistRouteDecision(
+        kind=kind,
+        reason=reason.strip(),
+        confidence=confidence,
+        audit_reason=kind.value,
+    )
+
+
+ClassifierCall = Callable[[list[dict[str, str]]], Awaitable[str]]
+
+
+async def classify_specialist_request(
+    request: str,
+    classifier: ClassifierCall,
+    *,
+    threshold: float = 0.80,
+    timeout: float = 12.0,
+    profiles: Optional[dict[str, str]] = None,
+) -> SpecialistRouteDecision:
+    """Run one bounded classifier call and turn every failure into fallback."""
+    if not isinstance(request, str) or not request.strip():
+        return _general("empty_request")
+    if not callable(classifier):
+        return _general("classifier_unavailable")
+    try:
+        pending = classifier(build_classifier_messages(request, profiles=profiles))
+        if not inspect.isawaitable(pending):
+            return _general("invalid_classifier_output")
+        raw = await asyncio.wait_for(pending, timeout=max(0.01, float(timeout)))
+    except asyncio.TimeoutError:
+        return _general("classifier_timeout")
+    except Exception:
+        return _general("classifier_error")
+    if not isinstance(raw, str):
+        return _general("invalid_classifier_output")
+    return parse_specialist_response(
+        raw,
+        threshold=threshold,
+        fallback_title=request,
+        profiles=profiles,
+    )

--- a/gateway/specialist_routing.py
+++ b/gateway/specialist_routing.py
@@ -11,23 +11,88 @@ import asyncio
 import inspect
 import json
 import math
+import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Optional, Protocol
+
+from gateway.capability_registry import CapabilitySignature, RegistryResolution
 
 
-DEFAULT_SPECIALIST_PROFILES: dict[str, str] = {
+SPECIALIST_PROFILES: dict[str, str] = {
     "task-orchestrator": "broad actionable work needing a plan, specialist handoffs, and final verification",
-    "patch-steward": "narrow corrective patches with focused regression evidence",
-    "acceptance-verifier": "acceptance evidence and release-gate verification",
-    "safety-reviewer": "security, privacy, and operational boundary review",
-    "data-quality-auditor": "data quality, freshness, and provenance review",
-    "execution-boundary-auditor": "side-effect and execution-boundary verification",
-    "dependency-health-sentinel": "dependency and development-tooling health",
-    "learning-steward": "governed learning and memory maintenance",
-    "ux-auditor": "operator experience and interface evidence",
+    "burndown-patch-steward": "exception burndowns and narrow corrective patches",
+    "acceptance-gate-verifier": "acceptance evidence and release-gate verification",
+    "paper-safety-guardian": "paper-trading safety and live-boundary review",
+    "market-data-authority-auditor": "market-data authority, freshness, and provenance",
+    "route-execution-boundary-auditor": "route and execution-boundary verification",
+    "dependency-tooling-health-sentinel": "dependency and development-tooling health",
+    "copilot-learning-steward": "governed Luna copilot learning and memory",
+    "mission-control-ux-auditor": "Mission Control operator UX evidence",
     "research-scout": "read-only research and evidence gathering",
     "performance-sentinel": "performance and latency diagnostics",
+}
+
+# Classifier output chooses only from ``SPECIALIST_PROFILES``. This separately
+# maps each fixed profile to an explicit, read-only capability signature for
+# the local registry lookup; no model-provided domain, action, or permission
+# becomes part of the lookup.
+_FIXED_PROFILE_CAPABILITIES: dict[str, tuple[str, tuple[str, ...], str]] = {
+    "task-orchestrator": (
+        "repository-evidence",
+        ("audit", "inspect", "read", "review", "validate"),
+        "repository-evidence:read",
+    ),
+    "burndown-patch-steward": (
+        "repository-evidence",
+        ("audit", "inspect", "read", "review", "validate"),
+        "repository-evidence:read",
+    ),
+    "acceptance-gate-verifier": (
+        "repository-evidence",
+        ("audit", "inspect", "read", "review", "validate"),
+        "repository-evidence:read",
+    ),
+    "paper-safety-guardian": (
+        "financial-analysis",
+        ("audit", "inspect", "read", "review", "validate"),
+        "financial-analysis:read",
+    ),
+    "market-data-authority-auditor": (
+        "market-data",
+        ("audit", "inspect", "read", "review", "validate"),
+        "market-data:read",
+    ),
+    "route-execution-boundary-auditor": (
+        "repository-evidence",
+        ("audit", "inspect", "read", "review", "validate"),
+        "repository-evidence:read",
+    ),
+    "dependency-tooling-health-sentinel": (
+        "repository-evidence",
+        ("audit", "inspect", "read", "review", "validate"),
+        "repository-evidence:read",
+    ),
+    "copilot-learning-steward": (
+        "repository-evidence",
+        ("audit", "inspect", "read", "review", "validate"),
+        "repository-evidence:read",
+    ),
+    "mission-control-ux-auditor": (
+        "repository-evidence",
+        ("audit", "inspect", "read", "review", "validate"),
+        "repository-evidence:read",
+    ),
+    "research-scout": (
+        "research",
+        ("audit", "read", "research", "review"),
+        "research:read",
+    ),
+    "performance-sentinel": (
+        "repository-evidence",
+        ("audit", "inspect", "read", "review", "validate"),
+        "repository-evidence:read",
+    ),
 }
 
 _RESPONSE_FIELDS = frozenset({"kind", "profile", "confidence", "reason", "title"})
@@ -62,16 +127,60 @@ def _general(audit_reason: str) -> SpecialistRouteDecision:
     return SpecialistRouteDecision(kind=RouteKind.GENERAL, audit_reason=audit_reason)
 
 
-def _profiles(value: Optional[dict[str, str]]) -> dict[str, str]:
-    return dict(value or DEFAULT_SPECIALIST_PROFILES)
+def capability_signature_for_profile(profile: str | None) -> CapabilitySignature | None:
+    """Return the fixed local lookup scope for one classifier-approved profile.
+
+    The mapping is intentionally closed over ``SPECIALIST_PROFILES``. Unknown
+    or generated profile names therefore cannot smuggle a scope, permission,
+    or registry lookup through the Discord ingress.
+    """
+    if not isinstance(profile, str):
+        return None
+    capability = _FIXED_PROFILE_CAPABILITIES.get(profile)
+    if capability is None:
+        return None
+    domain, actions, permission = capability
+    return CapabilitySignature(
+        domain=domain,
+        actions=actions,
+        evidence_class="diagnostic-only",
+        requested_permissions=(permission,),
+    )
 
 
-def build_classifier_messages(
-    request: str, *, profiles: Optional[dict[str, str]] = None
-) -> list[dict[str, str]]:
+def classify_explicit_burndown_patch_request(request: str) -> Optional[SpecialistRouteDecision]:
+    """Route the one unambiguous exception-burndown instruction without an LLM.
+
+    This is intentionally narrower than natural-language routing in general.
+    When the local classifier is occupied by a long-running model request, an
+    explicit request to perform an exception burndown *and* patch confirmed
+    failures must not fall through to the general chat agent and duplicate the
+    work.  Ordinary questions about exceptions, burndowns, or patches remain
+    model-classified (or normal chat).
+    """
+    if not isinstance(request, str):
+        return None
+    normalized = " ".join(request.casefold().split())
+    if (
+        "exception" not in normalized
+        or "burndown" not in normalized
+        or re.search(r"\bpatch(?:es|ed|ing)?\b", normalized) is None
+    ):
+        return None
+    return SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="burndown-patch-steward",
+        confidence=1.0,
+        reason="explicit exception burndown and patch request",
+        title="Narrow Exception Burndown and Patching",
+        audit_reason="deterministic_burndown_patch",
+    )
+
+
+def build_classifier_messages(request: str) -> list[dict[str, str]]:
     """Build a cache-independent, tool-free JSON-only auxiliary request."""
     routes = "\n".join(
-        f"- {name}: {description}" for name, description in _profiles(profiles).items()
+        f"- {name}: {description}" for name, description in SPECIALIST_PROFILES.items()
     )
     system = (
         "Classify whether the authorized user's message is a bounded task for one "
@@ -94,11 +203,7 @@ def build_classifier_messages(
 
 
 def parse_specialist_response(
-    raw: str,
-    *,
-    threshold: float = 0.80,
-    fallback_title: str = "",
-    profiles: Optional[dict[str, str]] = None,
+    raw: str, *, threshold: float = 0.80, fallback_title: str = ""
 ) -> SpecialistRouteDecision:
     """Validate an untrusted classifier answer without repair or coercion."""
     if not isinstance(raw, str):
@@ -133,7 +238,7 @@ def parse_specialist_response(
         return _general("invalid_confidence")
 
     if kind is RouteKind.SPECIALIST:
-        if not isinstance(profile, str) or profile not in _profiles(profiles):
+        if not isinstance(profile, str) or profile not in SPECIALIST_PROFILES:
             return _general("unknown_profile")
         if not title.strip():
             title = " ".join(fallback_title.split())[:_MAX_TITLE_CHARS]
@@ -163,21 +268,111 @@ def parse_specialist_response(
 ClassifierCall = Callable[[list[dict[str, str]]], Awaitable[str]]
 
 
+class CapabilityResolver(Protocol):
+    """Minimal local registry dependency for active-profile routing."""
+
+    def resolve(self, signature: CapabilitySignature) -> RegistryResolution:
+        """Return the locally verified resolution for one exact signature."""
+
+
+def _inactive_profile_decision() -> SpecialistRouteDecision:
+    return _general("inactive_profile")
+
+
+def _active_registry_decision(
+    resolution: RegistryResolution, fallback: SpecialistRouteDecision | None
+) -> SpecialistRouteDecision:
+    """Build a dispatch only from a local active-resolution receipt."""
+    if not isinstance(resolution.profile, str) or not resolution.profile.strip():
+        return _general("invalid_active_registry_profile")
+    return SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile=resolution.profile,
+        confidence=fallback.confidence if fallback is not None else None,
+        reason=resolution.reason,
+        title=(fallback.title if fallback is not None and fallback.title else "Specialist task"),
+        audit_reason="active_registry_match",
+    )
+
+
+def apply_registry_resolution(
+    resolution: RegistryResolution, *, fallback: SpecialistRouteDecision | None = None
+) -> SpecialistRouteDecision:
+    """Compose one trusted local resolution with an optional classifier fallback.
+
+    Only an ``active_match`` can select a profile outside the fixed baseline.
+    A no-match or ambiguity preserves a fixed-profile classifier result so the
+    handoff owner can open the inert Task-3 candidate request and use the
+    existing orchestrator fallback. Candidate names and malformed registry
+    output are never dispatchable.
+    """
+    if not isinstance(resolution, RegistryResolution):
+        return _general("registry_unavailable")
+    if resolution.status == "active_match":
+        return _active_registry_decision(resolution, fallback)
+    if resolution.status == "unavailable":
+        return _general("registry_unavailable")
+    if resolution.status not in {"no_match", "ambiguous"}:
+        return _general("registry_unavailable")
+    if fallback is None:
+        return _general(f"registry_{resolution.status}")
+    if not fallback.dispatches or fallback.profile not in SPECIALIST_PROFILES:
+        return _inactive_profile_decision()
+    return fallback
+
+
+def resolve_registry(
+    signature: CapabilitySignature, registry: CapabilityResolver
+) -> RegistryResolution:
+    """Resolve locally and turn registry faults into a typed no-dispatch result."""
+    if not isinstance(signature, CapabilitySignature) or not hasattr(registry, "resolve"):
+        return RegistryResolution(
+            status="unavailable", profile=None, reason="local capability registry is unavailable"
+        )
+    try:
+        resolution = registry.resolve(signature)
+    except Exception:
+        return RegistryResolution(
+            status="unavailable", profile=None, reason="local capability registry is unavailable"
+        )
+    if not isinstance(resolution, RegistryResolution):
+        return RegistryResolution(
+            status="unavailable", profile=None, reason="local capability registry returned invalid data"
+        )
+    return resolution
+
+
+def resolve_route(
+    signature: CapabilitySignature,
+    registry: CapabilityResolver,
+    *,
+    fallback: SpecialistRouteDecision | None = None,
+) -> SpecialistRouteDecision:
+    """Resolve an active specialist before using the fixed classifier baseline.
+
+    This function owns no provider call and cannot activate profiles. It only
+    composes an already-local capability lookup into a typed route decision.
+    """
+    return apply_registry_resolution(resolve_registry(signature, registry), fallback=fallback)
+
+
 async def classify_specialist_request(
     request: str,
     classifier: ClassifierCall,
     *,
     threshold: float = 0.80,
     timeout: float = 12.0,
-    profiles: Optional[dict[str, str]] = None,
 ) -> SpecialistRouteDecision:
     """Run one bounded classifier call and turn every failure into fallback."""
     if not isinstance(request, str) or not request.strip():
         return _general("empty_request")
+    explicit_burndown = classify_explicit_burndown_patch_request(request)
+    if explicit_burndown is not None:
+        return explicit_burndown
     if not callable(classifier):
         return _general("classifier_unavailable")
     try:
-        pending = classifier(build_classifier_messages(request, profiles=profiles))
+        pending = classifier(build_classifier_messages(request))
         if not inspect.isawaitable(pending):
             return _general("invalid_classifier_output")
         raw = await asyncio.wait_for(pending, timeout=max(0.01, float(timeout)))
@@ -187,9 +382,4 @@ async def classify_specialist_request(
         return _general("classifier_error")
     if not isinstance(raw, str):
         return _general("invalid_classifier_output")
-    return parse_specialist_response(
-        raw,
-        threshold=threshold,
-        fallback_title=request,
-        profiles=profiles,
-    )
+    return parse_specialist_response(raw, threshold=threshold, fallback_title=request)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -53,6 +53,37 @@ _gateway_running_pid_cache: dict[tuple[str, bool, bool], tuple[float, tuple[Any,
 logger = logging.getLogger(__name__)
 
 
+def specialist_discovery_status(
+    candidate_id: str,
+    *,
+    db_path: Optional[Path] = None,
+    board: Optional[str] = None,
+    now: Optional[int] = None,
+) -> dict[str, Any]:
+    """Return sanitized specialist-discovery lifecycle rows for diagnostics.
+
+    This status surface only reconstructs existing local durable receipts.  It
+    does not retry any advisory/benchmark operation, issue a canary, dispatch
+    a task, or alter a capability profile.
+    """
+    from gateway.lifecycle_ledger import recover_specialist_discovery
+
+    recovery = recover_specialist_discovery(candidate_id, db_path=db_path, board=board, now=now)
+    return {
+        "candidate_id": recovery.candidate_id,
+        "recovery_action": recovery.recovery_action,
+        "rows": [
+            {
+                "stage": row.stage,
+                "status": row.status,
+                "receipt_hash": row.receipt_hash,
+                "expires_at": row.expires_at,
+            }
+            for row in recovery.rows
+        ],
+    }
+
+
 class StormInfo(NamedTuple):
     """Result of a respawn-storm check: how many starts, over what window, and
     the backoff the caller should sleep to break the storm."""

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1197,6 +1197,17 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
         },
+        # Short, tool-free classifier used by explicitly opted-in specialist
+        # task routing. Invalid/unavailable results always fall back to chat.
+        "specialist_router": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 12,
+            "extra_body": {},
+            "reasoning_effort": "none",
+        },
         # Kanban decomposer — decomposes a triage task into a graph of
         # child tasks routed to specialist profiles by description.
         # Invoked by ``hermes kanban decompose`` and the kanban
@@ -2302,6 +2313,29 @@ DEFAULT_CONFIG = {
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
+        # Disabled by default. When enabled, only high-confidence bounded
+        # task requests create a subscribed Kanban card; all other messages
+        # retain the ordinary chat path.
+        "specialist_routing": {
+            "enabled": False,
+            "confidence_threshold": 0.80,
+            "timeout_seconds": 12,
+            # Optional profile-to-capability map. Defaults stay generic;
+            # deployments can replace them with profiles that actually exist.
+            "profiles": {
+                "task-orchestrator": "broad actionable work needing planning and verification",
+                "patch-steward": "narrow corrective patches with regression evidence",
+                "acceptance-verifier": "acceptance evidence and release-gate verification",
+                "safety-reviewer": "security, privacy, and operational boundary review",
+                "data-quality-auditor": "data quality, freshness, and provenance review",
+                "execution-boundary-auditor": "side-effect boundary verification",
+                "dependency-health-sentinel": "dependency and tooling health",
+                "learning-steward": "governed learning and memory maintenance",
+                "ux-auditor": "operator experience and interface evidence",
+                "research-scout": "read-only research and evidence gathering",
+                "performance-sentinel": "performance and latency diagnostics",
+            },
+        },
         "missed_message_backfill": {
             "enabled": False,             # Replay missed Discord messages after reconnect/startup
             "channels": "",               # Comma-separated channel IDs; empty uses free_response_channels

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2737,6 +2737,13 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # OAuth-authenticated dashboard subjects allowed to approve generated
+        # specialist promotion. Empty means fail closed. Subjects are exact
+        # ``<dashboard-auth-provider>:<user_id>`` values; a loopback session
+        # token never qualifies because it carries no human identity.
+        "specialist_operator_approvals": {
+            "allowed_subjects": [],
+        },
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7370,7 +7370,7 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, goal_mode, goal_max_turns, skills "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -7385,6 +7385,13 @@ def decompose_triage_task(
         # override with its own 'workspace_kind' / 'workspace_path'.
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
+        # A goal-mode root represents a durable objective, not a one-shot
+        # dispatch.  Its children must keep the same continuation contract;
+        # otherwise the first fan-out silently loses the goal loop and the
+        # coordinator receives premature worker exits instead of handoffs.
+        root_goal_mode = 1 if root_row["goal_mode"] else 0
+        root_goal_max_turns = root_row["goal_max_turns"]
+        root_skills = root_row["skills"]
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -7419,8 +7426,8 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, goal_mode, goal_max_turns, skills) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -7431,6 +7438,9 @@ def decompose_triage_task(
                     tenant,
                     now,
                     (author or "decomposer"),
+                    root_goal_mode,
+                    root_goal_max_turns,
+                    root_skills,
                 ),
             )
             _append_event(
@@ -11395,6 +11405,7 @@ def add_notify_sub(
     notifier_profile: Optional[str] = None,
     delivery_mode: Optional[str] = None,
     delivery_metadata: Optional[Mapping[str, Any]] = None,
+    allow_nested: bool = False,
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread).
@@ -11437,7 +11448,10 @@ def add_notify_sub(
     insert_chat_type = chat_type or "dm"
     now = int(time.time())
     metadata_json = _encode_notify_delivery_metadata(delivery_metadata)
-    with write_txn(conn):
+    # A caller that creates a task and its notification subscription as one
+    # durable handoff may opt into savepoint composition. The default remains
+    # deliberately loud for accidental nested writes.
+    with write_txn(conn, allow_nested=allow_nested):
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1514,6 +1514,174 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Append-only, local declarations used by the specialist capability resolver.
+-- The canonical scope is stored alongside its hashes so resolution can verify
+-- both integrity and a permission subset without contacting a provider.
+CREATE TABLE IF NOT EXISTS capability_profiles (
+    id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+    profile_id                TEXT NOT NULL,
+    signature_hash            TEXT NOT NULL,
+    permissions_hash          TEXT NOT NULL,
+    model_receipt_hash        TEXT NOT NULL,
+    verification_receipt_hash TEXT NOT NULL,
+    domain                    TEXT NOT NULL,
+    actions_json              TEXT NOT NULL,
+    evidence_class            TEXT NOT NULL,
+    requested_permissions_json TEXT NOT NULL,
+    expires_at                INTEGER,
+    status                    TEXT NOT NULL,
+    created_at                INTEGER NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS capability_profiles_no_update
+BEFORE UPDATE ON capability_profiles
+BEGIN
+    SELECT RAISE(ABORT, 'capability_profiles is append-only');
+END;
+
+CREATE TRIGGER IF NOT EXISTS capability_profiles_no_delete
+BEFORE DELETE ON capability_profiles
+BEGIN
+    SELECT RAISE(ABORT, 'capability_profiles is append-only');
+END;
+
+-- Local, append-only candidate requests for scopes that do not yet have an
+-- active specialist. ``request_hash`` is an idempotency identity, not a
+-- profile identifier; candidates remain inert until a later governed flow
+-- records every required receipt.
+CREATE TABLE IF NOT EXISTS candidate_profile_requests (
+    id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id                 TEXT NOT NULL UNIQUE,
+    request_hash               TEXT NOT NULL,
+    signature_hash             TEXT NOT NULL,
+    permissions_hash           TEXT NOT NULL,
+    source_key_hash            TEXT NOT NULL,
+    policy_digest              TEXT NOT NULL,
+    evidence_ref_hashes_json   TEXT NOT NULL,
+    lifecycle_status           TEXT NOT NULL,
+    reason_code                TEXT NOT NULL,
+    cooldown_until             INTEGER,
+    created_at                 INTEGER NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_update
+BEFORE UPDATE ON candidate_profile_requests
+BEGIN
+    SELECT RAISE(ABORT, 'candidate_profile_requests is append-only');
+END;
+
+CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_delete
+BEFORE DELETE ON candidate_profile_requests
+BEGIN
+    SELECT RAISE(ABORT, 'candidate_profile_requests is append-only');
+END;
+
+-- Durable, append-only receipts for the local specialist promotion gate.
+-- They contain opaque hashes and bounded local observations only; no provider
+-- response, prompt, credential, or executable sandbox payload is stored.
+CREATE TABLE IF NOT EXISTS specialist_benchmark_receipts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    result_hash TEXT NOT NULL UNIQUE,
+    candidate_id TEXT NOT NULL,
+    proposal_input_hash TEXT NOT NULL,
+    proposal_author TEXT NOT NULL,
+    sol_reviewer TEXT NOT NULL,
+    signature_hash TEXT NOT NULL,
+    permissions_hash TEXT NOT NULL,
+    case_set_hash TEXT NOT NULL,
+    scorer_model TEXT NOT NULL,
+    scores_json TEXT NOT NULL,
+    pass_threshold INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    issued_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS specialist_sandbox_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sandbox_id TEXT NOT NULL UNIQUE,
+    candidate_id TEXT NOT NULL,
+    benchmark_result_hash TEXT NOT NULL,
+    disposable INTEGER NOT NULL,
+    task_count INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS specialist_verification_receipts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    result_hash TEXT NOT NULL UNIQUE,
+    candidate_id TEXT NOT NULL,
+    benchmark_result_hash TEXT NOT NULL,
+    verifier_identity TEXT NOT NULL,
+    sandbox_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    issued_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS specialist_operator_approvals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    approval_hash TEXT NOT NULL UNIQUE,
+    approval_id TEXT NOT NULL,
+    candidate_id TEXT NOT NULL,
+    target_state TEXT NOT NULL,
+    operator_identity TEXT NOT NULL,
+    verification_result_hash TEXT NOT NULL,
+    approved INTEGER NOT NULL,
+    issued_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS specialist_promotion_proofs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    proof_hash TEXT NOT NULL UNIQUE,
+    candidate_id TEXT NOT NULL,
+    target_state TEXT NOT NULL,
+    profile_id TEXT,
+    signature_hash TEXT NOT NULL,
+    permissions_hash TEXT NOT NULL,
+    benchmark_result_hash TEXT NOT NULL,
+    verification_result_hash TEXT NOT NULL,
+    approval_hash TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+-- A canary is a local, synthetic, no-send observation.  It is deliberately
+-- separate from the promotion proof so neither a benchmark nor an approval
+-- can be mistaken for proof that the staged profile was exercised safely.
+CREATE TABLE IF NOT EXISTS specialist_canary_receipts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    result_hash TEXT NOT NULL UNIQUE,
+    candidate_id TEXT NOT NULL,
+    promotion_proof_hash TEXT NOT NULL,
+    verification_result_hash TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    status TEXT NOT NULL,
+    issued_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+-- Rollback is an append-only revocation, never an UPDATE of the active
+-- declaration.  Resolution consults it before returning a profile.
+CREATE TABLE IF NOT EXISTS specialist_profile_revocations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    revocation_hash TEXT NOT NULL UNIQUE,
+    profile_id TEXT NOT NULL,
+    signature_hash TEXT NOT NULL,
+    reason_code TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE TRIGGER IF NOT EXISTS specialist_benchmark_receipts_no_update BEFORE UPDATE ON specialist_benchmark_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_benchmark_receipts_no_delete BEFORE DELETE ON specialist_benchmark_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_sandbox_runs_no_update BEFORE UPDATE ON specialist_sandbox_runs BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_sandbox_runs_no_delete BEFORE DELETE ON specialist_sandbox_runs BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_verification_receipts_no_update BEFORE UPDATE ON specialist_verification_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_verification_receipts_no_delete BEFORE DELETE ON specialist_verification_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_operator_approvals_no_update BEFORE UPDATE ON specialist_operator_approvals BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_operator_approvals_no_delete BEFORE DELETE ON specialist_operator_approvals BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_promotion_proofs_no_update BEFORE UPDATE ON specialist_promotion_proofs BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_promotion_proofs_no_delete BEFORE DELETE ON specialist_promotion_proofs BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_canary_receipts_no_update BEFORE UPDATE ON specialist_canary_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_canary_receipts_no_delete BEFORE DELETE ON specialist_canary_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_profile_revocations_no_update BEFORE UPDATE ON specialist_profile_revocations BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+CREATE TRIGGER IF NOT EXISTS specialist_profile_revocations_no_delete BEFORE DELETE ON specialist_profile_revocations BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -1524,6 +1692,15 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_capability_profiles_active_scope
+    ON capability_profiles(status, expires_at, signature_hash, evidence_class);
+CREATE INDEX IF NOT EXISTS idx_candidate_profile_requests_hash_state
+    ON candidate_profile_requests(request_hash, lifecycle_status, created_at);
+CREATE INDEX IF NOT EXISTS idx_specialist_benchmark_candidate ON specialist_benchmark_receipts(candidate_id, result_hash);
+CREATE INDEX IF NOT EXISTS idx_specialist_verification_candidate ON specialist_verification_receipts(candidate_id, result_hash);
+CREATE INDEX IF NOT EXISTS idx_specialist_approval_candidate_target ON specialist_operator_approvals(candidate_id, target_state, approval_hash);
+CREATE INDEX IF NOT EXISTS idx_specialist_canary_candidate ON specialist_canary_receipts(candidate_id, result_hash);
+CREATE INDEX IF NOT EXISTS idx_specialist_revocation_profile ON specialist_profile_revocations(profile_id, signature_hash, created_at);
 """
 
 
@@ -2533,6 +2710,209 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
 
     Called by ``init_db`` so opening an old DB is always safe.
     """
+    # ``SCHEMA_SQL`` creates this table for fresh and legacy boards. Keep this
+    # guard in the migration pass too: callers can force ``init_db()`` after a
+    # partial or interrupted initialization, and the declaration registry must
+    # never be assumed present merely because the process cached the DB path.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS capability_profiles (
+            id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+            profile_id                TEXT NOT NULL,
+            signature_hash            TEXT NOT NULL,
+            permissions_hash          TEXT NOT NULL,
+            model_receipt_hash        TEXT NOT NULL,
+            verification_receipt_hash TEXT NOT NULL,
+            domain                    TEXT NOT NULL,
+            actions_json              TEXT NOT NULL,
+            evidence_class            TEXT NOT NULL,
+            requested_permissions_json TEXT NOT NULL,
+            expires_at                INTEGER,
+            status                    TEXT NOT NULL,
+            created_at                INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_capability_profiles_active_scope
+        ON capability_profiles(status, expires_at, signature_hash, evidence_class)
+        """
+    )
+    conn.executescript(
+        """
+        CREATE TRIGGER IF NOT EXISTS capability_profiles_no_update
+        BEFORE UPDATE ON capability_profiles
+        BEGIN
+            SELECT RAISE(ABORT, 'capability_profiles is append-only');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS capability_profiles_no_delete
+        BEFORE DELETE ON capability_profiles
+        BEGIN
+            SELECT RAISE(ABORT, 'capability_profiles is append-only');
+        END;
+        """
+    )
+
+    # Candidate requests created by the initial specialist-discovery rollout
+    # stored raw scope and evidence text. That data violates the durable
+    # sanitized-ledger contract and cannot be transformed safely: retain no
+    # legacy candidate rows, then recreate this one scoped table below with
+    # opaque hashes only. This is deliberately not a general data migration.
+    candidate_columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(candidate_profile_requests)")
+    }
+    canonical_candidate_columns = {
+        "id",
+        "request_id",
+        "evidence_ref_hashes_json",
+        "reason_code",
+        "request_hash",
+        "signature_hash",
+        "permissions_hash",
+        "source_key_hash",
+        "policy_digest",
+        "lifecycle_status",
+        "cooldown_until",
+        "created_at",
+    }
+    if candidate_columns and candidate_columns != canonical_candidate_columns:
+        conn.execute("DROP TABLE candidate_profile_requests")
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_requests (
+            id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+            request_id                 TEXT NOT NULL UNIQUE,
+            request_hash               TEXT NOT NULL,
+            signature_hash             TEXT NOT NULL,
+            permissions_hash           TEXT NOT NULL,
+            source_key_hash            TEXT NOT NULL,
+            policy_digest              TEXT NOT NULL,
+            evidence_ref_hashes_json   TEXT NOT NULL,
+            lifecycle_status           TEXT NOT NULL,
+            reason_code                TEXT NOT NULL,
+            cooldown_until             INTEGER,
+            created_at                 INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_candidate_profile_requests_hash_state
+        ON candidate_profile_requests(request_hash, lifecycle_status, created_at)
+        """
+    )
+    conn.executescript(
+        """
+        CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_update
+        BEFORE UPDATE ON candidate_profile_requests
+        BEGIN
+            SELECT RAISE(ABORT, 'candidate_profile_requests is append-only');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS candidate_profile_requests_no_delete
+        BEFORE DELETE ON candidate_profile_requests
+        BEGIN
+            SELECT RAISE(ABORT, 'candidate_profile_requests is append-only');
+        END;
+        """
+    )
+
+    # Additive durable promotion evidence.  Unlike the legacy candidate-table
+    # cleanup above, these tables never rewrite or delete existing records.
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS specialist_benchmark_receipts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, result_hash TEXT NOT NULL UNIQUE,
+            candidate_id TEXT NOT NULL, proposal_input_hash TEXT NOT NULL,
+            proposal_author TEXT NOT NULL, sol_reviewer TEXT NOT NULL,
+            signature_hash TEXT NOT NULL, permissions_hash TEXT NOT NULL,
+            case_set_hash TEXT NOT NULL, scorer_model TEXT NOT NULL, scores_json TEXT NOT NULL,
+            pass_threshold INTEGER NOT NULL, status TEXT NOT NULL, issued_at INTEGER NOT NULL,
+            expires_at INTEGER NOT NULL, created_at INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS specialist_sandbox_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, sandbox_id TEXT NOT NULL UNIQUE,
+            candidate_id TEXT NOT NULL, benchmark_result_hash TEXT NOT NULL,
+            disposable INTEGER NOT NULL, task_count INTEGER NOT NULL, created_at INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS specialist_verification_receipts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, result_hash TEXT NOT NULL UNIQUE,
+            candidate_id TEXT NOT NULL, benchmark_result_hash TEXT NOT NULL,
+            verifier_identity TEXT NOT NULL, sandbox_id TEXT NOT NULL, status TEXT NOT NULL,
+            issued_at INTEGER NOT NULL, expires_at INTEGER NOT NULL, created_at INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS specialist_operator_approvals (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, approval_hash TEXT NOT NULL UNIQUE,
+            approval_id TEXT NOT NULL, candidate_id TEXT NOT NULL, target_state TEXT NOT NULL,
+            operator_identity TEXT NOT NULL, verification_result_hash TEXT NOT NULL,
+            approved INTEGER NOT NULL, issued_at INTEGER NOT NULL, created_at INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS specialist_promotion_proofs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, proof_hash TEXT NOT NULL UNIQUE,
+            candidate_id TEXT NOT NULL, target_state TEXT NOT NULL, profile_id TEXT,
+            signature_hash TEXT NOT NULL, permissions_hash TEXT NOT NULL,
+            benchmark_result_hash TEXT NOT NULL, verification_result_hash TEXT NOT NULL,
+            approval_hash TEXT NOT NULL, created_at INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS specialist_canary_receipts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, result_hash TEXT NOT NULL UNIQUE,
+            candidate_id TEXT NOT NULL, promotion_proof_hash TEXT NOT NULL,
+            verification_result_hash TEXT NOT NULL, mode TEXT NOT NULL, status TEXT NOT NULL,
+            issued_at INTEGER NOT NULL, created_at INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS specialist_profile_revocations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, revocation_hash TEXT NOT NULL UNIQUE,
+            profile_id TEXT NOT NULL, signature_hash TEXT NOT NULL, reason_code TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_specialist_benchmark_candidate
+            ON specialist_benchmark_receipts(candidate_id, result_hash);
+        CREATE INDEX IF NOT EXISTS idx_specialist_verification_candidate
+            ON specialist_verification_receipts(candidate_id, result_hash);
+        CREATE INDEX IF NOT EXISTS idx_specialist_approval_candidate_target
+            ON specialist_operator_approvals(candidate_id, target_state, approval_hash);
+        CREATE INDEX IF NOT EXISTS idx_specialist_canary_candidate
+            ON specialist_canary_receipts(candidate_id, result_hash);
+        CREATE INDEX IF NOT EXISTS idx_specialist_revocation_profile
+            ON specialist_profile_revocations(profile_id, signature_hash, created_at);
+        CREATE TRIGGER IF NOT EXISTS specialist_benchmark_receipts_no_update BEFORE UPDATE ON specialist_benchmark_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_benchmark_receipts_no_delete BEFORE DELETE ON specialist_benchmark_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_sandbox_runs_no_update BEFORE UPDATE ON specialist_sandbox_runs BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_sandbox_runs_no_delete BEFORE DELETE ON specialist_sandbox_runs BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_verification_receipts_no_update BEFORE UPDATE ON specialist_verification_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_verification_receipts_no_delete BEFORE DELETE ON specialist_verification_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_operator_approvals_no_update BEFORE UPDATE ON specialist_operator_approvals BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_operator_approvals_no_delete BEFORE DELETE ON specialist_operator_approvals BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_promotion_proofs_no_update BEFORE UPDATE ON specialist_promotion_proofs BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_promotion_proofs_no_delete BEFORE DELETE ON specialist_promotion_proofs BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_canary_receipts_no_update BEFORE UPDATE ON specialist_canary_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_canary_receipts_no_delete BEFORE DELETE ON specialist_canary_receipts BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_profile_revocations_no_update BEFORE UPDATE ON specialist_profile_revocations BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        CREATE TRIGGER IF NOT EXISTS specialist_profile_revocations_no_delete BEFORE DELETE ON specialist_profile_revocations BEGIN SELECT RAISE(ABORT, 'specialist receipts are append-only'); END;
+        """
+    )
+
+    benchmark_columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(specialist_benchmark_receipts)")
+    }
+    if "proposal_author" not in benchmark_columns:
+        _add_column_if_missing(
+            conn,
+            "specialist_benchmark_receipts",
+            "proposal_author",
+            "proposal_author TEXT NOT NULL DEFAULT ''",
+        )
+    if "sol_reviewer" not in benchmark_columns:
+        _add_column_if_missing(
+            conn,
+            "specialist_benchmark_receipts",
+            "sol_reviewer",
+            "sol_reviewer TEXT NOT NULL DEFAULT ''",
+        )
+
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     if "tenant" not in cols:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")

--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -330,6 +330,10 @@ def _sync_board_default_workdir(proj, board_slug: str) -> None:
             return
         if slug != kb.DEFAULT_BOARD and not kb.board_exists(slug):
             return
-        kb.write_board_metadata(slug, default_workdir=proj.primary_path)
+        kb.write_board_metadata(
+            slug,
+            default_workdir=proj.primary_path,
+            project_id=proj.id,
+        )
     except Exception:
         pass

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -40,12 +40,13 @@ import json
 import logging
 import sqlite3
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
@@ -55,6 +56,137 @@ from hermes_cli import kanban_diagnostics as kd
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+class SpecialistApprovalInput(BaseModel):
+    """The scoped promotion decision submitted by an authenticated operator."""
+
+    candidate_id: str = Field(min_length=1, max_length=160)
+    verification_result_hash: str = Field(min_length=64, max_length=64)
+    target_state: Literal["staged", "active"]
+
+
+def _specialist_operator_subject(request: Request) -> str | None:
+    """Return the configured authenticated operator subject, else fail closed."""
+    try:
+        from gateway.operator_approval_authority import authenticated_operator_identity
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        kanban_cfg = cfg.get("kanban") if isinstance(cfg.get("kanban"), dict) else {}
+        approval_cfg = (
+            kanban_cfg.get("specialist_operator_approvals")
+            if isinstance(kanban_cfg.get("specialist_operator_approvals"), dict)
+            else {}
+        )
+        allowed_subjects = approval_cfg.get("allowed_subjects", ())
+        if not isinstance(allowed_subjects, (list, tuple)):
+            return None
+        return authenticated_operator_identity(
+            getattr(request.state, "session", None),
+            auth_required=bool(getattr(request.app.state, "auth_required", False)),
+            allowed_subjects=allowed_subjects,
+        )
+    except Exception:
+        return None
+
+
+@router.get("/specialist-approval-authority")
+def specialist_approval_authority(request: Request):
+    """Expose the current verified session subject for allowlist setup."""
+    try:
+        from gateway.operator_approval_authority import (
+            authenticated_operator_identity,
+            dashboard_session_subject,
+        )
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        kanban_cfg = cfg.get("kanban") if isinstance(cfg.get("kanban"), dict) else {}
+        approval_cfg = (
+            kanban_cfg.get("specialist_operator_approvals")
+            if isinstance(kanban_cfg.get("specialist_operator_approvals"), dict)
+            else {}
+        )
+        allowed_subjects = approval_cfg.get("allowed_subjects", ())
+        if not isinstance(allowed_subjects, (list, tuple)):
+            allowed_subjects = ()
+        auth_required = bool(getattr(request.app.state, "auth_required", False))
+        session = getattr(request.state, "session", None)
+        return {
+            "authenticated_subject": dashboard_session_subject(
+                session, auth_required=auth_required
+            ),
+            "approval_authorized": authenticated_operator_identity(
+                session, auth_required=auth_required, allowed_subjects=allowed_subjects
+            )
+            is not None,
+        }
+    except Exception:
+        return {"authenticated_subject": None, "approval_authorized": False}
+
+
+@router.post("/specialist-approvals")
+def record_specialist_approval(
+    payload: SpecialistApprovalInput, request: Request, board: Optional[str] = Query(None)
+):
+    """Record a durable, OAuth-authenticated operator promotion decision.
+
+    The dashboard's normal auth middleware must attach a verified session.
+    Legacy loopback session tokens and unauthorised authenticated users receive
+    no approval authority.
+    """
+    subject = _specialist_operator_subject(request)
+    if subject is None:
+        raise HTTPException(status_code=403, detail="authenticated operator approval required")
+    board = _resolve_board(board)
+    try:
+        from agent.profile_benchmark import CandidatePromotionGate, OperatorApproval
+        from gateway.candidate_profile_requests import CandidateProfileRequests
+        from gateway.capability_registry import CapabilityRegistry
+        from gateway.configured_board import configured_board_db_path
+
+        effective_board = board or kanban_db.get_current_board()
+        now = int(time.time())
+        db_path = configured_board_db_path(effective_board)
+        approval = OperatorApproval(
+            candidate_id=payload.candidate_id,
+            approval_id=f"dashboard-{uuid.uuid4().hex}",
+            operator_identity=subject,
+            verification_result_hash=payload.verification_result_hash,
+            target_state=payload.target_state,
+            approved=True,
+            issued_at=now,
+        )
+        gate = CandidatePromotionGate(
+            CandidateProfileRequests(db_path=db_path, board=effective_board),
+            CapabilityRegistry(db_path=db_path, board=effective_board),
+        )
+        if not gate.record_operator_approval(
+            approval, authenticated_operator_identity=subject
+        ):
+            raise HTTPException(status_code=409, detail="operator approval was not recorded")
+    except HTTPException:
+        raise
+    except Exception:
+        log.warning("specialist operator approval failed", exc_info=True)
+        raise HTTPException(status_code=400, detail="invalid specialist approval")
+    return {
+        "approval_id": approval.approval_id,
+        "candidate_id": approval.candidate_id,
+        "target_state": approval.target_state,
+        "operator_identity": approval.operator_identity,
+        "status": "recorded",
+    }
+
+
+@router.get("/dispatcher-readiness")
+def get_dispatcher_readiness():
+    """Strict readiness for the gateway-owned Kanban dispatcher."""
+    from hermes_cli.kanban import _dispatcher_readiness
+    from hermes_constants import get_hermes_home
+
+    return _dispatcher_readiness(hermes_home=get_hermes_home())
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +286,27 @@ BOARD_COLUMNS: list[str] = [
 
 
 _CARD_SUMMARY_PREVIEW_CHARS = 200
+
+
+def _current_run_started_at_map(
+    conn: sqlite3.Connection,
+    task_ids: list[str],
+) -> dict[str, Any]:
+    """Map task id -> started_at of its *current* run (active attempt).
+
+    ``tasks.started_at`` records the first attempt and survives reclaims;
+    the card/drawer clock must describe the active attempt instead.
+    """
+    if not task_ids:
+        return {}
+    placeholders = ",".join("?" for _ in task_ids)
+    rows = conn.execute(
+        "SELECT t.id AS task_id, r.started_at AS started_at "
+        f"FROM tasks t JOIN task_runs r ON r.id = t.current_run_id "
+        f"WHERE t.status = 'running' AND t.id IN ({placeholders})",
+        list(task_ids),
+    ).fetchall()
+    return {row["task_id"]: row["started_at"] for row in rows}
 
 
 def _task_dict(
@@ -461,6 +614,7 @@ def get_board(
         # for boards with hundreds of tasks). Truncated to a card-size
         # preview here — the full text is available via /tasks/:id.
         summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
+        current_run_starts = _current_run_started_at_map(conn, [t.id for t in tasks])
 
         for t in tasks:
             full = summary_map.get(t.id)
@@ -468,6 +622,10 @@ def get_board(
                 full[:_CARD_SUMMARY_PREVIEW_CHARS] if full else None
             )
             d = _task_dict(t, latest_summary=preview)
+            if t.id in current_run_starts:
+                # The card clock describes the active attempt, not the first
+                # attempt retained on tasks.started_at across reclaims.
+                d["started_at"] = current_run_starts[t.id]
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
@@ -549,6 +707,10 @@ def get_task(
         # a second round-trip. Cards on /board carry a 200-char preview.
         full_summary = kanban_db.latest_summary(conn, task_id)
         task_d = _task_dict(task, latest_summary=full_summary)
+        if task_id in (current_run_starts := _current_run_started_at_map(conn, [task_id])):
+            # The drawer clock must agree with the card: describe the active
+            # attempt, not the first attempt retained on tasks.started_at.
+            task_d["started_at"] = current_run_starts[task_id]
         links = _links_for(conn, task_id)
         child_ids = links["children"]
         child_summaries = kanban_db.latest_summaries(conn, child_ids)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6879,6 +6879,149 @@ class DiscordAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             return 50
 
+    def _specialist_routing_settings(self) -> dict[str, Any]:
+        """Return validated, explicitly opted-in specialist routing settings."""
+        raw = self.config.extra.get("specialist_routing")
+        if not isinstance(raw, dict):
+            return {"enabled": False}
+        enabled = raw.get("enabled", False)
+        if isinstance(enabled, str):
+            enabled = enabled.strip().lower() in {"true", "1", "yes", "on"}
+        board = raw.get("board")
+        if not enabled or not isinstance(board, str) or not board.strip():
+            return {"enabled": False}
+        try:
+            threshold = float(raw.get("confidence_threshold", 0.80))
+        except (TypeError, ValueError):
+            threshold = 0.80
+        if not math.isfinite(threshold) or not 0.0 <= threshold <= 1.0:
+            threshold = 0.80
+        try:
+            timeout = float(raw.get("timeout_seconds", 12))
+        except (TypeError, ValueError):
+            timeout = 12.0
+        profiles = raw.get("profiles")
+        if not isinstance(profiles, dict):
+            profiles = None
+        else:
+            profiles = {
+                str(name).strip(): str(description).strip()[:300]
+                for name, description in profiles.items()
+                if isinstance(name, str)
+                and isinstance(description, str)
+                and name.strip()
+                and description.strip()
+                and len(name.strip()) <= 80
+            }
+            if not profiles:
+                return {"enabled": False}
+        return {
+            "enabled": True,
+            "confidence_threshold": threshold,
+            "timeout_seconds": max(1.0, min(30.0, timeout)),
+            "model": str(raw.get("model") or "").strip(),
+            "board": board.strip(),
+            "profiles": profiles,
+        }
+
+    async def _classify_specialist_event(self, event: MessageEvent):
+        """Ask the bounded auxiliary router for one typed routing decision."""
+        settings = self._specialist_routing_settings()
+        from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+        from gateway.specialist_routing import classify_specialist_request
+
+        async def _classifier(messages):
+            response = await async_call_llm(
+                task="specialist_router",
+                model=settings["model"] or None,
+                messages=messages,
+                temperature=0.0,
+                max_tokens=180,
+                timeout=settings["timeout_seconds"],
+                reasoning_config={"enabled": False},
+            )
+            return extract_content_or_reasoning(response)
+
+        return await classify_specialist_request(
+            event.text,
+            _classifier,
+            threshold=settings["confidence_threshold"],
+            timeout=settings["timeout_seconds"],
+            profiles=settings["profiles"],
+        )
+
+    async def _maybe_route_specialist_event(self, event: MessageEvent) -> bool:
+        """Create a guarded specialist card, or return false for normal chat."""
+        settings = self._specialist_routing_settings()
+        if not settings.get("enabled") or event.message_type is not MessageType.TEXT:
+            return False
+        if not (event.text or "").strip() or getattr(event.source, "is_bot", False):
+            return False
+        try:
+            decision = await self._classify_specialist_event(event)
+        except Exception:
+            logger.warning("[Discord] specialist routing classifier failed", exc_info=True)
+            return False
+        if decision.kind.value == "general":
+            logger.info(
+                "[Discord] specialist routing fell through: %s",
+                decision.audit_reason,
+            )
+            return False
+        if decision.kind.value == "clarify":
+            await self.send(
+                event.source.chat_id,
+                content="Which configured specialist task should I start?",
+                reply_to=event.message_id,
+            )
+            return True
+        if not decision.dispatches:
+            return False
+        try:
+            from gateway.specialist_handoff import (
+                HandoffSource,
+                create_specialist_handoff,
+            )
+
+            platform = getattr(event.source.platform, "value", event.source.platform)
+            source = HandoffSource(
+                platform=str(platform),
+                chat_id=str(event.source.chat_id),
+                chat_type=str(event.source.chat_type or "group"),
+                user_id=(str(event.source.user_id) if event.source.user_id else None),
+                user_id_alt=(
+                    str(event.source.user_id_alt)
+                    if event.source.user_id_alt
+                    else None
+                ),
+                guild_id=(str(event.source.guild_id) if event.source.guild_id else None),
+                thread_id=(
+                    str(event.source.thread_id) if event.source.thread_id else None
+                ),
+                message_id=str(event.message_id or event.source.message_id or ""),
+                notifier_profile=getattr(event.source, "profile", None) or "default",
+            )
+            result = await asyncio.to_thread(
+                create_specialist_handoff,
+                decision=decision,
+                source=source,
+                request=event.text,
+                router_model=settings["model"] or "configured_auxiliary",
+                board=settings["board"],
+            )
+        except Exception:
+            logger.warning("[Discord] specialist routing handoff failed", exc_info=True)
+            return False
+        if not result.ok or not result.task_id:
+            logger.warning("[Discord] specialist routing handoff rejected: %s", result.reason)
+            return False
+        await self.send(
+            event.source.chat_id,
+            content=f"Planning `{result.task_id}` with `{decision.profile}`.",
+            reply_to=event.message_id,
+        )
+        return True
+
     async def _fetch_channel_context(
         self,
         channel: Any,
@@ -8534,6 +8677,9 @@ class DiscordAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
         )
+
+        if not recovered and await self._maybe_route_specialist_event(event):
+            return True
 
         # Track thread participation so the bot won't require @mention for
         # follow-up messages in threads it has already engaged in.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -797,6 +797,13 @@ class VoiceReceiver:
         if self._dave_session:
             with self._lock:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
+            if not user_id:
+                # Discord may not resend SPEAKING after a voice reconnect.
+                # Infer a sole permitted member before decrypting the first
+                # packet; waiting until check_silence() is too late because
+                # DAVE ciphertext has already been sent through Opus decode
+                # and becomes a silent WAV that VAD correctly rejects.
+                user_id = self._infer_user_for_ssrc(ssrc)
             if user_id:
                 try:
                     import davey
@@ -1097,6 +1104,11 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
         self._voice_timeout_seconds = self._load_voice_timeout()
         self._playback_timeout_seconds = self._load_playback_timeout()
+        (
+            self._voice_auto_join_channel_id,
+            self._voice_auto_join_user_ids,
+            self._voice_auto_join_text_channel_id,
+        ) = self._load_voice_auto_join_config()
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
@@ -1426,15 +1438,28 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
-                # Only track channels where the bot is connected
-                bot_guild_ids = set(adapter_self._voice_clients.keys())
-                if not bot_guild_ids:
-                    return
                 guild_id = member.guild.id
-                if guild_id not in bot_guild_ids:
-                    return
-                # Ignore the bot itself
                 if member == adapter_self._client.user:
+                    # A move performed outside this adapter (for example from
+                    # Discord's UI or REST API) makes discord.py replace the
+                    # UDP packet reader while retaining the VoiceClient.  The
+                    # existing VoiceReceiver remains attached to the old
+                    # reader, so it can still see websocket SPEAKING events
+                    # but receives no audio packets.  Refresh the receiver
+                    # after discord.py has completed its reconnect.
+                    if before.channel != after.channel and after.channel is not None:
+                        asyncio.ensure_future(
+                            adapter_self._refresh_voice_receiver_after_forced_move(guild_id)
+                        )
+                    return
+
+                await adapter_self._auto_join_voice_for_member(member, before, after)
+
+                # Only log ordinary member state changes while the bot is in
+                # this guild. Auto-join above runs before this guard because
+                # it is how an initially disconnected bot enters the room.
+                bot_guild_ids = set(adapter_self._voice_clients.keys())
+                if guild_id not in bot_guild_ids:
                     return
 
                 joined = before.channel is None and after.channel is not None
@@ -1476,6 +1501,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
             self._running = True
             self._start_liveness_probe()
+            # Plugin-registered native handlers (discord.py Bot — add_listener()/event hooks).
+            self._wire_plugin_handlers(self._client)
             return True
 
         except asyncio.TimeoutError:
@@ -2408,6 +2435,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return
         try:
+            await self._auto_join_configured_voice_channel_if_user_present()
             sync_policy = self._get_discord_command_sync_policy()
             if sync_policy == "off":
                 logger.info("[%s] Skipping Discord slash command sync (policy=off)", self.name)
@@ -4355,6 +4383,33 @@ class DiscordAdapter(BasePlatformAdapter):
             minimum=0,
         )
 
+    def _load_voice_auto_join_config(self) -> tuple[Optional[int], set[str], Optional[int]]:
+        """Load the voice room, user allowlist, and optional text reply channel.
+
+        Both values must be valid. A partial or malformed configuration stays
+        disabled so Hermes can never join a room merely because voice-state
+        events are enabled.
+        """
+        try:
+            from hermes_cli.config import read_raw_config
+
+            discord_cfg = (read_raw_config() or {}).get("discord") or {}
+            channel_id = int(discord_cfg.get("voice_auto_join_channel_id"))
+            text_channel_id_raw = discord_cfg.get("voice_auto_join_text_channel_id")
+            text_channel_id = int(text_channel_id_raw) if text_channel_id_raw else None
+            raw_user_ids = discord_cfg.get("voice_auto_join_user_ids") or []
+            if isinstance(raw_user_ids, str):
+                raw_user_ids = raw_user_ids.split(",")
+            user_ids = {str(value).strip() for value in raw_user_ids if str(value).strip().isdigit()}
+            if channel_id <= 0 or not user_ids:
+                return None, set(), None
+            if text_channel_id is not None and text_channel_id <= 0:
+                text_channel_id = None
+            return channel_id, user_ids, text_channel_id
+        except Exception as e:
+            logger.debug("Could not load Discord voice auto-join config: %s", e)
+            return None, set(), None
+
     def _load_playback_timeout(self) -> int:
         """Return minimum playback wait seconds for Discord VC audio."""
         return self._load_discord_int_config(
@@ -4607,6 +4662,99 @@ class DiscordAdapter(BasePlatformAdapter):
                     logger.warning("Voice mixer failed to start: %s", e)
 
             return True
+
+    async def _refresh_voice_receiver_after_forced_move(self, guild_id: int) -> None:
+        """Attach a new packet receiver after discord.py reconnects a moved bot.
+
+        Discord can force-move a bot without going through ``move_to``.  In
+        that case the VoiceClient survives but its UDP SocketReader changes;
+        the previous VoiceReceiver must be stopped and reattached.
+        """
+        # Give discord.py's voice-state handler time to replace the transport.
+        await asyncio.sleep(0.5)
+        vc = self._voice_clients.get(guild_id)
+        if not vc or not vc.is_connected():
+            logger.warning("Voice receiver refresh skipped: no connected client for guild %s", guild_id)
+            return
+
+        previous_receiver = self._voice_receivers.pop(guild_id, None)
+        if previous_receiver:
+            previous_receiver.stop()
+        previous_task = self._voice_listen_tasks.pop(guild_id, None)
+        if previous_task:
+            previous_task.cancel()
+
+        try:
+            receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
+            receiver.start()
+            self._voice_receivers[guild_id] = receiver
+            self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
+                self._voice_listen_loop(guild_id)
+            )
+            logger.info("Voice receiver refreshed after forced move (guild=%s)", guild_id)
+        except Exception as e:
+            logger.warning("Voice receiver refresh failed after forced move: %s", e)
+
+    async def _auto_join_voice_for_member(self, member, before, after) -> None:
+        """Join or leave the configured room when its configured user moves."""
+        channel_id = getattr(self, "_voice_auto_join_channel_id", None)
+        user_ids = getattr(self, "_voice_auto_join_user_ids", set())
+        if not channel_id or str(getattr(member, "id", "")) not in user_ids:
+            return
+
+        before_channel = getattr(before, "channel", None)
+        after_channel = getattr(after, "channel", None)
+        was_in_configured_channel = getattr(before_channel, "id", None) == channel_id
+        is_in_configured_channel = getattr(after_channel, "id", None) == channel_id
+
+        if is_in_configured_channel and not was_in_configured_channel:
+            text_channel_id = int(
+                getattr(self, "_voice_auto_join_text_channel_id", None) or channel_id
+            )
+            await self.join_voice_channel(
+                after_channel,
+                text_channel_id=text_channel_id,
+                source=self._voice_auto_join_source(text_channel_id, member.id),
+            )
+            return
+
+        if was_in_configured_channel and not is_in_configured_channel:
+            await self.leave_voice_channel(member.guild.id)
+
+    async def _auto_join_configured_voice_channel_if_user_present(self) -> None:
+        """Restore the configured voice session after Gateway startup."""
+        channel_id = getattr(self, "_voice_auto_join_channel_id", None)
+        user_ids = getattr(self, "_voice_auto_join_user_ids", set())
+        if not channel_id or not user_ids or not self._client:
+            return
+        channel = self._client.get_channel(channel_id)
+        if channel is None:
+            logger.warning("Configured voice auto-join channel %s is unavailable", channel_id)
+            return
+        for member in getattr(channel, "members", []):
+            if str(getattr(member, "id", "")) not in user_ids:
+                continue
+            text_channel_id = int(
+                getattr(self, "_voice_auto_join_text_channel_id", None) or channel_id
+            )
+            await self.join_voice_channel(
+                channel,
+                text_channel_id=text_channel_id,
+                source=self._voice_auto_join_source(text_channel_id, member.id),
+            )
+            return
+
+    @staticmethod
+    def _voice_auto_join_source(text_channel_id: int, user_id: int) -> Dict[str, str]:
+        """Build valid session metadata for a voice auto-join reply destination."""
+        user_id_str = str(user_id)
+        return {
+            "platform": Platform.DISCORD.value,
+            "chat_id": str(text_channel_id),
+            "user_id": user_id_str,
+            "user_name": user_id_str,
+            "chat_type": "channel",
+        }
 
     async def leave_voice_channel(self, guild_id: int) -> None:
         """Disconnect from the voice channel in a guild."""
@@ -6880,16 +7028,19 @@ class DiscordAdapter(BasePlatformAdapter):
             return 50
 
     def _specialist_routing_settings(self) -> dict[str, Any]:
-        """Return validated, explicitly opted-in specialist routing settings."""
+        """Return validated, explicitly opt-in Discord specialist routing settings."""
         raw = self.config.extra.get("specialist_routing")
         if not isinstance(raw, dict):
             return {"enabled": False}
         enabled = raw.get("enabled", False)
         if isinstance(enabled, str):
             enabled = enabled.strip().lower() in {"true", "1", "yes", "on"}
-        board = raw.get("board")
-        if not enabled or not isinstance(board, str) or not board.strip():
+        if not enabled:
             return {"enabled": False}
+        board = raw.get("board")
+        if not isinstance(board, str) or not board.strip():
+            return {"enabled": False}
+        board = board.strip()
         try:
             threshold = float(raw.get("confidence_threshold", 0.80))
         except (TypeError, ValueError):
@@ -6900,29 +7051,48 @@ class DiscordAdapter(BasePlatformAdapter):
             timeout = float(raw.get("timeout_seconds", 12))
         except (TypeError, ValueError):
             timeout = 12.0
-        profiles = raw.get("profiles")
-        if not isinstance(profiles, dict):
-            profiles = None
-        else:
-            profiles = {
-                str(name).strip(): str(description).strip()[:300]
-                for name, description in profiles.items()
-                if isinstance(name, str)
-                and isinstance(description, str)
-                and name.strip()
-                and description.strip()
-                and len(name.strip()) <= 80
-            }
-            if not profiles:
-                return {"enabled": False}
-        return {
-            "enabled": True,
-            "confidence_threshold": threshold,
-            "timeout_seconds": max(1.0, min(30.0, timeout)),
-            "model": str(raw.get("model") or "").strip(),
-            "board": board.strip(),
-            "profiles": profiles,
-        }
+        return {"enabled": True, "confidence_threshold": threshold,
+                "timeout_seconds": max(1.0, min(30.0, timeout)),
+                "model": str(raw.get("model") or "").strip(), "board": board}
+
+    async def _maybe_answer_progress_event(self, event: MessageEvent) -> bool:
+        """Answer a source-scoped status question before model specialist routing."""
+        settings = self._specialist_routing_settings()
+        if not settings.get("enabled") or event.message_type is not MessageType.TEXT:
+            return False
+        if not (event.text or "").strip() or getattr(event.source, "is_bot", False):
+            return False
+        try:
+            from gateway.progress_queries import (
+                ProgressSource,
+                is_progress_query,
+                resolve_progress_query,
+            )
+
+            if not is_progress_query(event.text):
+                return False
+            platform = getattr(event.source.platform, "value", event.source.platform)
+            source = ProgressSource(
+                platform=str(platform),
+                chat_id=str(event.source.chat_id),
+                thread_id=(str(event.source.thread_id) if event.source.thread_id else None),
+                reply_to_message_id=(
+                    str(event.reply_to_message_id) if event.reply_to_message_id else None
+                ),
+            )
+            result = await asyncio.to_thread(
+                resolve_progress_query,
+                event.text,
+                source=source,
+                board=settings["board"],
+            )
+        except Exception:
+            logger.warning("[Discord] progress query lookup failed", exc_info=True)
+            return False
+        if not result.handled:
+            return False
+        await self.send(event.source.chat_id, content=result.response, reply_to=event.message_id)
+        return True
 
     async def _classify_specialist_event(self, event: MessageEvent):
         """Ask the bounded auxiliary router for one typed routing decision."""
@@ -6932,22 +7102,15 @@ class DiscordAdapter(BasePlatformAdapter):
 
         async def _classifier(messages):
             response = await async_call_llm(
-                task="specialist_router",
-                model=settings["model"] or None,
-                messages=messages,
-                temperature=0.0,
-                max_tokens=180,
-                timeout=settings["timeout_seconds"],
-                reasoning_config={"enabled": False},
+                task="specialist_router", model=settings["model"] or None,
+                messages=messages, temperature=0.0, max_tokens=180,
+                timeout=settings["timeout_seconds"], reasoning_config={"enabled": False},
             )
             return extract_content_or_reasoning(response)
 
         return await classify_specialist_request(
-            event.text,
-            _classifier,
-            threshold=settings["confidence_threshold"],
+            event.text, _classifier, threshold=settings["confidence_threshold"],
             timeout=settings["timeout_seconds"],
-            profiles=settings["profiles"],
         )
 
     async def _maybe_route_specialist_event(self, event: MessageEvent) -> bool:
@@ -6963,51 +7126,44 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.warning("[Discord] specialist routing classifier failed", exc_info=True)
             return False
         if decision.kind.value == "general":
-            logger.info(
-                "[Discord] specialist routing fell through: %s",
-                decision.audit_reason,
-            )
+            logger.info("[Discord] specialist routing fell through: %s", decision.audit_reason)
             return False
         if decision.kind.value == "clarify":
             await self.send(
                 event.source.chat_id,
-                content="Which configured specialist task should I start?",
+                content=("Which specialist task should I start: an audit, a narrow patch, "
+                         "acceptance verification, safety review, research, or performance work?"),
                 reply_to=event.message_id,
             )
             return True
         if not decision.dispatches:
             return False
         try:
-            from gateway.specialist_handoff import (
-                HandoffSource,
-                create_specialist_handoff,
-            )
+            from gateway.capability_registry import CapabilityRegistry
+            from gateway.specialist_handoff import HandoffSource, create_specialist_handoff
+            from gateway.specialist_routing import capability_signature_for_profile
+
+            signature = capability_signature_for_profile(decision.profile)
+            if signature is None:
+                logger.warning("[Discord] specialist route had no fixed capability signature")
+                return False
 
             platform = getattr(event.source.platform, "value", event.source.platform)
             source = HandoffSource(
-                platform=str(platform),
-                chat_id=str(event.source.chat_id),
+                platform=str(platform), chat_id=str(event.source.chat_id),
                 chat_type=str(event.source.chat_type or "group"),
-                user_id=(str(event.source.user_id) if event.source.user_id else None),
-                user_id_alt=(
-                    str(event.source.user_id_alt)
-                    if event.source.user_id_alt
-                    else None
-                ),
-                guild_id=(str(event.source.guild_id) if event.source.guild_id else None),
-                thread_id=(
-                    str(event.source.thread_id) if event.source.thread_id else None
-                ),
+                user_id=str(event.source.user_id) if event.source.user_id else None,
+                user_id_alt=str(event.source.user_id_alt) if event.source.user_id_alt else None,
+                guild_id=str(event.source.guild_id) if event.source.guild_id else None,
+                thread_id=str(event.source.thread_id) if event.source.thread_id else None,
                 message_id=str(event.message_id or event.source.message_id or ""),
                 notifier_profile=getattr(event.source, "profile", None) or "default",
             )
             result = await asyncio.to_thread(
-                create_specialist_handoff,
-                decision=decision,
-                source=source,
-                request=event.text,
-                router_model=settings["model"] or "configured_auxiliary",
-                board=settings["board"],
+                create_specialist_handoff, decision=decision, source=source,
+                request=event.text, router_model=settings["model"] or "configured_auxiliary",
+                board=settings["board"], signature=signature,
+                registry=CapabilityRegistry(board=settings["board"]),
             )
         except Exception:
             logger.warning("[Discord] specialist routing handoff failed", exc_info=True)
@@ -7017,7 +7173,10 @@ class DiscordAdapter(BasePlatformAdapter):
             return False
         await self.send(
             event.source.chat_id,
-            content=f"Planning `{result.task_id}` with `{decision.profile}`.",
+            content=(
+                f"Planning `{result.task_id}` with the task orchestrator. "
+                "I’ll post the worker plan and progress here."
+            ),
             reply_to=event.message_id,
         )
         return True
@@ -8678,6 +8837,11 @@ class DiscordAdapter(BasePlatformAdapter):
             channel_context=_channel_context,
         )
 
+        # A high-confidence natural-language task request becomes one durable,
+        # subscribed Kanban card. General, invalid, unavailable, and failed
+        # classifications return false and preserve the existing chat flow.
+        if not recovered and await self._maybe_answer_progress_event(event):
+            return True
         if not recovered and await self._maybe_route_specialist_event(event):
             return True
 

--- a/tests/agent/test_profile_benchmark.py
+++ b/tests/agent/test_profile_benchmark.py
@@ -1,0 +1,331 @@
+"""Fail-closed contracts for local specialist benchmark and promotion receipts."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import replace
+
+from agent.profile_benchmark import (
+    CandidatePromotionGate,
+    CandidateProposal,
+    FrozenBenchmarkCaseSet,
+    OperatorApproval,
+)
+from gateway.candidate_profile_requests import CandidateProfileRequests
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature
+
+
+SIGNATURE = CapabilitySignature(
+    domain="market-data",
+    actions=("audit", "read"),
+    evidence_class="diagnostic-only",
+    requested_permissions=("market-data:read",),
+)
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _candidate(tmp_path, now: list[int]):
+    db_path = tmp_path / "benchmark.db"
+    requests = CandidateProfileRequests(db_path=db_path, clock=lambda: now[0])
+    opened = requests.open_or_reuse(SIGNATURE, source_key="test:benchmark")
+    assert opened.status == "candidate"
+    proposal = CandidateProposal(
+        candidate_id=opened.request_id,
+        proposal_author="claude",
+        sol_reviewer="sol",
+        proposal_hash=_digest("proposal"),
+        signature_hash=SIGNATURE.signature_hash,
+        permissions_hash=SIGNATURE.permissions_hash,
+    )
+    cases = FrozenBenchmarkCaseSet(case_ids=(_digest("case-a"), _digest("case-b")))
+    gate = CandidatePromotionGate(
+        requests,
+        CapabilityRegistry(db_path=db_path),
+        clock=lambda: now[0],
+    )
+    return requests, gate, proposal, cases
+
+
+def test_candidate_cannot_score_or_verify_its_own_proposal(tmp_path):
+    now = [1_000]
+    _, gate, proposal, cases = _candidate(tmp_path, now)
+
+    benchmark_result, receipt = gate.benchmark(
+        proposal, cases, scorer_model="claude", scores=(100, 100), scorer_available=True
+    )
+
+    assert benchmark_result.status == "rejected"
+    assert receipt.status == "rejected"
+
+
+def test_unavailable_scorer_fails_closed_without_benchmark_transition(tmp_path):
+    now = [1_000]
+    requests, gate, proposal, cases = _candidate(tmp_path, now)
+
+    result, receipt = gate.benchmark(
+        proposal, cases, scorer_model="benchmark-model", scores=(100, 100), scorer_available=False
+    )
+
+    assert result.status == "rejected"
+    assert receipt.status == "unavailable"
+    assert requests.lifecycle_snapshot(proposal.candidate_id).lifecycle_status == "candidate"
+
+
+def test_case_set_or_proposal_hash_change_invalidates_benchmark_receipt(tmp_path):
+    now = [1_000]
+    _, gate, proposal, cases = _candidate(tmp_path, now)
+    result, receipt = gate.benchmark(
+        proposal, cases, scorer_model="benchmark-model", scores=(90, 90), scorer_available=True
+    )
+    assert result.status == "benchmarked"
+
+    assert not gate.valid_benchmark(receipt, replace(proposal, proposal_hash=_digest("mutated")), cases)
+    assert not gate.valid_benchmark(
+        receipt,
+        proposal,
+        FrozenBenchmarkCaseSet(case_ids=(_digest("case-a"), _digest("mutated-case"))),
+    )
+    object.__setattr__(receipt, "case_set_hash", _digest("mutated-receipt-case-set"))
+    assert not gate.valid_benchmark(receipt, proposal, cases)
+
+
+def test_permission_delta_cannot_be_benchmarked_or_activated(tmp_path):
+    now = [1_000]
+    _, gate, proposal, cases = _candidate(tmp_path, now)
+    expanded = replace(proposal, permissions_hash=_digest("market-data-read-and-write"))
+
+    result, receipt = gate.benchmark(
+        expanded, cases, scorer_model="benchmark-model", scores=(100, 100), scorer_available=True
+    )
+
+    assert result.status == "rejected"
+    assert receipt.status == "rejected"
+
+
+def test_verified_candidate_needs_independent_disposable_sandbox_and_approval(tmp_path):
+    now = [1_000]
+    requests, gate, proposal, cases = _candidate(tmp_path, now)
+    benchmark_result, benchmark = gate.benchmark(
+        proposal, cases, scorer_model="benchmark-model", scores=(90, 90), scorer_available=True
+    )
+    assert benchmark_result.status == "benchmarked"
+    assert gate.open_disposable_sandbox(proposal, benchmark, sandbox_id="sandbox-1").status == "benchmarked"
+
+    rejected, own_verification = gate.verify(
+        proposal,
+        benchmark,
+        verifier_identity="benchmark-model",
+        sandbox_id="sandbox-1",
+        verifier_available=True,
+    )
+    assert rejected.status == "rejected"
+    assert own_verification.status == "rejected"
+
+    verified, verification = gate.verify(
+        proposal,
+        benchmark,
+        verifier_identity="independent-verifier",
+        sandbox_id="sandbox-1",
+        verifier_available=True,
+    )
+    assert verified.status == "verified"
+    assert gate.stage(proposal, benchmark, verification, None).status == "rejected"
+    assert requests.lifecycle_snapshot(proposal.candidate_id).lifecycle_status == "verified"
+
+
+def test_expired_receipts_and_missing_operator_approval_cannot_stage_or_activate(tmp_path):
+    now = [1_000]
+    _, gate, proposal, cases = _candidate(tmp_path, now)
+    _, benchmark = gate.benchmark(
+        proposal,
+        cases,
+        scorer_model="benchmark-model",
+        scores=(90, 90),
+        scorer_available=True,
+        receipt_lifetime_seconds=1,
+    )
+    assert gate.open_disposable_sandbox(proposal, benchmark, sandbox_id="sandbox-1").status == "benchmarked"
+    _, verification = gate.verify(
+        proposal,
+        benchmark,
+        verifier_identity="independent-verifier",
+        sandbox_id="sandbox-1",
+        verifier_available=True,
+    )
+    now[0] += 2
+    approval = OperatorApproval(
+        candidate_id=proposal.candidate_id,
+        approval_id="approval-1",
+        operator_identity="operator",
+        verification_result_hash=verification.result_hash,
+        target_state="staged",
+        approved=True,
+        issued_at=now[0],
+    )
+
+    assert gate.stage(proposal, benchmark, verification, approval).status == "rejected"
+    assert gate.activate(
+        proposal, SIGNATURE, "market-data-specialist", benchmark, verification, approval
+    ).status == "rejected"
+
+
+def test_unattested_operator_identity_cannot_stage_or_activate_a_candidate(tmp_path):
+    now = [1_000]
+    requests, gate, proposal, cases = _candidate(tmp_path, now)
+    _, benchmark = gate.benchmark(
+        proposal, cases, scorer_model="benchmark-model", scores=(90, 90), scorer_available=True
+    )
+    assert gate.open_disposable_sandbox(proposal, benchmark, sandbox_id="sandbox-1").status == "benchmarked"
+    _, verification = gate.verify(
+        proposal,
+        benchmark,
+        verifier_identity="independent-verifier",
+        sandbox_id="sandbox-1",
+        verifier_available=True,
+    )
+    approval = OperatorApproval(
+        candidate_id=proposal.candidate_id,
+        approval_id="approval-1",
+        operator_identity="operator",
+        verification_result_hash=verification.result_hash,
+        target_state="staged",
+        approved=True,
+        issued_at=now[0],
+    )
+    assert gate.record_operator_approval(approval) is False
+    assert gate.stage(proposal, benchmark, verification, approval).status == "rejected"
+    active_approval = OperatorApproval(
+        candidate_id=proposal.candidate_id,
+        approval_id="approval-2",
+        operator_identity="operator",
+        verification_result_hash=verification.result_hash,
+        target_state="active",
+        approved=True,
+        issued_at=now[0],
+    )
+    active = gate.activate(
+        proposal,
+        SIGNATURE,
+        "market-data-specialist",
+        benchmark,
+        verification,
+        active_approval,
+        expires_at=now[0] + 100,
+    )
+
+    assert active.status == "rejected"
+    assert requests.lifecycle_snapshot(proposal.candidate_id).lifecycle_status == "verified"
+
+
+def test_authenticated_allowlisted_operator_approval_is_durable_and_can_stage(tmp_path):
+    now = [1_000]
+    requests, gate, proposal, cases = _candidate(tmp_path, now)
+    _, benchmark = gate.benchmark(
+        proposal, cases, scorer_model="benchmark-model", scores=(90, 90), scorer_available=True
+    )
+    assert gate.open_disposable_sandbox(proposal, benchmark, sandbox_id="sandbox-1").status == "benchmarked"
+    _, verification = gate.verify(
+        proposal, benchmark, verifier_identity="independent-verifier", sandbox_id="sandbox-1", verifier_available=True
+    )
+    approval = OperatorApproval(
+        candidate_id=proposal.candidate_id,
+        approval_id="dashboard-approval-1",
+        operator_identity="portal:operator-1",
+        verification_result_hash=verification.result_hash,
+        target_state="staged",
+        approved=True,
+        issued_at=now[0],
+    )
+
+    assert gate.record_operator_approval(
+        approval, authenticated_operator_identity="portal:operator-1"
+    ) is True
+    assert gate.stage(proposal, benchmark, verification, approval).status == "staged"
+    with gate._connection() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM specialist_operator_approvals").fetchone()[0] == 1
+    assert requests.lifecycle_snapshot(proposal.candidate_id).lifecycle_status == "staged"
+
+
+def test_arbitrary_operator_identity_never_creates_staged_or_active_authority(tmp_path):
+    now = [1_000]
+    requests, gate, proposal, cases = _candidate(tmp_path, now)
+    _, benchmark = gate.benchmark(
+        proposal, cases, scorer_model="benchmark-model", scores=(90, 90), scorer_available=True
+    )
+    assert gate.open_disposable_sandbox(proposal, benchmark, sandbox_id="sandbox-1").status == "benchmarked"
+    _, verification = gate.verify(
+        proposal, benchmark, verifier_identity="independent-verifier", sandbox_id="sandbox-1", verifier_available=True
+    )
+    forged = OperatorApproval(
+        candidate_id=proposal.candidate_id,
+        approval_id="arbitrary-string-is-not-authority",
+        operator_identity="totally-unverified-identity",
+        verification_result_hash=verification.result_hash,
+        target_state="staged",
+        approved=True,
+        issued_at=now[0],
+    )
+
+    assert gate.record_operator_approval(forged) is False
+    assert gate.stage(proposal, benchmark, verification, forged).status == "rejected"
+    with gate._connection() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM specialist_operator_approvals").fetchone()[0] == 0
+    assert requests.lifecycle_snapshot(proposal.candidate_id).lifecycle_status == "verified"
+
+
+def test_constructed_receipts_or_approvals_cannot_bypass_durable_promotion_evidence(tmp_path):
+    now = [1_000]
+    requests, gate, proposal, cases = _candidate(tmp_path, now)
+    _, benchmark = gate.benchmark(
+        proposal, cases, scorer_model="benchmark-model", scores=(90, 90), scorer_available=True
+    )
+    assert gate.open_disposable_sandbox(proposal, benchmark, sandbox_id="sandbox-1").status == "benchmarked"
+    _, verification = gate.verify(
+        proposal, benchmark, verifier_identity="independent-verifier", sandbox_id="sandbox-1", verifier_available=True
+    )
+    forged_stage_approval = OperatorApproval(
+        candidate_id=proposal.candidate_id,
+        approval_id="forged-stage",
+        operator_identity="operator",
+        verification_result_hash=verification.result_hash,
+        target_state="staged",
+        approved=True,
+        issued_at=now[0],
+    )
+
+    assert gate.stage(proposal, benchmark, verification, forged_stage_approval).status == "rejected"
+    assert requests.lifecycle_snapshot(proposal.candidate_id).lifecycle_status == "verified"
+    assert CapabilityRegistry(db_path=requests._db_path).resolve(SIGNATURE).status == "no_match"
+
+
+def test_candidate_lifecycle_rejects_all_skips_and_reversals(tmp_path):
+    now = [1_000]
+    requests, gate, proposal, cases = _candidate(tmp_path, now)
+    receipt_hash = _digest("legal-transition-receipt")
+    illegal = (
+        ("candidate", "verified"),
+        ("candidate", "staged"),
+        ("candidate", "active"),
+        ("benchmarked", "candidate"),
+        ("verified", "benchmarked"),
+        ("staged", "verified"),
+        ("active", "staged"),
+    )
+    for expected, next_status in illegal:
+        try:
+            requests.append_lifecycle_transition(
+                proposal.candidate_id,
+                expected_status=expected,
+                next_status=next_status,
+                reason_code="illegal_transition",
+                receipt_hash=receipt_hash,
+            )
+        except ValueError:
+            pass
+        else:
+            assert False, f"accepted illegal lifecycle edge {expected}->{next_status}"
+    assert requests.lifecycle_snapshot(proposal.candidate_id).lifecycle_status == "candidate"
+    assert CapabilityRegistry(db_path=requests._db_path).resolve(SIGNATURE).status == "no_match"

--- a/tests/agent/test_profile_candidate_review.py
+++ b/tests/agent/test_profile_candidate_review.py
@@ -1,0 +1,260 @@
+"""Contracts for the inert specialist-profile advisory boundary."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from agent.profile_candidate_review import (
+    AdvisoryLimits,
+    AdvisoryProfileProposal,
+    AdvisoryRequest,
+    IntegrationCapability,
+    ReviewReceipt,
+    review_with,
+    validate_proposal,
+    validate_receipt,
+)
+from gateway.candidate_profile_requests import (
+    DEFAULT_POLICY_DIGEST,
+    OpaqueEvidenceReference,
+    SanitizedTaskEnvelope,
+)
+from gateway.capability_registry import CapabilitySignature
+
+
+SIGNATURE = CapabilitySignature(
+    domain="market-data",
+    actions=("audit", "read"),
+    evidence_class="diagnostic-only",
+    requested_permissions=("market-data:read",),
+)
+
+
+def _reference(label: str) -> OpaqueEvidenceReference:
+    return OpaqueEvidenceReference(digest=hashlib.sha256(label.encode()).hexdigest())
+
+
+def _capability(*, agent: str = "claude", allowed: bool = False) -> IntegrationCapability:
+    return IntegrationCapability(
+        agent=agent,
+        supported_operation="bounded local receipt",
+        authentication_owner="operator",
+        human_interaction_required=True,
+        egress_class="external-provider",
+        allowed=allowed,
+        evidence="phase-0 receipt",
+        failure_fallback="advisory_unavailable",
+    )
+
+
+def _request() -> AdvisoryRequest:
+    return AdvisoryRequest(
+        candidate_request_id="cpr_1234567890abcdef12345678_12345678",
+        signature=SIGNATURE,
+        envelope=SanitizedTaskEnvelope(evidence_refs=(_reference("case-1"),)),
+        limits=AdvisoryLimits(max_input_bytes=2_048, max_model_calls=1, timeout_seconds=5),
+        policy_digest=DEFAULT_POLICY_DIGEST,
+    )
+
+
+def _received_receipt(
+    request: AdvisoryRequest,
+    *,
+    policy_digest: str | None = None,
+    max_input_bytes: int | None = None,
+    max_model_calls: int | None = None,
+    timeout_seconds: int | None = None,
+    elapsed_seconds: int = 0,
+    model_calls: int = 0,
+    status: str = "advisory_received",
+) -> ReviewReceipt:
+    return ReviewReceipt(
+        provider_label="claude",
+        candidate_request_id=request.candidate_request_id,
+        input_hash=request.input_hash,
+        policy_digest=policy_digest or request.policy_digest,
+        max_input_bytes=max_input_bytes if max_input_bytes is not None else request.limits.max_input_bytes,
+        max_model_calls=max_model_calls if max_model_calls is not None else request.limits.max_model_calls,
+        timeout_seconds=timeout_seconds if timeout_seconds is not None else request.limits.timeout_seconds,
+        elapsed_seconds=elapsed_seconds,
+        model_calls=model_calls,
+        status=status,
+        reason="synthetic local receipt for contract validation",
+    )
+
+
+def _proposal(receipt: ReviewReceipt, *, claimed_permissions: tuple[str, ...] = ("market-data:read",),
+              soul_markdown: str = "Read the bounded evidence and report uncertainty.") -> AdvisoryProfileProposal:
+    return AdvisoryProfileProposal(
+        role_name="market-data-reviewer",
+        soul_markdown=soul_markdown,
+        benchmark_cases=("opaque-case",),
+        claimed_permissions=claimed_permissions,
+        limitations=("diagnostic-only",),
+        source_receipt_hash=receipt.source_receipt_hash,
+    )
+
+
+def test_unavailable_claude_adapter_emits_bound_receipt_and_never_substitutes_a_model():
+    result = review_with(_capability(), _request())
+
+    assert result.status == "advisory_unavailable"
+    assert result.proposal is None
+    assert result.receipt.provider_label == "claude"
+    assert result.receipt.candidate_request_id == _request().candidate_request_id
+    assert result.receipt.input_hash == _request().input_hash
+    assert result.receipt.policy_digest == DEFAULT_POLICY_DIGEST
+    assert result.receipt.model_calls == 0
+    assert result.receipt.source_receipt_hash
+
+
+def test_allowed_capability_without_a_wired_adapter_remains_unavailable_not_a_provider_call():
+    result = review_with(_capability(agent="codex", allowed=True), _request())
+
+    assert result.status == "advisory_unavailable"
+    assert result.receipt.provider_label == "codex"
+    assert result.receipt.model_calls == 0
+    assert result.receipt.reason == "no approved advisory adapter is wired"
+
+
+def test_timeout_receipt_is_rejected_when_it_exceeds_bound_budget():
+    request = _request()
+    result = validate_receipt(
+        ReviewReceipt(
+            provider_label="claude",
+            candidate_request_id=request.candidate_request_id,
+            input_hash=request.input_hash,
+            policy_digest=request.policy_digest,
+            max_input_bytes=request.limits.max_input_bytes,
+            max_model_calls=request.limits.max_model_calls,
+            timeout_seconds=request.limits.timeout_seconds,
+            elapsed_seconds=6,
+            model_calls=0,
+            status="advisory_timeout",
+            reason="local timeout observation",
+        ),
+        request,
+        _capability(),
+    )
+
+    assert result.status == "rejected"
+    assert result.reason == "receipt timeout exceeds requested budget"
+
+
+def test_malformed_receipt_cannot_be_bound_to_another_candidate_or_input():
+    request = _request()
+    result = validate_receipt(
+        ReviewReceipt(
+            provider_label="claude",
+            candidate_request_id="cpr_aaaaaaaaaaaaaaaaaaaaaaaa_bbbbbbbb",
+            input_hash="0" * 64,
+            policy_digest=request.policy_digest,
+            max_input_bytes=request.limits.max_input_bytes,
+            max_model_calls=0,
+            timeout_seconds=request.limits.timeout_seconds,
+            elapsed_seconds=0,
+            model_calls=0,
+            status="advisory_unavailable",
+            reason="malformed synthetic receipt",
+        ),
+        request,
+        _capability(),
+    )
+
+    assert result.status == "rejected"
+    assert result.reason == "receipt candidate or input binding does not match request"
+
+
+def test_proposal_rejects_secret_bearing_content():
+    request = _request()
+    receipt = _received_receipt(request)
+    proposal = _proposal(receipt, soul_markdown="Use api_key=not-a-secret-here when reviewing.")
+
+    result = validate_proposal(proposal, request, receipt, _capability(allowed=True))
+
+    assert result.status == "rejected"
+    assert result.reason == "proposal contains secret-like material"
+
+
+def test_proposal_rejects_unapproved_permission_delta():
+    request = _request()
+    receipt = _received_receipt(request)
+    proposal = _proposal(receipt, claimed_permissions=("market-data:read", "market-data:write"))
+
+    result = validate_proposal(proposal, request, receipt, _capability(allowed=True))
+
+    assert result.status == "rejected"
+    assert result.reason == "proposal expands requested permissions"
+
+
+def test_proposal_requires_a_bound_receipt():
+    request = _request()
+    receipt = _received_receipt(request)
+
+    result = validate_proposal(_proposal(receipt), request, None, _capability(allowed=True))
+
+    assert result.status == "rejected"
+    assert result.reason == "proposal requires a bound advisory receipt"
+
+
+def test_phase0_rejects_an_injected_received_receipt_even_when_compatibility_is_allowed():
+    request = _request()
+    receipt = _received_receipt(request)
+
+    result = validate_proposal(_proposal(receipt), request, receipt, _capability(allowed=True))
+
+    assert result.status == "rejected"
+    assert result.reason == "proposal receipt rejected: no advisory adapter is wired in Phase 0"
+
+
+@pytest.mark.parametrize(
+    ("receipt_kwargs", "expected_reason"),
+    (
+        ({"elapsed_seconds": 6, "status": "advisory_timeout"}, "receipt timeout exceeds requested budget"),
+        ({"policy_digest": "d" * 64}, "receipt policy digest does not match request"),
+        ({"max_input_bytes": 1}, "receipt budget does not match request"),
+        ({"model_calls": 2}, "receipt model calls exceed requested budget"),
+    ),
+)
+def test_proposal_rejects_any_invalid_bound_receipt(receipt_kwargs, expected_reason):
+    request = _request()
+    receipt = _received_receipt(request, **receipt_kwargs)
+
+    result = validate_proposal(_proposal(receipt), request, receipt, _capability(allowed=True))
+
+    assert result.status == "rejected"
+    assert result.reason == f"proposal receipt rejected: {expected_reason}"
+
+
+def test_proposal_rejects_secret_like_claimed_permission_before_scope_comparison():
+    request = _request()
+    receipt = _received_receipt(request)
+
+    result = validate_proposal(
+        _proposal(receipt, claimed_permissions=("api_key=not-a-secret-here",)),
+        request,
+        receipt,
+        _capability(allowed=True),
+    )
+
+    assert result.status == "rejected"
+    assert result.reason == "proposal contains secret-like material"
+
+
+def test_request_rejects_secret_like_requested_permission_at_input_boundary():
+    secret_signature = CapabilitySignature(
+        domain="market-data",
+        actions=("read",),
+        evidence_class="diagnostic-only",
+        requested_permissions=("api_key=not-a-secret-here",),
+    )
+
+    with pytest.raises(ValueError, match="secret-like"):
+        AdvisoryRequest(
+            candidate_request_id="cpr_1234567890abcdef12345678_12345678",
+            signature=secret_signature,
+            envelope=SanitizedTaskEnvelope(evidence_refs=(_reference("secret-permission"),)),
+            limits=AdvisoryLimits(max_input_bytes=2_048, max_model_calls=1, timeout_seconds=5),
+        )

--- a/tests/gateway/test_candidate_profile_requests.py
+++ b/tests/gateway/test_candidate_profile_requests.py
@@ -1,0 +1,532 @@
+"""Safety contracts for inert, local specialist-candidate requests."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from gateway.candidate_profile_requests import (
+    CandidateProfileRequests,
+    DEFAULT_POLICY_DIGEST,
+    OpaqueEvidenceReference,
+    SanitizedTaskEnvelope,
+)
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature, RegistryResolution
+from gateway.specialist_handoff import HandoffSource, create_specialist_handoff
+from gateway.specialist_routing import RouteKind, SpecialistRouteDecision
+from hermes_cli import kanban_db as kb
+
+
+NO_MATCH = CapabilitySignature(
+    domain="market-data",
+    actions=("audit", "read"),
+    evidence_class="diagnostic-only",
+    requested_permissions=("market-data:read",),
+)
+WRITE_CAPABILITY = CapabilitySignature(
+    domain="market-data",
+    actions=("read", "write"),
+    evidence_class="diagnostic-only",
+    requested_permissions=("market-data:read", "market-data:write"),
+)
+NO_MATCH_RESOLUTION = RegistryResolution(
+    status="no_match", profile=None, reason="no active profile"
+)
+
+
+def _opaque_reference(label: str) -> OpaqueEvidenceReference:
+    return OpaqueEvidenceReference(digest=hashlib.sha256(label.encode("utf-8")).hexdigest())
+
+
+@pytest.fixture
+def requests(tmp_path):
+    return CandidateProfileRequests(db_path=tmp_path / "candidate-requests.db")
+
+
+def test_no_match_creates_one_inert_candidate_and_orchestrator_fallback(requests):
+    result = requests.open_or_reuse(
+        NO_MATCH,
+        source_key="discord:1",
+        resolution=NO_MATCH_RESOLUTION,
+        envelope=SanitizedTaskEnvelope(evidence_refs=(_opaque_reference("task-1"),)),
+    )
+
+    assert result.status == "candidate"
+    assert result.profile_id is None
+
+
+def test_forged_no_match_cannot_create_candidate_when_local_registry_matches(tmp_path):
+    db_path = tmp_path / "candidate-requests.db"
+    CapabilityRegistry(db_path=db_path).register_fixed_baseline(
+        profile_id="market-data-authority-auditor", signature=NO_MATCH
+    )
+    requests = CandidateProfileRequests(db_path=db_path)
+    forged = RegistryResolution(
+        status="no_match", profile=None, reason="untrusted caller data"
+    )
+
+    result = requests.open_or_reuse(
+        NO_MATCH,
+        source_key="discord:forged-no-match",
+        resolution=forged,
+        envelope=SanitizedTaskEnvelope(evidence_refs=(_opaque_reference("forged-no-match"),)),
+    )
+
+    assert result.status == "rejected"
+    assert result.request_id == ""
+    with kb.connect_closing(db_path) as conn:
+        rows = conn.execute("SELECT request_id FROM candidate_profile_requests").fetchall()
+    assert rows == []
+
+
+def test_duplicate_source_and_scope_reuses_candidate_request(requests):
+    first = requests.open_or_reuse(
+        NO_MATCH, source_key="discord:1", resolution=NO_MATCH_RESOLUTION
+    )
+    repeated = requests.open_or_reuse(
+        NO_MATCH, source_key="discord:1", resolution=NO_MATCH_RESOLUTION
+    )
+
+    assert first.status == "candidate"
+    assert repeated.status == "duplicate"
+    assert repeated.request_id == first.request_id
+    assert repeated.profile_id is None
+
+
+def test_candidate_rejects_non_read_only_permission_delta(requests):
+    result = requests.open_or_reuse(
+        WRITE_CAPABILITY, source_key="discord:2", resolution=NO_MATCH_RESOLUTION
+    )
+
+    assert result.status == "rejected"
+    assert result.profile_id is None
+    assert "read-only" in result.reason
+
+
+def test_rejected_candidate_enters_finite_cooldown(requests):
+    first = requests.open_or_reuse(
+        WRITE_CAPABILITY, source_key="discord:2", resolution=NO_MATCH_RESOLUTION
+    )
+    repeated = requests.open_or_reuse(
+        WRITE_CAPABILITY, source_key="discord:2", resolution=NO_MATCH_RESOLUTION
+    )
+
+    assert first.status == "rejected"
+    assert repeated.status == "cooldown"
+    assert repeated.request_id == first.request_id
+
+
+def test_corrected_envelope_cannot_bypass_latest_rejection_cooldown(tmp_path):
+    now = [1_000]
+    requests = CandidateProfileRequests(
+        db_path=tmp_path / "candidate-requests.db", cooldown_seconds=10, clock=lambda: now[0]
+    )
+    rejected = requests.open_or_reuse(
+        NO_MATCH,
+        source_key="discord:fixed-state",
+        resolution=NO_MATCH_RESOLUTION,
+        envelope=SanitizedTaskEnvelope(evidence_refs=("api_key=not-safe",)),
+    )
+    corrected = requests.open_or_reuse(
+        NO_MATCH,
+        source_key="discord:fixed-state",
+        resolution=NO_MATCH_RESOLUTION,
+        envelope=SanitizedTaskEnvelope(evidence_refs=(_opaque_reference("corrected"),)),
+    )
+
+    assert rejected.status == "rejected"
+    assert corrected.status == "cooldown"
+    assert corrected.request_id == rejected.request_id
+
+
+def test_later_terminal_state_supersedes_an_older_candidate(tmp_path):
+    now = [1_000]
+    requests = CandidateProfileRequests(
+        db_path=tmp_path / "candidate-requests.db", cooldown_seconds=10, clock=lambda: now[0]
+    )
+    candidate = requests.open_or_reuse(
+        NO_MATCH, source_key="discord:terminal-state", resolution=NO_MATCH_RESOLUTION
+    )
+    with kb.connect_closing(requests._db_path) as conn:
+        request_hash = conn.execute(
+            "SELECT request_hash FROM candidate_profile_requests WHERE request_id = ?",
+            (candidate.request_id,),
+        ).fetchone()["request_hash"]
+        with kb.write_txn(conn):
+            CandidateProfileRequests._insert(
+                conn,
+                request_hash=request_hash,
+                signature=NO_MATCH,
+                source_key="discord:terminal-state",
+                policy_digest=DEFAULT_POLICY_DIGEST,
+                evidence_ref_hashes=(),
+                lifecycle_status="rejected",
+                reason_code="test_terminal",
+                cooldown_until=now[0] + 10,
+                now=now[0],
+            )
+
+    retried = requests.open_or_reuse(
+        NO_MATCH, source_key="discord:terminal-state", resolution=NO_MATCH_RESOLUTION
+    )
+
+    assert retried.status == "cooldown"
+
+
+def test_rejected_candidate_can_be_reconsidered_after_its_bounded_cooldown(tmp_path):
+    now = [1_000]
+    requests = CandidateProfileRequests(
+        db_path=tmp_path / "candidate-requests.db", cooldown_seconds=10, clock=lambda: now[0]
+    )
+    first = requests.open_or_reuse(
+        WRITE_CAPABILITY, source_key="discord:2", resolution=NO_MATCH_RESOLUTION
+    )
+    now[0] += 11
+    reconsidered = requests.open_or_reuse(
+        WRITE_CAPABILITY, source_key="discord:2", resolution=NO_MATCH_RESOLUTION
+    )
+
+    assert first.status == "rejected"
+    assert reconsidered.status == "rejected"
+    assert reconsidered.request_id != first.request_id
+
+
+@pytest.mark.parametrize(
+    "permission",
+    ("network:read", "credential:read", "task:concurrency", "operator:authority"),
+)
+def test_candidate_rejects_egress_credential_concurrency_and_authority_deltas(requests, permission):
+    signature = CapabilitySignature(
+        domain="diagnostics",
+        actions=("read",),
+        evidence_class="diagnostic-only",
+        requested_permissions=(permission,),
+    )
+
+    result = requests.open_or_reuse(
+        signature, source_key=f"discord:{permission}", resolution=NO_MATCH_RESOLUTION
+    )
+
+    assert result.status == "rejected"
+
+
+@pytest.mark.parametrize("permission", (".env:read", "ssh-private-key:read", "s3:read", "tcp:read"))
+def test_candidate_rejects_unknown_read_namespaces(requests, permission):
+    signature = CapabilitySignature(
+        domain="financial-analysis",
+        actions=("read",),
+        evidence_class="diagnostic-only",
+        requested_permissions=(permission,),
+    )
+
+    assert requests.open_or_reuse(
+        signature, source_key=f"discord:unknown:{permission}", resolution=NO_MATCH_RESOLUTION
+    ).status == "rejected"
+
+
+def test_candidate_allows_explicit_safe_financial_analysis_scope(requests):
+    signature = CapabilitySignature(
+        domain="financial-analysis",
+        actions=("audit", "read"),
+        evidence_class="diagnostic-only",
+        requested_permissions=("financial-analysis:read",),
+    )
+
+    assert requests.open_or_reuse(
+        signature, source_key="discord:financial-analysis", resolution=NO_MATCH_RESOLUTION
+    ).status == "candidate"
+
+
+def test_unsanitized_evidence_is_rejected_and_not_persisted(requests):
+    result = requests.open_or_reuse(
+        NO_MATCH,
+        source_key="discord:3",
+        resolution=NO_MATCH_RESOLUTION,
+        envelope=SanitizedTaskEnvelope(evidence_refs=("api_key=not-safe",)),
+    )
+
+    assert result.status == "rejected"
+    assert "sanitized" in result.reason
+    with kb.connect_closing(requests._db_path) as conn:
+        stored = conn.execute(
+            "SELECT evidence_ref_hashes_json FROM candidate_profile_requests"
+        ).fetchone()
+    assert stored is not None
+    assert "api_key" not in stored["evidence_ref_hashes_json"]
+
+
+def test_candidate_ledger_never_persists_rejected_private_scope_or_plaintext_evidence(requests):
+    unsafe_signature = CapabilitySignature(
+        domain="/Users/alice/private-research",
+        actions=("read",),
+        evidence_class="diagnostic-only",
+        requested_permissions=("ssh-private-key:read",),
+    )
+    requests.open_or_reuse(
+        unsafe_signature,
+        source_key="discord:Bearer-very-private-value",
+        resolution=NO_MATCH_RESOLUTION,
+        envelope=SanitizedTaskEnvelope(evidence_refs=("https://private.example/evidence",)),
+    )
+
+    with kb.connect_closing(requests._db_path) as conn:
+        stored = conn.execute("SELECT * FROM candidate_profile_requests").fetchone()
+    persisted = " ".join(str(stored[column]) for column in stored.keys())
+    for forbidden in (
+        "/Users/alice/private-research",
+        "ssh-private-key",
+        "https://private.example/evidence",
+        "Bearer-very-private-value",
+    ):
+        assert forbidden not in persisted
+
+
+def test_candidate_request_rows_are_append_only(requests):
+    result = requests.open_or_reuse(
+        NO_MATCH, source_key="discord:append-only", resolution=NO_MATCH_RESOLUTION
+    )
+
+    with kb.connect_closing(requests._db_path) as conn:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "UPDATE candidate_profile_requests SET lifecycle_status = 'active' WHERE request_id = ?",
+                (result.request_id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "DELETE FROM candidate_profile_requests WHERE request_id = ?", (result.request_id,)
+            )
+
+
+def test_candidate_request_migration_is_idempotent(tmp_path):
+    db_path = tmp_path / "candidate-requests.db"
+
+    kb.init_db(db_path)
+    kb.init_db(db_path)
+
+    with kb.connect_closing(db_path) as conn:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(candidate_profile_requests)")
+        }
+        triggers = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'candidate_profile_requests'"
+            )
+        }
+    assert {"request_hash", "source_key_hash", "policy_digest", "lifecycle_status"} <= columns
+    assert triggers == {
+        "candidate_profile_requests_no_delete",
+        "candidate_profile_requests_no_update",
+    }
+
+
+def test_legacy_plaintext_candidate_ledger_is_replaced_before_opening_requests(tmp_path):
+    db_path = tmp_path / "legacy-candidate-requests.db"
+    kb.init_db(db_path)
+    with kb.connect_closing(db_path) as conn:
+        conn.execute("DROP TABLE candidate_profile_requests")
+        conn.execute(
+            """
+            CREATE TABLE candidate_profile_requests (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                request_id TEXT NOT NULL UNIQUE,
+                request_hash TEXT NOT NULL,
+                signature_hash TEXT NOT NULL,
+                permissions_hash TEXT NOT NULL,
+                source_key_hash TEXT NOT NULL,
+                policy_digest TEXT NOT NULL,
+                domain TEXT NOT NULL,
+                actions_json TEXT NOT NULL,
+                evidence_class TEXT NOT NULL,
+                requested_permissions_json TEXT NOT NULL,
+                evidence_refs_json TEXT NOT NULL,
+                lifecycle_status TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                cooldown_until INTEGER,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO candidate_profile_requests (
+                request_id, request_hash, signature_hash, permissions_hash, source_key_hash,
+                policy_digest, domain, actions_json, evidence_class, requested_permissions_json,
+                evidence_refs_json, lifecycle_status, reason, cooldown_until, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-raw-request",
+                "a" * 64,
+                "b" * 64,
+                "c" * 64,
+                "d" * 64,
+                "e" * 64,
+                "/Users/alice/private-scope",
+                '["read"]',
+                "diagnostic-only",
+                '["ssh-private-key:read"]',
+                '["https://private.example/evidence"]',
+                "candidate",
+                "legacy raw reason",
+                None,
+                1,
+            ),
+        )
+
+    kb.init_db(db_path)
+    requests = CandidateProfileRequests(db_path=db_path)
+    result = requests.open_or_reuse(
+        NO_MATCH,
+        source_key="discord:legacy-upgrade",
+        resolution=NO_MATCH_RESOLUTION,
+        envelope=SanitizedTaskEnvelope(evidence_refs=(_opaque_reference("legacy-upgrade"),)),
+    )
+
+    assert result.status == "candidate"
+    kb.init_db(db_path)
+    with kb.connect_closing(db_path) as conn:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(candidate_profile_requests)")
+        }
+        rows = conn.execute("SELECT * FROM candidate_profile_requests").fetchall()
+        indexes = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'candidate_profile_requests'"
+            )
+        }
+        triggers = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'candidate_profile_requests'"
+            )
+        }
+    assert {"evidence_ref_hashes_json", "reason_code"} <= columns
+    assert not {"domain", "actions_json", "evidence_refs_json", "reason"} & columns
+    assert "idx_candidate_profile_requests_hash_state" in indexes
+    assert triggers == {
+        "candidate_profile_requests_no_delete",
+        "candidate_profile_requests_no_update",
+    }
+    persisted = " ".join(str(row[column]) for row in rows for column in row.keys())
+    for raw_legacy_value in (
+        "/Users/alice/private-scope",
+        "ssh-private-key:read",
+        "https://private.example/evidence",
+        "legacy raw reason",
+    ):
+        assert raw_legacy_value not in persisted
+
+
+def test_hybrid_candidate_ledger_is_replaced_before_opening_requests(tmp_path):
+    db_path = tmp_path / "hybrid-candidate-requests.db"
+    kb.init_db(db_path)
+    with kb.connect_closing(db_path) as conn:
+        conn.execute("ALTER TABLE candidate_profile_requests ADD COLUMN domain TEXT")
+        conn.execute(
+            """
+            INSERT INTO candidate_profile_requests (
+                request_id, request_hash, signature_hash, permissions_hash, source_key_hash,
+                policy_digest, evidence_ref_hashes_json, lifecycle_status, reason_code,
+                cooldown_until, created_at, domain
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "hybrid-raw-request",
+                "a" * 64,
+                "b" * 64,
+                "c" * 64,
+                "d" * 64,
+                "e" * 64,
+                '["' + "f" * 64 + '"]',
+                "candidate",
+                "missing_active_specialist",
+                None,
+                1,
+                "/Users/alice/private-scope",
+            ),
+        )
+
+    kb.init_db(db_path)
+    requests = CandidateProfileRequests(db_path=db_path)
+    result = requests.open_or_reuse(
+        NO_MATCH,
+        source_key="discord:hybrid-upgrade",
+        resolution=NO_MATCH_RESOLUTION,
+        envelope=SanitizedTaskEnvelope(evidence_refs=(_opaque_reference("hybrid-upgrade"),)),
+    )
+
+    assert result.status == "candidate"
+    with kb.connect_closing(db_path) as conn:
+        columns = {row["name"] for row in conn.execute("PRAGMA table_info(candidate_profile_requests)")}
+        rows = conn.execute("SELECT * FROM candidate_profile_requests").fetchall()
+    assert "domain" not in columns
+    assert "/Users/alice/private-scope" not in " ".join(
+        str(row[column]) for row in rows for column in row.keys()
+    )
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    for profile in ("task-orchestrator", "market-data-authority-auditor"):
+        (home / "profiles" / profile).mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_no_match_handoff_uses_existing_orchestrator_and_preserves_source_idempotency(kanban_home):
+    source = HandoffSource(
+        platform="discord",
+        chat_id="channel-1",
+        chat_type="group",
+        user_id="user-1",
+        message_id="message-no-match",
+    )
+    decision = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="generated-market-data-candidate",
+        confidence=1.0,
+        reason="request requires a local capability",
+        title="Audit market data",
+    )
+    kwargs = {
+        "decision": decision,
+        "source": source,
+        "request": "Audit the supplied market-data evidence.",
+        "signature": NO_MATCH,
+        "registry": CapabilityRegistry(board=kb.DEFAULT_BOARD),
+        "board": kb.DEFAULT_BOARD,
+    }
+
+    first = create_specialist_handoff(**kwargs)
+    repeated = create_specialist_handoff(**kwargs)
+
+    assert first.ok, first.reason
+    assert repeated.ok, repeated.reason
+    assert first.created is True
+    assert repeated.created is False
+    assert first.task_id == repeated.task_id
+    with kb.connect() as conn:
+        task = kb.get_task(conn, first.task_id)
+        subscriptions = conn.execute(
+            "SELECT COUNT(*) AS count FROM kanban_notify_subs WHERE task_id = ?", (first.task_id,)
+        ).fetchone()
+        candidate_rows = conn.execute(
+            "SELECT request_hash, lifecycle_status FROM candidate_profile_requests"
+        ).fetchall()
+    assert task is not None
+    assert task.assignee == "task-orchestrator"
+    assert json.loads(task.body)["candidate_request_id"] == first.candidate_request_id
+    assert subscriptions["count"] == 1
+    assert len(candidate_rows) == 1
+    assert candidate_rows[0]["lifecycle_status"] == "candidate"

--- a/tests/gateway/test_capability_registry.py
+++ b/tests/gateway/test_capability_registry.py
@@ -1,0 +1,212 @@
+"""Contract tests for the local specialist capability registry."""
+
+from __future__ import annotations
+
+import sqlite3
+import json
+import time
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature
+from hermes_cli import kanban_db as kb
+
+
+MARKET_DATA = CapabilitySignature(
+    domain="market-data",
+    actions=("audit", "read"),
+    evidence_class="diagnostic-only",
+    requested_permissions=("market-data:read",),
+)
+
+
+@pytest.fixture
+def registry(tmp_path):
+    return CapabilityRegistry(db_path=tmp_path / "capabilities.db")
+
+
+def test_resolve_returns_only_unexpired_exact_scope_active_profile(registry):
+    registry.register_fixed_baseline(profile_id="market-data-authority-auditor", signature=MARKET_DATA)
+
+    resolution = registry.resolve(MARKET_DATA)
+
+    assert resolution.status == "active_match"
+    assert resolution.profile == "market-data-authority-auditor"
+
+
+def test_resolve_rejects_expired_or_permission_expanding_profile(registry):
+    registry.register_fixed_baseline(
+        profile_id="market-data-authority-auditor",
+        signature=MARKET_DATA,
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+
+    with pytest.raises(ValueError, match="direct arbitrary"):
+        registry.add_active(
+            profile_id="permission-expanding",
+            signature=CapabilitySignature(
+                domain=MARKET_DATA.domain,
+                actions=MARKET_DATA.actions,
+                evidence_class=MARKET_DATA.evidence_class,
+                requested_permissions=("market-data:read", "market-data:write"),
+            ),
+        )
+
+    resolution = registry.resolve(MARKET_DATA)
+
+    assert resolution.status == "no_match"
+    assert resolution.profile is None
+
+
+def test_resolve_returns_ambiguous_instead_of_choosing_between_profiles(registry):
+    with kb.connect_closing(registry._db_path) as conn:
+        for profile_id in ("one", "two"):
+            conn.execute(
+                """
+                INSERT INTO capability_profiles (
+                    profile_id, signature_hash, permissions_hash,
+                    model_receipt_hash, verification_receipt_hash,
+                    domain, actions_json, evidence_class, requested_permissions_json,
+                    expires_at, status, created_at
+                ) VALUES (?, ?, ?, '', '', ?, ?, ?, ?, NULL, 'active', ?)
+                """,
+                (
+                    profile_id,
+                    MARKET_DATA.signature_hash,
+                    MARKET_DATA.permissions_hash,
+                    MARKET_DATA.domain,
+                    json.dumps(MARKET_DATA.actions),
+                    MARKET_DATA.evidence_class,
+                    json.dumps(MARKET_DATA.requested_permissions),
+                    int(time.time()),
+                ),
+            )
+
+    resolution = registry.resolve(MARKET_DATA)
+
+    assert resolution.status == "ambiguous"
+    assert resolution.profile is None
+
+
+def test_migration_is_idempotent_and_creates_append_only_registry_table(tmp_path):
+    db_path = tmp_path / "capabilities.db"
+
+    kb.init_db(db_path)
+    kb.init_db(db_path)
+
+    with kb.connect_closing(db_path) as conn:
+        columns = {row["name"] for row in conn.execute("PRAGMA table_info(capability_profiles)")}
+
+    assert {
+        "profile_id",
+        "signature_hash",
+        "permissions_hash",
+        "model_receipt_hash",
+        "verification_receipt_hash",
+        "expires_at",
+        "status",
+    } <= columns
+
+
+def test_public_direct_active_registration_cannot_bypass_promotion_gates(registry):
+    with pytest.raises(ValueError, match="direct arbitrary"):
+        registry.add_active(
+            profile_id="generated-bypass",
+            signature=MARKET_DATA,
+            model_receipt_hash="a" * 64,
+            verification_receipt_hash="b" * 64,
+        )
+
+    assert registry.resolve(MARKET_DATA).status == "no_match"
+
+
+def test_capability_profiles_reject_direct_update_and_delete(registry):
+    registry.register_fixed_baseline(profile_id="market-data-authority-auditor", signature=MARKET_DATA)
+
+    with kb.connect_closing(registry._db_path) as conn:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "UPDATE capability_profiles SET status = 'inactive' WHERE profile_id = 'market-data-authority-auditor'"
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute("DELETE FROM capability_profiles WHERE profile_id = 'market-data-authority-auditor'")
+
+    resolution = registry.resolve(MARKET_DATA)
+    assert resolution.status == "active_match"
+    assert resolution.profile == "market-data-authority-auditor"
+
+
+def test_migration_restores_capability_profile_immutability_triggers(tmp_path):
+    db_path = tmp_path / "capabilities.db"
+    kb.init_db(db_path)
+
+    with kb.connect_closing(db_path) as conn:
+        conn.execute("DROP TRIGGER capability_profiles_no_update")
+        conn.execute("DROP TRIGGER capability_profiles_no_delete")
+
+    kb.init_db(db_path)
+
+    with kb.connect_closing(db_path) as conn:
+        triggers = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'capability_profiles'"
+            )
+        }
+
+    assert triggers == {"capability_profiles_no_delete", "capability_profiles_no_update"}
+
+
+def test_resolve_rejects_malformed_persisted_expiry(registry):
+    with kb.connect_closing(registry._db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO capability_profiles (
+                profile_id, signature_hash, permissions_hash,
+                model_receipt_hash, verification_receipt_hash,
+                domain, actions_json, evidence_class, requested_permissions_json,
+                expires_at, status, created_at
+            ) VALUES (?, ?, ?, '', '', ?, ?, ?, ?, ?, 'active', ?)
+            """,
+            (
+                "malformed-expiry",
+                MARKET_DATA.signature_hash,
+                MARKET_DATA.permissions_hash,
+                MARKET_DATA.domain,
+                json.dumps(MARKET_DATA.actions),
+                MARKET_DATA.evidence_class,
+                json.dumps(MARKET_DATA.requested_permissions),
+                "invalid-time",
+                int(time.time()),
+            ),
+        )
+
+    resolution = registry.resolve(MARKET_DATA)
+
+    assert resolution.status == "no_match"
+    assert resolution.profile is None
+
+
+def test_hash_only_promotion_cannot_create_an_active_profile(registry):
+    with pytest.raises(ValueError, match="hash-only promotion is disabled"):
+        registry.add_active_from_promotion(
+            profile_id="forged-promotion",
+            signature=MARKET_DATA,
+            benchmark_receipt_hash="a" * 64,
+            verification_receipt_hash="b" * 64,
+        )
+
+    assert registry.resolve(MARKET_DATA).status == "no_match"
+
+
+def test_durable_looking_generated_promotion_still_fails_without_authenticated_approval_authority(registry):
+    with pytest.raises(ValueError, match="authenticated operator approval authority"):
+        registry.add_active_from_durable_promotion(
+            profile_id="generated-profile",
+            signature=MARKET_DATA,
+            candidate_id="cpr_1234567890abcdef12345678_12345678",
+            promotion_proof_hash="a" * 64,
+        )
+
+    assert registry.resolve(MARKET_DATA).status == "no_match"

--- a/tests/gateway/test_discord_specialist_routing.py
+++ b/tests/gateway/test_discord_specialist_routing.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    import plugins.platforms.discord.adapter as discord_platform
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    monkeypatch.setattr(
+        discord_platform.discord,
+        "DMChannel",
+        type("DMChannel", (), {}),
+        raising=False,
+    )
+    value = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="fake-token",
+            extra={
+                "specialist_routing": {
+                    "enabled": True,
+                    "board": "project-maintenance",
+                    "profiles": {
+                        "task-orchestrator": "broad coordinated work",
+                        "patch-steward": "narrow corrective patches",
+                    },
+                }
+            },
+        )
+    )
+    value._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    value.send = AsyncMock()
+    return value
+
+
+def _event(text="Patch the confirmed failure"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        message_id="message-1",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="project-updates",
+            chat_type="group",
+            user_id="operator-1",
+        ),
+    )
+
+
+def test_settings_keep_only_bounded_explicit_profile_descriptions(adapter):
+    settings = adapter._specialist_routing_settings()
+
+    assert settings["enabled"] is True
+    assert settings["profiles"] == {
+        "task-orchestrator": "broad coordinated work",
+        "patch-steward": "narrow corrective patches",
+    }
+
+
+def test_empty_profile_map_disables_routing(adapter):
+    adapter.config.extra["specialist_routing"]["profiles"] = {}
+
+    assert adapter._specialist_routing_settings() == {"enabled": False}
+
+
+def test_config_bridges_discord_specialist_routing(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "discord:\n"
+        "  specialist_routing:\n"
+        "    enabled: true\n"
+        "    board: project-maintenance\n"
+        "    profiles:\n"
+        "      patch-steward: narrow corrective patches\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.DISCORD].extra["specialist_routing"][
+        "profiles"
+    ] == {"patch-steward": "narrow corrective patches"}
+
+
+def test_specialist_route_creates_one_handoff_and_acknowledges(adapter, monkeypatch):
+    from gateway.specialist_handoff import HandoffResult
+    from gateway.specialist_routing import RouteKind, SpecialistRouteDecision
+
+    adapter._classify_specialist_event = AsyncMock(
+        return_value=SpecialistRouteDecision(
+            kind=RouteKind.SPECIALIST,
+            profile="patch-steward",
+            confidence=0.95,
+            reason="bounded patch",
+            title="Patch confirmed failure",
+        )
+    )
+    create = AsyncMock(return_value=HandoffResult(True, task_id="t_abc", created=True))
+
+    async def fake_to_thread(func, **kwargs):
+        return await create(**kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    handled = asyncio.run(adapter._maybe_route_specialist_event(_event()))
+
+    assert handled is True
+    create.assert_awaited_once()
+    adapter.send.assert_awaited_once_with(
+        "project-updates",
+        content="Planning `t_abc` with `patch-steward`.",
+        reply_to="message-1",
+    )
+
+
+def test_general_route_preserves_normal_chat_path(adapter):
+    from gateway.specialist_routing import RouteKind, SpecialistRouteDecision
+
+    adapter._classify_specialist_event = AsyncMock(
+        return_value=SpecialistRouteDecision(
+            kind=RouteKind.GENERAL,
+            reason="ordinary conversation",
+            confidence=0.0,
+            audit_reason="general",
+        )
+    )
+
+    assert asyncio.run(adapter._maybe_route_specialist_event(_event("Hello"))) is False
+    adapter.send.assert_not_awaited()

--- a/tests/gateway/test_kanban_budget_notification.py
+++ b/tests/gateway/test_kanban_budget_notification.py
@@ -1,0 +1,18 @@
+from gateway.kanban_watchers import _format_gave_up_notification
+
+
+def test_budget_exhaustion_is_not_described_as_a_spawn_failure():
+    message = _format_gave_up_notification(
+        board_tag="[board] ",
+        tag="@worker ",
+        task_id="t_budget",
+        payload={
+            "trigger_outcome": "timed_out",
+            "budget_used": 18,
+            "budget_max": 18,
+            "error": "Iteration budget exhausted (18/18)",
+        },
+    )
+
+    assert "iteration budget exhausted (18/18)" in message.lower()
+    assert "spawn failure" not in message.lower()

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -624,6 +624,32 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
     assert remaining == []
 
 
+def test_notifier_delivers_decomposition_plan(tmp_path, monkeypatch):
+    db_path = tmp_path / "decomposed.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="coordinated work", assignee="orchestrator")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb._append_event(
+            conn,
+            tid,
+            "decomposed",
+            {"child_ids": ["t_one", "t_two"]},
+        )
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert tid in adapter.sent[0]["text"]
+    assert "planned 2 coordinated workers" in adapter.sent[0]["text"]
+
+
 # ---------------------------------------------------------------------------
 # Handoffs that hand a decision back to the origin must wake it, not only ping
 # it: `review_requested` (implementation done, waiting for a reviewer) and

--- a/tests/gateway/test_operator_approval_authority.py
+++ b/tests/gateway/test_operator_approval_authority.py
@@ -1,0 +1,30 @@
+"""Contracts for authenticated Hermes specialist-promotion approval."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gateway.operator_approval_authority import authenticated_operator_identity
+
+
+def _session(*, user_id: str = "operator-1", provider: str = "portal"):
+    return SimpleNamespace(user_id=user_id, provider=provider, org_id="org-1")
+
+
+def test_only_gated_session_with_explicit_subject_allowlist_is_operator():
+    identity = authenticated_operator_identity(
+        _session(),
+        auth_required=True,
+        allowed_subjects=("portal:operator-1",),
+    )
+
+    assert identity == "portal:operator-1"
+
+
+def test_loopback_token_or_unlisted_session_cannot_be_operator():
+    assert authenticated_operator_identity(
+        _session(), auth_required=False, allowed_subjects=("portal:operator-1",)
+    ) is None
+    assert authenticated_operator_identity(
+        _session(), auth_required=True, allowed_subjects=("portal:someone-else",)
+    ) is None

--- a/tests/gateway/test_specialist_discovery_e2e.py
+++ b/tests/gateway/test_specialist_discovery_e2e.py
@@ -1,0 +1,330 @@
+"""End-to-end local contracts for governed specialist discovery.
+
+All inputs are synthetic opaque hashes.  These tests exercise no provider,
+model, network, task worker, Discord adapter, or external write.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+
+from agent.profile_benchmark import (
+    CandidatePromotionGate,
+    CandidateProposal,
+    FrozenBenchmarkCaseSet,
+    OperatorApproval,
+)
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature
+from gateway.candidate_profile_requests import CandidateProfileRequests
+from gateway.configured_board import configured_board_db_path
+from gateway.specialist_handoff import HandoffSource, create_specialist_handoff
+from gateway.specialist_routing import RouteKind, SpecialistRouteDecision
+from gateway.status import specialist_discovery_status
+from hermes_cli import kanban_db as kb
+
+
+SIGNATURE = CapabilitySignature(
+    domain="market-data",
+    actions=("audit", "read"),
+    evidence_class="diagnostic-only",
+    requested_permissions=("market-data:read",),
+)
+BOARD = "exampleproject-burndown"
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _source(message_id: str) -> HandoffSource:
+    return HandoffSource(
+        # This is only a persisted subscription shape; the test never calls
+        # an adapter or sends a notification.
+        platform="discord",
+        chat_id="local-no-send",
+        chat_type="group",
+        user_id="synthetic-operator",
+        message_id=message_id,
+    )
+
+
+def _provision_test_profiles(home: Path) -> None:
+    for profile in (
+        "task-orchestrator",
+        "burndown-patch-steward",
+        "market-data-authority-auditor",
+    ):
+        (home / "profiles" / profile).mkdir(parents=True)
+
+
+def _decision() -> SpecialistRouteDecision:
+    return SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="market-data-authority-auditor",
+        confidence=0.99,
+        reason="synthetic local no-match",
+        title="Synthetic local capability audit",
+    )
+
+
+def test_no_match_stays_inert_without_authenticated_approval_and_exposes_recovery(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _provision_test_profiles(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = configured_board_db_path(BOARD)
+    kb.init_db(db_path)
+    registry = CapabilityRegistry(db_path=db_path)
+
+    task = create_specialist_handoff(
+        decision=_decision(),
+        source=_source("no-match-to-active"),
+        request="Synthetic local-only diagnostic evidence audit.",
+        signature=SIGNATURE,
+        registry=registry,
+        board=BOARD,
+    )
+
+    assert task.ok, task.reason
+    assert task.candidate_request_id
+    assert task.candidate_status == "candidate"
+    with kb.connect_closing(db_path) as conn:
+        source_task = kb.get_task(conn, task.task_id)
+    assert source_task is not None
+    assert source_task.assignee == "task-orchestrator"
+
+    now = [10_000]
+    requests = CandidateProfileRequests(db_path=db_path, clock=lambda: now[0])
+    proposal = CandidateProposal(
+        candidate_id=task.candidate_request_id,
+        proposal_author="claude",
+        sol_reviewer="sol",
+        proposal_hash=_hash("synthetic-proposal"),
+        signature_hash=SIGNATURE.signature_hash,
+        permissions_hash=SIGNATURE.permissions_hash,
+    )
+    gate = CandidatePromotionGate(requests, registry, clock=lambda: now[0])
+    cases = FrozenBenchmarkCaseSet(case_ids=(_hash("case-1"), _hash("case-2")))
+
+    assert registry.resolve(SIGNATURE).status == "no_match"
+
+    benchmarked, benchmark = gate.benchmark(
+        proposal, cases, scorer_model="independent-benchmark", scores=(90, 91), scorer_available=True
+    )
+    assert benchmarked.status == "benchmarked"
+    assert gate.open_disposable_sandbox(proposal, benchmark, sandbox_id="synthetic-sandbox").status == "benchmarked"
+    verified, verification = gate.verify(
+        proposal,
+        benchmark,
+        verifier_identity="independent-verifier",
+        sandbox_id="synthetic-sandbox",
+        verifier_available=True,
+    )
+    assert verified.status == "verified"
+    assert gate.stage(proposal, benchmark, verification, None).status == "rejected"
+    assert gate.activate(proposal, SIGNATURE, "synthetic-specialist", benchmark, verification, None).status == "rejected"
+
+    staged_approval = OperatorApproval(
+        candidate_id=proposal.candidate_id,
+        approval_id="synthetic-stage-approval",
+        operator_identity="operator",
+        verification_result_hash=verification.result_hash,
+        target_state="staged",
+        approved=True,
+        issued_at=now[0],
+    )
+    assert gate.record_operator_approval(staged_approval) is False
+    assert gate.stage(proposal, benchmark, verification, staged_approval).status == "rejected"
+    assert gate.activate(proposal, SIGNATURE, "synthetic-specialist", benchmark, verification, None).status == "rejected"
+
+    canary_result, canary = gate.run_local_no_send_canary(proposal, verification)
+    assert canary_result.status == "rejected"
+    assert canary is None
+    assert registry.resolve(SIGNATURE).status == "no_match"
+    active_approval = OperatorApproval(
+        candidate_id=proposal.candidate_id,
+        approval_id="synthetic-active-approval",
+        operator_identity="operator",
+        verification_result_hash=verification.result_hash,
+        target_state="active",
+        approved=True,
+        issued_at=now[0],
+    )
+    assert gate.record_operator_approval(active_approval) is False
+    active = gate.activate(
+        proposal, SIGNATURE, "synthetic-specialist", benchmark, verification, active_approval
+    )
+    assert active.status == "rejected"
+    assert registry.resolve(SIGNATURE).status == "no_match"
+
+    before = specialist_discovery_status(task.candidate_request_id, db_path=db_path, now=now[0])
+    after = specialist_discovery_status(task.candidate_request_id, db_path=db_path, now=now[0])
+    assert after == before  # restart reconciliation is a pure durable read; no rerun.
+    assert before["recovery_action"] == "task_orchestrator"
+    by_stage = {row["stage"]: row for row in before["rows"]}
+    assert by_stage["source_task"]["status"] == "triage"
+    assert by_stage["candidate_request"]["status"] == "verified"
+    assert by_stage["benchmark"]["receipt_hash"] == benchmark.result_hash
+    assert by_stage["sandbox"]["status"] == "verified_shape"
+    assert by_stage["verification"]["receipt_hash"] == verification.result_hash
+    assert by_stage["canary"]["status"] == "not_run"
+    assert by_stage["active_profile"]["status"] == "not_active"
+
+
+def test_expired_or_revoked_profiles_stop_resolving_and_handoff_uses_safe_fallback(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _provision_test_profiles(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = configured_board_db_path(BOARD)
+    kb.init_db(db_path)
+    registry = CapabilityRegistry(db_path=db_path)
+    registry.register_fixed_baseline(
+        profile_id="market-data-authority-auditor", signature=SIGNATURE, expires_at=int(time.time()) - 1
+    )
+    assert registry.resolve(SIGNATURE).status == "no_match"
+
+    registry.register_fixed_baseline(profile_id="market-data-authority-auditor", signature=SIGNATURE)
+    assert registry.resolve(SIGNATURE).profile == "market-data-authority-auditor"
+    registry.revoke(
+        profile_id="market-data-authority-auditor", signature=SIGNATURE, reason_code="synthetic_rollback"
+    )
+    assert registry.resolve(SIGNATURE).status == "no_match"
+
+    fallback = create_specialist_handoff(
+        decision=_decision(),
+        source=_source("revoked-safe-fallback"),
+        request="Synthetic fallback after local revocation.",
+        signature=SIGNATURE,
+        registry=registry,
+        board=BOARD,
+    )
+    assert fallback.ok, fallback.reason
+    assert fallback.candidate_request_id
+    with kb.connect_closing(db_path) as conn:
+        source_task = kb.get_task(conn, fallback.task_id)
+    assert source_task is not None
+    assert source_task.assignee == "task-orchestrator"
+
+
+def test_status_recovery_opens_sqlite_read_only_and_refuses_missing_or_uninitialized_db(tmp_path):
+    db_path = tmp_path / "status.db"
+    now = [10_000]
+    requests = CandidateProfileRequests(db_path=db_path, clock=lambda: now[0])
+    candidate = requests.open_or_reuse(SIGNATURE, source_key="local:read-only-status")
+    assert candidate.status == "candidate"
+
+    # Keep a standard WAL writer open so the reader takes the same fresh path
+    # used during a concurrent revocation. The writer—not recovery—creates the
+    # WAL; recovery must leave its bytes unchanged.
+    writer = kb.connect(db_path)
+    writer.execute("PRAGMA journal_mode=WAL")
+    writer.execute("PRAGMA user_version = 1")
+    writer.commit()
+
+    # A fresh read-only SQLite connection may attach/create -shm while it
+    # observes a live WAL; it must not mutate the database or WAL evidence.
+    paths = [db_path, db_path.with_name(db_path.name + "-wal")]
+    before = {path: path.read_bytes() if path.exists() else None for path in paths}
+    status = specialist_discovery_status(candidate.request_id, db_path=db_path, now=now[0])
+    after = {path: path.read_bytes() if path.exists() else None for path in paths}
+    writer.close()
+
+    assert status["recovery_action"] == "task_orchestrator"
+    assert after == before
+
+    missing = tmp_path / "missing.db"
+    missing_status = specialist_discovery_status(candidate.request_id, db_path=missing, now=now[0])
+    assert missing_status["recovery_action"] == "normal_triage"
+    assert missing.exists() is False
+    assert missing.with_name(missing.name + "-wal").exists() is False
+    assert missing.with_name(missing.name + "-shm").exists() is False
+
+    uninitialized = tmp_path / "uninitialized.db"
+    uninitialized.write_bytes(b"not sqlite")
+    original = uninitialized.read_bytes()
+    uninitialized_status = specialist_discovery_status(candidate.request_id, db_path=uninitialized, now=now[0])
+    assert uninitialized_status["recovery_action"] == "normal_triage"
+    assert uninitialized.read_bytes() == original
+
+
+def test_status_reader_sees_committed_wal_revocation_without_mutating_db_or_wal(tmp_path):
+    db_path = tmp_path / "live-wal-status.db"
+    now = int(time.time())
+    candidate = CandidateProfileRequests(db_path=db_path, clock=lambda: now).open_or_reuse(
+        SIGNATURE, source_key="local:wal-revocation"
+    )
+    assert candidate.status == "candidate"
+    benchmark_hash = _hash("wal-benchmark")
+    verification_hash = _hash("wal-verification")
+    revocation_hash = _hash("wal-revocation")
+    writer = kb.connect(db_path)
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute(
+            """
+            INSERT INTO specialist_benchmark_receipts (
+                result_hash, candidate_id, proposal_input_hash, proposal_author, sol_reviewer,
+                signature_hash, permissions_hash, case_set_hash, scorer_model, scores_json,
+                pass_threshold, status, issued_at, expires_at, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'passed', ?, ?, ?)
+            """,
+            (
+                benchmark_hash, candidate.request_id, _hash("proposal"), "claude", "sol",
+                SIGNATURE.signature_hash, SIGNATURE.permissions_hash, _hash("case-set"),
+                "independent-benchmark", json.dumps([100]), 80, now, now + 3_600, now,
+            ),
+        )
+        writer.execute(
+            """
+            INSERT INTO specialist_verification_receipts (
+                result_hash, candidate_id, benchmark_result_hash, verifier_identity, sandbox_id,
+                status, issued_at, expires_at, created_at
+            ) VALUES (?, ?, ?, ?, ?, 'verified', ?, ?, ?)
+            """,
+            (verification_hash, candidate.request_id, benchmark_hash, "independent-verifier", "sandbox-1", now, now + 3_600, now),
+        )
+        writer.execute(
+            """
+            INSERT INTO capability_profiles (
+                profile_id, signature_hash, permissions_hash,
+                model_receipt_hash, verification_receipt_hash,
+                domain, actions_json, evidence_class, requested_permissions_json,
+                expires_at, status, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 'active', ?)
+            """,
+            (
+                "market-data-authority-auditor", SIGNATURE.signature_hash, SIGNATURE.permissions_hash,
+                benchmark_hash, verification_hash, SIGNATURE.domain, json.dumps(SIGNATURE.actions),
+                SIGNATURE.evidence_class, json.dumps(SIGNATURE.requested_permissions), now,
+            ),
+        )
+        writer.commit()
+        assert specialist_discovery_status(candidate.request_id, db_path=db_path, now=now)["recovery_action"] == "active_resolution"
+
+        writer.execute(
+            """
+            INSERT INTO specialist_profile_revocations (
+                revocation_hash, profile_id, signature_hash, reason_code, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (revocation_hash, "market-data-authority-auditor", SIGNATURE.signature_hash, "wal_rollback", now),
+        )
+        writer.commit()
+        watched = [db_path, db_path.with_name(db_path.name + "-wal")]
+        before = {path: path.read_bytes() if path.exists() else None for path in watched}
+        status = specialist_discovery_status(candidate.request_id, db_path=db_path, now=now)
+        after = {path: path.read_bytes() if path.exists() else None for path in watched}
+
+        by_stage = {row["stage"]: row for row in status["rows"]}
+        assert status["recovery_action"] == "task_orchestrator"
+        assert by_stage["rollback"]["receipt_hash"] == revocation_hash
+        assert by_stage["active_profile"]["status"] == "revoked"
+        assert after == before
+    finally:
+        writer.close()

--- a/tests/gateway/test_specialist_handoff_orchestration.py
+++ b/tests/gateway/test_specialist_handoff_orchestration.py
@@ -1,0 +1,158 @@
+"""Discord specialist work enters the durable orchestration lifecycle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gateway.specialist_handoff import HandoffSource, create_specialist_handoff
+from gateway.specialist_routing import (
+    RouteKind,
+    SpecialistRouteDecision,
+    parse_specialist_response,
+)
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profile_exists",
+        lambda profile: profile in {"patch-steward", "task-orchestrator"},
+    )
+    kb.init_db()
+    return home
+
+
+def test_specialist_handoff_creates_goal_mode_triage_root(kanban_home):
+    decision = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="patch-steward",
+        confidence=1.0,
+        reason="explicit request",
+        title="Narrow corrective patch",
+    )
+    source = HandoffSource(
+        platform="discord",
+        chat_id="channel-1",
+        chat_type="group",
+        user_id="user-1",
+        message_id="message-1",
+    )
+
+    result = create_specialist_handoff(
+        decision=decision,
+        source=source,
+        request="Audit and patch the confirmed failures.",
+        board="project-maintenance",
+    )
+
+    assert result.ok, result.reason
+    assert result.task_id
+    with kb.connect(board="project-maintenance") as conn:
+        task = kb.get_task(conn, result.task_id)
+    assert task is not None
+    assert task.status == "triage"
+    assert task.goal_mode is True
+    assert task.goal_max_turns == 12
+    assert task.skills is None
+
+
+def test_specialist_handoff_explicit_board_ignores_database_environment_override(
+    kanban_home, monkeypatch, tmp_path
+):
+    decision = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="patch-steward",
+        confidence=1.0,
+        reason="explicit request",
+        title="Patch confirmed failures",
+    )
+    source = HandoffSource(
+        platform="discord",
+        chat_id="channel-1",
+        chat_type="group",
+        user_id="user-1",
+        message_id="message-env-isolation",
+    )
+    board = "project-maintenance"
+    with kb.connect(board=board):
+        pass
+    override_path = tmp_path / "override" / "kanban.db"
+    with kb.connect(db_path=override_path):
+        pass
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(override_path))
+
+    result = create_specialist_handoff(
+        decision=decision,
+        source=source,
+        request="Patch the confirmed exception failures.",
+        board=board,
+    )
+
+    assert result.ok, result.reason
+    monkeypatch.delenv("HERMES_KANBAN_DB")
+    with kb.connect(board=board) as configured_conn:
+        configured_task = kb.get_task(configured_conn, result.task_id)
+    with kb.connect(db_path=override_path) as override_conn:
+        override_task = kb.get_task(override_conn, result.task_id)
+    assert configured_task is not None
+    assert override_task is None
+
+
+def test_router_accepts_task_orchestrator_for_broad_actionable_work():
+    decision = parse_specialist_response(
+        '{"kind":"specialist","profile":"task-orchestrator",'
+        '"confidence":0.91,"reason":"requires planning across roles",'
+        '"title":"Implement the requested workflow"}'
+    )
+
+    assert decision.dispatches is True
+    assert decision.profile == "task-orchestrator"
+
+
+def test_router_accepts_only_profiles_from_the_explicit_route_map():
+    raw = (
+        '{"kind":"specialist","profile":"release-reviewer",'
+        '"confidence":0.91,"reason":"release evidence",'
+        '"title":"Review release evidence"}'
+    )
+
+    rejected = parse_specialist_response(raw)
+    accepted = parse_specialist_response(
+        raw,
+        profiles={"release-reviewer": "release evidence and gate review"},
+    )
+
+    assert rejected.dispatches is False
+    assert accepted.dispatches is True
+    assert accepted.profile == "release-reviewer"
+
+
+def test_specialist_handoff_rejects_profile_that_is_not_installed(kanban_home):
+    decision = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="missing-profile",
+        confidence=1.0,
+        reason="explicit request",
+        title="Unavailable route",
+    )
+    result = create_specialist_handoff(
+        decision=decision,
+        source=HandoffSource(
+            platform="discord",
+            chat_id="channel-1",
+            chat_type="group",
+            user_id="user-1",
+            message_id="message-missing-profile",
+        ),
+        request="Run the unavailable route.",
+        board="project-maintenance",
+    )
+
+    assert result == type(result)(False, reason="profile_unavailable")

--- a/tests/gateway/test_specialist_handoff_orchestration.py
+++ b/tests/gateway/test_specialist_handoff_orchestration.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature, RegistryResolution
 from gateway.specialist_handoff import HandoffSource, create_specialist_handoff
 from gateway.specialist_routing import (
     RouteKind,
@@ -19,12 +20,14 @@ from hermes_cli import kanban_db as kb
 def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
+    for profile in (
+        "task-orchestrator",
+        "burndown-patch-steward",
+        "market-data-authority-auditor",
+    ):
+        (home / "profiles" / profile).mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    monkeypatch.setattr(
-        "hermes_cli.profiles.profile_exists",
-        lambda profile: profile in {"patch-steward", "task-orchestrator"},
-    )
     kb.init_db()
     return home
 
@@ -32,10 +35,10 @@ def kanban_home(tmp_path, monkeypatch):
 def test_specialist_handoff_creates_goal_mode_triage_root(kanban_home):
     decision = SpecialistRouteDecision(
         kind=RouteKind.SPECIALIST,
-        profile="patch-steward",
+        profile="burndown-patch-steward",
         confidence=1.0,
         reason="explicit request",
-        title="Narrow corrective patch",
+        title="Narrow Exception Burndown and Patching",
     )
     source = HandoffSource(
         platform="discord",
@@ -48,19 +51,18 @@ def test_specialist_handoff_creates_goal_mode_triage_root(kanban_home):
     result = create_specialist_handoff(
         decision=decision,
         source=source,
-        request="Audit and patch the confirmed failures.",
-        board="project-maintenance",
+        request="Audit exception burndown and patch confirmed failures.",
+        board="exampleproject-burndown",
     )
 
     assert result.ok, result.reason
     assert result.task_id
-    with kb.connect(board="project-maintenance") as conn:
+    with kb.connect(board="exampleproject-burndown") as conn:
         task = kb.get_task(conn, result.task_id)
     assert task is not None
     assert task.status == "triage"
     assert task.goal_mode is True
     assert task.goal_max_turns == 12
-    assert task.skills is None
 
 
 def test_specialist_handoff_explicit_board_ignores_database_environment_override(
@@ -68,10 +70,10 @@ def test_specialist_handoff_explicit_board_ignores_database_environment_override
 ):
     decision = SpecialistRouteDecision(
         kind=RouteKind.SPECIALIST,
-        profile="patch-steward",
+        profile="burndown-patch-steward",
         confidence=1.0,
         reason="explicit request",
-        title="Patch confirmed failures",
+        title="Patch Exception Burndown",
     )
     source = HandoffSource(
         platform="discord",
@@ -80,7 +82,7 @@ def test_specialist_handoff_explicit_board_ignores_database_environment_override
         user_id="user-1",
         message_id="message-env-isolation",
     )
-    board = "project-maintenance"
+    board = "exampleproject-burndown"
     with kb.connect(board=board):
         pass
     override_path = tmp_path / "override" / "kanban.db"
@@ -116,43 +118,149 @@ def test_router_accepts_task_orchestrator_for_broad_actionable_work():
     assert decision.profile == "task-orchestrator"
 
 
-def test_router_accepts_only_profiles_from_the_explicit_route_map():
-    raw = (
-        '{"kind":"specialist","profile":"release-reviewer",'
-        '"confidence":0.91,"reason":"release evidence",'
-        '"title":"Review release evidence"}'
-    )
-
-    rejected = parse_specialist_response(raw)
-    accepted = parse_specialist_response(
-        raw,
-        profiles={"release-reviewer": "release evidence and gate review"},
-    )
-
-    assert rejected.dispatches is False
-    assert accepted.dispatches is True
-    assert accepted.profile == "release-reviewer"
-
-
-def test_specialist_handoff_rejects_profile_that_is_not_installed(kanban_home):
+def test_handoff_rejects_unresolved_candidate_profile_without_a_missing_scope_receipt(kanban_home):
     decision = SpecialistRouteDecision(
         kind=RouteKind.SPECIALIST,
-        profile="missing-profile",
-        confidence=1.0,
-        reason="explicit request",
-        title="Unavailable route",
+        profile="generated-market-data-candidate",
+        confidence=0.95,
+        reason="model suggestion",
+        title="Generated candidate",
     )
-    result = create_specialist_handoff(
-        decision=decision,
-        source=HandoffSource(
-            platform="discord",
-            chat_id="channel-1",
-            chat_type="group",
-            user_id="user-1",
-            message_id="message-missing-profile",
-        ),
-        request="Run the unavailable route.",
-        board="project-maintenance",
+    source = HandoffSource(
+        platform="discord",
+        chat_id="channel-1",
+        chat_type="group",
+        user_id="user-1",
+        message_id="message-candidate-without-resolution",
     )
 
-    assert result == type(result)(False, reason="profile_unavailable")
+    result = create_specialist_handoff(
+        decision=decision,
+        source=source,
+        request="Audit the supplied evidence.",
+    )
+
+    assert result.ok is False
+    assert result.reason == "non_dispatch_decision"
+
+
+def test_handoff_uses_active_registry_profile_before_fixed_classifier_profile(kanban_home, tmp_path):
+    signature = CapabilitySignature(
+        domain="market-data",
+        actions=("audit", "read"),
+        evidence_class="diagnostic-only",
+        requested_permissions=("market-data:read",),
+    )
+    registry = CapabilityRegistry(db_path=tmp_path / "capability-registry.db")
+    registry.register_fixed_baseline(profile_id="market-data-authority-auditor", signature=signature)
+    decision = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="market-data-authority-auditor",
+        confidence=0.95,
+        reason="classifier fixed profile",
+        title="Audit market data",
+    )
+    source = HandoffSource(
+        platform="discord",
+        chat_id="channel-1",
+        chat_type="group",
+        user_id="user-1",
+        message_id="message-active-registry-match",
+    )
+
+    result = create_specialist_handoff(
+        decision=decision,
+        source=source,
+        request="Audit the supplied market-data evidence.",
+        signature=signature,
+        registry=registry,
+        board=kb.DEFAULT_BOARD,
+    )
+
+    assert result.ok, result.reason
+    with kb.connect() as conn:
+        task = kb.get_task(conn, result.task_id)
+    assert task is not None
+    assert task.assignee == "market-data-authority-auditor"
+
+
+def test_forged_active_registry_resolution_cannot_create_a_profile_assigned_handoff(kanban_home):
+    decision = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="market-data-authority-auditor",
+        confidence=0.95,
+        reason="classifier fixed profile",
+        title="Audit market data",
+    )
+    source = HandoffSource(
+        platform="discord",
+        chat_id="channel-1",
+        chat_type="group",
+        user_id="user-1",
+        message_id="message-forged-active-resolution",
+    )
+    forged = RegistryResolution(
+        status="active_match",
+        profile="forged-profile",
+        reason="untrusted caller data",
+    )
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'resolution'"):
+        create_specialist_handoff(
+            decision=decision,
+            source=source,
+            request="Audit the supplied market-data evidence.",
+            board=kb.DEFAULT_BOARD,
+            resolution=forged,
+        )
+
+    with kb.connect() as conn:
+        rows = conn.execute("SELECT assignee FROM tasks").fetchall()
+    assert rows == []
+
+
+def test_duck_typed_registry_cannot_authorize_a_profile_assigned_handoff(kanban_home):
+    signature = CapabilitySignature(
+        domain="market-data",
+        actions=("audit", "read"),
+        evidence_class="diagnostic-only",
+        requested_permissions=("market-data:read",),
+    )
+    decision = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="market-data-authority-auditor",
+        confidence=0.95,
+        reason="classifier fixed profile",
+        title="Audit market data",
+    )
+    source = HandoffSource(
+        platform="discord",
+        chat_id="channel-1",
+        chat_type="group",
+        user_id="user-1",
+        message_id="message-duck-typed-registry",
+    )
+
+    class ForgedRegistry:
+        def resolve(self, requested_signature):
+            assert requested_signature == signature
+            return RegistryResolution(
+                status="active_match",
+                profile="forged-profile",
+                reason="untrusted caller data",
+            )
+
+    result = create_specialist_handoff(
+        decision=decision,
+        source=source,
+        request="Audit the supplied market-data evidence.",
+        board=kb.DEFAULT_BOARD,
+        signature=signature,
+        registry=ForgedRegistry(),
+    )
+
+    assert result.ok is False
+    assert result.reason == "non_dispatch_decision"
+    with kb.connect() as conn:
+        rows = conn.execute("SELECT assignee FROM tasks").fetchall()
+    assert rows == []

--- a/tests/gateway/test_specialist_routing.py
+++ b/tests/gateway/test_specialist_routing.py
@@ -1,0 +1,104 @@
+"""Fail-closed routing tests for active specialist capability resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.capability_registry import CapabilityRegistry, CapabilitySignature
+from gateway.specialist_routing import (
+    RouteKind,
+    SPECIALIST_PROFILES,
+    SpecialistRouteDecision,
+    capability_signature_for_profile,
+    parse_specialist_response,
+    resolve_route,
+)
+
+
+MARKET_DATA = CapabilitySignature(
+    domain="market-data",
+    actions=("audit", "read"),
+    evidence_class="diagnostic-only",
+    requested_permissions=("market-data:read",),
+)
+CANDIDATE_PROFILE_JSON = (
+    '{"kind":"specialist","profile":"generated-market-data-candidate",'
+    '"confidence":0.95,"reason":"new capability appears useful",'
+    '"title":"Generated candidate"}'
+)
+
+
+@pytest.fixture
+def registry(tmp_path):
+    return CapabilityRegistry(db_path=tmp_path / "capabilities.db")
+
+
+def _fixed_profile_decision() -> SpecialistRouteDecision:
+    return SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="burndown-patch-steward",
+        confidence=0.95,
+        reason="bounded patch work",
+        title="Patch confirmed failures",
+        audit_reason="specialist",
+    )
+
+
+def test_classifier_cannot_dispatch_a_candidate_profile(registry):
+    decision = parse_specialist_response(CANDIDATE_PROFILE_JSON)
+
+    assert decision.dispatches is False
+    assert decision.audit_reason == "unknown_profile"
+
+
+def test_every_fixed_classifier_profile_has_a_closed_local_capability_signature():
+    signatures = {
+        profile: capability_signature_for_profile(profile) for profile in SPECIALIST_PROFILES
+    }
+
+    assert all(signature is not None for signature in signatures.values())
+    assert capability_signature_for_profile("generated-market-data-candidate") is None
+
+
+def test_active_registry_match_precedes_fixed_profile_classifier(registry):
+    registry.register_fixed_baseline(profile_id="market-data-authority-auditor", signature=MARKET_DATA)
+
+    decision = resolve_route(MARKET_DATA, registry, fallback=_fixed_profile_decision())
+
+    assert decision.dispatches is True
+    assert decision.profile == "market-data-authority-auditor"
+    assert decision.audit_reason == "active_registry_match"
+
+
+def test_no_active_registry_match_uses_existing_fixed_profile_fallback(registry):
+    decision = resolve_route(MARKET_DATA, registry, fallback=_fixed_profile_decision())
+
+    assert decision == _fixed_profile_decision()
+
+
+def test_candidate_decision_never_bypasses_fixed_or_active_profiles(registry):
+    candidate = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="generated-market-data-candidate",
+        confidence=0.95,
+        reason="model suggestion",
+        title="Generated candidate",
+        audit_reason="specialist",
+    )
+
+    decision = resolve_route(MARKET_DATA, registry, fallback=candidate)
+
+    assert decision.dispatches is False
+    assert decision.audit_reason == "inactive_profile"
+
+
+def test_registry_exception_falls_back_to_normal_chat_with_auditable_reason():
+    class BrokenRegistry:
+        def resolve(self, signature):
+            raise RuntimeError("database is unavailable")
+
+    decision = resolve_route(MARKET_DATA, BrokenRegistry(), fallback=_fixed_profile_decision())
+
+    assert decision.kind is RouteKind.GENERAL
+    assert decision.dispatches is False
+    assert decision.audit_reason == "registry_unavailable"

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -88,5 +88,54 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_inherits_goal_lifecycle_to_children(kanban_home):
+    """A routed goal must not fan out into one-shot child workers."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="durable orchestration root",
+            triage=True,
+            goal_mode=True,
+            goal_max_turns=12,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "first slice", "assignee": "researcher"},
+                {"title": "second slice", "assignee": "engineer"},
+            ],
+            author="decomposer",
+        )
+    assert child_ids is not None
 
+    with kb.connect() as conn:
+        children = [kb.get_task(conn, child_id) for child_id in child_ids]
+
+    assert all(child is not None and child.goal_mode for child in children)
+    assert [child.goal_max_turns for child in children] == [12, 12]
+
+
+def test_decompose_inherits_forced_skills_to_children(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="navigation-bound root",
+            triage=True,
+            skills=["project-worktree-navigation"],
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[{"title": "first slice", "assignee": "researcher"}],
+        )
+    assert child_ids is not None
+
+    with kb.connect() as conn:
+        child = kb.get_task(conn, child_ids[0])
+
+    assert child is not None
+    assert child.skills == ["project-worktree-navigation"]
 

--- a/tests/hermes_cli/test_projects_cli.py
+++ b/tests/hermes_cli/test_projects_cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import argparse
 
 import pytest
@@ -57,5 +59,27 @@ def test_rename_and_archive(tmp_path):
         assert len(pdb.list_projects(conn)) == 1
 
 
+def test_bound_board_metadata_keeps_project_identity(monkeypatch):
+    from hermes_cli import kanban_db as kb
+
+    captured = {}
+    monkeypatch.setattr(kb, "_normalize_board_slug", lambda value: value)
+    monkeypatch.setattr(kb, "board_exists", lambda value: True)
+    monkeypatch.setattr(
+        kb,
+        "write_board_metadata",
+        lambda slug, **values: captured.update(slug=slug, **values),
+    )
+
+    projects_cmd._sync_board_default_workdir(
+        SimpleNamespace(id="p_example", primary_path="/repo/example"),
+        "project-board",
+    )
+
+    assert captured == {
+        "slug": "project-board",
+        "default_workdir": "/repo/example",
+        "project_id": "p_example",
+    }
 
 

--- a/tests/plugins/test_kanban_specialist_approval.py
+++ b/tests/plugins/test_kanban_specialist_approval.py
@@ -1,0 +1,86 @@
+"""Dashboard-authenticated operator approvals for specialist promotion."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+def _router():
+    source = Path(__file__).resolve().parents[2] / "plugins/kanban/dashboard/plugin_api.py"
+    spec = importlib.util.spec_from_file_location("specialist_approval_plugin", source)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.router
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"specialist_operator_approvals": {"allowed_subjects": ["portal:operator-1"]}}},
+    )
+    kb.init_db()
+    app = FastAPI()
+    app.state.auth_required = True
+
+    @app.middleware("http")
+    async def authenticated_session(request: Request, call_next):
+        request.state.session = SimpleNamespace(provider="portal", user_id="operator-1", org_id="org")
+        return await call_next(request)
+
+    app.include_router(_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+def test_authenticated_allowlisted_dashboard_session_records_operator_approval(client):
+    response = client.post(
+        "/api/plugins/kanban/specialist-approvals",
+        json={
+            "candidate_id": "candidate-1",
+            "verification_result_hash": "a" * 64,
+            "target_state": "staged",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["operator_identity"] == "portal:operator-1"
+
+
+def test_authenticated_dashboard_can_inspect_its_approval_subject(client):
+    response = client.get("/api/plugins/kanban/specialist-approval-authority")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "authenticated_subject": "portal:operator-1",
+        "approval_authorized": True,
+    }
+
+
+def test_loopback_token_mode_cannot_record_operator_approval(client):
+    client.app.state.auth_required = False
+
+    response = client.post(
+        "/api/plugins/kanban/specialist-approvals",
+        json={
+            "candidate_id": "candidate-1",
+            "verification_result_hash": "a" * 64,
+            "target_state": "staged",
+        },
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary

Focused follow-up to #95918. This extracts specialist candidate discovery, benchmark verification, capability-registry approval, revocation, recovery, and authenticated operator approval from the cumulative upgrade train. Candidate requests remain local and bounded; only verified fixed capabilities can become active profiles.

## Review shape

- 23 files changed
- 5,668 additions and 177 deletions
- Parent implementation: #95918 at a430e16a7b
- No desktop, trading, or unrelated fork-sync changes

## Verification

- Specialist/approval/discovery tests: 81 passed
- git diff --check: clean

This is the focused replacement for the specialist-discovery portion of cumulative PR #97684.