### PR TITLE
fix(desktop): surface Tailscale SSH browser checks

### DIFF
--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -221,6 +221,16 @@ function fakeChild({ code = 0, stdout = '', stderr = '', errorEvent = null, hang
   }
 
   if (hang) {
+    process.nextTick(() => {
+      if (stdout) {
+        child.stdout.emit('data', Buffer.from(stdout))
+      }
+
+      if (stderr) {
+        child.stderr.emit('data', Buffer.from(stderr))
+      }
+    })
+
     return child // never emits close → drives the timeout path
   }
 
@@ -413,6 +423,35 @@ test('open() surfaces a classified auth error', async () => {
     (err: any) => {
       assert.equal(err.kind, SSH_ERROR.AUTH_FAILED)
       assert.match(err.message, /ssh-agent|ssh-add/)
+
+      return true
+    }
+  )
+})
+
+test('open() turns a Tailscale browser-check timeout into safe interactive-auth guidance', async () => {
+  const checkUrl = 'https://login.tailscale.com/a/example-one-time-check'
+
+  const spawnFn = scriptedSpawn(args => {
+    if (args.includes('check')) {
+      return { code: 255 }
+    }
+
+    return {
+      hang: true,
+      stderr: `# Tailscale SSH requires an additional check.\n# To authenticate, visit: ${checkUrl}\n`
+    }
+  })
+
+  const conn = new SshConnection({ host: 'box', user: 'me' }, { spawnFn, controlDir: '/tmp/d', connectTimeoutMs: 20 })
+
+  await assert.rejects(
+    () => conn.open(),
+    (err: any) => {
+      assert.equal(err.kind, SSH_ERROR.INTERACTIVE_AUTH)
+      assert.match(err.message, /Tailscale SSH requires an interactive browser check/)
+      assert.match(err.message, /ssh me@box true/)
+      assert.doesNotMatch(err.message, /login\.tailscale\.com|example-one-time-check/)
 
       return true
     }

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -324,6 +324,7 @@ function forwardSpec(localPort, remotePort, remoteHost = '127.0.0.1') {
 const SSH_ERROR = {
   UNREACHABLE: 'unreachable',
   AUTH_FAILED: 'auth-failed',
+  INTERACTIVE_AUTH: 'interactive-auth',
   HOST_KEY_CHANGED: 'host-key-changed',
   TIMEOUT: 'timeout',
   UNKNOWN: 'unknown'
@@ -340,6 +341,12 @@ function classifySshError(stderr) {
     )
   ) {
     return SSH_ERROR.HOST_KEY_CHANGED
+  }
+
+  if (
+    /Tailscale SSH requires an additional check|To authenticate, visit:\s*https:\/\/login\.tailscale\.com\//i.test(text)
+  ) {
+    return SSH_ERROR.INTERACTIVE_AUTH
   }
 
   if (
@@ -380,6 +387,16 @@ function sshErrorMessage(kind, conn, stderr?) {
         `ssh-agent first (e.g. \`ssh-add ~/.ssh/id_ed25519\`), or set an IdentityFile in ` +
         `~/.ssh/config. Original error: ${String(stderr || '').trim()}`
       )
+    case SSH_ERROR.INTERACTIVE_AUTH: {
+      const portArg = conn.port && conn.port !== 22 ? ` -p ${conn.port}` : ''
+
+      return (
+        `Tailscale SSH requires an interactive browser check for ${host}. ` +
+        `Hermes Desktop runs SSH non-interactively. In Terminal, run ` +
+        `\`ssh${portArg} ${host} true\`, complete the browser check, then retry. ` +
+        `If checks recur, use a key-authenticated OpenSSH route or adjust the tailnet SSH check policy.`
+      )
+    }
 
     case SSH_ERROR.UNREACHABLE:
       return `Could not reach ${host} over SSH. Check the host, port, and your network. Original error: ${String(stderr || '').trim()}`
@@ -440,6 +457,10 @@ function runSsh(args, { timeoutMs, spawnFn = spawn, stdin = 'ignore', stdinData,
 
       const err: any = new Error(`ssh timed out after ${timeoutMs}ms`)
       err.kind = SSH_ERROR.TIMEOUT
+      // Keep only a safe classification of buffered stderr. Tailscale's
+      // browser-check line carries a one-time URL that must not escape through
+      // Desktop errors or lifecycle logs.
+      err.stderrKind = classifySshError(stderr)
       signal?.removeEventListener('abort', onAbort)
       reject(err)
     }, timeoutMs)
@@ -602,8 +623,11 @@ class SshConnection {
     }
 
     if (stderrOrErr && stderrOrErr.kind === SSH_ERROR.TIMEOUT) {
-      const err: any = new Error(sshErrorMessage(SSH_ERROR.TIMEOUT, this))
-      err.kind = SSH_ERROR.TIMEOUT
+      const kind =
+        stderrOrErr.stderrKind === SSH_ERROR.INTERACTIVE_AUTH ? SSH_ERROR.INTERACTIVE_AUTH : SSH_ERROR.TIMEOUT
+
+      const err: any = new Error(sshErrorMessage(kind, this))
+      err.kind = kind
 
       return err
     }


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop now recognizes when Tailscale SSH is waiting for an interactive browser check instead of reporting the wait as a generic half-open connection timeout.

The timeout path keeps only a safe classification of buffered SSH stderr. It does not retain or surface Tailscale's one-time authentication URL. Desktop tells the user to complete the check from Terminal and retry.

This is deliberately narrower than changing timeout lengths or SSH lifecycle behavior. Generic timeouts still use the existing half-open connection message.

## Related Issue

Fixes #97867

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/ssh-connection.ts`
  - classifies Tailscale SSH browser-check output as interactive authentication;
  - carries only that classification across the hard-timeout boundary;
  - returns safe, actionable Terminal pre-authentication guidance.
- `apps/desktop/electron/ssh-connection.test.ts`
  - lets hanging fake SSH children emit stderr before timeout;
  - reproduces the Tailscale challenge and verifies the one-time URL never reaches the user-facing error.

## How to Test

1. Run `cd apps/desktop && npx vitest run --project electron electron/ssh-connection.test.ts`.
2. Confirm the Tailscale regression reports `interactive-auth`, includes `ssh user@host true` guidance, and excludes `login.tailscale.com` plus the one-time URL token.
3. Run `npx prettier --check electron/ssh-connection.ts electron/ssh-connection.test.ts`, ESLint on both files, `npx tsc -p tsconfig.electron.json --noEmit`, and the full Electron Vitest project.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass - N/A, this is isolated TypeScript/Electron code
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux contract tests; the original failure was observed on macOS Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no public configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Verification

Blaxel Linux microVM, Node `v22.22.1`, npm `10.9.8`:

- RED: focused suite reproduced the bug with exactly one expected failure (`timeout` instead of `interactive-auth`).
- GREEN: focused Desktop SSH suite **68 passed**.
- `prettier --check`: passed.
- ESLint on the two changed files with `--max-warnings=0`: passed.
- Electron TypeScript typecheck: passed.
- An exploratory broader Electron run passed 1,929 tests and skipped 6. Four tests and two suites could not run because the slim worker intentionally omitted Python and Electron's postinstall binary. Those failures were outside `ssh-connection` and were classified as worker-prerequisite failures, not patch regressions.
- Live patched macOS artifact was not rebuilt. The real failure was observed there; the fix is verified at the process/error-contract boundary.

## Provenance

Prepared by Cad, an AI agent, under Luis Felipe Abarca's direction. The `arcabotai` contributor identity is human-stewarded by Luis Felipe, who authorized this issue and pull-request submission. Public background and project context: [felirami.com](https://felirami.com), [arcabot.ai](https://arcabot.ai), and [arca.computer](https://arca.computer).

