### PR TITLE
fix(skills): grill-me keeps its name (reverts #97831 rename, keeps content upgrade)

### DIFF
--- a/optional-skills/software-development/grill-me/SKILL.md
+++ b/optional-skills/software-development/grill-me/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: plan-interrogation
+name: grill-me
 description: "Adversarial plan interview before implementation."
 version: 2.0.0
 author: "Rafael Zendron (rafaumeu) + Matt Pocock (mattpocock/skills, grilling) + Hermes Agent"
@@ -11,19 +11,19 @@ metadata:
     related_skills: [plan, requesting-code-review, subagent-driven-development, test-driven-development]
 ---
 
-# Plan Interrogation
+# Grill Me
 
 Stress-tests a plan through structured adversarial questioning before any
 code is written. Models the plan as a **design tree** — every decision
 branches into the decisions that hang off it — and interviews the user in
 rounds until every branch is resolved and nothing is silently assumed.
 
-Formerly `grill-me`. Combines the phase discipline of the original with the
-frontier-rounds mechanic from mattpocock/skills' `grilling`.
+Combines the phase discipline of the original with the frontier-rounds
+mechanic from mattpocock/skills' `grilling`.
 
 ## When to Use
 
-- User says "interrogate my plan", "grill me", "stress test this idea"
+- User says "grill me", "interview my plan", "stress test this idea"
 - Before complex work: auth flows, schema changes, migrations, payments
 - A plan has unresolved decisions or seems vague
 - Before `subagent-driven-development` decomposition

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -233,7 +233,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**code-wiki**](/docs/user-guide/skills/optional/software-development/software-development-code-wiki) | Generate wiki docs + Mermaid diagrams for any codebase. |
-| [**plan-interrogation**](/docs/user-guide/skills/optional/software-development/software-development-plan-interrogation) | Adversarial plan interview before implementation. |
+| [**grill-me**](/docs/user-guide/skills/optional/software-development/software-development-grill-me) | Adversarial plan interview before implementation. |
 | [**rest-graphql-debug**](/docs/user-guide/skills/optional/software-development/software-development-rest-graphql-debug) | Debug REST/GraphQL APIs: status codes, auth, schemas, repro. |
 | [**subagent-driven-development**](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development) | Execute plans via delegate_task subagents (2-stage review). |
 

--- a/website/docs/user-guide/skills/optional/software-development/software-development-grill-me.md
+++ b/website/docs/user-guide/skills/optional/software-development/software-development-grill-me.md
@@ -1,12 +1,12 @@
 ---
-title: "Plan Interrogation — Adversarial plan interview before implementation"
-sidebar_label: "Plan Interrogation"
+title: "Grill Me — Adversarial plan interview before implementation"
+sidebar_label: "Grill Me"
 description: "Adversarial plan interview before implementation"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
-# Plan Interrogation
+# Grill Me
 
 Adversarial plan interview before implementation.
 
@@ -14,8 +14,8 @@ Adversarial plan interview before implementation.
 
 | | |
 |---|---|
-| Source | Optional — install with `hermes skills install official/software-development/plan-interrogation` |
-| Path | `optional-skills/software-development/plan-interrogation` |
+| Source | Optional — install with `hermes skills install official/software-development/grill-me` |
+| Path | `optional-skills/software-development/grill-me` |
 | Version | `2.0.0` |
 | Author | Rafael Zendron (rafaumeu) + Matt Pocock (mattpocock/skills, grilling) + Hermes Agent |
 | License | MIT |
@@ -29,19 +29,19 @@ Adversarial plan interview before implementation.
 The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
 :::
 
-# Plan Interrogation
+# Grill Me
 
 Stress-tests a plan through structured adversarial questioning before any
 code is written. Models the plan as a **design tree** — every decision
 branches into the decisions that hang off it — and interviews the user in
 rounds until every branch is resolved and nothing is silently assumed.
 
-Formerly `grill-me`. Combines the phase discipline of the original with the
-frontier-rounds mechanic from mattpocock/skills' `grilling`.
+Combines the phase discipline of the original with the frontier-rounds
+mechanic from mattpocock/skills' `grilling`.
 
 ## When to Use
 
-- User says "interrogate my plan", "grill me", "stress test this idea"
+- User says "grill me", "interview my plan", "stress test this idea"
 - Before complex work: auth flows, schema changes, migrations, payments
 - A plan has unresolved decisions or seems vague
 - Before `subagent-driven-development` decomposition

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -602,7 +602,7 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   items: [
                     'user-guide/skills/optional/software-development/software-development-code-wiki',
-                    'user-guide/skills/optional/software-development/software-development-plan-interrogation',
+                    'user-guide/skills/optional/software-development/software-development-grill-me',
                     'user-guide/skills/optional/software-development/software-development-rest-graphql-debug',
                     'user-guide/skills/optional/software-development/software-development-subagent-driven-development',
                   ],


### PR DESCRIPTION
## Summary
The optional skill renamed to `plan-interrogation` in #97831 goes back to its original name, `grill-me` — maintainer decision mid-merge. The frontier-rounds content upgrade from that PR stays intact.

## Changes
- `optional-skills/software-development/plan-interrogation/` → `grill-me/`; frontmatter name + title restored
- Docs page, catalog row, sidebar entry renamed back (regenerated; unrelated generator drift excluded)

## Validation
| | Result |
|---|---|
| `tests/skills/test_authoring_standards.py` | 1220 passed |

## Infographic

![grill-me restore](https://v3b.fal.media/files/b/0aa84518/KeF2rM6wiA32zdRtj88WL_U0eJm4jr.png)
