### PR TITLE
fix(dashboard): show the slot model as current in aux/MoA pickers

### DIFF
--- a/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
+++ b/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
@@ -295,12 +295,16 @@ describe('status-chrome timers under an occluding overlay', () => {
     nowSpy.mockReturnValue(T0 + 300_000)
     rule.clear()
     resetOverlayState()
-    await flush()
+
+    // Event-based: a single 20ms flush is not enough under CI load (the
+    // reveal frame never lands, so stdout stays empty after `clear()`).
+    await vi.waitFor(() => {
+      expect(rule.output()).toContain('6m 0s')
+    })
 
     const resumed = rule.output()
 
     // Caught up to real elapsed time, not stuck on the pre-overlay values.
-    expect(resumed).toContain('6m 0s')
     expect(resumed).toContain('✓ 5m 5s')
     expect(resumed).not.toContain('1m 0s')
 

--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -11,6 +11,12 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn, themedBody } from "@/lib/utils";
 import { fuzzyRank } from "@/lib/fuzzy";
+import {
+  formatPickerCurrentLabel,
+  isAutoPickerCurrent,
+  resolveInitialProviderSlug,
+  resolvePickerCurrent,
+} from "@/lib/model-picker-current";
 import { queryMatchesProviderOnly } from "@/lib/model-picker-filter";
 import { modelSearchText } from "@/lib/model-search-text";
 
@@ -88,6 +94,12 @@ interface Props {
   title?: string;
   /** If true, hides "Persist globally" checkbox — always saves to config.yaml. */
   alwaysGlobal?: boolean;
+  /**
+   * Current assignment for this picker *slot* (auxiliary task, MoA model).
+   * The options loader always returns the main chat model; without this,
+   * "Set Auxiliary: Vision" shows `current: glm-5.3` while Vision is Qwen.
+   */
+  currentAssignment?: { model?: string; provider?: string } | null;
 }
 
 export function ModelPickerDialog(props: Props) {
@@ -100,6 +112,7 @@ export function ModelPickerDialog(props: Props) {
     onClose,
     title = "Switch Model",
     alwaysGlobal = false,
+    currentAssignment,
   } = props;
   const standalone = !!loader && !!onApply;
 
@@ -120,12 +133,13 @@ export function ModelPickerDialog(props: Props) {
 
   const applyOptions = (r: ModelOptionsResponse) => {
     const next = r?.providers ?? [];
+    const current = resolvePickerCurrent(r, currentAssignment);
     setProviders(next);
-    setCurrentModel(String(r?.model ?? ""));
-    setCurrentProviderSlug(String(r?.provider ?? ""));
+    setCurrentModel(current.model);
+    setCurrentProviderSlug(current.provider);
     setSelectedSlug((prev) => {
       if (prev && next.some((p) => p.slug === prev)) return prev;
-      return (next.find((p) => p.is_current) ?? next[0])?.slug ?? "";
+      return resolveInitialProviderSlug(next, current.provider);
     });
     setSelectedModel("");
   };
@@ -376,8 +390,11 @@ export function ModelPickerDialog(props: Props) {
             {title}
           </h2>
           <p className="text-xs text-muted-foreground mt-1 font-mono">
-            current: {currentModel || "(unknown)"}
-            {currentProviderSlug && ` · ${currentProviderSlug}`}
+            current:{" "}
+            {formatPickerCurrentLabel({
+              model: currentModel,
+              provider: currentProviderSlug,
+            })}
           </p>
         </header>
 
@@ -401,6 +418,7 @@ export function ModelPickerDialog(props: Props) {
             providers={filteredProviders}
             total={providers.length}
             selectedSlug={selectedSlug}
+            currentProviderSlug={currentProviderSlug}
             query={trimmedQuery}
             onSelect={(slug) => {
               setSelectedSlug(slug);
@@ -501,6 +519,7 @@ function ProviderColumn({
   providers,
   total,
   selectedSlug,
+  currentProviderSlug,
   query,
   onSelect,
 }: {
@@ -509,6 +528,7 @@ function ProviderColumn({
   providers: ModelOptionProvider[];
   total: number;
   selectedSlug: string;
+  currentProviderSlug: string;
   query: string;
   onSelect(slug: string): void;
 }) {
@@ -534,6 +554,9 @@ function ProviderColumn({
 
       {providers.map((p) => {
         const active = p.slug === selectedSlug;
+        const isCurrentProvider =
+          p.slug === currentProviderSlug &&
+          !isAutoPickerCurrent({ model: "", provider: currentProviderSlug });
         return (
           <ListItem
             key={p.slug}
@@ -546,7 +569,7 @@ function ProviderColumn({
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-1.5">
                 <span className="font-medium truncate">{p.name}</span>
-                {p.is_current && <CurrentTag />}
+                {isCurrentProvider && <CurrentTag />}
               </div>
               <div className="text-xs text-text-secondary font-mono truncate">
                 {p.slug} · {p.total_models ?? p.models?.length ?? 0} models

--- a/web/src/lib/model-picker-current.test.ts
+++ b/web/src/lib/model-picker-current.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  assignmentToPickerCurrent,
+  formatPickerCurrentLabel,
+  isAutoPickerCurrent,
+  resolveInitialProviderSlug,
+  resolvePickerCurrent,
+} from "./model-picker-current";
+
+const MAIN = { model: "glm-5.3", provider: "zxl" };
+const VISION = { model: "qwen/qwen2.5-flash", provider: "nous" };
+
+const PROVIDERS = [
+  { slug: "zxl", is_current: true },
+  { slug: "nous", is_current: false },
+  { slug: "openrouter", is_current: false },
+];
+
+describe("assignmentToPickerCurrent", () => {
+  it("maps a pinned auxiliary task onto that provider/model", () => {
+    expect(assignmentToPickerCurrent(VISION)).toEqual(VISION);
+  });
+
+  it("treats missing, empty, or auto provider as auto", () => {
+    expect(assignmentToPickerCurrent(undefined)).toEqual({
+      model: "",
+      provider: "auto",
+    });
+    expect(assignmentToPickerCurrent({ provider: "auto", model: "ignored" })).toEqual({
+      model: "",
+      provider: "auto",
+    });
+    expect(assignmentToPickerCurrent({ provider: "", model: "glm-5.3" })).toEqual({
+      model: "",
+      provider: "auto",
+    });
+  });
+});
+
+describe("resolvePickerCurrent", () => {
+  it("uses the catalog main model when no slot override is given", () => {
+    expect(resolvePickerCurrent(MAIN)).toEqual(MAIN);
+  });
+
+  it("does not let the main chat model leak into an auxiliary slot", () => {
+    // The screenshot bug: Set Auxiliary: Vision showed glm-5.3 · zxl
+    // because the loader is always /api/model/options (main).
+    expect(resolvePickerCurrent(MAIN, VISION)).toEqual(VISION);
+  });
+
+  it("keeps an explicit auto override instead of falling back to main", () => {
+    expect(resolvePickerCurrent(MAIN, { model: "", provider: "auto" })).toEqual({
+      model: "",
+      provider: "auto",
+    });
+  });
+});
+
+describe("formatPickerCurrentLabel", () => {
+  it("matches the previous main-picker label shape", () => {
+    expect(formatPickerCurrentLabel(MAIN)).toBe("glm-5.3 · zxl");
+  });
+
+  it("shows auto (use main model) for unset auxiliary slots", () => {
+    expect(formatPickerCurrentLabel({ model: "", provider: "auto" })).toBe(
+      "auto (use main model)",
+    );
+    expect(isAutoPickerCurrent({ model: "glm-5.3", provider: "" })).toBe(true);
+  });
+});
+
+describe("resolveInitialProviderSlug", () => {
+  it("opens the auxiliary provider, not the main-model provider", () => {
+    expect(resolveInitialProviderSlug(PROVIDERS, "nous")).toBe("nous");
+  });
+
+  it("falls back to the catalog's current provider when the slot is auto", () => {
+    expect(resolveInitialProviderSlug(PROVIDERS, "auto")).toBe("zxl");
+  });
+
+  it("falls back when the pinned provider is missing from the catalog", () => {
+    expect(resolveInitialProviderSlug(PROVIDERS, "missing-custom")).toBe("zxl");
+  });
+});

--- a/web/src/lib/model-picker-current.ts
+++ b/web/src/lib/model-picker-current.ts
@@ -1,0 +1,71 @@
+/**
+ * Resolve what the dashboard model picker should treat as "current".
+ *
+ * `/api/model/options` always returns the *main* chat model. Auxiliary and
+ * MoA pickers reuse that catalog, so they must pass the slot assignment or
+ * the header/highlight will show GLM (or whatever the chat model is) while
+ * the task list shows the real Vision/MoA pin.
+ */
+
+export interface PickerCurrent {
+  model: string;
+  provider: string;
+}
+
+export function isAutoPickerCurrent(current: PickerCurrent): boolean {
+  const provider = current.provider.trim().toLowerCase();
+  return !provider || provider === "auto";
+}
+
+/** Map an auxiliary-task row onto picker current. Auto/empty → auto. */
+export function assignmentToPickerCurrent(
+  assignment: { model?: string; provider?: string } | null | undefined,
+): PickerCurrent {
+  const provider = String(assignment?.provider ?? "").trim();
+  const model = String(assignment?.model ?? "").trim();
+  if (!provider || provider.toLowerCase() === "auto") {
+    return { model: "", provider: "auto" };
+  }
+  return { model, provider };
+}
+
+/**
+ * `override` wins when the picker is for a non-main slot. Missing override
+ * keeps the catalog's main model (chat-session / Set Main Model).
+ */
+export function resolvePickerCurrent(
+  options: { model?: string; provider?: string } | null | undefined,
+  override?: { model?: string; provider?: string } | null,
+): PickerCurrent {
+  if (override) {
+    return {
+      model: String(override.model ?? ""),
+      provider: String(override.provider ?? ""),
+    };
+  }
+  return {
+    model: String(options?.model ?? ""),
+    provider: String(options?.provider ?? ""),
+  };
+}
+
+export function formatPickerCurrentLabel(current: PickerCurrent): string {
+  if (isAutoPickerCurrent(current)) {
+    return "auto (use main model)";
+  }
+  const model = current.model.trim() || "(unknown)";
+  const provider = current.provider.trim();
+  return provider ? `${model} · ${provider}` : model;
+}
+
+export function resolveInitialProviderSlug(
+  providers: readonly { slug: string; is_current?: boolean }[],
+  currentProvider: string,
+): string {
+  const slug = currentProvider.trim();
+  if (slug && slug.toLowerCase() !== "auto") {
+    const match = providers.find((p) => p.slug === slug);
+    if (match) return match.slug;
+  }
+  return (providers.find((p) => p.is_current) ?? providers[0])?.slug ?? "";
+}

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -42,6 +42,7 @@ import { useI18n } from "@/i18n";
 import { PluginSlot } from "@/plugins";
 import { ModelPickerDialog } from "@/components/ModelPickerDialog";
 import { ModelReloadConfirm } from "@/components/ModelReloadConfirm";
+import { assignmentToPickerCurrent } from "@/lib/model-picker-current";
 
 const PERIODS = [
   { label: "7d", days: 7 },
@@ -667,6 +668,9 @@ function AuxiliaryTasksModal({
             key={`picker-${refreshKey}`}
             loader={api.getModelOptions}
             alwaysGlobal
+            currentAssignment={assignmentToPickerCurrent(
+              aux?.tasks.find((a) => a.task === picker.task),
+            )}
             title={`Set Auxiliary: ${
               AUX_TASKS.find((t) => t.key === picker.task)?.label ??
               picker.task
@@ -904,6 +908,11 @@ function MoaModelsModal({
           key={`moa-picker-${refreshKey}-${selected}-${picker.kind}-${picker.kind === "reference" ? picker.index : "agg"}`}
           loader={api.getModelOptions}
           alwaysGlobal
+          currentAssignment={
+            picker.kind === "aggregator"
+              ? preset.aggregator
+              : preset.reference_models[picker.index]
+          }
           title="Select MoA Model"
           onApply={async ({ provider, model }) => {
             if ((provider || "").toLowerCase() === "moa") {


### PR DESCRIPTION
## Summary

- Opening **Set Auxiliary: Vision** showed `current: glm-5.3` (the main chat model) even after Vision was already pinned to Qwen. The save itself worked; the picker header/highlight always came from `/api/model/options`.
- Auxiliary and MoA pickers now pass the slot assignment, so `current:` matches the task list and the picker opens on that provider.

## Test plan

- [x] `npx vitest run src/lib/model-picker-current.test.ts` (from `web/`, 10 passed)
- [ ] Dashboard → Models → Auxiliary Tasks → pin Vision to a model that is not the main chat model
- [ ] Click Change on Vision: header shows that Vision model/provider, not the main chat model
- [ ] Tasks still on `auto` show `current: auto (use main model)`
- [ ] MoA Change on a reference/aggregator slot shows that slot, not the main model