### PR TITLE
fix(desktop): exempt the newest turn from the transcript render budget

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -215,17 +215,39 @@ describe('firstVisibleGroupIndex', () => {
   })
 
   it('walks newest-first and hides everything before the turn that meets the budget', () => {
-    const groups = [group('old', 50), group('mid', 30), group('new', 30)]
+    const groups = [group('oldest', 50), group('old', 30), group('mid', 30), group('new', 999)]
 
-    // newest-first: 30 (new) < 60, +30 (mid) = 60 >= 60 → mid is the first
-    // visible group, old is hidden.
+    // The newest turn is exempt, then newest-first over history: 30 (mid) < 60,
+    // +30 (old) = 60 >= 60 → old is the first visible group, oldest is hidden.
     expect(firstVisibleGroupIndex(groups, 60)).toBe(1)
   })
 
   it('keeps whole turns intact — the turn that crosses the budget stays visible', () => {
-    const groups = [group('old', 5), group('huge', 500)]
+    const groups = [group('old', 5), group('huge', 500), group('new', 10)]
 
     expect(firstVisibleGroupIndex(groups, 60)).toBe(1)
+  })
+
+  it('exempts the newest turn — the cut cannot move while it grows or completes', () => {
+    // The streaming turn's weight climbs per flush and lands in bulk at
+    // completion. Counting it walked the cut forward mid-turn, dropping settled
+    // turns off the top and shifting scrollHeight under stick-to-bottom.
+    const history = [group('g0', 30), group('g1', 40), group('g2', 30)]
+
+    const streaming = firstVisibleGroupIndex([...history, group('new', 1)], 60)
+    const completed = firstVisibleGroupIndex([...history, group('new', 500)], 60)
+
+    expect(streaming).toBe(1)
+    expect(completed).toBe(streaming)
+  })
+
+  it('moves the cut only when the finished turn joins history', () => {
+    const groups = [group('g0', 30), group('g1', 40), group('g2', 30), group('done', 500)]
+
+    // Same transcript, next turn begins: `done` is now history and its full
+    // weight spends the budget in one step — the cut advances past it at a
+    // natural content-change moment, not mid-stream.
+    expect(firstVisibleGroupIndex([...groups, group('next', 1)], 60)).toBe(3)
   })
 
   it('returns groups.length for an empty list', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -231,11 +231,21 @@ export function buildGroups(signature: string): MessageGroup[] {
 // Walk turns newest-first, summing their render weights until the budget is met;
 // everything before the first kept turn is hidden. `minVisible` turns are kept
 // regardless of weight. Returns the index of that first visible group.
+//
+// The NEWEST turn spends none of the budget. Its weight climbs on every store
+// flush while it streams and lands in bulk as it completes, and counting it
+// walked this cut forward MID-TURN — each step dropping a settled turn off the
+// top, shrinking scrollHeight under the stick-to-bottom lock (the recurring
+// flicker/jump on long agent turns). Exempt, the cut is a function of settled
+// history only: it can move only when the next turn begins, never while the
+// current one grows or finishes.
 export function firstVisibleGroupIndex(groups: readonly MessageGroup[], budget: number, minVisible = 0): number {
   let firstVisible = groups.length
 
   for (let i = groups.length - 1, weight = 0; i >= 0; i--) {
-    weight += groups[i].weight
+    if (i < groups.length - 1) {
+      weight += groups[i].weight
+    }
     firstVisible = i
 
     if (weight >= budget) {


### PR DESCRIPTION
## Problem

On long agent sessions the transcript flickers / the scroll jumps repeatedly while a turn streams, and again in a burst when it completes.

`firstVisibleGroupIndex` (the DOM history budget in `apps/desktop/src/components/assistant-ui/thread/list.tsx`) walks turns newest-first, summing render weights until the budget is met, **including the newest turn's weight**. While an agent turn streams, its weight climbs on every store flush — and lands in bulk at completion — so the hidden-history boundary advances mid-turn. Each step drops a settled turn off the top and shrinks `scrollHeight` under the stick-to-bottom lock (overflow-anchor is disabled), which reads as flicker/jump. With multiple mounted panes the per-pane budget floor is `RENDER_BUDGET/4`, so a single tool-heavy turn crosses it many times.

The live-tail parts budget (975f4ef38d) fixed the *virtualization* tail sizing but left this *hidden-history* cut mobile.

## Fix

The newest turn spends none of the budget. The cut becomes a function of settled history only: it moves exactly when the next turn begins (its predecessor's now-final weight enters the walk once, at a natural content-change moment), and never while the current turn grows or finishes.

## Tests

- Updated the two fixtures whose expectations encode the old semantics (the crossing-turn-stays-visible intent is preserved with a newest group present).
- Added two regressions: the cut is invariant to the newest turn's weight (streaming → completed), and it advances only when the finished turn joins history.
- `npx vitest run src/components/assistant-ui/thread/list.test.ts` — 30/30 pass.

Running this patch on a source build (macOS arm64) eliminates the mid-turn flicker on long tool-heavy sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)