### PR TITLE
fix: proxy platform webhooks past the dashboard OAuth gate

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3286,6 +3286,126 @@ _PORT_BINDING_PLATFORM_PORTS: Dict[str, Tuple[str, int]] = {
 # Platform states that mean the adapter is NOT serving its port right now.
 _PLATFORM_DEAD_STATES = frozenset({"fatal", "disconnected", "stopped"})
 
+# Default webhook paths for platforms whose adapter runs its own webhook
+# server on a separate port (see ``_PORT_BINDING_PLATFORM_PORTS`` above).
+# These requests never hit a real route on THIS app — only the dashboard's
+# cookie gate does, because it runs as global middleware ahead of routing.
+# Without this table, every non-loopback deployment that exposes only this
+# app's port (the common case on single-public-port PaaS hosts) silently
+# drops inbound platform webhooks: LINE/Feishu/WeCom already verify the
+# request themselves (HMAC/signature — see each adapter's own ``verify_*``
+# function), so bouncing them through the dashboard's session-cookie gate is
+# both wrong (no browser session exists to check) and redundant (the gate
+# would just be duplicating the adapter's own auth). Mirrors the existing
+# ``/api/cron/fire`` precedent in ``dashboard_auth/public_paths.py``, which
+# bypasses the same gate for the same reason — its own short-lived JWT is
+# the real auth boundary, not this allowlist.
+#
+# A path is proxied ONLY when it matches a platform's DEFAULT path exactly
+# (or a sub-path of it, e.g. LINE's ``/line/webhook/health``). An operator
+# who set a custom ``extra.webhook_path`` / ``extra.path`` away from the
+# default isn't covered — same as before this table existed. Only entries
+# verified against the adapter source are listed; extend this table (and
+# reuse ``_PORT_BINDING_PLATFORM_PORTS`` for the port) as further platforms
+# are confirmed.
+_WEBHOOK_PROXY_DEFAULT_PATHS: Dict[str, str] = {
+    "line": "/line/webhook",
+    "feishu": "/feishu/webhook",
+    "wecom_callback": "/wecom/callback",
+}
+
+
+def _resolve_webhook_proxy_port(platform: str) -> int:
+    """Resolve the live host port for ``platform``'s webhook server.
+
+    Reads this process's own config (top-level ``platforms:`` wins over
+    ``gateway.platforms:``, matching ``load_gateway_config()`` precedence),
+    falling back to the adapter's documented default port. Best-effort: any
+    read/parse failure falls back to the default rather than raising, so a
+    config hiccup degrades to "try the default port" instead of dropping
+    the webhook outright.
+    """
+    port_key, default_port = _PORT_BINDING_PLATFORM_PORTS[platform]
+    try:
+        cfg = load_config() or {}
+        gateway_cfg = cfg.get("gateway") if isinstance(cfg.get("gateway"), dict) else {}
+        block: Dict[str, Any] = {}
+        for src in ((gateway_cfg or {}).get("platforms"), cfg.get("platforms")):
+            if isinstance(src, dict) and isinstance(src.get(platform), dict):
+                block.update(src[platform])
+        extra = block.get("extra") if isinstance(block.get("extra"), dict) else {}
+        raw = block.get(port_key, (extra or {}).get(port_key, default_port))
+        return int(raw)
+    except Exception:
+        return default_port
+
+
+async def _proxy_platform_webhook(request: Request, platform: str) -> "Response":
+    """Forward ``request`` verbatim to ``platform``'s own webhook server.
+
+    The platform adapter authenticates the request itself (signature/HMAC);
+    this proxy adds no auth of its own and must only ever be reached for a
+    path matched against ``_WEBHOOK_PROXY_DEFAULT_PATHS``.
+    """
+    import httpx
+
+    port = _resolve_webhook_proxy_port(platform)
+    body = await request.body()
+    # Hop-by-hop headers must not be forwarded (RFC 7230 SS6.1); Host/
+    # Content-Length are recomputed by httpx for the new target/body.
+    excluded = {
+        "host", "content-length", "connection", "keep-alive",
+        "transfer-encoding", "upgrade", "proxy-authenticate",
+        "proxy-authorization", "te", "trailer",
+    }
+    headers = {k: v for k, v in request.headers.items() if k.lower() not in excluded}
+    target = f"http://127.0.0.1:{port}{request.url.path}"
+    if request.url.query:
+        target = f"{target}?{request.url.query}"
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+            upstream = await client.request(
+                request.method, target, content=body, headers=headers,
+            )
+    except httpx.RequestError as exc:
+        _log.warning(
+            "Webhook proxy: %s adapter unreachable on port %s: %s",
+            platform, port, exc,
+        )
+        return JSONResponse(
+            status_code=502,
+            content={"detail": f"{platform} webhook adapter unreachable"},
+        )
+    response_headers = {
+        k: v for k, v in upstream.headers.items() if k.lower() not in excluded
+    }
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=response_headers,
+    )
+
+
+@app.middleware("http")
+async def _webhook_proxy_gate(request: Request, call_next):
+    """Forward known platform-webhook paths straight to their own server.
+
+    Must run before ``_dashboard_auth_gate``: these paths carry no browser
+    session, are authenticated by the platform's own signature check inside
+    the adapter, and — critically — don't correspond to any real route on
+    THIS app at all when the platform's adapter runs on a separate port (the
+    common single-public-port PaaS deployment, e.g. a Fly.io app that only
+    declares one public service). Letting the auth gate see them first means
+    an unauthenticated caller (LINE's own servers, with a valid signature)
+    gets bounced to /login and the webhook is silently dropped — the bug
+    this closes.
+    """
+    path = request.url.path
+    for platform, default_path in _WEBHOOK_PROXY_DEFAULT_PATHS.items():
+        if path == default_path or path.startswith(default_path + "/"):
+            return await _proxy_platform_webhook(request, platform)
+    return await call_next(request)
+
 
 def _profile_platform_ports(profile_home: Path, runtime: Optional[dict]) -> Dict[str, int]:
     """Best-effort map of ``platform -> host TCP port`` for one profile's gateway.

--- a/tests/hermes_cli/test_webhook_proxy_gate.py
+++ b/tests/hermes_cli/test_webhook_proxy_gate.py
@@ -1,0 +1,150 @@
+"""Tests for the platform-webhook proxy gate.
+
+Regression context: on a single-public-port deployment (e.g. a Fly.io app
+that only exposes the dashboard's port), a platform adapter's own webhook
+server (LINE on 8646, Feishu on its own port, etc.) is never reachable from
+the internet directly. Before this gate, those requests hit THIS app's
+global dashboard-auth middleware instead — which has no route for
+``/line/webhook`` and, under the OAuth gate, bounced every request to
+``/login`` (or 401'd it), silently dropping the webhook. See
+docs in ``hermes-config/skills/realife/realife-line-management`` (private
+repo) for the live incident this reproduces.
+
+These tests mock the internal HTTP call (``httpx.AsyncClient.request``) so
+they never depend on a real listener on the platform's port.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth import clear_providers, register_provider
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+
+@pytest.fixture
+def gated_app():
+    """Same shape as test_dashboard_auth_middleware.gated_app: OAuth-gated,
+    non-loopback bind, one stub provider registered."""
+    clear_providers()
+    register_provider(StubAuthProvider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+    yield client
+    clear_providers()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+def test_unmatched_path_still_hits_the_auth_gate(gated_app):
+    """Regression guard: only the allowlisted platform paths bypass auth —
+    everything else must keep redirecting to /login exactly as before."""
+    r = gated_app.post("/not/a/webhook", json={}, follow_redirects=False)
+    assert r.status_code == 302
+    assert "/login" in r.headers.get("location", "")
+
+
+@pytest.mark.parametrize(
+    "path,platform",
+    [
+        ("/line/webhook", "line"),
+        ("/line/webhook/health", "line"),
+        ("/feishu/webhook", "feishu"),
+        ("/wecom/callback", "wecom_callback"),
+    ],
+)
+def test_platform_webhook_bypasses_the_auth_gate_and_proxies(
+    monkeypatch, gated_app, path, platform
+):
+    """A known platform-webhook path skips the cookie gate entirely and is
+    forwarded to the adapter's own port — no session, no /login bounce."""
+    captured: dict = {}
+
+    async def fake_request(self, method, url, *, content=None, headers=None):
+        captured["method"] = method
+        captured["url"] = str(url)
+        captured["content"] = content
+        captured["headers"] = dict(headers or {})
+        return httpx.Response(
+            200,
+            content=b"OK",
+            headers={"content-type": "text/plain", "x-upstream": "adapter"},
+            request=httpx.Request(method, url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "request", fake_request)
+
+    r = gated_app.post(
+        path,
+        content=b'{"events": []}',
+        headers={
+            "X-Line-Signature": "deadbeef",
+            "Content-Type": "application/json",
+            "Cookie": "should=not-leak-to-upstream-unmodified",
+        },
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 200, r.text
+    assert r.text == "OK"
+    assert r.headers.get("x-upstream") == "adapter"
+
+    assert captured["method"] == "POST"
+    assert captured["url"].startswith(f"http://127.0.0.1:")
+    assert captured["url"].endswith(path)
+    assert captured["content"] == b'{"events": []}'
+    # The adapter's own signature check must still see the header.
+    assert captured["headers"].get("x-line-signature") == "deadbeef"
+    # Hop-by-hop / rewritten headers must not leak through verbatim.
+    assert "host" not in captured["headers"]
+    assert "content-length" not in captured["headers"]
+
+
+def test_line_webhook_forwards_query_string(monkeypatch, gated_app):
+    captured: dict = {}
+
+    async def fake_request(self, method, url, *, content=None, headers=None):
+        captured["url"] = str(url)
+        return httpx.Response(200, content=b"ok", request=httpx.Request(method, url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "request", fake_request)
+
+    gated_app.get("/line/webhook/health?probe=1", follow_redirects=False)
+    assert captured["url"].endswith("/line/webhook/health?probe=1")
+
+
+def test_unreachable_adapter_returns_502_not_a_login_bounce(monkeypatch, gated_app):
+    """If the adapter's port isn't listening (crashed / still starting), the
+    caller must see a clean 502 — never a 401/302 that looks like an auth
+    failure to LINE's retry logic."""
+
+    async def fake_request(self, method, url, *, content=None, headers=None):
+        raise httpx.ConnectError("connection refused", request=httpx.Request(method, url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "request", fake_request)
+
+    r = gated_app.post("/line/webhook", json={}, follow_redirects=False)
+    assert r.status_code == 502
+    assert r.json()["detail"] == "line webhook adapter unreachable"
+
+
+def test_resolve_webhook_proxy_port_prefers_config_over_default(monkeypatch):
+    monkeypatch.setattr(
+        web_server,
+        "load_config",
+        lambda: {"gateway": {"platforms": {"line": {"port": 19999}}}},
+    )
+    assert web_server._resolve_webhook_proxy_port("line") == 19999
+
+
+def test_resolve_webhook_proxy_port_falls_back_to_default_on_bad_config(monkeypatch):
+    monkeypatch.setattr(web_server, "load_config", lambda: (_ for _ in ()).throw(OSError()))
+    assert web_server._resolve_webhook_proxy_port("line") == 8646


### PR DESCRIPTION
## What does this PR do?

On any deployment where the dashboard binds a public/non-loopback host and only ONE port is publicly reachable (e.g. a Fly.io app that declares a single `[http_service]`), a platform adapter's own webhook server never gets exposed. `LINE`'s adapter, for example, runs a separate `aiohttp` server on port 8646 (`plugins/platforms/line/adapter.py`) — a real request to `/line/webhook` on the public hostname never reaches it. Instead it hits this app's global dashboard-auth middleware, which has no route for that path and, under the OAuth gate, bounces every request to `/login`. Confirmed live against a real deployment: LINE's own webhook-verification API call got a `302` (expected `200`), meaning real inbound events are silently dropped — no error surfaces anywhere, the webhook just doesn't fire.

`hermes_cli/dashboard_auth/public_paths.py` already documents the right precedent for this exact class of problem: `/api/cron/fire` bypasses the cookie gate because it carries its own short-lived JWT, which is the real auth boundary — the allowlist isn't the security control there, the JWT is. LINE, Feishu, and WeCom's callback endpoint already verify every request with their own signature/HMAC check inside the adapter (`verify_line_signature`, etc.), so routing them through the dashboard's browser-session gate is both wrong (no browser session exists for a server-to-server LINE callback) and redundant.

## Related Issue

No existing issue — opening this PR directly since the root cause and fix were both identified and verified together. Happy to file a companion issue if preferred.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`:
  - Added `_WEBHOOK_PROXY_DEFAULT_PATHS`, mapping platform name to its adapter's default webhook path (`line`, `feishu`, `wecom_callback` — see Scope below).
  - Added `_resolve_webhook_proxy_port()`, reusing the existing `_PORT_BINDING_PLATFORM_PORTS` table and the same config-precedence logic `_profile_platform_ports()` already uses for the dashboard's topology display, to find the adapter's actual live port (config override, falling back to the documented default).
  - Added `_proxy_platform_webhook()`, an `httpx.AsyncClient`-based reverse proxy that forwards method/body/headers (minus hop-by-hop headers) to `http://127.0.0.1:<port><path>` and streams the response back unmodified.
  - Added `_webhook_proxy_gate`, a new `@app.middleware("http")` registered so it intercepts a matching path before `_dashboard_auth_gate` ever sees it. Unmatched paths fall through unchanged to the existing middleware chain.
- `tests/hermes_cli/test_webhook_proxy_gate.py` (new): full coverage of the new gate — bypass + proxy for each listed platform, query-string forwarding, header stripping, unreachable-adapter to 502, config-port resolution + its fallback-on-error path, and a regression guard that an unrelated path still hits the OAuth gate exactly as before.

## Scope (intentionally conservative)

Only `line`, `feishu`, and `wecom_callback` are in the initial table — each verified directly against its adapter's source for the exact default path (`plugins/platforms/line/adapter.py`, `plugins/platforms/feishu/adapter.py`, `plugins/platforms/wecom/callback_adapter.py`). The other `_PORT_BINDING_PLATFORM_PORTS` entries (`msgraph_webhook`, `bluebubbles`, `sms`, `whatsapp_cloud`) are deliberately left out: I could not confirm their exact default webhook path against source with confidence in this pass (e.g. `sms`'s path lives under the `/webhooks/` namespace shared with the generic user-defined-webhooks feature, which needs a closer look to avoid a path collision), and a wrong guess here would silently misroute traffic rather than fail loudly. Extending the table for a verified platform is a one-line addition to `_WEBHOOK_PROXY_DEFAULT_PATHS` (plus `_PORT_BINDING_PLATFORM_PORTS` if it's not already there).

An operator-customized `extra.webhook_path` / `extra.path` (away from the adapter's default) also isn't covered — the path-match is against the *default* path only. This is no worse than today (such a setup already required fronting the platform's port directly, e.g. via its own Cloudflare Tunnel), just not yet improved by this PR.

## How to Test

1. `pytest tests/hermes_cli/test_webhook_proxy_gate.py -q` — new tests, fully mocked (no real listener required).
2. Reproduce the bug on `main` first: `TestClient` a gated `app` (see the `gated_app` fixture in `tests/hermes_cli/test_dashboard_auth_middleware.py`) and `POST /line/webhook` -> `302` to `/login`.
3. With this branch: the same request instead reaches `_webhook_proxy_gate` and proxies through (mocked in the test suite; on a machine with a real LINE adapter running locally on 8646, it forwards to the real adapter — I confirmed this by hand against my own running instance and got back a genuine `401 invalid signature` from the adapter itself, proving the proxy actually reaches the real service end-to-end).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits (`fix:`)
- [x] I searched existing PRs/issues for a duplicate report of this — didn't find one
- [x] This PR contains only changes related to this fix (no unrelated commits — my local checkout had unrelated pre-existing modifications to other files; none of them are in this branch/commit)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the directly-affected suites instead (`tests/hermes_cli/*dashboard_auth*`, `*webhook*`, `test_web_server*.py` — 397 tests total across both runs), all passing except one pre-existing, unrelated failure (`test_custom_endpoint_save_scopes_to_the_requested_profile`, a Windows/cp932 locale `UnicodeDecodeError` in the custom-endpoint-save code path) that reproduces identically on `main` without this change. I did not run the full multi-thousand-test suite end-to-end due to time constraints — happy to let CI cover the remainder.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — not yet; happy to add a short note to `website/docs/user-guide/messaging/webhooks/` (or wherever maintainers prefer) if this approach looks right
- [ ] I've updated `cli-config.yaml.example` — N/A, no new config keys (this reuses existing platform config already documented there)
- [ ] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A, no workflow/architecture change beyond this one middleware
- [x] I've considered cross-platform impact — the proxy is a plain loopback HTTP call (`httpx.AsyncClient` to `127.0.0.1`), no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool-facing change

## Screenshots / Logs

Live repro (before this fix), against a real Fly.io-hosted Cloud Agent instance:

```
$ curl -s -X POST https://api.line.me/v2/bot/channel/webhook/test -H "Authorization: Bearer $LINE_CHANNEL_ACCESS_TOKEN"
{"success":false,"timestamp":"2026-08-29T11:57:02.003289Z","statusCode":302,"reason":"ERROR_STATUS_CODE","detail":"302"}

$ curl -s -o /dev/null -D - -X POST "https://<redacted>.agents.nousresearch.com/line/webhook" -d '{}'
HTTP/1.1 302 Found
location: /auth/login?provider=nous&next=%2Fline%2Fwebhook
```

`/api/health` and `/api/status` on the same host correctly return `200` (they're in `PUBLIC_API_PATHS`), confirming this is the dashboard's own auth gate intercepting an unrouted path, not an infrastructure-level block.
