### PR TITLE
feat(agent): implement session_token_hard_stop fuse

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -605,6 +605,8 @@ def init_agent(
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
     run_budget_seconds: Optional[float] = None,
+    session_token_hard_stop: Optional[int] = None,
+    session_token_warn: Optional[int] = None,
     fallback_model: Dict[str, Any] = None,
     credential_pool=None,
     checkpoints_enabled: bool = False,
@@ -1027,6 +1029,16 @@ def init_agent(
     agent._run_budget_started_at = None
     # One-shot latch for the 80% wrap-up notice (reset each turn).
     agent._run_budget_wrapup_injected = False
+
+    # Per-session billed-token fuse (#96814). Constructor arg wins; else
+    # resolved from config.yaml further below. None = feature fully off.
+    from agent.session_token_hard_stop import normalize_session_token_limit
+
+    agent.session_token_hard_stop = normalize_session_token_limit(
+        session_token_hard_stop
+    )
+    agent.session_token_warn = normalize_session_token_limit(session_token_warn)
+    agent._session_token_warn_injected = False
 
     # Activity tracking — updated on each API call, tool execution, and
     # stream chunk.  Used by the gateway timeout handler to report what the
@@ -2006,6 +2018,18 @@ def init_agent(
     if agent.run_budget_seconds is None:
         agent.run_budget_seconds = _normalize_run_budget_seconds(
             _agent_section.get("run_budget_seconds")
+        )
+
+    # Session billed-token fuse from config — only when the constructor
+    # did not already set a positive cap (same "arg wins" shape as
+    # run_budget_seconds).
+    if agent.session_token_hard_stop is None:
+        agent.session_token_hard_stop = normalize_session_token_limit(
+            _agent_section.get("session_token_hard_stop")
+        )
+    if agent.session_token_warn is None:
+        agent.session_token_warn = normalize_session_token_limit(
+            _agent_section.get("session_token_warn")
         )
 
     # Empty-response retry guard config (NS-503): additive

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -47,6 +47,13 @@ from agent.turn_context import (
     compose_user_api_content,
     reanchor_current_turn_user_idx,
 )
+from agent.session_token_hard_stop import (
+    SESSION_TOKEN_WARN_NOTICE,
+    billed_session_tokens,
+    hard_stop_exhausted,
+    hard_stop_user_message,
+    should_emit_warn,
+)
 from agent.turn_retry_state import TurnRetryState
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
@@ -191,6 +198,42 @@ def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) 
             )
             return True
     return False
+
+
+def _append_notice_to_newest_tool_message(
+    messages: List[Dict[str, Any]], notice: str
+) -> bool:
+    """Append ``notice`` to the newest tool message (cache-safe /steer channel)."""
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if isinstance(msg, dict) and msg.get("role") == "tool":
+            existing = msg.get("content", "")
+            if isinstance(existing, str):
+                msg["content"] = existing + f"\n\n{notice}"
+            else:
+                try:
+                    blocks = list(existing) if existing else []
+                    blocks.append({"type": "text", "text": notice})
+                    msg["content"] = blocks
+                except Exception:
+                    return False
+            return True
+    return False
+
+
+def _maybe_inject_session_token_warn(agent: Any, messages: List[Dict[str, Any]]) -> bool:
+    """Inject the one-time session-token wind-down notice when past the warn threshold."""
+    if not should_emit_warn(agent):
+        return False
+    if not _append_notice_to_newest_tool_message(messages, SESSION_TOKEN_WARN_NOTICE):
+        return False
+    agent._session_token_warn_injected = True
+    logger.info(
+        "Session token warn notice injected (used=%d, threshold=%s)",
+        billed_session_tokens(agent),
+        getattr(agent, "session_token_warn", None),
+    )
+    return True
 
 
 def _restore_user_after_reference_handoff(
@@ -2062,6 +2105,15 @@ def run_conversation(
                     f"the review tool loop before the next provider call."
                 )
             break
+
+        # Session billed-token fuse (#96814): stop before the next provider
+        # call so crossing the cap does not spend another request.
+        if hard_stop_exhausted(agent):
+            _turn_exit_reason = "token_hard_stop"
+            final_response = hard_stop_user_message(agent)
+            if not agent.quiet_mode:
+                agent._safe_print(f"\n⏹️  {final_response}")
+            break
         
         api_call_count += 1
         agent._api_call_count = api_call_count
@@ -2171,6 +2223,7 @@ def run_conversation(
         # result); dormant when no budget is set.
         if getattr(agent, "run_budget_seconds", None):
             _maybe_inject_run_budget_wrapup(agent, messages)
+        _maybe_inject_session_token_warn(agent, messages)
 
         # Prepare messages for API call
         # If we have an ephemeral system prompt, prepend it to the messages

--- a/agent/session_token_hard_stop.py
+++ b/agent/session_token_hard_stop.py
@@ -1,0 +1,162 @@
+"""Per-session billed-token hard stop (``agent.session_token_hard_stop``).
+
+Operators can set this key believing it is a fuse. Until #96814 it was
+accepted (or silently ignored) with no reader. This module is the reader.
+
+Formula (documented, billed tokens — not a turn cap):
+
+    used = session_input_tokens
+         + session_cache_read_tokens
+         + session_cache_write_tokens
+         + session_output_tokens
+
+That matches :attr:`agent.usage_pricing.CanonicalUsage.total_tokens` as
+accumulated on ``session_*`` counters. Fresh input + output alone would miss
+the cache-read-dominated runaway the issue describes; cache tokens are billed
+and are therefore part of the fuse.
+
+``0`` / ``null`` / absent / invalid = disabled (default). The check is
+evaluated at the top of the conversation loop, before the next provider
+call, so crossing the cap does not spend another request.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# Older names that were accepted (or written by operators) with no
+# implementation. Warn at config load — silently accepting a safety key
+# is worse than rejecting it.
+UNIMPLEMENTED_BUDGET_KEYS = frozenset(
+    {
+        "gateway_usage_hard_api_calls",
+        "gateway_usage_hard_tokens",
+        "gateway_usage_warn_api_calls",
+        "gateway_usage_warn_tokens",
+        "gateway_usage_hard_api_calls_warn",
+        "gateway_usage_hard_tokens_warn",
+    }
+)
+
+SESSION_TOKEN_WARN_NOTICE = (
+    "[SYSTEM NOTICE — session token budget] "
+    "This session is approaching its billed-token ceiling. "
+    "Wind down: stop new discovery, finish the current deliverable, "
+    "and avoid starting work that needs another long tool loop."
+)
+
+
+def normalize_session_token_limit(value: Any) -> Optional[int]:
+    """Normalize a token-limit config value to a positive int or None.
+
+    None / absent / non-numeric / non-positive / bool all resolve to
+    ``None`` (feature off) so a malformed YAML value can never arm the
+    fuse, only leave it dormant.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        tokens = int(value)
+    except (TypeError, ValueError):
+        return None
+    if tokens <= 0:
+        return None
+    return tokens
+
+
+def billed_session_tokens(agent: Any) -> int:
+    """Return billed tokens accumulated on this session.
+
+    Prefers the split canonical counters (fresh + cache + output). Falls
+    back to ``session_total_tokens`` when the split counters are absent
+    (older pickles / minimal stubs).
+    """
+    split_names = (
+        "session_input_tokens",
+        "session_cache_read_tokens",
+        "session_cache_write_tokens",
+        "session_output_tokens",
+    )
+    if any(hasattr(agent, name) for name in split_names):
+        try:
+            fresh = int(getattr(agent, "session_input_tokens", 0) or 0)
+            cache_read = int(getattr(agent, "session_cache_read_tokens", 0) or 0)
+            cache_write = int(getattr(agent, "session_cache_write_tokens", 0) or 0)
+            output = int(getattr(agent, "session_output_tokens", 0) or 0)
+            return max(0, fresh + cache_read + cache_write + output)
+        except (TypeError, ValueError):
+            pass
+    try:
+        return max(0, int(getattr(agent, "session_total_tokens", 0) or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def resolve_hard_stop(agent: Any) -> Optional[int]:
+    return normalize_session_token_limit(
+        getattr(agent, "session_token_hard_stop", None)
+    )
+
+
+def resolve_warn_threshold(agent: Any) -> Optional[int]:
+    """Absolute warn threshold in billed tokens.
+
+    Explicit ``agent.session_token_warn`` wins when set. Otherwise, if a
+    hard stop is configured, warn at 80% of that ceiling (same shape as
+    ``run_budget_seconds``).
+    """
+    explicit = normalize_session_token_limit(
+        getattr(agent, "session_token_warn", None)
+    )
+    if explicit is not None:
+        return explicit
+    cap = resolve_hard_stop(agent)
+    if cap is None:
+        return None
+    return max(1, int(cap * 0.8))
+
+
+def hard_stop_exhausted(agent: Any) -> bool:
+    cap = resolve_hard_stop(agent)
+    if cap is None:
+        return False
+    return billed_session_tokens(agent) >= cap
+
+
+def should_emit_warn(agent: Any) -> bool:
+    if getattr(agent, "_session_token_warn_injected", False):
+        return False
+    threshold = resolve_warn_threshold(agent)
+    if threshold is None:
+        return False
+    if hard_stop_exhausted(agent):
+        # Hard stop owns the turn; do not also inject a wind-down notice.
+        return False
+    return billed_session_tokens(agent) >= threshold
+
+
+def hard_stop_user_message(agent: Any) -> str:
+    cap = resolve_hard_stop(agent) or 0
+    used = billed_session_tokens(agent)
+    return (
+        f"Session token hard stop reached ({used:,}/{cap:,} billed tokens). "
+        "Start a new session (/new) to continue."
+    )
+
+
+def unimplemented_budget_keys_present(config: Any) -> list[str]:
+    """Return unimplemented budget key names found in a config dict."""
+    if not isinstance(config, dict):
+        return []
+    found: list[str] = []
+    agent_section = config.get("agent")
+    sections = [config]
+    if isinstance(agent_section, dict):
+        sections.append(agent_section)
+    seen: set[str] = set()
+    for section in sections:
+        for key in UNIMPLEMENTED_BUDGET_KEYS:
+            if key in section and key not in seen:
+                seen.add(key)
+                found.append(key)
+    return sorted(found)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1001,6 +1001,17 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Per-session billed-token fuse (default: unset/null = disabled).
+  # Counts fresh input + cache read/write + output across the session
+  # (not reset per user message — unlike max_turns). When crossed, the
+  # current turn ends before the next model call with end_reason
+  # token_hard_stop. Older unused keys (gateway_usage_hard_tokens, …)
+  # are NOT implemented — setting them warns at config load.
+  # session_token_hard_stop: 5000000
+  # Optional absolute warn threshold (tokens). Unset + hard stop set
+  # => warn once at 80% of the ceiling.
+  # session_token_warn: 4000000
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2286,6 +2286,21 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 f"Move '{key}' under the appropriate section",
             ))
 
+    # ── Unimplemented budget / fuse keys (#96814) ────────────────────
+    # These names were accepted in operator configs with no reader.
+    # Warn loudly: a silently inert safety key is worse than rejecting it.
+    from agent.session_token_hard_stop import unimplemented_budget_keys_present
+
+    for inert_key in unimplemented_budget_keys_present(config):
+        issues.append(ConfigIssue(
+            "warning",
+            f"Config key '{inert_key}' is not implemented and has no effect. "
+            "Use agent.session_token_hard_stop (billed tokens per session) "
+            "instead of the older gateway_usage_hard_* names.",
+            "Set agent.session_token_hard_stop to a positive integer; "
+            "remove the unimplemented key.",
+        ))
+
     return issues
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -54,6 +54,17 @@ DEFAULT_CONFIG = {
         # implicit provider stale timeouts are capped to the remaining
         # budget. CLI one-shot equivalent: `hermes chat --run-budget N`.
         "run_budget_seconds": None,
+        # Per-session billed-token fuse (#96814). 0/null = disabled (default).
+        # Counted as CanonicalUsage.total_tokens: fresh input + cache read +
+        # cache write + output, accumulated across the session (not per turn).
+        # When crossed, the conversation loop ends the turn BEFORE the next
+        # provider call with end_reason token_hard_stop.
+        "session_token_hard_stop": None,
+        # Optional absolute billed-token warn threshold. When unset and a
+        # hard stop is set, a one-time system notice fires at 80% of the
+        # ceiling so the model can wind down. 0/null with no hard stop =
+        # no warn.
+        "session_token_warn": None,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/run_agent.py
+++ b/run_agent.py
@@ -515,6 +515,8 @@ class AIAgent:
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
         run_budget_seconds: Optional[float] = None,
+        session_token_hard_stop: Optional[int] = None,
+        session_token_warn: Optional[int] = None,
         fallback_model: Dict[str, Any] = None,
         credential_pool=None,
         checkpoints_enabled: bool = False,
@@ -606,6 +608,8 @@ class AIAgent:
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
             run_budget_seconds=run_budget_seconds,
+            session_token_hard_stop=session_token_hard_stop,
+            session_token_warn=session_token_warn,
             fallback_model=fallback_model,
             credential_pool=credential_pool,
             checkpoints_enabled=checkpoints_enabled,
@@ -798,6 +802,7 @@ class AIAgent:
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
+        self._session_token_warn_injected = False
 
         # Session boundary: the usage anchor describes the OLD session's
         # transcript — a fresh/branched/resumed session must fall back to

--- a/tests/agent/test_session_token_hard_stop.py
+++ b/tests/agent/test_session_token_hard_stop.py
@@ -1,0 +1,392 @@
+"""Tests for the per-session billed-token fuse (#96814).
+
+Covers:
+
+1. Normalization of ``session_token_hard_stop`` / ``session_token_warn``
+2. Documented billed-token formula (fresh + cache + output)
+3. Conversation-loop hard stop BEFORE the next provider call
+4. One-shot warn notice (explicit threshold and 80% default)
+5. Config plumbing + unimplemented older key warnings
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.session_token_hard_stop import (
+    SESSION_TOKEN_WARN_NOTICE,
+    billed_session_tokens,
+    hard_stop_exhausted,
+    hard_stop_user_message,
+    normalize_session_token_limit,
+    resolve_warn_threshold,
+    should_emit_warn,
+    unimplemented_budget_keys_present,
+)
+from hermes_cli.config import validate_config_structure
+from run_agent import AIAgent
+
+
+# --------------------------------------------------------------------------------------
+# Normalization
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw,expected", [
+    (None, None),
+    (0, None),
+    (-5, None),
+    ("abc", None),
+    (True, None),
+    (False, None),
+    (5000, 5000),
+    ("850", 850),
+    (1.9, 1),
+])
+def test_normalize_session_token_limit(raw, expected):
+    assert normalize_session_token_limit(raw) == expected
+
+
+# --------------------------------------------------------------------------------------
+# Formula
+# --------------------------------------------------------------------------------------
+
+
+def test_billed_session_tokens_sums_canonical_split():
+    agent = SimpleNamespace(
+        session_input_tokens=100,
+        session_cache_read_tokens=1000,
+        session_cache_write_tokens=50,
+        session_output_tokens=25,
+        session_total_tokens=9999,
+    )
+    assert billed_session_tokens(agent) == 1175
+
+
+def test_billed_session_tokens_falls_back_to_session_total():
+    agent = SimpleNamespace(session_total_tokens=42)
+    assert billed_session_tokens(agent) == 42
+
+
+def test_hard_stop_exhausted_requires_positive_cap():
+    agent = SimpleNamespace(
+        session_token_hard_stop=None,
+        session_input_tokens=999,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_output_tokens=0,
+    )
+    assert hard_stop_exhausted(agent) is False
+    agent.session_token_hard_stop = 0
+    assert hard_stop_exhausted(agent) is False
+    agent.session_token_hard_stop = 100
+    assert hard_stop_exhausted(agent) is True
+    agent.session_input_tokens = 99
+    assert hard_stop_exhausted(agent) is False
+
+
+def test_warn_threshold_defaults_to_80_percent():
+    agent = SimpleNamespace(session_token_hard_stop=1000, session_token_warn=None)
+    assert resolve_warn_threshold(agent) == 800
+
+
+def test_explicit_warn_threshold_wins():
+    agent = SimpleNamespace(session_token_hard_stop=1000, session_token_warn=200)
+    assert resolve_warn_threshold(agent) == 200
+
+
+def test_should_emit_warn_latches_and_skips_when_already_stopped():
+    agent = SimpleNamespace(
+        session_token_hard_stop=100,
+        session_token_warn=None,
+        session_input_tokens=80,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_output_tokens=0,
+        _session_token_warn_injected=False,
+    )
+    assert should_emit_warn(agent) is True
+    agent._session_token_warn_injected = True
+    assert should_emit_warn(agent) is False
+    agent._session_token_warn_injected = False
+    agent.session_input_tokens = 100
+    assert hard_stop_exhausted(agent) is True
+    assert should_emit_warn(agent) is False
+
+
+def test_unimplemented_budget_keys_present_scans_agent_and_root():
+    keys = unimplemented_budget_keys_present({
+        "agent": {"gateway_usage_hard_tokens": 1},
+        "gateway_usage_hard_api_calls": 9,
+    })
+    assert keys == ["gateway_usage_hard_api_calls", "gateway_usage_hard_tokens"]
+    assert unimplemented_budget_keys_present({"agent": {"session_token_hard_stop": 5}}) == []
+
+
+# --------------------------------------------------------------------------------------
+# Config plumbing
+# --------------------------------------------------------------------------------------
+
+
+def _write_config(tmp_path, body: str) -> None:
+    (tmp_path / "config.yaml").write_text(body or "{}\n", encoding="utf-8")
+
+
+def _make_agent(tmp_path, monkeypatch, config_body: str = "", **overrides):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(tmp_path, config_body)
+    kwargs = dict(
+        model="gpt-5.5",
+        provider="openai",
+        api_key="sk-dummy",
+        base_url="https://api.openai.com/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    kwargs.update(overrides)
+    return AIAgent(**kwargs)
+
+
+def test_no_hard_stop_by_default(monkeypatch, tmp_path):
+    agent = _make_agent(tmp_path, monkeypatch)
+    assert agent.session_token_hard_stop is None
+    assert agent.session_token_warn is None
+    assert agent._session_token_warn_injected is False
+
+
+def test_config_key_sets_hard_stop(monkeypatch, tmp_path):
+    agent = _make_agent(
+        tmp_path, monkeypatch,
+        config_body="agent:\n  session_token_hard_stop: 2500\n  session_token_warn: 2000\n",
+    )
+    assert agent.session_token_hard_stop == 2500
+    assert agent.session_token_warn == 2000
+
+
+def test_constructor_arg_wins_over_config(monkeypatch, tmp_path):
+    agent = _make_agent(
+        tmp_path, monkeypatch,
+        config_body="agent:\n  session_token_hard_stop: 2500\n",
+        session_token_hard_stop=900,
+    )
+    assert agent.session_token_hard_stop == 900
+
+
+def test_reset_session_state_clears_warn_latch(monkeypatch, tmp_path):
+    agent = _make_agent(tmp_path, monkeypatch, session_token_hard_stop=100)
+    agent._session_token_warn_injected = True
+    agent.session_input_tokens = 50
+    agent.reset_session_state()
+    assert agent._session_token_warn_injected is False
+    assert agent.session_input_tokens == 0
+
+
+def test_validate_config_warns_on_unimplemented_budget_keys():
+    issues = validate_config_structure({
+        "agent": {"gateway_usage_hard_tokens": 1_000_000},
+    })
+    warnings = [i for i in issues if i.severity == "warning"]
+    assert any("gateway_usage_hard_tokens" in i.message and "not implemented" in i.message for i in warnings)
+
+
+def test_validate_config_does_not_warn_on_session_token_hard_stop():
+    issues = validate_config_structure({
+        "agent": {"session_token_hard_stop": 5_000_000},
+    })
+    assert not any("not implemented" in i.message for i in issues)
+
+
+# --------------------------------------------------------------------------------------
+# Conversation loop
+# --------------------------------------------------------------------------------------
+
+
+def _tool_call() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments='{"query": "x"}'),
+    )
+
+
+def _tool_response(prompt_tokens: int) -> SimpleNamespace:
+    message = SimpleNamespace(
+        content=None,
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=[_tool_call()],
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+        model="test/model",
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=1,
+            total_tokens=prompt_tokens + 1,
+        ),
+    )
+
+
+def _final_response() -> SimpleNamespace:
+    message = SimpleNamespace(
+        content="done",
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _tool_definition() -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the web",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def _make_loop_agent(**overrides):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[_tool_definition()]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("agent.model_metadata.get_model_context_length", return_value=256_000),
+        patch("agent.context_compressor.get_model_context_length", return_value=256_000),
+    ):
+        kwargs = dict(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=10,
+        )
+        kwargs.update(overrides)
+        agent = AIAgent(**kwargs)
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent._disable_streaming = True
+    agent.tool_delay = 0
+    agent.save_trajectories = False
+    agent.max_compression_attempts = 1
+
+    compressor = MagicMock()
+    compressor.protect_first_n = 3
+    compressor.protect_last_n = 20
+    compressor.threshold_tokens = 999_999_999
+    compressor.context_length = 1_000_000_000
+    compressor.last_prompt_tokens = -1
+    compressor._verify_compaction_cleared_threshold = False
+    compressor.awaiting_real_usage_after_compression = False
+    compressor.should_compress.return_value = False
+    compressor.should_compress_info.return_value = (False, None)
+    compressor.should_compress_preflight.return_value = False
+    compressor.should_defer_preflight_to_real_usage.return_value = False
+    compressor.get_active_compression_failure_cooldown.return_value = None
+    compressor.select_context.return_value = None
+    compressor.get_automatic_compaction_status_message.return_value = ""
+    agent.compression_enabled = False
+    agent.context_compressor = compressor
+
+    def _fake_execute_tool_calls(assistant_message, messages, *_args):
+        tool_call = assistant_message.tool_calls[0]
+        messages.append(
+            {
+                "role": "tool",
+                "name": tool_call.function.name,
+                "tool_call_id": tool_call.id,
+                "content": "ok",
+            }
+        )
+
+    agent._execute_tool_calls = _fake_execute_tool_calls
+    return agent
+
+
+def _run_with_responses(agent, responses):
+    agent.client.chat.completions.create.side_effect = responses
+    with (
+        patch.object(agent, "_flush_messages_to_session_db", return_value=True),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation("do some tool work")
+
+
+def test_hard_stop_already_crossed_makes_zero_provider_calls():
+    agent = _make_loop_agent(session_token_hard_stop=100)
+    agent.session_input_tokens = 100
+    agent.session_output_tokens = 0
+    result = _run_with_responses(agent, [_final_response(), _final_response()])
+    assert agent.client.chat.completions.create.call_count == 0
+    assert result.get("turn_exit_reason") == "token_hard_stop"
+    assert "hard stop" in (result.get("final_response") or "").lower()
+
+
+def test_hard_stop_after_crossing_blocks_next_provider_call():
+    agent = _make_loop_agent(session_token_hard_stop=100)
+    responses = [
+        _tool_response(99),
+        _tool_response(99),
+        _final_response(),
+    ]
+    result = _run_with_responses(agent, responses)
+    assert agent.client.chat.completions.create.call_count == 1
+    assert billed_session_tokens(agent) >= 100
+    assert result.get("turn_exit_reason") == "token_hard_stop"
+    assert "hard stop" in (result.get("final_response") or "").lower()
+
+
+def test_disabled_hard_stop_leaves_loop_unbounded():
+    agent = _make_loop_agent()
+    responses = [
+        _tool_response(50_000),
+        _tool_response(50_000),
+        _tool_response(50_000),
+        _final_response(),
+    ]
+    result = _run_with_responses(agent, responses)
+    assert agent.client.chat.completions.create.call_count == 4
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+
+
+def test_warn_notice_appended_once_to_tool_result():
+    from agent.conversation_loop import _maybe_inject_session_token_warn
+
+    agent = SimpleNamespace(
+        session_token_hard_stop=1000,
+        session_token_warn=100,
+        session_input_tokens=100,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_output_tokens=0,
+        _session_token_warn_injected=False,
+    )
+    messages = [{"role": "tool", "content": "ok", "tool_call_id": "t1"}]
+    assert _maybe_inject_session_token_warn(agent, messages) is True
+    assert SESSION_TOKEN_WARN_NOTICE in messages[0]["content"]
+    assert agent._session_token_warn_injected is True
+    assert _maybe_inject_session_token_warn(agent, messages) is False
+    assert messages[0]["content"].count(SESSION_TOKEN_WARN_NOTICE) == 1

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1108,6 +1108,22 @@ When a budget is set, two things happen:
 
 The budget is per `run_conversation` turn (it resets on each user message) and the feature is completely dormant when unset — no clock reads, no injection, no timeout changes.
 
+## Session Token Hard Stop
+
+`max_turns` resets every user message, so it cannot bound a runaway conversation — only a runaway turn. `session_token_hard_stop` is a **per-session billed-token fuse**:
+
+```yaml
+agent:
+  session_token_hard_stop: 5000000   # null/0/unset = disabled (default)
+  session_token_warn: 4000000        # optional; default is 80% of the hard stop
+```
+
+**Formula:** billed tokens = fresh input + cache-read + cache-write + output (the same split Hermes already accumulates as `session_input_tokens`, `session_cache_*_tokens`, and `session_output_tokens`). Cache reads are included because they are billed and dominate long-session cost.
+
+When the ceiling is crossed, the conversation loop ends the turn **before** the next provider call with a visible `token_hard_stop` exit reason. It does not spend an extra wrap-up API call.
+
+Older unused names (`agent.gateway_usage_hard_api_calls`, `gateway_usage_hard_tokens`, and their warn variants) are **not** implemented. Setting them warns at config load so a safety key is never silently inert.
+
 ## Verify-on-Stop (coding verification)
 
 When enabled, Hermes refuses to accept a final answer on a turn where the agent edited code in a workspace but produced no fresh verification evidence (a passing test run, build, lint, etc.) — it injects a synthetic follow-up asking the agent to verify or explain why it can't. Doc/markdown/skill-only edits never trigger it, and the loop is bounded so it can never trap the agent.


### PR DESCRIPTION
## What does this PR do?

Operators can set `agent.session_token_hard_stop` (and older unused names such as `gateway_usage_hard_tokens`) in `config.yaml` and believe they installed a per-session billing fuse. Those keys were accepted with no reader, so a runaway session kept calling the model. `max_turns` cannot bound that case: it resets on every user message.

This PR adds the missing reader. `session_token_hard_stop` is a billed-token ceiling for the whole session (fresh input + cache read + cache write + output). When the ceiling is already crossed, the conversation loop ends the turn **before** the next provider call with `turn_exit_reason=token_hard_stop` and a visible notice. Default is off (`null` / `0`). Setting the older unimplemented `gateway_usage_hard_*` names now warns at config load instead of staying silently inert. An optional `session_token_warn` (or 80% of the hard stop) injects a one-time wind-down notice on the newest tool result.

## Related Issue

Fixes #96814

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/session_token_hard_stop.py` — billed-token formula, normalize/disable rules, hard-stop and warn predicates, unimplemented-key list
- `agent/conversation_loop.py` — fuse check at the top of each iteration (before the next provider call); one-shot warn notice on the newest tool message
- `agent/agent_init.py`, `run_agent.py` — constructor/config plumbing; warn latch cleared in `reset_session_state`
- `hermes_cli/config.py` — config-load warning when unimplemented `gateway_usage_hard_*` keys are present
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example` — default-off schema and commented example
- `website/docs/user-guide/configuration.md` — formula, exit reason, and inert-key warning
- `tests/agent/test_session_token_hard_stop.py` — normalize/formula, config warnings, zero provider calls when already over cap, stop after crossing, warn-once

## How to Test

1. `pytest tests/agent/test_session_token_hard_stop.py -q`
2. Set `agent.session_token_hard_stop` to a small positive integer (for example `100`) in `config.yaml`, start a session that already has more billed tokens than the cap (or let one tool call cross it). The turn should end with a hard-stop message and `token_hard_stop` without another model call.
3. Put `agent.gateway_usage_hard_tokens: 1000000` in `config.yaml` and load config. Startup should warn that the key is not implemented and point at `agent.session_token_hard_stop`. Leave the new key unset (or `0`) and confirm existing sessions are unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_session_token_hard_stop.py -q
..........................                                               [100%]
26 passed in 5.40s
```