### PR TITLE
fix(desktop): preserve authoritative session workspace

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -46,6 +46,11 @@ def set_session_cwd(cwd: str | None) -> Token:
     return _SESSION_CWD.set((cwd or "").strip())
 
 
+def reset_session_cwd(token: Token) -> None:
+    """Restore the cwd value that preceded a nested session binding."""
+    _SESSION_CWD.reset(token)
+
+
 def clear_session_cwd() -> None:
     _SESSION_CWD.set("")
 
@@ -55,6 +60,15 @@ def _session_cwd_override() -> str:
     if value is _UNSET:
         return ""
     return str(value).strip()
+
+
+def authoritative_session_cwd() -> str:
+    """Return the explicitly bound session cwd, or empty when unproven.
+
+    Lifecycle and plugin attribution must not use ``TERMINAL_CWD`` or the
+    process cwd. One gateway process can serve many concurrent workspaces.
+    """
+    return _session_cwd_override()
 
 
 def resolve_agent_cwd() -> Path:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -48,6 +48,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
 )
+from agent.runtime_cwd import authoritative_session_cwd
 
 logger = logging.getLogger(__name__)
 
@@ -1338,6 +1339,7 @@ def build_turn_context(
             platform=getattr(agent, "platform", None) or "",
             parent_session_id=getattr(agent, "_parent_session_id", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            cwd=authoritative_session_cwd(),
         )
         _ctx_parts: list[str] = []
         # Spill oversized per-hook context to disk so a runaway plugin

--- a/cli.py
+++ b/cli.py
@@ -5022,6 +5022,23 @@ class _SeededQueryMessage:
         return self.text
 
 
+def _run_conversation_with_authoritative_workspace(agent, **kwargs):
+    """Run one classic local-CLI turn with its launch workspace bound."""
+    if (
+        os.environ.get("_HERMES_GATEWAY") == "1"
+        or os.environ.get("TERMINAL_ENV", "local").strip().lower() != "local"
+    ):
+        return agent.run_conversation(**kwargs)
+
+    from agent.runtime_cwd import reset_session_cwd, set_session_cwd
+
+    token = set_session_cwd(os.environ.get("TERMINAL_CWD") or os.getcwd())
+    try:
+        return agent.run_conversation(**kwargs)
+    finally:
+        reset_session_cwd(token)
+
+
 def _should_seed_interactive(query, image, quiet: bool, oneshot: bool) -> bool:
     """Whether a ``-q/--image`` invocation should seed an interactive session.
 
@@ -9878,7 +9895,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         flush_tool_summary()
         _cli_visible_print()
     
-    def _notify_session_boundary(self, event_type: str) -> None:
+    def _notify_session_boundary(
+        self,
+        event_type: str,
+        *,
+        old_session_id: str | None = None,
+        new_session_id: str | None = None,
+    ) -> None:
         """Fire a session-boundary plugin hook (on_session_finalize or on_session_reset).
 
         Non-blocking — errors are caught and logged.  Safe to call from any
@@ -9888,13 +9911,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from hermes_cli.lifecycle import finalize_session, invoke_hook
 
             context = {
-                "session_id": self.agent.session_id if self.agent else None,
+                "session_id": (
+                    new_session_id
+                    or (self.agent.session_id if self.agent else None)
+                ),
                 "platform": getattr(self, "platform", None) or "cli",
                 "reason": (
                     "new_session"
                     if event_type == "on_session_reset"
                     else "session_boundary"
                 ),
+                "old_session_id": old_session_id,
+                "new_session_id": new_session_id,
             }
             if event_type == "on_session_finalize":
                 finalize_session(**context)
@@ -10177,7 +10205,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         )
             except Exception:
                 pass
-            self._notify_session_boundary("on_session_reset")
+            self._notify_session_boundary(
+                "on_session_reset",
+                old_session_id=old_session_id,
+                new_session_id=self.session_id,
+            )
 
         if not silent:
             if title:
@@ -16773,7 +16805,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 )
                 self._pending_one_turn_model_restore = None
                 try:
-                    result = self.agent.run_conversation(
+                    result = _run_conversation_with_authoritative_workspace(
+                        self.agent,
                         user_message=agent_message,
                         conversation_history=self.conversation_history[:-1],  # Exclude the message we just added
                         stream_callback=stream_callback,
@@ -21184,7 +21217,8 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     max_turns = task.goal_max_turns or _DEF_TURNS
 
     def _run_turn(prompt: str) -> str:
-        result = cli.agent.run_conversation(
+        result = _run_conversation_with_authoritative_workspace(
+            cli.agent,
             user_message=prompt,
             conversation_history=cli.conversation_history,
         )
@@ -21766,7 +21800,8 @@ def main(
                         # from display.tool_progress at construction).
                         cli.agent.tool_progress_mode = "off"
                         try:
-                            result = cli.agent.run_conversation(
+                            result = _run_conversation_with_authoritative_workspace(
+                                cli.agent,
                                 user_message=effective_query,
                                 conversation_history=cli.conversation_history,
                             )

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -37,7 +37,7 @@ needs to replace the import + call site:
 """
 
 from contextlib import contextmanager
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 from typing import Any, Iterator
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
@@ -58,6 +58,15 @@ _UNSET: Any = object()
 # os.environ fallback is preserved (no concurrency to leak across). Monotonic
 # latch — once any host binds a session, the process stays engaged for life.
 _session_context_engaged: bool = False
+
+
+class _SessionContextTokens(list):
+    """Backward-compatible token list with nested-scope restoration metadata."""
+
+    def __init__(self, tokens: list, *, cwd_token: Any, restore_outer: bool):
+        super().__init__(tokens)
+        self.cwd_token = cwd_token
+        self.restore_outer = restore_outer
 
 
 def session_context_engaged() -> bool:
@@ -246,10 +255,9 @@ def set_session_vars(
     """Set all session context variables and return reset tokens.
 
     Call ``clear_session_vars(tokens)`` in a ``finally`` block when the handler
-    exits. Note ``clear_session_vars`` resets every var to ``""`` (to suppress
-    the ``os.environ`` fallback) rather than restoring prior values — these
-    helpers are not nestable/stack-safe, and the returned tokens are accepted
-    only for API compatibility.
+    exits. Nested cleanup restores a concrete outer binding. Top-level cleanup
+    resets every variable explicitly so stale ``os.environ`` fallback cannot
+    reappear after the turn.
 
     ``cwd`` pins the logical working directory for this context.
 
@@ -288,27 +296,32 @@ def set_session_vars(
         _CRON_SESSION.set(cron_session),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
     ]
+    cwd_token = None
     try:
         from agent.runtime_cwd import set_session_cwd
 
-        set_session_cwd(cwd)
+        cwd_token = set_session_cwd(cwd)
     except Exception:
         pass
-    return tokens
+    prior_values = [token.old_value for token in tokens]
+    if cwd_token is not None:
+        prior_values.append(cwd_token.old_value)
+    restore_outer = any(
+        value not in (Token.MISSING, _UNSET, "") for value in prior_values
+    )
+    return _SessionContextTokens(
+        tokens, cwd_token=cwd_token, restore_outer=restore_outer
+    )
 
 
 def clear_session_vars(tokens: list) -> None:
-    """Mark session context variables as explicitly cleared.
+    """Restore a nested scope or explicitly clear a top-level scope.
 
-    Sets all variables to ``""`` so that ``get_session_env`` returns an empty
-    string instead of falling back to (potentially stale) ``os.environ``
-    values.  The *tokens* argument is accepted for API compatibility with
-    callers that saved the return value of ``set_session_vars``, but the
-    actual clearing uses ``var.set("")`` rather than ``var.reset(token)``
-    to ensure the "explicitly cleared" state is distinguishable from
-    "never set" (which holds the ``_UNSET`` sentinel).
+    Nested cleanup resets the tokens returned by ``set_session_vars``.
+    Top-level cleanup writes explicit empty values so ``get_session_env``
+    cannot fall back to potentially stale ``os.environ`` values.
     """
-    for var in (
+    token_vars = (
         _SESSION_PLATFORM,
         _SESSION_SOURCE,
         _SESSION_CHAT_ID,
@@ -327,7 +340,21 @@ def clear_session_vars(tokens: list) -> None:
         _BROWSER_CONTROL_PRINCIPAL,
         _BROWSER_CONTROL_TRANSPORT_FAMILY,
         _CRON_SESSION,
-    ):
+        _SESSION_ASYNC_DELIVERY,
+    )
+    if isinstance(tokens, _SessionContextTokens) and tokens.restore_outer:
+        for var, token in reversed(list(zip(token_vars, tokens))):
+            var.reset(token)
+        if tokens.cwd_token is not None:
+            try:
+                from agent.runtime_cwd import reset_session_cwd
+
+                reset_session_cwd(tokens.cwd_token)
+            except Exception:
+                pass
+        return
+
+    for var in token_vars[:-1]:
         var.set("")
     # Reset async-delivery capability to the "never set" sentinel rather than a
     # falsy value: a cleared context should fall back to the default-supported

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -7,6 +7,17 @@ from typing import Any, List
 
 logger = logging.getLogger(__name__)
 
+# Machine-readable producer seal for governed plugins. Consumers must inspect
+# this production module instead of inferring support from hook names or tests.
+# An explicit reset edge includes initial construction as ``None -> new``.
+# Desktop close/create is ``finalize(old)`` followed by ``None -> new``; it is
+# not a replacement edge and consumers must not infer one from process state.
+CORTEX_PLUGIN_PRODUCER_CONTRACT = (
+    "pre_llm.authoritative_workspace.v1",
+    "pre_llm.desktop_session_workspace.v1",
+    "session_reset.explicit_edge.v1",
+)
+
 
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     """Notify first-party observers, then invoke compatibility plugin hooks."""

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -67,6 +67,23 @@ class TestSessionCwdOverride:
         finally:
             rt._SESSION_CWD.reset(token)
 
+    def test_authoritative_session_cwd_never_uses_global_fallbacks(
+        self, monkeypatch, tmp_path
+    ):
+        bound = tmp_path / "bound"
+        bound.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        clear_session_cwd()
+
+        assert rt.authoritative_session_cwd() == ""
+
+        token = set_session_cwd(str(bound))
+        try:
+            assert rt.authoritative_session_cwd() == str(bound)
+        finally:
+            rt._SESSION_CWD.reset(token)
+
 
     def test_clear_session_cwd_restores_terminal_cwd(self, monkeypatch, tmp_path):
         other = tmp_path / "other"

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -140,6 +140,37 @@ def _prepare_cli_with_active_session(tmp_path):
     return cli
 
 
+def test_classic_cli_turn_binds_resolved_workspace(monkeypatch, tmp_path):
+    from agent.runtime_cwd import authoritative_session_cwd
+    import cli as cli_module
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    observed = []
+
+    class FakeAgent:
+        def run_conversation(self, **kwargs):
+            observed.append((authoritative_session_cwd(), kwargs))
+            return {"final_response": "ok"}
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+
+    result = cli_module._run_conversation_with_authoritative_workspace(
+        FakeAgent(), user_message="hello", conversation_history=[]
+    )
+
+    assert result == {"final_response": "ok"}
+    assert observed == [
+        (
+            str(workspace),
+            {"user_message": "hello", "conversation_history": []},
+        )
+    ]
+    assert authoritative_session_cwd() == ""
+
+
 @pytest.fixture(autouse=True)
 def _reset_session_id_context():
     from gateway.session_context import _UNSET, _VAR_MAP

--- a/tests/cli/test_session_boundary_hooks.py
+++ b/tests/cli/test_session_boundary_hooks.py
@@ -19,6 +19,7 @@ def test_session_finalize_on_reset(mock_finalize_session, mock_invoke_hook):
     """Verify on_session_finalize fires when /new or /reset is used."""
     cli = HermesCLI()
     cli.agent = MagicMock()
+    cli.session_id = "test-session-id"
     cli.agent.session_id = "test-session-id"
 
     # Simulate /new command which triggers on_session_finalize for the old session
@@ -36,6 +37,9 @@ def test_session_finalize_on_reset(mock_finalize_session, mock_invoke_hook):
         c.args == ("on_session_reset",)
         and c.kwargs["session_id"] == cli.session_id
         and c.kwargs["platform"] == "cli"
+        and c.kwargs["reason"] == "new_session"
+        and c.kwargs["old_session_id"] == "test-session-id"
+        and c.kwargs["new_session_id"] == cli.session_id
         for c in mock_invoke_hook.call_args_list
     )
 

--- a/tests/gateway/test_session_context_inheritance.py
+++ b/tests/gateway/test_session_context_inheritance.py
@@ -36,6 +36,8 @@ from gateway.session_context import (
     _UNSET,
     _VAR_MAP,
     async_delivery_supported,
+    clear_session_vars,
+    get_session_env,
     reset_session_vars,
     set_session_vars,
 )
@@ -146,6 +148,58 @@ def test_reset_session_vars_closes_inheritance_leak():
     # B's own session still binds correctly after the reset window.
     assert captured["bound"]["HERMES_SESSION_CHAT_ID"] == "FOREIGN_CHAT"
     assert captured["bound"]["HERMES_SESSION_KEY"] == FOREIGN["session_key"]
+
+
+def test_nested_session_context_restores_outer_identity_and_cwd(tmp_path):
+    from agent.runtime_cwd import authoritative_session_cwd
+
+    outer_cwd = tmp_path / "outer"
+    inner_cwd = tmp_path / "inner"
+    outer_cwd.mkdir()
+    inner_cwd.mkdir()
+
+    outer_tokens = set_session_vars(
+        session_key="outer-session", cwd=str(outer_cwd)
+    )
+    try:
+        inner_tokens = set_session_vars(
+            session_key="inner-session", cwd=str(inner_cwd)
+        )
+        try:
+            assert get_session_env("HERMES_SESSION_KEY") == "inner-session"
+            assert authoritative_session_cwd() == str(inner_cwd)
+        finally:
+            clear_session_vars(inner_tokens)
+
+        assert get_session_env("HERMES_SESSION_KEY") == "outer-session"
+        assert authoritative_session_cwd() == str(outer_cwd)
+    finally:
+        clear_session_vars(outer_tokens)
+
+
+def test_nested_session_context_restores_cron_workdir_without_session_key(
+    tmp_path,
+):
+    from agent.runtime_cwd import authoritative_session_cwd
+
+    outer_cwd = tmp_path / "cron-workdir"
+    inner_cwd = tmp_path / "inner"
+    outer_cwd.mkdir()
+    inner_cwd.mkdir()
+
+    outer_tokens = set_session_vars(session_key="", cwd=str(outer_cwd))
+    try:
+        inner_tokens = set_session_vars(
+            session_key="inner-session", cwd=str(inner_cwd)
+        )
+        try:
+            assert authoritative_session_cwd() == str(inner_cwd)
+        finally:
+            clear_session_vars(inner_tokens)
+
+        assert authoritative_session_cwd() == str(outer_cwd)
+    finally:
+        clear_session_vars(outer_tokens)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_lifecycle.py
+++ b/tests/hermes_cli/test_lifecycle.py
@@ -4,6 +4,14 @@ from agent import relay_runtime
 from hermes_cli import lifecycle, observability, plugins
 
 
+def test_cortex_plugin_producer_contract_is_explicit_and_complete():
+    assert set(lifecycle.CORTEX_PLUGIN_PRODUCER_CONTRACT) == {
+        "pre_llm.authoritative_workspace.v1",
+        "pre_llm.desktop_session_workspace.v1",
+        "session_reset.explicit_edge.v1",
+    }
+
+
 def test_invoke_hook_notifies_builtin_observers_before_plugins(monkeypatch):
     calls = []
     manager = SimpleNamespace(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -161,7 +161,11 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
     launcher = tmp_path / "apps" / "desktop"
     launcher.mkdir(parents=True)
 
-    server._sessions[sid] = {"session_key": session_key, "cwd": str(project)}
+    server._sessions[sid] = {
+        "session_key": session_key,
+        "cwd": str(project),
+        "explicit_cwd": True,
+    }
     monkeypatch.delenv("TERMINAL_CWD", raising=False)
     monkeypatch.chdir(launcher)
 
@@ -340,6 +344,25 @@ def test_compute_host_explicit_images_do_not_clear_later_attachment(monkeypatch)
 
     assert response["result"]["status"] == "streaming"
     assert session["attached_images"] == ["/tmp/c.png"]
+
+
+def test_compute_host_turn_frame_preserves_workspace_proof(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    explicit = _session(cwd=str(workspace), explicit_cwd=True)
+    fallback = _session(cwd=str(workspace), explicit_cwd=False)
+
+    explicit_frame = server._compute_host_turn_frame(
+        "explicit-rid", "explicit-sid", explicit, "turn"
+    )
+    fallback_frame = server._compute_host_turn_frame(
+        "fallback-rid", "fallback-sid", fallback, "turn"
+    )
+
+    assert explicit_frame["cwd"] == str(workspace)
+    assert explicit_frame["explicit_cwd"] is True
+    assert fallback_frame["cwd"] == str(workspace)
+    assert fallback_frame["explicit_cwd"] is False
 
 
 def test_prompt_submit_unknown_session_logs_warning(caplog):
@@ -681,6 +704,182 @@ def test_session_context_explicit_cwd_for_ephemeral_task(monkeypatch, tmp_path):
         assert resolve_agent_cwd() == project
     finally:
         server._clear_session_context(tokens)
+
+
+def test_prompt_background_does_not_promote_parent_fallback_cwd(
+    monkeypatch, tmp_path
+):
+    import sys
+    import types
+
+    fallback = tmp_path / "configured-fallback"
+    fallback.mkdir()
+    captured = []
+
+    class _ImmediateThread:
+        def __init__(self, target=None, **_kwargs):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    class _Agent:
+        def __init__(self, **_kwargs):
+            pass
+
+        def run_conversation(self, **_kwargs):
+            return {"final_response": "done"}
+
+    session = _session(
+        session_key="parent-key",
+        cwd=str(fallback),
+        explicit_cwd=False,
+        agent=types.SimpleNamespace(),
+    )
+    server._sessions["parent"] = session
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        server,
+        "_set_session_context",
+        lambda session_key, cwd=None, **_kwargs: captured.append(
+            (session_key, cwd)
+        )
+        or [],
+    )
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "run_agent", types.SimpleNamespace(AIAgent=_Agent))
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "background",
+                "method": "prompt.background",
+                "params": {"session_id": "parent", "text": "work"},
+            }
+        )
+    finally:
+        server._sessions.pop("parent", None)
+
+    assert "result" in response, response
+    assert captured[0][0].startswith("bg_")
+    assert captured[0][1] == ""
+
+
+def test_preview_restart_does_not_promote_parent_fallback_cwd(
+    monkeypatch, tmp_path
+):
+    import sys
+    import types
+
+    fallback = tmp_path / "configured-fallback"
+    fallback.mkdir()
+    captured = []
+
+    class _ImmediateThread:
+        def __init__(self, target=None, **_kwargs):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    class _Agent:
+        def __init__(self, **_kwargs):
+            pass
+
+        def run_conversation(self, **_kwargs):
+            return {"final_response": "done"}
+
+    session = _session(
+        session_key="parent-key",
+        cwd=str(fallback),
+        explicit_cwd=False,
+        agent=types.SimpleNamespace(),
+    )
+    server._sessions["parent"] = session
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        server,
+        "_set_session_context",
+        lambda session_key, cwd=None, **_kwargs: captured.append(
+            (session_key, cwd)
+        )
+        or [],
+    )
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "run_agent", types.SimpleNamespace(AIAgent=_Agent))
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "preview",
+                "method": "preview.restart",
+                "params": {
+                    "session_id": "parent",
+                    "url": "http://localhost:3000",
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("parent", None)
+
+    assert "result" in response, response
+    assert captured[0][0].startswith("preview_")
+    assert captured[0][1] == ""
+
+
+def test_deferred_session_record_preserves_workspace_proof(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    explicit = server._deferred_session_record(
+        "stored-session",
+        cols=80,
+        cwd=str(workspace),
+        explicit_cwd=True,
+        history=[],
+        lease=None,
+    )
+    fallback = server._deferred_session_record(
+        "fallback-session",
+        cols=80,
+        cwd=str(workspace),
+        explicit_cwd=False,
+        history=[],
+        lease=None,
+    )
+
+    assert explicit["explicit_cwd"] is True
+    assert fallback["explicit_cwd"] is False
+
+
+def test_display_cwd_healing_does_not_persist_fallback_workspace(
+    monkeypatch, tmp_path
+):
+    fallback = tmp_path / "vanished-worktree"
+    healed = tmp_path / "repo"
+    healed.mkdir()
+    persisted = []
+    session = {
+        "session_key": "desktop-unbound",
+        "source": "desktop",
+        "cwd": str(fallback),
+        "explicit_cwd": False,
+    }
+
+    monkeypatch.setattr(server, "_is_local_terminal_backend", lambda: True)
+    monkeypatch.setattr(server, "_heal_dead_cwd", lambda _cwd: str(healed))
+    monkeypatch.setattr(
+        server,
+        "_persist_session_cwd_and_schedule_git_meta",
+        lambda target, cwd: persisted.append((target, cwd)),
+    )
+
+    assert server._display_session_cwd(session) == str(healed)
+    assert session["cwd"] == str(healed)
+    assert session["explicit_cwd"] is False
+    assert persisted == []
 
 
 def _write_profile_cfg(home: Path, cwd: str | None) -> Path:
@@ -5653,7 +5852,9 @@ def test_init_session_fires_reset_hook(monkeypatch):
     monkeypatch.setattr(
         server,
         "_notify_session_boundary",
-        lambda event, session_id, *_args: hooks.append((event, session_id)),
+        lambda event, session_id, *_args, **kwargs: hooks.append(
+            (event, session_id, kwargs)
+        ),
     )
 
     import tools.approval as _approval
@@ -5670,9 +5871,90 @@ def test_init_session_fires_reset_hook(monkeypatch):
             history=[],
             cols=80,
         )
-        assert ("on_session_reset", "session-key") in hooks
+        assert (
+            "on_session_reset",
+            "session-key",
+            {
+                "reason": "session_start",
+                "old_session_id": None,
+                "new_session_id": "session-key",
+            },
+        ) in hooks
     finally:
         server._sessions.pop(sid, None)
+
+
+def test_desktop_close_then_create_emits_exact_boundary_identities(monkeypatch):
+    boundaries = []
+
+    class _FakeWorker:
+        def __init__(self, key, model, profile_home=None):
+            self.key = key
+
+        def close(self):
+            return None
+
+    def _agent(session_id):
+        return types.SimpleNamespace(
+            model="x",
+            session_id=session_id,
+            _session_messages=[],
+            close=lambda: None,
+        )
+
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "_notify_session_boundary",
+        lambda event, session_id, *_args, **kwargs: boundaries.append(
+            (event, session_id, kwargs)
+        ),
+    )
+
+    import tools.approval as _approval
+
+    monkeypatch.setattr(_approval, "register_gateway_notify", lambda key, cb: None)
+    monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
+    monkeypatch.setattr(_approval, "unregister_gateway_notify", lambda key: None)
+
+    try:
+        server._init_session(
+            "old-sid", "old-key", _agent("old-key"), history=[], cols=80
+        )
+        closed = server._methods["session.close"](
+            "close", {"session_id": "old-sid"}
+        )
+        assert closed["result"]["closed"] is True
+        server._init_session(
+            "new-sid", "new-key", _agent("new-key"), history=[], cols=80
+        )
+
+        assert boundaries == [
+            (
+                "on_session_reset",
+                "old-key",
+                {
+                    "reason": "session_start",
+                    "old_session_id": None,
+                    "new_session_id": "old-key",
+                },
+            ),
+            ("on_session_finalize", "old-key", {}),
+            (
+                "on_session_reset",
+                "new-key",
+                {
+                    "reason": "session_start",
+                    "old_session_id": None,
+                    "new_session_id": "new-key",
+                },
+            ),
+        ]
+    finally:
+        server._sessions.pop("old-sid", None)
+        server._sessions.pop("new-sid", None)
 
 
 def test_session_title_creates_row_and_sets_immediately_when_not_ready(monkeypatch):
@@ -7037,6 +7319,107 @@ def _configure_immediate_prompt_run(
     monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_args: False)
     monkeypatch.setattr(server, "_voice_tts_enabled", lambda: False)
     monkeypatch.setattr(server, "_get_db", lambda: None)
+
+
+def test_prompt_turn_emits_each_desktop_session_workspace(monkeypatch, tmp_path):
+    """Desktop ingress must keep pre-LLM workspace envelopes session-local."""
+    from agent.runtime_cwd import authoritative_session_cwd
+    from hermes_cli import lifecycle
+    from tests.agent.test_turn_context import _FakeAgent, _build
+
+    original_set_session_context = server._set_session_context
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    monkeypatch.setattr(server, "_set_session_context", original_set_session_context)
+    monkeypatch.setattr(
+        server, "_sync_agent_compression_with_config", lambda *_args: None
+    )
+    monkeypatch.setattr(server, "_sync_bot_capabilities", lambda *_args: None)
+
+    envelopes = []
+
+    def capture_hook(event, **kwargs):
+        if event == "pre_llm_call":
+            envelopes.append(kwargs)
+        return []
+
+    monkeypatch.setattr(lifecycle, "invoke_hook", capture_hook)
+
+    class _TurnAgent(_FakeAgent):
+        def __init__(self, session_id):
+            super().__init__()
+            self.session_id = session_id
+            self.platform = "tui"
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(
+            self,
+            prompt,
+            conversation_history=None,
+            stream_callback=None,
+            **_kwargs,
+        ):
+            _build(
+                self,
+                user_message=prompt,
+                conversation_history=conversation_history,
+                task_id=self.session_id,
+                stream_callback=stream_callback,
+            )
+            return {"final_response": "", "messages": []}
+
+    project_a = tmp_path / "project-a"
+    project_b = tmp_path / "project-b"
+    fallback = tmp_path / "configured-fallback"
+    project_a.mkdir()
+    project_b.mkdir()
+    fallback.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(fallback))
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+
+    created = server._methods["session.create"]("create-unbound", {"source": "desktop"})
+    unbound_sid = created["result"]["session_id"]
+    unbound_key = created["result"]["stored_session_id"]
+    unbound_session = server._sessions[unbound_sid]
+    assert unbound_session["explicit_cwd"] is False
+    assert unbound_session["cwd"] == str(fallback)
+    unbound_session.update(
+        agent=_TurnAgent(unbound_key),
+        running=True,
+    )
+
+    cases = [
+        ("desktop-a", "session-a", str(project_a)),
+        ("desktop-b", "session-b", str(project_b)),
+    ]
+
+    try:
+        for sid, session_key, cwd in cases:
+            session = _session(
+                session_key=session_key,
+                agent=_TurnAgent(session_key),
+                running=True,
+                cwd=cwd,
+                explicit_cwd=True,
+                source="desktop",
+            )
+            server._sessions[sid] = session
+            server._run_prompt_submit("rid", sid, session, "turn")
+            server._sessions.pop(sid, None)
+        server._run_prompt_submit("rid", unbound_sid, unbound_session, "turn")
+    finally:
+        for sid, _, _ in cases:
+            server._sessions.pop(sid, None)
+        server._sessions.pop(unbound_sid, None)
+
+    assert [(item["session_id"], item["cwd"]) for item in envelopes] == [
+        ("session-a", str(project_a)),
+        ("session-b", str(project_b)),
+        (unbound_key, ""),
+    ]
+    assert authoritative_session_cwd() == ""
 
 
 def test_run_prompt_submit_binds_exact_steer_authority_and_resets_contextvars(
@@ -14966,6 +15349,7 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
             seen["created"] = new_key
             seen["parent"] = kwargs.get("parent_session_id")
             seen["profile_name"] = kwargs.get("profile_name")
+            seen["created_cwd"] = kwargs.get("cwd")
 
         def append_message(self, **kwargs):
             seen["msgs"].append(kwargs)
@@ -15000,7 +15384,7 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
         "running": False,
         "cols": 80,
         "profile_home": str(profile_home),
-        "source": "tui",
+        "source": "desktop",
         "agent": FakeAgent(),
         "created_at": 1.0,
         "last_active": 1.0,
@@ -15033,6 +15417,7 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
         assert "result" in resp, resp
         assert seen.get("created")
         assert seen.get("parent") == "parent-key"
+        assert seen.get("created_cwd") is None
         # The branch row is self-describing: stamped with the parent's owning
         # profile, not left NULL for aggregators to mis-tag as "default".
         assert seen.get("profile_name") == "mlperf"
@@ -21355,6 +21740,78 @@ def test_persist_live_session_system_prompt_binds_session_cwd(monkeypatch, tmp_p
     expected = f"Current working directory: {session_cwd}"
     assert result["cached"] == expected, result["cached"]
     assert persisted["prompt"] == expected, persisted["prompt"]
+
+
+def test_persist_live_session_system_prompt_keeps_fallback_cwd_unbound(tmp_path):
+    from agent.runtime_cwd import authoritative_session_cwd
+
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+    observed = []
+
+    class FakeAgent:
+        session_id = "fallback-session"
+        _cached_system_prompt = None
+
+        def _build_system_prompt(self, _system_message=None):
+            observed.append(authoritative_session_cwd())
+            return "prompt"
+
+    class FakeDB:
+        def update_system_prompt(self, _session_id, _prompt):
+            pass
+
+    agent = FakeAgent()
+    agent._session_db = FakeDB()
+    session = {
+        "agent": agent,
+        "session_key": "fallback-session",
+        "cwd": str(fallback),
+        "explicit_cwd": False,
+        "source": "desktop",
+    }
+
+    server._persist_live_session_system_prompt(session)
+
+    assert observed == [""]
+
+
+def test_bot_capability_rebuild_keeps_fallback_cwd_unbound(monkeypatch, tmp_path):
+    import tools.bot_mode_probe as bot_mode_probe
+
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+    captured = []
+
+    old_agent = types.SimpleNamespace(_session_title_hint="Bot Chat")
+    new_agent = types.SimpleNamespace()
+    session = {
+        "agent": old_agent,
+        "session_key": "bot-session",
+        "cwd": str(fallback),
+        "explicit_cwd": False,
+        "source": "desktop",
+        "bot_caps_seen": "old",
+    }
+
+    monkeypatch.setattr(bot_mode_probe, "capability_fingerprint", lambda _home: "new")
+    monkeypatch.setattr(
+        server,
+        "_set_session_context",
+        lambda session_key, cwd=None, **_kwargs: captured.append(
+            (session_key, cwd)
+        )
+        or [],
+    )
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_make_agent", lambda *_args, **_kwargs: new_agent)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("model", "provider"))
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    server._sync_bot_capabilities("bot-sid", session)
+
+    assert captured == [("bot-sid", "")]
+    assert session["agent"] is new_agent
 
 
 def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -48,6 +48,47 @@ def test_compute_host_workers_inherit_tui_pool_env_or_8(monkeypatch):
     assert _default_workers() == 8
 
 
+def test_compute_host_reconstruction_preserves_workspace_proof(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    captured = {}
+    agent = object()
+    host = object.__new__(ComputeHost)
+    host._transport = object()
+
+    monkeypatch.setattr(server, "_make_agent", lambda *_args, **_kwargs: agent)
+    monkeypatch.setattr(server, "_transfer_db_to_agent", lambda *_args: False)
+
+    def _init_session(sid, key, built_agent, history, **kwargs):
+        captured.update(kwargs)
+        server._sessions[sid] = {
+            "session_key": key,
+            "agent": built_agent,
+            "history": history,
+        }
+
+    monkeypatch.setattr(server, "_init_session", _init_session)
+    try:
+        session = host._ensure_server_session(
+            server,
+            {
+                "sid": "compute-sid",
+                "session_key": "compute-key",
+                "cwd": str(workspace),
+                "explicit_cwd": True,
+                "history": [],
+            },
+        )
+    finally:
+        server._sessions.pop("compute-sid", None)
+
+    assert captured["cwd"] == str(workspace)
+    assert captured["explicit_cwd"] is True
+    assert session["session_key"] == "compute-key"
+
+
 def test_mutator_route_table_matches_prd_inventory():
     assert MUTATOR_ROUTE_TABLE == {
         "prompt.submit": "turn-path",

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -538,6 +538,7 @@ class ComputeHost:
                 session["cols"] = int(frame.get("cols") or 80)
             if frame.get("cwd"):
                 session["cwd"] = str(frame.get("cwd"))
+            session["explicit_cwd"] = bool(frame.get("explicit_cwd"))
             if frame.get("profile_home"):
                 session["profile_home"] = str(frame.get("profile_home"))
             if isinstance(frame.get("attached_images"), list):
@@ -602,6 +603,7 @@ class ComputeHost:
                     list(history),
                     cols=int(frame.get("cols") or 80),
                     cwd=str(frame.get("cwd") or "") or None,
+                    explicit_cwd=bool(frame.get("explicit_cwd")),
                     session_db=session_db,
                     source=frame.get("source"),
                 )
@@ -624,6 +626,7 @@ class ComputeHost:
                 "attached_images": [],
                 "image_counter": 0,
                 "cwd": str(frame.get("cwd") or os.getcwd()),
+                "explicit_cwd": bool(frame.get("explicit_cwd")),
                 "cols": int(frame.get("cols") or 80),
                 "slash_worker": None,
                 "show_reasoning": server._load_show_reasoning(),

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1329,7 +1329,9 @@ def _(rid, params: dict) -> dict:
     task_id = f"bg_{uuid.uuid4().hex[:6]}"
 
     def run():
-        session_tokens = _set_session_context(task_id, cwd=_session_cwd(session))
+        session_tokens = _set_session_context(
+            task_id, cwd=_authoritative_session_cwd(session)
+        )
         try:
             from run_agent import AIAgent
 
@@ -1442,7 +1444,9 @@ def _(rid, params: dict) -> dict:
     def run():
         # Pin the validated preview cwd, else the parent workspace — never an
         # invalid client path, which would silently fall back to the launch dir.
-        session_tokens = _set_session_context(task_id, cwd=(preview_cwd or _session_cwd(session)))
+        session_tokens = _set_session_context(
+            task_id, cwd=(preview_cwd or _authoritative_session_cwd(session))
+        )
         try:
             from run_agent import AIAgent
             from tools.terminal_tool import register_task_env_overrides

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -593,9 +593,8 @@ def _(rid, params: dict) -> dict:
                 target, exc,
             )
 
-        profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
-            profile_home
-        )
+        stored_resume_cwd = str(found.get("cwd") or "").strip()
+        profile_resume_cwd = stored_resume_cwd or _profile_configured_cwd(profile_home)
 
         def _reuse_live_payload(sid: str, session: dict) -> dict:
             payload = _live_session_payload(
@@ -676,6 +675,7 @@ def _(rid, params: dict) -> dict:
                 target,
                 cols=cols,
                 cwd=cwd,
+                explicit_cwd=bool(stored_resume_cwd),
                 history=history,
                 lease=lease,
                 source=source,
@@ -743,6 +743,7 @@ def _(rid, params: dict) -> dict:
                 target,
                 cols=cols,
                 cwd=cwd,
+                explicit_cwd=bool(stored_resume_cwd),
                 history=[],
                 lease=lease,
                 source=source,
@@ -838,6 +839,7 @@ def _(rid, params: dict) -> dict:
                 target,
                 cols=cols,
                 cwd=cwd,
+                explicit_cwd=bool(stored_resume_cwd),
                 history=history,
                 lease=lease,
                 source=source,
@@ -978,6 +980,7 @@ def _(rid, params: dict) -> dict:
                         history,
                         cols=cols,
                         cwd=profile_resume_cwd,
+                        explicit_cwd=bool(stored_resume_cwd),
                         session_db=db,
                         source=source,
                     )
@@ -3188,7 +3191,7 @@ def _(rid, params: dict) -> dict:
                 # thing that surfaces TUI branches. See issue #20856.
                 model_config={"_branched_from": old_key},
                 parent_session_id=old_key,
-                cwd=_session_cwd(session),
+                cwd=_persisted_session_cwd(session),
                 # The branch stays on its parent's profile. Explicit stamp (not
                 # just the parent-backfill) so it holds even when the parent row
                 # predates the profile_name column.
@@ -3285,6 +3288,7 @@ def _(rid, params: dict) -> dict:
                 list(history),
                 cols=session.get("cols", 80),
                 cwd=_session_cwd(session),
+                explicit_cwd=bool(session.get("explicit_cwd")),
                 session_db=branch_db,
                 source=source,
                 profile_home=parent_home,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -610,7 +610,13 @@ def _load_interim_assistant_messages() -> bool:
 
 
 def _notify_session_boundary(
-    event_type: str, session_id: str | None, platform: str | None = None
+    event_type: str,
+    session_id: str | None,
+    platform: str | None = None,
+    *,
+    reason: str = "session_boundary",
+    old_session_id: str | None = None,
+    new_session_id: str | None = None,
 ) -> None:
     """Fire session lifecycle hooks with CLI parity."""
     try:
@@ -626,6 +632,9 @@ def _notify_session_boundary(
                 event_type,
                 session_id=session_id,
                 platform=_resolve_agent_platform(platform),
+                reason=reason,
+                old_session_id=old_session_id,
+                new_session_id=new_session_id,
             )
     except Exception:
         pass
@@ -2634,6 +2643,7 @@ def _compute_host_turn_frame(
         "history_version": history_version,
         "cols": int(session.get("cols", 80) or 80),
         "cwd": _session_cwd(session),
+        "explicit_cwd": bool(session.get("explicit_cwd")),
         "profile_home": session.get("profile_home") or "",
         "model_override": session.get("model_override"),
         "reasoning_config_override": session.get("create_reasoning_override"),
@@ -3317,7 +3327,14 @@ def _start_agent_build(sid: str, session: dict) -> None:
             with _sessions_lock:
                 if sid in _sessions:
                     _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-            _notify_session_boundary("on_session_reset", key, _session_source(current))
+            _notify_session_boundary(
+                "on_session_reset",
+                key,
+                _session_source(current),
+                reason="session_start",
+                old_session_id=None,
+                new_session_id=key,
+            )
 
             info = _session_info(agent, current)
             cfg_warn = _probe_config_health(_load_cfg())
@@ -3561,6 +3578,13 @@ def _session_cwd(session: dict | None) -> str:
     return _completion_cwd()
 
 
+def _authoritative_session_cwd(session: dict | None) -> str:
+    """Return the session cwd only when its workspace provenance is proven."""
+    if not session or not session.get("explicit_cwd"):
+        return ""
+    return str(session.get("cwd") or "").strip()
+
+
 # Sources whose launch directory is an artifact of how the app was started, not
 # a workspace the user picked. Everything else is terminal-started: the process
 # runs in a directory the user deliberately cd'd into.
@@ -3662,7 +3686,8 @@ def _display_session_cwd(session: dict | None) -> str:
     healed = _heal_dead_cwd(cwd)
     if healed and healed != cwd and session is not None:
         session["cwd"] = healed
-        _persist_session_cwd_and_schedule_git_meta(session, healed)
+        if _persisted_session_cwd(session):
+            _persist_session_cwd_and_schedule_git_meta(session, healed)
 
     return healed
 
@@ -4448,22 +4473,6 @@ def _save_cfg(cfg: dict):
             _cfg_mtime = None
 
 
-def _cwd_for_session_key(session_key: str) -> str:
-    """Reverse-map session_key to the session's logical cwd.
-
-    Snapshots ``_sessions`` first: concurrent RPC handlers mutate it from the
-    thread pool, so iterating the live view risks ``RuntimeError: dictionary
-    changed size during iteration``.
-    """
-    if not session_key:
-        return ""
-    with _sessions_lock:
-        for sess in list(_sessions.values()):
-            if sess.get("session_key") == session_key:
-                return str(sess.get("cwd") or "")
-    return ""
-
-
 def _set_session_context(
     session_key: str,
     cwd: str | None = None,
@@ -4477,7 +4486,12 @@ def _set_session_context(
         # reverse-map returns "" and would clear the cwd override. Callers that
         # know the parent workspace pass it explicitly so spawned agents inherit
         # it instead of falling back to the gateway launch dir.
-        resolved = cwd if cwd is not None else _cwd_for_session_key(session_key)
+        # ``session["cwd"]`` also carries the execution fallback used by tools
+        # and completion.  That fallback is process/profile configuration, not
+        # proof that this conversation selected a workspace.  Only an explicit
+        # caller cwd (ephemeral child tasks) or a session marked explicit may
+        # enter the authoritative session ContextVar consumed by lifecycle hooks.
+        resolved = cwd if cwd is not None else ""
         source = _resolve_session_platform()
         browser_control_principal = ""
         browser_control_transport_family = ""
@@ -4494,6 +4508,8 @@ def _set_session_context(
         with _sessions_lock:
             for sess in list(_sessions.values()):
                 if sess.get("session_key") == session_key:
+                    if cwd is None and sess.get("explicit_cwd"):
+                        resolved = str(sess.get("cwd") or "")
                     source = _session_source(sess)
                     session_id = (
                         getattr(sess.get("agent"), "session_id", None) or session_key
@@ -5575,7 +5591,7 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
     # turns restore the stored bytes without change, because the turn
     # prologue rebuilds only when _cached_system_prompt is None.
     session_tokens = _set_session_context(
-        session_key, cwd=_session_cwd(session)
+        session_key, cwd=_authoritative_session_cwd(session)
     )
     try:
         prompt = agent._build_system_prompt(None)
@@ -6443,7 +6459,9 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
     # session_id/key, so the DB-backed history and (epoch-refreshed) system
     # prompt carry over; only tool definitions and prompt bytes change.
     try:
-        tokens = _set_session_context(sid, cwd=_session_cwd(session))
+        tokens = _set_session_context(
+            sid, cwd=_authoritative_session_cwd(session)
+        )
         try:
             new_agent = _make_agent(
                 sid,
@@ -8834,6 +8852,7 @@ def _init_session(
     history: list,
     cols: int = 80,
     cwd: str | None = None,
+    explicit_cwd: bool = False,
     session_db=None,
     source: str | None = None,
     profile_home: str | None = None,
@@ -8853,6 +8872,7 @@ def _init_session(
             "attached_images": [],
             "image_counter": 0,
             "cwd": cwd or _completion_cwd(),
+            "explicit_cwd": explicit_cwd,
             "cols": cols,
             "slash_worker": None,
             "show_reasoning": _load_show_reasoning(),
@@ -8901,12 +8921,13 @@ def _init_session(
                 with _sessions_lock:
                     if sid in _sessions:
                         _sessions[sid]["cwd"] = row["cwd"]
+                        _sessions[sid]["explicit_cwd"] = True
             else:
                 try:
-                    _cwd = _sessions[sid]["cwd"]
-                    if hasattr(db, "update_session_cwd"):
+                    workspace = _persisted_session_cwd(_sessions[sid])
+                    if workspace and hasattr(db, "update_session_cwd"):
                         _persist_session_cwd_and_schedule_git_meta(
-                            _sessions[sid], _cwd, db=db
+                            _sessions[sid], workspace, db=db
                         )
                 except Exception:
                     logger.debug(
@@ -8951,7 +8972,14 @@ def _init_session(
     with _sessions_lock:
         if sid in _sessions:
             _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-    _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
+    _notify_session_boundary(
+        "on_session_reset",
+        key,
+        _session_source(_sessions.get(sid, {})),
+        reason="session_start",
+        old_session_id=None,
+        new_session_id=key,
+    )
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)
 
@@ -10235,6 +10263,7 @@ def _deferred_session_record(
     *,
     cols: int,
     cwd: str,
+    explicit_cwd: bool,
     history: list,
     lease,
     source: str = "tui",
@@ -10260,7 +10289,7 @@ def _deferred_session_record(
         "cwd": cwd,
         "display_history_prefix": display_history_prefix or [],
         "edit_snapshots": {},
-        "explicit_cwd": False,
+        "explicit_cwd": explicit_cwd,
         "history": history,
         "history_lock": threading.Lock(),
         "history_version": 0,


### PR DESCRIPTION
## Summary

- Separate Desktop execution cwd from authoritative session workspace provenance.
- Preserve `explicit_cwd` through create, resume, branch, compute-host, background, preview, healing, and rebuild carriers.
- Make nested lifecycle ContextVar cleanup stack-safe, including cron workdirs without a session key.
- Emit explicit reset identities and producer capability seals for the Cortex lifecycle adapter.
- Bind classic local CLI turns to the resolved workspace without leaking ContextVar state after the turn.

## Why

Several simultaneous Desktop conversations can share one MCP transport, but they must not inherit workspace ownership from process-global or configured cwd fallback. A fallback path remains useful for tool execution. It is not proof of conversation ownership.

This change keeps those values separate and fails closed when authoritative workspace provenance is absent.

## Verification

- `679` repair-focused tests passed.
- `16` cron workdir/isolation tests passed.
- Ruff passed on all modified Python files.
- Python compilation passed on all modified production files.
- `git diff --check` passed.
- Independent moved-base cold review: **ready**, with no P0–P3 findings.
- Reviewed base: `b1ff8722a53ee223485ac9804945acf07ef5c601`.
- Reviewed full-index diff SHA-256: `d16ca7a29cd66b55295634810036120135c195a4b7c0a777cce97bf99896c092`.

## Baseline limitation

`tests/test_tui_gateway_server.py::test_model_options_preserves_canonical_custom_row_after_agent_init` fails with an unexpected `anthropic` provider row. The same assertion fails unchanged on a clean `b1ff8722a53ee223485ac9804945acf07ef5c601` worktree, so it is not introduced by this patch.

## Scope

This PR changes repository source and tests only. It does not install, restart, deploy, or activate the lifecycle adapter.