### PR TITLE
fix(cli): suppress duplicate response panel when TTS displays without token streaming

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16648,6 +16648,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 except Exception:
                     pass
 
+            # Track whether TTS displayed content this turn — used to suppress
+            # the final Rich Panel when TTS is the sole display path.
+            self._tts_displayed_this_turn = False
+
             if use_streaming_tts:
                 text_queue = queue.Queue()
                 stop_event = threading.Event()
@@ -16663,6 +16667,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     def display_callback(sentence: str):
                         """Called by TTS consumer when a sentence is ready to display + speak."""
                         nonlocal _streaming_box_opened
+                        self._tts_displayed_this_turn = True
                         if not _streaming_box_opened:
                             _streaming_box_opened = True
                             w = self._scrollback_box_width(getattr(self.console, "width", 80))
@@ -17108,7 +17113,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
                 is_error_response = result and (result.get("failed") or result.get("partial"))
                 already_streamed = self._stream_started and self._stream_box_opened and not is_error_response
-                if use_streaming_tts and _streaming_box_opened and not is_error_response:
+                # TTS display callback (when streaming_enabled=False) is the sole
+                # display path. It sets _streaming_box_opened locally AND
+                # self._tts_displayed_this_turn as a thread-safe indicator.
+                tts_already_displayed = (
+                    use_streaming_tts
+                    and (self._tts_displayed_this_turn or _streaming_box_opened)
+                    and not is_error_response
+                )
+                if tts_already_displayed:
                     # Text was already printed sentence-by-sentence; just close the box
                     w = self._scrollback_box_width()
                     _cprint(f"\n{_ACCENT}╰{'─' * (w - 2)}╯{_RST}")


### PR DESCRIPTION
## Summary

- Fixes a CLI bug where the final response panel duplicates when TTS output is active but token streaming is disabled
- The TTS `display_callback` prints sentences as they're spoken; the final Rich Panel was supposed to be suppressed, but the guard relied on a nonlocal boolean set by the TTS callback in a separate thread — when it failed, the panel rendered on top of TTS output
- Adds an instance variable (`self._tts_displayed_this_turn`) as a reliable, thread-safe indicator; widens the guard to check both the instance var and the local flag
- Normal token streaming path (`streaming_enabled=True`) is unaffected

## Reproduction

This exact conversation showed the bug: running `git push origin master + 4 commands` via Hermes CLI produced the full response twice in terminal output — once from the TTS display callback and once from the Rich Panel rendering the same `response` string.

## Validation

- [ ] Test with TTS enabled, token streaming disabled — confirm no duplicate panel
- [ ] Test with TTS disabled, token streaming enabled — confirm normal streaming behavior unchanged  
- [ ] Test with both enabled — confirm no regression

🤖 Generated with [Claude Code](https://cli.claude.com)