### PR TITLE
fix: declare LINE adapter as non-editable to fix message splitting

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -693,6 +693,16 @@ class LineAdapter(BasePlatformAdapter):
 
     # LINE has its own message-edit story (none) — we always send fresh
     # bubbles, never edit, so REQUIRES_EDIT_FINALIZE stays False.
+    #
+    # SUPPORTS_MESSAGE_EDITING must also be False: without it, the gateway's
+    # streaming consumer (gateway/run.py _build_stream_consumer_config)
+    # defaults to True and tries edit-based streaming anyway — sending a
+    # partial bubble it can never update, then a second bubble with the
+    # rest of the turn. The split lands wherever the streaming buffer
+    # happened to flush, not on a word boundary, producing the "message
+    # gets cut in half" symptom (mid-word split, occasional replacement-
+    # character artifact right at the cut) reported over LINE.
+    SUPPORTS_MESSAGE_EDITING = False
 
     def __init__(self, config, **kwargs):
         platform = Platform("line")

--- a/tests/gateway/test_line_no_edit_streaming.py
+++ b/tests/gateway/test_line_no_edit_streaming.py
@@ -1,0 +1,71 @@
+"""LINE must never enter edit-based streaming — it has no message-edit API.
+
+Symptom reported over a real LINE deployment: a single agent reply arrives
+as two bubbles, split mid-word, with a stray replacement-character artifact
+right at the cut (e.g. "テスト受信しました。正常■" / "に動作しています...").
+
+Root cause: ``gateway/run.py`` ``_build_stream_consumer_config`` decides
+whether to skip streaming for a platform via
+``getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)`` — defaulting to
+``True`` when the adapter doesn't declare it. ``LineAdapter`` never declared
+it, so the gateway's streaming consumer ran edit-based streaming against a
+platform that can only ever send NEW messages (LINE's Messaging API has no
+edit-message endpoint): it sends a partial bubble it can never update, then
+a second bubble with the rest of the turn — the exact "duplicate messages
+(partial + final)" failure mode this same function's docstring/comment
+already names for QQ/WeChat-style platforms.
+
+These tests exercise the real ``_build_stream_consumer_config`` gate (it
+doesn't touch ``self``, so it's called directly) against a real
+``LineAdapter`` instance.
+"""
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import PlatformConfig, Platform, StreamingConfig
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_line_adapter():
+    from plugins.platforms.line.adapter import LineAdapter
+
+    return LineAdapter(PlatformConfig(enabled=True))
+
+
+def test_line_adapter_declares_no_message_editing():
+    """Direct regression pin on the class attribute itself."""
+    adapter = _make_line_adapter()
+    assert adapter.SUPPORTS_MESSAGE_EDITING is False
+
+
+def test_line_skips_streaming_on_the_in_process_agent_path():
+    """``on_missing_cursor="raise"`` is what the in-process agent-run path
+    uses (see ``gateway/run.py`` call site) — the caller's ``except`` then
+    skips streaming for this turn entirely, so the full reply goes out as a
+    single normal ``send()`` once generation finishes. No edit-based
+    consumer ever runs, so there is no partial bubble to split."""
+    adapter = _make_line_adapter()
+    source = SessionSource(platform=Platform.LINE, chat_id="U-test")
+    scfg = StreamingConfig()
+
+    with pytest.raises(RuntimeError, match="skip streaming for non-editable platform"):
+        GatewayRunner._build_stream_consumer_config(
+            None, source, scfg, adapter, on_missing_cursor="raise",
+        )
+
+
+def test_line_gets_a_cursorless_fallback_on_the_proxy_path():
+    """``on_missing_cursor="fallback"`` (the remote-proxy agent path) must
+    not raise for a non-editable adapter — it streams anyway with an empty
+    cursor (``_effective_cursor == ""``), matching the pre-existing fallback
+    semantics documented on ``_build_stream_consumer_config``."""
+    adapter = _make_line_adapter()
+    source = SessionSource(platform=Platform.LINE, chat_id="U-test")
+    scfg = StreamingConfig()
+
+    consumer_cfg, _pause_hook = GatewayRunner._build_stream_consumer_config(
+        None, source, scfg, adapter, on_missing_cursor="fallback",
+    )
+    assert consumer_cfg.cursor == ""


### PR DESCRIPTION
## What does this PR do?

Fixes a message-splitting bug on LINE: a single agent reply arrives as two separate bubbles, cut wherever the streaming buffer happened to flush rather than on a word boundary — occasionally with a stray replacement-character artifact right at the cut point (e.g. `"テスト受信しました。正常■"` followed by a second bubble `"に動作しています。何かご用件があればお気軽にどうぞ。"` — one sentence, split mid-word).

LINE's Messaging API has no endpoint to edit an already-sent message — every send is a brand-new bubble. `gateway/run.py`'s streaming consumer gate (`_build_stream_consumer_config`) decides whether to skip edit-based streaming for a platform via `getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)`, defaulting to `True` when an adapter doesn't declare it. `LineAdapter` never declared it, so the gateway ran edit-based streaming against LINE anyway.

The function's own comment already names the exact resulting failure mode:

> Platforms that don't support editing sent messages (e.g. QQ, WeChat) should skip streaming entirely — without edit support, the consumer sends a partial first message that can never be updated, resulting in duplicate messages (partial + final).

`LineAdapter`'s own class docstring already documents the correct mental model for a *different*, related flag: `"LINE has its own message-edit story (none) — we always send fresh bubbles, never edit, so REQUIRES_EDIT_FINALIZE stays False."` — `SUPPORTS_MESSAGE_EDITING` was simply the one flag missed.

## Related Issue

No existing issue — same pass as #97878, filed as a separate PR since it's an unrelated root cause in a different file.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/line/adapter.py`: added `SUPPORTS_MESSAGE_EDITING = False` on `LineAdapter`, matching the existing precedent on `WeComAdapter` and `PhotonAdapter`. This routes LINE through the same "skip streaming, send the complete answer once" path those platforms already use.
- `tests/gateway/test_line_no_edit_streaming.py` (new):
  - a direct regression pin on the class attribute itself
  - a test that calls the real `_build_stream_consumer_config` gate (it doesn't touch `self`, so it's callable directly without constructing a full `GatewayRunner`) with a real `LineAdapter` and `on_missing_cursor="raise"` (the in-process agent path) and asserts it now raises, correctly skipping streaming for the turn
  - a test that calls the same gate with `on_missing_cursor="fallback"` (the remote-proxy agent path) and asserts the pre-existing documented cursorless-fallback behavior, so the proxy path isn't regressed by this change

## How to Test

1. `pytest tests/gateway/test_line_no_edit_streaming.py -q` — new tests.
2. `pytest tests/gateway/test_line_plugin.py -q` — existing LINE adapter suite (34 tests), confirming no regression.
3. Reproduce on `main` first: build a real `LineAdapter`, call `GatewayRunner._build_stream_consumer_config(None, source, StreamingConfig(), adapter, on_missing_cursor="raise")` — it returns a consumer config instead of raising, because `SUPPORTS_MESSAGE_EDITING` defaults to `True`. With this branch, the same call raises `RuntimeError("skip streaming for non-editable platform")`, matching the behavior already established for QQ/WeChat-style adapters.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits (`fix:`)
- [x] I searched existing PRs/issues for a duplicate report — didn't find one
- [x] This PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `tests/gateway/test_line_plugin.py` (34 tests) and the new `tests/gateway/test_line_no_edit_streaming.py` (3 tests) in a clean environment: all pass. Did not run the full multi-thousand-test suite due to time constraints.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — not yet; happy to add a note to `website/docs/user-guide/messaging/line.md` if useful
- [ ] I've updated `cli-config.yaml.example` — N/A, no new config keys
- [ ] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure Python class attribute, no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
