### PR TITLE
fix(desktop): recover visible sessions after stale runtime RPC

### DIFF
--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -23,10 +23,16 @@ vi.mock('@/store/gateway', async importActual => ({
 }))
 
 const probe = vi.hoisted(() => ({ resolveSessionOwner: vi.fn(async () => undefined as unknown) }))
+const sessionMocks = vi.hoisted(() => ({ requestSessionResume: vi.fn() }))
 
 vi.mock('@/app/session/hooks/use-session-actions/utils', async importActual => ({
   ...(await importActual<Record<string, unknown>>()),
   resolveSessionOwner: probe.resolveSessionOwner
+}))
+
+vi.mock('@/store/session', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  requestSessionResume: sessionMocks.requestSessionResume
 }))
 
 const { createSessionRpcDispatcher } = await import('./session-rpc-dispatcher')
@@ -40,13 +46,16 @@ const { isSessionOwnerResolutionError } = await import('@/store/session-owner-re
 const { $sessionTiles } = await import('@/store/session-states')
 const { makeSessionInfo } = await import('@/test/session-info')
 
-function dispatcher(ambientRequest = vi.fn(async () => ({ ambient: true }))) {
+function dispatcher(
+  ambientRequest = vi.fn(async () => ({ ambient: true })),
+  selectedStoredSessionId: null | string = null
+) {
   return {
     ambientRequest,
     request: createSessionRpcDispatcher({
       ambientRequest: ambientRequest as never,
       runtimeIdByStoredSessionIdRef: { current: new Map([['stored-omar', 'rt-omar']]) },
-      selectedStoredSessionIdRef: { current: null },
+      selectedStoredSessionIdRef: { current: selectedStoredSessionId },
       sessionStateByRuntimeIdRef: { current: new Map() }
     })
   }
@@ -67,6 +76,7 @@ afterEach(() => {
   $sessionTiles.set([])
   $profiles.set([])
   _resetSessionOwnerHintsForTests({ storage: true })
+  sessionMocks.requestSessionResume.mockReset()
   vi.clearAllMocks()
 })
 
@@ -192,5 +202,52 @@ describe('createSessionRpcDispatcher: exact owner rungs', () => {
       session_id: 'stored-tg',
       text: 'hi'
     })
+  })
+})
+
+describe('createSessionRpcDispatcher: stale runtime recovery', () => {
+  it('requests a durable rebind for the visible session after a structured 4001, while preserving the RPC error', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockRejectedValueOnce(Object.assign(new Error('runtime was reaped'), { code: 4001 }))
+    const { request } = dispatcher(undefined, 'stored-omar')
+
+    await expect(request('process.list', { session_id: 'rt-omar' })).rejects.toThrow('runtime was reaped')
+
+    expect(sessionMocks.requestSessionResume).toHaveBeenCalledWith('stored-omar', {
+      connectionId: 'local',
+      profile: 'omar'
+    })
+  })
+
+  it('does not let a background or stale error pull a different session into the foreground', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockRejectedValueOnce(Object.assign(new Error('session not found'), { code: 4001 }))
+    const { request } = dispatcher(undefined, 'stored-other')
+
+    await expect(request('process.list', { session_id: 'rt-omar' })).rejects.toThrow('session not found')
+
+    expect(sessionMocks.requestSessionResume).not.toHaveBeenCalled()
+  })
+
+  it('does not interpret an unrelated structured RPC failure as a stale runtime', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockRejectedValueOnce(
+      Object.assign(new Error('tool output says session not found'), { code: 5007 })
+    )
+    const { request } = dispatcher(undefined, 'stored-omar')
+
+    await expect(request('process.list', { session_id: 'rt-omar' })).rejects.toThrow('tool output says session not found')
+
+    expect(sessionMocks.requestSessionResume).not.toHaveBeenCalled()
+  })
+
+  it('leaves the warm resume lifecycle to recover its own stale session.activate failure', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockRejectedValueOnce(Object.assign(new Error('session not found'), { code: 4001 }))
+    const { request } = dispatcher(undefined, 'stored-omar')
+
+    await expect(request('session.activate', { session_id: 'rt-omar' })).rejects.toThrow('session not found')
+
+    expect(sessionMocks.requestSessionResume).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
@@ -35,7 +35,7 @@ import type { MutableRefObject } from 'react'
 
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { ClientSessionState } from '@/app/types'
-import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
+import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows, requestSessionResume } from '@/store/session'
 import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
@@ -54,6 +54,26 @@ export interface SessionRpcDispatcherDeps {
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionIdRef: MutableRefObject<null | string>
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+}
+
+/** Gateway code from tui_gateway.server._sess_nowait for a runtime that was
+ * reaped after this renderer missed its disconnect/reclaim event. Prefer the
+ * structured code: an unrelated RPC can legitimately mention the same words.
+ * Older bridges sometimes lose the code, so retain the narrow message fallback
+ * only when there is no numeric code at all. */
+function isStaleRuntimeSessionError(error: unknown): boolean {
+  const code =
+    error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'number'
+      ? (error as { code: number }).code
+      : undefined
+
+  if (code !== undefined) {
+    return code === 4001
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return /session not found/i.test(message)
 }
 
 export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): AmbientGatewayRequest {
@@ -97,6 +117,37 @@ export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): Ambi
     // backend "session not found" on a backend that never held the runtime.
     assertSessionOwnerResolved(owner, { method, sessionId: paramSessionId ? routingSessionId : null })
 
-    return requestForSessionProfile<T>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
+    try {
+      return await requestForSessionProfile<T>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
+    } catch (error) {
+      // A renderer can miss session.reclaimed while its persistent WS is briefly
+      // disconnected. The server then reaps the old runtime and any later
+      // session-scoped RPC gets 4001, even though its stored transcript remains
+      // resumable. Prompt actions already retry their own RPCs; this shared seam
+      // covers the other callers (status, approvals, process controls) and wakes
+      // the route-resume hook so the visible chat rebinds without an app restart.
+      //
+      // Deliberately do not retry the failing RPC here: it may be a destructive
+      // action, and a fresh runtime binding is asynchronous. Preserve its error
+      // contract and only request a recovery for the currently visible main
+      // session. Tiles own their own recovery lifecycle, while background rows
+      // must never steal the foreground route.
+      if (
+        // These two RPCs are the resume lifecycle itself. A warm rebind first
+        // activates the cached runtime; on 4001 resumeSession drops that map
+        // and falls through to durable session.resume. Re-triggering from the
+        // activate failure would enqueue a second explicit resume request.
+        method !== 'session.resume' &&
+        method !== 'session.activate' &&
+        paramSessionId &&
+        routingSessionId &&
+        routingSessionId === selectedStoredSessionIdRef.current &&
+        isStaleRuntimeSessionError(error)
+      ) {
+        requestSessionResume(routingSessionId, typeof owner === 'object' && owner ? owner : undefined)
+      }
+
+      throw error
+    }
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2392,6 +2392,54 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
   })
 
+  it('drops a stale warm runtime after session.activate 4001 and fully resumes the durable session', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-stale']])
+    }
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-stale', clientState('stored-A')]])
+    }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.activate') {
+        throw Object.assign(new Error('session not found'), { code: 4001 })
+      }
+
+      if (method === 'session.resume') {
+        return {
+          session_id: 'rt-A-fresh',
+          resumed: params?.session_id,
+          messages: [],
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    expect(requestGateway.mock.calls.map(([method]) => method)).toEqual(['session.activate', 'session.resume'])
+    expect(requestGateway).toHaveBeenLastCalledWith(
+      'session.resume',
+      expect.objectContaining({ session_id: 'stored-A' })
+    )
+    expect(sessionStateByRuntimeIdRef.current.has('rt-stale')).toBe(false)
+  })
+
   it('re-arms a pending clarify in place on the warm session.activate path', async () => {
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
       current: new Map([['stored-A', 'rt-A']])


### PR DESCRIPTION
## Summary

When Desktop misses a transient WebSocket disconnect and the gateway reaps the runtime session, a later session-scoped RPC can return 4001 even though the durable session still exists.

This routes that signal into the existing route-resume mechanism for the currently visible main session. The original RPC is deliberately not retried: it may be destructive, while the recovery rebinding is asynchronous.

- trigger a durable rebind only for an explicit 4001 (or legacy code-less equivalent) on the selected stored session
- preserve the session owner route for cross-profile/connection recovery
- exclude `session.activate` and `session.resume`, which are the recovery lifecycle itself, so a stale warm-cache activation cannot queue a duplicate resume
- leave tiles and background sessions to their existing recovery lifecycles

Part of #97764.

## Tests

- `npm --workspace apps/desktop run test:ui -- session-rpc-dispatcher.test.ts use-session-actions.test.tsx use-route-resume.test.tsx`
- `npm --workspace apps/desktop exec eslint -- src/app/contrib/session-rpc-dispatcher.ts src/app/contrib/session-rpc-dispatcher.test.ts src/app/session/hooks/use-session-actions.test.tsx`

Snape independently reviewed the final commit and found no remaining blocker, should, or nit.