### PR TITLE
feat(desktop): allow image attachments on live-turn steer

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -917,6 +917,7 @@ def init_agent(
     # prefix, cancel only the in-flight model request, and rebuild its tail with
     # the correction. The loop drains this slot at a role-safe boundary.
     agent._pending_redirect: Optional[str] = None
+    agent._pending_redirect_images: List[str] = []
     agent._pending_redirect_lock = threading.Lock()
 
     # Concurrent-tool worker thread tracking.  `_execute_tool_calls_concurrent`

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -375,7 +375,12 @@ def _moa_reference_metrics_for_hook(agent: Any) -> Any:
         return None
 
 
-def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text: str) -> None:
+def _apply_active_turn_redirect(
+    agent: Any,
+    messages: List[Dict[str, Any]],
+    text: str,
+    image_paths: Optional[List[str]] = None,
+) -> None:
     """Append a provider-safe checkpoint and correction to the live turn.
 
     Incomplete provider reasoning blocks are not valid replay items (Anthropic
@@ -422,11 +427,35 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
             ["Visible response before the interruption:", visible]
         )
     checkpoint = "\n\n".join(checkpoint_parts)
-    correction = (
-        "[Context from the interrupted assistant response]\n"
-        f"{checkpoint}\n\n"
-        f"{text}"
-    )
+    paths = list(image_paths or [])
+    user_visible = text
+    if paths:
+        from agent.steer_media import build_redirect_user_payload
+
+        user_visible, api_suffix = build_redirect_user_payload(agent, text, paths)
+        if isinstance(api_suffix, list):
+            correction: Any = [
+                {
+                    "type": "text",
+                    "text": (
+                        "[Context from the interrupted assistant response]\n"
+                        f"{checkpoint}\n\n"
+                    ),
+                },
+                *api_suffix,
+            ]
+        else:
+            correction = (
+                "[Context from the interrupted assistant response]\n"
+                f"{checkpoint}\n\n"
+                f"{api_suffix}"
+            )
+    else:
+        correction = (
+            "[Context from the interrupted assistant response]\n"
+            f"{checkpoint}\n\n"
+            f"{text}"
+        )
 
     # The normal live tail is user or tool, so an assistant placeholder
     # followed by the correction preserves strict alternation. If a transport
@@ -437,7 +466,7 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
         # scaffolded form so it still sees the interrupted context.
         append_message(
             messages,
-            {"role": "user", "content": text, "api_content": correction},
+            {"role": "user", "content": user_visible, "api_content": correction},
         )
     else:
         # Placeholder preserves role alternation only. Scaffold bytes must
@@ -466,7 +495,7 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
         append_message(messages, placeholder)
         append_message(
             messages,
-            {"role": "user", "content": text, "api_content": correction},
+            {"role": "user", "content": user_visible, "api_content": correction},
         )
 
     agent._current_streamed_assistant_text = ""
@@ -2027,13 +2056,24 @@ def run_conversation(
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
-        _redirect_text = agent._drain_pending_redirect()
-        if _redirect_text:
-            _apply_active_turn_redirect(agent, messages, _redirect_text)
+        _drain_payload = getattr(agent, "_drain_pending_redirect_payload", None)
+        if callable(_drain_payload):
+            _redirect_text, _redirect_images = _drain_payload()
+        else:
+            _redirect_text = agent._drain_pending_redirect()
+            _redirect_images = []
+        if _redirect_text or _redirect_images:
+            _apply_active_turn_redirect(
+                agent,
+                messages,
+                _redirect_text or "",
+                image_paths=_redirect_images,
+            )
             if isinstance(original_user_message, str):
+                _note = _redirect_text or "image correction"
                 original_user_message = (
                     f"{original_user_message}\n\n"
-                    f"User correction during the turn: {_redirect_text}"
+                    f"User correction during the turn: {_note}"
                 )
             agent._persist_session(messages, conversation_history)
 

--- a/agent/steer_media.py
+++ b/agent/steer_media.py
@@ -1,0 +1,130 @@
+"""Helpers for live-turn redirect/steer payloads that include images.
+
+Text-only steer still appends to the last tool result. Images cannot ride
+that string, so they are delivered as a normal multimodal user correction
+at the next role-safe loop boundary (after the current tool batch, or after
+cancelling an in-flight model request).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List, Optional, Sequence, Tuple, Union
+
+RedirectUserContent = Union[str, List[dict]]
+
+
+def normalize_image_paths(image_paths: Optional[Sequence[Any]]) -> List[str]:
+    """Return existing local image paths, dropping blanks and missing files."""
+    out: List[str] = []
+    seen: set[str] = set()
+    for raw in image_paths or []:
+        path = str(raw or "").strip()
+        if not path or path in seen:
+            continue
+        if not Path(path).exists():
+            continue
+        seen.add(path)
+        out.append(path)
+    return out
+
+
+def supports_image_redirect(agent: Any) -> bool:
+    """Codex app-server turn/steer is text-only; queue images instead."""
+    return getattr(agent, "api_mode", None) != "codex_app_server"
+
+
+def persist_image_correction_text(user_text: str, image_paths: Sequence[str]) -> str:
+    """UI/session form: caption plus ``@image:`` refs (desktop renders these)."""
+    from agent.context_references import format_reference_value
+
+    text = (user_text or "").strip()
+    refs = "\n".join(
+        f"@image:{format_reference_value(p)}" for p in image_paths if Path(p).exists()
+    )
+    if not refs:
+        return text
+    return f"{text}\n{refs}" if text else refs
+
+
+def text_mode_image_correction(user_text: str, image_paths: Sequence[str]) -> str:
+    """Model-facing text when native vision is off: inspect via vision_analyze."""
+    parts: List[str] = []
+    for path in image_paths:
+        p = Path(path)
+        if not p.exists():
+            continue
+        parts.append(
+            f"[The user attached an image: {p.name}]\n"
+            f"[Examine it with the vision_analyze tool using image_url: {p}]"
+        )
+    text = (user_text or "").strip()
+    prefix = "\n\n".join(parts)
+    if prefix:
+        return f"{prefix}\n\n{text}" if text else prefix
+    return text or "What do you see in this image?"
+
+
+def build_redirect_user_payload(
+    agent: Any,
+    text: str,
+    image_paths: Sequence[str],
+) -> Tuple[str, RedirectUserContent]:
+    """Return (display_text, api_content_suffix) for an active-turn correction."""
+    paths = normalize_image_paths(image_paths)
+    cleaned = (text or "").strip()
+    if not paths:
+        return cleaned, cleaned
+
+    display = persist_image_correction_text(cleaned, paths)
+    mode = "text"
+    try:
+        from hermes_cli.config import load_config
+        from agent.image_routing import decide_image_input_mode
+
+        cfg = load_config()
+        mode = decide_image_input_mode(
+            getattr(agent, "provider", "") or "",
+            getattr(agent, "model", "") or "",
+            cfg,
+            requested_provider=getattr(agent, "requested_provider", "") or "",
+        )
+        if getattr(agent, "api_mode", "") == "codex_app_server":
+            mode = "text"
+    except Exception:
+        mode = "text"
+
+    if mode == "native":
+        try:
+            from agent.image_routing import build_native_content_parts
+
+            parts, _skipped = build_native_content_parts(cleaned, list(paths))
+            if any(isinstance(p, dict) and p.get("type") == "image_url" for p in parts):
+                return display, parts
+        except Exception:
+            pass
+    return display, text_mode_image_correction(cleaned, paths)
+
+
+def parse_redirect_image_paths(params: Any) -> List[str]:
+    raw = params.get("image_paths") if isinstance(params, dict) else None
+    if not isinstance(raw, list):
+        return []
+    return [str(p).strip() for p in raw if str(p).strip()]
+
+
+def call_redirect_like(fn: Any, text: str, image_paths: Sequence[str]) -> Any:
+    try:
+        return fn(text, image_paths=list(image_paths) or None)
+    except TypeError:
+        return fn(text)
+
+
+def merge_redirect_text(existing: Optional[str], incoming: str) -> str:
+    cleaned = (incoming or "").strip()
+    prior = (existing or "").strip()
+    if not cleaned:
+        return prior
+    if not prior:
+        return cleaned
+    return f"{prior}\n\n[Additional user correction]\n{cleaned}"

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -306,7 +306,7 @@ export function useComposerQueue({
 
       triggerHaptic('submit')
 
-      const accepted = await Promise.resolve(onSteer(entry.text))
+      const accepted = await Promise.resolve(onSteer(entry.text, entry.attachments))
 
       // Rejected (turn already settling, gateway said no): leave the entry
       // queued exactly where it was — the settle drain picks it up, so the

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -202,16 +202,14 @@ export function useComposerSubmit({
         triggerHaptic('submit')
         clearDraft()
         dispatchSubmit(text)
-      } else if (!compacting && !blockingPrompt && !attachments.length && text.trim()) {
-        // Cursor-style stop-and-correct: interrupt the live turn and redirect
-        // it with this text. redirect() preserves the shown reasoning/work; if
-        // the turn already ended, steerDraft re-queues so nothing is lost.
+      } else if (
+        !compacting &&
+        !blockingPrompt &&
+        attachments.every(attachment => attachment.kind === 'image') &&
+        (text.trim() || attachments.length > 0)
+      ) {
         steerDraft()
       } else if (payloadPresent) {
-        // Attachments can't ride a redirect (no tool-result image carriage) —
-        // queue the whole payload for the next turn. Same for a turn parked on
-        // an approval/sudo/secret prompt: a steer can't reach the model while
-        // the tool batch is blocked, so the message runs as the next turn.
         queueCurrentDraft()
       } else {
         // Stop button (the only way to reach here while busy with an empty
@@ -238,19 +236,26 @@ export function useComposerSubmit({
   // tool boundary. If the turn already ended, queue the words instead.
   const steerDraft = () => {
     const text = draftRef.current.trim()
+    const steeredAttachments = cloneAttachments(attachments)
+    const hasImages = steeredAttachments.some(attachment => attachment.kind === 'image')
+    const hasNonImages = steeredAttachments.some(attachment => attachment.kind !== 'image')
 
-    // Guard on live editor state, not the render-lagged `canSteer`: a redirect
-    // fired on a fast Enter must not be dropped because state hasn't synced.
-    if (!onSteer || !text || attachments.length > 0 || SLASH_COMMAND_RE.test(text)) {
+    if (
+      !onSteer ||
+      hasNonImages ||
+      SLASH_COMMAND_RE.test(text) ||
+      (!text && !hasImages)
+    ) {
       return
     }
 
     triggerHaptic('submit')
     clearDraft()
+    scope.attachments.clear()
 
-    void Promise.resolve(onSteer(text)).then(accepted => {
+    void Promise.resolve(onSteer(text, steeredAttachments)).then(accepted => {
       if (!accepted && activeQueueSessionKey) {
-        enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments: [] })
+        enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments: steeredAttachments })
       }
     })
   }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -344,11 +344,15 @@ export function ChatBar({
   const hasComposerPayload = hasText || attachments.length > 0
   const canSubmit = busy || hasComposerPayload
 
-  // Steer only makes sense mid-turn, text-only (the gateway can't carry images
-  // into a tool result) and never for a slash command (those execute inline).
-  // A blocking prompt (approval/sudo/secret) also rules it out: the tool batch
-  // is parked on the user, so a steer can't reach the model — text queues.
-  const canSteer = busy && !compacting && !blockingPrompt && !!onSteer && attachments.length === 0 && isSteerableText
+  const imageAttachments = attachments.filter(attachment => attachment.kind === 'image')
+  const hasNonImageAttachments = attachments.some(attachment => attachment.kind !== 'image')
+  const canSteer =
+    busy &&
+    !compacting &&
+    !blockingPrompt &&
+    !!onSteer &&
+    !hasNonImageAttachments &&
+    (isSteerableText || imageAttachments.length > 0)
 
   // While busy: text redirects the live turn (Cursor-style stop-and-correct),
   // attachments queue for the next turn, an empty composer stops.

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
+import type { ComposerAttachment } from '@/store/composer'
 import type { HermesGateway } from '@/hermes'
 
 import type { DroppedFile } from '../hooks/use-composer-actions'
@@ -54,7 +55,7 @@ export interface ChatBarProps {
   onPickFolders?: () => void
   onPickImages?: () => void
   onRemoveAttachment?: (id: string) => void
-  onSteer?: (text: string) => Promise<boolean> | boolean
+  onSteer?: (text: string, attachments?: ComposerAttachment[]) => Promise<boolean> | boolean
   onSubmit: (value: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
   onTranscribeAudio?: (audio: Blob) => Promise<string>
 }

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -26,7 +26,7 @@ import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-s
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
-import { migrateSessionDraft } from '@/store/composer'
+import { type ComposerAttachment, migrateSessionDraft } from '@/store/composer'
 import { migrateQueuedPrompts, parkQueuedPrompts } from '@/store/composer-queue'
 import { $introSplash } from '@/store/intro-splash'
 import { $pinnedSessionIds } from '@/store/layout'
@@ -98,7 +98,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onPickFolders: () => void
   onPickImages: () => void
   onRemoveAttachment: (id: string) => void
-  onSteer: (text: string) => Promise<boolean> | boolean
+  onSteer: (text: string, attachments?: ComposerAttachment[]) => Promise<boolean> | boolean
   onSubmit: (text: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
   onThreadMessagesChange: (messages: readonly ThreadMessage[]) => void
   onEdit: (message: AppendMessage) => Promise<void>

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -759,14 +759,15 @@ export function usePromptActions({
   // completed work intact. During a tool it waits for the safe result boundary.
   // Returns false when the turn raced to completion so the composer can queue.
   const redirectPrompt = useCallback(
-    async (rawText: string): Promise<boolean> => {
+    async (rawText: string, attachments?: ComposerAttachment[]): Promise<boolean> => {
       const text = sanitizeComposerInput(rawText).trim()
+      const imageAttachments = (attachments ?? []).filter(attachment => attachment.kind === 'image')
       // Ref, not the closure-captured prop — see cancelRun above. A redirect
       // reaches the live model mid-turn, so a stale target delivers the user's
       // correction into a conversation they are no longer looking at.
       const sessionId = activeSessionIdRef.current
 
-      if (!text || !sessionId) {
+      if ((!text && imageAttachments.length === 0) || !sessionId) {
         return false
       }
 
@@ -776,12 +777,30 @@ export function usePromptActions({
       // message after the interrupted checkpoint, matching the durable core
       // transcript rather than a system note that changes role after reload.
       const send = async (id: string): Promise<boolean> => {
+        let imagePaths: string[] = []
+        let bubbleText = text
+        if (imageAttachments.length > 0) {
+          const synced = await syncAttachmentsForSubmit(id, imageAttachments, {
+            updateComposerAttachments: false
+          })
+          imagePaths = synced.attachments
+            .map(attachment => attachment.path)
+            .filter((path): path is string => Boolean(path))
+          if (imagePaths.length === 0) {
+            return false
+          }
+          const refs = synced.attachments
+            .map(attachment => attachment.refText)
+            .filter((ref): ref is string => Boolean(ref))
+          bubbleText = [text, ...refs].filter(Boolean).join('\n')
+        }
+
         // Redirect aborts the model request, so the completion event can race
         // its RPC response. Record the correction *before* awaiting the
         // gateway, in arrival order: sealed already-streamed output above,
         // correction bubble below it, post-redirect deltas below that
         // (#73793, #83151).
-        const messageId = appendSessionTextMessage(id, 'user', text, undefined, { appendAfterActiveReply: true })
+        const messageId = appendSessionTextMessage(id, 'user', bubbleText, undefined, { appendAfterActiveReply: true })
 
         const discardOptimisticMessage = () =>
           updateSessionState(id, state => ({
@@ -799,7 +818,19 @@ export function usePromptActions({
           })
 
         try {
-          const result = await requestGateway<SessionRedirectResponse>('session.redirect', { session_id: id, text })
+          const result = await requestGateway<SessionRedirectResponse>('session.redirect', {
+            session_id: id,
+            text,
+            ...(imagePaths.length > 0 ? { image_paths: imagePaths } : {})
+          })
+
+          if (result?.reason === 'images_unsupported') {
+            notify({
+              kind: 'warning',
+              title: t.composer.steerImagesUnsupportedTitle,
+              message: t.composer.steerImagesUnsupported
+            })
+          }
 
           if (result?.status === 'redirected') {
             triggerHaptic('submit')
@@ -844,7 +875,7 @@ export function usePromptActions({
 
       return false
     },
-    [activeSessionIdRef, appendSessionTextMessage, requestGateway, selectedStoredSessionIdRef, updateSessionState]
+    [activeSessionIdRef, appendSessionTextMessage, requestGateway, selectedStoredSessionIdRef, syncAttachmentsForSubmit, t, updateSessionState]
   )
 
   // After a durable rewind the surviving bubbles' cached rowIds are stale (the

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -88,6 +88,7 @@ export interface SessionSteerResponse {
 export interface SessionRedirectResponse {
   status?: 'redirected' | 'queued' | 'rejected'
   text?: string
+  reason?: 'images_unsupported'
 }
 
 export interface SessionTitleResponse {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1887,6 +1887,8 @@ export const ar = defineLocale({
     queueEdit: 'تحرير الرسالة المجدولة',
     queueSendNext: 'إرسالها تاليا',
     queueSteer: 'توجيه — تصحيح الدور الجاري فورا',
+    steerImagesUnsupportedTitle: 'لا يمكن توجيه هذا التشغيل بالصور',
+    steerImagesUnsupported: 'لا يمكن توجيه هذا التشغيل بالصور؛ تم وضعها في طابور الدور التالي',
     queueSend: 'إرسالها الآن',
     queueDelete: 'حذف من الطابور',
     queueStuckTitle: 'لم تُرسل الرسالة في قائمة الانتظار',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2418,6 +2418,8 @@ export const en: Translations = {
     queueEdit: 'Edit',
     queueSendNext: 'Next',
     queueSteer: 'Steer — redirect the live turn now',
+    steerImagesUnsupportedTitle: 'Images cannot steer this runtime',
+    steerImagesUnsupported: 'Images cannot steer this runtime; queued for the next turn',
     queueSend: 'Send',
     queueDelete: 'Delete',
     queueResume: 'Resume',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2091,6 +2091,8 @@ export const ja = defineLocale({
     queueEdit: '編集',
     queueSendNext: '次に送信',
     queueSteer: 'ステア — 現在のターンを今すぐ修正',
+    steerImagesUnsupportedTitle: 'このランタイムでは画像ステアできません',
+    steerImagesUnsupported: '画像はこのランタイムをステアできません。次のターンにキューしました',
     queueSend: '送信',
     queueDelete: '削除',
     queueResume: '再開',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2051,6 +2051,8 @@ export interface Translations {
     queueSendNext: string
     queueSend: string
     queueSteer: string
+    steerImagesUnsupportedTitle: string
+    steerImagesUnsupported: string
     queueDelete: string
     queueResume: string
     queueResumeTip: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2023,6 +2023,8 @@ export const zhHant = defineLocale({
     queueEdit: '編輯',
     queueSendNext: '下一個',
     queueSteer: '引導 — 立即修正目前回合',
+    steerImagesUnsupportedTitle: '目前執行階段無法用圖片引導',
+    steerImagesUnsupported: '圖片無法引導此執行階段；已排隊到下一回合',
     queueSend: '傳送',
     queueDelete: '刪除',
     queueResume: '繼續',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2597,6 +2597,8 @@ export const zh: Translations = {
     queueEdit: '编辑',
     queueSendNext: '下一个',
     queueSteer: '引导 — 立即修正当前回合',
+    steerImagesUnsupportedTitle: '当前运行时无法用图片引导',
+    steerImagesUnsupported: '图片无法引导此运行时；已排队到下一回合',
     queueSend: '发送',
     queueDelete: '删除',
     queueResume: '继续',

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -9,6 +9,7 @@ import {
   enqueueQueuedPrompt,
   getQueuedPrompts,
   isQueueParked,
+  isSteerableEntry,
   migrateQueuedPrompts,
   parkQueuedPrompts,
   promoteQueuedPrompt,
@@ -258,5 +259,28 @@ describe('parked queue sessions', () => {
     migrateQueuedPrompts('rt-old', 'rt-new')
 
     expect(isQueueParked('rt-new')).toBe(false)
+  })
+
+  it('treats text and image attachments as steerable, files as not', () => {
+    expect(isSteerableEntry({ text: 'nudge', attachments: [] })).toBe(true)
+    expect(
+      isSteerableEntry({
+        text: 'look',
+        attachments: [attachment('shot', 'image')]
+      })
+    ).toBe(true)
+    expect(
+      isSteerableEntry({
+        text: '',
+        attachments: [attachment('shot', 'image')]
+      })
+    ).toBe(true)
+    expect(
+      isSteerableEntry({
+        text: 'open this',
+        attachments: [attachment('doc', 'file')]
+      })
+    ).toBe(false)
+    expect(isSteerableEntry({ text: '/status', attachments: [] })).toBe(false)
   })
 })

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -15,13 +15,24 @@ export interface QueuedPromptEntry {
   queuedAt: number
 }
 
-/** Whether a queued entry can ride a mid-turn redirect: text-only, non-empty,
- *  not a slash command — the same gate `steerDraft` applies to the live draft
- *  (attachments can't ride a redirect; slash commands execute, not steer). */
+export const isImageOnlyAttachmentSet = (
+  attachments: readonly Pick<ComposerAttachment, 'kind'>[]
+): boolean => attachments.every(attachment => attachment.kind === 'image')
+
+/** Whether a queued entry can ride a mid-turn redirect: non-slash text and/or
+ *  images. Non-image attachments still queue — they cannot ride redirect. */
 export const isSteerableEntry = (entry: Pick<QueuedPromptEntry, 'attachments' | 'text'>): boolean => {
   const text = entry.text.trim()
 
-  return Boolean(text) && entry.attachments.length === 0 && !SLASH_COMMAND_RE.test(text)
+  if (SLASH_COMMAND_RE.test(text)) {
+    return false
+  }
+
+  if (!isImageOnlyAttachmentSet(entry.attachments)) {
+    return false
+  }
+
+  return Boolean(text) || entry.attachments.length > 0
 }
 
 type QueueState = Record<string, QueuedPromptEntry[]>

--- a/run_agent.py
+++ b/run_agent.py
@@ -3355,6 +3355,7 @@ class AIAgent:
                 if hard_cancel:
                     _admit_hard_cancel()
                 self._pending_redirect = None
+                self._pending_redirect_images = []
         else:
             self._interrupt_requested = True
             self._interrupt_message = message
@@ -3362,6 +3363,7 @@ class AIAgent:
             if hard_cancel:
                 _admit_hard_cancel()
             self._pending_redirect = None
+            self._pending_redirect_images = []
 
         # Codex app-server owns its model/tool loop and watches a private
         # interrupt event rather than Hermes' per-thread flag.
@@ -3471,7 +3473,7 @@ class AIAgent:
         _redirect_lock = getattr(self, "_pending_redirect_lock", None)
         if _redirect_lock is not None:
             with _redirect_lock:
-                if preserve_redirect and not self._pending_redirect:
+                if preserve_redirect and not self._has_pending_redirect_unlocked():
                     return False
                 self._interrupt_requested = False
                 self._interrupt_message = None
@@ -3479,8 +3481,9 @@ class AIAgent:
                 getattr(self, "_hard_interrupt_requested", threading.Event()).clear()
                 if not preserve_redirect:
                     self._pending_redirect = None
+                    self._pending_redirect_images = []
         else:
-            if preserve_redirect and not getattr(self, "_pending_redirect", None):
+            if preserve_redirect and not self._has_pending_redirect_unlocked():
                 return False
             self._interrupt_requested = False
             self._interrupt_message = None
@@ -3488,6 +3491,7 @@ class AIAgent:
             getattr(self, "_hard_interrupt_requested", threading.Event()).clear()
             if not preserve_redirect:
                 self._pending_redirect = None
+                self._pending_redirect_images = []
         self._interrupt_thread_signal_pending = False
         if self._execution_thread_id is not None:
             _set_interrupt(False, self._execution_thread_id)
@@ -3518,7 +3522,7 @@ class AIAgent:
                 self._pending_steer = None
         return True
 
-    def steer(self, text: str) -> bool:
+    def steer(self, text: str, image_paths: Optional[List[str]] = None) -> bool:
         """
         Inject a user message into the next tool result without interrupting.
 
@@ -3527,18 +3531,31 @@ class AIAgent:
         result's content once the current tool batch finishes. The model
         sees the steer as part of the tool output on its next iteration.
 
+        Images cannot ride a tool-result string. They are stashed as a
+        pending redirect (no interrupt) and applied as a multimodal user
+        correction at the next role-safe loop boundary.
+
         Thread-safe: callable from gateway/CLI/TUI threads. Multiple calls
         before the drain point concatenate with newlines.
 
         Args:
-            text: The user text to inject. Empty strings are ignored.
+            text: The user text to inject. Empty strings are ignored unless
+                ``image_paths`` are present.
+            image_paths: Optional local image paths to deliver with the steer.
 
         Returns:
-            True if the steer was accepted, False if the text was empty.
+            True if the steer was accepted, False if the payload was empty.
         """
-        if not text or not text.strip():
+        from agent.steer_media import normalize_image_paths, supports_image_redirect
+
+        paths = normalize_image_paths(image_paths)
+        cleaned = (text or "").strip()
+        if not cleaned and not paths:
             return False
-        cleaned = text.strip()
+        if paths:
+            if not supports_image_redirect(self):
+                return False
+            return self._stash_pending_redirect(cleaned, paths, interrupt=False)
         _lock = getattr(self, "_pending_steer_lock", None)
         if _lock is None:
             # Test stubs that built AIAgent via object.__new__ skip __init__.
@@ -3554,7 +3571,7 @@ class AIAgent:
                 self._pending_steer = cleaned
         return True
 
-    def redirect(self, text: str) -> bool:
+    def redirect(self, text: str, image_paths: Optional[List[str]] = None) -> bool:
         """Redirect the active turn without converting it into a new task.
 
         During a normal Hermes model request this cancels only that request;
@@ -3563,18 +3580,22 @@ class AIAgent:
         correction as a real user message, and retries. During tool execution
         it degrades to ``steer()`` so the tool can finish at a safe boundary.
         Codex app-server has a native ``turn/steer`` operation and uses it
-        directly instead of cancelling.
+        directly instead of cancelling. Images are rejected on Codex so the
+        gateway can queue a lossless next-turn fallback.
 
-        Returns ``False`` when there is no live turn or the text is empty, so
+        Returns ``False`` when there is no live turn or the payload is empty, so
         surfaces can fall back to their existing next-turn queue.
         """
-        if not text or not text.strip():
-            return False
-        cleaned = text.strip()
+        from agent.steer_media import normalize_image_paths, supports_image_redirect
 
-        # Codex owns its internal reasoning/tool loop, so use its first-class
-        # active-turn steering protocol rather than interrupting the subprocess.
+        paths = normalize_image_paths(image_paths)
+        cleaned = (text or "").strip()
+        if not cleaned and not paths:
+            return False
+
         if getattr(self, "api_mode", None) == "codex_app_server":
+            if paths or not supports_image_redirect(self):
+                return False
             _codex_session = getattr(self, "_codex_session", None)
             _native_steer = getattr(_codex_session, "request_steer", None)
             if callable(_native_steer):
@@ -3591,44 +3612,17 @@ class AIAgent:
                     logger.debug("Codex app-server turn/steer failed", exc_info=True)
                     return False
 
-        # Never kill a tool merely to deliver conversational guidance. The
-        # existing steer drain puts it on the final tool result before the next
-        # model decision, including delegate_task children.
+        # Never kill a tool merely to deliver conversational guidance.
         if getattr(self, "_executing_tools", False):
+            if paths:
+                return self._stash_pending_redirect(cleaned, paths, interrupt=False)
             return self.steer(cleaned)
 
         _model_active = getattr(self, "_model_request_active", None)
-        _redirect_lock = getattr(self, "_pending_redirect_lock", None)
-        if _redirect_lock is None:
-            if _model_active is None or not _model_active.is_set():
-                return False
-            existing = getattr(self, "_pending_redirect", None)
-            if self._interrupt_requested and not existing:
-                return False
-            self._pending_redirect = (
-                f"{existing}\n\n[Additional user correction]\n{cleaned}"
-                if existing
-                else cleaned
-            )
-            self._interrupt_requested = True
-            self._interrupt_message = None
-        else:
-            with _redirect_lock:
-                if _model_active is None or not _model_active.is_set():
-                    # The response completed before we acquired the state lock.
-                    # Reject so the surface queues a new turn.
-                    return False
-                if self._interrupt_requested and not self._pending_redirect:
-                    return False
-                if self._pending_redirect:
-                    self._pending_redirect = (
-                        f"{self._pending_redirect}\n\n"
-                        f"[Additional user correction]\n{cleaned}"
-                    )
-                else:
-                    self._pending_redirect = cleaned
-                self._interrupt_requested = True
-                self._interrupt_message = None
+        if _model_active is None or not _model_active.is_set():
+            return False
+        if not self._stash_pending_redirect(cleaned, paths, interrupt=True):
+            return False
 
         # Interrupt only the model request. Do not fan out to tool workers or
         # child agents as interrupt() does.
@@ -3646,24 +3640,79 @@ class AIAgent:
                 logger.debug("Failed to abort request for redirect", exc_info=True)
         return True
 
+    def _stash_pending_redirect(
+        self,
+        text: str,
+        image_paths: Optional[List[str]] = None,
+        *,
+        interrupt: bool = True,
+    ) -> bool:
+        """Store a pending redirect/steer payload. Optionally request interrupt."""
+        from agent.steer_media import merge_redirect_text, normalize_image_paths
+
+        cleaned = (text or "").strip()
+        paths = normalize_image_paths(image_paths)
+        if not cleaned and not paths:
+            return False
+
+        def _apply() -> bool:
+            if interrupt:
+                _model_active = getattr(self, "_model_request_active", None)
+                if _model_active is None or not _model_active.is_set():
+                    return False
+                if self._interrupt_requested and not self._has_pending_redirect_unlocked():
+                    return False
+            existing = getattr(self, "_pending_redirect", None)
+            if cleaned:
+                self._pending_redirect = merge_redirect_text(existing, cleaned)
+            existing_imgs = list(getattr(self, "_pending_redirect_images", None) or [])
+            for path in paths:
+                if path not in existing_imgs:
+                    existing_imgs.append(path)
+            self._pending_redirect_images = existing_imgs
+            if interrupt:
+                self._interrupt_requested = True
+                self._interrupt_message = None
+            return True
+
+        _redirect_lock = getattr(self, "_pending_redirect_lock", None)
+        if _redirect_lock is None:
+            return _apply()
+        with _redirect_lock:
+            return _apply()
+
+    def _has_pending_redirect_unlocked(self) -> bool:
+        return bool(getattr(self, "_pending_redirect", None)) or bool(
+            getattr(self, "_pending_redirect_images", None)
+        )
+
     def _has_pending_redirect(self) -> bool:
         """Return whether an active-turn redirect is waiting to be applied."""
         _redirect_lock = getattr(self, "_pending_redirect_lock", None)
         if _redirect_lock is None:
-            return bool(getattr(self, "_pending_redirect", None))
+            return self._has_pending_redirect_unlocked()
         with _redirect_lock:
-            return bool(self._pending_redirect)
+            return self._has_pending_redirect_unlocked()
 
-    def _drain_pending_redirect(self) -> Optional[str]:
-        """Return and clear pending active-turn correction text."""
+    def _drain_pending_redirect_payload(self) -> tuple:
+        """Return and clear pending redirect text plus image paths."""
         _redirect_lock = getattr(self, "_pending_redirect_lock", None)
         if _redirect_lock is None:
             text = getattr(self, "_pending_redirect", None)
+            images = list(getattr(self, "_pending_redirect_images", None) or [])
             self._pending_redirect = None
-            return text
+            self._pending_redirect_images = []
+            return text, images
         with _redirect_lock:
             text = self._pending_redirect
+            images = list(getattr(self, "_pending_redirect_images", None) or [])
             self._pending_redirect = None
+            self._pending_redirect_images = []
+        return text, images
+
+    def _drain_pending_redirect(self) -> Optional[str]:
+        """Return and clear pending active-turn correction text."""
+        text, _images = self._drain_pending_redirect_payload()
         return text
 
     def _drain_pending_steer(self) -> Optional[str]:

--- a/tests/agent/test_steer_media.py
+++ b/tests/agent/test_steer_media.py
@@ -1,0 +1,36 @@
+from agent.steer_media import (
+    normalize_image_paths,
+    persist_image_correction_text,
+    supports_image_redirect,
+    text_mode_image_correction,
+)
+
+
+def test_normalize_image_paths_drops_missing(tmp_path):
+    real = tmp_path / "ok.png"
+    real.write_bytes(b"x")
+    assert normalize_image_paths([str(real), str(tmp_path / "gone.png"), "", str(real)]) == [
+        str(real)
+    ]
+
+
+def test_persist_and_text_mode_include_caption(tmp_path):
+    shot = tmp_path / "shot.png"
+    shot.write_bytes(b"x")
+    persist = persist_image_correction_text("see the error", [str(shot)])
+    assert persist.startswith("see the error")
+    assert "@image:" in persist
+    text_mode = text_mode_image_correction("see the error", [str(shot)])
+    assert "vision_analyze" in text_mode
+    assert "see the error" in text_mode
+
+
+def test_codex_does_not_support_image_redirect():
+    class _A:
+        api_mode = "codex_app_server"
+
+    class _B:
+        api_mode = "chat_completions"
+
+    assert supports_image_redirect(_A()) is False
+    assert supports_image_redirect(_B()) is True

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -24,6 +24,7 @@ def _bare_agent() -> AIAgent:
     agent._pending_steer = None
     agent._pending_steer_lock = threading.Lock()
     agent._pending_redirect = None
+    agent._pending_redirect_images = []
     agent._pending_redirect_lock = threading.Lock()
     agent._model_request_active = threading.Event()
     agent._executing_tools = False
@@ -847,3 +848,56 @@ class TestLegacyHiddenPlaceholderWireSubstitution:
         wire = agent.client.chat.completions.create.call_args.kwargs["messages"]
         wire_assistants = [m for m in wire if m.get("role") == "assistant"]
         assert wire_assistants[0]["content"] == "visible text"
+
+
+class TestMultimodalRedirect:
+    def test_text_only_steer_unchanged(self):
+        agent = _bare_agent()
+        assert agent.steer("keep going") is True
+        assert agent._pending_steer == "keep going"
+        assert agent._pending_redirect is None
+
+    def test_image_steer_during_tools_does_not_interrupt(self, tmp_path):
+        shot = tmp_path / "ui.png"
+        shot.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        agent = _bare_agent()
+        agent._executing_tools = True
+
+        assert agent.redirect("look at this", image_paths=[str(shot)]) is True
+        assert agent._interrupt_requested is False
+        assert agent._pending_steer is None
+        assert agent._pending_redirect == "look at this"
+        assert agent._pending_redirect_images == [str(shot)]
+
+    def test_codex_rejects_image_redirect(self, tmp_path):
+        shot = tmp_path / "ui.png"
+        shot.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        agent = _bare_agent()
+        agent.api_mode = "codex_app_server"
+        agent._model_request_active.set()
+
+        assert agent.redirect("look at this", image_paths=[str(shot)]) is False
+        assert agent._pending_redirect is None
+
+    def test_apply_redirect_persists_image_ref(self, tmp_path):
+        from agent.conversation_loop import _apply_active_turn_redirect
+
+        shot = tmp_path / "diagram.png"
+        shot.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        agent = _bare_agent()
+        agent._current_streamed_assistant_text = ""
+        messages = [
+            {"role": "user", "content": "start"},
+            {"role": "tool", "content": "done", "tool_call_id": "1"},
+        ]
+
+        _apply_active_turn_redirect(
+            agent, messages, "fix this", image_paths=[str(shot)]
+        )
+
+        assert messages[-1]["role"] == "user"
+        assert "@image:" in messages[-1]["content"]
+        assert "fix this" in messages[-1]["content"]
+        replayed = messages[-1]["api_content"]
+        replay_text = replayed if isinstance(replayed, str) else str(replayed)
+        assert "vision_analyze" in replay_text or "image_url" in replay_text

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11581,6 +11581,74 @@ def test_session_redirect_calls_capable_core_agent(monkeypatch):
     assert before is None or session["last_active"] >= before
 
 
+def test_session_redirect_accepts_image_paths_and_records_refs(tmp_path):
+    shot = tmp_path / "ui.png"
+    shot.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+    calls = []
+
+    def _redirect(text, image_paths=None):
+        calls.append((text, list(image_paths or [])))
+        return True
+
+    agent = types.SimpleNamespace(
+        _supports_active_turn_redirect=True,
+        api_mode="chat_completions",
+        redirect=_redirect,
+    )
+    session = _session(agent=agent)
+    session["inflight_turn"] = {"user": "original request", "assistant": ""}
+    server._sessions["sid"] = session
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.redirect",
+                "params": {
+                    "session_id": "sid",
+                    "text": "look here",
+                    "image_paths": [str(shot)],
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp["result"]["status"] == "redirected"
+    assert "@image:" in resp["result"]["text"]
+    assert calls == [("look here", [str(shot)])]
+    assert any("@image:" in item for item in session["inflight_turn"]["corrections"])
+
+
+def test_session_redirect_queues_images_on_codex():
+    agent = types.SimpleNamespace(
+        _supports_active_turn_redirect=True,
+        api_mode="codex_app_server",
+        redirect=lambda text, image_paths=None: True,
+    )
+    session = _session(agent=agent, running=True)
+    session["inflight_turn"] = {"user": "original request", "assistant": ""}
+    server._sessions["sid"] = session
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.redirect",
+                "params": {
+                    "session_id": "sid",
+                    "text": "look here",
+                    "image_paths": ["/tmp/does-not-need-to-exist.png"],
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp["result"]["status"] == "queued"
+    assert resp["result"]["reason"] == "images_unsupported"
+    queued = session.get("queued_prompt") or {}
+    assert queued.get("image_paths") == ["/tmp/does-not-need-to-exist.png"]
+
+
 def test_session_redirect_rpc_drops_queued_duplicate_of_inflight_user():
     """#84417: Desktop ``session.redirect`` must purge stale self-duplicates.
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3558,75 +3558,102 @@ def _(rid, params: dict) -> dict:
     Mirrors AIAgent.steer(). Safe to call while a turn is running — the text
     lands on the last tool result of the next tool batch and the model sees
     it on its next iteration. No interrupt, no new user turn, no role
-    alternation violation.
+    alternation violation. Image paths ride the same payload as redirect
+    and land as a multimodal user correction at the next loop boundary.
     """
+    from agent.steer_media import (
+        call_redirect_like,
+        parse_redirect_image_paths,
+        persist_image_correction_text,
+        supports_image_redirect,
+    )
+
     text = (params.get("text") or "").strip()
-    if not text:
-        return _err(rid, 4002, "text is required")
+    image_paths = parse_redirect_image_paths(params)
+    if not text and not image_paths:
+        return _err(rid, 4002, "text or image_paths is required")
     session, err = _sess_nowait(params, rid)
     if err:
         return err
     agent = session.get("agent")
     if agent is None or not hasattr(agent, "steer"):
         return _err(rid, 4010, "agent does not support steer")
+    display = persist_image_correction_text(text, image_paths) if image_paths else text
+    if image_paths:
+        if not supports_image_redirect(agent):
+            _enqueue_prompt(
+                session, text, current_transport() or _stdio_transport, image_paths=image_paths
+            )
+            session["last_active"] = time.time()
+            return _ok(
+                rid,
+                {"status": "queued", "text": display, "reason": "images_unsupported"},
+            )
     try:
-        accepted = agent.steer(text)
+        accepted = call_redirect_like(agent.steer, text, image_paths)
     except Exception as exc:
         return _err(rid, 5000, f"steer failed: {exc}")
     if accepted:
-        # Record the correction on the live turn exactly like session.redirect
-        # does. Without this, a resume/reconnect while the turn is running
-        # rebuilds the transcript from the inflight snapshot and the steered
-        # text has no user bubble — the "my message vanished on reload" loss.
         with session["history_lock"]:
-            _record_inflight_correction(session, text)
-            # #84417: steer does not cancel the live original, but a server
-            # queue self-copy of that original must still not re-fire after
-            # settle (same class as redirect).
+            _record_inflight_correction(session, display)
             _drop_queued_duplicates_of_inflight_user(session)
             session["last_active"] = time.time()
-    return _ok(rid, {"status": "queued" if accepted else "rejected", "text": text})
+    return _ok(rid, {"status": "queued" if accepted else "rejected", "text": display})
 
 
 @method("session.redirect")
 def _(rid, params: dict) -> dict:
     """Redirect the active model turn while preserving valid work/context."""
+    from agent.steer_media import (
+        call_redirect_like,
+        parse_redirect_image_paths,
+        persist_image_correction_text,
+        supports_image_redirect,
+    )
+
     text = (params.get("text") or "").strip()
-    if not text:
-        return _err(rid, 4002, "text is required")
+    image_paths = parse_redirect_image_paths(params)
+    if not text and not image_paths:
+        return _err(rid, 4002, "text or image_paths is required")
     session, err = _sess_nowait(params, rid)
     if err:
         return err
     agent = session.get("agent")
-    # Turn-build window: a fresh turn flips running=True and kicks off an async
-    # agent build, so session["agent"] is briefly None. That is not an
-    # unsupported runtime — queue the correction server-side so it reaches the
-    # model as the next turn, instead of a misleading 4010 the client silently
-    # swallows into a lost follow-up.
+    display = persist_image_correction_text(text, image_paths) if image_paths else text
     if agent is None and session.get("running"):
-        _enqueue_prompt(session, text, current_transport() or _stdio_transport)
+        _enqueue_prompt(
+            session, text, current_transport() or _stdio_transport, image_paths=image_paths
+        )
         session["last_active"] = time.time()
-        return _ok(rid, {"status": "queued", "text": text})
+        return _ok(rid, {"status": "queued", "text": display})
     if (
         agent is None
         or getattr(agent, "_supports_active_turn_redirect", False) is not True
         or not hasattr(agent, "redirect")
     ):
         return _err(rid, 4010, "agent does not support active-turn redirect")
+    if image_paths:
+        if not supports_image_redirect(agent):
+            _enqueue_prompt(
+                session, text, current_transport() or _stdio_transport, image_paths=image_paths
+            )
+            session["last_active"] = time.time()
+            return _ok(
+                rid,
+                {"status": "queued", "text": display, "reason": "images_unsupported"},
+            )
     try:
-        accepted = agent.redirect(text)
+        accepted = call_redirect_like(agent.redirect, text, image_paths)
     except Exception as exc:
         return _err(rid, 5000, f"redirect failed: {exc}")
     if accepted:
         with session["history_lock"]:
-            _record_inflight_correction(session, text)
-            # #84417: purge server-queue self-duplicates of the live original
-            # so post-turn drain cannot restart the pre-correction prompt.
+            _record_inflight_correction(session, display)
             _drop_queued_duplicates_of_inflight_user(session)
             session["last_active"] = time.time()
     return _ok(
         rid,
-        {"status": "redirected" if accepted else "rejected", "text": text},
+        {"status": "redirected" if accepted else "rejected", "text": display},
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Desktop live-turn Steer currently accepts text only. If you attach a screenshot while the agent is busy, the composer queues it as the next turn instead of delivering it into the active run. That loses the point of Steer: the agent already has the current tools and context, but not the visual evidence.

This PR lets a busy Desktop draft carry text plus image attachments as a steer/redirect. Images are staged through the existing upload path, sent on `session.redirect` / `session.steer` as `image_paths`, and applied at the next role-safe loop boundary as a normal multimodal user correction. Text-only steer is unchanged: it still appends to the last tool result and does not interrupt the current tool. If the runtime cannot accept an image steer, the payload is queued for the next turn with an explicit status and a Desktop toast.

## Related Issue

Fixes #96759

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx` and `use-composer-submit.ts`: Steer is allowed when attachments are images (not only when the draft is text-only).
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts`: upload attachments, then call `session.redirect` with `image_paths`.
- `apps/desktop/src/store/composer-queue.ts`: queue-panel steer accepts image attachments; files still cannot steer.
- `apps/desktop/src/i18n/en.ts` (and ar/ja/zh/zh-hant): toast when images cannot steer the current runtime.
- `tui_gateway/methods_session.py`: `session.steer` and `session.redirect` accept `image_paths`; unsupported runtimes enqueue with `reason: images_unsupported`.
- `agent/steer_media.py`: path normalize, persist `@image:` display text, native/text-mode model payload.
- `run_agent.py`: `steer` / `redirect` take optional `image_paths`; during tools, images are stashed without interrupting.
- `agent/conversation_loop.py`: drain pending image paths and append one multimodal user correction.
- Tests: `tests/agent/test_steer_media.py`, `tests/run_agent/test_steer.py`, `tests/test_tui_gateway_server.py`, `apps/desktop/src/store/composer-queue.test.ts`.

## How to Test

1. Start Hermes Desktop against this tree, begin a turn that stays busy (a long tool or a slow model call), attach a screenshot plus a short caption, and send Steer. The draft should leave the composer as a steer, not as a queued next prompt.
2. Confirm the running turn is not force-stopped just to deliver the image. After the current tool batch (or after the in-flight model request is cancelled for a mid-generation redirect), the agent’s next decision should see the image. The transcript should show one user correction with an `@image:` attachment, not a duplicate bubble.
3. Text-only Steer on a busy turn should still inject into the tool-result path and must not interrupt the current tool.
4. On a runtime that cannot take image steer, send a screenshot Steer and confirm the UI reports that images were queued for the next turn and the files are still on that queued prompt.
5. Targeted tests:
   `scripts/run_tests.sh tests/run_agent/test_steer.py tests/agent/test_steer_media.py tests/test_tui_gateway_server.py -k "steer or redirect or image_paths or Multimodal" -q`
   From `apps/desktop`: `npx vitest run src/store/composer-queue.test.ts`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
scripts/run_tests.sh tests/run_agent/test_steer.py tests/agent/test_steer_media.py \
  tests/test_tui_gateway_server.py -k "steer or redirect or image_paths or Multimodal" -q
# 54 passed

npx vitest run src/store/composer-queue.test.ts
# Test Files  1 passed (1)
# Tests  24 passed (24)

POST https://openrouter.ai/api/v1/chat/completions
# model=openai/gpt-4o-mini  HTTP 200
# reply: Crimson
```