### PR TITLE
fix(desktop): make HUD a solid themed card, not a see-through overlay

### DIFF
--- a/apps/desktop/src/app/hud/glass.test.tsx
+++ b/apps/desktop/src/app/hud/glass.test.tsx
@@ -33,10 +33,9 @@ afterEach(() => {
 Object.assign(window, { hermesDesktop: { hud: { setFrost } } })
 
 describe('useHudGlass', () => {
-  // The bug this replaced: the caller widened the gate to "recent or held", so
-  // a turn merely running raised the window's material while the scrim that is
-  // supposed to be painted over it — focus-gated in styles.css — stayed down.
-  // On a light theme that is a white slab under the band's white ink.
+  // Frost stays focus-only even though the CSS sheet also paints on
+  // `data-hud-recent`. Native vibrancy under unfocused streaming is what
+  // washed HUD text into the desktop; the opaque card does not need it.
   it('leaves the window bare while a turn runs with the composer unfocused', () => {
     render(<Harness backing />)
 

--- a/apps/desktop/src/app/hud/glass.ts
+++ b/apps/desktop/src/app/hud/glass.ts
@@ -28,13 +28,13 @@ const DRAWER_SELECTOR = '[data-slot="composer-completion-drawer"]'
  * untinted frost on screen — a grey blurred rectangle that pops out at the end
  * instead of a band fading away.
  *
- * Engaged means the caret is in the composer, and it is the SAME gate the
- * `[data-hud-glass]` scrim runs on — the frost is what that scrim is painted
- * over, so a frost the scrim doesn't cover is bare material. The caller used
- * to widen this to "recent or held", which put the window's material up for
- * the whole of a turn while the scrim stayed down: on a light theme that is a
- * white slab under the band's unconditionally white ink, and there is nothing
- * to read. One gate, or the two drift again.
+ * Engaged means the caret is in the composer. Native frost stays on that
+ * gate even though the CSS sheet also paints while `data-hud-recent` is set:
+ * the sheet is opaque theme paper now, so unfocused streaming does not need
+ * vibrancy. Raising frost without the user sitting down in the composer is
+ * what washed unfocused HUD text into the desktop. The caller used to widen
+ * frost to "recent or held", which put the window's material up for the whole
+ * of a turn. Frost stays focus-only.
  *
  * Merely holding window focus does not count: activating a window restores
  * focus to whatever had it last, so grabbing the bar to drag the HUD would

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -153,8 +153,8 @@ function useRecentActivity(): [boolean, () => void] {
  *
  * Pinning on busy was deliberately avoided while the band brought its tinted
  * sheet up with it — that put an opaque panel across the screen for as long as
- * the agent worked. The sheet is a translucent scrim now, so a held band is
- * legible text rather than a slab.
+ * the agent worked. The sheet is the HUD's own card now, so a held band is
+ * readable theme text on paper rather than overlay ink on someone else's UI.
  */
 function useHudHeld(gameUnder: boolean): boolean {
   const awaiting = useStore($activeSessionAwaitingInput)

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -149,12 +149,15 @@ function useRecentActivity(): [boolean, () => void] {
  *   chat frame, and a chat frame that erases itself a second after each line is
  *   useless: you look back at it when there is a lull in the game, not when the
  *   text happens to be fresh. This is what every in-game chat log does, and it
- *   costs nothing here because the band over a game is bare text with no panel.
+ *   costs nothing here because the band over a game is overlay text: the CSS
+ *   sheet stays down until the composer is focused, and then it is a
+ *   translucent scrim rather than the desktop HUD's opaque card.
  *
  * Pinning on busy was deliberately avoided while the band brought its tinted
  * sheet up with it — that put an opaque panel across the screen for as long as
- * the agent worked. The sheet is the HUD's own card now, so a held band is
- * readable theme text on paper rather than overlay ink on someone else's UI.
+ * the agent worked. On the desktop HUD the sheet is the window's own card, so
+ * a held band is readable theme text on paper rather than overlay ink on
+ * someone else's UI. Over a game, hold still means overlay text, not a card.
  */
 function useHudHeld(gameUnder: boolean): boolean {
   const awaiting = useStore($activeSessionAwaitingInput)

--- a/apps/desktop/src/app/hud/styles-contract.test.ts
+++ b/apps/desktop/src/app/hud/styles-contract.test.ts
@@ -68,10 +68,14 @@ describe('HUD sheet CSS contract', () => {
   it('shows the sheet while a turn is recent, not only while the composer is focused', () => {
     // The bug: composer-bounds rose on data-hud-recent, but the glass stayed
     // at opacity 0 until :focus. White overlay ink then sat on the desktop.
-    const recent = of('[data-hud-shell][data-hud-recent] [data-hud-glass]')
+    // Games are excluded — they pin data-hud-recent for the whole overlay
+    // session, and a sheet that followed recent would cover the action.
+    const recent = of('[data-hud-shell][data-hud-recent]:not([data-hud-game]) [data-hud-glass]')
+    const gameRecent = of('[data-hud-shell][data-hud-game][data-hud-recent] [data-hud-glass]')
 
     expect(recent.opacity).toBe('1')
     expect(recent.translate).toBe('none')
+    expect(gameRecent.opacity ?? '').not.toBe('1')
   })
 
   it('paints the resting sheet as opaque theme paper, not a translucent scrim', () => {
@@ -82,8 +86,10 @@ describe('HUD sheet CSS contract', () => {
   })
 
   it('keeps focusing from punching a hole back through to the desktop', () => {
-    const focused = of("[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass]")
-    const recent = of('[data-hud-shell][data-hud-recent] [data-hud-glass]')
+    const focused = of(
+      "[data-hud-shell]:not([data-hud-game]):has([data-slot='composer-rich-input']:focus) [data-hud-glass]"
+    )
+    const recent = of('[data-hud-shell][data-hud-recent]:not([data-hud-game]) [data-hud-glass]')
 
     expect(focused.background).toBe('var(--ui-bg-elevated)')
     expect(recent.background).toBe('var(--ui-bg-elevated)')
@@ -118,9 +124,23 @@ describe('HUD sheet CSS contract', () => {
     expect(gameDescendants.color).toContain('!important')
   })
 
-  it('keeps a translucent scrim only over a game', () => {
-    const gameGlass = of('[data-hud-shell][data-hud-game] [data-hud-glass]')
+  it('keeps a translucent scrim over a game, including Glass-on and focus', () => {
+    // The (0,3,0) game-only rule lost to later opaque-paper rules
+    // (focus :has is (0,4,0); glass-on resting is (0,4,0); glass-on +
+    // recent/focus is higher). Overlay ink is #fff, so those losses put
+    // white text on --ui-bg-elevated.
+    const scrim = /rgb\(12 14 18\s*\/\s*0\.\d+\)/
+    const gameStates = [
+      '[data-hud-shell][data-hud-game] [data-hud-glass]',
+      '[data-hud-shell][data-hud-game][data-hud-recent] [data-hud-glass]',
+      "[data-hud-shell][data-hud-game]:has([data-slot='composer-rich-input']:focus) [data-hud-glass]",
+      ':root[data-hermes-glass-on] [data-hud-shell][data-hud-game] [data-hud-glass]',
+      ':root[data-hermes-glass-on] [data-hud-shell][data-hud-game][data-hud-recent] [data-hud-glass]',
+      ":root[data-hermes-glass-on] [data-hud-shell][data-hud-game]:has([data-slot='composer-rich-input']:focus) [data-hud-glass]"
+    ]
 
-    expect(gameGlass.background).toMatch(/rgb\(12 14 18\s*\/\s*0\.\d+\)/)
+    for (const selector of gameStates) {
+      expect(of(selector).background, selector).toMatch(scrim)
+    }
   })
 })

--- a/apps/desktop/src/app/hud/styles-contract.test.ts
+++ b/apps/desktop/src/app/hud/styles-contract.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const css = readFileSync(resolve(process.cwd(), 'src/styles.css'), 'utf8')
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
+function normalizeSelector(selector: string): string {
+  return selector.trim().replace(/\s+/g, ' ')
+}
+
+/** Last-write-wins map of selector → concatenated declaration bodies. */
+function ruleBodies(source: string): Map<string, string> {
+  const bodies = new Map<string, string>()
+  const re = /([^{}]+)\{([^{}]*)\}/g
+  let match: RegExpExecArray | null
+
+  while ((match = re.exec(stripComments(source)))) {
+    const body = match[2].trim()
+
+    for (const selector of match[1].split(',').map(normalizeSelector)) {
+      if (!selector) {
+        continue
+      }
+
+      const previous = bodies.get(selector)
+
+      bodies.set(selector, previous ? `${previous}; ${body}` : body)
+    }
+  }
+
+  return bodies
+}
+
+function declarations(body: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {}
+
+  if (!body) {
+    return out
+  }
+
+  for (const part of body.split(';')) {
+    const index = part.indexOf(':')
+
+    if (index < 0) {
+      continue
+    }
+
+    const property = part.slice(0, index).trim()
+    const value = part.slice(index + 1).trim()
+
+    if (property) {
+      out[property] = value
+    }
+  }
+
+  return out
+}
+
+const rules = ruleBodies(css)
+const of = (selector: string) => declarations(rules.get(normalizeSelector(selector)))
+
+describe('HUD sheet CSS contract', () => {
+  it('shows the sheet while a turn is recent, not only while the composer is focused', () => {
+    // The bug: composer-bounds rose on data-hud-recent, but the glass stayed
+    // at opacity 0 until :focus. White overlay ink then sat on the desktop.
+    const recent = of('[data-hud-shell][data-hud-recent] [data-hud-glass]')
+
+    expect(recent.opacity).toBe('1')
+    expect(recent.translate).toBe('none')
+  })
+
+  it('paints the resting sheet as opaque theme paper, not a translucent scrim', () => {
+    const glass = of('[data-hud-shell] [data-hud-glass]')
+
+    expect(glass.background).toBe('var(--ui-bg-elevated)')
+    expect(glass.background).not.toMatch(/\/\s*0\.\d+/)
+  })
+
+  it('keeps focusing from punching a hole back through to the desktop', () => {
+    const focused = of("[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass]")
+    const recent = of('[data-hud-shell][data-hud-recent] [data-hud-glass]')
+
+    expect(focused.background).toBe('var(--ui-bg-elevated)')
+    expect(recent.background).toBe('var(--ui-bg-elevated)')
+  })
+
+  it('fills the window below the bar instead of an inset, content-sized band', () => {
+    // Inset + --hud-band-height left gutters and a hole under the last line
+    // where the desktop (and whatever was behind the HUD) showed through.
+    const glass = of('[data-hud-shell] [data-hud-glass]')
+    const topEdge = of("[data-hud-shell][data-hud-edge='top'] [data-hud-glass]")
+
+    expect(glass.top).toBe('0')
+    expect(glass.right).toBe('0')
+    expect(glass.left).toBe('0')
+    expect(glass.height).toBe('auto')
+    expect(glass['border-radius']).toBe('0')
+    expect(glass.bottom).toBe('var(--hud-bar-height, var(--composer-fallback-height))')
+    expect(topEdge.bottom).toBe('0')
+    expect(css).not.toMatch(/\[data-hud-glass\][^{]*\{[^}]*--hud-band-height/)
+  })
+
+  it('uses theme ink on the card and keeps overlay ink for game overlay only', () => {
+    const bounds = of("[data-hud-shell] [data-slot='composer-bounds']")
+    const gameBounds = of("[data-hud-shell][data-hud-game] [data-slot='composer-bounds']")
+    const descendants = of("[data-hud-shell] [data-slot='composer-bounds'] *")
+    const gameDescendants = of("[data-hud-shell][data-hud-game] [data-slot='composer-bounds'] *")
+
+    expect(bounds.color).toBe('var(--ui-text-primary)')
+    expect(gameBounds.color).toBe('var(--hud-overlay-ink)')
+    expect(gameBounds['--hud-overlay-ink']).toBe('#fff')
+    expect(descendants.color ?? '').not.toContain('!important')
+    expect(gameDescendants.color).toContain('!important')
+  })
+
+  it('keeps a translucent scrim only over a game', () => {
+    const gameGlass = of('[data-hud-shell][data-hud-game] [data-hud-glass]')
+
+    expect(gameGlass.background).toMatch(/rgb\(12 14 18\s*\/\s*0\.\d+\)/)
+  })
+})

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2648,14 +2648,13 @@ button[data-slot='aui_msg-reactions'] svg {
 
      No fill of its own — the sheet is its own layer ([data-hud-glass]) so it
      can animate independently of the text. */
-  inset: auto var(--hud-band-inset) var(--hud-bar-height, var(--composer-fallback-height)) var(--hud-band-inset) !important;
-  height: var(--hud-band-height, 0px) !important;
+  inset: 0 0 var(--hud-bar-height, var(--composer-fallback-height)) 0 !important;
+  height: auto !important;
   width: auto !important;
   max-width: none !important;
   flex: none !important;
   border: 0 !important;
-  /* Rounded away from the bar, square where it meets it. */
-  border-radius: 0.75rem 0.75rem 0 0;
+  border-radius: 0;
   background: transparent !important;
   /* Three opacity states: gone at rest, half strength when a turn is recent or
      you've just let go of the composer (there to glance at, not to demand
@@ -2704,20 +2703,28 @@ button[data-slot='aui_msg-reactions'] svg {
    no blur to separate the band from what it lies over, the sheet is the only
    thing keeping half-opacity text off someone else's UI. Fade the words, keep
    the paper. */
-/* A DARK scrim, not the theme's card. The band's ink is white unconditionally
-   (see above), so the sheet it lands on has to be dark in every theme —
-   `--dt-card` is near-white on a light theme and would put white text on a white
-   panel. This is the overlay's own surface, the way a game's chat backdrop is
-   its own thing rather than a piece of the desktop UI. */
+/* Opaque theme paper, not a dark overlay scrim. Forced white ink on a 62%
+   dark sheet mixed with the desktop (and macOS vibrancy) is what washed
+   unfocused HUD text the wrong colour. Game overlay keeps the translucent
+   scrim below. */
 [data-hud-shell] [data-hud-glass] {
   position: absolute;
-  right: var(--hud-band-inset);
+  /* Flush to the window. An inset sheet left gutters of empty transparent
+     chrome — and because the window is taller than the message rows, a
+     content-sized band left a hole under the last line where the desktop
+     (and whatever serif headline sat there) showed through. The card is
+     the window below the bar. */
+  top: 0;
+  right: 0;
   bottom: var(--hud-bar-height, var(--composer-fallback-height));
-  left: var(--hud-band-inset);
+  left: 0;
   z-index: 0;
   pointer-events: none;
-  border-radius: 0.75rem 0.75rem 0 0;
-  background: rgb(12 14 18 / 0.62);
+  border-radius: 0;
+  /* Opaque theme paper. A 62% dark scrim mixed with the desktop behind it
+     and macOS's always-active vibrancy, which is why unfocused HUD text
+     came out the wrong colour — washed, grey-green, not the theme. */
+  background: var(--ui-bg-elevated);
   /* Slides down behind the bar as it fades. A TRANSFORM, not height: it is
      composited, so it stays smooth where animating height re-lays-out the panel
      every frame and looked coarse — and it leaves the box alone, which matters
@@ -2725,10 +2732,10 @@ button[data-slot='aui_msg-reactions'] svg {
      messages spilled out of a zero-height box. Translate rather than scale: the
      panel keeps its proportions on the way out instead of being squashed.
  
-     The height below still tracks the transcript; only the offset animates on
-     exit, and it finishes ahead of the fade so the panel has left while the last
-     of the text is still going. */
-  height: var(--hud-band-height, 0px);
+     Height is auto so the card fills to the bar instead of shrinking to the
+     message rows (that leftover hole showed the desktop under the last
+     line). Only the offset animates on exit. */
+  height: auto;
   translate: 0 var(--hud-exit-shift, 2.5rem);
   opacity: 0;
   transform-origin: bottom center;
@@ -2737,15 +2744,13 @@ button[data-slot='aui_msg-reactions'] svg {
     translate var(--hud-collapse) var(--hud-ease-exit),
     scale var(--hud-dim) var(--hud-ease-enter),
     filter var(--hud-dim) var(--hud-ease-enter),
-    height var(--hud-reveal) var(--hud-ease-enter),
     background-color var(--hud-dim) var(--hud-ease-enter);
 }
 
-/* The sheet is FOCUS-ONLY. A turn landing brings the text up (see
-   `composer-bounds` below) but must not paint a panel behind it: over a game
-   the tinted sheet is the thing that reads as a desktop window parked on the
-   action, and it is most of the HUD's rectangle. Streaming shows words on the
-   game; sitting down to read promotes the surface. */
+/* The sheet rides the band: visible while a turn is recent/held OR while the
+   composer has the caret. Focus-only left the text up (data-hud-recent) with
+   the paper gone — white overlay ink on whatever was behind the window. */
+[data-hud-shell][data-hud-recent] [data-hud-glass],
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
   translate: none;
   opacity: 1;
@@ -2762,10 +2767,9 @@ button[data-slot='aui_msg-reactions'] svg {
    transparent window that owns its own backgrounds (isChatWindow). Two flags,
    because the HUD wants the setting without the rewrite. */
 :root[data-hermes-glass-on] [data-hud-shell] [data-hud-glass] {
-  /* Same dark scrim under Glass. The docked thread's `--ui-bg-chrome` follows
-     the theme and goes near-white on a light one, which is the wrong paper for
-     this band's white ink — the HUD is over a game, not inside the app. */
-  background: rgb(12 14 18 / 0.55);
+  /* Same opaque theme paper under Glass. The previous 55% dark scrim plus
+     live vibrancy is what washed the unfocused HUD into the desktop. */
+  background: var(--ui-bg-elevated);
 }
 
 /* The band spans the window edge to edge under glass. The 8px side inset keeps
@@ -2788,18 +2792,18 @@ button[data-slot='aui_msg-reactions'] svg {
    radius set here unqualified wins everywhere and rounds the corners that meet
    the bar while squaring the free ones. */
 :root[data-hermes-glass-on] [data-hud-shell] [data-hud-glass] {
-  border-radius: 0.75rem 0.75rem 0 0;
+  border-radius: 0;
 }
 
 :root[data-hermes-glass-on] [data-hud-shell][data-hud-edge='top'] [data-hud-glass] {
-  border-radius: 0 0 0.75rem 0.75rem;
+  border-radius: 0;
 }
 
-/* Engaged, the field steps up the same way the docked thread's does — but
-   never below the resting tint, so a high lever cannot make focusing the
-   composer paint MORE transparent than glancing at it. */
+/* Engaged, the field stays the same opaque paper — focusing must not punch
+   a hole back through to the desktop. */
+:root[data-hermes-glass-on] [data-hud-shell][data-hud-recent] [data-hud-glass],
 :root[data-hermes-glass-on] [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
-  background: rgb(12 14 18 / 0.72);
+  background: var(--ui-bg-elevated);
 }
 
 /* Engaged means the caret is in the composer, not merely that the window holds
@@ -2808,16 +2812,17 @@ button[data-slot='aui_msg-reactions'] svg {
    to use it, and the transcript flew open every time it was moved. Hit-testing
    below stays on :focus-within — being permissive about what can be clicked is
    harmless, being permissive about what lights up is not. */
+[data-hud-shell][data-hud-recent] [data-hud-glass],
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
-  background: rgb(12 14 18 / 0.82);
+  background: var(--ui-bg-elevated);
 }
 
 /* Flipped, the sheet hangs from the bar instead of standing on it. */
 [data-hud-shell][data-hud-edge='top'] [data-hud-glass] {
   top: var(--hud-bar-height, var(--composer-fallback-height));
-  bottom: auto;
+  bottom: 0;
   --hud-exit-shift: -2.5rem;
-  border-radius: 0 0 0.75rem 0.75rem;
+  border-radius: 0;
 }
 
 /* WHAT ANSWERS THE CURSOR — and, because `useHudClickThrough` hands the window
@@ -2891,38 +2896,28 @@ button[data-slot='aui_msg-reactions'] svg {
   transition-timing-function: var(--hud-ease-enter);
 }
 
-/* THE BAND IS ALWAYS LIGHT-ON-DARK. Unconditional, and that is the point: the
-   transcript here is either bare text over another app or text on a translucent
-   scrim, and in both cases the theme's near-black body ink is the wrong ink.
-   Every earlier cut gated this on something — focus, then `data-hud-game` — and
-   every gate produced a state where the words went black on a dark game. A
-   HUD's legibility cannot depend on a condition being evaluated correctly; it
-   is a property of the surface. The scrim below is darkened to match, so white
-   is right whether the sheet is up or not. */
+/* THE BAND USES THEME INK on the opaque card. Forced white overlay text was
+   right for bare words over a game and wrong everywhere else — unfocused HUD
+   inherited it while the sheet was down, so the transcript went pale against
+   whatever was behind the window. Game overlay keeps the overlay ink below. */
 [data-hud-shell] [data-slot='composer-bounds'] {
+  color: var(--ui-text-primary);
+}
+
+[data-hud-shell][data-hud-game] [data-slot='composer-bounds'] {
   --hud-overlay-ink: #fff;
-  /* WoW-epic gold: reads as "yours" against white agent text and survives being
-     over a dark cave or a bright loading screen. */
   --hud-overlay-ink-user: #ffcf6b;
   color: var(--hud-overlay-ink);
   text-shadow:
     0 1px 2px rgb(0 0 0 / 0.9),
     0 0 6px rgb(0 0 0 / 0.55);
-  /* Ramp the scrollback out at the top instead of guillotining it against the
-     bar. With no sheet to end on, a hard edge reads as text sliced off; the
-     fade says "there is more above" the way a game's chat log does. */
   --hud-top-fade: 3.5rem;
 }
 
-/* The mask has to ride the SCROLLER, not the band. `composer-bounds` is a
-   static box: the rows scroll inside the thread viewport nested in it, so a
-   mask there ramps over the band's own first 3.5rem while the overflowing text
-   is already ABOVE that box (measured: rows at -117px, -81px, -55px relative
-   to the band, and `scrollHeight === clientHeight` — nothing overflows the
-   band itself). The viewport clips it hard before the band's mask is ever
-   consulted, which is why raising the value changed nothing on screen. Masking
-   the viewport puts the ramp where the clipping actually happens. */
-[data-hud-shell] [data-slot='aui_thread-viewport'] {
+/* The mask has to ride the SCROLLER, not the band. Only over a game, where
+   the sheet stays down and text sits on the action — an opaque card does not
+   need a fade-to-desktop. */
+[data-hud-shell][data-hud-game] [data-slot='aui_thread-viewport'] {
   -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 var(--hud-top-fade, 3.5rem));
   mask-image: linear-gradient(to bottom, transparent 0, #000 var(--hud-top-fade, 3.5rem));
 }
@@ -2931,7 +2926,7 @@ button[data-slot='aui_msg-reactions'] svg {
    markdown, timestamps — inherits it too, or the ink change reaches the
    wrapper and nothing you can actually read. Widgets carve themselves out by
    resetting the variable (see below), so this stays one rule. */
-[data-hud-shell] [data-slot='composer-bounds'] * {
+[data-hud-shell][data-hud-game] [data-slot='composer-bounds'] * {
   color: var(--hud-overlay-ink) !important;
 }
 
@@ -2979,8 +2974,8 @@ button[data-slot='aui_msg-reactions'] svg {
    ink so it costs no surface. Warm gold rather than the theme's accent: it has
    to hold up over whatever is behind the window, and a blue or purple lands on
    top of exactly the palette most games use for their own UI. */
-[data-hud-shell] :is([data-slot='aui_user-message-root'], .composer-human-message),
-[data-hud-shell] :is([data-slot='aui_user-message-root'], .composer-human-message) * {
+[data-hud-shell][data-hud-game] :is([data-slot='aui_user-message-root'], .composer-human-message),
+[data-hud-shell][data-hud-game] :is([data-slot='aui_user-message-root'], .composer-human-message) * {
   color: var(--hud-overlay-ink-user) !important;
 }
 
@@ -3112,8 +3107,9 @@ button[data-slot='aui_msg-reactions'] svg {
 /* Flipped, the band hangs from the bar instead of standing on it. */
 [data-hud-shell][data-hud-edge='top'] [data-slot='composer-bounds'] {
   top: var(--hud-bar-height, var(--composer-fallback-height)) !important;
-  bottom: auto !important;
-  border-radius: 0 0 0.75rem 0.75rem;
+  bottom: 0 !important;
+  height: auto !important;
+  border-radius: 0;
 }
 
 /* …so the edge it falls back from is the bar's, which is now above it. */
@@ -3368,6 +3364,12 @@ button[data-slot='aui_msg-reactions'] svg {
 [data-hud-shell][data-hud-game] [data-slot='composer-dock']:hover {
   opacity: 1;
   transition: opacity var(--hud-reveal) var(--hud-ease-enter);
+}
+
+/* Over a game the card steps back to a translucent scrim so the action stays
+   visible under the log. Desktop HUD keeps the opaque theme paper. */
+[data-hud-shell][data-hud-game] [data-hud-glass] {
+  background: rgb(12 14 18 / 0.62);
 }
 
 /* Long-press drag armed — the whole bar is the handle until release. */

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2747,10 +2747,14 @@ button[data-slot='aui_msg-reactions'] svg {
     background-color var(--hud-dim) var(--hud-ease-enter);
 }
 
-/* The sheet rides the band: visible while a turn is recent/held OR while the
-   composer has the caret. Focus-only left the text up (data-hud-recent) with
-   the paper gone — white overlay ink on whatever was behind the window. */
-[data-hud-shell][data-hud-recent] [data-hud-glass],
+/* Desktop sheet rides the band: visible while a turn is recent/held OR while
+   the composer has the caret. Focus-only left the text up (data-hud-recent)
+   with the paper gone — white overlay ink on whatever was behind the window.
+
+   Games are excluded: they pin data-hud-recent for the whole overlay session
+   (useHudHeld), and a sheet that follows recent would park a panel on the
+   action. Over a game the sheet stays focus-only, same as before. */
+[data-hud-shell][data-hud-recent]:not([data-hud-game]) [data-hud-glass],
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
   translate: none;
   opacity: 1;
@@ -2800,9 +2804,10 @@ button[data-slot='aui_msg-reactions'] svg {
 }
 
 /* Engaged, the field stays the same opaque paper — focusing must not punch
-   a hole back through to the desktop. */
-:root[data-hermes-glass-on] [data-hud-shell][data-hud-recent] [data-hud-glass],
-:root[data-hermes-glass-on] [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
+   a hole back through to the desktop. Games are excluded so overlay ink
+   cannot land on --ui-bg-elevated. */
+:root[data-hermes-glass-on] [data-hud-shell][data-hud-recent]:not([data-hud-game]) [data-hud-glass],
+:root[data-hermes-glass-on] [data-hud-shell]:not([data-hud-game]):has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
   background: var(--ui-bg-elevated);
 }
 
@@ -2812,8 +2817,8 @@ button[data-slot='aui_msg-reactions'] svg {
    to use it, and the transcript flew open every time it was moved. Hit-testing
    below stays on :focus-within — being permissive about what can be clicked is
    harmless, being permissive about what lights up is not. */
-[data-hud-shell][data-hud-recent] [data-hud-glass],
-[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
+[data-hud-shell][data-hud-recent]:not([data-hud-game]) [data-hud-glass],
+[data-hud-shell]:not([data-hud-game]):has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
   background: var(--ui-bg-elevated);
 }
 
@@ -3366,9 +3371,17 @@ button[data-slot='aui_msg-reactions'] svg {
   transition: opacity var(--hud-reveal) var(--hud-ease-enter);
 }
 
-/* Over a game the card steps back to a translucent scrim so the action stays
-   visible under the log. Desktop HUD keeps the opaque theme paper. */
-[data-hud-shell][data-hud-game] [data-hud-glass] {
+/* Over a game the sheet is a translucent scrim so the action stays visible
+   under the log. These selectors must outrank the opaque-paper
+   recent/focus/glass-on rules — otherwise overlay ink (#fff) lands on
+   --ui-bg-elevated. Games also pin data-hud-recent, so the glass-on +
+   recent override is the steady state, not an edge case. */
+[data-hud-shell][data-hud-game] [data-hud-glass],
+[data-hud-shell][data-hud-game][data-hud-recent] [data-hud-glass],
+[data-hud-shell][data-hud-game]:has([data-slot='composer-rich-input']:focus) [data-hud-glass],
+:root[data-hermes-glass-on] [data-hud-shell][data-hud-game] [data-hud-glass],
+:root[data-hermes-glass-on] [data-hud-shell][data-hud-game][data-hud-recent] [data-hud-glass],
+:root[data-hermes-glass-on] [data-hud-shell][data-hud-game]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
   background: rgb(12 14 18 / 0.62);
 }
 


### PR DESCRIPTION
## What does this PR do?

Stops the desktop HUD from painting as a see-through overlay on top of whatever is behind the window.

Unfocused HUD forced white overlay ink onto a missing sheet, so the transcript picked up the desktop (washed grey-green text, and whatever serif headline sat behind the window). Focused HUD still left a hole under the last line because the glass was inset, rounded, content-sized, and 62% opaque — mixed with macOS vibrancy.

The transcript is now opaque theme paper (`var(--ui-bg-elevated)`) filling the window below the composer. The sheet rides `data-hud-recent` **or** composer focus. Theme ink is used on that card. Game overlay keeps the translucent scrim and overlay ink. Native frost stays focus-only: raising vibrancy for an unfocused streaming turn is what washed the text.

## Related Issue

N/A — reproduced from a user report. Adjacent to #94333 (HUD frost follows the scrim); this does not change frost gating.

No open PR already addresses the opaque-card / unfocused-ink case.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/styles.css`: flush opaque HUD card; show the sheet on `data-hud-recent` as well as focus; theme ink on the card; game overlay keeps the 62% scrim and overlay ink.
- `apps/desktop/src/app/hud/hud-shell.tsx`: comment only — held band is now the HUD's own card.
- `apps/desktop/src/app/hud/glass.ts` / `glass.test.tsx`: document that native frost stays focus-only even though the CSS sheet also paints while a turn is recent.
- `apps/desktop/src/app/hud/styles-contract.test.ts`: pin the sheet-visibility, opaque-paper, flush-geometry, theme-ink, and game-scrim invariants.

## How to Test

1. Check out `origin/main` (`b1ff8722a5`), run `npx vitest run --project ui src/app/hud/styles-contract.test.ts` from `apps/desktop`. All 6 contract tests fail (no recent-sheet rule, 62% scrim, inset `--hud-band-height` band, overlay ink on every HUD, no game-only scrim).
2. Check out this head (`d4729b7de7`) and run the same command; 6 passed.
3. Run `npx vitest run --project ui src/app/hud` (30 passed), `npm run typecheck`, and targeted ESLint.
4. Manual: open HUD over the desktop, send a turn, click away. The transcript should sit on a solid theme card with no desktop showing through. Focus the composer: still opaque, no gutters under the last line. Over a fullscreen game the log should stay a translucent scrim.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop TypeScript/CSS-only change; no Python files changed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 arm64, Node.js 26.3.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: CSS/comment contract only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — CSS-only surface; frost remains focus-only on every platform; game overlay still uses the translucent scrim
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Both captures are the same HUD window on macOS 15.6, over a desktop browser.

| Before — `main` HUD, white overlay ink on a missing/translucent sheet | After — `d4729b7de7`, opaque theme card filling to the composer |
|---|---|
| <img width="520" alt="Before: unfocused HUD transcript washed over the desktop, serif page text showing through" src="https://gist.githubusercontent.com/jorgemdnt/06ee913b6ee230c7c2ad09538e0537e7/raw/hud-before.png"> | <img width="520" alt="After: HUD transcript on a solid theme card, no desktop bleed" src="https://gist.githubusercontent.com/jorgemdnt/06ee913b6ee230c7c2ad09538e0537e7/raw/hud-after.png"> |

### Red / control / green

| Run | Result |
|---|---|
| Upstream `b1ff8722a5` styles.css | HUD sheet contract: **6 failed** (recent opacity missing, `rgb(12 14 18 / 0.62)` scrim, inset `--hud-band-height` band, overlay ink on every HUD, no game-only scrim) |
| This head `d4729b7de7` | HUD sheet contract: **6 passed**. Full `src/app/hud` suite: **30 passed**. `npm run typecheck` passed. Targeted ESLint clean. |

Python tests were not run because this PR changes only the desktop TypeScript/CSS surface.
