### PR TITLE
fix(desktop): clear stale macOS backend ownership records

### DIFF
--- a/apps/desktop/electron/backend-ownership.test.ts
+++ b/apps/desktop/electron/backend-ownership.test.ts
@@ -7,7 +7,8 @@ import {
   type BackendIdentity,
   createBackendOwnership,
   createBackendShutdownCoordinator,
-  parseBackendOwnership
+  parseBackendOwnership,
+  processProbeConfirmsMissing
 } from './backend-ownership'
 
 function memoryStore(initial = '') {
@@ -60,6 +61,14 @@ function createOwnership(store = memoryStore(), overrides: Partial<Parameters<ty
     ...overrides
   })
 }
+
+test('macOS ps exit 1 confirms a missing process without weakening other platforms', () => {
+  assert.equal(processProbeConfirmsMissing({ code: 1 }, 'darwin'), true)
+  assert.equal(processProbeConfirmsMissing({ code: '1' }, 'darwin'), true)
+  assert.equal(processProbeConfirmsMissing({ code: 1 }, 'linux'), false)
+  assert.equal(processProbeConfirmsMissing({ code: 'ETIMEDOUT' }, 'darwin'), false)
+  assert.equal(processProbeConfirmsMissing({ code: 'ESRCH' }, 'linux'), true)
+})
 
 test('claim persists the caller-supplied exact identity before resolving', async () => {
   const store = memoryStore()

--- a/apps/desktop/electron/backend-ownership.ts
+++ b/apps/desktop/electron/backend-ownership.ts
@@ -36,6 +36,20 @@ export interface BackendClaim extends BackendIdentity {
   parentStartMarker?: string
 }
 
+/**
+ * `ps -p <pid>` exits 1 on macOS when the PID no longer exists. Node exposes
+ * that status as a numeric `error.code`, not `ESRCH`, so treating only the
+ * symbolic errno values as definitive leaves every dead ownership entry in
+ * the store forever. Keep the numeric interpretation Darwin-only: exit 1 from
+ * other process probes can mean something less specific and must remain an
+ * uncertain result.
+ */
+export function processProbeConfirmsMissing(error: unknown, platform: NodeJS.Platform): boolean {
+  const code = error && typeof error === 'object' ? (error as { code?: unknown }).code : undefined
+
+  return code === 'ENOENT' || code === 'ESRCH' || (platform === 'darwin' && (code === 1 || code === '1'))
+}
+
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -54,7 +54,12 @@ import {
   makeUnsignedOauthError,
   waitForHermesReady
 } from './backend-health'
-import { backendCommandMatches, createBackendOwnership, createBackendShutdownCoordinator } from './backend-ownership'
+import {
+  backendCommandMatches,
+  createBackendOwnership,
+  createBackendShutdownCoordinator,
+  processProbeConfirmsMissing
+} from './backend-ownership'
 import {
   canImportHermesCli,
   execProbeSync,
@@ -3305,7 +3310,7 @@ async function processIdentityMatches(identity) {
   try {
     return (await processStartMarker(identity.pid)) === identity.startMarker
   } catch (error) {
-    return error?.code === 'ENOENT' || error?.code === 'ESRCH' ? false : undefined
+    return processProbeConfirmsMissing(error, process.platform) ? false : undefined
   }
 }
 
@@ -3333,7 +3338,7 @@ async function backendParentMatches(entry) {
   try {
     return (await processStartMarker(entry.parentPid)) === entry.parentStartMarker
   } catch (error) {
-    return error?.code === 'ENOENT' || error?.code === 'ESRCH' ? false : undefined
+    return processProbeConfirmsMissing(error, process.platform) ? false : undefined
   }
 }
 


### PR DESCRIPTION
## Summary

On macOS, the process identity probe uses ps -p. When the PID no longer exists, ps exits with status 1 and Node reports error.code as numeric 1. The existing code only treated ENOENT and ESRCH as definitive absence, so a dead backend or parent stayed indeterminate and its ownership record survived every reap.

This change:

- recognizes ps exit status 1 as a definitive missing-process result on Darwin only
- applies the same rule to backend and parent identity probes
- keeps non-Darwin exit status 1 conservative
- covers numeric and string status forms with a pure behavior test

This is a narrow bookkeeping fix related to #89298. It does not claim to solve ownership-file loss or scan for unrecorded live orphan processes.

## Validation

- Electron Vitest project: 109 tests passed
- npm audit: 0 vulnerabilities
- signed macOS arm64 Desktop package and install succeeded
- real node-pty smoke passed in source, packaged, and installed-app contexts