### PR TITLE
fix(desktop): position find bar below titlebar to not overlap window controls

### DIFF
--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -1,8 +1,10 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
 import { useLocation } from 'react-router'
 
 import { appViewForPath, isOverlayView } from '@/app/routes'
+import { TITLEBAR_HEIGHT } from '@/app/shell/titlebar'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { findBarKeyAction, formatMatchLabel } from '@/lib/find-in-page'
@@ -278,7 +280,15 @@ export function FindBar() {
 
   const matchLabel = formatMatchLabel(query, matchOrdinal, matchCount)
 
-  const barStyle = filesPaneRight != null ? { right: `calc(${filesPaneRight}px + 0.75rem)` } : undefined
+  const barStyle: CSSProperties = {
+    // The find bar mounts inside the ContribController subtree, which sets
+    // --titlebar-height: 0px on the app shell div. Without overriding it here,
+    // the bar renders at top: 0.5rem — inside the 34px titlebar strip,
+    // overlapping the window controls (issue #97890). Set the var to the real
+    // titlebar height so the top offset clears the titlebar band.
+    '--titlebar-height': `${TITLEBAR_HEIGHT}px`,
+    ...(filesPaneRight != null ? { right: `calc(${filesPaneRight}px + 0.75rem)` } : {})
+  }
 
   return (
     <div


### PR DESCRIPTION
## Summary

Fixes the Ctrl+F find bar overlapping the titlebar window controls on Windows/Linux (issue #97890).

### Root cause

The find bar (`FindBar`) mounts inside the `ContribController` subtree, which explicitly sets `--titlebar-height: 0px` on the app shell div (`controller.tsx` line 841). The find bar's className uses `top-[calc(var(--titlebar-height,34px)+0.5rem)]` — the `34px` fallback was meant to handle this case, but an explicit `0px` value on an ancestor wins over the fallback in the `var()` function. So the bar renders at `top: 0.5rem`, inside the 34px titlebar strip, overlapping the native min/max/close controls.

### Fix

Set `--titlebar-height` to `TITLEBAR_HEIGHT` (34px) on the find bar's root `<div>` via the inline `style` prop. This scopes the override to just the find bar element — no other elements that depend on the `0px` value are affected.

This is the simplest and most targeted fix. Alternatives considered:
- Changing `--titlebar-height` from `0px` to `34px` in `controller.tsx` would affect every element inside the app shell that uses the var for layout offsets (sidebar padding, thread list padding, right sidebar `pt`, etc.) — too risky.
- Hardcoding `34px` in the find bar className instead of using the CSS var would lose the single source of truth for the titlebar height.

Closes #97890