### PR TITLE
fix(plugins): report effective bundled status

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1805,10 +1805,11 @@ def _is_portable_plugin_dir(dir_path) -> bool:
         return False
 
 
-# Manifest kinds that are active-by-default when bundled: backends auto-load,
-# platforms register lazily but are available out of the box, model providers
-# run through providers/ discovery (see PluginManager.discover_and_load).
-_BUNDLED_DEFAULT_ON_KINDS = frozenset({"backend", "platform", "model-provider"})
+# Manifest kinds whose bundled activation is owned by PluginManager: backends
+# auto-load and platforms register lazily.  Filesystem model providers use the
+# separate providers/ discovery path, which does not honor plugins.disabled,
+# so they must not be represented as toggleable general plugins here.
+_BUNDLED_DEFAULT_ON_KINDS = frozenset({"backend", "platform"})
 
 
 def _bundled_default_on(dir_path) -> bool:
@@ -1868,7 +1869,10 @@ def _scan_level(
 
 def _discover_all_plugins() -> list:
     """Return a list of (name, version, description, source, dir_path, key) for
-    every plugin the loader can see — user + bundled + project + entry point.
+    every general plugin the loader can see — user + bundled + entry point.
+
+    Provider categories with dedicated discovery are intentionally omitted
+    when their activation is not governed by the general plugin toggle.
 
     Matches the ordering/dedup of ``PluginManager.discover_and_load``:
     bundled first, then user, then project, then entry points. Later sources
@@ -1877,14 +1881,15 @@ def _discover_all_plugins() -> list:
     seen: dict = {}  # key -> (name, version, description, source, path, key)
 
     # Bundled (<repo>/plugins/<name>/), excluding memory/, context_engine/
-    # and model-providers/ — model providers load through the dedicated
-    # provider registry (providers/__init__.py), not the general PluginManager
-    # opt-in surface, so listing them as toggleable plugins is misleading.
+    # and model-providers/.  Filesystem model providers (bundled or user) load
+    # through the dedicated provider registry (providers/__init__.py), not the
+    # general PluginManager toggle surface, so listing them here would expose
+    # enable/disable controls that do not govern their runtime activation.
     from hermes_cli.plugins import get_bundled_plugins_dir
     repo_plugins = get_bundled_plugins_dir()
     for base, source, skip in (
         (repo_plugins, "bundled", {"memory", "context_engine", "model-providers"}),
-        (_plugins_dir(), "user", set()),
+        (_plugins_dir(), "user", {"model-providers"}),
     ):
         _scan_level(base, source, skip, "", 0, seen)
 
@@ -1928,11 +1933,21 @@ def _discover_entrypoint_plugins() -> list[tuple[str, str, str, str]]:
     return entries
 
 
-def _plugin_status(name: str, enabled: set, disabled: set, key: str = "") -> str:
-    """Return the user-facing activation state for a plugin name or key."""
+def _plugin_status(
+    name: str,
+    enabled: set,
+    disabled: set,
+    key: str = "",
+    *,
+    source: str = "",
+    dir_path=None,
+) -> str:
+    """Return the effective activation state for one discovered plugin."""
     if name in disabled or key in disabled:
         return "disabled"
     if name in enabled or key in enabled:
+        return "enabled"
+    if source == "bundled" and dir_path is not None and _bundled_default_on(dir_path):
         return "enabled"
     return "not enabled"
 
@@ -1945,7 +1960,14 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     if getattr(args, "enabled", False):
         filtered = [
             entry for entry in filtered
-            if _plugin_status(entry[0], enabled, disabled, key=entry[5]) == "enabled"
+            if _plugin_status(
+                entry[0],
+                enabled,
+                disabled,
+                key=entry[5],
+                source=entry[3],
+                dir_path=entry[4],
+            ) == "enabled"
         ]
     return filtered
 
@@ -1970,7 +1992,14 @@ def cmd_list(args: Any | None = None) -> None:
         payload = [
             {
                 "name": name,
-                "status": _plugin_status(name, enabled, disabled, key=key),
+                "status": _plugin_status(
+                    name,
+                    enabled,
+                    disabled,
+                    key=key,
+                    source=source,
+                    dir_path=_dir,
+                ),
                 "version": str(version),
                 "description": description,
                 "source": source,
@@ -1982,7 +2011,14 @@ def cmd_list(args: Any | None = None) -> None:
 
     if getattr(args, "plain", False):
         for name, version, _description, source, _dir, key in entries:
-            status = _plugin_status(name, enabled, disabled, key=key)
+            status = _plugin_status(
+                name,
+                enabled,
+                disabled,
+                key=key,
+                source=source,
+                dir_path=_dir,
+            )
             print(f"{status:12} {source:8} {str(version):8} {name}")
         return
 
@@ -1998,7 +2034,14 @@ def cmd_list(args: Any | None = None) -> None:
     table.add_column("Source", style="dim")
 
     for name, version, description, source, _dir, key in entries:
-        status_name = _plugin_status(name, enabled, disabled, key=key)
+        status_name = _plugin_status(
+            name,
+            enabled,
+            disabled,
+            key=key,
+            source=source,
+            dir_path=_dir,
+        )
         if status_name == "disabled":
             status = "[red]disabled[/red]"
         elif status_name == "enabled":
@@ -2013,7 +2056,10 @@ def cmd_list(args: Any | None = None) -> None:
     console.print("[dim]Compact view:[/dim] hermes plugins list --plain --no-bundled")
     console.print("[dim]Interactive toggle:[/dim] hermes plugins")
     console.print("[dim]Enable/disable:[/dim] hermes plugins enable/disable <name>")
-    console.print("[dim]Plugins are opt-in by default — only 'enabled' plugins load.[/dim]")
+    console.print(
+        "[dim]User and bundled standalone plugins are opt-in; bundled "
+        "backends and platforms are available unless disabled.[/dim]"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2214,7 +2260,14 @@ def cmd_show(name: str) -> None:
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
-    status = _plugin_status(pname, enabled, disabled, key=key)
+    status = _plugin_status(
+        pname,
+        enabled,
+        disabled,
+        key=key,
+        source=source,
+        dir_path=dir_path,
+    )
 
     console.print()
     console.print(f"[bold]{pname}[/bold]" + (f" [dim]v{version}[/dim]" if version else ""))
@@ -2252,6 +2305,7 @@ def cmd_toggle() -> None:
     # only the key — so "explicit disable wins" kept a bundled backend off
     # forever (pi314's #40190 symptom). Keys keep every surface aligned.
     plugin_keys = []
+    plugin_names = []
     plugin_labels = []
     plugin_selected = set()
 
@@ -2260,14 +2314,22 @@ def cmd_toggle() -> None:
         if source == "bundled":
             label = f"{label} [bundled]"
         plugin_keys.append(key)
+        plugin_names.append(name)
         plugin_labels.append(label)
-        # Selected (enabled) when in enabled-set AND not in disabled-set.
-        # Accept the legacy bare name on either side for back-compat with
-        # existing configs written before this normalization.
+        # Render the same effective state used by list/show/runtime-facing
+        # surfaces. In particular, bundled backend/platform plugins are on by
+        # default even without a plugins.enabled entry, unless explicitly
+        # disabled.
         is_on = (
-            (key in enabled_set or name in enabled_set)
-            and key not in disabled_set
-            and name not in disabled_set
+            _plugin_status(
+                name,
+                enabled_set,
+                disabled_set,
+                key=key,
+                source=source,
+                dir_path=_d,
+            )
+            == "enabled"
         )
         if is_on:
             plugin_selected.add(i)
@@ -2297,14 +2359,49 @@ def cmd_toggle() -> None:
     try:
         import curses
         _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
-                          disabled_set, categories, console)
+                          disabled_set, categories, console, plugin_names)
     except ImportError:
         _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
-                                disabled_set, categories, console)
+                                disabled_set, categories, console, plugin_names)
+
+
+def _updated_plugin_toggle_sets(
+    plugin_keys,
+    plugin_names,
+    initially_selected,
+    chosen,
+    enabled,
+    disabled,
+):
+    """Apply only checkbox changes and normalize changed entries to their key.
+
+    Effective default-on plugins need not be present in ``plugins.enabled``.
+    Leaving the UI unchanged must therefore preserve the original allow/deny
+    lists instead of materializing every visible checkbox into config.
+    """
+    new_enabled = set(enabled)
+    new_disabled = set(disabled)
+
+    for i, key in enumerate(plugin_keys):
+        was_selected = i in initially_selected
+        is_selected = i in chosen
+        if was_selected == is_selected:
+            continue
+
+        name = plugin_names[i] if i < len(plugin_names) else key.split("/")[-1]
+        aliases = {key, key.split("/")[-1], name}
+        new_enabled.difference_update(aliases)
+        new_disabled.difference_update(aliases)
+        if is_selected:
+            new_enabled.add(key)
+        else:
+            new_disabled.add(key)
+
+    return new_enabled, new_disabled
 
 
 def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
-                      disabled, categories, console):
+                      disabled, categories, console, plugin_names=None):
     """Custom curses screen with checkboxes + category action rows."""
     from hermes_cli.curses_ui import flush_stdin
 
@@ -2524,26 +2621,15 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
     curses.wrapper(_draw)
     flush_stdin()
 
-    # Persist by canonical key. Unchecked plugins are written to the
-    # disabled-list so they stay off even if a future plugin auto-enables
-    # itself — but we ONLY ever write the canonical key (never the bare
-    # manifest name), so the disabled-list can't drift out of sync with
-    # what ``cmd_enable`` clears or what PluginManager gates on (#40190).
-    new_enabled: set = set()
-    new_disabled: set = set(disabled)  # preserve existing disabled state for unseen plugins
-    for i, key in enumerate(plugin_keys):
-        bare = key.split("/")[-1]
-        if i in chosen:
-            new_enabled.add(key)
-            new_disabled.discard(key)
-            # Drop any stale legacy bare-leaf disable so re-enabling here
-            # fully clears the plugin from the disabled-list.
-            if bare != key:
-                new_disabled.discard(bare)
-        else:
-            new_disabled.add(key)
-
     prev_enabled = _get_enabled_set()
+    new_enabled, new_disabled = _updated_plugin_toggle_sets(
+        plugin_keys,
+        plugin_names or [],
+        plugin_selected,
+        chosen,
+        prev_enabled,
+        disabled,
+    )
     enabled_changed = new_enabled != prev_enabled
     disabled_changed = new_disabled != disabled
 
@@ -2551,8 +2637,8 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
         _save_enabled_set(new_enabled)
         _save_disabled_set(new_disabled)
         console.print(
-            f"\n[green]\u2713[/green] General plugins: {len(new_enabled)} enabled, "
-            f"{len(plugin_keys) - len(new_enabled)} disabled."
+            f"\n[green]\u2713[/green] General plugins: {len(chosen)} enabled, "
+            f"{len(plugin_keys) - len(chosen)} disabled."
         )
     elif n_plugins > 0:
         console.print("\n[dim]General plugins unchanged.[/dim]")
@@ -2571,7 +2657,7 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
 
 
 def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
-                            disabled, categories, console):
+                            disabled, categories, console, plugin_names=None):
     """Text-based fallback for the composite plugins UI."""
     from hermes_cli.colors import Colors, color
 
@@ -2599,21 +2685,15 @@ def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
                 return
             print()
 
-        # Persist by canonical key only — never the bare manifest name — so
-        # the disabled-list stays aligned with cmd_enable / PluginManager
-        # (#40190).
-        new_enabled: set = set()
-        new_disabled: set = set(disabled)
-        for i, key in enumerate(plugin_keys):
-            bare = key.split("/")[-1]
-            if i in chosen:
-                new_enabled.add(key)
-                new_disabled.discard(key)
-                if bare != key:
-                    new_disabled.discard(bare)
-            else:
-                new_disabled.add(key)
         prev_enabled = _get_enabled_set()
+        new_enabled, new_disabled = _updated_plugin_toggle_sets(
+            plugin_keys,
+            plugin_names or [],
+            plugin_selected,
+            chosen,
+            prev_enabled,
+            disabled,
+        )
         if new_enabled != prev_enabled or new_disabled != disabled:
             _save_enabled_set(new_enabled)
             _save_disabled_set(new_disabled)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18778,6 +18778,7 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
         _discover_context_engines,
         _get_disabled_set,
         _get_enabled_set,
+        _plugin_status,
         _read_manifest as _read_plugin_manifest_at,
     )
 
@@ -18795,20 +18796,21 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
     rows: List[Dict[str, Any]] = []
 
     for name, version, description, source, dir_str, key in _discover_all_plugins():
-        # Both the path-derived key (nested category plugins) and the bare
-        # manifest name count for enabled/disabled state, matching the runtime
-        # loader's back-compat lookup.
-        aliases = {name}
-        if key:
-            aliases.add(key)
-        if aliases & disabled_set:
-            runtime_status = "disabled"
-        elif aliases & enabled_set:
-            runtime_status = "enabled"
-        else:
-            runtime_status = "inactive"
-
         dir_path = Path(dir_str)
+        effective_status = _plugin_status(
+            name,
+            enabled_set,
+            disabled_set,
+            key=key,
+            source=source,
+            dir_path=dir_path,
+        )
+        # Keep the dashboard API's existing vocabulary while sharing the
+        # effective-state resolver with CLI, TUI, and PluginManager-facing
+        # surfaces.
+        runtime_status = (
+            "inactive" if effective_status == "not enabled" else effective_status
+        )
         dm = dash_by_name.get(name)
         has_dash_manifest = dm is not None or (dir_path / "dashboard" / "manifest.json").exists()
 

--- a/tests/hermes_cli/test_plugins_cmd_category_discovery.py
+++ b/tests/hermes_cli/test_plugins_cmd_category_discovery.py
@@ -186,12 +186,11 @@ class TestDiscoverAllPlugins:
 
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    def test_user_model_providers_subdir_is_still_scanned(
+    def test_user_model_providers_subdir_is_not_a_general_plugin(
         self, mock_user_dir, mock_bundled_dir, tmp_path
     ):
-        """The model-providers skip only applies to *bundled* — a user plugin
-        at ``~/.hermes/plugins/model-providers/<x>/`` is still discovered so
-        ``hermes plugins list`` shows what the user installed."""
+        """Filesystem providers have a dedicated loader that does not use the
+        general plugins.enabled/plugins.disabled toggle contract."""
         from hermes_cli.plugins_cmd import _discover_all_plugins
 
         bundled = tmp_path / "bundled"
@@ -206,7 +205,7 @@ class TestDiscoverAllPlugins:
 
         entries = _discover_all_plugins()
         keys = [e[5] for e in entries]
-        assert "model-providers/acme" in keys
+        assert "model-providers/acme" not in keys
 
 
 # ---------------------------------------------------------------------------
@@ -224,6 +223,58 @@ class TestPluginStatus:
     def test_neither_name_nor_key(self):
         from hermes_cli.plugins_cmd import _plugin_status
         assert _plugin_status("unknown", {"other"}, set(), key="cat/unknown") == "not enabled"
+
+    def test_bundled_backend_is_effectively_enabled(self, tmp_path):
+        from hermes_cli.plugins_cmd import _plugin_status
+
+        plugin = _make_plugin_dir(tmp_path, "renderer", {
+            "name": "renderer", "kind": "backend"
+        })
+        assert _plugin_status(
+            "renderer", set(), set(), source="bundled", dir_path=plugin
+        ) == "enabled"
+
+    def test_bundled_platform_is_effectively_enabled(self, tmp_path):
+        from hermes_cli.plugins_cmd import _plugin_status
+
+        plugin = _make_plugin_dir(tmp_path, "chat", {
+            "name": "chat", "kind": "platform"
+        })
+        assert _plugin_status(
+            "chat", set(), set(), source="bundled", dir_path=plugin
+        ) == "enabled"
+
+    def test_model_provider_is_outside_general_default_on_policy(self, tmp_path):
+        from hermes_cli.plugins_cmd import _bundled_default_on
+
+        plugin = _make_plugin_dir(tmp_path, "acme", {
+            "name": "acme", "kind": "model-provider"
+        })
+        assert _bundled_default_on(plugin) is False
+
+    def test_explicit_disable_wins_for_bundled_backend(self, tmp_path):
+        from hermes_cli.plugins_cmd import _plugin_status
+
+        plugin = _make_plugin_dir(tmp_path, "renderer", {
+            "name": "renderer", "kind": "backend"
+        })
+        assert _plugin_status(
+            "renderer", set(), {"renderer"}, source="bundled", dir_path=plugin
+        ) == "disabled"
+
+    @pytest.mark.parametrize("source,kind", [
+        ("user", "backend"),
+        ("bundled", "standalone"),
+    ])
+    def test_non_default_on_plugin_stays_opt_in(self, tmp_path, source, kind):
+        from hermes_cli.plugins_cmd import _plugin_status
+
+        plugin = _make_plugin_dir(tmp_path, f"{source}-{kind}", {
+            "name": f"{source}-{kind}", "kind": kind
+        })
+        assert _plugin_status(
+            f"{source}-{kind}", set(), set(), source=source, dir_path=plugin
+        ) == "not enabled"
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +298,21 @@ class TestFilterPluginEntries:
         result = _filter_plugin_entries(entries, args, {"web/tavily"}, set())
         assert len(result) == 1
         assert result[0][5] == "web/tavily"
+
+    def test_enabled_filter_includes_default_on_bundled_backend(self, tmp_path):
+        from hermes_cli.plugins_cmd import _filter_plugin_entries
+
+        plugin = _make_plugin_dir(tmp_path, "renderer", {
+            "name": "renderer", "kind": "backend"
+        })
+        entries = [
+            ("renderer", "1.0.0", "render", "bundled", plugin, "renderer"),
+        ]
+        args = MagicMock(no_bundled=False, user=False, enabled=True)
+
+        result = _filter_plugin_entries(entries, args, set(), set())
+
+        assert result == entries
 
 
 # ---------------------------------------------------------------------------
@@ -308,3 +374,37 @@ class TestCmdListJson:
             payload = json.loads(captured.out)
             assert len(payload) == 1
             assert payload[0]["status"] == "enabled"
+
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_json_reports_default_on_bundled_backend_as_enabled(
+        self, mock_user_dir, mock_bundled_dir, tmp_path, capsys
+    ):
+        from hermes_cli.plugins_cmd import cmd_list
+
+        bundled = tmp_path / "bundled"
+        user = tmp_path / "user"
+        user.mkdir()
+        _make_category_plugin(bundled, "image_gen", "openai-codex", {
+            "name": "openai-codex", "version": "1.0.0", "kind": "backend"
+        })
+        mock_user_dir.return_value = user
+        mock_bundled_dir.return_value = bundled
+
+        args = MagicMock(
+            json=True,
+            plain=False,
+            no_bundled=False,
+            user=False,
+            enabled=False,
+        )
+        cmd_list(args)
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload == [{
+            "name": "openai-codex",
+            "status": "enabled",
+            "version": "1.0.0",
+            "description": "",
+            "source": "bundled",
+        }]

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -10,6 +10,7 @@ nested bundled plugin can actually be toggled.
 
 import sys  # noqa: F401
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -70,7 +71,9 @@ class TestResolvePluginKey:
         """Same leaf name under two categories must NOT silently pick one."""
         from hermes_cli.plugins_cmd import _resolve_plugin_key
         _make_category_plugin(tmp_path, "image_gen", "openai", {"name": "image-gen-openai"})
-        _make_category_plugin(tmp_path, "model-providers", "openai", {"name": "mp-openai"})
+        _make_category_plugin(
+            tmp_path, "observability", "openai", {"name": "observability-openai"}
+        )
         mock_user.return_value = tmp_path
         mock_bundled.return_value = tmp_path / "nonexistent"
         # Bare "openai" is ambiguous -> None; the full key still resolves.
@@ -208,7 +211,7 @@ class TestCompositeMenuWritesCanonicalKey:
     @patch("hermes_cli.plugins_cmd._save_disabled_set")
     @patch("hermes_cli.plugins_cmd._save_enabled_set")
     @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
-    def test_fallback_unchecked_plugin_disables_by_key_not_name(
+    def test_fallback_toggle_off_disables_by_key_not_name(
         self, mock_en, mock_save_en, mock_save_dis,
     ):
         from hermes_cli.plugins_cmd import _run_composite_fallback
@@ -217,16 +220,131 @@ class TestCompositeMenuWritesCanonicalKey:
         # key differs from the manifest name, mirroring web/firecrawl.
         plugin_keys = ["web/firecrawl"]
         plugin_labels = ["web-firecrawl — firecrawl [bundled]"]
-        plugin_selected = set()  # unchecked → should be disabled
+        plugin_selected = {0}
 
-        # First input() toggles nothing (blank Enter confirms immediately),
-        # second (category prompt) is skipped with blank Enter.
-        with patch("builtins.input", return_value=""):
+        # Toggle the selected plugin off, then confirm. This proves an actual
+        # user change persists the canonical key; merely opening/closing the
+        # menu is covered separately as a no-op.
+        with patch("builtins.input", side_effect=["1", ""]):
             _run_composite_fallback(
                 plugin_keys, plugin_labels, plugin_selected,
-                set(), [], Console(),
+                set(), [], Console(), ["web-firecrawl"],
             )
 
         saved_dis = mock_save_dis.call_args[0][0]
         assert "web/firecrawl" in saved_dis      # canonical key persisted
         assert "web-firecrawl" not in saved_dis   # never the bare name
+
+    def test_cmd_toggle_preselects_effective_status_and_noop_preserves_config(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import plugins_cmd
+
+        backend = _make_category_plugin(
+            tmp_path,
+            "image_gen",
+            "openai-codex",
+            {"name": "openai-codex", "kind": "backend"},
+        )
+        platform = _make_category_plugin(
+            tmp_path,
+            "platforms",
+            "telegram",
+            {"name": "telegram", "kind": "platform"},
+        )
+        standalone = _make_plugin_dir(
+            tmp_path,
+            "opt-in",
+            {"name": "opt-in", "kind": "standalone"},
+        )
+        entries = [
+            (
+                "openai-codex",
+                "1.0.0",
+                "Codex image backend",
+                "bundled",
+                backend,
+                "image_gen/openai-codex",
+            ),
+            (
+                "telegram",
+                "1.0.0",
+                "Telegram platform",
+                "bundled",
+                platform,
+                "platforms/telegram",
+            ),
+            ("opt-in", "1.0.0", "Opt-in", "bundled", standalone, "opt-in"),
+            (
+                "package-plugin",
+                "1.0.0",
+                "Entry point",
+                "entrypoint",
+                "package.module:register",
+                "package-plugin",
+            ),
+        ]
+        enabled = {"package-plugin"}
+        disabled = {"platforms/telegram"}
+        saved_enabled = []
+        saved_disabled = []
+        observed = {}
+
+        monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+        monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(enabled))
+        monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set(disabled))
+        monkeypatch.setattr(plugins_cmd, "_get_current_memory_provider", lambda: "")
+        monkeypatch.setattr(
+            plugins_cmd, "_get_current_context_engine", lambda: "compressor"
+        )
+        monkeypatch.setattr(plugins_cmd, "_save_enabled_set", saved_enabled.append)
+        monkeypatch.setattr(plugins_cmd, "_save_disabled_set", saved_disabled.append)
+        monkeypatch.setattr(
+            plugins_cmd.sys, "stdin", SimpleNamespace(isatty=lambda: True)
+        )
+        monkeypatch.setitem(sys.modules, "curses", SimpleNamespace())
+
+        def run_fallback(
+            _curses,
+            keys,
+            labels,
+            selected,
+            disabled_set,
+            categories,
+            console,
+            names,
+        ):
+            observed["selected"] = set(selected)
+            plugins_cmd._run_composite_fallback(
+                keys,
+                labels,
+                selected,
+                disabled_set,
+                categories,
+                console,
+                names,
+            )
+
+        monkeypatch.setattr(plugins_cmd, "_run_composite_ui", run_fallback)
+
+        # Confirm both sections without changing a checkbox or provider.
+        with patch("builtins.input", side_effect=["", ""]):
+            plugins_cmd.cmd_toggle()
+
+        # Bundled backend is effectively on; explicit disable wins for the
+        # bundled platform; standalone remains opt-in; enabled entry point is on.
+        assert observed["selected"] == {0, 3}
+        assert saved_enabled == []
+        assert saved_disabled == []
+
+        # Toggle the effective default-on backend off through cmd_toggle and
+        # confirm the shared persistence path records only that explicit
+        # change while retaining the existing entry-point enable and platform
+        # disable.
+        with patch("builtins.input", side_effect=["1", "", ""]):
+            plugins_cmd.cmd_toggle()
+
+        assert saved_enabled == [{"package-plugin"}]
+        assert saved_disabled == [
+            {"image_gen/openai-codex", "platforms/telegram"}
+        ]

--- a/tests/hermes_cli/test_plugins_hub_perf_guard.py
+++ b/tests/hermes_cli/test_plugins_hub_perf_guard.py
@@ -140,6 +140,73 @@ def test_plugins_hub_short_ttl_cache_collapses_duplicate_fetches(monkeypatch):
     assert first is second
 
 
+def test_plugins_hub_endpoint_uses_effective_plugin_status(monkeypatch, tmp_path):
+    import asyncio
+
+    backend = tmp_path / "image_gen" / "openai-codex"
+    platform = tmp_path / "platforms" / "telegram"
+    standalone = tmp_path / "opt-in"
+    for plugin_dir, manifest in (
+        (backend, "name: openai-codex\nkind: backend\n"),
+        (platform, "name: telegram\nkind: platform\n"),
+        (standalone, "name: opt-in\nkind: standalone\n"),
+    ):
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(manifest, encoding="utf-8")
+
+    entries = [
+        (
+            "openai-codex",
+            "1.0.0",
+            "Codex image backend",
+            "bundled",
+            backend,
+            "image_gen/openai-codex",
+        ),
+        (
+            "telegram",
+            "1.0.0",
+            "Telegram platform",
+            "bundled",
+            platform,
+            "platforms/telegram",
+        ),
+        ("opt-in", "1.0.0", "Opt-in", "bundled", standalone, "opt-in"),
+        (
+            "package-plugin",
+            "1.0.0",
+            "Entry point",
+            "entrypoint",
+            "package.module:register",
+            "package-plugin",
+        ),
+    ]
+    _patch_minimal_hub_dependencies(
+        monkeypatch,
+        check_fn=lambda: True,
+        discover_all_plugins=lambda: entries,
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"package-plugin"})
+    monkeypatch.setattr(
+        plugins_cmd, "_get_disabled_set", lambda: {"platforms/telegram"}
+    )
+    monkeypatch.setattr(plugins_cmd, "_read_manifest", lambda _path: {})
+    monkeypatch.setattr(web_server, "_require_token", lambda _request: None)
+    web_server._invalidate_plugins_hub_cache()
+
+    payload = asyncio.run(web_server.get_plugins_hub(object()))
+    statuses = {
+        plugin["name"]: plugin["runtime_status"] for plugin in payload["plugins"]
+    }
+
+    assert statuses == {
+        "openai-codex": "enabled",
+        "telegram": "disabled",
+        "opt-in": "inactive",
+        "package-plugin": "enabled",
+    }
+
+
 def test_plugin_install_endpoint_invalidates_hub_cache(monkeypatch):
     import asyncio
 

--- a/tests/test_plugins_manage_profile_scope.py
+++ b/tests/test_plugins_manage_profile_scope.py
@@ -72,3 +72,40 @@ def test_plugins_manage_unscoped_still_lists(monkeypatch):
 
     assert "result" in resp, resp
     assert "plugins" in resp["result"]
+
+
+def test_plugins_manage_reports_bundled_backend_effective_status(
+    tmp_path, monkeypatch
+):
+    """The gateway must surface PluginManager's bundled-backend default."""
+    plugin_dir = tmp_path / "openai-codex"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: openai-codex\nkind: backend\n",
+        encoding="utf-8",
+    )
+
+    import hermes_cli.plugins_cmd as plugins_cmd
+
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_all_plugins",
+        lambda: [
+            (
+                "openai-codex",
+                "1.0.0",
+                "Codex OAuth image generation",
+                "bundled",
+                plugin_dir,
+                "image_gen/openai-codex",
+            )
+        ],
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    resp = server.handle_request(
+        {"id": "4", "method": "plugins.manage", "params": {"action": "list"}}
+    )
+
+    assert resp["result"]["plugins"][0]["status"] == "enabled"

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2456,7 +2456,6 @@ def _(rid, params: dict) -> dict:
         return err
     try:
         from hermes_cli.plugins_cmd import (
-            _bundled_default_on,
             _discover_all_plugins,
             _get_disabled_set,
             _get_enabled_set,
@@ -2471,17 +2470,14 @@ def _(rid, params: dict) -> dict:
             for name, version, desc, source, _dir, key in sorted(
                 _discover_all_plugins()
             ):
-                status = _plugin_status(name, enabled, disabled, key=key)
-                # Bundled backends/platforms/providers are active without an
-                # explicit enable (they "just work" — plugins.py). Reporting
-                # them "not enabled" reads as OFF in clients when they are in
-                # fact running; surface the truthful default instead.
-                if (
-                    status == "not enabled"
-                    and source == "bundled"
-                    and _bundled_default_on(_dir)
-                ):
-                    status = "enabled"
+                status = _plugin_status(
+                    name,
+                    enabled,
+                    disabled,
+                    key=key,
+                    source=source,
+                    dir_path=_dir,
+                )
                 out.append(
                     {
                         "name": name,

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -2,12 +2,12 @@
 sidebar_position: 12
 sidebar_label: "Built-in Plugins"
 title: "Built-in Plugins"
-description: "Plugins shipped with Hermes Agent that run automatically via lifecycle hooks — disk-cleanup and friends"
+description: "Plugins shipped with Hermes Agent, including opt-in extensions and built-in backends"
 ---
 
 # Built-in Plugins
 
-Hermes ships a small set of plugins bundled with the repository. They live under `<repo>/plugins/<name>/` and load automatically alongside user-installed plugins in `~/.hermes/plugins/`. They use the same plugin surface as third-party plugins — hooks, tools, slash commands — just maintained in-tree.
+Hermes ships a set of plugins with the repository. They live under `<repo>/plugins/` and use the same plugin surface as third-party plugins — hooks, tools, slash commands, backends, and platform adapters — but their activation depends on the plugin kind.
 
 See the [Plugins](/user-guide/features/plugins) page for the general plugin system, and [Build a Hermes Plugin](/developer-guide/plugins) to write your own.
 
@@ -22,11 +22,11 @@ The `PluginManager` scans four sources, in order:
 
 On name collision, later sources win — a user plugin named `disk-cleanup` would replace the bundled one.
 
-`plugins/memory/` and `plugins/context_engine/` are deliberately excluded from bundled scanning. Those directories use their own discovery paths because memory providers and context engines are single-select providers configured through `hermes memory setup` / `context.engine` in config.
+`plugins/memory/`, `plugins/context_engine/`, and `plugins/model-providers/` use dedicated discovery paths instead of the general plugin toggle. Memory and context-engine providers are selected through `hermes memory setup` / `context.engine`. Filesystem model-provider profiles are discovered by the provider registry and are not controlled by `plugins.enabled` or `plugins.disabled`.
 
-## Bundled plugins are opt-in
+## Activation depends on plugin kind
 
-Bundled plugins ship disabled. Discovery finds them (they appear in `hermes plugins list` and the interactive `hermes plugins` UI), but none load until you explicitly enable them:
+Bundled standalone plugins are opt-in. Discovery finds them (they appear in `hermes plugins list` and the interactive `hermes plugins` UI), but they do not load until you explicitly enable them:
 
 ```bash
 hermes plugins enable disk-cleanup
@@ -40,32 +40,33 @@ plugins:
     - disk-cleanup
 ```
 
-This is the same mechanism user-installed plugins use. Bundled plugins are never auto-enabled — not on fresh install, not for existing users upgrading to a newer Hermes. You always opt in explicitly.
+Bundled `backend` plugins are different: the general `PluginManager` loads them automatically so an existing core tool can select one through its category config. Bundled `platform` plugins are also available by default, but their modules load lazily on first use. Their own credentials and category settings still determine whether they can actually serve a request.
 
-To turn a bundled plugin off again:
+Both default-on kinds honor an explicit deny-list. For example, to prevent the bundled Codex image backend from registering:
 
 ```bash
-hermes plugins disable disk-cleanup
-# or: remove it from plugins.enabled in config.yaml
+hermes plugins disable image_gen/openai-codex
 ```
+
+Filesystem model-provider profiles are a separate case. The provider registry discovers them outside the general `PluginManager`; use model/provider configuration to choose a provider. The generic plugin enable/disable commands do not control those profiles.
 
 ## Currently shipped
 
-The repo ships these bundled plugins under `plugins/`. All are opt-in — enable them via `hermes plugins enable <name>`.
+The repo ships these bundled plugins under `plugins/`:
 
-| Plugin | Kind | Purpose |
-|---|---|---|
-| `disk-cleanup` | hooks + slash command | Auto-track ephemeral files and clean them on session end |
-| `security-guidance` | hooks | Pattern-match dangerous code on `write_file`/`patch` and append a security warning (or block) — 25 rules (Apache-2.0 fork of Anthropic's `claude-plugins-official` patterns) |
-| `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
-| `teams_pipeline` | standalone | Microsoft Teams meeting pipeline — Graph-backed, transcript-first meeting summaries |
-| `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
-| `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
-| `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
-| `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
-| `image_gen/xai` | image backend | xAI `grok-2-image` backend |
-| `hermes-achievements` | dashboard tab | Steam-style collectible badges generated from your real Hermes session history |
-| `kanban/dashboard` | dashboard tab | Kanban board UI for the multi-agent dispatcher — tasks, comments, fan-out, board switching. See [Kanban Multi-Agent](./kanban.md). |
+| Plugin | Kind | Activation | Purpose |
+|---|---|---|---|
+| `disk-cleanup` | hooks + slash command | Opt-in | Auto-track ephemeral files and clean them on session end |
+| `security-guidance` | hooks | Opt-in | Pattern-match dangerous code on `write_file`/`patch` and append a security warning (or block) — 25 rules (Apache-2.0 fork of Anthropic's `claude-plugins-official` patterns) |
+| `observability/langfuse` | hooks | Opt-in | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
+| `teams_pipeline` | standalone | Opt-in | Microsoft Teams meeting pipeline — Graph-backed, transcript-first meeting summaries |
+| `spotify` | backend (7 tools) | Loaded by default; auth-gated | Native Spotify playback, queue, search, playlists, albums, library |
+| `google_meet` | standalone | Opt-in | Join Meet calls, live-caption transcription, optional realtime duplex audio |
+| `image_gen/openai` | image backend | Loaded by default; selected by config | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
+| `image_gen/openai-codex` | image backend | Loaded by default; selected by config | OpenAI image generation via Codex OAuth |
+| `image_gen/xai` | image backend | Loaded by default; selected by config | xAI `grok-2-image` backend |
+| `hermes-achievements` | dashboard tab | Dashboard discovery | Steam-style collectible badges generated from your real Hermes session history |
+| `kanban/dashboard` | dashboard tab | Dashboard discovery | Kanban board UI for the multi-agent dispatcher — tasks, comments, fan-out, board switching. See [Kanban Multi-Agent](./kanban.md). |
 
 Memory providers (`plugins/memory/*`) and context engines (`plugins/context_engine/*`) are listed separately on [Memory Providers](./memory-providers.md) — they're managed through `hermes memory` and `hermes plugins` respectively. The full per-plugin detail for the two long-running hooks-based plugins follows.
 


### PR DESCRIPTION
## Summary

- report bundled backend and platform plugins as enabled by default, matching PluginManager runtime behavior
- keep explicit disable precedence, opt-in standalone/entry-point semantics, and remove filesystem model-providers from the generic toggle surface their loader does not honor
- make CLI list/info, interactive toggle, plugins.manage, and the web plugins hub use the same effective status
- preserve config on no-op/ESC and persist only actual checkbox deltas
- document the distinct bundled, dashboard, and model-provider activation paths

## Tests

- scripts/run_tests.sh on the four relevant files: 41 passed
- uv run ruff check on all touched Python files
- git diff HEAD^ --check

An independent review initially caught destructive no-op toggle persistence and web-hub status drift; both were fixed and the final review plus evidence verifier passed.