### PR TITLE
feat(image-gen): configure Codex host model

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -14,6 +14,11 @@ Selection precedence for the tier (first hit wins):
 3. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
 4. :data:`DEFAULT_MODEL` — ``gpt-image-2-medium``
 
+The Codex chat model that hosts the ``image_generation`` tool defaults to
+``gpt-5.5`` for compatibility. It can be selected independently with
+``image_gen.openai-codex.host_model``; this never changes the underlying
+``gpt-image-2`` image model or its quality tier.
+
 Output is saved as PNG under ``$HERMES_HOME/cache/images/``. Source images for
 image-to-image/editing are sent as Responses ``input_image`` content parts.
 """
@@ -175,8 +180,17 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
 
     if candidate is not None:
         return candidate, _MODELS[candidate]
-
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_host_model() -> str:
+    """Return the Codex chat model that hosts ``image_generation``."""
+    cfg = _load_image_gen_config()
+    sub = cfg.get("openai-codex") if isinstance(cfg.get("openai-codex"), dict) else {}
+    candidate = sub.get("host_model") if isinstance(sub, dict) else None
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate.strip()
+    return _CODEX_CHAT_MODEL
 
 
 def _read_codex_access_token() -> Optional[str]:
@@ -317,7 +331,7 @@ def _build_responses_payload(
     if input_images:
         content.extend(input_images)
     return {
-        "model": _CODEX_CHAT_MODEL,
+        "model": _resolve_host_model(),
         "store": False,
         "instructions": _CODEX_INSTRUCTIONS,
         "input": [{

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import pytest
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
 # The plugin directory uses a hyphen, which is not a valid Python identifier
 # for the dotted-import form. Load it via importlib so tests don't need to
 # touch sys.path or rename the directory.
@@ -161,6 +163,73 @@ class TestGenerate:
         # Progressive previews disabled: partial frames were being saved as
         # finals and presented as smeared/unfinished images.
         assert tool["partial_images"] == 0
+
+    def test_codex_stream_host_model_can_be_configured_independently(
+        self, provider, monkeypatch, tmp_path
+    ):
+        default_home = tmp_path
+        profile_home = tmp_path / "profiles" / "artist"
+        profile_home.mkdir(parents=True)
+        (default_home / "config.yaml").write_text(
+            """\
+image_gen:
+  model: gpt-image-2-low
+  openai-codex:
+    host_model: gpt-5.4
+""",
+            encoding="utf-8",
+        )
+        (profile_home / "config.yaml").write_text(
+            """\
+image_gen:
+  model: gpt-image-2-low
+  openai-codex:
+    model: gpt-image-2-high
+    host_model: " gpt-5.6-sol "
+""",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality, input_images=None):
+            captured.update(codex_plugin._build_responses_payload(
+                prompt=prompt,
+                size=size,
+                quality=quality,
+                input_images=input_images,
+            ))
+            return {"b64": _b64_png(), "source": "final"}
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            result = provider.generate("a cat")
+        finally:
+            reset_hermes_home_override(token)
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-high"
+        assert captured["model"] == "gpt-5.6-sol"
+        assert captured["tools"][0]["model"] == "gpt-image-2"
+
+    @pytest.mark.parametrize("configured", [None, "", "   ", 42])
+    def test_invalid_host_model_keeps_compatible_default(self, monkeypatch, configured):
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"openai-codex": {"host_model": configured}},
+        )
+
+        payload = codex_plugin._build_responses_payload(
+            prompt="a cat",
+            size="1024x1024",
+            quality="medium",
+        )
+
+        assert payload["model"] == "gpt-5.5"
+        assert payload["tools"][0]["model"] == "gpt-image-2"
 
     def test_capabilities_advertise_image_inputs(self, provider):
         caps = provider.capabilities()

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -73,6 +73,25 @@ image_gen:
 to the global tool-worker limit, so image providers receive bounded parallel
 requests without allowing an image batch to bypass the agent's concurrency cap.
 
+### OpenAI (Codex auth): host model
+
+The `openai-codex` backend runs the Responses API `image_generation` tool under
+a Codex chat model. That host is separate from the underlying `gpt-image-2`
+image model and its quality tier. It defaults to `gpt-5.5`; override it for the
+current Hermes profile in `config.yaml` with `host_model`:
+
+```yaml
+image_gen:
+  provider: openai-codex
+  openai-codex:
+    model: gpt-image-2-high
+    host_model: gpt-5.6-sol
+```
+
+Changing `host_model` only selects the chat model that invokes the image tool.
+It does not change the generated-image model (`gpt-image-2`) or the configured
+`low`, `medium`, or `high` image tier.
+
 ### OpenRouter: the full Image API catalog
 
 With `image_gen.provider: openrouter`, the model picker lists OpenRouter's


### PR DESCRIPTION
## Summary

- add image_gen.openai-codex.host_model for the Responses API host model
- default to gpt-5.5 while keeping the image tool model (gpt-image-2) and quality tier independent
- resolve profile-specific values through the real Hermes config loader
- document host model versus image model/tier

## Tests

- scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py: 33 passed
- real temporary default/profile HERMES_HOME/config.yaml coverage, including profile isolation and fallback behavior
- uv run ruff check on touched Python files
- git diff HEAD^ --check

Independent final review and evidence verifier passed.