### PR TITLE
fix(profiles): scope gateway service cleanup past an ambient home override

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1945,8 +1945,21 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
     import platform as _platform
 
     # Derive service name for this profile
-    # Temporarily set HERMES_HOME so _profile_suffix resolves correctly
+    # Temporarily set HERMES_HOME so _profile_suffix resolves correctly.
+    # get_hermes_home() checks the context-local override BEFORE the env
+    # var, so mutating only os.environ leaves an ambient override (the
+    # dashboard delete endpoint, profile-scoped gateway contexts) shadowing
+    # the target profile: _profile_suffix() then derives the default — or
+    # the wrong profile's — service name, and the real plist/service file
+    # survives the delete. Scope both layers to profile_dir and restore
+    # both in the finally block.
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
     old_home = os.environ.get("HERMES_HOME")
+    token = set_hermes_home_override(profile_dir)
     try:
         os.environ["HERMES_HOME"] = str(profile_dir)
         from hermes_cli.gateway import get_service_name, get_launchd_plist_path
@@ -1982,6 +1995,7 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
     except Exception as e:
         print(f"⚠ Service cleanup: {e}")
     finally:
+        reset_hermes_home_override(token)
         if old_home is not None:
             os.environ["HERMES_HOME"] = old_home
         elif "HERMES_HOME" in os.environ:

--- a/tests/hermes_cli/test_profile_delete_service_scope.py
+++ b/tests/hermes_cli/test_profile_delete_service_scope.py
@@ -1,0 +1,151 @@
+"""Service cleanup during profile delete must survive an ambient home override.
+
+``_cleanup_gateway_service`` scopes ``_profile_suffix()`` to the profile being
+deleted by setting ``HERMES_HOME``. But ``get_hermes_home()`` resolves the
+context-local override (``set_hermes_home_override``) BEFORE the env var, so
+when the delete runs inside a context that already holds an override — the
+dashboard's delete endpoint, or a profile-scoped gateway context — the env
+trick is shadowed and the plist path resolves to the default (or the wrong
+profile's) service. The orphaned plist then respawns the "deleted" profile
+via launchd ``KeepAlive`` (#97897). These tests pin the fix: the override
+layer is scoped alongside the env var, on both the happy path and the
+swallowed-exception path.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import gateway as gateway_mod
+from hermes_cli import profiles as profiles_mod
+from hermes_constants import (
+    get_hermes_home,
+    get_hermes_home_override,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    """Isolate profile paths from the user's real Hermes installation."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return default_home
+
+
+@pytest.fixture()
+def darwin_service_branch(monkeypatch):
+    """Force the launchd branch regardless of the host OS.
+
+    The Linux/systemd branch shells out to systemctl and the Darwin branch
+    to launchctl; both subprocess calls are mocked in the tests below, but
+    the plist assertions only make sense on the Darwin branch.
+    """
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+
+
+@pytest.fixture()
+def launch_agents(tmp_path, monkeypatch):
+    """Redirect launchd artifacts away from the real ~/Library/LaunchAgents.
+
+    ``get_launchd_plist_path()`` appends ``Library/LaunchAgents`` itself, so
+    the fake user home is the tmp root and the plist dir lives one level
+    below it.
+    """
+    monkeypatch.setattr(gateway_mod, "_launchd_user_home", lambda: tmp_path)
+    agents_dir = tmp_path / "Library" / "LaunchAgents"
+    agents_dir.mkdir(parents=True)
+    return agents_dir
+
+
+def test_cleanup_removes_target_plist_under_ambient_home_override(
+    profile_env, launch_agents, darwin_service_branch, monkeypatch
+):
+    """An ambient context-local override must not shadow the deleted profile.
+
+    Before the fix, ``get_hermes_home()`` returned the caller's override, so
+    ``_profile_suffix()`` derived the default profile's service name: the
+    target plist survived (KeepAlive respawn) and the default's plist was
+    unlinked instead.
+    """
+    profile_dir = profile_env / "profiles" / "rnobot"
+    profile_dir.mkdir(parents=True)
+    target_plist = launch_agents / "ai.hermes.gateway-rnobot.plist"
+    target_plist.write_text("rnobot service")
+    default_plist = launch_agents / "ai.hermes.gateway.plist"
+    default_plist.write_text("default service")
+
+    launchctl_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        subprocess, "run", lambda cmd, **kwargs: launchctl_calls.append(list(cmd))
+    )
+
+    # Simulate the dashboard delete endpoint / profile-scoped gateway
+    # context: a context-local override pointing at the default home is
+    # active while the target profile's service is cleaned up.
+    token = set_hermes_home_override(profile_env)
+    try:
+        profiles_mod._cleanup_gateway_service("rnobot", profile_dir)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert not target_plist.exists(), (
+        "the deleted profile's plist must be unlinked, or launchd KeepAlive "
+        "respawns it (#97897)"
+    )
+    assert default_plist.exists(), (
+        "the shadowed-resolution bug unloads/unlinks the DEFAULT profile's "
+        "plist instead of the deleted one"
+    )
+    assert launchctl_calls == [["launchctl", "unload", str(target_plist)]]
+
+
+def test_cleanup_without_ambient_override_keeps_working(
+    profile_env, launch_agents, darwin_service_branch, monkeypatch
+):
+    """Plain CLI deletes (no override active) still remove the plist."""
+    profile_dir = profile_env / "profiles" / "coder"
+    profile_dir.mkdir(parents=True)
+    target_plist = launch_agents / "ai.hermes.gateway-coder.plist"
+    target_plist.write_text("coder service")
+
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **kwargs: None)
+
+    assert get_hermes_home_override() is None
+    profiles_mod._cleanup_gateway_service("coder", profile_dir)
+
+    assert not target_plist.exists()
+
+
+def test_cleanup_restores_env_when_service_removal_raises(
+    profile_env, launch_agents, darwin_service_branch, monkeypatch
+):
+    """A swallowed cleanup failure must not leak the temporary env scoping."""
+
+    def _boom(cmd, **kwargs):
+        raise RuntimeError("launchctl exploded")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+
+    profile_dir = profile_env / "profiles" / "rnobot"
+    profile_dir.mkdir(parents=True)
+    (launch_agents / "ai.hermes.gateway-rnobot.plist").write_text("service")
+
+    token = set_hermes_home_override(profile_env)
+    try:
+        # The exception is caught and printed by the function under test;
+        # the finally block must still restore the scoping layers.
+        profiles_mod._cleanup_gateway_service("rnobot", profile_dir)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert os.environ.get("HERMES_HOME") == str(profile_env)
+    assert get_hermes_home() == profile_env


### PR DESCRIPTION
## What does this PR do?

`hermes profile delete` could leave the deleted profile's launchd service definition (`ai.hermes.gateway-<profile>.plist`) behind, so launchd `KeepAlive` kept respawning the "deleted" gateway — and when two profiles shared a bot token, the resurrected empty profile held the only live connection (#97897).

Root cause: `_cleanup_gateway_service()` scopes `_profile_suffix()` to the deleted profile by mutating `os.environ["HERMES_HOME"]`. But `get_hermes_home()` resolves the **context-local override (`set_hermes_home_override`) before the env var** (documented in `hermes_constants.py`). When the delete runs inside a context that already holds an override — the dashboard's delete endpoint (`web_routers/profiles.py`), or profile-scoped gateway contexts (`gateway/run.py` `_profile_runtime_scope`) — the env value is shadowed, so:

- `_profile_suffix()` derives the **default** (or the wrong profile's) service name when the ambient override points at the default root;
- the deleted profile's plist is never unlinked (the orphan), and worse, the shadowed resolution can `launchctl unload` + **unlink the default profile's plist** instead;
- the broad `try/except` only prints `⚠ Service cleanup: ...`, so the delete reports success either way.

The fix scopes the override layer to `profile_dir` alongside the env var (`set_hermes_home_override` / `reset_hermes_home_override` token pair) and restores both in the `finally` block — exactly the scoping pattern `get_launchd_plist_path()`/`get_service_name()` document. The env mutation is kept (restored unchanged) so downstream consumers that read the env directly (e.g. the Windows branch in flight) are unaffected. The Linux/systemd branch resolves through the same `_profile_suffix()`, so it benefits from the same fix.

Scope note: the command-alias half of the report is a different mechanism — `remove_wrapper_script()` works under `Path.home()/.local/bin`, which does not consult `get_hermes_home()` at all, so it is not affected by this shadowing. This PR fixes the service-definition half only.

## Related Issue

Fixes #97897

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — `_cleanup_gateway_service()`: wrap the existing env scoping with a `set_hermes_home_override(profile_dir)` / `reset_hermes_home_override(token)` pair so an ambient context-local override can no longer shadow the deleted profile during service-name resolution; both layers restored in `finally`.
- `tests/hermes_cli/test_profile_delete_service_scope.py` — new regression tests: (1) with an ambient override active (the dashboard delete scenario) the target plist is unlinked and `launchctl` receives the target plist path, while the default profile's plist is untouched; (2) plain no-override deletes still work; (3) a swallowed cleanup failure still restores the env/override scoping.

## How to Test

1. `python -m pytest tests/hermes_cli/test_profile_delete_service_scope.py -v` → 3 passed (Observed result: 3 passed locally).
2. Reverse check: revert only the `hermes_cli/profiles.py` hunk and rerun → the ambient-override test fails (target plist survives, default plist gets unlinked), the no-override test still passes, confirming the regression test pins the reported bug and that plain CLI behavior is unchanged.
3. `python -m pytest tests/hermes_cli/test_profiles.py tests/hermes_cli/test_deleted_profile_tombstone.py -q` → 72 passed, 2 skipped (no regressions in the profile-delete neighborhood).
4. Tests mock `subprocess.run` and redirect `_launchd_user_home()` into `tmp_path`, so nothing touches the real `~/Library/LaunchAgents` or runs `launchctl`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
