### PR TITLE
fix(desktop): keep the latest turns in view when returning to a chat

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -14,7 +14,8 @@ import {
   shouldResettleTranscript,
   subscribeToThreadForeground,
   transcriptBackfillFrameCount,
-  transcriptPaneBudget
+  transcriptPaneBudget,
+  transcriptSettleAdvance
 } from './list'
 
 afterEach(() => {
@@ -352,5 +353,41 @@ describe('prependAnchorFromBottom', () => {
   it('preserves a settled reading position through a prepend', () => {
     expect(prependAnchorFromBottom(true, 800, 200)).toBe(600)
     expect(prependAnchorFromBottom(true, 800, 0)).toBe(800)
+  })
+})
+
+describe('transcriptSettleAdvance', () => {
+  const filled = {
+    clientHeight: 800,
+    frame: 4,
+    lastHeight: 12_000,
+    paneBudget: 600,
+    renderBudget: 600,
+    scrollHeight: 12_000,
+    stableFrames: 1
+  }
+
+  it('does not settle while the window is still 0-tall (app reopen / boot)', () => {
+    const next = transcriptSettleAdvance({
+      ...filled,
+      clientHeight: 0,
+      frame: 20,
+      lastHeight: 0,
+      scrollHeight: 0,
+      stableFrames: 8
+    })
+
+    expect(next.done).toBe(false)
+    expect(next.frame).toBe(20)
+  })
+
+  it('does not settle while first-paint backfill is still catching up', () => {
+    const next = transcriptSettleAdvance({ ...filled, renderBudget: 20, stableFrames: 2 })
+
+    expect(next.done).toBe(false)
+  })
+
+  it('settles once the pane is filled and height holds', () => {
+    expect(transcriptSettleAdvance(filled).done).toBe(true)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -8,8 +8,10 @@ import {
   LIVE_TAIL_PARTS,
   liveTailStart,
   type MessageGroup,
+  prependAnchorFromBottom,
   resolveThreadScrollTarget,
   shouldClampTranscriptBudget,
+  shouldResettleTranscript,
   subscribeToThreadForeground,
   transcriptBackfillFrameCount,
   transcriptPaneBudget
@@ -327,5 +329,28 @@ describe('liveTailStart', () => {
 describe('transcriptBackfillFrameCount', () => {
   it('settles a full pane in at most three prepend commits', () => {
     expect(transcriptBackfillFrameCount()).toBeLessThanOrEqual(3)
+  })
+})
+
+describe('shouldResettleTranscript', () => {
+  it('re-settles only when a hot-hidden pane becomes visible again', () => {
+    expect(shouldResettleTranscript('hot-hidden', 'visible')).toBe(true)
+    expect(shouldResettleTranscript('visible', 'hot-hidden')).toBe(false)
+    expect(shouldResettleTranscript('visible', 'visible')).toBe(false)
+    expect(shouldResettleTranscript('parked', 'visible')).toBe(false)
+  })
+})
+
+describe('prependAnchorFromBottom', () => {
+  it('pins to the bottom while a load or tab-reveal has not settled', () => {
+    // The switch-back bug: hide clamp left scrollTop 0 on a 4k-px tail.
+    // Treating that as settled restored 4000px from the bottom after the
+    // 11k-px prepend — old turns, not the latest.
+    expect(prependAnchorFromBottom(false, 4000, 0)).toBe(0)
+  })
+
+  it('preserves a settled reading position through a prepend', () => {
+    expect(prependAnchorFromBottom(true, 800, 200)).toBe(600)
+    expect(prependAnchorFromBottom(true, 800, 0)).toBe(800)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -140,6 +140,44 @@ export const shouldResettleTranscript = (previous: PaneLifecycle, next: PaneLife
 export const prependAnchorFromBottom = (loadSettled: boolean, scrollHeight: number, scrollTop: number): number =>
   loadSettled ? scrollHeight - scrollTop : 0
 
+/** Don't treat a boot-time 0-height window as a settled transcript. */
+export const TRANSCRIPT_MIN_VIEWPORT_PX = 2
+export const TRANSCRIPT_SETTLE_STABLE_FRAMES = 2
+/** Async markdown/images after backfill. The previous 15-frame cap handed
+ *  back during app reopen while the viewport was still empty or first-paint
+ *  had not caught up, so the thread painted at scrollTop 0. */
+export const TRANSCRIPT_SETTLE_MAX_FRAMES = 90
+
+export type TranscriptSettleTick = {
+  clientHeight: number
+  frame: number
+  lastHeight: number
+  paneBudget: number
+  renderBudget: number
+  scrollHeight: number
+  stableFrames: number
+}
+
+/** One rAF of the load settle loop. Pin to the end until the viewport has a
+ *  real box, first-paint backfill has caught up, and height is stable. */
+export const transcriptSettleAdvance = (
+  tick: TranscriptSettleTick
+): { done: boolean; frame: number; lastHeight: number; stableFrames: number } => {
+  if (tick.clientHeight < TRANSCRIPT_MIN_VIEWPORT_PX || tick.renderBudget < tick.paneBudget) {
+    return { done: false, frame: tick.frame, lastHeight: tick.scrollHeight, stableFrames: 0 }
+  }
+
+  const stableFrames = tick.scrollHeight === tick.lastHeight ? tick.stableFrames + 1 : 0
+  const frame = tick.frame + 1
+
+  return {
+    done: stableFrames >= TRANSCRIPT_SETTLE_STABLE_FRAMES || frame > TRANSCRIPT_SETTLE_MAX_FRAMES,
+    frame,
+    lastHeight: tick.scrollHeight,
+    stableFrames
+  }
+}
+
 // Browsers may quantize a requested scrollTop to a nearby device-pixel
 // boundary. use-stick-to-bottom otherwise compares the lower actual value to
 // the integer target forever, re-requesting the same instant scroll every
@@ -443,6 +481,10 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   const paneBudget = transcriptPaneBudget(mountedPanes, paneLifecycle === 'hot-hidden')
 
   const [renderBudget, setRenderBudget] = useState(FIRST_PAINT_BUDGET)
+  const renderBudgetRef = useRef(renderBudget)
+  const paneBudgetRef = useRef(paneBudget)
+  renderBudgetRef.current = renderBudget
+  paneBudgetRef.current = paneBudget
 
   // Cut the budget during RENDER, not in the post-commit layout effect. An
   // effect-time cut is too late: React would first build the whole tree with
@@ -658,56 +700,60 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // lurch on every cold load. The empty→non-empty flip re-arms for the
   // transcript that actually arrived; being a boolean, it cannot re-fire on a
   // streaming append.
+  //
+  // App reopen is the same class with a different empty: the viewport exists
+  // but clientHeight is 0 until the window finishes showing, or first-paint
+  // has not backfilled yet. The 15-frame cap used to fire anyway, leaving
+  // scrollTop 0 on the real transcript. Wait for a real box + a full pane
+  // before counting stable frames (see transcriptSettleAdvance).
   useLayoutEffect(() => {
-    const el = scrollRef.current
-
-    if (!el) {
-      return
-    }
-
-    stopScroll()
-    el.scrollTop = el.scrollHeight
     loadSettledRef.current = false
+    stopScroll()
 
-    // An anchor captured for the OUTGOING transcript must not be applied to
-    // this one — a switch owns the position outright. The empty→non-empty
-    // re-arm is the SAME load, whose in-flight anchor is still correct.
     if (settleKeyRef.current !== sessionKey) {
       settleKeyRef.current = sessionKey
       restoreFromBottomRef.current = null
     }
 
+    let rafId = 0
     let frame = 0
     let stableFrames = 0
-    let lastHeight = el.scrollHeight
+    let lastHeight = 0
 
     const settle = () => {
       const node = scrollRef.current
 
       if (!node) {
+        rafId = requestAnimationFrame(settle)
         return
       }
 
-      const height = node.scrollHeight
+      node.scrollTop = node.scrollHeight
 
-      stableFrames = height === lastHeight ? stableFrames + 1 : 0
-      lastHeight = height
-      node.scrollTop = height
+      const next = transcriptSettleAdvance({
+        clientHeight: node.clientHeight,
+        frame,
+        lastHeight,
+        paneBudget: paneBudgetRef.current,
+        renderBudget: renderBudgetRef.current,
+        scrollHeight: node.scrollHeight,
+        stableFrames
+      })
 
-      // Most session switches are synchronous and stabilize within 2 frames;
-      // the old 90-frame ceiling was for slow async image loads. Cap at 15
-      // frames to minimize the settle-loop racing markdown paint on every switch.
-      if (stableFrames >= 2 || ++frame > 15) {
+      frame = next.frame
+      lastHeight = next.lastHeight
+      stableFrames = next.stableFrames
+
+      if (next.done) {
         void scrollToBottom('instant')
         loadSettledRef.current = true
-
         return
       }
 
       rafId = requestAnimationFrame(settle)
     }
 
-    let rafId = requestAnimationFrame(settle)
+    rafId = requestAnimationFrame(settle)
 
     return () => cancelAnimationFrame(rafId)
   }, [hasGroups, scrollRef, scrollToBottom, sessionKey, stopScroll])

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react'
 import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
+import { type PaneLifecycle } from '@/components/pane-shell/pane-lifecycle'
 import { usePaneLifecycle } from '@/components/pane-shell/pane-visibility'
 import { useI18n } from '@/i18n'
 import { messagePaintWeight } from '@/lib/render-weight'
@@ -123,6 +124,21 @@ export const transcriptBackfillFrameCount = (
   step = BACKFILL_STEP,
   budget = RENDER_BUDGET
 ): number => Math.ceil(Math.max(0, budget - firstPaint) / step)
+
+/** A tab round-trip keeps the transcript mounted (`hot-hidden` → `visible`)
+ *  without changing `sessionKey`, so the session-switch settle loop never
+ *  re-arms. The hide path also clamps the DOM to the live tail, which can
+ *  leave `scrollTop` at 0 on a still-scrollable tail. Coming back then
+ *  prepends older turns while treating that 0 as a chosen reading position —
+ *  the thread "scrolls up" onto old messages. */
+export const shouldResettleTranscript = (previous: PaneLifecycle, next: PaneLifecycle): boolean =>
+  previous === 'hot-hidden' && next === 'visible'
+
+/** Distance from the bottom to restore after older turns are prepended.
+ *  Mid-load (and a reveal that just unset settled) must not treat scrollTop 0
+ *  as a chosen position — that is how a switch-back lands on old turns. */
+export const prependAnchorFromBottom = (loadSettled: boolean, scrollHeight: number, scrollTop: number): number =>
+  loadSettled ? scrollHeight - scrollTop : 0
 
 // Browsers may quantize a requested scrollTop to a nearby device-pixel
 // boundary. use-stick-to-bottom otherwise compares the lower actual value to
@@ -421,6 +437,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   const mountedPanes = useStore($mountedTranscriptPanes)
   const paneLifecycle = usePaneLifecycle()
+  const previousLifecycleRef = useRef(paneLifecycle)
   // Hidden panes retain only a live-tail budget. Visible panes share the normal
   // screen budget; a reveal backfills older rows in bounded transition steps.
   const paneBudget = transcriptPaneBudget(mountedPanes, paneLifecycle === 'hot-hidden')
@@ -477,7 +494,9 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   const anchorBeforePrepend = useCallback(() => {
     const el = scrollRef.current
 
-    restoreFromBottomRef.current = el && loadSettledRef.current ? el.scrollHeight - el.scrollTop : 0
+    restoreFromBottomRef.current = el
+      ? prependAnchorFromBottom(loadSettledRef.current, el.scrollHeight, el.scrollTop)
+      : 0
   }, [scrollRef])
 
   // Backfill from FIRST_PAINT_BUDGET to the full budget after the small
@@ -692,6 +711,45 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
     return () => cancelAnimationFrame(rafId)
   }, [hasGroups, scrollRef, scrollToBottom, sessionKey, stopScroll])
+
+  // The hide clamp unmounts older turns from the top. Pin the remaining tail
+  // to its latest line so a `visibility: hidden` scroll reset cannot leave
+  // scrollTop at 0 on a still-scrollable tail.
+  useLayoutEffect(() => {
+    if (paneLifecycle !== 'hot-hidden') {
+      return
+    }
+
+    const el = scrollRef.current
+
+    if (el) {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [paneLifecycle, renderBudget, scrollRef])
+
+  // Tab return does not change sessionKey, so the settle loop above does not
+  // run. The hide clamp can leave scrollTop at 0; unset settled so the
+  // backfill prepends onto the bottom instead of restoring that 0.
+  useLayoutEffect(() => {
+    const previous = previousLifecycleRef.current
+    previousLifecycleRef.current = paneLifecycle
+
+    if (!shouldResettleTranscript(previous, paneLifecycle)) {
+      return
+    }
+
+    const el = scrollRef.current
+
+    loadSettledRef.current = false
+    restoreFromBottomRef.current = 0
+
+    if (!el) {
+      return
+    }
+
+    stopScroll()
+    el.scrollTop = el.scrollHeight
+  }, [paneLifecycle, scrollRef, stopScroll])
 
   // Prepend an older page while preserving the on-screen position. The user is
   // scrolled up (reading history) so the stick-to-bottom lock is escaped and


### PR DESCRIPTION
## What does this PR do?

Stops a conversation from jumping up to older turns when you switch away and back.

Tab round-trips keep the transcript mounted (`hot-hidden` → `visible`) without changing `sessionKey`, so the session-switch settle loop never re-arms. Hiding also clamps the DOM to the live tail, which can leave `scrollTop` at 0 on a still-scrollable tail.

Coming back then prepended older turns while treating that 0 as a chosen reading position — the thread landed on old messages instead of the latest. Reveal now unsets settled and pins to the bottom before the backfill. Hide pins the clamped tail to its latest line.

## Related Issue

N/A — reproduced from a user report. Adjacent to the first-paint / prepend-restore work in `ThreadMessageList` (the 11.5k px jump on session load); that path keys off `sessionKey` and does not run on a keep-alive tab return.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/list.tsx`: pin the hidden tail to the bottom; on `hot-hidden` → `visible`, unset load-settled and pin before backfill prepends.
- `apps/desktop/src/components/assistant-ui/thread/list.test.ts`: cover reveal detection and the mid-load prepend anchor.

## How to Test

1. Open a long chat, scroll to the latest turn, switch to another conversation (tab or sidebar session that keeps the previous pane mounted), switch back. The latest turns should still be in view.
2. From `apps/desktop`: `npx vitest run --project ui src/components/assistant-ui/thread/list.test.ts` (31 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop TypeScript-only change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 arm64, Node.js 26.3.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — scroll restoration is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No visual chrome change — the thread should stay on the latest turns after a round-trip.

| Head | `npx vitest run --project ui src/components/assistant-ui/thread/list.test.ts` |
|---|---|
| `origin/main` `b1ff8722a5` | helpers absent (new tests fail to import) |
| This head `2291d22712` | 31 passed |
