### PR TITLE
chore: map provider-salvage contributor emails (Neel49, amrrs)

### DIFF
--- a/contributors/emails/1littlecoder@gmail.com
+++ b/contributors/emails/1littlecoder@gmail.com
@@ -1,0 +1,2 @@
+amrrs
+# PR #28253 salvage (Nebius Token Factory provider)

--- a/contributors/emails/neel.patel@ramp.com
+++ b/contributors/emails/neel.patel@ramp.com
@@ -1,0 +1,2 @@
+Neel49
+# PR #93548 salvage (Ramp Router provider)

--- a/contributors/emails/neel49@users.noreply.github.com
+++ b/contributors/emails/neel49@users.noreply.github.com
@@ -1,0 +1,2 @@
+Neel49
+# PR #93548 salvage (Ramp Router provider)


### PR DESCRIPTION
Email→login mappings for the provider salvage PRs that follow: Neel49 (#93548 Ramp Router, both emails) and amrrs (#28253 Nebius Token Factory). simonweng@tencent.com (#96939) is already mapped. Mappings verified against each PR's commit author metadata.