### PR TITLE
fix(desktop): probe /api/health on pooled SSH dispatch, not /api/status

### DIFF
--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   ensureHealthyPooledRemoteBackendForDispatch,
+  POOLED_REMOTE_DISPATCH_PROBE_PATH,
   POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS,
   REMOTE_LIVENESS_FAILURE_LIMIT,
   REMOTE_LIVENESS_FAILURE_WINDOW_MS,
@@ -292,9 +293,11 @@ describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
       })
     ).resolves.toBe(replacement)
 
-    expect(probe).toHaveBeenCalledWith(stale, '/api/status', {
+    expect(probe).toHaveBeenCalledWith(stale, POOLED_REMOTE_DISPATCH_PROBE_PATH, {
       timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
     })
+    expect(POOLED_REMOTE_DISPATCH_PROBE_PATH).toBe('/api/health')
+    expect(POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS).toBe(5_000)
     expect(retire).toHaveBeenCalledOnce()
     expect(reconnect).toHaveBeenCalledOnce()
   })

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,9 +1,12 @@
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
 // Dispatch is synchronous user intent: a cached descriptor must prove its
-// forwarded endpoint is alive before it can be returned. Keep this probe much
-// shorter than the background liveness budget so a dead tunnel reconnects
-// promptly instead of making the click feel hung.
-export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 2_500
+// forwarded endpoint is alive before it can be returned. Probe cheap
+// /api/health — not /api/status, whose cold payload on a no-mux SSH forward
+// routinely exceeds 2.5s and then kills the tunnel. Match the health-probe
+// budget (DEFAULT_HEALTH_PROBE_TIMEOUT_MS) and stay shorter than background
+// liveness so a dead tunnel still reconnects promptly.
+export const POOLED_REMOTE_DISPATCH_PROBE_PATH = '/api/health'
+export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 5_000
 export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // Even at the capped retry path, consecutive liveness observations are at most
 // about 48s apart (ticket mint + socket open + backoff + the next status probe).
@@ -100,7 +103,7 @@ export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection ex
       return reconnect()
     }
 
-    await probe(connection, '/api/status', {
+    await probe(connection, POOLED_REMOTE_DISPATCH_PROBE_PATH, {
       timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
     })
   } catch (error) {


### PR DESCRIPTION
## Bug Description

Windows Desktop SSH (no-mux `ssh -N -L`) connects, spawns the remote dashboard, then immediately flaps:

```
Pooled remote backend "conn:<id>::<profile>" failed its dispatch probe (Timed out connecting to Hermes backend after 2500ms)
connection closed (no-mux tunnels killed)
```

SSH auth and remote `hermes` already succeeded. The client then kills the tunnel.

This is not #49841 (stale, still edits `main.cjs`; background liveness is already 10s).

## Root Cause

`ensureHealthyPooledRemoteBackendForDispatch` probes `/api/status` with a 2.5s budget. Bootstrap already used cheap `/api/health`. Cold `/api/status` through a new Windows/Tailscale forward is ~2.5–3s / ~6KB; `/api/health` is ~20–50ms / 52 bytes. A miss retires the pooled backend and tears down every no-mux tunnel, so the next click pays a full respawn.

The function comment already called this a cheap health probe.

## Fix

- Dispatch probe path: `/api/health`
- Timeout: 5s (`DEFAULT_HEALTH_PROBE_TIMEOUT_MS`), still shorter than background liveness (10s `/api/status`)
- Regression assertions on path + timeout

Shared Electron code (Linux/macOS included). Symptom is worst on Windows because OpenSSH has no ControlMaster.

## How to Verify

1. `cd apps/desktop && npx vitest run electron/remote-liveness.test.ts`
2. Windows Desktop → SSH gateway. After a cold spawn, dispatch should not log `after 2500ms` or immediately `no-mux tunnels killed`.
3. `GET /api/health` on the local forward should stay ~20–50ms.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing `remote-liveness` tests still pass (22/22)
- [x] Manual verification on Windows 11 → Linux SSH remote: 0× `2500ms` after rebuild; live `/api/health` 18–33ms

## Risk Assessment

Low — dispatch liveness only. Background/post-resume still probes `/api/status` at 10s. Current backends (0.19+) expose `/api/health`; a missing route fails dispatch and reconnects, same as a dead tunnel.