### PR TITLE
fix(prompt): skills section — de-dupe hermes-agent teaching, presence-gate the skill pointer, drop '(mandatory)'

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -158,14 +158,19 @@ DEFAULT_AGENT_IDENTITY = (
 )
 
 HERMES_AGENT_HELP_GUIDANCE = (
+    # "when the two differ" was cut (#95681): a model that just read the
+    # skill won't ALSO fetch the docs to diff them, so the clause was dead
+    # weight — the docs-are-authoritative sentence already carries the
+    # precedence. Injected only when skill_view exists AND the hermes-agent
+    # skill is actually installed (see system_prompt.py slot resolution).
     "You run on Hermes Agent (by Nous Research). When the user needs help with "
     "Hermes itself — configuring, setting up, using, extending, or troubleshooting "
     "it — or when you need to understand your own features, tools, or capabilities, "
     "the documentation at https://hermes-agent.nousresearch.com/docs is your "
     "authoritative reference and always holds the latest, most up-to-date "
-    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "for additional guidance and proven workflows, but treat the docs as the source "
-    "of truth when the two differ."
+    "information. The `hermes-agent` skill has the actual commands and proven "
+    "workflows — load it with skill_view(name='hermes-agent') before configuring, "
+    "modifying, or troubleshooting Hermes so you don't guess or invent workarounds."
 )
 
 # Variant injected when the skill tools are not in the session's toolset
@@ -2074,7 +2079,7 @@ def _build_skills_system_prompt_inner(
                     index_lines.append(f"    - {name}")
 
         result = (
-            "## Skills (mandatory)\n"
+            "## Skills\n"
             "Before replying, scan the skills below. If a skill matches or is even partially relevant "
             "to your task, you MUST load it with skill_view(name) and follow its instructions. "
             "Err on the side of loading — it is always better to have context you don't need "
@@ -2085,11 +2090,6 @@ def _build_skills_system_prompt_inner(
             "Skills also encode the user's preferred approach, conventions, and quality standards "
             "for tasks like code review, planning, and testing — load them even for tasks you "
             "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
-            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
-            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
             "If a skill has issues, fix it with skill_manage(action='patch').\n"
             "After difficult/iterative tasks, offer to save as a skill. "
             "If a skill you loaded was missing steps, had wrong commands, or needed "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -392,15 +392,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # Fallback to hardcoded identity
         stable_parts.append(DEFAULT_AGENT_IDENTITY)
 
-    # Pointer to the hermes-agent skill + docs for user questions about Hermes
-    # itself. When the session has no skill tools (Blank Slate with the skills
-    # toolset off), skill_view() would be a dangling reference — inject the
-    # docs-only variant instead. Toolset is fixed per-session, so cache-safe.
+    # Pointer to the docs (and, when it exists, the hermes-agent skill) for
+    # user questions about Hermes itself. The skill_view() pointer is a
+    # dangling reference in two cases — no skill tools in the toolset
+    # (Blank Slate) OR the hermes-agent skill not installed — so the
+    # variant is chosen AFTER the skills index is built (see below) and
+    # this slot holds its position. Toolset and skill set are fixed
+    # per-session, so cache-safe either way.
     _has_skill_view = "skill_view" in (agent.valid_tool_names or set())
-    stable_parts.append(
-        HERMES_AGENT_HELP_GUIDANCE if _has_skill_view
-        else HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS
-    )
+    _help_guidance_slot = len(stable_parts)
+    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS)
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes
@@ -551,6 +552,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         )
     else:
         skills_prompt = ""
+
+    # Resolve the help-guidance variant now that the skills index exists:
+    # the skill-pointer variant requires BOTH skill_view in the toolset AND
+    # the hermes-agent skill actually present in the index (gating on the
+    # rendered index line keeps this a pure string check — no second
+    # filesystem scan, and it inherits the index cache's stability).
+    if _has_skill_view and "- hermes-agent:" in skills_prompt:
+        stable_parts[_help_guidance_slot] = HERMES_AGENT_HELP_GUIDANCE
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt


### PR DESCRIPTION
Campaign entry (#95681), maintainer-directed. Three defects in the skills section / help guidance:

1. **'## Skills (mandatory)' header** — the '(mandatory)' was noise (maintainer call); the body's MUST-load rule carries the actual obligation. Now '## Skills'.

2. **Duplicate hermes-agent teaching** — the skills section carried a whole paragraph ("Whenever the user asks you to configure, set up, install… load the hermes-agent skill first…") that duplicates HERMES_AGENT_HELP_GUIDANCE, which appears earlier in the same prompt. Deleted from the skills section; the help-guidance block is the single home (−63 tok on every skills-bearing session).

3. **Skill pointer not presence-gated** — HERMES_AGENT_HELP_GUIDANCE told every session to skill_view(name='hermes-agent'), but only gated on the skill_view TOOL existing, not on the hermes-agent SKILL being installed. On installs without that skill the pointer dangles. Now: the guidance slot is resolved AFTER the skills index is built, and the skill-pointer variant requires BOTH skill_view in the toolset AND '- hermes-agent:' present in the rendered index (pure string check — no second filesystem scan, inherits the index cache's byte-stability). Otherwise the docs-only variant serves.

Also cut: **"when the two differ"** — a model that just read the skill will not also fetch the docs to diff them (maintainer: "probably stupid"); the clause was dead weight. The docs-are-authoritative sentence already establishes precedence; the skill sentence now frames it as commands/workflows, load-before-configuring.

## Numbers
Help guidance 130→120; skills section header/paragraph −65; net **−75/call** on typical skills-bearing sessions (plus correctness on skill-less installs).

## Verification (real prompt builds, all three states)
- skill tools + hermes-agent installed → skill-pointer variant, clean header, no dupe, no differ-clause ✅
- skill tools + EMPTY skills dir → docs-only variant, no dangling pointer ✅
- no skill tools → docs-only variant (unchanged behavior) ✅
116 prompt/system tests pass (1 pre-existing IDENTITY-snapshot failure, stash-verified on clean main earlier today).