### PR TITLE
fix(state): disable sqlite statement cache on SessionDB connections

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3893,6 +3893,12 @@ class SessionTurnLeaseLostError(RuntimeError):
 def _connect_tracked_db(path, tracking_path=None, **kwargs):
     """``sqlite3.connect`` that registers the open fd for lock-safety.
 
+    The CPython sqlite3 statement cache is disabled for every SessionDB
+    connection.  These connections may be handed across threads via
+    ``check_same_thread=False``; CPython issues #118172 and #146471 document
+    cache corruption and native crashes under concurrent use, with
+    ``cached_statements=0`` as the supported workaround.
+
     While a connection is live, byte-level probes of the same file are
     refused: an ``open()``/``close()`` cancels every POSIX advisory lock this
     process holds on it -- including a running VACUUM's EXCLUSIVE lock.
@@ -3904,6 +3910,7 @@ def _connect_tracked_db(path, tracking_path=None, **kwargs):
     connect would disable the guard for the lifetime of that connection,
     which is precisely the failure mode this module exists to prevent.
     """
+    kwargs.setdefault("cached_statements", 0)
     try:
         from hermes_cli.sqlite_safe_read import connect_tracked
     except ImportError:

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -66,6 +66,36 @@ def _read(db):
     db.get_messages("s1")
 
 
+def test_tracked_connections_disable_sqlite_statement_cache(monkeypatch, tmp_path):
+    """Shared SessionDB connections must not use CPython's unsafe cache.
+
+    CPython issues #118172 and #146471 show that concurrent use of a
+    ``check_same_thread=False`` connection can corrupt the sqlite3 statement
+    cache and segfault in ``bounded_lru_cache_wrapper``.  Every SessionDB
+    connection passes through ``_connect_tracked_db``, so pin the documented
+    ``cached_statements=0`` workaround at that choke point.
+    """
+    import hermes_cli.sqlite_safe_read as safe_read
+    import hermes_state as state
+
+    observed = {}
+    sentinel = object()
+
+    def fake_connect_tracked(path, **kwargs):
+        observed.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(safe_read, "connect_tracked", fake_connect_tracked)
+
+    result = state._connect_tracked_db(
+        tmp_path / "state.db",
+        check_same_thread=False,
+    )
+
+    assert result is sentinel
+    assert observed["cached_statements"] == 0
+
+
 @pytest.mark.requires_wal
 def test_read_pool_is_bounded_across_many_threads(db):
     """150 short-lived reader threads must not pin 150 connections.


### PR DESCRIPTION
## Summary

`SessionDB` connections can hard-crash the interpreter (native `SIGSEGV`, no
Python traceback) when a single `check_same_thread=False` sqlite3 connection is
executed on more than one thread at once. This disables CPython's per-connection
sqlite3 statement LRU cache on every tracked SessionDB connection via the
documented `cached_statements=0` workaround.

## Symptom / evidence

The gateway crashes natively under read-load peaks. macOS crash dumps show an
identical signature on a background worker thread:

```
_pysqlite_query_execute
  → bounded_lru_cache_wrapper
    → _PyDict_GetItem_KnownHash   ← segfault (reads address 0x8)
```

Faulting thread is `thread_run → pythread_wrapper` (a worker), never the main
loop. Runtime Python 3.11.15, sqlite3 3.53.1.

## Root cause

- The read path borrows pooled connections, but when the pool is at capacity
  (`_READ_POOL_MAX` reached), `_read_ctx` falls back to serving the read from
  the **shared writer connection** (`self._conn`), opened with
  `check_same_thread=False`.
- That means two threads — the dedicated writer plus whichever reader blew past
  the pool ceiling — can issue `.execute()` on the same `sqlite3.Connection` at
  once.
- CPython's `sqlite3` module keeps an internal per-connection LRU cache for
  prepared statements. Concurrent `.execute()` on one connection corrupts that
  cache dict; the interpreter walks a corrupted node and dies natively.

CPython issues #118172 and #146471 document this class of cache corruption under
concurrent use of a shared connection and recommend `cached_statements=0` as the
supported workaround.

## Fix

`cached_statements=0` is pinned at `_connect_tracked_db`, the choke point every
SessionDB connection flows through — including the pool fallback that borrows
the writer connection. This removes the corrupted-cache race vector for the
entire bug class rather than only widening the pool.

## Why this approach

- **One-line, low-risk, no behavior change** to SQL semantics or transaction
  handling — it only disables statement caching.
- **Covers every connection**, including the fallback path that was crashing,
  without depending on pool accounting.
- Disabling the statement cache on these connections costs prepared-statement
  re-preparation per execute, a negligible price for session-state queries.

## Testing

- New regression test `test_tracked_connections_disable_sqlite_statement_cache`
  proves every tracked connection gets `cached_statements=0`.
- Existing pool tests pass (concurrency-correctness paths remain green).
- Live verification: a real `_connect_tracked_db` connection was exercised from
  a second thread (the scenario that previously segfaulted) with no errors.

## Notes

- This is a genuine upstream gap: no existing issue/PR references
  `cached_statements` in `hermes_state.py`.
- Local reproductions were load-triggered; the crash signature above is from
  macOS `.ips` crash reports.
