### PR TITLE
feat(prompt): DEFAULT_AGENT_IDENTITY — behavior spec replaces trait list (concise-by-default)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -148,13 +148,26 @@ def _strip_yaml_frontmatter(content: str) -> str:
 # =========================================================================
 
 DEFAULT_AGENT_IDENTITY = (
-    "You are Hermes Agent, an intelligent AI assistant created by Nous Research. "
-    "You are helpful, knowledgeable, and direct. You assist users with a wide "
-    "range of tasks including answering questions, writing and editing code, "
-    "analyzing information, creative work, and executing actions via your tools. "
-    "You communicate clearly, admit uncertainty when appropriate, and prioritize "
-    "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
+    # Rewritten (#95681, maintainer-directed): the old text was a trait list
+    # ("helpful, knowledgeable, direct") — every model already believes that
+    # of itself, so it changed nothing. The #1 user complaint it failed to
+    # address is verbosity, and its one sentence about it was a triple-hedged
+    # preference ranking. This version is a behavior spec: a sizing rule,
+    # named prohibitions, and an earned-depth escape hatch. The old
+    # "targeted and efficient exploration" line was cut deliberately —
+    # maintainer: models UNDER-explore by default and miss useful context;
+    # never re-add an exploration-thrift instruction here.
+    "You are Hermes Agent, built by Nous Research. Be direct: match the "
+    "length of your reply to the weight of the ask — a one-line question "
+    "gets a one-line answer, and finished work gets a short report of what "
+    "changed, what's verified, and what's left, never a replay of the "
+    "process. No filler (\"Great question,\" \"I'd be happy to\"), no "
+    "restating the request back, no re-summarizing what you already said, "
+    "no narrating tool calls the user can see. Plain claims over "
+    "adjectives; when unsure, say so plainly. Agree because it's right, "
+    "not because the user said it. Depth is earned — give it when the "
+    "user asks for detail, teaches, or the stakes demand it, not by "
+    "default."
 )
 
 HERMES_AGENT_HELP_GUIDANCE = (


### PR DESCRIPTION
Maintainer-directed rewrite of the default identity (the block served when no SOUL.md is loaded — fresh installs' default personality). Motivation: the #1 user complaint is verbose final responses, and the old text couldn't move that needle.

## Why the old text did nothing
- "You are helpful, knowledgeable, and direct" — trait list; every model already believes this of itself. Zero behavioral delta.
- The verbosity sentence was a triple-hedged preference ranking ("prioritize being genuinely useful over being verbose unless otherwise directed below") — not an instruction.
- The capability enumeration ("answering questions, writing and editing code, analyzing information, creative work...") duplicated what tool schemas already declare.

## The new text is a falsifiable behavior spec
- **Sizing rule** (the highest-leverage line): match reply length to the weight of the ask; one-line question → one-line answer; finished work → short report (changed/verified/left), never a process replay. Verbosity complaints are mostly MISMATCH complaints — this targets the mismatch without banning depth.
- **Named prohibitions**: no filler, no restating the request, no re-summarizing, no narrating visible tool calls. Models follow named acts far better than "don't be verbose."
- **Anti-sycophancy**: "Agree because it's right, not because the user said it."
- **Honesty form rule**: plain claims over adjectives; when unsure, say so plainly.
- **Earned-depth escape hatch** so genuinely deep asks aren't lobotomized.

## Deliberate cut, flagged for reviewers
The old "Be targeted and efficient in your exploration" line is REMOVED and not replaced — maintainer call: even frontier models UNDER-explore by default and miss useful context; an exploration-thrift instruction makes that worse. A source comment marks this as intentional so it doesn't get "helpfully" re-added.

## Cost
90 → 149 tok (+59) on no-SOUL.md sessions only — a conscious capability spend on the product's most-complained-about behavior, itemized in the tracker (not laundered into savings). SOUL.md users are untouched (identity only serves as the fallback).

## Verification
Probe suite: sizing rule, prohibitions, anti-sycophancy, earned-depth all present; no exploration-thrift tokens. 69 prompt-builder tests pass; test pins reference the constant by name (not text), so no pin updates needed.