### PR TITLE
feat(desktop): polish Bot Mode conversations

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -552,6 +552,7 @@ function ToolEntry({ part }: ToolEntryProps) {
       data-slot="tool-block"
       data-tool-open={open ? '' : undefined}
       data-tool-row=""
+      data-tool-view={toolViewMode}
       ref={enterRef}
     >
       <div className={cn(open && 'border-b border-(--ui-stroke-tertiary) px-2 py-1.5')}>

--- a/apps/desktop/src/plugins/hermes-bots/bot-mode.css
+++ b/apps/desktop/src/plugins/hermes-bots/bot-mode.css
@@ -179,6 +179,7 @@
   min-height: 2.25rem;
   border: 0;
   background: transparent;
+  padding-block: 0.75rem 0.25rem;
   box-shadow: none;
   resize: none;
 }

--- a/apps/desktop/src/plugins/hermes-bots/bot-mode.css
+++ b/apps/desktop/src/plugins/hermes-bots/bot-mode.css
@@ -1,0 +1,222 @@
+/* Bot Mode borrows Grokbot's conversation-first rhythm while retaining the
+   shared Hermes transcript, composer, themes, accessibility, and controls. */
+
+:root[data-hermes-bot-mode] {
+  --conversation-text-font-size: 0.9375rem;
+  --conversation-line-height: 1.35rem;
+  --conversation-turn-gap: 0.875rem;
+  --turn-block-gap: 0.5rem;
+  --composer-shell-pad-block-end: 1rem;
+  --message-text-indent: 0;
+  --ui-text-tertiary: color-mix(in srgb, var(--ui-base) 66%, transparent);
+  --ui-text-quaternary: color-mix(in srgb, var(--ui-base) 84%, transparent);
+  --conversation-scaffold-text: color-mix(in srgb, var(--ui-base) 72%, transparent);
+  --conversation-scaffold-meta: color-mix(in srgb, var(--ui-base) 56%, transparent);
+}
+
+:root[data-hermes-bot-mode] [data-slot='aui_thread-content'] {
+  padding-inline: 2rem;
+}
+
+/* Keep the sticky prompt container's reserved layout space; only the visible
+   prompt becomes a compact right-aligned capsule. */
+:root[data-hermes-bot-mode] [data-slot='aui_user-message-root'] {
+  width: 100%;
+  padding: 0;
+  background: transparent;
+}
+
+:root[data-hermes-bot-mode] [data-slot='aui_user-message-root'] .composer-human-message {
+  width: fit-content;
+  min-width: 3.5rem;
+  max-width: min(82%, 42rem);
+  margin-inline-start: auto;
+  border-color: transparent;
+  border-radius: 1.35rem;
+  background: color-mix(in srgb, var(--ui-base) 92%, var(--ui-bg-editor));
+  color: var(--ui-bg-editor);
+  padding: 0.65rem 1rem;
+  box-shadow: none;
+}
+
+:root[data-hermes-bot-mode] [data-slot='aui_user-message-root'] .composer-human-message * {
+  color: inherit;
+}
+
+/* Replies read as quiet cards. Each sealed commentary segment stays its own
+   bubble, matching Grokbot's short status → result cadence. */
+:root[data-hermes-bot-mode]
+  [data-slot='aui_assistant-message-root']:has(> [data-slot='aui_assistant-message-content']) {
+  width: fit-content;
+  max-width: min(82%, 42rem);
+  overflow: visible;
+}
+
+:root[data-hermes-bot-mode] [data-slot='aui_assistant-message-root'] > [data-slot='aui_assistant-message-content'] {
+  padding: 0.7rem 1rem;
+  border-radius: 1.2rem;
+  background: color-mix(in srgb, var(--ui-bg-secondary) 88%, var(--ui-text-primary) 12%);
+}
+
+:root[data-hermes-bot-mode] [data-slot='aui_assistant-message-root'] [data-slot='timeline-timestamp'],
+:root[data-hermes-bot-mode] [data-slot='aui_user-message-root'] [data-slot='timeline-timestamp'] {
+  display: none;
+}
+
+/* Product mode is intentionally clean: no tool rows at all. Technical mode is
+   the persisted Settings → Appearance opt-in and remains fully inspectable. */
+:root[data-hermes-bot-mode] [data-slot='tool-block'][data-tool-view='product'] {
+  display: none;
+}
+
+:root[data-hermes-bot-mode] [data-slot='composer-root'] {
+  border-radius: 999px;
+}
+
+:root[data-hermes-bot-mode] [data-slot='composer-surface'] {
+  min-height: 3.25rem;
+  grid-template-rows: auto;
+  border-radius: inherit;
+  box-shadow: 0 0.125rem 0.75rem color-mix(in srgb, #000 8%, transparent);
+}
+
+:root[data-hermes-bot-mode] [data-slot='composer-fade'] {
+  justify-content: center;
+}
+
+/* Roster: keep Hermes' multi-gateway grouping, but use Grokbot's 280px rail,
+   generous rows, restrained section labels, and soft selected surface. */
+:root[data-hermes-bot-mode] [data-bot-roster] {
+  background: var(--ui-bg-sidebar);
+}
+
+:root[data-hermes-bot-mode] [data-bot-roster] [role='button'] {
+  border-radius: 0.75rem;
+}
+
+:root[data-hermes-bot-mode] [data-bot-roster] input {
+  min-height: 2rem;
+  border-radius: 0.625rem;
+}
+
+/* Group rooms preserve Hermes threads, safety holds, and routing, but present
+   open exchanges on the same avatar + message rail as Grokbot. */
+:root[data-hermes-bot-mode] [data-bot-group-workspace] {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--ui-bg-primary);
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-header] {
+  min-height: 3rem;
+  padding-inline: 1rem;
+  border-bottom: 1px solid var(--ui-stroke-secondary);
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-activity] {
+  border-bottom-color: color-mix(in srgb, var(--ui-stroke-secondary) 60%, transparent);
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-messages] {
+  overflow-x: hidden;
+  padding-top: 0.625rem;
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-entry] {
+  width: fit-content;
+  min-width: 0;
+  max-width: min(82%, 48rem);
+  gap: 0.625rem;
+  margin-block: 0.25rem;
+  padding: 0;
+  background: transparent;
+  font-size: var(--conversation-text-font-size);
+  line-height: var(--conversation-line-height);
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-entry] > :last-child,
+:root[data-hermes-bot-mode] [data-bot-group-entry] [data-selectable-text='true'] {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-entry][data-role='user'] {
+  align-items: center;
+  margin-inline: auto 0;
+  border-radius: 1.35rem;
+  background: var(--ui-text-primary);
+  color: var(--ui-bg-editor);
+  padding: 0.3rem 1rem 0.9rem;
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-entry][data-role='user'] * {
+  color: inherit !important;
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-entry] code:not(pre code) {
+  border-radius: 0.35rem;
+  padding-inline: 0.3rem;
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-composer] {
+  border-top: 0;
+  padding: 1rem 1.5rem;
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-composer] form > div:last-child {
+  min-height: 3.25rem;
+  gap: 0.375rem;
+  border: 1px solid var(--ui-stroke-secondary);
+  border-radius: 999px;
+  background: var(--dt-input);
+  padding: 0.35rem 0.45rem 0.35rem 0.85rem;
+  box-shadow: 0 0.125rem 0.75rem color-mix(in srgb, #000 8%, transparent);
+}
+
+:root[data-hermes-bot-mode] [data-bot-group-composer] textarea {
+  display: block;
+  min-height: 2.25rem;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  resize: none;
+}
+
+@media (max-width: 720px) {
+  :root[data-hermes-bot-mode] [data-slot='aui_thread-content'] {
+    padding-inline: 1rem;
+  }
+
+  :root[data-hermes-bot-mode] [data-slot='aui_user-message-root'],
+  :root[data-hermes-bot-mode]
+    [data-slot='aui_assistant-message-root']:has(> [data-slot='aui_assistant-message-content']) {
+    max-width: 92%;
+  }
+
+  :root[data-hermes-bot-mode] [data-bot-group-messages] {
+    padding-right: 2rem;
+  }
+
+  :root[data-hermes-bot-mode] [data-bot-group-entry][data-role='assistant'] {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  :root[data-hermes-bot-mode] [data-bot-group-entry][data-role='user'] {
+    width: fit-content;
+    max-width: 92%;
+  }
+
+  :root[data-hermes-bot-mode] [data-bot-group-entry] code:not(pre code) {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: normal;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+  }
+
+  :root[data-hermes-bot-mode] [data-bot-group-composer] {
+    padding-inline: 1rem;
+  }
+}

--- a/apps/desktop/src/plugins/hermes-bots/bot-mode.css
+++ b/apps/desktop/src/plugins/hermes-bots/bot-mode.css
@@ -184,6 +184,12 @@
   resize: none;
 }
 
+:root[data-hermes-bot-mode] [data-bot-group-composer] textarea:placeholder-shown {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @media (max-width: 720px) {
   :root[data-hermes-bot-mode] [data-slot='aui_thread-content'] {
     padding-inline: 1rem;

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -656,7 +656,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
     members.map(b => displayName(b, botRosterMeta(b, allMeta))).join(', ') || 'No bots in this group chat'
 
   const header = (
-    <div className="flex items-center gap-2 px-2.5 pt-2.5 pb-2">
+    <div className="flex items-center gap-2 px-2.5 pt-2.5 pb-2" data-bot-group-header="">
       <Button onClick={() => (onBack ? onBack() : $groupChatWorkspace.set(null))} size="sm" variant="ghost">
         Back
       </Button>
@@ -736,7 +736,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
   }
 
   const activityPanel = (
-    <div className="border-b border-(--ui-stroke-secondary)">
+    <div className="border-b border-(--ui-stroke-secondary)" data-bot-group-activity="">
       <div className="flex items-center gap-1">
         <RowButton
           aria-controls={`group-activity:${group}`}
@@ -986,6 +986,8 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
           'group flex items-start gap-2',
           isUser ? 'rounded-md bg-(--chrome-action-hover) px-2 py-1.5' : 'px-2 py-1'
         )}
+        data-bot-group-entry=""
+        data-role={isUser ? 'user' : 'assistant'}
         key={entryKey}
       >
         {appearance ? (
@@ -1022,7 +1024,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
             ) : null}
           </div>
           <div
-            className="text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:overflow-x-auto" // The app shell sets user-select: none globally; message bodies opt
+            className="text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:overflow-x-auto" // The app shell sets user-select: none globally; message bodies opt
             // back in so drag-select and ⌘C work in group chat logs.
             data-selectable-text="true"
           >
@@ -1208,6 +1210,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
   return (
     <div
       className="relative flex h-full flex-col"
+      data-bot-group-workspace=""
       onDragLeave={event => {
         // Only clear when leaving the room container itself, not when the
         // cursor moves between its children. React types relatedTarget as a
@@ -1234,8 +1237,8 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
       ) : null}
       {header}
       {activityPanel}
-      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
-        <div className="grid gap-1.5 px-2.5 pb-2">
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain" data-bot-group-messages="">
+        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)] gap-1.5 px-2.5 pb-2">
           {room.log.length
             ? logChildren
             : [
@@ -1261,7 +1264,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
           <div aria-hidden key={'bottom-sentinel'} ref={bottomSentinelRef} />
         </div>
       </div>
-      <div className="border-t border-(--ui-stroke-secondary) p-2">
+      <div className="border-t border-(--ui-stroke-secondary) p-2" data-bot-group-composer="">
         <form
           className="grid gap-0"
           onSubmit={event => {

--- a/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
@@ -154,6 +154,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   mocks.botChatOwnsWorkspace.mockReturnValue(false)
   mocks.sessionOwnsWorkspace.mockReturnValue(false)
+  globalThis.document.documentElement.removeAttribute('data-hermes-bot-mode')
 })
 
 afterEach(() => {
@@ -171,10 +172,29 @@ describe('the Bots pane dock', () => {
     const data = harness.find('pane')!.data!
 
     expect(data.dock).toEqual({ enforce: true, pane: 'sessions', pos: 'center' })
+    expect(data.width).toBe('280px')
     // A 'bottom' split was the old workaround for the lone-pane auto-hide trap.
     expect((data.dock as { pos: string }).pos).not.toBe('bottom')
     // No heal token: the invariant runs at every adoption, unconditionally.
     expect(data).not.toHaveProperty('heal')
+
+    harness.dispose()
+  })
+
+  it('keeps the Bot Mode presentation while a collapsed narrow layout still shows a group chat', async () => {
+    const store = paneStores()
+    const harness = recordingContext()
+    const { $groupChatWorkspace } = await import('./group-chat')
+
+    plugin.register(harness.ctx)
+    store(`hermes-bots:pane`).set(true)
+    $groupChatWorkspace.set('Coder, Hermes, Volt')
+    store(`hermes-bots:pane`).set(false)
+
+    expect(globalThis.document.documentElement.hasAttribute('data-hermes-bot-mode')).toBe(true)
+
+    $groupChatWorkspace.set(null)
+    expect(globalThis.document.documentElement.hasAttribute('data-hermes-bot-mode')).toBe(false)
 
     harness.dispose()
   })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -15,6 +15,8 @@
  * bot-initiated sends use `hermes -p <bot> chat --in ~ -c "Bot Chat"`.
  */
 
+import './bot-mode.css'
+
 import { CHAT_EMPTY_AREA, COMPOSER_AREAS, host, PALETTE_AREA, translateNow } from '@hermes/plugin-sdk'
 import type { ChatEmptyProps, PluginContext } from '@hermes/plugin-sdk'
 
@@ -384,7 +386,7 @@ export default {
       // zone's tab strip, so the pane stays reachable while collapsed.
       data: {
         placement: 'left',
-        width: '260px',
+        width: '280px',
         collapsible: true,
         hideOnly: true,
         dock: {
@@ -438,6 +440,13 @@ export default {
       const $sidebarVisible = host.paneVisibility(`${ID}:pane`)
       let unregisterRoutines: null | (() => void) = null
 
+      const syncBotModePresentation = () => {
+        document.documentElement.toggleAttribute(
+          'data-hermes-bot-mode',
+          $botsPaneVisible.get() || Boolean($groupChatWorkspace.get()) || Boolean($openBotChat.get())
+        )
+      }
+
       const syncRoutinesPane = () => {
         if (botChatOwnsWorkspace()) {
           unregisterRoutines ??= registerRoutinesPane()
@@ -460,6 +469,7 @@ export default {
 
       const stopSidebarSync = $sidebarVisible.listen(visible => {
         $botsPaneVisible.set(Boolean(visible))
+        syncBotModePresentation()
 
         if (visible) {
           const group = $groupChatWorkspace.get()
@@ -498,7 +508,12 @@ export default {
         syncRoutinesPane()
       })
 
-      const stopGroupSync = $groupChatWorkspace.listen(syncRoutinesPane)
+      const stopGroupSync = $groupChatWorkspace.listen(() => {
+        syncBotModePresentation()
+        syncRoutinesPane()
+      })
+
+      const stopOpenBotSync = $openBotChat.listen(syncBotModePresentation)
 
       // React on the NEXT tick — a layout notification arrives mid-mutation,
       // and registering/unregistering panes from inside it would re-enter the
@@ -521,6 +536,7 @@ export default {
           ? focusStore.listen(id => {
               $botChatFocused.set(Boolean(id))
               releaseStaleOpenBotChat(id)
+              syncBotModePresentation()
               syncRoutinesPane()
             })
           : null
@@ -587,6 +603,7 @@ export default {
 
       $botsPaneVisible.set(Boolean($sidebarVisible.get()))
       $botChatFocused.set(sessionOwnsWorkspace())
+      syncBotModePresentation()
       // A persisted layout can boot directly into Bot Mode. Reconcile now,
       // then once more after the layout mutation finishes.
       syncRoutinesPane()
@@ -598,8 +615,10 @@ export default {
         ctx.onDispose(() => {
           stopSidebarSync()
           stopGroupSync()
+          stopOpenBotSync()
           stopFocusSync?.()
           stopReclaimSync?.()
+          document.documentElement.removeAttribute('data-hermes-bot-mode')
         })
       }
     } else {

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -241,6 +241,7 @@ export function BotsPane() {
   const { t } = useI18n()
   const b = useBots()
   const { data, error, isLoading, refetch } = useRoster()
+
   const gatewayState = useValue(host.state.gateway)
   const gatewayUp = gatewayState === 'open'
   const activeProfile = (useValue(host.state.profile) || 'default').trim() || 'default'
@@ -601,7 +602,7 @@ export function BotsPane() {
   )
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col" data-bot-roster="">
       <div className="flex items-center justify-between gap-2 px-2.5 pt-2.5 pb-1.5">
         <span className="text-[0.6875rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary)">
           Bots


### PR DESCRIPTION
## What does this PR do?

Polishes Hermes Desktop Bot Mode into a more spacious, conversation-first interface while preserving the existing Bot Mode stores, gateway RPCs, assistant-ui renderers, group threads, and persisted settings.

The styling is scoped to `data-hermes-bot-mode`, so ordinary Hermes conversations are unchanged.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a Bot Mode-only visual system for the roster, direct conversations, group chats, assistant rows, outgoing message pills, composer, and responsive narrow layouts.
- Keep raw tool details hidden in Product mode while preserving the persisted Technical mode view.
- Align group-chat message typography with direct Bot Chat typography and improve inline-code wrapping without horizontal overflow.
- Add Bot Mode lifecycle/data markers and preserve the existing group-chat and assistant-ui architecture.
- Expand pane tests to cover the updated 280px Bots rail and scoped presentation contract.

## How to Test

1. Run the focused Desktop tests:
   `cd apps/desktop && NODE_ENV=test npx vitest run src/plugins/hermes-bots/group-chat-parts.test.tsx src/plugins/hermes-bots/plugin-panes.test.tsx`
2. Build Desktop:
   `cd apps/desktop && npm run build`
3. Launch `apps/desktop` and inspect direct Bot Chat and group-chat conversations at desktop width and approximately 408×628 logical pixels.
4. Toggle the group Activity disclosure and switch between direct bots and group chats.

## Validation

- Focused Bot Mode tests: **18 passed, 0 failed**
- Desktop production build: **passed**
- Prettier and `git diff --check`: **passed**
- Served-surface review: desktop and 408×628 narrow layouts passed for typography, wrapping, containment, and horizontal overflow; Activity expand/collapse was exercised.
- Repo-wide `npm run check`: **not green** because unrelated Desktop/Web/TUI suites fail broadly with `TypeError: act is not a function`; no failures pointed to the changed Bot Mode files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Hermes Desktop Electron app

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A; this changes Desktop presentation only
- [x] `cli-config.yaml.example`: N/A; no configuration keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; architecture and workflows are unchanged
- [x] Cross-platform impact considered: CSS/React-only changes use existing Desktop tokens and responsive layout primitives
- [x] Tool descriptions/schemas: N/A; no tool behavior changed

## Screenshots / Logs

### Bot Mode desktop UX

<img width="2334" height="1870" alt="Hermes Desktop Bot Mode showing the Bots roster and a conversation-first chat layout" src="https://github.com/user-attachments/assets/753bc10a-4db5-4f98-ade3-bcd281dcba81" />

The screenshot shows the Bots roster, selected bot state, long-form assistant output, compact outgoing messages, assistant response treatment, and the shared composer.
