### PR TITLE
fix(update): unrelated transitional Windows services no longer abort updates (salvage of #96381)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1061,6 +1061,7 @@ def find_windows_gateway_services(
         if profile_processes is None:
             profile_processes = find_profile_gateway_processes(strict=True)
         service_names_by_pid: dict[int, set[str]] = {}
+        indeterminate_services_by_pid: dict[int, list[tuple[str, object]]] = {}
         for service in psutil_module.win_service_iter():
             try:
                 if all(
@@ -1086,9 +1087,11 @@ def find_windows_gateway_services(
             if service_status == "stopped":
                 continue
             if service_status != "running":
-                raise RuntimeError(
-                    f"SCM service {service_name} has indeterminate status: {service_status}"
-                )
+                if service_pid > 0:
+                    indeterminate_services_by_pid.setdefault(service_pid, []).append(
+                        (service_name, service_status)
+                    )
+                continue
             if service_pid <= 0:
                 raise RuntimeError(
                     f"Running SCM service {service_name} has no valid process ID"
@@ -1107,6 +1110,14 @@ def find_windows_gateway_services(
             ) > 0.001:
                 raise RuntimeError("Gateway process identity changed during SCM discovery")
             ancestor_pids = [int(parent.pid) for parent in gateway_process.parents()]
+            for pid in ancestor_pids:
+                indeterminate_services = indeterminate_services_by_pid.get(pid, [])
+                if indeterminate_services:
+                    service_name, service_status = indeterminate_services[0]
+                    raise RuntimeError(
+                        f"SCM service {service_name} has indeterminate status: "
+                        f"{service_status}"
+                    )
             shared_service_pids = [
                 pid
                 for pid in ancestor_pids

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1015,15 +1015,16 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
     profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
 
     class FakeService:
-        def __init__(self, name, pid):
+        def __init__(self, name, pid, status="running"):
             self.name = name
             self.pid = pid
+            self.status = status
 
         def as_dict(self):
             return {
                 "name": self.name,
                 "pid": self.pid,
-                "status": "running",
+                "status": self.status,
             }
 
     class FakeProcess:
@@ -1044,7 +1045,7 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
     fake_psutil = SimpleNamespace(
         win_service_iter=lambda: [
             FakeService("HermesGateway", 100),
-            FakeService("UnrelatedService", 900),
+            FakeService("UnrelatedService", 900, "stop_pending"),
         ],
         Process=FakeProcess,
     )
@@ -1066,6 +1067,37 @@ def test_find_windows_gateway_services_maps_verified_pid_tree(monkeypatch):
             gateway_create_time=300.0,
         )
     ]
+
+
+def test_find_windows_gateway_services_rejects_transitional_ancestor(monkeypatch):
+    """A transitional service in the gateway ancestry remains fail-closed."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def as_dict(self):
+            return {"name": "HermesGateway", "pid": 100, "status": "stop_pending"}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(100)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService()],
+        Process=FakeProcess,
+    )
+
+    with pytest.raises(RuntimeError, match="indeterminate status: stop_pending"):
+        gateway.find_windows_gateway_services(
+            psutil_module=fake_psutil,
+            profile_processes=[profile],
+        )
 
 
 def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypatch):


### PR DESCRIPTION
## Summary

Salvage of PR #96381 by @fangliquanflq onto current `main`, authorship preserved.

A single unrelated Windows service stuck in a transitional SCM state (paused, START_PENDING, STOP_PENDING — e.g. FontCache3.0.0.0, cortsmartserver) no longer aborts every Desktop/CLI update with "SCM service enumeration failed" (#96860, #97856, #96360). `find_windows_gateway_services()` now records transitional services instead of raising during enumeration, and stays **fail-closed exactly where it matters**: if a transitional service PID sits in a validated gateway's ancestor chain, the update still aborts with the original error.

Cluster resolution (4 competing PRs):
- **#96381 (this) wins**: precise semantics — skip unrelated transitional services, fail closed on gateway-ancestry ones; smallest correct diff (+49/-6); both regression directions tested (unrelated STOP_PENDING passes; ancestor STOP_PENDING raises).
- #97238: skips ALL non-running services including a gateway's own transitional host — loses the fail-closed guarantee 790e1eb6bd deliberately added.
- #96398: same semantics as #96381 plus PID create-time identity re-checks for transitional services (+265/-5) — heavier variant of the same idea; the identity re-check duplicates the check already done on the gateway side of the join.
- #97220: different bug (Task Scheduler ownership misattribution) — NOT closed as a duplicate; triaged separately.

## Changes
- `hermes_cli/gateway.py`: transitional services collected into `indeterminate_services_by_pid` instead of raising; raise deferred to ancestry join
- `tests/hermes_cli/test_gateway.py`: unrelated `stop_pending` service tolerated; transitional ancestor still fail-closed

## Validation
| | result |
|---|---|
| tests/hermes_cli/test_gateway.py | 35 passed, 3 skipped |
| mutation (gateway.py reverted to main) | 2 failed → restored: 35 passed |

Closes #96381
Fixes #96860
Fixes #97856
Fixes #96360
Refs #97238, #96398
