### PR TITLE
fix(telegram): inject bot identity into channel_prompt for group messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9300,27 +9300,45 @@ class TelegramAdapter(BasePlatformAdapter):
         )
 
     def _apply_telegram_group_observe_attribution(self, event: MessageEvent) -> MessageEvent:
-        """Align triggered group turns with observed-history attribution."""
-        if not self._telegram_observe_unmentioned_group_messages():
-            return event
+        """Align triggered group turns with observed-history attribution.
+
+        Always injects the bot identity hint into ``channel_prompt`` for
+        group messages, even when ``observe_unmentioned_group_messages`` is
+        off — the agent needs to know its own @-mention handle to recognize
+        that messages addressed to ``@<bot>`` are requests for it. Without
+        this hint the agent treats ``@<bot> test`` as an unknown third-party
+        mention and stays silent.
+        """
         raw_message = getattr(event, "raw_message", None)
         if not raw_message or not self._is_group_chat(raw_message):
             return event
+
+        # Always-on identity hint for group messages. The bot needs to know
+        # its own handle to interpret "@<bot> test" as addressed-to-it
+        # rather than as a third-party mention to ignore.
+        identity_prompt = self._telegram_bot_identity_channel_prompt()
+        channel_prompt = (
+            f"{event.channel_prompt}\n\n{identity_prompt}"
+            if event.channel_prompt
+            else identity_prompt
+        )
+
+        if not self._telegram_observe_unmentioned_group_messages():
+            return dataclasses.replace(event, channel_prompt=channel_prompt)
+
+        # Observed-history attribution path (unchanged).
         chat_id_str = str(getattr(getattr(raw_message, "chat", None), "id", ""))
         allowed = self._telegram_observe_allowed_chats()
         if not allowed or chat_id_str not in allowed:
-            return event
+            return dataclasses.replace(event, channel_prompt=channel_prompt)
         shared_source = self._telegram_group_observe_shared_source(event.source)
         observe_prompt = self._telegram_group_observe_channel_prompt()
-        channel_prompt = f"{event.channel_prompt}\n\n{observe_prompt}" if event.channel_prompt else observe_prompt
+        channel_prompt = (
+            f"{channel_prompt}\n\n{observe_prompt}"
+            if channel_prompt
+            else observe_prompt
+        )
         if event.message_type == MessageType.COMMAND:
-            # Commands must retain the original source (with user_id) so
-            # slash-access control (_check_slash_access) can identify the
-            # sender.  Replacing the source with an anonymised shared source
-            # (user_id=None) causes admin-only commands like /new to be
-            # denied even when the sender is an admin, because
-            # SlashAccessPolicy.is_admin(None) is always False.
-            # Still inject channel_prompt for group context.
             return dataclasses.replace(
                 event,
                 channel_prompt=channel_prompt,
@@ -9330,6 +9348,20 @@ class TelegramAdapter(BasePlatformAdapter):
             text=self._telegram_group_observe_attributed_text(event),
             source=shared_source,
             channel_prompt=channel_prompt,
+        )
+
+    def _telegram_bot_identity_channel_prompt(self) -> str:
+        """Return a short channel-prompt block announcing the bot's identity
+        so the agent knows its own @-mention handle in Telegram group chats.
+        """
+        username = self._current_bot_username() or "unknown"
+        bot_id = getattr(getattr(self, "_bot", None), "id", None) or "unknown"
+        return (
+            "Telegram group context:\n"
+            f"- Your identity: user_id={bot_id}, @-mention name in this group=@{username}\n"
+            "- When the current message contains your @-mention, treat it as "
+            "addressed to you even if the leading handle was stripped from the "
+            "message text. Reply accordingly."
         )
 
     def _media_message_type(self, msg: Message) -> MessageType:

--- a/tests/gateway/test_telegram_group_identity_hint.py
+++ b/tests/gateway/test_telegram_group_identity_hint.py
@@ -1,0 +1,173 @@
+"""Regression test: Telegram group messages must always include the bot's
+@-mention handle in ``channel_prompt``, regardless of the
+``observe_unmentioned_group_messages`` setting.
+
+Before this fix, the bot-identity hint was injected only on the
+``observe_unmentioned_group_messages`` code path. With that setting off (the
+default), a group message addressed to the bot as ``@<bot> test`` would be
+dispatched to the agent loop with no context about who the bot is. The model
+would treat the leading ``@<bot>`` mention as an unknown third-party handle
+and stay silent, because:
+
+1. ``_clean_bot_trigger_text`` strips ``@<bot>`` from the message text, so the
+   agent only sees the bare ``test`` with no indication it was addressed to
+   the bot.
+2. ``channel_prompt`` had no mention of the bot's @-username, so the agent
+   had no way to recognize that the (now-stripped) prefix referred to itself.
+
+After this fix, every Telegram group message carries a short identity block
+in ``channel_prompt`` so the agent always knows its own @-mention handle.
+"""
+
+import asyncio
+import inspect
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType, SessionSource
+
+
+def _make_adapter(bot_username=None, observe_unmentioned=False):
+    """Build a TelegramAdapter stub."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    extra = {
+        "allowed_chats": [],
+        "group_allowed_chats": [],
+        "allowed_topics": [],
+        "mention_patterns": [],
+        "observe_unmentioned_group_messages": observe_unmentioned,
+    }
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra=extra)
+    adapter._bot = SimpleNamespace(
+        id=999, username=bot_username, get_me=AsyncMock()
+    )
+    adapter._bot_username_observed = bot_username
+    adapter._bot_identity_checked_at = 0.0
+    adapter._webhook_mode = False
+    return adapter
+
+
+def _make_event(chat_type="supergroup", text="hello"):
+    """Build a real MessageEvent with the minimum attributes the adapter reads."""
+    from gateway.platforms.base import MessageEvent
+
+    raw = SimpleNamespace(
+        chat=SimpleNamespace(id=-1001, type=chat_type),
+        from_user=SimpleNamespace(id=42, username="someone"),
+        message_id=1,
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        user_id="42",
+        user_name="someone",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            user_id="42",
+            user_name="someone",
+        ),
+        channel_prompt="",
+        raw_message=raw,
+        message_id="1",
+    )
+
+
+def test_identity_prompt_injected_when_observe_unmentioned_off():
+    """Default config (observe_unmentioned_group_messages=False) must still
+    inject the bot identity hint into channel_prompt. Otherwise the agent
+    cannot recognize ``@<bot>`` mentions as addressed to itself.
+    """
+    adapter = _make_adapter(bot_username="myninamaxbot", observe_unmentioned=False)
+    event = _make_event(chat_type="supergroup", text="hello")
+    out = adapter._apply_telegram_group_observe_attribution(event)
+    assert "myninamaxbot" in out.channel_prompt, (
+        "channel_prompt must include the bot's @-mention so the agent can "
+        "recognize mentions addressed to it"
+    )
+
+
+def test_identity_prompt_injected_when_observe_unmentioned_on():
+    """When observe_unmentioned_group_messages=True AND the chat is in the
+    observe-allowlist, both the identity hint AND the observe-attribution
+    block must appear in channel_prompt.
+    """
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    extra = {
+        "allowed_chats": ["-1001"],
+        "group_allowed_chats": ["-1001"],
+        "allowed_topics": [],
+        "mention_patterns": [],
+        "observe_unmentioned_group_messages": True,
+    }
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra=extra)
+    adapter._bot = SimpleNamespace(
+        id=999, username="myninamaxbot", get_me=AsyncMock()
+    )
+    adapter._bot_username_observed = "myninamaxbot"
+    adapter._bot_identity_checked_at = 0.0
+    adapter._webhook_mode = False
+
+    event = _make_event(chat_type="supergroup", text="hello")
+    out = adapter._apply_telegram_group_observe_attribution(event)
+    assert "myninamaxbot" in out.channel_prompt
+    # And the observe-attribution block also fires (because chat is in observe allowlist).
+    assert "observed Telegram group context" in out.channel_prompt
+
+
+def test_identity_prompt_skipped_for_dm():
+    """DMs must NOT receive the group-context identity block — the prompt is
+    only for group chats where the bot's @-mention is meaningful.
+    """
+    adapter = _make_adapter(bot_username="myninamaxbot")
+    event = _make_event(chat_type="private", text="hello")
+    out = adapter._apply_telegram_group_observe_attribution(event)
+    # DM: no change to channel_prompt.
+    assert out.channel_prompt == ""
+
+
+def test_identity_prompt_includes_handle_hint():
+    """The injected prompt must explicitly tell the agent that ``@<bot>``
+    mentions addressed to it should be answered.
+    """
+    adapter = _make_adapter(bot_username="myninamaxbot")
+    event = _make_event(chat_type="supergroup", text="@myninamaxbot hi")
+    out = adapter._apply_telegram_group_observe_attribution(event)
+    # The hint explicitly says the agent should respond to mentions addressed
+    # to it, even when the leading handle was stripped from the message text.
+    assert "treat it as" in out.channel_prompt.lower()
+    assert "addressed to you" in out.channel_prompt.lower()
+
+
+def test_mention_strip_does_not_lose_intent():
+    """End-to-end: when a user types ``@myninamaxbot hello`` in a group, the
+    agent receives:
+      - event.text = "hello" (mention stripped, as before)
+      - event.channel_prompt = "...@myninamaxbot...addressed to you..."
+    So the model can recover the intent ("hello" was addressed to me).
+    """
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = _make_adapter(bot_username="myninamaxbot")
+
+    # Mimic _clean_bot_trigger_text output: "hello" instead of "@myninamaxbot hello"
+    raw_text = "@myninamaxbot hello"
+    cleaned = adapter._clean_bot_trigger_text(raw_text)
+    assert cleaned == "hello"  # confirm the strip is what we expect
+
+    event = _make_event(chat_type="supergroup", text=cleaned)
+    out = adapter._apply_telegram_group_observe_attribution(event)
+
+    # Strip removed the mention; identity prompt carries it instead.
+    assert "myninamaxbot" not in out.text
+    assert "myninamaxbot" in out.channel_prompt


### PR DESCRIPTION
## Summary

Fix a latent issue where Telegram group messages addressed to the bot as `@<bot> <text>` were silently dropped after the leading handle was stripped.

### The bug

When a user types `@myninamaxbot hello` in a Telegram group, the adapter strips `@myninamaxbot` from `event.text` via `_clean_bot_trigger_text` (line 9243) before dispatching to the agent loop. The agent receives just `hello` with no indication that the message was addressed to it, and stays silent because the system prompt never tells it what its own @-mention handle is.

This was masked because the only place that injects a bot-identity hint into `channel_prompt` is `_apply_telegram_group_observe_attribution`, which is gated by `observe_unmentioned_group_messages` (off by default). Most installs never enable that setting, so the identity hint never fires — and the agent never knows its own handle.

### The fix

Make the bot-identity hint **unconditional** for group messages:
- A new method `_telegram_bot_identity_channel_prompt()` returns a short block announcing the bot's @-username and ID, plus a reminder that stripped mentions were addressed to it.
- `_apply_telegram_group_observe_attribution` now injects this block for every group message (DMs are unaffected), regardless of the `observe_unmentioned_group_messages` setting.
- The existing observe-attribution behavior is preserved: when that setting is on AND the chat is in the observe allowlist, the observe block is appended after the identity hint.

### Diff stats

```
plugins/platforms/telegram/adapter.py              |  56 +++++--
tests/gateway/test_telegram_group_identity_hint.py | 173 +++++++++++++++++++++
2 files changed, 217 insertions(+), 12 deletions(-)
```

### Tests

Five regression tests in `test_telegram_group_identity_hint.py`:
- `test_identity_prompt_injected_when_observe_unmentioned_off` — the bug case
- `test_identity_prompt_injected_when_observe_unmentioned_on` — both blocks fire
- `test_identity_prompt_skipped_for_dm` — DMs unaffected
- `test_identity_prompt_includes_handle_hint` — explicit recovery language
- `test_mention_strip_does_not_lose_intent` — end-to-end strip + identity propagation

**Verification:**
- 3/5 tests **FAIL** against the unpatched adapter (proves they catch the bug)
- 5/5 pass with the patch
- 24 existing telegram tests still pass (no regressions)

### Reproduction (before the fix)

1. Add the bot to a Telegram group with Send Messages permission.
2. Type `@myninamaxbot hello` in the group.
3. The adapter's gate accepts the message (`require_mention=false` default, `exclusive_bot_mentions` falls through when cache is empty).
4. `_clean_bot_trigger_text` strips the leading handle, so the agent receives `hello` as `event.text` with empty `channel_prompt`.
5. The agent doesn't know `@myninamaxbot` is its own handle and stays silent.

### After the fix

Same scenario: the agent receives `hello` as `event.text` AND a `channel_prompt` block that says `Your @-mention name in this group is @myninamaxbot ... When the current message contains your @-mention, treat it as addressed to you even if the leading handle was stripped from the message text. Reply accordingly.` The model responds.

### Related work

This builds on the upstream username-cache work in `08130a26f` ("fix(telegram): follow @username renames and support non-bot handles") which addressed the gate-side stale-handle issue. This PR addresses the complementary prompt-side issue: even with a correct cache, the agent wouldn't recognize mentions without an explicit identity hint.

Also related: PR #3870 introduced `_should_process_message` and the original mention-gate logic.