### PR TITLE
fix(kanban): guard first-review self-review when reviewer is omitted (#97910)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6597,6 +6597,25 @@ def request_review(
                     )
                 reviewer = prior_reviewer
         reviewer = _canonical_assignee(reviewer) if reviewer is not None else None
+        # Four-eyes guard: refuse first-review self-review unless opted in
+        # via ``kanban.allow_self_review``.  When ``reviewer`` is omitted on a
+        # first review the assignee stays as the implementer, silently routing
+        # the card back to the same profile that just built it (#97910).
+        effective_reviewer = reviewer if reviewer is not None else implementer
+        if (
+            effective_reviewer is not None
+            and effective_reviewer == implementer
+            and not self_review_allowed()
+        ):
+            return _ret(
+                False,
+                "review would be assigned to the implementer "
+                f"({implementer}); pass reviewer= explicitly or set "
+                "kanban.allow_self_review: true to opt in",
+            )
+        self_review_warning = (
+            effective_reviewer == implementer and self_review_allowed()
+        )
         assignee_sql = ", assignee = ?" if reviewer is not None else ""
         params: tuple[Any, ...]
         if expected_run_id is None:
@@ -6654,6 +6673,7 @@ def request_review(
                 "summary": event_summary or None,
                 "implementer": implementer,
                 "reviewer": reviewer,
+                "self_review": True if self_review_warning else None,
             },
             run_id=run_id,
         )
@@ -9619,6 +9639,24 @@ def review_dispatch_enabled() -> bool:
         )
     except Exception:
         return True
+
+
+def self_review_allowed() -> bool:
+    """Return whether a profile may review its own implementation work.
+
+    The default is **False** because the review lane exists to enforce a
+    four-eyes separation: when ``reviewer`` is omitted on a first review the
+    assignee stays as the implementer, silently routing the card back to the
+    same profile that just built it.  Single-profile boards that legitimately
+    want self-review can opt in with ``kanban.allow_self_review: true``.
+    """
+    try:
+        from hermes_cli.config import load_config
+        return bool(
+            (load_config() or {}).get("kanban", {}).get("allow_self_review", False)
+        )
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -257,6 +257,7 @@ def test_parent_reopen_blocks_request_review_until_parent_is_done(conn) -> None:
         conn,
         task_id,
         summary="must wait",
+        reviewer="reviewer",
         expected_run_id=implementation.current_run_id,
     )
     still_running = kb.get_task(conn, task_id)
@@ -267,6 +268,7 @@ def test_parent_reopen_blocks_request_review_until_parent_is_done(conn) -> None:
         conn,
         task_id,
         summary="parent stable",
+        reviewer="reviewer",
         expected_run_id=implementation.current_run_id,
     )
 
@@ -541,8 +543,8 @@ def test_goal_run_status_is_bound_to_original_run(conn) -> None:
 
 
 def test_parked_review_approval_without_evidence_still_creates_audit_run(conn) -> None:
-    task_id = kb.create_task(conn, title="Manual approval", assignee="reviewer")
-    assert kb.request_review(conn, task_id, summary="implementation handoff")
+    task_id = kb.create_task(conn, title="Manual approval", assignee="builder")
+    assert kb.request_review(conn, task_id, summary="implementation handoff", reviewer="reviewer")
     assert kb.complete_task(conn, task_id)
     completed_event = _event(kb.list_events(conn, task_id), "completed")
     assert completed_event.run_id is not None

--- a/tests/hermes_cli/test_kanban_self_review_guard.py
+++ b/tests/hermes_cli/test_kanban_self_review_guard.py
@@ -1,0 +1,120 @@
+"""Tests for the kanban self-review guard (#97910).
+
+When ``reviewer`` is omitted on a first review, the assignee stays as the
+implementer, silently routing the card back to the same profile that just
+built it.  The guard refuses this unless ``kanban.allow_self_review`` is
+enabled, and records a ``self_review`` flag on the event when opted in.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _event(events, kind):
+    for e in reversed(events):
+        if e.kind == kind:
+            return e
+    return None
+
+
+def test_first_review_without_reviewer_is_rejected(conn) -> None:
+    """Omitting ``reviewer`` on a first review returns False with a diagnostic."""
+    task_id = kb.create_task(conn, title="Implement feature X", assignee="builder")
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None
+    ok, reason = kb.request_review(
+        conn,
+        task_id,
+        summary="ready for review",
+        expected_run_id=implementation.current_run_id,
+        with_reason=True,
+    )
+    assert ok is False
+    assert "implementer" in (reason or "")
+    assert "allow_self_review" in (reason or "")
+
+
+def test_first_review_with_explicit_different_reviewer_succeeds(conn) -> None:
+    """Passing ``reviewer=`` with a different profile works normally."""
+    task_id = kb.create_task(conn, title="Implement feature Y", assignee="builder")
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        summary="ready for review",
+        reviewer="reviewer",
+        expected_run_id=implementation.current_run_id,
+    )
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "review"
+    assert task.assignee == "reviewer"
+
+
+def test_explicit_self_review_is_rejected(conn) -> None:
+    """Passing ``reviewer=`` equal to the implementer is also rejected."""
+    task_id = kb.create_task(conn, title="Implement feature Z", assignee="builder")
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None
+    ok, reason = kb.request_review(
+        conn,
+        task_id,
+        summary="ready for review",
+        reviewer="builder",
+        expected_run_id=implementation.current_run_id,
+        with_reason=True,
+    )
+    assert ok is False
+    assert "implementer" in (reason or "")
+
+
+def test_rereview_without_reviewer_uses_provenance(conn) -> None:
+    """Re-review without ``reviewer=`` recovers prior reviewer from events — not blocked."""
+    task_id = kb.create_task(conn, title="Re-review flow", assignee="builder")
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        summary="v1",
+        reviewer="reviewer",
+        expected_run_id=implementation.current_run_id,
+    )
+    review = kb.claim_review_task(conn, task_id, claimer="reviewer:1")
+    assert review is not None
+    assert kb.request_changes(
+        conn,
+        task_id,
+        reason="needs fixes",
+        expected_run_id=review.current_run_id,
+    ) == (True, "builder")
+
+    # Re-review without reviewer= — should recover "reviewer" from prior event
+    retry = kb.claim_task(conn, task_id, claimer="builder:2")
+    assert retry is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        summary="v2",
+        expected_run_id=retry.current_run_id,
+    )
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "review"
+    assert task.assignee == "reviewer"


### PR DESCRIPTION
## Summary

Fixes #97910.

When `reviewer` is omitted on a **first review** (`kanban_request_review` without a prior `changes_requested` cycle), the assignee stays as the implementer, silently routing the card back to the same profile that just built it. The four-eyes property the review lane exists for is lost — no error, no warning, and the event trail looks healthy at a glance.

## Root Cause

In `request_review()`, the re-review path already guards against missing reviewer provenance (refuses unless it can recover the reviewer from the latest `changes_requested` event). The first-review path has no equivalent guard: when `reviewer is None` and there's no prior `changes_requested` run, `reviewer` stays `None`, `assignee_sql` is empty, and the assignee is never updated — it remains the implementer.

## Fix

Added a four-eyes guard after reviewer resolution:

1. **`self_review_allowed()` config helper** — checks `kanban.allow_self_review` (default `False`), following the same pattern as `review_dispatch_enabled()`.

2. **Guard in `request_review()`** — computes `effective_reviewer = reviewer if reviewer is not None else implementer`. If `effective_reviewer == implementer` and self-review is not opted in, returns a diagnostic error:
   ```
   review would be assigned to the implementer (dev); pass reviewer= explicitly
   or set kanban.allow_self_review: true to opt in
   ```

3. **`self_review` flag on event** — when self-review IS allowed (opted in via config), the `review_requested` event records `"self_review": true` so it's visible in `hermes kanban show` and dispatcher logs.

4. **Opt-in escape hatch** — single-profile boards that legitimately want self-review can set `kanban.allow_self_review: true` in `config.yaml`.

## Test Plan

- [x] `test_first_review_without_reviewer_is_rejected` — verifies the guard fires
- [x] `test_first_review_with_explicit_different_reviewer_succeeds` — verifies normal path works
- [x] `test_explicit_self_review_is_rejected` — verifies passing `reviewer=` equal to implementer is also blocked
- [x] `test_rereview_without_reviewer_uses_provenance` — verifies re-review still recovers prior reviewer
- [x] All 22 existing review lifecycle tests pass (updated 2 to pass `reviewer=` explicitly)
- [x] All 26 tests pass together

## Note

PR #90002 from @brunopradof addresses the same root issue at the **dispatcher** level (preventing respawn of the same profile). This PR addresses it at the **transition** level (preventing the silent self-assignment in the first place). The approaches are complementary.