### PR TITLE
feat(whatsapp): per-contact toolset overrides via contact_toolsets

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -4,6 +4,7 @@ and the official WhatsApp Cloud API adapter.
 
 The mixin provides:
 - Allow-list / DM / group gating
+- Per-contact toolset overrides (``contact_toolsets``)
 - Mention detection (explicit @-mentions + configurable regex patterns)
 - Quoted-reply-to-bot detection
 - Broadcast / Channel / Newsletter filtering
@@ -287,6 +288,96 @@ class WhatsAppBehaviorMixin:
         if self._group_policy == "open":
             return True
         return False
+
+    # --------------------------------------------------- per-contact toolsets
+    def toolsets_for_source(self, source) -> Optional[list]:
+        """Per-contact toolset override for WhatsApp-triggered agent runs.
+
+        ``platform_toolsets.whatsapp`` is platform-wide: every allowlisted
+        contact shares one toolset list. That makes the allowlist all-or-
+        nothing in practice — admitting a low-trust contact (a courier, a
+        client, a receptionist) to answer messages also hands them whatever
+        the platform list carries, and the platform default for WhatsApp
+        includes ``terminal``. The only way to narrow that today is to narrow
+        it for *every* WhatsApp contact, including the operator.
+
+        ``contact_toolsets`` closes that gap by mapping a contact identifier to
+        the toolset list used for runs that contact triggers::
+
+            platforms:
+              whatsapp:
+                extra:
+                  contact_toolsets:
+                    "923001234567": [web, vision, clarify]
+                    "923009876543@s.whatsapp.net": [web]
+
+        Keys are matched with :meth:`_matches_whatsapp_allowlist`, so a phone
+        number, a full JID, or a LID form all resolve to the same contact
+        (WhatsApp delivers senders in either form). DMs match on the sender;
+        group chats match on the group JID, then fall back to the sender so a
+        per-contact restriction still applies to that contact's messages
+        inside a group.
+
+        Returns ``None`` when no entry matches, leaving the normal
+        ``platform_toolsets.whatsapp`` resolution untouched. The gateway
+        validates any returned list through the same ``_get_platform_tools``
+        path as platform config, so unknown or platform-restricted names are
+        dropped rather than trusted — an entry cannot self-grant a toolset
+        that platform config could not.
+
+        A ``"*"`` key is deliberately NOT special-cased here: matching every
+        contact is what ``platform_toolsets.whatsapp`` already does, and
+        honoring it would silently shadow that setting.
+        """
+        extra = getattr(self.config, "extra", None) or {}
+        mapping = extra.get("contact_toolsets") or extra.get("contactToolsets")
+        if not isinstance(mapping, dict) or not mapping:
+            return None
+
+        candidates: list[str] = []
+        chat_id = str(getattr(source, "chat_id", "") or "").strip()
+        user_id = str(getattr(source, "user_id", "") or "").strip()
+        # Group JID first so a group-wide entry wins over a per-sender one;
+        # DMs carry the contact in chat_id anyway, so one ordering serves both.
+        if str(getattr(source, "chat_type", "") or "") == "group":
+            candidates = [c for c in (chat_id, user_id) if c]
+        else:
+            candidates = [c for c in (user_id or chat_id,) if c]
+        if not candidates:
+            return None
+
+        for candidate in candidates:
+            for key, toolsets in mapping.items():
+                key_str = str(key).strip()
+                if not key_str or key_str == "*":
+                    continue
+                if not self._matches_whatsapp_allowlist(candidate, {key_str}):
+                    continue
+                if not isinstance(toolsets, list):
+                    logger.warning(
+                        "[%s] contact_toolsets['%s'] must be a list, got %s — "
+                        "ignoring this entry",
+                        getattr(self, "name", "whatsapp"),
+                        key_str,
+                        type(toolsets).__name__,
+                    )
+                    continue
+                cleaned = [str(t).strip() for t in toolsets if str(t).strip()]
+                if not cleaned:
+                    # An empty list cannot mean "no tools": the gateway treats a
+                    # falsy override as "no override" and would fall back to the
+                    # platform list, quietly WIDENING access. Refuse instead.
+                    logger.warning(
+                        "[%s] contact_toolsets['%s'] is empty — ignoring. An "
+                        "empty list cannot express 'no toolsets'; list the "
+                        "toolsets this contact may use, or remove them from "
+                        "the allowlist to deny access entirely.",
+                        getattr(self, "name", "whatsapp"),
+                        key_str,
+                    )
+                    continue
+                return cleaned
+        return None
 
     def _compile_mention_patterns(self):
         patterns = self.config.extra.get("mention_patterns")

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -400,6 +400,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
     - group_policy: "open" | "allowlist" | "disabled" | "pairing" — which groups are processed (default: "pairing")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
+    - contact_toolsets: Map of contact ID -> toolset list, restricting what runs
+      that contact triggers may use (overrides ``platform_toolsets.whatsapp``
+      for that contact only). Keys accept phone / JID / LID forms.
     - send_read_receipts: Mark accepted inbound WhatsApp messages as read
 
     Behavior (gating, mention parsing, markdown conversion, chunking) is

--- a/tests/gateway/test_whatsapp_contact_toolsets.py
+++ b/tests/gateway/test_whatsapp_contact_toolsets.py
@@ -1,0 +1,226 @@
+"""Per-contact WhatsApp toolset overrides (adapter.toolsets_for_source).
+
+``platform_toolsets.whatsapp`` is platform-wide, so every allowlisted contact
+shares one toolset list. ``platforms.whatsapp.extra.contact_toolsets`` maps a
+contact identifier to the toolset list used for runs that contact triggers, so
+a low-trust contact can answer messages without inheriting the platform list
+(whose WhatsApp default includes ``terminal``).
+
+Keys resolve through the same phone/JID/LID alias matching as ``allow_from``,
+and the gateway validates any override through ``_get_platform_tools`` — an
+entry cannot self-grant a toolset that platform config could not.
+"""
+
+import logging
+
+from gateway.platforms.base import BasePlatformAdapter
+from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.run import GatewayRunner
+from hermes_cli.tools_config import _get_platform_tools
+
+
+class _Cfg:
+    def __init__(self, extra):
+        self.extra = extra
+
+
+class _Src:
+    def __init__(self, chat_id, user_id=None, chat_type="dm"):
+        self.chat_id = chat_id
+        self.user_id = user_id
+        self.chat_type = chat_type
+
+
+def _make_adapter(contact_toolsets, *, key="contact_toolsets"):
+    wa = object.__new__(WhatsAppBehaviorMixin)
+    wa.config = _Cfg({key: contact_toolsets} if contact_toolsets is not None else {})
+    wa.name = "whatsapp"
+    return wa
+
+
+def _make_runner(adapter):
+    gr = object.__new__(GatewayRunner)
+    gr._adapter_for_source = lambda source: adapter
+    return gr
+
+
+BASE_CONFIG = {"platform_toolsets": {"whatsapp": ["web", "vision", "terminal"]}}
+
+
+class TestContactToolsetsMatching:
+    def test_dm_sender_match_returns_list(self):
+        wa = _make_adapter({"923001234567": ["web", "vision"]})
+        src = _Src("923001234567@s.whatsapp.net", user_id="923001234567@s.whatsapp.net")
+        assert wa.toolsets_for_source(src) == ["web", "vision"]
+
+    def test_jid_key_matches_bare_number_sender(self):
+        # Operators configure either form; both must resolve to one contact.
+        wa = _make_adapter({"923001234567@s.whatsapp.net": ["web"]})
+        assert wa.toolsets_for_source(_Src("923001234567", user_id="923001234567")) == [
+            "web"
+        ]
+
+    def test_bare_number_key_matches_jid_sender(self):
+        wa = _make_adapter({"923001234567": ["web"]})
+        src = _Src("923001234567@s.whatsapp.net", user_id="923001234567@s.whatsapp.net")
+        assert wa.toolsets_for_source(src) == ["web"]
+
+    def test_unlisted_contact_returns_none(self):
+        wa = _make_adapter({"923001234567": ["web"]})
+        assert wa.toolsets_for_source(_Src("923009999999", user_id="923009999999")) is None
+
+    def test_camel_case_key_accepted(self):
+        wa = _make_adapter({"923001234567": ["web"]}, key="contactToolsets")
+        assert wa.toolsets_for_source(_Src("923001234567", user_id="923001234567")) == [
+            "web"
+        ]
+
+    def test_no_mapping_returns_none(self):
+        assert _make_adapter(None).toolsets_for_source(_Src("923001234567")) is None
+        assert _make_adapter({}).toolsets_for_source(_Src("923001234567")) is None
+
+    def test_group_jid_entry_matches_group_chat(self):
+        wa = _make_adapter({"12345-67890@g.us": ["web"]})
+        src = _Src("12345-67890@g.us", user_id="923001234567", chat_type="group")
+        assert wa.toolsets_for_source(src) == ["web"]
+
+    def test_group_falls_back_to_sender_entry(self):
+        # A per-contact restriction still applies inside a group chat.
+        wa = _make_adapter({"923001234567": ["web"]})
+        src = _Src("12345-67890@g.us", user_id="923001234567", chat_type="group")
+        assert wa.toolsets_for_source(src) == ["web"]
+
+    def test_group_entry_wins_over_sender_entry(self):
+        wa = _make_adapter(
+            {"12345-67890@g.us": ["vision"], "923001234567": ["web"]}
+        )
+        src = _Src("12345-67890@g.us", user_id="923001234567", chat_type="group")
+        assert wa.toolsets_for_source(src) == ["vision"]
+
+    def test_empty_source_returns_none(self):
+        wa = _make_adapter({"923001234567": ["web"]})
+        assert wa.toolsets_for_source(_Src("", user_id="")) is None
+
+
+class TestContactToolsetsMalformedEntries:
+    def test_empty_list_is_ignored_not_treated_as_deny(self, caplog):
+        # An empty override is falsy, so the gateway would fall back to the
+        # platform list — silently WIDENING access. Must be refused loudly.
+        wa = _make_adapter({"923001234567": []})
+        with caplog.at_level(logging.WARNING):
+            result = wa.toolsets_for_source(
+                _Src("923001234567", user_id="923001234567")
+            )
+        assert result is None
+        assert "empty" in caplog.text.lower()
+
+    def test_blank_strings_are_stripped_then_ignored(self, caplog):
+        wa = _make_adapter({"923001234567": ["  ", ""]})
+        with caplog.at_level(logging.WARNING):
+            assert (
+                wa.toolsets_for_source(_Src("923001234567", user_id="923001234567"))
+                is None
+            )
+
+    def test_non_list_value_is_ignored(self, caplog):
+        wa = _make_adapter({"923001234567": "web"})
+        with caplog.at_level(logging.WARNING):
+            result = wa.toolsets_for_source(
+                _Src("923001234567", user_id="923001234567")
+            )
+        assert result is None
+        assert "must be a list" in caplog.text
+
+    def test_non_dict_mapping_is_ignored(self):
+        wa = _make_adapter(["923001234567"])
+        assert wa.toolsets_for_source(_Src("923001234567", user_id="923001234567")) is None
+
+    def test_wildcard_key_is_not_honored(self):
+        # "*" would shadow platform_toolsets.whatsapp; that's what the platform
+        # setting is for, so it must not match here.
+        wa = _make_adapter({"*": ["web"]})
+        assert wa.toolsets_for_source(_Src("923001234567", user_id="923001234567")) is None
+
+    def test_blank_key_is_skipped(self):
+        wa = _make_adapter({"   ": ["web"]})
+        assert wa.toolsets_for_source(_Src("923001234567", user_id="923001234567")) is None
+
+    def test_values_are_stringified_and_trimmed(self):
+        wa = _make_adapter({"923001234567": ["  web  ", "vision"]})
+        assert wa.toolsets_for_source(
+            _Src("923001234567", user_id="923001234567")
+        ) == ["web", "vision"]
+
+
+class TestBaseAdapterDefaultUnchanged:
+    def test_base_adapter_still_returns_none(self):
+        wa = _make_adapter({"923001234567": ["web"]})
+        assert (
+            BasePlatformAdapter.toolsets_for_source(wa, _Src("923001234567")) is None
+        )
+
+
+class TestGatewayIntegration:
+    def test_override_replaces_platform_resolution(self):
+        wa = _make_adapter({"923001234567": ["web", "vision"]})
+        gr = _make_runner(wa)
+        res = GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr,
+            BASE_CONFIG,
+            _Src("923001234567", user_id="923001234567"),
+            "whatsapp",
+        )
+        assert "web" in res and "vision" in res
+        # The security promise: the platform list carries terminal, the
+        # per-contact override does not, and the override fully replaces it.
+        assert "terminal" not in res
+
+    def test_override_validated_like_platform_config(self):
+        override = ["web", "vision", "discord_admin"]
+        wa = _make_adapter({"923001234567": override})
+        gr = _make_runner(wa)
+        res = GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr,
+            BASE_CONFIG,
+            _Src("923001234567", user_id="923001234567"),
+            "whatsapp",
+        )
+        expected = sorted(
+            _get_platform_tools(
+                {"platform_toolsets": {"whatsapp": list(override)}}, "whatsapp"
+            )
+        )
+        assert res == expected
+        # Platform-restricted toolsets are dropped, exactly as for platform config.
+        assert "discord_admin" not in res
+
+    def test_unlisted_contact_uses_platform_resolution(self):
+        wa = _make_adapter({"923001234567": ["web"]})
+        gr = _make_runner(wa)
+        res = GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr,
+            BASE_CONFIG,
+            _Src("923009999999", user_id="923009999999"),
+            "whatsapp",
+        )
+        assert res == sorted(_get_platform_tools(BASE_CONFIG, "whatsapp"))
+
+    def test_original_config_not_mutated(self):
+        cfg = {"platform_toolsets": {"whatsapp": ["web", "terminal"]}}
+        wa = _make_adapter({"923001234567": ["web"]})
+        gr = _make_runner(wa)
+        GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr, cfg, _Src("923001234567", user_id="923001234567"), "whatsapp"
+        )
+        assert cfg["platform_toolsets"]["whatsapp"] == ["web", "terminal"]
+
+    def test_adapter_exception_falls_back_to_platform_resolution(self):
+        wa = _make_adapter({})
+        wa.toolsets_for_source = lambda source: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        )
+        gr = _make_runner(wa)
+        res = GatewayRunner._resolve_enabled_toolsets_for_source(
+            gr, BASE_CONFIG, _Src("923001234567"), "whatsapp"
+        )
+        assert res == sorted(_get_platform_tools(BASE_CONFIG, "whatsapp"))


### PR DESCRIPTION
## Summary

`platform_toolsets.whatsapp` is platform-wide, so every allowlisted contact shares one toolset list. That makes `allow_from` effectively all-or-nothing: admitting a low-trust contact — a courier, a client, a receptionist — so the agent can answer their messages also hands them whatever the platform list carries.

On a default install that list is not small. Resolving it on a real config:

```python
>>> sorted(_get_platform_tools(cfg, 'whatsapp'))
['browser', 'clarify', 'code_execution', 'computer_use', 'cronjob', 'delegation',
 'file', 'image_gen', 'kanban', 'memory', 'session_search', 'skills',
 'terminal', 'todo', 'tts', 'vision', 'web']
```

So an allowlisted WhatsApp DM reaches `terminal`, `file`, `code_execution` and `computer_use`. The only way to narrow that today is to narrow it for *every* WhatsApp contact, the operator included — which is why I hit this: I wanted a contact gatekept to "can talk, cannot touch the shell" and there was no way to express it.

## Approach

Implement `toolsets_for_source()` on `WhatsAppBehaviorMixin`, reading an optional `platforms.whatsapp.extra.contact_toolsets` map:

```yaml
platforms:
  whatsapp:
    extra:
      contact_toolsets:
        "923001234567": [web, vision, clarify]
        "923009876543@s.whatsapp.net": [web]
```

This deliberately adds **no new mechanism**. `toolsets_for_source()` is the existing per-source override hook that `WebhookAdapter` already uses for per-route toolsets, and the gateway validates whatever it returns through the same `_get_platform_tools` path as platform config. An entry therefore cannot self-grant a toolset that platform config could not: unknown and platform-restricted names are dropped rather than trusted (asserted in `test_override_validated_like_platform_config`).

Landing it on the shared mixin rather than the bridge adapter means the Baileys adapter and `WhatsAppCloudAdapter` both get it from one implementation.

## Design notes

- **Alias-form matching.** Keys go through the existing `_matches_whatsapp_allowlist`, so phone / JID / LID forms all resolve to one contact. WhatsApp delivers inbound senders in LID form while operators configure phone numbers — the reason raw set membership was already insufficient for `allow_from`.
- **Groups.** Group chats match the group JID first, then fall back to the sender, so a per-contact restriction still applies to that contact's messages inside a group. A group-wide entry wins over a per-sender one.
- **An empty list is refused, with a warning.** This is the sharp edge. The gateway's gate is `if override and isinstance(override, list)`, so `[]` is falsy and would fall through to the *platform* list — silently **widening** access, the exact opposite of what someone writing `contact_toolsets: {"923...": []}` intends. Honoring it as "no tools" would need a gateway-side sentinel change; refusing it loudly keeps this PR to one layer and cannot fail open. The warning names the alternative (remove them from the allowlist to deny entirely).
- **`"*"` is not special-cased.** Matching every contact is what `platform_toolsets.whatsapp` already does; honoring a wildcard here would shadow that setting.
- **No new env var.** Per `AGENTS.md`, this is behavioral config and lives in `config.yaml` only. `extra` is pass-through, so no whitelist needed.
- **Inert when unset.** Absent `contact_toolsets`, resolution is byte-identical to before — the method returns `None` and the platform path runs untouched.

## Test plan

23 new cases in `tests/gateway/test_whatsapp_contact_toolsets.py`, mirroring the structure of the existing `test_webhook_route_toolsets.py`:

- alias-form matching in both directions (bare number key ↔ JID sender, and the reverse)
- group JID entry, group→sender fallback, group-entry precedence
- malformed entries: non-list value, non-dict mapping, blank key, blank/whitespace toolset strings
- the empty-list refusal and its warning
- the wildcard non-match
- gateway integration: override replaces (not merges) the platform list, `terminal` is absent from the restricted result while present in the platform list, validation parity with platform config, config non-mutation, and adapter-exception fallback

Verified with `scripts/run_tests.sh` — **119 passed, 0 failed, 2 skipped** across the 9 related gateway suites:

```
tests/gateway/test_whatsapp_contact_toolsets.py          23✓   (new)
tests/gateway/test_whatsapp_cloud.py                     43✓
tests/gateway/test_webhook_route_toolsets.py             12✓
tests/gateway/test_whatsapp_connect.py                   10✓
tests/gateway/test_multiplex_toolsets_profile_isolation.py 9✓
tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py 6✓
tests/gateway/test_whatsapp_cloud_allowed_users.py        6✓
tests/gateway/test_whatsapp_allowlist_lid_resolution.py   5✓
tests/gateway/test_api_server_toolset.py                  5✓
```

One honest note on my environment: `test_whatsapp_cloud.py` initially showed 10 failures (`'NoneType' object has no attribute 'Response'`). I stashed my change and re-ran on pristine `main` — **identical 10 failures**, so they were `aiohttp` missing from my venv, not a regression. Installing `aiohttp` cleared all 10. Flagging it in case CI images differ.

## What I did not do

- Did not touch the gateway's override gate, so "deny all tools" is still inexpressible. That needs a sentinel (`False` vs `[]`) and belongs in its own PR if wanted.
- Did not add per-contact toolsets to other platforms. The same gap exists for Telegram/Discord `allow_from`; this PR fixes the one I could test end-to-end rather than speculating across adapters.
