### PR TITLE
fix(mem0): apply mem0ai's entity-id contract at OSS setup and init

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -355,6 +355,22 @@ class Mem0MemoryProvider(MemoryProvider):
             configured = None
         self._user_id = configured or kwargs.get("user_id") or _DEFAULT_USER_ID
         self._agent_id = self._config.get("agent_id", "hermes")
+        # mem0ai's OSS Memory.add() rejects entity ids containing whitespace
+        # on the first memory operation, leaving a configured-but-unusable
+        # provider (#97922). Values persisted before that contract was
+        # enforced at setup time are rejected here, at initialization, with
+        # the same rule — the memory stack degrades instead of failing at
+        # first use. Only the OSS backend runs mem0ai's local validator, so
+        # other modes keep their own (server-side) contracts.
+        if self._mode == "oss":
+            from ._setup import _validate_entity_id
+
+            for name, value in (("user_id", configured), ("agent_id", self._agent_id)):
+                if value is None:
+                    continue
+                err = _validate_entity_id(str(value), name)
+                if err:
+                    raise ValueError(f"mem0.json: {err}")
         # Persisted rerank preference (setup wizard / mem0.json). Used as the
         # DEFAULT for mem0_search when the model doesn't pass ``rerank``
         # explicitly; per-call args still win. Platform-only feature — other

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -51,6 +51,22 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
     return val or (default or "")
 
 
+def _validate_entity_id(value: str, name: str) -> str | None:
+    """Apply mem0ai's entity-ID contract before a value is saved (#97922).
+
+    Mirrors ``_validate_and_trim_entity_id`` in the pinned mem0ai
+    (trim outer whitespace, reject blank, reject internal whitespace) so an
+    identifier the SDK would reject on the first memory operation fails at
+    setup time instead. Returns an error message, or None when valid.
+    """
+    trimmed = value.strip()
+    if not trimmed:
+        return f"Invalid {name}: cannot be empty or whitespace-only."
+    if any(c.isspace() for c in trimmed):
+        return f"Invalid {name}: cannot contain whitespace (got {value!r})."
+    return None
+
+
 def has_oss_flags() -> bool:
     """Check if OSS-related flags are present in sys.argv."""
     flags = parse_flags(sys.argv[1:])
@@ -455,7 +471,11 @@ def _setup_oss(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
             print(f"  Error: {e}", file=sys.stderr)
         sys.exit(1)
 
-    user_id = flags.get("user_id") or os.getenv("USER", "hermes-user")
+    user_id = (flags.get("user_id") or os.getenv("USER", "hermes-user")).strip()
+    err = _validate_entity_id(user_id, "user_id")
+    if err:
+        print(f"  Error: {err}", file=sys.stderr)
+        sys.exit(1)
 
     llm_id = oss_config["llm"]["provider"]
     embedder_id = oss_config["embedder"]["provider"]
@@ -804,6 +824,12 @@ def _setup_oss_interactive(hermes_home: str, config: dict) -> None:
 
     agent_id = input("  Agent ID [hermes]: ").strip()
     agent_id = agent_id or "hermes"
+
+    for name, value in (("user_id", user_id), ("agent_id", agent_id)):
+        err = _validate_entity_id(value, name)
+        if err:
+            print(f"  Error: {err}", file=sys.stderr)
+            return
 
     flags = {
         "oss_llm": llm_id,

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -12,6 +12,7 @@ from plugins.memory.mem0._setup import (
     build_oss_config,
     _write_env,
     _prompt_api_key,
+    _validate_entity_id,
     post_setup,
     _check_qdrant_path,
     _check_ollama,
@@ -222,6 +223,49 @@ class TestDryRun:
     def test_dry_run_flag_parsed(self):
         flags = parse_flags(["--mode", "oss", "--oss-llm-key", "sk-oai", "--dry-run"])
         assert flags["dry_run"] is True
+
+
+class TestEntityIdValidation:
+    """#97922: mem0ai rejects entity ids containing whitespace on the first
+    memory operation; OSS setup must apply the same contract before saving."""
+
+    def test_validate_entity_id_contract(self):
+        assert _validate_entity_id("hermes-user", "user_id") is None
+        assert _validate_entity_id("  spaced-user  ", "user_id") is None
+        assert "cannot be empty" in _validate_entity_id("", "user_id")
+        assert "cannot be empty" in _validate_entity_id("   ", "user_id")
+        assert "cannot contain whitespace" in _validate_entity_id("user alpha", "user_id")
+        assert "cannot contain whitespace" in _validate_entity_id("agent\talpha", "agent_id")
+
+    def test_oss_flag_mode_rejects_whitespace_user_id(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("sys.argv", [
+            "hermes", "--mode", "oss", "--oss-llm", "openai",
+            "--oss-llm-key", "sk-test", "--user-id", "user alpha",
+        ])
+        monkeypatch.setattr("plugins.memory.mem0._setup.get_hermes_home", lambda: tmp_path)
+        _inject_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr("plugins.memory.mem0._setup._install_provider_deps", lambda *a: None)
+        monkeypatch.setattr("plugins.memory.mem0._setup._run_connectivity_checks", lambda c: None)
+        config = {"memory": {}}
+        with pytest.raises(SystemExit) as ei:
+            post_setup(str(tmp_path), config)
+        assert ei.value.code == 1
+        assert not (tmp_path / "mem0.json").exists()
+
+    def test_oss_flag_mode_saves_trimmed_user_id(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("sys.argv", [
+            "hermes", "--mode", "oss", "--oss-llm", "openai",
+            "--oss-llm-key", "sk-test", "--user-id", "  hermes-user  ",
+        ])
+        monkeypatch.setattr("plugins.memory.mem0._setup.get_hermes_home", lambda: tmp_path)
+        _inject_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr("plugins.memory.mem0._setup._install_provider_deps", lambda *a: None)
+        monkeypatch.setattr("plugins.memory.mem0._setup._run_connectivity_checks", lambda c: None)
+        config = {"memory": {}}
+        post_setup(str(tmp_path), config)
+        assert config["memory"]["provider"] == "mem0"
+        mem0_json = json.loads((tmp_path / "mem0.json").read_text())
+        assert mem0_json["user_id"] == "hermes-user"  # outer whitespace trimmed
 
 
 class TestConnectivityChecks:

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -281,6 +281,52 @@ class TestMem0ModeSwitch:
         assert provider._mode == "platform"
         assert provider._user_id == "old-user"
 
+    def test_oss_mode_rejects_whitespace_user_id(self, monkeypatch, tmp_path):
+        """#97922: ids with internal whitespace fail at init, not at the
+        first mem0ai operation."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(
+            '{"mode": "oss", "user_id": "user alpha", "agent_id": "hermes"}'
+        )
+        provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
+        with pytest.raises(ValueError, match="cannot contain whitespace"):
+            provider.initialize("test")
+
+    def test_oss_mode_rejects_whitespace_agent_id(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(
+            '{"mode": "oss", "user_id": "u1", "agent_id": "agent\\talpha"}'
+        )
+        provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
+        with pytest.raises(ValueError, match="cannot contain whitespace"):
+            provider.initialize("test")
+
+    def test_oss_mode_valid_ids_initialize(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(
+            '{"mode": "oss", "user_id": "u1", "agent_id": "hermes"}'
+        )
+        provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
+        provider.initialize("test")
+        assert provider._user_id == "u1"
+        assert provider._agent_id == "hermes"
+
+    def test_platform_mode_keeps_server_side_id_contract(self, monkeypatch, tmp_path):
+        """Non-OSS backends never run mem0ai's local entity validator, so a
+        whitespace id stays a server-side concern there (#97922)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "mem0.json").write_text(
+            '{"mode": "platform", "user_id": "user alpha"}'
+        )
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: None  # type: ignore[method-assign]
+        provider.initialize("test")
+        assert provider._user_id == "user alpha"
+
     def test_is_available_platform_needs_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MEM0_API_KEY", raising=False)


### PR DESCRIPTION
## What does this PR do?

Mem0 OSS setup accepted `user_id`/`agent_id` values containing internal whitespace (e.g. `user alpha`) and saved them to `mem0.json`. The pinned `mem0ai==2.0.10` validates entity ids on the first memory operation (`_validate_and_trim_entity_id` in `mem0/memory/main.py`: trims outer whitespace, rejects blank, rejects internal whitespace), so setup appeared successful but every OSS memory add/search raised `ValueError` at runtime — the configured provider was unusable (#97922).

This applies the SDK's own contract before the value can be persisted or reach the backend:

- OSS flag-based setup trims the value and exits with a clear error when it is blank or contains internal whitespace, before any file is written.
- OSS interactive setup reports the same error and aborts before `_write_env`/`_save_mem0_json`, so a typo costs one re-run instead of a broken provider.
- `Mem0MemoryProvider.initialize()` rejects persisted ids containing internal whitespace in **oss mode only** — the OSS backend is the only one that runs mem0ai's local entity validator, so platform/self-hosted modes keep their server-side contracts unchanged. The memory stack degrades at initialization (with a clear message pointing at `mem0.json`) instead of failing at first use.

## Related Issue

Fixes #97922

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/_setup.py` — new `_validate_entity_id()` mirroring mem0ai's contract; wired into the OSS flag path (trim + validate + `sys.exit(1)`) and the interactive OSS path (validate + abort before any write)
- `plugins/memory/mem0/__init__.py` — `initialize()` rejects configured `user_id`/`agent_id` values with internal whitespace in oss mode with a `ValueError` naming the offending field
- `tests/plugins/memory/test_mem0_setup.py` — contract unit tests plus flag-mode tests: `user alpha` exits 1 with no `mem0.json` written; `  hermes-user  ` is saved trimmed
- `tests/plugins/memory/test_mem0_v3.py` — initialization tests: oss mode rejects whitespace `user_id`/`agent_id`, valid ids initialize, platform mode keeps whitespace ids (server-side contract)

## How to Test

1. `HERMES_HOME=/tmp/profile-alpha hermes --mode oss --oss-llm openai --oss-llm-key sk-test --user-id "user alpha"` → exits 1 with `Invalid user_id: cannot contain whitespace`, and no `mem0.json` is created. Observed result: `Error: Invalid user_id: cannot contain whitespace (got 'user alpha')`, exit code 1.
2. Same command with `--user-id "  hermes-user  "` → setup completes and `mem0.json` contains the trimmed `hermes-user`. Observed result: `user_id == "hermes-user"`.
3. Write `{"mode": "oss", "user_id": "user alpha", "agent_id": "hermes"}` to `$HERMES_HOME/mem0.json` and initialize the provider → `ValueError: mem0.json: Invalid user_id: cannot contain whitespace ...` instead of a failure at the first memory operation. Observed result: raises at `initialize()`.
4. `pytest tests/plugins/memory/test_mem0_setup.py tests/plugins/memory/test_mem0_v3.py -q` → 51 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior is documented in the new helper's docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
