### PR TITLE
security(redact): redact sensitive CLI flag values

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -9,6 +9,7 @@ import os
 import re
 import shlex
 import threading
+from collections.abc import Collection
 from urllib.parse import unquote_plus
 
 # Shared with agent/file_safety's read-block list so the two defenses can't
@@ -354,6 +355,25 @@ _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f\u200b-\u200f\u2028-\u202f\u2060\
 _TOKEN_BODY_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.")
 
 
+# CLI sensitive long-form flags. Space-form matches `--flag VALUE`; equals-form
+# matches `--flag=VALUE`. Both anchored to flag start (lookbehind protects
+# against `x--password`) and require either space/tab (space form) or `=` (equals
+# form) immediately after the keyword, which prevents suffix collisions with
+# `--passwordStore`, `--tokenize`, `--secretary`, etc.
+_CLI_SENSITIVE_SPACE_VALUE_RE = re.compile(
+    r"(?<![A-Za-z0-9_\-])"
+    r"(--(?:password|passwd|secret|token|api[-_]key|client-secret))"
+    r"([ \t]+)",
+    re.IGNORECASE,
+)
+_CLI_SENSITIVE_EQUALS_VALUE_RE = re.compile(
+    r"(?<![A-Za-z0-9_\-])"
+    r"(--(?:password|passwd|secret|token|api[-_]key|client-secret))"
+    r"(=)",
+    re.IGNORECASE,
+)
+
+
 def _compile_prefix_matcher(patterns: list) -> "re.Pattern[str]":
     return re.compile(r"(?<![A-Za-z0-9_-])(" + "|".join(patterns) + r")(?![A-Za-z0-9_-])")
 
@@ -400,6 +420,113 @@ def _mask_control_split_tokens(text: str, mask_fn) -> str:
 # mask_secret strips EVERY control char (incl. \n/\t, C1, DEL, zero-width) so a
 # masked secret never emits multiline or invisible bytes into display output.
 _DISPLAY_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f\x80-\x9f\u200b-\u200f\u202a-\u202e\u2060-\u2064]")
+
+
+def _count_preceding_backslashes(text: str, index: int) -> int:
+    """Count consecutive backslashes immediately before ``index``."""
+    count = 0
+    cursor = index - 1
+    while cursor >= 0 and text[cursor] == "\\":
+        count += 1
+        cursor -= 1
+    return count
+
+
+def _find_unescaped_closing_quote(text: str, start: int, quote: str) -> int | None:
+    """Find a same-type closing quote, respecting shell-style backslash parity."""
+    cursor = start
+    while cursor < len(text):
+        char = text[cursor]
+        if char in "\r\n":
+            return None
+        if char == quote and _count_preceding_backslashes(text, cursor) % 2 == 0:
+            return cursor
+        cursor += 1
+    return None
+
+
+def _redact_cli_sensitive_value_match(
+    text: str,
+    match: "re.Match[str]",
+    *,
+    skip_next_flag: bool,
+) -> tuple[str, int]:
+    """Return replacement text and original end offset for one CLI flag value."""
+    value_start = match.end()
+    if value_start >= len(text) or text[value_start] in "\r\n":
+        return match.group(0), match.end()
+
+    flag_and_separator = f"{match.group(1)}{match.group(2)}"
+    quote = text[value_start]
+    if quote in {"'", '"'}:
+        value_content_start = value_start + 1
+        closing_quote = _find_unescaped_closing_quote(text, value_content_start, quote)
+        if closing_quote is None:
+            value_end = value_content_start
+            while value_end < len(text) and text[value_end] not in "\r\n":
+                value_end += 1
+            # Unterminated quoted CLI secrets are redacted through EOL so an
+            # escaped quote cannot expose the sensitive suffix that follows it.
+            return f"{flag_and_separator}{quote}***", value_end
+        if closing_quote == value_content_start:
+            return text[match.start():closing_quote + 1], closing_quote + 1
+        return f"{flag_and_separator}{quote}***{quote}", closing_quote + 1
+
+    if skip_next_flag and text.startswith("--", value_start):
+        return match.group(0), match.end()
+
+    value_end = value_start
+    while value_end < len(text) and text[value_end] not in "\r\n\t ' \"":
+        value_end += 1
+    if value_end == value_start:
+        return match.group(0), match.end()
+    return f"{flag_and_separator}***", value_end
+
+
+def _redact_cli_sensitive_value_matches(
+    text: str,
+    pattern: "re.Pattern[str]",
+    *,
+    skip_next_flag: bool,
+) -> str:
+    """Redact CLI sensitive values matched by a flag/separator pattern."""
+    chunks: list[str] = []
+    last_end = 0
+    changed = False
+    for match in pattern.finditer(text):
+        if match.start() < last_end:
+            continue
+        replacement, value_end = _redact_cli_sensitive_value_match(
+            text,
+            match,
+            skip_next_flag=skip_next_flag,
+        )
+        chunks.append(text[last_end:match.start()])
+        chunks.append(replacement)
+        last_end = value_end
+        changed = changed or replacement != text[match.start():value_end]
+    if not chunks:
+        return text
+    chunks.append(text[last_end:])
+    redacted = "".join(chunks)
+    return redacted if changed else text
+
+
+def _redact_cli_sensitive_space_values(text: str) -> str:
+    """Redact values passed with sensitive CLI flags."""
+    if "--" not in text:
+        return text
+
+    text = _redact_cli_sensitive_value_matches(
+        text,
+        _CLI_SENSITIVE_SPACE_VALUE_RE,
+        skip_next_flag=True,
+    )
+    return _redact_cli_sensitive_value_matches(
+        text,
+        _CLI_SENSITIVE_EQUALS_VALUE_RE,
+        skip_next_flag=False,
+    )
 
 
 def mask_secret(value: str, *, head: int = 4, tail: int = 4, floor: int = 12,
@@ -555,8 +682,251 @@ def _redact_phone(m):
     return phone[:keep] + "****" + phone[-keep:]
 
 
+def _normalize_sensitive_key(key: str) -> str:
+    """Canonicalize a caller-supplied exact sensitive key name."""
+    return key.strip().casefold().replace("-", "_")
+
+
+def _normalize_extra_sensitive_keys(
+    extra_sensitive_keys: Collection[str] | None,
+) -> frozenset[str]:
+    """Validate and normalize per-call exact sensitive keys.
+
+    Empty strings are ignored after ``strip()`` so an accidental blank entry
+    cannot create an empty-key pattern. ``str`` and ``bytes`` are rejected as
+    the top-level collection because they almost always mean the caller passed
+    one key directly instead of an iterable of keys.
+    """
+    if extra_sensitive_keys is None:
+        return frozenset()
+    if isinstance(extra_sensitive_keys, (str, bytes)):
+        raise TypeError("extra_sensitive_keys must be a collection of strings, not a string")
+    normalized: set[str] = set()
+    for key in extra_sensitive_keys:
+        if not isinstance(key, str):
+            raise TypeError("extra_sensitive_keys entries must be strings")
+        normalized_key = _normalize_sensitive_key(key)
+        if normalized_key:
+            normalized.add(normalized_key)
+    return frozenset(normalized)
+
+
+def _extra_sensitive_key_pattern(extra_sensitive_keys: frozenset[str]) -> str:
+    """Build a bounded regex alternation for exact per-call keys.
+
+    Each normalized key is split on ``_`` and rejoined with ``[-_]`` so callers
+    may pass either separator and the regex matches both forms (``api-key`` and
+    ``api_key``). ``re.escape`` neutralizes regex metacharacters in each part.
+    """
+    variants = []
+    for key in sorted(extra_sensitive_keys, key=len, reverse=True):
+        parts = key.split("_")
+        variants.append(r"[-_]".join(re.escape(part) for part in parts))
+    return "(?:" + "|".join(variants) + ")"
+
+
+def _redact_extra_sensitive_key_values(text: str, extra_sensitive_keys: frozenset[str]) -> str:
+    """Redact KEY=value / JSON / YAML values for explicit per-call keys.
+
+    Operates only when ``extra_sensitive_keys`` is non-empty. Produces a stable
+    ``***`` sentinel so a second invocation is byte-identical to the first.
+    Idempotent against the existing structured redaction pipeline.
+    """
+    if not extra_sensitive_keys or not text:
+        return text
+
+    key_pat = _extra_sensitive_key_pattern(extra_sensitive_keys)
+
+    def _mask_value(value: str) -> str:
+        # Explicitly selected values are fully replaced. The stable sentinel
+        # makes a second pass byte-identical to the first.
+        return "***" if value else value
+
+    def _line_end(source: str, start: int) -> int:
+        end = start
+        while end < len(source) and source[end] not in "\r\n":
+            end += 1
+        return end
+
+    def _yaml_single_quote_end(source: str, start: int) -> int | None:
+        cursor = start
+        while cursor < len(source):
+            char = source[cursor]
+            if char in "\r\n":
+                return None
+            if char == "'":
+                if cursor + 1 < len(source) and source[cursor + 1] == "'":
+                    cursor += 2
+                    continue
+                return cursor
+            cursor += 1
+        return None
+
+    def _rewrite_matches(source: str, pattern: "re.Pattern[str]", replacer) -> str:
+        chunks: list[str] = []
+        last_end = 0
+        for match in pattern.finditer(source):
+            if match.start() < last_end:
+                continue
+            replacement = replacer(source, match)
+            if replacement is None:
+                continue
+            replacement_text, value_end = replacement
+            if replacement_text == source[match.start():value_end]:
+                continue
+            chunks.append(source[last_end:match.start()])
+            chunks.append(replacement_text)
+            last_end = value_end
+        if not chunks:
+            return source
+        chunks.append(source[last_end:])
+        return "".join(chunks)
+
+    if "=" in text:
+        assign_re = re.compile(
+            rf"(^[ \t]*(?:export[ \t]+)?|(?<![A-Za-z0-9_.\-]))"
+            rf"({key_pat})([ \t]*=[ \t]*)",
+            re.IGNORECASE | re.MULTILINE,
+        )
+
+        def _redact_assignment(source: str, match: "re.Match[str]") -> tuple[str, int] | None:
+            # Defense-in-depth: ensure the matched key (post-normalization) is
+            # actually in the caller-supplied set. The alternation pattern
+            # already constrains to the set, but a malformed variant (e.g. an
+            # underscored fragment that happened to match the alternation)
+            # could slip through.
+            matched_key = _normalize_sensitive_key(match.group(2))
+            if matched_key not in extra_sensitive_keys:
+                return None
+
+            value_start = match.end()
+            if value_start >= len(source) or source[value_start] in "&\r\n":
+                return None
+
+            prefix = f"{match.group(1)}{match.group(2)}{match.group(3)}"
+            quote = source[value_start]
+            if quote in {"'", '"'}:
+                content_start = value_start + 1
+                closing_quote = _find_unescaped_closing_quote(source, content_start, quote)
+                if closing_quote is None:
+                    value_end = _line_end(source, content_start)
+                    value = source[content_start:value_end]
+                    if not value:
+                        return None
+                    return f"{prefix}{quote}{_mask_value(value)}", value_end
+                value = source[content_start:closing_quote]
+                if not value:
+                    return None
+                return (
+                    f"{prefix}{quote}{_mask_value(value)}{quote}",
+                    closing_quote + 1,
+                )
+
+            # Unquoted ENV-style extra keys are redacted through the physical
+            # line boundary. A raw ``&`` is not a safe delimiter here: treating
+            # it as a form-body separator leaks a sensitive suffix. Conservative
+            # same-line over-redaction is intentional; never cross CR/LF.
+            value_end = value_start
+            while value_end < len(source) and source[value_end] not in "\r\n":
+                value_end += 1
+            value = source[value_start:value_end]
+            if not value:
+                return None
+            return f"{prefix}{_mask_value(value)}", value_end
+
+        text = _rewrite_matches(text, assign_re, _redact_assignment)
+
+    if ":" in text:
+        json_re = re.compile(
+            rf'("({key_pat})"[ \t]*:[ \t]*")',
+            re.IGNORECASE,
+        )
+        yaml_re = re.compile(
+            rf"^([ \t]*)({key_pat})(:[ \t]*)",
+            re.IGNORECASE | re.MULTILINE,
+        )
+
+        def _redact_json(source: str, match: "re.Match[str]") -> tuple[str, int] | None:
+            matched_key = _normalize_sensitive_key(match.group(2))
+            if matched_key not in extra_sensitive_keys:
+                return None
+            value_start = match.end()
+            closing_quote = _find_unescaped_closing_quote(source, value_start, '"')
+            if closing_quote is None:
+                value_end = _line_end(source, value_start)
+                value = source[value_start:value_end]
+                if not value:
+                    return None
+                return f"{match.group(1)}{_mask_value(value)}", value_end
+            value = source[value_start:closing_quote]
+            if not value:
+                return None
+            return (
+                f'{match.group(1)}{_mask_value(value)}"',
+                closing_quote + 1,
+            )
+
+        def _redact_yaml(source: str, match: "re.Match[str]") -> tuple[str, int] | None:
+            matched_key = _normalize_sensitive_key(match.group(2))
+            if matched_key not in extra_sensitive_keys:
+                return None
+
+            prefix = f"{match.group(1)}{match.group(2)}{match.group(3)}"
+            value_start = match.end()
+            if value_start >= len(source) or source[value_start] in "\r\n":
+                return None
+
+            quote = source[value_start]
+            if quote in {"'", '"'}:
+                content_start = value_start + 1
+                if quote == "'":
+                    closing_quote = _yaml_single_quote_end(source, content_start)
+                else:
+                    closing_quote = _find_unescaped_closing_quote(
+                        source,
+                        content_start,
+                        quote,
+                    )
+                if closing_quote is None:
+                    value_end = _line_end(source, content_start)
+                    value = source[content_start:value_end]
+                    if not value:
+                        return None
+                    return f"{prefix}{quote}{_mask_value(value)}", value_end
+                value = source[content_start:closing_quote]
+                if not value:
+                    return None
+                return (
+                    f"{prefix}{quote}{_mask_value(value)}{quote}",
+                    closing_quote + 1,
+                )
+
+            # Unquoted YAML: consume through EOL, stripping an optional
+            # trailing ` #comment`. This addresses Teknium's review finding
+            # on the predecessor PR (unquoted multi-word values half-redacted).
+            line_end = _line_end(source, value_start)
+            value_end = line_end
+            for cursor in range(value_start, line_end):
+                if source[cursor] != "#" or source[cursor - 1] not in " \t":
+                    continue
+                value_end = cursor
+                while value_end > value_start and source[value_end - 1] in " \t":
+                    value_end -= 1
+                break
+            value = source[value_start:value_end]
+            if not value:
+                return None
+            return f"{prefix}{_mask_value(value)}", value_end
+
+        text = _rewrite_matches(text, json_re, _redact_json)
+        text = _rewrite_matches(text, yaml_re, _redact_yaml)
+
+    return text
+
+
 def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = False,
-                          file_read: bool = False, redact_url_credentials: bool = False) -> str:
+                          file_read: bool = False, redact_url_credentials: bool = False,
+                          extra_sensitive_keys: Collection[str] | None = None) -> str:
     """Apply all redaction patterns to a block of text.
 
     Safe on any string. Enabled by default (``security.redact_secrets: false``
@@ -572,6 +942,15 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     sentinel (``«redacted:ghp_…»``) instead of a head/tail mask an agent could
     write back into config.yaml as a dead credential.
 
+    ``extra_sensitive_keys`` adds caller-supplied exact key names to the
+    KEY=value / JSON / YAML redaction passes. Keys are stripped, casefolded,
+    and hyphens are normalized to underscores (``session-id`` ==
+    ``session_id``). Empty / whitespace-only entries are ignored. This
+    parameter is keyword-only, defaults to ``None`` (no extension), and does
+    not mutate any global sensitive-key set or persist between calls.
+    Passing a single ``str`` or ``bytes`` as the top-level collection, or a
+    collection containing a non-string entry, raises ``TypeError``.
+
     Every regex sits behind a cheap substring gate that its pattern requires,
     so the gates are never false-negative.
 
@@ -586,6 +965,19 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     if not text or not (force or _REDACT_ENABLED):
         return text
     code_file = code_file or file_read
+
+    # Per-call extra sensitive keys (caller-supplied). Runs before the existing
+    # pipeline so opted-in keys mask their values even when main's value-shape
+    # gate would otherwise pass them through.
+    normalized_extra_sensitive_keys = _normalize_extra_sensitive_keys(extra_sensitive_keys)
+    if normalized_extra_sensitive_keys:
+        text = _redact_extra_sensitive_key_values(text, normalized_extra_sensitive_keys)
+
+    # Global CLI flag-value redaction. Cheap pre-gate on ``--`` preserves
+    # performance discipline; the regex itself is anchored so suffix-flag
+    # collisions (``--passwordStore``, ``--tokenize``) cannot match.
+    if "--" in text:
+        text = _redact_cli_sensitive_space_values(text)
 
     # Control/zero-width chars can split a token body so _PREFIX_RE alone misses it.
     if _has_known_prefix_substring(text):

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1,5 +1,6 @@
 """Tests for agent.redact -- secret masking in logs and output."""
 
+import inspect
 import logging
 
 import pytest
@@ -1178,3 +1179,397 @@ class TestValueAwareGatingCorpus:
         result = redact_sensitive_text(block, force=True)
         assert prose_line in result
         assert "A9f3kZq7Lm2Xw8Rt4Yv6" not in result
+
+
+class TestRedactSensitiveTextApiCompatibility:
+    def test_extra_sensitive_keys_is_keyword_only_with_default_none(self):
+        # Signature regression guard: ``extra_sensitive_keys`` must remain
+        # keyword-only with a default of ``None``. This catches accidental
+        # conversion to a positional parameter (which would break all 74
+        # existing keyword callers) and accidental change of the default.
+        # We deliberately do NOT pin the absolute parameter list so that
+        # future independent kw-only additions do not force a churn here.
+        sig = inspect.signature(redact_sensitive_text)
+        assert "extra_sensitive_keys" in sig.parameters
+        param = sig.parameters["extra_sensitive_keys"]
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+        assert param.default is None
+
+    def test_existing_keyword_only_parameters_unchanged(self):
+        # Pin the four existing keyword-only parameters and their defaults so
+        # an accidental reorder or default change surfaces here.
+        sig = inspect.signature(redact_sensitive_text)
+        for name, expected_default in (
+            ("force", False),
+            ("code_file", False),
+            ("file_read", False),
+            ("redact_url_credentials", False),
+        ):
+            assert name in sig.parameters
+            assert sig.parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+            assert sig.parameters[name].default is expected_default
+
+    def test_normal_text_with_no_extra_sensitive_keys_passes_through(self):
+        # ``force=True`` with all features off must pass benign text through
+        # unchanged. Pins the no-op default behavior.
+        assert redact_sensitive_text(
+            "normal",
+            force=True,
+            code_file=True,
+            file_read=False,
+            redact_url_credentials=False,
+        ) == "normal"
+
+
+class TestExtraSensitiveKeys:
+    def test_session_id_without_opt_in_is_unchanged(self):
+        text = "session_id=session-value"
+        assert redact_sensitive_text(text, force=True) == text
+
+    def _assert_focused_repair(self, text, expected, *, secrets):
+        result = redact_sensitive_text(
+            text,
+            force=True,
+            extra_sensitive_keys={"session_id"},
+        )
+        assert result == expected
+        for secret in secrets:
+            assert secret not in result
+        assert redact_sensitive_text(
+            result,
+            force=True,
+            extra_sensitive_keys={"session_id"},
+        ) == result
+        return result
+
+    def test_focused_repair_nested_unquoted_yaml_preserves_indentation(self):
+        self._assert_focused_repair(
+            "parent:\n  session_id: secret",
+            "parent:\n  session_id: ***",
+            secrets=("secret",),
+        )
+
+    def test_focused_repair_nested_quoted_yaml_preserves_mapping(self):
+        import yaml
+
+        result = self._assert_focused_repair(
+            'parent:\n    session_id: "secret"',
+            'parent:\n    session_id: "***"',
+            secrets=("secret",),
+        )
+        assert yaml.safe_load(result) == {"parent": {"session_id": "***"}}
+
+    def test_focused_repair_yaml_preserves_mixed_indentation_bytes(self):
+        self._assert_focused_repair(
+            "parent:\n \t session_id: secret",
+            "parent:\n \t session_id: ***",
+            secrets=("secret",),
+        )
+
+    def test_focused_repair_unquoted_yaml_redacts_complete_multiword_value(self):
+        # Teknium review finding on predecessor PR: unquoted multi-word values
+        # must redact the WHOLE value, not just the first token.
+        self._assert_focused_repair(
+            "session_id: my secret value",
+            "session_id: ***",
+            secrets=("my", "secret", "value"),
+        )
+
+    def test_focused_repair_assignment_redacts_complete_multiword_value(self):
+        self._assert_focused_repair(
+            "session_id = my secret value",
+            "session_id = ***",
+            secrets=("my", "secret", "value"),
+        )
+
+    def test_focused_repair_yaml_preserves_separated_trailing_comment(self):
+        self._assert_focused_repair(
+            "session_id: my secret value # trailing comment",
+            "session_id: *** # trailing comment",
+            secrets=("my", "secret", "value"),
+        )
+
+    def test_focused_repair_yaml_unspaced_hash_remains_in_sensitive_value(self):
+        self._assert_focused_repair(
+            "session_id: my#secret # public",
+            "session_id: *** # public",
+            secrets=("my", "secret"),
+        )
+
+    def test_focused_repair_double_quoted_yaml_uses_true_closing_quote(self):
+        self._assert_focused_repair(
+            'session_id: "my \\" secret" # public',
+            'session_id: "***" # public',
+            secrets=("my", "secret"),
+        )
+
+    def test_focused_repair_json_uses_true_closing_quote(self):
+        self._assert_focused_repair(
+            '{"session_id": "my \\" secret", "public": "ok"}',
+            '{"session_id": "***", "public": "ok"}',
+            secrets=("my", "secret"),
+        )
+
+    def test_focused_repair_single_quoted_yaml_honors_doubled_quotes(self):
+        self._assert_focused_repair(
+            "session_id: 'my ''secret''' # public",
+            "session_id: '***' # public",
+            secrets=("my", "secret"),
+        )
+
+    def test_focused_repair_quoted_assignment_preserves_public_suffix(self):
+        self._assert_focused_repair(
+            'session_id = "my secret" public-content',
+            'session_id = "***" public-content',
+            secrets=("my", "secret"),
+        )
+
+    def test_unquoted_extra_sensitive_assignment_redacts_raw_ampersand_through_eol(self):
+        text = "session_id=LEFTPART&RIGHTPART\nSAFE_KEY=visible"
+        result = redact_sensitive_text(
+            text,
+            force=True,
+            extra_sensitive_keys={"session_id"},
+        )
+        assert result == "session_id=***\nSAFE_KEY=visible"
+        assert "LEFTPART" not in result
+        assert "RIGHTPART" not in result
+        assert "SAFE_KEY=visible" in result
+
+    def test_unquoted_extra_sensitive_assignment_with_ampersand_preserves_next_line(self):
+        text = "session_id=my secret&next=value\nSAFE_KEY=visible"
+        result = redact_sensitive_text(
+            text,
+            force=True,
+            extra_sensitive_keys={"session_id"},
+        )
+        assert result == "session_id=***\nSAFE_KEY=visible"
+        assert "my secret" not in result
+        assert "next=value" not in result
+        assert "SAFE_KEY=visible" in result
+
+    @pytest.mark.parametrize("line_ending", ["\r", "\n", "\r\n"], ids=["cr", "lf", "crlf"])
+    def test_focused_repair_assignment_does_not_cross_line_endings(self, line_ending):
+        self._assert_focused_repair(
+            f"session_id=my secret{line_ending}public=value",
+            f"session_id=***{line_ending}public=value",
+            secrets=("my", "secret"),
+        )
+
+    @pytest.mark.parametrize(
+        "text,key,secret",
+        [
+            ("session_id=session-value", "session_id", "session-value"),
+            ("session-id=session-value", "session_id", "session-value"),
+            ("SESSION_ID=session-value", "session_id", "session-value"),
+            ('"session_id": "session-value"', "session_id", "session-value"),
+            ("session_id: session-value", "session_id", "session-value"),
+            ("session_id='session-value'", "session_id", "session-value"),
+            ('session_id="session-value"', "session_id", "session-value"),
+            ("  session_id: 'session-value'", "session_id", "session-value"),
+        ],
+    )
+    def test_explicit_key_redacts_supported_textual_forms(self, text, key, secret):
+        result = redact_sensitive_text(text, force=True, extra_sensitive_keys={key})
+        assert secret not in result
+        assert "***" in result
+
+    def test_hyphen_key_opt_in_matches_underscore(self):
+        result = redact_sensitive_text(
+            "session_id=session-value",
+            force=True,
+            extra_sensitive_keys={"session-id"},
+        )
+        assert "session-value" not in result
+
+    def test_unrelated_similar_keys_remain_unchanged(self):
+        text = "session_name=session-value token_count=12345678901234567890"
+        assert redact_sensitive_text(text, force=True, extra_sensitive_keys={"session_id"}) == text
+
+    @pytest.mark.parametrize("bad", ["session_id", b"session_id"])
+    def test_top_level_string_collections_rejected(self, bad):
+        with pytest.raises(TypeError):
+            redact_sensitive_text("session_id=session-value", force=True, extra_sensitive_keys=bad)
+
+    def test_non_string_entry_rejected(self):
+        with pytest.raises(TypeError):
+            redact_sensitive_text(
+                "session_id=session-value",
+                force=True,
+                extra_sensitive_keys={object()},  # type: ignore[arg-type]
+            )
+
+    def test_empty_collection_does_not_change_behavior(self):
+        text = "session_id=session-value"
+        assert redact_sensitive_text(text, force=True, extra_sensitive_keys=set()) == text
+
+    def test_empty_keys_are_ignored(self):
+        text = "session_id=session-value"
+        assert redact_sensitive_text(text, force=True, extra_sensitive_keys={"", "   "}) == text
+
+    def test_does_not_persist_between_calls(self):
+        first = redact_sensitive_text(
+            "session_id=session-value",
+            force=True,
+            extra_sensitive_keys={"session_id"},
+        )
+        second = redact_sensitive_text("session_id=session-value", force=True)
+        assert "session-value" not in first
+        assert second == "session_id=session-value"
+
+    def test_code_file_explicit_key_still_redacts(self):
+        # ``code_file=True`` skips the structured redaction pipeline for source
+        # code, but caller-opted-in keys must still mask.
+        text = "SESSION_ID=session-value"
+        result = redact_sensitive_text(
+            text,
+            force=True,
+            code_file=True,
+            extra_sensitive_keys={"session_id"},
+        )
+        assert "session-value" not in result
+
+
+class TestCliSensitiveSeparateValues:
+    def _assert_secret_redacted(
+        self,
+        text,
+        *,
+        secrets,
+        preserved=(),
+        expected=None,
+    ):
+        result = redact_sensitive_text(text, force=True)
+        assert "***" in result
+        for secret in secrets:
+            assert secret not in result
+        for external in preserved:
+            assert external in result
+        if expected is not None:
+            assert result == expected
+        assert redact_sensitive_text(result, force=True) == result
+
+    @pytest.mark.parametrize(
+        "text,secret,expected",
+        [
+            ("cmd --password secret-value", "secret-value", "cmd --password ***"),
+            ('cmd --password "secret-value"', "secret-value", 'cmd --password "***"'),
+            ("cmd --password 'secret-value'", "secret-value", "cmd --password '***'"),
+            ("cmd --passwd secret-value", "secret-value", "cmd --passwd ***"),
+            ("cmd --secret secret-value", "secret-value", "cmd --secret ***"),
+            ("cmd --token secret-value", "secret-value", "cmd --token ***"),
+            ("cmd --api-key secret-value", "secret-value", "cmd --api-key ***"),
+            ("cmd --api_key secret-value", "secret-value", "cmd --api_key ***"),
+            ("cmd --client-secret secret-value", "secret-value", "cmd --client-secret ***"),
+            ("cmd --password   secret-value", "secret-value", "cmd --password   ***"),
+        ],
+    )
+    def test_space_separated_sensitive_flag_values(self, text, secret, expected):
+        result = redact_sensitive_text(text, force=True)
+        assert secret not in result
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "--password",
+            "--passwd",
+            "--secret",
+            "--token",
+            "--api-key",
+            "--api_key",
+            "--client-secret",
+        ],
+    )
+    def test_each_sensitive_long_flag_equals_form_redacts_full_payload(self, flag):
+        payload = "LEFT=MIDDLE=RIGHT"
+        result = redact_sensitive_text(f"cmd {flag}={payload}", force=True)
+        assert result == f"cmd {flag}=***"
+        for fragment in ("LEFT", "MIDDLE", "RIGHT"):
+            assert fragment not in result
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "cmd --password=secret-value",
+            "cmd --token=secret-value",
+            "cmd --api-key=secret-value",
+        ],
+    )
+    def test_equals_form_still_redacts(self, text):
+        result = redact_sensitive_text(text, force=True)
+        assert "secret-value" not in result
+
+    def test_multiple_sensitive_flags_one_line(self):
+        result = redact_sensitive_text("cmd --password one --token two", force=True)
+        assert "one" not in result
+        assert "two" not in result
+        assert result == "cmd --password *** --token ***"
+
+    def test_flag_at_end_stable(self):
+        # ``--password`` alone (no value, EOL) must remain unchanged.
+        assert redact_sensitive_text("cmd --password", force=True) == "cmd --password"
+
+    def test_next_flag_not_consumed(self):
+        # ``--password --verbose``: the second flag is a sibling flag, not a
+        # value. ``skip_next_flag`` protects the space form from consuming it.
+        assert redact_sensitive_text("cmd --password --verbose", force=True) == "cmd --password --verbose"
+
+    def test_similar_prefix_flag_unchanged(self):
+        # The trailing ``[ \t]+`` / ``=`` anchor ensures suffix-flag names
+        # (``--password-file``) cannot match the keyword class.
+        assert redact_sensitive_text("cmd --password-file path", force=True) == "cmd --password-file path"
+
+    def test_quoted_empty_not_changed(self):
+        # ``--password ""`` and ``--password=""`` must remain unchanged; an
+        # empty value carries no secret and PR's contract preserves benign
+        # forms.
+        assert redact_sensitive_text('cmd --password ""', force=True) == 'cmd --password ""'
+        assert redact_sensitive_text('cmd --password=""', force=True) == 'cmd --password=""'
+
+    def test_unterminated_escaped_quote_redacts_through_eol_only(self):
+        # An escaped quote inside an unterminated quoted value must not expose
+        # the sensitive suffix. PR redacts through EOL.
+        text = 'cmd --secret "prefix ' + '\\"' + ' sensitive-suffix --next' + "\nvisible-next-line"
+        result = redact_sensitive_text(text, force=True)
+        assert result == 'cmd --secret "***\nvisible-next-line'
+        assert "prefix" not in result
+        assert "sensitive-suffix" not in result
+        assert "--next" not in result
+        assert "visible-next-line" in result
+        assert redact_sensitive_text(result, force=True) == result
+
+    def test_idempotent_redaction(self):
+        first = redact_sensitive_text("cmd --password hunter2", force=True)
+        second = redact_sensitive_text(first, force=True)
+        assert first == second
+        assert "hunter2" not in first
+
+    def test_equals_form_consumes_embedded_equals_in_value(self):
+        # ``--password=KEY=VAL`` must consume the full value payload including
+        # any embedded ``=`` characters. The value-extraction terminator class
+        # does not include ``=``, so the loop continues through it.
+        result = redact_sensitive_text("cmd --password=KEY=VAL", force=True)
+        assert "KEY" not in result
+        assert "VAL" not in result
+        assert result == "cmd --password=***"
+
+    def test_equals_form_consumes_chained_equals(self):
+        # Use a value payload whose characters do not collide with the flag
+        # name (``--password``) or the command prefix (``cmd``) so we can
+        # assert each character was consumed.
+        result = redact_sensitive_text("xyz --password=ONE=TWO=THR", force=True)
+        assert "ONE" not in result
+        assert "TWO" not in result
+        assert "THR" not in result
+        assert result == "xyz --password=***"
+
+    def test_equals_form_jwt_like_value_redacted(self):
+        # ``--token=header.payload.signature`` — a JWT-shaped value with
+        # embedded ``.``. None of these characters is in the value-extraction
+        # terminator class, so the whole value is consumed.
+        result = redact_sensitive_text("cmd --token=header.payload.signature", force=True)
+        assert "header" not in result
+        assert "payload" not in result
+        assert "signature" not in result
+        assert result == "cmd --token=***"


### PR DESCRIPTION
## Summary

* redact values supplied to sensitive CLI flags in both `--flag value` and `--flag=value` forms;
* support caller-provided `extra_sensitive_keys`;
* preserve benign CLI arguments and existing redaction behavior;
* retain the existing JSON/YAML/env/URL/prefix redaction behavior.

## Scope

Exactly two files:

* `agent/redact.py`
* `tests/agent/test_redact.py`

## Validation

* independent review: PASS
* final live-main reanchor: PASS
* target-path drift: none
* reviewed candidate bytes preserved exactly
* focused post-seal tests: 63 passed, 0 failed
* CLI secret leak witnesses: none
* `extra_sensitive_keys`: PASS
* benign flag preservation: PASS
* `git diff --check`: PASS
* compile/import validation: PASS

## Replacement

This PR supersedes #88606.

#88606 contains the earlier implementation on a stale historical base.
This replacement is a clean single-parent commit directly on the current validated main base, preserving the independently reviewed candidate bytes.