### PR TITLE
fix(desktop): preserve zoom across Windows maximize

### DIFF
--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -77,7 +77,7 @@ test('extreme percentages clamp to the level bounds', () => {
   assert.equal(percentToZoomLevel(1_000_000), 9)
 })
 
-test('installZoomReassertOnWindowEvents wires show, restore, focus, resize, and cross-display moves on macOS and Windows', () => {
+test('installZoomReassertOnWindowEvents wires Windows maximize transitions in addition to normal lifecycle events', () => {
   const handlers = new Map()
 
   const win = {
@@ -100,9 +100,15 @@ test('installZoomReassertOnWindowEvents wires show, restore, focus, resize, and 
   handlers.get('show')()
   handlers.get('restore')()
   handlers.get('focus')()
+  handlers.get('maximize')()
+  handlers.get('unmaximize')()
   handlers.get('resized')()
   handlers.get('moved')()
-  assert.equal(calls, 5)
+  assert.equal(calls, 7)
+})
+
+test('zoomReassertWindowEvents does not add Windows-only maximize events on macOS', () => {
+  assert.deepEqual(zoomReassertWindowEvents('darwin'), ['show', 'restore', 'focus', 'resized', 'moved'])
 })
 
 test('focus event reasserts zoom immediately without debounce on Windows (high-DPI alt-tab, #50837)', () => {

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -78,9 +78,15 @@ export const ZOOM_REASSERT_SETTLE_DELAY_MS = 300
 export const ZOOM_REASSERT_MAX_SETTLE_CHECKS = 3
 
 export function zoomReassertWindowEvents(platform = process.platform) {
-  return platform === 'linux'
-    ? ['show', 'restore', 'focus', 'resize', 'move']
-    : ['show', 'restore', 'focus', 'resized', 'moved']
+  if (platform === 'linux') {
+    return ['show', 'restore', 'focus', 'resize', 'move']
+  }
+
+  if (platform === 'win32') {
+    return ['show', 'restore', 'focus', 'maximize', 'unmaximize', 'resized', 'moved']
+  }
+
+  return ['show', 'restore', 'focus', 'resized', 'moved']
 }
 
 // Linux/Wayland fires `focus` on intra-app focus shifts (sidebar clicks,


### PR DESCRIPTION
## What does this PR do?

Preserves the persisted Desktop UI zoom when a Windows high-DPI window is maximized or restored from maximized state.

Windows can reset Chromium `webContents` zoom during DPI re-evaluation. Hermes already reasserts the persisted level on lifecycle events, but the Windows event list did not include `maximize` or `unmaximize`. This adds those events without changing Linux or macOS behavior.

## Related Issue

Fixes #92990

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/electron/zoom.ts`: add `maximize` and `unmaximize` to the Windows-only zoom reassert event list.
- `apps/desktop/electron/zoom.test.ts`: cover both Windows transitions and verify the macOS event set remains unchanged.

## How to Test

1. `cd apps/desktop`
2. Run `npx vitest run electron/zoom.test.ts`
3. On Windows 11 with display scaling above 100%, set UI scale to 125%, maximize and unmaximize the window, and confirm the UI stays at 125%.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added regression coverage
- [x] I've considered cross-platform impact
- [x] Documentation/config/tool-schema changes are N/A
