### PR TITLE
fix(desktop): allow Skills Hub links and clipboard writes

### DIFF
--- a/apps/desktop/src/app/skills/embedded-hub-picker.test.tsx
+++ b/apps/desktop/src/app/skills/embedded-hub-picker.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@nanostores/react', () => ({
+  useStore: () => undefined
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, size: _size, variant: _variant, ...props }: any) => <button {...props}>{children}</button>
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      skills: {
+        hub: {
+          actionFailed: 'Action failed',
+          actionLog: 'Action log',
+          alreadyInstalled: (name: string) => `${name} is already installed`,
+          installStarted: (name: string) => `Installing ${name}`,
+          pickerBrowse: 'Browse',
+          pickerHide: 'Hide',
+          pickerHint: 'Browse skills',
+          pickerTitle: 'Skills Hub',
+          updateAll: 'Update all',
+          updateStarted: 'Update started',
+          updating: 'Updating'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/lib/icons', () => ({
+  Loader2: () => <span />
+}))
+
+vi.mock('@/lib/use-session-slice', () => ({
+  useStoreSelector: () => false
+}))
+
+vi.mock('@/store/hub-actions', () => ({
+  $hubActions: {},
+  installHubSkill: vi.fn(),
+  UPDATE_ALL_KEY: 'update-all',
+  updateHubSkills: vi.fn()
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/store/panes', () => ({
+  $paneHeightOverride: () => ({}),
+  setPaneHeightOverride: vi.fn()
+}))
+
+import { EmbeddedHubPicker } from './embedded-hub-picker'
+
+describe('EmbeddedHubPicker iframe policy', () => {
+  it('allows user-initiated hub links and clipboard writes without broader iframe privileges', () => {
+    const { container } = render(<EmbeddedHubPicker installedNames={new Set()} />)
+    const iframe = container.querySelector('iframe')
+
+    expect(iframe).not.toBeNull()
+    expect(iframe?.getAttribute('allow')).toBe('clipboard-write')
+    expect(iframe?.getAttribute('sandbox')).toBe(
+      'allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox'
+    )
+  })
+})

--- a/apps/desktop/src/app/skills/embedded-hub-picker.test.tsx
+++ b/apps/desktop/src/app/skills/embedded-hub-picker.test.tsx
@@ -70,7 +70,7 @@ import { EmbeddedHubPicker } from './embedded-hub-picker'
 
 describe('EmbeddedHubPicker iframe policy', () => {
   it('allows user-initiated hub links and clipboard writes without broader iframe privileges', () => {
-    const { container } = render(<EmbeddedHubPicker installedNames={new Set()} />)
+    const { container } = render(<EmbeddedHubPicker installedNames={new Set<string>()} />)
     const iframe = container.querySelector('iframe')
 
     expect(iframe).not.toBeNull()

--- a/apps/desktop/src/app/skills/embedded-hub-picker.test.tsx
+++ b/apps/desktop/src/app/skills/embedded-hub-picker.test.tsx
@@ -1,13 +1,22 @@
 // @vitest-environment jsdom
 import { render } from '@testing-library/react'
+import type { ComponentProps, ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
+
+type MockButtonProps = Omit<ComponentProps<'button'>, 'size'> & {
+  children?: ReactNode
+  size?: string
+  variant?: string
+}
 
 vi.mock('@nanostores/react', () => ({
   useStore: () => undefined
 }))
 
 vi.mock('@/components/ui/button', () => ({
-  Button: ({ children, size: _size, variant: _variant, ...props }: any) => <button {...props}>{children}</button>
+  Button: ({ children, size: _size, variant: _variant, ...props }: MockButtonProps) => (
+    <button {...props}>{children}</button>
+  )
 }))
 
 vi.mock('@/i18n', () => ({

--- a/apps/desktop/src/app/skills/embedded-hub-picker.tsx
+++ b/apps/desktop/src/app/skills/embedded-hub-picker.tsx
@@ -225,7 +225,8 @@ export const EmbeddedHubPicker = memo(function EmbeddedHubPicker({
             }}
           >
             <iframe
-              sandbox="allow-scripts allow-same-origin"
+              allow="clipboard-write"
+              sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
               src={HUB_PICKER_URL}
               style={{
                 background: 'transparent',


### PR DESCRIPTION
## What does this PR do?

Restores the embedded Skills Hub's user-visible external links and Copy controls while keeping the iframe policy narrow.

The picker currently allows only scripts and same-origin behavior. That blocks user-initiated popups from external links and Clipboard API writes used by the Copy control. This delegates only `clipboard-write` and adds popup capability. Clipboard read, top-level navigation, forms, downloads, and Node access remain unavailable.

## Related Issue

Fixes #91612

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/skills/embedded-hub-picker.tsx`: allow clipboard writes and user-initiated popup links for the cross-origin Skills Hub iframe.
- `apps/desktop/src/app/skills/embedded-hub-picker.test.tsx`: pin the exact iframe permission and sandbox policy.

## How to Test

1. `cd apps/desktop`
2. Run `npx vitest run --project ui src/app/skills/embedded-hub-picker.test.tsx`
3. Open the embedded Skills Hub in Desktop, verify an external documentation/GitHub link opens, and verify Copy install command writes to the clipboard.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added regression coverage
- [x] I've considered the security and cross-platform impact
- [x] Documentation/config/tool-schema changes are N/A
