### PR TITLE
Hermes Telegram V1: topic isolation, risk routing and approval gates

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19743,6 +19743,209 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    # ------------------------------------------------------------------
+    # Telegram task risk router (gateway/task_router.py)
+    #
+    # Classifies each inbound Telegram task's risk and either (a) routes
+    # LOW/MEDIUM straight to gpt-5.6-luna via a one-turn model override, or
+    # (b) for HIGH/CRITICAL, pauses the turn and sends a Telegram
+    # approve/reject prompt — the agent never runs until an authorized
+    # approver approves it. Scoped to Telegram only; every other platform's
+    # message flow, and Telegram's own slash-command/shell-approval paths,
+    # are untouched.
+    # ------------------------------------------------------------------
+
+    async def _route_telegram_task_risk(
+        self, *, source, session_key: str, message_text: str, event,
+    ):
+        """Return ``(paused, task_id)``.
+
+        ``paused=True`` means the caller MUST return without calling
+        ``_run_agent`` — a HIGH/CRITICAL task is awaiting approval (or a
+        duplicate delivery landed on one still pending) and the approval
+        prompt has already been sent. ``task_id`` is set when the caller
+        should call ``_mark_task_route_executed`` once the turn finishes so
+        the audit trail records completion; it is ``None`` when there is
+        nothing to track (non-Telegram platforms, internal/system events,
+        blank text).
+        """
+        if source.platform != Platform.TELEGRAM:
+            return False, None
+
+        from gateway.task_router import get_task_registry
+        from gateway.session import build_telegram_topic_session_key
+
+        registry = get_task_registry()
+        event_metadata = getattr(event, "metadata", None) or {}
+        resume_task_id = event_metadata.get("task_router_resume_task_id")
+
+        if resume_task_id:
+            # Re-entry after approval: _resume_approved_telegram_task already
+            # consumed the task for execution; just apply its agent override
+            # for this turn and proceed.
+            route = registry.get(resume_task_id)
+            if route is None:
+                return False, None
+            await self._apply_task_route_model_override(session_key, route.agent)
+            return False, resume_task_id
+
+        if getattr(event, "internal", False):
+            return False, None
+        if not message_text or not message_text.strip():
+            return False, None
+
+        from gateway.task_router import (
+            approval_reason,
+            classify_and_select,
+            infer_environment,
+            requires_approval,
+        )
+
+        risk, agent = classify_and_select(message_text)
+        message_id = getattr(event, "message_id", None)
+        dedupe_key = f"{session_key}:{message_id}" if message_id else None
+
+        route = registry.create_or_get(
+            dedupe_key=dedupe_key,
+            session_key=build_telegram_topic_session_key(
+                source.chat_id, getattr(source, "thread_id", None)
+            ),
+            chat_id=str(source.chat_id or ""),
+            thread_id=str(getattr(source, "thread_id", None) or ""),
+            user_id=str(source.user_id or ""),
+            request_text=message_text,
+            risk=risk,
+            agent=agent,
+        )
+
+        if requires_approval(route.risk):
+            if registry.claim_prompt(route.task_id) is not None:
+                try:
+                    adapter = self._adapter_for_source(source)
+                    send_fn = getattr(adapter, "send_task_approval", None)
+                    if callable(send_fn):
+                        await send_fn(
+                            chat_id=str(source.chat_id or ""),
+                            task_id=route.task_id,
+                            request_text=message_text,
+                            risk=risk.value,
+                            session_key=session_key,
+                            environment=infer_environment(message_text),
+                            reason=approval_reason(route.risk),
+                            proposed_agent=f"{route.agent.model} via {route.agent.provider}",
+                            metadata={
+                                "thread_id": str(getattr(source, "thread_id", None) or "")
+                            },
+                        )
+                    else:
+                        logger.warning(
+                            "task_router: adapter for %s has no send_task_approval; "
+                            "task %s left pending with no prompt sent",
+                            source.platform, route.task_id,
+                        )
+                except Exception:
+                    registry.release_prompt_claim(route.task_id)
+                    logger.error(
+                        "task_router: failed to send approval prompt for task %s",
+                        route.task_id, exc_info=True,
+                    )
+            # Whether we just sent the prompt or a duplicate delivery hit an
+            # already-pending task, the turn must not proceed to _run_agent.
+            return True, None
+
+        # LOW/MEDIUM: auto-approved by the registry at creation time. Consume
+        # it for execution now — the single-use execution gate. A redelivered
+        # duplicate resolves to the same task_id via dedupe above but cannot
+        # be consumed a second time.
+        consumed = registry.consume_for_execution(route.task_id)
+        if consumed is None:
+            return True, None
+        await self._apply_task_route_model_override(session_key, consumed.agent)
+        return False, consumed.task_id
+
+    async def _apply_task_route_model_override(self, session_key: str, agent) -> None:
+        """Apply a task-router agent selection as a one-turn session override.
+
+        Reuses the exact ``/model --once`` mechanism (snapshot now, restore
+        in the existing per-turn ``finally`` via
+        ``_restore_pending_one_turn_model_override``) so the switch never
+        outlives this one turn and never touches the user's own persisted
+        model choice.
+        """
+        try:
+            runtime_kwargs = await asyncio.to_thread(
+                _resolve_runtime_agent_kwargs_for_provider, agent.provider
+            )
+        except Exception:
+            logger.warning(
+                "task_router: failed to resolve credentials for provider=%s; "
+                "running the turn without a model override",
+                agent.provider, exc_info=True,
+            )
+            return
+        restore_snapshot = self._snapshot_session_model_override(session_key)
+        self._session_model_overrides[session_key] = {
+            "model": agent.model,
+            "provider": runtime_kwargs.get("provider") or agent.provider,
+            "api_key": runtime_kwargs.get("api_key"),
+            "base_url": runtime_kwargs.get("base_url"),
+            "api_mode": runtime_kwargs.get("api_mode"),
+        }
+        self._pending_one_turn_model_restores[session_key] = restore_snapshot
+        self._evict_cached_agent(session_key)
+
+    def _mark_task_route_executed(self, task_id: str, agent_result) -> None:
+        try:
+            from gateway.task_router import get_task_registry
+            success = bool(agent_result.get("success")) if isinstance(agent_result, dict) else True
+            get_task_registry().mark_executed(task_id, success=success)
+        except Exception:
+            logger.debug("task_router: failed to mark task %s executed", task_id, exc_info=True)
+
+    async def _resume_approved_telegram_task(self, task_id: str) -> None:
+        """Re-dispatch a HIGH/CRITICAL task after it clears Telegram approval.
+
+        Called by the adapter's ``tr:approve:`` callback handler once
+        ``TaskApprovalRegistry.approve`` has atomically verified the task was
+        pending and transitioned it to approved. Consumes it for execution
+        here (APPROVED -> EXECUTING, single-use) and re-injects it as an
+        inbound message so it gets the SAME session/transcript/delivery
+        handling as any other Telegram turn — just routed to
+        claude-sonnet-5 instead of re-classified.
+        """
+        from gateway.task_router import get_task_registry
+
+        registry = get_task_registry()
+        route = registry.consume_for_execution(task_id)
+        if route is None:
+            logger.warning(
+                "task_router: resume requested for task %s but it was not "
+                "APPROVED (already consumed, rejected, or unknown)", task_id,
+            )
+            return
+
+        chat_type = "dm" if not str(route.chat_id).startswith("-") else "group"
+        event = MessageEvent(
+            text=route.request_text,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=route.chat_id,
+                user_id=route.user_id,
+                chat_type=chat_type,
+                thread_id=route.thread_id or None,
+            ),
+            message_id=f"task-router-resume-{route.task_id}",
+            metadata={"task_router_resume_task_id": route.task_id},
+        )
+        try:
+            await self._handle_message(event)
+        except Exception:
+            logger.error(
+                "task_router: approved task %s failed during resumed execution",
+                task_id, exc_info=True,
+            )
+            registry.mark_executed(task_id, success=False)
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -21103,6 +21306,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             run_generation,
         )
 
+        # Telegram task risk router: classify + gate BEFORE the agent runs.
+        # LOW/MEDIUM proceed immediately (routed to gpt-5.6-luna below).
+        # HIGH/CRITICAL pause here — the approval prompt has already been
+        # sent — and this turn returns without ever calling _run_agent.
+        _task_route_paused, _task_route_id = await self._route_telegram_task_risk(
+            source=source, session_key=session_key, message_text=message_text,
+            event=event,
+        )
+        if _task_route_paused:
+            return None
+
         try:
             # Emit agent:start hook
             hook_ctx = {
@@ -21139,6 +21353,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message_type=event.message_type,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
+            if _task_route_id:
+                self._mark_task_route_executed(_task_route_id, agent_result)
 
             # Stop persistent typing indicator now that the agent is done.
             # Slack AI status is scoped to a thread/workspace, so preserve the

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1211,6 +1211,19 @@ def build_session_key(
     return ":".join(str(part) for part in key_parts)
 
 
+def build_telegram_topic_session_key(chat_id: object, thread_id: object = None) -> str:
+    """Build the stable, platform-facing Telegram topic identity key.
+
+    The SessionStore continues to use its profile-aware internal namespace
+    from :func:`build_session_key`; this compact key is used by Telegram task
+    routing/audit records and makes the topic boundary explicit. Missing
+    ``message_thread_id`` maps to the general lane.
+    """
+    chat = str(chat_id or "")
+    thread = str(thread_id or "general")
+    return f"telegram:{chat}:{thread}"
+
+
 class _SessionFlight:
     def __init__(self) -> None:
         self.event = threading.Event()

--- a/gateway/task_router.py
+++ b/gateway/task_router.py
@@ -1,0 +1,430 @@
+"""Risk-based task router for incoming Telegram tasks.
+
+Classifies an inbound Telegram task's risk (LOW/MEDIUM/HIGH/CRITICAL) and
+selects which agent/model is allowed to run it:
+
+  - LOW/MEDIUM    -> gpt-5.6-luna via the openai-codex provider. No approval
+                      gate; the task proceeds immediately.
+  - HIGH/CRITICAL -> paused pending explicit Telegram approval. Only after an
+                      authorized approver approves does it route to
+                      claude-sonnet-5 via the anthropic provider.
+
+DeepSeek is never selected by this router, at any risk level, and never used
+as a fallback (see ``_FORBIDDEN_PROVIDER_SUBSTRINGS``).
+
+This module owns its own pending-approval registry (task_id keyed,
+thread-safe, atomic approve/reject/consume). It is intentionally separate
+from ``tools.approval``'s dangerous-shell-command queue: task-routing
+approval (which *agent* runs a whole task) and in-turn command approval
+(whether one shell command inside an already-running turn is allowed) are
+different concerns with different payload shapes and lifecycles. Keeping
+them apart means this module can be added, tested, and reasoned about
+without touching the existing, heavily-exercised command-approval logic.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger("gateway.task_router")
+
+_AUDIT_TEXT_PREVIEW_CHARS = 200
+_LONG_TASK_MEDIUM_THRESHOLD = 4000
+
+
+class RiskLevel(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class TaskApprovalStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    EXECUTING = "executing"
+    EXECUTED = "executed"
+
+
+@dataclass(frozen=True)
+class AgentSelection:
+    provider: str
+    model: str
+
+
+# The only two agent selections this router may ever return. DeepSeek (or
+# any other provider) must never be selected here, at any risk level, and
+# never substituted as a fallback.
+_LOW_MEDIUM_AGENT = AgentSelection(provider="openai-codex", model="gpt-5.6-luna")
+_HIGH_CRITICAL_AGENT = AgentSelection(provider="anthropic", model="claude-sonnet-5")
+
+_FORBIDDEN_PROVIDER_SUBSTRINGS = ("deepseek",)
+
+
+def _assert_not_forbidden(selection: AgentSelection) -> AgentSelection:
+    provider = (selection.provider or "").lower()
+    model = (selection.model or "").lower()
+    for bad in _FORBIDDEN_PROVIDER_SUBSTRINGS:
+        if bad in provider or bad in model:
+            raise RuntimeError(
+                f"task_router: refusing forbidden agent selection {selection!r}"
+            )
+    return selection
+
+
+# --- Risk classification ----------------------------------------------------
+#
+# Keyword/regex heuristics only. ``text`` is untrusted user input: it is
+# matched read-only against these patterns and is never evaluated, executed,
+# or interpolated into a shell/SQL/format string.
+
+_CRITICAL_PATTERNS = [
+    r"\brm\s+-rf\b",
+    r"\bdrop\s+(table|database)\b",
+    r"\bdelete\s+from\b",
+    r"\bformat\s+c:",
+    r"\bshutdown\b",
+    r"\breboot\b",
+    r"\bwipe\b",
+    r"\brevoke\b",
+    r"\bproduction\b.*\b(deploy|delete|migrat)",
+    r"\bcredentials?\b",
+    r"\bapi[_ ]?keys?\b",
+    r"\bsecrets?\b",
+    r"\bprivate[_ ]?keys?\b",
+    r"\bpayment\b",
+    r"\btransfer\s+(funds|money)\b",
+    r"\bwire\s+transfer\b",
+    r"\bpush\s+--force\b",
+    r"\bforce[- ]push\b",
+    r"\bdeploy\s+to\s+prod",
+    r"\bchmod\s+777\b",
+    r"\bsudo\s+rm\b",
+    r"\bdisable\s+(firewall|auth)\b",
+]
+
+_HIGH_PATTERNS = [
+    r"\bdeploy\b",
+    r"\bmigrat(e|ion)\b",
+    r"\bdrop\b",
+    r"\bdelete\b",
+    r"\boverwrite\b",
+    r"\breset\s+(database|db)\b",
+    r"\bgit\s+push\b",
+    r"\bpublish\b",
+    r"\brelease\b",
+    r"\bgrant\s+access\b",
+    r"\bchange\s+password\b",
+    r"\brotate\s+(key|secret)\b",
+    r"\bmerge\s+to\s+main\b",
+    r"\bkill\s+process\b",
+    r"\brls\b",
+    r"\brow[- ]level\s+security\b",
+    r"\bsecurity\s+polic(?:y|ies)\b",
+    r"\brbac\b",
+    r"\bauthentication\b",
+]
+
+
+def classify_task_risk(text: Optional[str]) -> RiskLevel:
+    """Classify the risk of an inbound task's free-text request.
+
+    Pure and read-only: pattern-matches ``text`` and never executes,
+    evaluates, or shells out to it. Defaults to LOW when the text is empty
+    or matches nothing risky — HIGH/CRITICAL tasks are recognizable by
+    clearly destructive or sensitive verbs, so an unmatched task is the
+    safe default rather than a missed one.
+    """
+    if not text or not text.strip():
+        return RiskLevel.LOW
+    lowered = text.lower()
+    for pattern in _CRITICAL_PATTERNS:
+        if re.search(pattern, lowered):
+            return RiskLevel.CRITICAL
+    for pattern in _HIGH_PATTERNS:
+        if re.search(pattern, lowered):
+            return RiskLevel.HIGH
+    if len(text) > _LONG_TASK_MEDIUM_THRESHOLD:
+        return RiskLevel.MEDIUM
+    return RiskLevel.LOW
+
+
+def select_agent_for_risk(risk: RiskLevel) -> AgentSelection:
+    """Map a risk level to the agent/model allowed to run it.
+
+    LOW/MEDIUM route directly to gpt-5.6-luna (OpenAI Codex).
+    HIGH/CRITICAL route to claude-sonnet-5 (Anthropic) — callers MUST NOT
+    execute a HIGH/CRITICAL task with this selection until it has cleared
+    the approval gate in :class:`TaskApprovalRegistry`.
+    """
+    if risk in (RiskLevel.LOW, RiskLevel.MEDIUM):
+        return _assert_not_forbidden(_LOW_MEDIUM_AGENT)
+    if risk in (RiskLevel.HIGH, RiskLevel.CRITICAL):
+        return _assert_not_forbidden(_HIGH_CRITICAL_AGENT)
+    raise ValueError(f"unknown risk level: {risk!r}")
+
+
+def requires_approval(risk: RiskLevel) -> bool:
+    return risk in (RiskLevel.HIGH, RiskLevel.CRITICAL)
+
+
+def infer_environment(text: Optional[str]) -> str:
+    """Infer the affected environment for a human approval summary."""
+    lowered = (text or "").lower()
+    if re.search(r"\bproduction\b|\bprod\b", lowered):
+        return "production"
+    if re.search(r"\bstaging\b|\bstage\b", lowered):
+        return "staging"
+    return "local"
+
+
+def approval_reason(risk: RiskLevel) -> str:
+    if risk == RiskLevel.CRITICAL:
+        return "destructive, production-sensitive, or secret-bearing operation"
+    if risk == RiskLevel.HIGH:
+        return "architecture, security, access-control, database, or deployment change"
+    return "routine task"
+
+
+def classify_and_select(text: Optional[str]) -> tuple[RiskLevel, AgentSelection]:
+    """Convenience: classify risk then select the corresponding agent."""
+    risk = classify_task_risk(text)
+    return risk, select_agent_for_risk(risk)
+
+
+# --- Task approval registry --------------------------------------------------
+
+
+def _preview(text: str, limit: int = _AUDIT_TEXT_PREVIEW_CHARS) -> str:
+    text = (text or "").replace("\n", " ")
+    return text[:limit] + ("…" if len(text) > limit else "")
+
+
+@dataclass
+class TaskRoute:
+    """One inbound Telegram task's risk-routing + approval state."""
+
+    task_id: str
+    session_key: str
+    chat_id: str
+    thread_id: str
+    user_id: str
+    request_text: str
+    risk: RiskLevel
+    agent: AgentSelection
+    status: TaskApprovalStatus
+    created_at: float = field(default_factory=time.time)
+    decided_at: Optional[float] = None
+    decided_by: Optional[str] = None
+    executed_at: Optional[float] = None
+    execution_status: str = "not_started"
+    prompt_sent: bool = False
+
+
+def _copy(route: TaskRoute) -> TaskRoute:
+    return dataclasses.replace(route)
+
+
+class TaskApprovalRegistry:
+    """Thread-safe registry for task risk-routing + approval state.
+
+    Mirrors the atomic pop/consume idempotency pattern used by
+    ``tools.approval``'s gateway approval queue, but keyed by ``task_id`` and
+    carrying task-routing fields (risk, selected agent) rather than
+    shell-command payloads.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._tasks: dict[str, TaskRoute] = {}
+        self._dedupe: dict[str, str] = {}  # dedupe_key -> task_id
+
+    def create_or_get(
+        self,
+        *,
+        dedupe_key: Optional[str],
+        session_key: str,
+        chat_id: str,
+        thread_id: str,
+        user_id: str,
+        request_text: str,
+        risk: RiskLevel,
+        agent: AgentSelection,
+    ) -> TaskRoute:
+        """Create a new task route, or return the existing one for ``dedupe_key``.
+
+        Idempotent duplicate protection: a redelivered Telegram update (same
+        ``dedupe_key``, e.g. ``f"{session_key}:{message_id}"``) resolves to
+        the SAME task rather than spawning a second approval request or a
+        second execution.
+        """
+        with self._lock:
+            if dedupe_key:
+                existing_id = self._dedupe.get(dedupe_key)
+                if existing_id is not None:
+                    existing = self._tasks.get(existing_id)
+                    # Telegram retries preserve the original payload.  Do
+                    # not let a reused/malformed message id make a different
+                    # request inherit the earlier route in this process.
+                    if existing is not None and existing.request_text == request_text:
+                        return _copy(existing)
+            task_id = uuid.uuid4().hex
+            auto_approved = not requires_approval(risk)
+            status = TaskApprovalStatus.APPROVED if auto_approved else TaskApprovalStatus.PENDING
+            route = TaskRoute(
+                task_id=task_id,
+                session_key=session_key,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                user_id=user_id,
+                request_text=request_text,
+                risk=risk,
+                agent=agent,
+                status=status,
+            )
+            if auto_approved:
+                route.decided_at = time.time()
+                route.decided_by = "auto:risk_router"
+            self._tasks[task_id] = route
+            if dedupe_key:
+                self._dedupe[dedupe_key] = task_id
+        _audit("created", route)
+        return _copy(route)
+
+    def get(self, task_id: str) -> Optional[TaskRoute]:
+        with self._lock:
+            route = self._tasks.get(task_id)
+            return _copy(route) if route else None
+
+    def claim_prompt(self, task_id: str) -> Optional[TaskRoute]:
+        """Atomically claim the one approval prompt for a pending task."""
+        with self._lock:
+            route = self._tasks.get(task_id)
+            if route is None or route.status != TaskApprovalStatus.PENDING:
+                return None
+            if route.prompt_sent:
+                return None
+            route.prompt_sent = True
+            snapshot = _copy(route)
+        _audit("prompt_claimed", snapshot)
+        return snapshot
+
+    def release_prompt_claim(self, task_id: str) -> None:
+        """Allow a failed delivery attempt to be retried safely."""
+        with self._lock:
+            route = self._tasks.get(task_id)
+            if route is not None and route.status == TaskApprovalStatus.PENDING:
+                route.prompt_sent = False
+
+    def approve(self, task_id: str, decided_by: str) -> Optional[TaskRoute]:
+        """Atomically verify PENDING and transition to APPROVED.
+
+        Returns ``None`` if the task is unknown or not pending — including
+        a second call for a task already approved/rejected. Callers MUST
+        treat ``None`` as "already handled", never retry as a fresh
+        approval. This is the sole authorization + atomic-consume point for
+        the approval decision itself (execution is gated separately by
+        :meth:`consume_for_execution`).
+        """
+        with self._lock:
+            route = self._tasks.get(task_id)
+            if route is None or route.status != TaskApprovalStatus.PENDING:
+                return None
+            route.status = TaskApprovalStatus.APPROVED
+            route.decided_at = time.time()
+            route.decided_by = decided_by
+        _audit("approved", route)
+        return _copy(route)
+
+    def reject(self, task_id: str, decided_by: str) -> Optional[TaskRoute]:
+        """Atomically verify PENDING and transition to REJECTED.
+
+        Returns ``None`` if the task is unknown or not pending. A rejected
+        task can never later be approved or executed — :meth:`approve` and
+        :meth:`consume_for_execution` both require the prior state
+        (PENDING / APPROVED respectively), which REJECTED never satisfies.
+        """
+        with self._lock:
+            route = self._tasks.get(task_id)
+            if route is None or route.status != TaskApprovalStatus.PENDING:
+                return None
+            route.status = TaskApprovalStatus.REJECTED
+            route.decided_at = time.time()
+            route.decided_by = decided_by
+            route.execution_status = "rejected"
+        _audit("rejected", route)
+        return _copy(route)
+
+    def consume_for_execution(self, task_id: str) -> Optional[TaskRoute]:
+        """Atomically verify APPROVED and transition to EXECUTING.
+
+        A task can be consumed for execution at most once — the single
+        execution gate. Returns ``None`` for anything not currently
+        APPROVED (unknown, still pending, rejected, or already consumed),
+        so "approve twice" or "run twice" can never execute twice.
+        """
+        with self._lock:
+            route = self._tasks.get(task_id)
+            if route is None or route.status != TaskApprovalStatus.APPROVED:
+                return None
+            route.status = TaskApprovalStatus.EXECUTING
+            route.execution_status = "executing"
+        _audit("executing", route)
+        return _copy(route)
+
+    def mark_executed(self, task_id: str, *, success: bool) -> None:
+        with self._lock:
+            route = self._tasks.get(task_id)
+            if route is None:
+                return
+            route.status = TaskApprovalStatus.EXECUTED
+            route.execution_status = "executed" if success else "failed"
+            route.executed_at = time.time()
+            snapshot = _copy(route)
+        _audit("executed", snapshot)
+
+
+_registry = TaskApprovalRegistry()
+
+
+def get_task_registry() -> TaskApprovalRegistry:
+    return _registry
+
+
+def _audit(event: str, route: TaskRoute) -> None:
+    """Emit one structured audit log line for a task-routing lifecycle event.
+
+    Deliberately a single ``logger.info`` call with lazy ``%s`` args (not an
+    f-string) so the standard logging pipeline's ``RedactingFormatter``
+    (see ``hermes_logging.py``) gets a chance to scrub secret-shaped
+    substrings before anything reaches disk.
+    """
+    logger.info(
+        "task_audit event=%s task_id=%s chat_id=%s message_thread_id=%s "
+        "risk=%s agent_provider=%s agent_model=%s approval_status=%s "
+        "execution_status=%s request_preview=%r created_at=%s decided_at=%s "
+        "decided_by=%s executed_at=%s",
+        event,
+        route.task_id,
+        route.chat_id,
+        route.thread_id or "",
+        route.risk.value,
+        route.agent.provider,
+        route.agent.model,
+        route.status.value,
+        route.execution_status,
+        _preview(route.request_text),
+        route.created_at,
+        route.decided_at,
+        route.decided_by,
+        route.executed_at,
+    )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -839,6 +839,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
+        # Task-router approval button state: task_id → session_key (HIGH/CRITICAL
+        # risk-routed tasks paused pending approval; see gateway/task_router.py).
+        self._task_approval_state: Dict[str, str] = {}
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
@@ -6437,6 +6440,68 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_slash_confirm failed: %s", self.name, _redact_telegram_error_text(e))
             return SendResult(success=False, error=_redact_telegram_error_text(e))
 
+    async def send_task_approval(
+        self, chat_id: str, task_id: str, request_text: str, risk: str,
+        session_key: str, environment: str = "local", reason: str = "",
+        proposed_agent: str = "claude-sonnet-5 via anthropic",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render an Approve/Reject prompt for a HIGH/CRITICAL risk-routed task.
+
+        Sent by the gateway's task risk router (gateway/task_router.py) before
+        a HIGH/CRITICAL task is allowed to run. The buttons call
+        ``TaskApprovalRegistry.approve``/``.reject`` via ``_handle_callback_query``
+        — same idempotent pop-then-resolve shape as ``send_exec_approval``.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            preview = self.format_message(
+                f"⚠️ *APPROVAL REQUIRED*\n\n"
+                f"*Task:* {self._truncate_preview(request_text, 1200)}\n"
+                f"*Risk:* {risk.upper()}\n"
+                f"*Reason:* {reason or 'policy-gated operation'}\n"
+                f"*Proposed agent:* {proposed_agent}\n"
+                f"*Affected environment:* {environment}\n\n"
+                f"*Actions:* Approve / Reject / Revise"
+            )
+
+            keyboard = InlineKeyboardMarkup([
+                [
+                    InlineKeyboardButton("✅ Approve", callback_data=f"tr:approve:{task_id}"),
+                    InlineKeyboardButton("❌ Reject", callback_data=f"tr:reject:{task_id}"),
+                    InlineKeyboardButton("✏️ Revise", callback_data=f"tr:revise:{task_id}"),
+                ],
+            ])
+
+            thread_id = self._metadata_thread_id(metadata)
+            kwargs: Dict[str, Any] = {
+                "chat_id": normalize_telegram_chat_id(chat_id),
+                "text": preview,
+                "parse_mode": ParseMode.MARKDOWN_V2,
+                "reply_markup": keyboard,
+                **self._link_preview_kwargs(),
+            }
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+            kwargs["reply_to_message_id"] = reply_to_id
+            kwargs.update(
+                self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode
+                )
+            )
+
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            self._task_approval_state[task_id] = session_key
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_task_approval failed: %s", self.name, _redact_telegram_error_text(e))
+            return SendResult(success=False, error=_redact_telegram_error_text(e))
+
     async def send_clarify(
         self,
         chat_id: str,
@@ -7405,6 +7470,101 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Task-router approval callbacks (tr:choice:task_id) ---
+        # HIGH/CRITICAL risk-routed tasks (gateway/task_router.py) pause
+        # before running and wait for one of these two buttons.
+        if data.startswith("tr:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3:
+                choice = parts[1]  # approve, reject
+                task_id = parts[2]
+
+                # Only authorized users may decide a paused task.
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to decide this task.")
+                    return
+
+                # First idempotency layer: pop the per-adapter marker so a
+                # second tap on the SAME button (before the registry round
+                # trip even starts) is rejected immediately.
+                if task_id not in self._task_approval_state:
+                    await query.answer(text="This task approval has already been resolved.")
+                    return
+                self._task_approval_state.pop(task_id, None)
+
+                user_display = getattr(query.from_user, "first_name", "User")
+                decided_by = f"telegram:{caller_id}:{user_display}"
+
+                from gateway.task_router import get_task_registry
+                registry = get_task_registry()
+                # Second, authoritative idempotency layer: the registry's
+                # approve/reject only succeed out of PENDING and are
+                # lock-guarded, so a race between two taps (or a replayed
+                # callback) can resolve the task at most once either way.
+                if choice == "approve":
+                    route = registry.approve(task_id, decided_by)
+                elif choice in {"reject", "revise"}:
+                    route = registry.reject(task_id, decided_by)
+                else:
+                    route = None
+
+                if route is None:
+                    label = "⌛ Already resolved"
+                    edit_text = (
+                        f"{label} — this task was already approved, rejected, "
+                        f"or is no longer pending."
+                    )
+                elif choice == "approve":
+                    label = "✅ Approved"
+                    edit_text = (
+                        f"{label} by {user_display} — running with "
+                        f"{route.agent.provider}/{route.agent.model}."
+                    )
+                elif choice == "revise":
+                    label = "✏️ Revision requested"
+                    edit_text = (
+                        f"{label} by {user_display}. This request will not run; "
+                        "send a new task with the requested changes."
+                    )
+                else:
+                    label = "❌ Rejected"
+                    edit_text = f"{label} by {user_display}. This task will not run."
+
+                await query.answer(text=label)
+                try:
+                    await query.edit_message_text(
+                        text=self.format_message(edit_text),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+
+                if route is not None and choice == "approve":
+                    # Hand off to the gateway to actually run the now-approved
+                    # task. Reached via the bound _handle_message method the
+                    # runner registered as our message handler — same
+                    # indirection _is_callback_user_authorized already uses
+                    # to reach back into the runner without a hard import.
+                    runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+                    resume_fn = getattr(runner, "_resume_approved_telegram_task", None)
+                    if callable(resume_fn):
+                        try:
+                            await resume_fn(task_id)
+                        except Exception:
+                            logger.error(
+                                "[%s] Failed to resume approved task %s",
+                                self.name, task_id, exc_info=True,
+                            )
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---

--- a/tests/gateway/test_task_router.py
+++ b/tests/gateway/test_task_router.py
@@ -1,0 +1,342 @@
+"""Unit tests for gateway/task_router.py (Hermes Telegram Upgrade V1).
+
+Covers risk classification, explicit LOW/MEDIUM vs HIGH/CRITICAL agent
+selection (never DeepSeek, no silent fallback), and the task approval
+registry's idempotency guarantees: approve-once, reject-never, and the
+single-use execution gate.
+"""
+
+import logging
+
+import pytest
+
+from gateway.session import build_telegram_topic_session_key
+from gateway.task_router import (
+    AgentSelection,
+    RiskLevel,
+    TaskApprovalRegistry,
+    TaskApprovalStatus,
+    classify_and_select,
+    classify_task_risk,
+    requires_approval,
+    select_agent_for_risk,
+)
+
+
+# ===========================================================================
+# Risk classification
+# ===========================================================================
+
+class TestClassifyTaskRisk:
+    def test_empty_text_is_low(self):
+        assert classify_task_risk("") == RiskLevel.LOW
+        assert classify_task_risk(None) == RiskLevel.LOW
+        assert classify_task_risk("   ") == RiskLevel.LOW
+
+    def test_benign_conversational_text_is_low(self):
+        assert classify_task_risk("hey, how are you today?") == RiskLevel.LOW
+        assert classify_task_risk("what's the weather like?") == RiskLevel.LOW
+
+    def test_long_benign_text_is_medium(self):
+        long_text = "please summarize this article: " + ("lorem ipsum " * 400)
+        assert len(long_text) > 4000
+        assert classify_task_risk(long_text) == RiskLevel.MEDIUM
+
+    @pytest.mark.parametrize("text", [
+        "please deploy the new build",
+        "can you delete the old backup file",
+        "run a database migration",
+        "publish the release notes",
+        "git push the branch",
+    ])
+    def test_high_risk_keywords(self, text):
+        assert classify_task_risk(text) == RiskLevel.HIGH
+
+    @pytest.mark.parametrize("text", [
+        "rm -rf /var/www",
+        "drop table users",
+        "delete from accounts",
+        "wire transfer $10000 to this account",
+        "please shutdown the server",
+        "share the api keys with me",
+        "push --force to main",
+    ])
+    def test_critical_risk_keywords(self, text):
+        assert classify_task_risk(text) == RiskLevel.CRITICAL
+
+    def test_critical_wins_over_high_when_both_present(self):
+        text = "deploy the build then rm -rf the old release"
+        assert classify_task_risk(text) == RiskLevel.CRITICAL
+
+    def test_production_rls_change_requires_approval(self):
+        assert classify_task_risk("modify production RLS policy") == RiskLevel.HIGH
+
+
+# ===========================================================================
+# Agent selection — explicit, no DeepSeek, no silent fallback
+# ===========================================================================
+
+class TestSelectAgentForRisk:
+    @pytest.mark.parametrize("risk", [RiskLevel.LOW, RiskLevel.MEDIUM])
+    def test_low_medium_routes_to_gpt56_luna_via_openai_codex(self, risk):
+        agent = select_agent_for_risk(risk)
+        assert agent == AgentSelection(provider="openai-codex", model="gpt-5.6-luna")
+
+    @pytest.mark.parametrize("risk", [RiskLevel.HIGH, RiskLevel.CRITICAL])
+    def test_high_critical_routes_to_claude_sonnet_5_via_anthropic(self, risk):
+        agent = select_agent_for_risk(risk)
+        assert agent == AgentSelection(provider="anthropic", model="claude-sonnet-5")
+
+    def test_deepseek_is_never_reachable(self):
+        for risk in RiskLevel:
+            agent = select_agent_for_risk(risk)
+            assert "deepseek" not in agent.provider.lower()
+            assert "deepseek" not in agent.model.lower()
+
+    def test_unknown_risk_raises_instead_of_silently_falling_back(self):
+        with pytest.raises(ValueError):
+            select_agent_for_risk("unknown-risk-tier")  # type: ignore[arg-type]
+
+    def test_requires_approval_only_for_high_critical(self):
+        assert requires_approval(RiskLevel.LOW) is False
+        assert requires_approval(RiskLevel.MEDIUM) is False
+        assert requires_approval(RiskLevel.HIGH) is True
+        assert requires_approval(RiskLevel.CRITICAL) is True
+
+    def test_classify_and_select_is_consistent_with_the_two_step_calls(self):
+        risk, agent = classify_and_select("please deploy to production")
+        assert risk == classify_task_risk("please deploy to production")
+        assert agent == select_agent_for_risk(risk)
+
+
+# ===========================================================================
+# TaskApprovalRegistry — topic identity, dedupe, approve-once, reject-never
+# ===========================================================================
+
+def _make_route(registry: TaskApprovalRegistry, *, risk=RiskLevel.LOW,
+                 chat_id="123", thread_id="", user_id="u1",
+                 request_text="hello", dedupe_key=None):
+    agent = select_agent_for_risk(risk)
+    return registry.create_or_get(
+        dedupe_key=dedupe_key,
+        session_key=f"agent:main:telegram:group:{chat_id}:{thread_id}" if thread_id
+        else f"agent:main:telegram:dm:{chat_id}",
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id=user_id,
+        request_text=request_text,
+        risk=risk,
+        agent=agent,
+    )
+
+
+class TestTaskApprovalRegistryLowMedium:
+    def test_low_medium_task_is_auto_approved_at_creation(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.LOW)
+        assert route.status == TaskApprovalStatus.APPROVED
+        assert route.decided_by == "auto:risk_router"
+        assert route.agent.provider == "openai-codex"
+
+    def test_low_medium_task_can_be_consumed_for_execution_immediately(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.MEDIUM)
+        consumed = registry.consume_for_execution(route.task_id)
+        assert consumed is not None
+        assert consumed.status == TaskApprovalStatus.EXECUTING
+
+
+class TestTaskApprovalRegistryHighCriticalPause:
+    def test_high_critical_task_starts_pending_not_auto_approved(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.HIGH, request_text="please deploy")
+        assert route.status == TaskApprovalStatus.PENDING
+        assert route.decided_by is None
+        assert route.agent.provider == "anthropic"
+
+    def test_high_critical_task_cannot_be_consumed_before_approval(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.CRITICAL, request_text="rm -rf /data")
+        assert registry.consume_for_execution(route.task_id) is None
+
+
+class TestApproveOnce:
+    """Approving the same task twice must resolve — and execute — only once."""
+
+    def test_second_approve_call_is_a_noop(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.HIGH)
+
+        first = registry.approve(route.task_id, "telegram:1:Alice")
+        second = registry.approve(route.task_id, "telegram:1:Alice")
+
+        assert first is not None
+        assert first.status == TaskApprovalStatus.APPROVED
+        assert second is None
+
+    def test_double_consume_for_execution_runs_once(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.HIGH)
+        registry.approve(route.task_id, "telegram:1:Alice")
+
+        first = registry.consume_for_execution(route.task_id)
+        second = registry.consume_for_execution(route.task_id)
+
+        assert first is not None
+        assert first.status == TaskApprovalStatus.EXECUTING
+        assert second is None
+
+    def test_approve_then_execute_twice_via_registry_never_double_executes(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.HIGH)
+        registry.approve(route.task_id, "telegram:1:Alice")
+        registry.approve(route.task_id, "telegram:1:Alice")  # duplicate tap
+
+        executions = [registry.consume_for_execution(route.task_id) for _ in range(3)]
+        successful = [r for r in executions if r is not None]
+        assert len(successful) == 1
+
+
+class TestRejectNever:
+    """A rejected task must never later be approved or executed."""
+
+    def test_reject_transitions_to_rejected(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.CRITICAL)
+        rejected = registry.reject(route.task_id, "telegram:1:Bob")
+        assert rejected is not None
+        assert rejected.status == TaskApprovalStatus.REJECTED
+        assert rejected.execution_status == "rejected"
+
+    def test_second_reject_call_is_a_noop(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.CRITICAL)
+        registry.reject(route.task_id, "telegram:1:Bob")
+        assert registry.reject(route.task_id, "telegram:1:Bob") is None
+
+    def test_approve_after_reject_is_refused(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.CRITICAL)
+        registry.reject(route.task_id, "telegram:1:Bob")
+        assert registry.approve(route.task_id, "telegram:1:Alice") is None
+
+    def test_rejected_task_can_never_be_consumed_for_execution(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, risk=RiskLevel.CRITICAL)
+        registry.reject(route.task_id, "telegram:1:Bob")
+        assert registry.consume_for_execution(route.task_id) is None
+
+
+# ===========================================================================
+# Topic isolation / General-topic fallback
+# ===========================================================================
+
+class TestTopicIdentityIsolation:
+    def test_distinct_topics_in_the_same_chat_produce_independent_routes(self):
+        registry = TaskApprovalRegistry()
+        general = _make_route(
+            registry, chat_id="-100999", thread_id="1", request_text="deploy",
+            risk=RiskLevel.HIGH, dedupe_key="sk:general:m1",
+        )
+        topic_42 = _make_route(
+            registry, chat_id="-100999", thread_id="42", request_text="deploy",
+            risk=RiskLevel.HIGH, dedupe_key="sk:topic42:m1",
+        )
+
+        assert general.task_id != topic_42.task_id
+        assert general.thread_id == "1"
+        assert topic_42.thread_id == "42"
+        assert general.chat_id == topic_42.chat_id == "-100999"
+
+    def test_general_topic_uses_the_existing_sentinel_thread_id(self):
+        """Telegram's General-topic sentinel ("1") must flow through to the
+        audit trail unchanged — the router must not invent its own sentinel
+        or collapse it to an empty/None thread id."""
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, chat_id="-100999", thread_id="1")
+        assert route.thread_id == "1"
+
+    def test_private_dm_with_no_thread_records_empty_thread_id(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, chat_id="555", thread_id="")
+        assert route.thread_id == ""
+        assert route.chat_id == "555"
+
+    def test_redelivered_duplicate_in_same_topic_resolves_to_same_task(self):
+        registry = TaskApprovalRegistry()
+        first = _make_route(registry, chat_id="1", thread_id="7", dedupe_key="sk7:m1")
+        duplicate = _make_route(registry, chat_id="1", thread_id="7", dedupe_key="sk7:m1")
+        assert first.task_id == duplicate.task_id
+
+    def test_same_message_id_in_different_topics_does_not_collide(self):
+        """Dedupe is scoped per (session_key, message_id) — the caller folds
+        chat/topic identity into session_key, so identical message ids in
+        two different topics of the same chat must not merge into one task.
+        """
+        registry = TaskApprovalRegistry()
+        topic_a = _make_route(registry, chat_id="1", thread_id="7", dedupe_key="sk-topic7:m1")
+        topic_b = _make_route(registry, chat_id="1", thread_id="8", dedupe_key="sk-topic8:m1")
+        assert topic_a.task_id != topic_b.task_id
+
+
+# ===========================================================================
+# Audit trail fields
+# ===========================================================================
+
+class TestAuditFields:
+    def test_task_route_carries_all_required_audit_fields(self):
+        registry = TaskApprovalRegistry()
+        route = _make_route(
+            registry, chat_id="-100777", thread_id="3", user_id="u42",
+            request_text="deploy the app", risk=RiskLevel.HIGH,
+        )
+        assert route.task_id
+        assert route.chat_id == "-100777"
+        assert route.thread_id == "3"
+        assert route.user_id == "u42"
+        assert route.request_text == "deploy the app"
+        assert route.risk == RiskLevel.HIGH
+        assert route.agent.provider == "anthropic"
+        assert route.agent.model == "claude-sonnet-5"
+        assert route.status == TaskApprovalStatus.PENDING
+        assert route.execution_status == "not_started"
+        assert route.created_at is not None
+
+    def test_audit_log_emits_task_id_chat_id_and_thread_id(self, caplog):
+        caplog.set_level(logging.INFO, logger="gateway.task_router")
+        registry = TaskApprovalRegistry()
+        route = _make_route(
+            registry, chat_id="-100777", thread_id="3", request_text="deploy now",
+            risk=RiskLevel.HIGH,
+        )
+        registry.approve(route.task_id, "telegram:1:Alice")
+        registry.consume_for_execution(route.task_id)
+        registry.mark_executed(route.task_id, success=True)
+
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert f"task_id={route.task_id}" in joined
+        assert "chat_id=-100777" in joined
+        assert "message_thread_id=3" in joined
+        assert "risk=high" in joined
+        assert "agent_provider=anthropic" in joined
+        assert "agent_model=claude-sonnet-5" in joined
+        assert "approval_status=approved" in joined or "approval_status=executing" in joined
+        assert "execution_status=executed" in joined
+        assert "decided_by=telegram:1:Alice" in joined
+
+    def test_audit_log_records_rejection(self, caplog):
+        caplog.set_level(logging.INFO, logger="gateway.task_router")
+        registry = TaskApprovalRegistry()
+        route = _make_route(registry, chat_id="42", thread_id="", risk=RiskLevel.CRITICAL,
+                             request_text="rm -rf /")
+        registry.reject(route.task_id, "telegram:1:Bob")
+
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "event=rejected" in joined
+        assert "execution_status=rejected" in joined
+        assert "decided_by=telegram:1:Bob" in joined
+
+
+def test_telegram_topic_session_key_uses_general_fallback():
+    assert build_telegram_topic_session_key("-100123", "17585") == "telegram:-100123:17585"
+    assert build_telegram_topic_session_key("-100123", None) == "telegram:-100123:general"

--- a/tests/gateway/test_task_router_integration.py
+++ b/tests/gateway/test_task_router_integration.py
@@ -1,0 +1,390 @@
+"""Integration tests for the Telegram task risk router wiring.
+
+Complements ``tests/gateway/test_task_router.py`` (pure ``gateway.task_router``
+unit tests) by exercising the actual GatewayRunner hook
+(``_route_telegram_task_risk`` / ``_resume_approved_telegram_task`` /
+``_mark_task_route_executed`` in gateway/run.py) and the Telegram adapter's
+``tr:approve:``/``tr:reject:`` callback branch, plus a regression lock on the
+existing ``build_session_key`` topic-isolation/General-lane compatibility
+that the router must not disturb.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, build_session_key
+from gateway.task_router import TaskApprovalStatus, get_task_registry, select_agent_for_risk, RiskLevel
+from tests.gateway.test_telegram_topic_mode import _make_event, _make_runner, _make_source
+
+
+# ---------------------------------------------------------------------------
+# Regression lock: task routing must not touch session-key derivation.
+# ---------------------------------------------------------------------------
+
+class TestExistingTopicKeyCompatibilityIsUnchanged:
+    def test_dm_topic_key_still_includes_thread_id(self):
+        source = _make_source(thread_id="17585")
+        assert build_session_key(source) == "agent:main:telegram:dm:208214988:17585"
+
+    def test_dm_without_thread_still_falls_back_to_the_general_lane_key(self):
+        source = _make_source(thread_id=None)
+        assert build_session_key(source) == "agent:main:telegram:dm:208214988"
+
+    def test_distinct_topics_still_produce_distinct_keys(self):
+        key_a = build_session_key(_make_source(thread_id="111"))
+        key_b = build_session_key(_make_source(thread_id="222"))
+        general_key = build_session_key(_make_source(thread_id=None))
+        assert len({key_a, key_b, general_key}) == 3
+
+
+@pytest.fixture
+def fake_runtime_kwargs(monkeypatch):
+    """Deterministic credential stand-in so tests never touch real config."""
+    import gateway.run as gateway_run
+
+    def _fake(provider):
+        return {
+            "provider": provider,
+            "api_key": f"fake-key-for-{provider}",
+            "base_url": f"https://example.test/{provider}",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        }
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs_for_provider", _fake)
+    return _fake
+
+
+class TestGatewayRouteTelegramTaskRisk:
+    @pytest.mark.asyncio
+    async def test_low_risk_task_routes_to_codex_without_pausing(self, fake_runtime_kwargs):
+        runner = _make_runner()
+        event = _make_event("please summarize this article", thread_id="17585")
+        source = event.source
+        session_key = runner._session_key_for_source(source)
+
+        paused, task_id = await runner._route_telegram_task_risk(
+            source=source, session_key=session_key,
+            message_text=event.text, event=event,
+        )
+
+        assert paused is False
+        assert task_id is not None
+        override = runner._session_model_overrides[session_key]
+        assert override["provider"] == "openai-codex"
+        assert override["model"] == "gpt-5.6-luna"
+
+    @pytest.mark.asyncio
+    async def test_high_risk_task_pauses_and_sends_approval_prompt(self, fake_runtime_kwargs):
+        runner = _make_runner()
+        adapter = runner.adapters[Platform.TELEGRAM]
+        adapter.send_task_approval = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="99")
+        )
+        event = _make_event("please deploy this to production", thread_id="17585")
+        source = event.source
+        session_key = runner._session_key_for_source(source)
+
+        paused, task_id = await runner._route_telegram_task_risk(
+            source=source, session_key=session_key,
+            message_text=event.text, event=event,
+        )
+
+        assert paused is True
+        assert task_id is None  # nothing ran; nothing to mark-executed
+        adapter.send_task_approval.assert_awaited_once()
+        kwargs = adapter.send_task_approval.await_args.kwargs
+        assert kwargs["risk"] == "high"
+        assert kwargs["chat_id"] == source.chat_id
+        assert session_key not in dict(runner._session_model_overrides)
+
+    @pytest.mark.asyncio
+    async def test_critical_risk_task_also_pauses(self, fake_runtime_kwargs):
+        runner = _make_runner()
+        adapter = runner.adapters[Platform.TELEGRAM]
+        adapter.send_task_approval = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="99")
+        )
+        event = _make_event("rm -rf the old deployment directory", thread_id="17585")
+        source = event.source
+        session_key = runner._session_key_for_source(source)
+
+        paused, task_id = await runner._route_telegram_task_risk(
+            source=source, session_key=session_key,
+            message_text=event.text, event=event,
+        )
+
+        assert paused is True
+        assert adapter.send_task_approval.await_args.kwargs["risk"] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_delivery_of_pending_task_sends_only_one_prompt(
+        self, fake_runtime_kwargs,
+    ):
+        runner = _make_runner()
+        adapter = runner.adapters[Platform.TELEGRAM]
+        adapter.send_task_approval = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="99")
+        )
+        source = _make_source(thread_id="17585")
+        event = MessageEvent(text="please deploy this to production", source=source, message_id="dup-1")
+        session_key = runner._session_key_for_source(source)
+
+        for _ in range(2):
+            paused, _ = await runner._route_telegram_task_risk(
+                source=source, session_key=session_key,
+                message_text=event.text, event=event,
+            )
+            assert paused is True
+
+        adapter.send_task_approval.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_telegram_platform_is_never_gated(self, fake_runtime_kwargs):
+        runner = _make_runner()
+        source = SessionSource(platform=Platform.DISCORD, chat_id="1", chat_type="dm", user_id="1")
+        event = MessageEvent(text="please deploy this to production", source=source, message_id="d1")
+
+        paused, task_id = await runner._route_telegram_task_risk(
+            source=source, session_key="agent:main:discord:dm:1",
+            message_text=event.text, event=event,
+        )
+
+        assert (paused, task_id) == (False, None)
+
+    @pytest.mark.asyncio
+    async def test_internal_system_events_bypass_routing(self, fake_runtime_kwargs):
+        runner = _make_runner()
+        source = _make_source(thread_id=None)
+        event = MessageEvent(
+            text="[SYSTEM: kanban task completed]", source=source,
+            message_id="wake-1", internal=True,
+        )
+        session_key = runner._session_key_for_source(source)
+
+        paused, task_id = await runner._route_telegram_task_risk(
+            source=source, session_key=session_key, message_text=event.text, event=event,
+        )
+
+        assert (paused, task_id) == (False, None)
+        assert session_key not in dict(runner._session_model_overrides)
+
+    @pytest.mark.asyncio
+    async def test_private_dm_low_risk_message_still_flows_through(self, fake_runtime_kwargs):
+        """Regression: an ordinary private-chat task must not be paused, and
+        its session key must be derived exactly as before (existing
+        DM/topic behavior preserved)."""
+        runner = _make_runner()
+        event = _make_event("what's on my calendar today?", thread_id=None)
+        source = event.source
+        assert source.chat_type == "dm"
+        session_key_before = runner._session_key_for_source(source)
+
+        paused, task_id = await runner._route_telegram_task_risk(
+            source=source, session_key=session_key_before,
+            message_text=event.text, event=event,
+        )
+
+        assert paused is False
+        assert task_id is not None
+        assert runner._session_key_for_source(source) == session_key_before
+        assert session_key_before == build_session_key(source)
+
+
+class TestGatewayResumeAfterApproval:
+    @pytest.mark.asyncio
+    async def test_resume_after_approval_dispatches_claude_sonnet_task_once(
+        self, fake_runtime_kwargs,
+    ):
+        runner = _make_runner()
+        runner._handle_message = AsyncMock(return_value="done")
+        registry = get_task_registry()
+        route = registry.create_or_get(
+            dedupe_key=f"resume-test-{id(runner)}",
+            session_key="agent:main:telegram:dm:208214988:17585",
+            chat_id="208214988", thread_id="17585", user_id="208214988",
+            request_text="please deploy this to production",
+            risk=RiskLevel.HIGH, agent=select_agent_for_risk(RiskLevel.HIGH),
+        )
+        registry.approve(route.task_id, "telegram:208214988:Owner")
+
+        await runner._resume_approved_telegram_task(route.task_id)
+
+        runner._handle_message.assert_awaited_once()
+        dispatched_event = runner._handle_message.await_args.args[0]
+        assert dispatched_event.text == route.request_text
+        assert dispatched_event.source.chat_id == "208214988"
+        assert dispatched_event.source.thread_id == "17585"
+        assert dispatched_event.metadata == {"task_router_resume_task_id": route.task_id}
+        assert registry.get(route.task_id).status == TaskApprovalStatus.EXECUTING
+
+    @pytest.mark.asyncio
+    async def test_resume_is_noop_for_rejected_task(self, fake_runtime_kwargs):
+        runner = _make_runner()
+        runner._handle_message = AsyncMock(return_value="done")
+        registry = get_task_registry()
+        route = registry.create_or_get(
+            dedupe_key=f"resume-reject-test-{id(runner)}",
+            session_key="agent:main:telegram:dm:1:2",
+            chat_id="1", thread_id="2", user_id="1",
+            request_text="please deploy this to production",
+            risk=RiskLevel.HIGH, agent=select_agent_for_risk(RiskLevel.HIGH),
+        )
+        registry.reject(route.task_id, "telegram:1:Owner")
+
+        await runner._resume_approved_telegram_task(route.task_id)
+
+        runner._handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resumed_task_route_applies_claude_sonnet_override(self, fake_runtime_kwargs):
+        runner = _make_runner()
+        registry = get_task_registry()
+        route = registry.create_or_get(
+            dedupe_key=f"resume-override-test-{id(runner)}",
+            session_key="agent:main:telegram:dm:1:2",
+            chat_id="1", thread_id="2", user_id="1",
+            request_text="please deploy this to production",
+            risk=RiskLevel.HIGH, agent=select_agent_for_risk(RiskLevel.HIGH),
+        )
+        registry.approve(route.task_id, "telegram:1:Owner")
+        assert registry.consume_for_execution(route.task_id) is not None
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM, chat_id="1", chat_type="dm", user_id="1", thread_id="2",
+        )
+        event = MessageEvent(
+            text=route.request_text, source=source, message_id="resume-evt",
+            metadata={"task_router_resume_task_id": route.task_id},
+        )
+
+        paused, task_id = await runner._route_telegram_task_risk(
+            source=source, session_key="agent:main:telegram:dm:1:2",
+            message_text=event.text, event=event,
+        )
+
+        assert paused is False
+        assert task_id == route.task_id
+        override = runner._session_model_overrides["agent:main:telegram:dm:1:2"]
+        assert override["provider"] == "anthropic"
+        assert override["model"] == "claude-sonnet-5"
+
+
+# ---------------------------------------------------------------------------
+# Telegram adapter: tr:approve:/tr:reject: callback branch
+# ---------------------------------------------------------------------------
+
+def _make_adapter(extra=None):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    config = PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _make_query(data, *, chat_id=12345, user_id="12345", first_name="Owner"):
+    query = AsyncMock()
+    query.data = data
+    query.message = MagicMock()
+    query.message.chat_id = chat_id
+    query.from_user = MagicMock()
+    query.from_user.id = user_id
+    query.from_user.first_name = first_name
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+    return update, query
+
+
+class TestTelegramTaskApprovalCallback:
+    @pytest.mark.asyncio
+    async def test_approve_callback_resolves_registry_and_resumes_task(self, monkeypatch):
+        import os
+
+        adapter = _make_adapter()
+        registry = get_task_registry()
+        route = registry.create_or_get(
+            dedupe_key="cb-approve-1", session_key="agent:main:telegram:dm:12345:9",
+            chat_id="12345", thread_id="9", user_id="12345",
+            request_text="please deploy this", risk=RiskLevel.HIGH,
+            agent=select_agent_for_risk(RiskLevel.HIGH),
+        )
+        adapter._task_approval_state[route.task_id] = route.session_key
+
+        resume_mock = AsyncMock()
+        runner_stub = SimpleNamespace(_resume_approved_telegram_task=resume_mock)
+        bound = SimpleNamespace(__self__=runner_stub)
+        adapter._message_handler = bound
+
+        update, query = _make_query(f"tr:approve:{route.task_id}")
+        context = MagicMock()
+
+        import os as _os
+        monkeypatch.setattr(_os, "environ", {**_os.environ, "TELEGRAM_ALLOWED_USERS": "*"})
+        await adapter._handle_callback_query(update, context)
+
+        assert registry.get(route.task_id).status == TaskApprovalStatus.APPROVED
+        resume_mock.assert_awaited_once_with(route.task_id)
+        query.answer.assert_called_once()
+        assert "Approved" in query.answer.call_args.kwargs.get("text", "")
+
+    @pytest.mark.asyncio
+    async def test_reject_callback_resolves_registry_and_never_resumes(self, monkeypatch):
+        import os as _os
+
+        adapter = _make_adapter()
+        registry = get_task_registry()
+        route = registry.create_or_get(
+            dedupe_key="cb-reject-1", session_key="agent:main:telegram:dm:12345:9",
+            chat_id="12345", thread_id="9", user_id="12345",
+            request_text="rm -rf /data", risk=RiskLevel.CRITICAL,
+            agent=select_agent_for_risk(RiskLevel.CRITICAL),
+        )
+        adapter._task_approval_state[route.task_id] = route.session_key
+
+        resume_mock = AsyncMock()
+        runner_stub = SimpleNamespace(_resume_approved_telegram_task=resume_mock)
+        adapter._message_handler = SimpleNamespace(__self__=runner_stub)
+
+        update, query = _make_query(f"tr:reject:{route.task_id}")
+        context = MagicMock()
+
+        monkeypatch.setattr(_os, "environ", {**_os.environ, "TELEGRAM_ALLOWED_USERS": "*"})
+        await adapter._handle_callback_query(update, context)
+
+        assert registry.get(route.task_id).status == TaskApprovalStatus.REJECTED
+        resume_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_double_click_approve_only_resolves_once(self, monkeypatch):
+        import os as _os
+
+        adapter = _make_adapter()
+        registry = get_task_registry()
+        route = registry.create_or_get(
+            dedupe_key="cb-double-1", session_key="agent:main:telegram:dm:12345:9",
+            chat_id="12345", thread_id="9", user_id="12345",
+            request_text="please deploy this", risk=RiskLevel.HIGH,
+            agent=select_agent_for_risk(RiskLevel.HIGH),
+        )
+        adapter._task_approval_state[route.task_id] = route.session_key
+        resume_mock = AsyncMock()
+        adapter._message_handler = SimpleNamespace(
+            __self__=SimpleNamespace(_resume_approved_telegram_task=resume_mock)
+        )
+        monkeypatch.setattr(_os, "environ", {**_os.environ, "TELEGRAM_ALLOWED_USERS": "*"})
+
+        update1, query1 = _make_query(f"tr:approve:{route.task_id}")
+        await adapter._handle_callback_query(update1, MagicMock())
+        update2, query2 = _make_query(f"tr:approve:{route.task_id}")
+        await adapter._handle_callback_query(update2, MagicMock())
+
+        resume_mock.assert_awaited_once_with(route.task_id)
+        assert "already been resolved" in query2.answer.call_args.kwargs.get("text", "")

--- a/tests/gateway/test_telegram_task_approval_buttons.py
+++ b/tests/gateway/test_telegram_task_approval_buttons.py
@@ -1,0 +1,305 @@
+"""Tests for the Telegram task-router Approve/Reject inline buttons.
+
+Covers ``TelegramAdapter.send_task_approval`` (the HIGH/CRITICAL approval
+prompt) and the ``tr:`` branch of ``_handle_callback_query`` — idempotent
+button handling (approve-once, reject-never) and authorization, plus a
+regression check that the pre-existing ``ea:`` exec-approval callback path
+(shell command approval) is unaffected.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from gateway.config import Platform, PlatformConfig
+from gateway.task_router import TaskApprovalRegistry, RiskLevel, select_agent_for_risk
+
+
+def _make_adapter(extra=None):
+    config = PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+class _AuthRunner:
+    """Minimal runner shim providing both auth and task-resume hooks."""
+
+    def __init__(self, authorized: bool = True):
+        self.authorized = authorized
+        self.resumed_task_ids = []
+
+    async def _handle_message(self, event):
+        return None
+
+    def _is_user_authorized(self, source):
+        return self.authorized
+
+    async def _resume_approved_telegram_task(self, task_id):
+        self.resumed_task_ids.append(task_id)
+
+
+def _make_route(registry, *, risk=RiskLevel.HIGH, chat_id="12345", thread_id="",
+                 request_text="please deploy to production"):
+    agent = select_agent_for_risk(risk)
+    session_key = f"agent:main:telegram:group:{chat_id}:{thread_id}" if thread_id \
+        else f"agent:main:telegram:dm:{chat_id}"
+    return registry.create_or_get(
+        dedupe_key=None,
+        session_key=session_key,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id="111",
+        request_text=request_text,
+        risk=risk,
+        agent=agent,
+    )
+
+
+def _make_callback_query(*, data, chat_id=12345, chat_type="private", thread_id=None,
+                          user_id="111", user_name="Alice"):
+    query = AsyncMock()
+    query.data = data
+    query.message = MagicMock()
+    query.message.chat_id = chat_id
+    query.message.chat = MagicMock()
+    query.message.chat.type = chat_type
+    query.message.message_thread_id = thread_id
+    query.from_user = MagicMock()
+    query.from_user.id = user_id
+    query.from_user.first_name = user_name
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+    context = MagicMock()
+    return update, context, query
+
+
+# ===========================================================================
+# send_task_approval
+# ===========================================================================
+
+class TestSendTaskApproval:
+    @pytest.mark.asyncio
+    async def test_sends_approval_summary_and_action_buttons(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_task_approval(
+            chat_id="12345",
+            task_id="task-abc",
+            request_text="please deploy to production",
+            risk="high",
+            session_key="agent:main:telegram:dm:12345",
+            environment="production",
+            reason="deployment change",
+            proposed_agent="claude-sonnet-5 via anthropic",
+        )
+
+        assert result.success is True
+        assert result.message_id == "77"
+        adapter._bot.send_message.assert_called_once()
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs["chat_id"] == 12345
+        assert "APPROVAL REQUIRED" in kwargs["text"]
+        assert "HIGH" in kwargs["text"] or "high" in kwargs["text"].lower()
+        assert "production" in kwargs["text"]
+        assert "claude\\-sonnet\\-5" in kwargs["text"]
+        assert "Reason" in kwargs["text"]
+        assert "Actions" in kwargs["text"]
+        assert kwargs["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_records_task_approval_state_for_callback_lookup(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+
+        await adapter.send_task_approval(
+            chat_id="999", task_id="task-xyz", request_text="drop table users",
+            risk="critical", session_key="agent:main:telegram:dm:999",
+        )
+
+        assert adapter._task_approval_state["task-xyz"] == "agent:main:telegram:dm:999"
+
+    @pytest.mark.asyncio
+    async def test_callback_data_uses_tr_prefix_for_approve_and_reject(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+        captured = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: captured.append((text, callback_data)) or text,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup", lambda rows: rows
+        )
+
+        await adapter.send_task_approval(
+            chat_id="1", task_id="task-1", request_text="deploy", risk="high",
+            session_key="sk",
+        )
+
+        callback_data = {cd for _, cd in captured}
+        assert "tr:approve:task-1" in callback_data
+        assert "tr:reject:task-1" in callback_data
+        assert "tr:revise:task-1" in callback_data
+
+
+# ===========================================================================
+# _handle_callback_query — tr: approve/reject idempotency
+# ===========================================================================
+
+class TestTaskApprovalCallback:
+    @pytest.mark.asyncio
+    async def test_approve_tap_resolves_and_resumes_the_task(self, monkeypatch):
+        adapter = _make_adapter()
+        registry = TaskApprovalRegistry()
+        monkeypatch.setattr("gateway.task_router.get_task_registry", lambda: registry)
+        route = _make_route(registry, risk=RiskLevel.HIGH)
+        adapter._task_approval_state[route.task_id] = route.session_key
+
+        runner = _AuthRunner(authorized=True)
+        adapter._message_handler = runner._handle_message
+
+        update, context, query = _make_callback_query(data=f"tr:approve:{route.task_id}")
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TELEGRAM_ALLOWED_USERS", "*")
+            await adapter._handle_callback_query(update, context)
+
+        stored = registry.get(route.task_id)
+        assert stored.status.value == "executing" or stored.status.value == "approved"
+        assert route.task_id not in adapter._task_approval_state
+        assert runner.resumed_task_ids == [route.task_id]
+        query.answer.assert_called_once()
+        assert "Approved" in query.answer.call_args[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_second_approve_tap_is_a_noop_and_does_not_resume_again(self, monkeypatch):
+        """Approve twice must execute (resume) only once."""
+        adapter = _make_adapter()
+        registry = TaskApprovalRegistry()
+        monkeypatch.setattr("gateway.task_router.get_task_registry", lambda: registry)
+        route = _make_route(registry, risk=RiskLevel.HIGH)
+        adapter._task_approval_state[route.task_id] = route.session_key
+
+        runner = _AuthRunner(authorized=True)
+        adapter._message_handler = runner._handle_message
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TELEGRAM_ALLOWED_USERS", "*")
+            update1, context1, query1 = _make_callback_query(data=f"tr:approve:{route.task_id}")
+            await adapter._handle_callback_query(update1, context1)
+
+            update2, context2, query2 = _make_callback_query(data=f"tr:approve:{route.task_id}")
+            await adapter._handle_callback_query(update2, context2)
+
+        assert runner.resumed_task_ids == [route.task_id]  # resumed exactly once
+        assert "already been resolved" in query2.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_reject_tap_resolves_and_never_resumes(self, monkeypatch):
+        adapter = _make_adapter()
+        registry = TaskApprovalRegistry()
+        monkeypatch.setattr("gateway.task_router.get_task_registry", lambda: registry)
+        route = _make_route(registry, risk=RiskLevel.CRITICAL, request_text="rm -rf /data")
+        adapter._task_approval_state[route.task_id] = route.session_key
+
+        runner = _AuthRunner(authorized=True)
+        adapter._message_handler = runner._handle_message
+
+        update, context, query = _make_callback_query(data=f"tr:reject:{route.task_id}")
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TELEGRAM_ALLOWED_USERS", "*")
+            await adapter._handle_callback_query(update, context)
+
+        stored = registry.get(route.task_id)
+        assert stored.status.value == "rejected"
+        assert runner.resumed_task_ids == []
+        assert "Rejected" in query.answer.call_args[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_reject_then_approve_tap_never_executes(self, monkeypatch):
+        """Once rejected, a later (replayed/duplicate) approve tap must not run it."""
+        adapter = _make_adapter()
+        registry = TaskApprovalRegistry()
+        monkeypatch.setattr("gateway.task_router.get_task_registry", lambda: registry)
+        route = _make_route(registry, risk=RiskLevel.CRITICAL, request_text="rm -rf /data")
+
+        runner = _AuthRunner(authorized=True)
+        adapter._message_handler = runner._handle_message
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TELEGRAM_ALLOWED_USERS", "*")
+            adapter._task_approval_state[route.task_id] = route.session_key
+            update1, context1, _ = _make_callback_query(data=f"tr:reject:{route.task_id}")
+            await adapter._handle_callback_query(update1, context1)
+
+            # Simulate a stale/duplicate button re-registering state (defense
+            # in depth): even if the adapter-side marker were somehow still
+            # present, the registry itself must refuse to approve/execute a
+            # REJECTED task.
+            adapter._task_approval_state[route.task_id] = route.session_key
+            update2, context2, query2 = _make_callback_query(data=f"tr:approve:{route.task_id}")
+            await adapter._handle_callback_query(update2, context2)
+
+        stored = registry.get(route.task_id)
+        assert stored.status.value == "rejected"
+        assert runner.resumed_task_ids == []
+        assert registry.consume_for_execution(route.task_id) is None
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_cannot_decide_task(self, monkeypatch):
+        adapter = _make_adapter()
+        registry = TaskApprovalRegistry()
+        monkeypatch.setattr("gateway.task_router.get_task_registry", lambda: registry)
+        route = _make_route(registry, risk=RiskLevel.HIGH)
+        adapter._task_approval_state[route.task_id] = route.session_key
+
+        runner = _AuthRunner(authorized=False)
+        adapter._message_handler = runner._handle_message
+
+        update, context, query = _make_callback_query(data=f"tr:approve:{route.task_id}")
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TELEGRAM_ALLOWED_USERS", "")
+            await adapter._handle_callback_query(update, context)
+
+        assert "not authorized" in query.answer.call_args[1]["text"].lower()
+        stored = registry.get(route.task_id)
+        assert stored.status.value == "pending"
+        assert route.task_id in adapter._task_approval_state
+        assert runner.resumed_task_ids == []
+
+
+# ===========================================================================
+# Regression: pre-existing shell exec-approval (ea:) callback is unaffected
+# ===========================================================================
+
+class TestExecApprovalRegression:
+    @pytest.mark.asyncio
+    async def test_ea_callback_still_resolves_independently_of_task_router(self):
+        adapter = _make_adapter()
+        adapter._approval_state[9] = "agent:main:telegram:dm:12345"
+
+        update, context, query = _make_callback_query(data="ea:once:9")
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("TELEGRAM_ALLOWED_USERS", "*")
+            from unittest.mock import patch
+            with patch("tools.approval.resolve_gateway_approval", return_value=1):
+                await adapter._handle_callback_query(update, context)
+
+        assert 9 not in adapter._approval_state
+        assert "Approved" in query.edit_message_text.call_args[1]["text"] \
+            or query.edit_message_text.called


### PR DESCRIPTION
## Implemented
- Telegram topic/session isolation (`build_telegram_topic_session_key`)
- LOW/MEDIUM Codex routing (gpt-5.6-luna via openai-codex, one-turn model override)
- HIGH/CRITICAL approval gate (Telegram Approve/Reject/Revise buttons; execution paused until approval)
- Claude routing after approval (claude-sonnet-5 via anthropic, approved tasks only)
- Reject handling (PENDING -> REJECTED, zero execution)
- Duplicate-delivery/execution protection (dedupe key, single-use consume-for-execution gate)
- Private-chat compatibility preserved (Telegram-only routing branch; other platforms untouched)

## Validation
- Focused V1 suite: 109 passed, 0 failed
- `py_compile`: PASS
- Scoped `git diff --check`: PASS
- Live CRM topic: PASS
- Live Design topic: PASS
- Codex live routing: PASS (model=gpt-5.6-luna, provider=openai, output=CODEX_PONG)
- HIGH Reject (live, audited via `task_audit` log): PASS — task transitioned `created -> prompt_claimed -> rejected`, no `executing`/`executed` event recorded, execution_count = 0, no Claude call, no DB/RLS/production change
- HIGH Approve routing (live): approval routing = PASS, Claude provider selection = PASS, execution completion = BLOCKED_BY_PROVIDER_LIMIT (Claude session/provider quota, not a code defect)
- Production changes: NONE

## Known limitations
- Task registry is currently in-memory; pending approval state does not survive a gateway restart
- Independent Claude Sonnet code review is pending due to a provider/session limit (`REVIEW_PENDING_LIMIT`); no fallback model was substituted
- The full gateway test suite (`tests/gateway/`) has 77 pre-existing failures unrelated to this change, previously triaged as environmental/Windows-specific/pre-existing/fixture issues (0 confirmed V1-caused regressions)
- `execution_count` is inferred from audit-event presence/absence in the `task_audit` log rather than a dedicated persisted counter field

**Do not merge. Do not deploy. Do not modify production.**
