### PR TITLE
ci: run Windows footgun guard on native runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -157,7 +157,7 @@ jobs:
     # shebang scripts via subprocess, bare open() without encoding=, etc.
     # See scripts/check-windows-footguns.py for the full rule list.
     name: Windows footguns (blocking)
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     timeout-minutes: 5
     steps:
       - name: Checkout code

--- a/tests/ci/test_workflow_platform_contracts.py
+++ b/tests/ci/test_workflow_platform_contracts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -19,6 +20,13 @@ if _CLASSIFIER_SPEC is None or _CLASSIFIER_SPEC.loader is None:
 _CLASSIFIER = importlib.util.module_from_spec(_CLASSIFIER_SPEC)
 _CLASSIFIER_SPEC.loader.exec_module(_CLASSIFIER)
 classify = _CLASSIFIER.classify
+
+
+def _is_valid_windows_runner(runner: object) -> bool:
+    return isinstance(runner, str) and runner in {
+        "windows-latest",
+        "windows-latest-32-core",
+    }
 
 
 def _load_workflow(name: str) -> dict:
@@ -65,12 +73,23 @@ def test_os_matrix_binds_windows_marker_to_native_runner():
 
     by_marker = {entry["marker"]: entry for entry in matrix}
     windows_runner = by_marker["windows_only"]["runner"]
-    assert isinstance(windows_runner, str)
-    assert windows_runner == "windows-latest" or windows_runner.startswith(
-        "windows-latest-"
-    )
+    assert _is_valid_windows_runner(windows_runner)
     assert by_marker["windows_only"]["name"] == "Windows-only tests"
     assert by_marker["macos_only"]["runner"] == "macos-latest"
+
+
+@pytest.mark.parametrize(
+    "runner",
+    [
+        "windows-latest-",
+        "windows-latest-linux",
+        "windows-latest-self-hosted",
+        "windows-latest-32-core-extra",
+    ],
+)
+def test_os_matrix_rejects_malformed_windows_runner_labels(runner: str):
+    """The Windows runner contract must reject near-miss labels."""
+    assert not _is_valid_windows_runner(runner)
 
 
 def test_os_selector_fails_closed_for_empty_selection():

--- a/tests/ci/test_workflow_platform_contracts.py
+++ b/tests/ci/test_workflow_platform_contracts.py
@@ -64,7 +64,11 @@ def test_os_matrix_binds_windows_marker_to_native_runner():
     matrix = workflow["jobs"]["os-tests"]["strategy"]["matrix"]["include"]
 
     by_marker = {entry["marker"]: entry for entry in matrix}
-    assert by_marker["windows_only"]["runner"] == "windows-latest"
+    windows_runner = by_marker["windows_only"]["runner"]
+    assert isinstance(windows_runner, str)
+    assert windows_runner == "windows-latest" or windows_runner.startswith(
+        "windows-latest-"
+    )
     assert by_marker["windows_only"]["name"] == "Windows-only tests"
     assert by_marker["macos_only"]["runner"] == "macos-latest"
 

--- a/tests/ci/test_workflow_platform_contracts.py
+++ b/tests/ci/test_workflow_platform_contracts.py
@@ -1,0 +1,80 @@
+"""Regression tests for the CI platform and selector contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+_CLASSIFIER_PATH = REPO_ROOT / "scripts" / "ci" / "classify_changes.py"
+_CLASSIFIER_SPEC = importlib.util.spec_from_file_location(
+    "classify_changes", _CLASSIFIER_PATH
+)
+if _CLASSIFIER_SPEC is None or _CLASSIFIER_SPEC.loader is None:
+    raise ImportError("Failed to load classify_changes.py")
+_CLASSIFIER = importlib.util.module_from_spec(_CLASSIFIER_SPEC)
+_CLASSIFIER_SPEC.loader.exec_module(_CLASSIFIER)
+classify = _CLASSIFIER.classify
+
+
+def _load_workflow(name: str) -> dict:
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def _run_script(workflow: dict, step_name: str) -> str:
+    for step in workflow["jobs"]["os-tests"]["steps"]:
+        if step.get("name") == step_name:
+            return step["run"]
+    raise AssertionError(f"missing step {step_name!r}")
+
+
+def test_workflow_change_activates_python_and_ci_review_lanes():
+    """The changed lint workflow must reach its Python and review lanes."""
+    lanes = classify([".github/workflows/lint.yml"])
+
+    assert lanes["python"] is True
+    assert lanes["ci_review"] is True
+
+
+def test_windows_footgun_guard_uses_native_windows_and_keeps_check_name():
+    """The Windows-focused blocking guard must not be hosted on Linux."""
+    workflow = _load_workflow("lint.yml")
+    job = workflow["jobs"]["windows-footguns"]
+
+    assert job["name"] == "Windows footguns (blocking)"
+    assert job["runs-on"] == "windows-latest"
+
+    checker_steps = [
+        step for step in job["steps"] if step.get("name") == "Run footgun checker"
+    ]
+    assert len(checker_steps) == 1
+    assert checker_steps[0]["name"] == "Run footgun checker"
+    assert checker_steps[0]["run"] == (
+        "python scripts/check-windows-footguns.py --all"
+    )
+
+
+def test_os_matrix_binds_windows_marker_to_native_runner():
+    """The Windows-only pytest marker has a real Windows execution lane."""
+    workflow = _load_workflow("tests-os.yml")
+    matrix = workflow["jobs"]["os-tests"]["strategy"]["matrix"]["include"]
+
+    by_marker = {entry["marker"]: entry for entry in matrix}
+    assert by_marker["windows_only"]["runner"] == "windows-latest"
+    assert by_marker["windows_only"]["name"] == "Windows-only tests"
+    assert by_marker["macos_only"]["runner"] == "macos-latest"
+
+
+def test_os_selector_fails_closed_for_empty_selection():
+    """A renamed marker or empty pytest selection must fail the job."""
+    workflow = _load_workflow("tests-os.yml")
+    run = _run_script(workflow, "Run ${{ matrix.marker }} tests")
+
+    assert "scripts/ci/list_os_marked_tests.py" in run
+    assert 'if [ ! -s "$LIST" ]' in run
+    assert 'if [ "$status" -eq 5 ]' in run
+    assert '-m "${{ matrix.marker }} and not integration"' in run


### PR DESCRIPTION
## Summary
- run the Windows footgun guard on native `windows-latest`
- bind the OS matrix contract to the exact hosted Windows labels in use
- reject malformed near-miss labels such as `windows-latest-self-hosted`

## Verification
- `tests/ci/test_workflow_platform_contracts.py`: 8/8 passed
- Windows footgun checker: 1026 files, 0 findings
- YAML parse: 2/2; AST parse: 1/1
- `git diff --check`: passed
- delivery base: latest upstream `d5632392c7`

Hosted Windows execution remains the external gate. Brain was unavailable; no Brain-backed evidence is claimed.
