### PR TITLE
fix(mem0): scope OSS history db to the active Hermes profile

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -203,6 +203,9 @@ class Mem0MemoryProvider(MemoryProvider):
         self._mode = "platform"
         self._api_key = ""
         self._host = ""
+        # Active HERMES_HOME from initialize() kwargs; scopes OSS-local
+        # storage (mem0 history db) to the running profile (#97923).
+        self._hermes_home = ""
         self._user_id = _DEFAULT_USER_ID
         self._agent_id = "hermes"
         self._rerank_default = False
@@ -280,7 +283,7 @@ class Mem0MemoryProvider(MemoryProvider):
         try:
             if self._mode == "oss":
                 from ._backend import OSSBackend
-                return OSSBackend(self._config.get("oss", {}))
+                return OSSBackend(self._config.get("oss", {}), hermes_home=self._hermes_home)
             if self._host:
                 from ._backend import SelfHostedBackend
                 return SelfHostedBackend(self._api_key, self._host)
@@ -335,6 +338,10 @@ class Mem0MemoryProvider(MemoryProvider):
             )
 
     def initialize(self, session_id: str, **kwargs) -> None:
+        # Profile-scoped storage root: always present per the MemoryProvider
+        # contract. Captured before anything builds a backend so OSS-local
+        # state lands under the active profile, not the native home (#97923).
+        self._hermes_home = kwargs.get("hermes_home") or ""
         self._config = _load_config()
         self._mode = self._config.get("mode", "platform")
         self._api_key = self._config.get("api_key", "")

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -156,7 +156,7 @@ class SelfHostedBackend(Mem0Backend):
 class OSSBackend(Mem0Backend):
     """Wraps mem0.Memory for self-hosted (OSS) mode."""
 
-    def __init__(self, oss_config: dict):
+    def __init__(self, oss_config: dict, hermes_home: str | None = None):
         import os
         from mem0 import Memory
 
@@ -203,6 +203,20 @@ class OSSBackend(Mem0Backend):
             "embedder": _provider_block("embedder"),
             "version": "v1.1",
         }
+        # mem0ai derives history_db_path from MEM0_DIR or the native home at
+        # import time, so every profile in the process would share one
+        # history.db of raw recent messages (#97923). Scope it to the active
+        # Hermes profile unless the operator pinned an explicit path — via the
+        # oss config block or MEM0_DIR, which the SDK honors as its own
+        # default. mem0ai's SQLiteManager does not create parent directories,
+        # so the profile-local one must exist before Memory opens the db.
+        explicit_history_db = oss_config.get("history_db_path")
+        if explicit_history_db:
+            config["history_db_path"] = explicit_history_db
+        elif hermes_home and not os.environ.get("MEM0_DIR"):
+            history_dir = os.path.join(hermes_home, "mem0")
+            os.makedirs(history_dir, exist_ok=True)
+            config["history_db_path"] = os.path.join(history_dir, "history.db")
         self._memory = Memory.from_config(config)
 
     @staticmethod

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -153,6 +153,100 @@ class TestOSSBackend:
         assert raw == before
 
 
+def _oss_test_config(tmp_path):
+    """Minimal OSS config: local qdrant under tmp, offline-capable providers."""
+    return {
+        "llm": {"provider": "openai", "config": {"model": "gpt-5-mini", "api_key": "sk-test"}},
+        "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small", "api_key": "sk-test"}},
+        "vector_store": {"provider": "qdrant", "config": {"path": str(tmp_path / "vs")}},
+    }
+
+
+class TestOSSHistoryDbScoping:
+    """#97923: OSS history.db must land under the active Hermes profile, with
+    operator-pinned paths (oss config key or MEM0_DIR) left to the SDK."""
+
+    def _stub_mem0(self, monkeypatch):
+        import sys
+        import types
+
+        captured = {}
+
+        class Memory:
+            @staticmethod
+            def from_config(config):
+                captured.update(config)
+                return FakeOSSMemory()
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = Memory  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+        return captured
+
+    def test_history_db_scoped_to_hermes_home(self, monkeypatch, tmp_path):
+        captured = self._stub_mem0(monkeypatch)
+        monkeypatch.delenv("MEM0_DIR", raising=False)
+        OSSBackend(_oss_test_config(tmp_path), hermes_home=str(tmp_path / "alpha"))
+        assert captured["history_db_path"] == str(tmp_path / "alpha" / "mem0" / "history.db")
+        # mem0ai's SQLiteManager does not create parent dirs; the fix must.
+        assert (tmp_path / "alpha" / "mem0").is_dir()
+
+    def test_history_db_not_injected_without_hermes_home(self, monkeypatch, tmp_path):
+        captured = self._stub_mem0(monkeypatch)
+        monkeypatch.delenv("MEM0_DIR", raising=False)
+        OSSBackend(_oss_test_config(tmp_path))
+        assert "history_db_path" not in captured
+
+    def test_mem0_dir_env_keeps_sdk_default(self, monkeypatch, tmp_path):
+        captured = self._stub_mem0(monkeypatch)
+        monkeypatch.setenv("MEM0_DIR", str(tmp_path / "pinned"))
+        OSSBackend(_oss_test_config(tmp_path), hermes_home=str(tmp_path / "alpha"))
+        # Operator pinned MEM0_DIR: the SDK default (<MEM0_DIR>/history.db) wins.
+        assert "history_db_path" not in captured
+
+    def test_explicit_config_path_wins(self, monkeypatch, tmp_path):
+        captured = self._stub_mem0(monkeypatch)
+        monkeypatch.delenv("MEM0_DIR", raising=False)
+        raw = _oss_test_config(tmp_path)
+        raw["history_db_path"] = str(tmp_path / "pinned" / "custom.db")
+        OSSBackend(raw, hermes_home=str(tmp_path / "alpha"))
+        assert captured["history_db_path"] == str(tmp_path / "pinned" / "custom.db")
+
+
+class TestOSSHistoryDbRealSDK:
+    """#97923 integration: two profiles sharing one native HOME must get
+    distinct history.db files from the real pinned mem0ai SDK.
+
+    Skipped unless the ``mem0`` extra is installed (CI runs the stubbed
+    tests above; this runs wherever mem0ai==2.0.10 is available)."""
+
+    def test_two_profiles_get_distinct_history_dbs(self, monkeypatch, tmp_path):
+        # Keep the SDK's import-time side effects (native ~/.mem0 dir,
+        # telemetry store) inside the test sandbox.
+        monkeypatch.setenv("HOME", str(tmp_path / "native-home"))
+        monkeypatch.setenv("MEM0_TELEMETRY", "False")
+        monkeypatch.delenv("MEM0_DIR", raising=False)
+        pytest.importorskip("mem0")
+
+        def backend_for(profile):
+            cfg = _oss_test_config(tmp_path)
+            cfg["vector_store"]["config"]["path"] = str(tmp_path / profile / "vs")
+            return OSSBackend(cfg, hermes_home=str(tmp_path / profile))
+
+        alpha, beta = backend_for("alpha"), backend_for("beta")
+        alpha_path = alpha._memory.config.history_db_path
+        beta_path = beta._memory.config.history_db_path
+        assert alpha_path == str(tmp_path / "alpha" / "mem0" / "history.db")
+        assert beta_path == str(tmp_path / "beta" / "mem0" / "history.db")
+        assert alpha_path != beta_path
+        # The SQLiteManager actually opened the profile-local file, and no
+        # shared history.db appeared under the native home.
+        assert alpha._memory.db.db_path == alpha_path
+        assert (tmp_path / "alpha" / "mem0" / "history.db").exists()
+        assert (tmp_path / "beta" / "mem0" / "history.db").exists()
+        assert not (tmp_path / "native-home" / ".mem0" / "history.db").exists()
+
+
 httpx = pytest.importorskip("httpx")
 
 

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -383,7 +383,7 @@ class TestCreateBackendRouting:
 
     def test_oss_mode_takes_precedence_over_host(self, monkeypatch):
         class OB(_SentinelBackend):
-            def __init__(self, cfg):
+            def __init__(self, cfg, hermes_home=None):
                 pass
 
         monkeypatch.setattr("plugins.memory.mem0._backend.OSSBackend", OB)


### PR DESCRIPTION
## What does this PR do?

Scopes the Mem0 OSS `history.db` to the active Hermes profile. mem0ai (pinned 2.0.10) derives `MemoryConfig.history_db_path` from `MEM0_DIR` or the native home **at import time**, and Hermes passed no explicit path into the OSS `Memory` config — so two Hermes profiles sharing a native `HOME` (or one process serving several profiles) silently shared one `history.db`, which contains raw recent messages. That is the profile data-isolation problem from #97923.

The fix threads the `MemoryProvider.initialize()` contract's `hermes_home` (already guaranteed in the kwargs) through `_create_backend()` into `OSSBackend`, and passes an explicit profile-local `history_db_path` (`<hermes_home>/mem0/history.db`) into `Memory.from_config()`. This is a per-instance config key on the SDK's own `MemoryConfig`, so it does not touch `MEM0_DIR` or any SDK module global — safe for multi-profile processes. The parent directory is created up front because mem0ai's `SQLiteManager` does not create parent dirs.

Precedence (all covered by tests):
1. An explicit `history_db_path` in the `oss` config block wins verbatim.
2. An operator-set `MEM0_DIR` env var is respected — nothing is injected and the SDK default (`$MEM0_DIR/history.db`) applies, which is the documented way to retain a legacy shared path.
3. Otherwise the profile-local path is injected.

No existing shared data is moved or migrated — profile ownership of the old shared file is ambiguous, per the issue's expectation.

Scope note: the issue also names `migrations_qdrant`. In mem0ai 2.0.10 that directory is hardcoded inside `Memory.__init__` against the SDK's module-level `mem0_dir` with **no per-instance configuration surface** (`telemetry_config_dict['path'] = os.path.join(mem0_dir, ...)` in `mem0/memory/main.py`), so it cannot be scoped from the host side without mutating process globals — exactly what the issue rules out. It only holds the SDK's anonymous telemetry identity vectors, not user conversation data; the privacy-relevant surface (`history.db` of raw messages) is fully scoped by this PR. An SDK-side per-instance data-dir setting would let Hermes scope it in one line later.

## Related Issue

Fixes #97923

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/__init__.py` — capture `hermes_home` from `initialize()` kwargs (constructor default `""`), pass it to `OSSBackend` in `_create_backend()`.
- `plugins/memory/mem0/_backend.py` — `OSSBackend.__init__` accepts `hermes_home`; injects `config["history_db_path"] = <hermes_home>/mem0/history.db` (creating the parent dir) unless an explicit `history_db_path` is configured or `MEM0_DIR` is set.
- `tests/plugins/memory/test_mem0_backend.py` — new `TestOSSHistoryDbScoping` (stubbed SDK: injection, no-hermes_home back-compat, `MEM0_DIR` respect, explicit-config precedence) and `TestOSSHistoryDbRealSDK` (real pinned SDK, skipped without the `mem0` extra).
- `tests/plugins/memory/test_mem0_v3.py` — routing sentinel accepts the new `hermes_home` kwarg.

## How to Test

1. `python -m pytest tests/plugins/memory/test_mem0_backend.py tests/plugins/memory/test_mem0_v3.py tests/plugins/memory/test_mem0_setup.py tests/plugins/memory/test_mem0_providers.py -q` → Observed result: 61 passed, 1 skipped (the real-SDK test skips without the `mem0` extra).
2. With the `mem0` extra installed (`pip install "mem0ai==2.0.10"`), run `python -m pytest tests/plugins/memory/test_mem0_backend.py::TestOSSHistoryDbRealSDK -q` → Observed result: 1 passed. This builds two `OSSBackend`s for two temp profiles sharing one native `HOME` and asserts each `Memory` resolved and opened its own `<profile>/mem0/history.db` with no shared `history.db` under the native home.
3. `ruff check` on the touched files → All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the real-SDK integration test also reproduces the issue's Ubuntu scenario path-wise (same Python/SDK code path, `os.path.join` only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config key; `history_db_path` in the oss block is honored if an operator sets one, same as any `MemoryConfig` passthrough)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — paths are built with `os.path.join` from the profile root; no platform-specific behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
