### PR TITLE
packaging: exempt every exact pin from exclude-newer (release-day update brick)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -433,7 +433,124 @@ exclude-newer = "14 days"
 # firecrawl-anydoc: same exact-pin shape (==0.2.4, hosted-OCR wiring PR).
 # The pin bump WAS the review; exclude-newer adds zero float protection to
 # an exact pin and would only delay the reviewed version 14 days.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, firecrawl-anydoc = false }
+#
+# Every other exact-pinned package below: the release-day brick shape
+# (observed 2026-08-29 updating three long-running installs v0.20.0 ->
+# v0.20.6 — one Termux, two Linux servers). Each release exact-pins at least
+# one dependency to a version published days before the release (v0.20.6
+# pinned snowballstemmer==3.1.1 and psutil==7.2.2 in core, plus fastapi /
+# uvicorn / python-telegram-bot pins across extras). For two weeks after
+# release the cutoff filters those versions out, so any venv that predates
+# the release bricks on `hermes update` ("no version of
+# snowballstemmer==3.1.1") until the window passes. Same zero-float-
+# protection logic as setuptools/pillow/mcp above; enforced for every exact
+# pin by
+# tests/test_packaging_metadata.py::test_exact_pinned_deps_exempt_from_exclude_newer.
+#
+# maturin, setuptools-rust: build-system.requires of the cryptography pin
+# above. cryptography itself is exempted, but on wheel-less platforms
+# (Termux/Android) it must build from sdist, and the isolated build
+# environment resolves under the same cutoff ("Failed to resolve
+# requirements from build-system.requires ... maturin>=1.9,<2").
+[tool.uv.exclude-newer-package]
+agent-client-protocol = false
+ai-edge-litert = false
+aiohttp = false
+aiohttp-socks = false
+aiosqlite = false
+alibabacloud-dingtalk = false
+anthropic = false
+asyncpg = false
+azure-identity = false
+boto3 = false
+brotlicffi = false
+certifi = false
+concurrent-log-handler = false
+croniter = false
+cryptography = false
+daytona = false
+debugpy = false
+defusedxml = false
+dingtalk-stream = false
+discord-py = false
+edge-tts = false
+elevenlabs = false
+exa-py = false
+fal-client = false
+fastapi = false
+faster-whisper = false
+fire = false
+firecrawl-anydoc = false
+firecrawl-py = false
+google-api-python-client = false
+google-auth = false
+google-auth-httplib2 = false
+google-auth-oauthlib = false
+h2 = false
+hindsight-client = false
+honcho-ai = false
+httplib2 = false
+httpx = false
+httpx2 = false
+huggingface_hub = false
+jinja2 = false
+lark-oapi = false
+markdown = false
+maturin = false
+mautrix = false
+mcp = false
+mem0ai = false
+microsoft-teams-apps = false
+mistralai = false
+modal = false
+nemo-relay = false
+numpy = false
+onnxruntime = false
+openai = false
+opentelemetry-exporter-otlp-proto-http = false
+opentelemetry-sdk = false
+openwakeword = false
+packaging = false
+parallel-web = false
+pathspec = false
+pillow = false
+prompt-toolkit = false
+psutil = false
+pvporcupine = false
+pyasn1 = false
+pydantic = false
+pyjwt = false
+pytest = false
+pytest-asyncio = false
+python-dotenv = false
+python-multipart = false
+python-olm = false
+python-telegram-bot = false
+pyyaml = false
+qrcode = false
+requests = false
+rich = false
+ruamel-yaml = false
+ruff = false
+sentencepiece = false
+setuptools = false
+setuptools-rust = false
+sherpa-onnx = false
+slack-bolt = false
+slack-sdk = false
+snowballstemmer = false
+sounddevice = false
+starlette = false
+supermemory = false
+tenacity = false
+ty = false
+tzdata = false
+unpaddedbase64 = false
+uvicorn = false
+vercel = false
+websockets = false
+youtube-transcript-api = false
+
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -286,6 +286,40 @@ def test_build_system_requires_exempt_from_exclude_newer():
     )
 
 
+def test_exact_pinned_deps_exempt_from_exclude_newer():
+    """Regression guard for the release-day brick class.
+
+    Every release exact-pins at least one dependency to a version published
+    days before the release (v0.20.6: snowballstemmer==3.1.1,
+    psutil==7.2.2). For two weeks after release the relative
+    ``exclude-newer`` cutoff filters those versions out, so any venv that
+    predates the release cannot resolve the new pins at all ("no version of
+    snowballstemmer==3.1.1" — observed 2026-08-29 updating three production
+    installs v0.20.0 -> v0.20.6, one Termux and two Linux servers). The pin
+    bump WAS the review, so the cutoff adds zero float protection for an
+    exact pin and can only brick.
+
+    Every exact-pinned package in [project].dependencies and
+    optional-dependencies must therefore appear in the
+    ``exclude-newer-package`` whitelist (set to ``false``) for as long as a
+    relative ``exclude-newer`` cutoff is configured.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    uv_cfg = data.get("tool", {}).get("uv", {})
+    if "exclude-newer" not in uv_cfg:
+        pytest.skip("no exclude-newer cutoff configured — nothing to exempt")
+    whitelist = {
+        _canonical(name)
+        for name, enabled in uv_cfg.get("exclude-newer-package", {}).items()
+        if enabled is False
+    }
+    missing = sorted(set(_pins_from_specs(_pyproject_pinned_specs())) - whitelist)
+    assert not missing, (
+        "exact-pinned packages are subject to the exclude-newer cutoff but "
+        "missing from the [tool.uv].exclude-newer-package whitelist — "
+        "release-day updates brick while the pinned version is younger than "
+        f"the cutoff: {missing}"
+    )
 
 
 def _lazy_deps_by_feature():


### PR DESCRIPTION
## Problem

Every release exact-pins at least one dependency to a version published days before the release. With the relative `exclude-newer = "14 days"` cutoff, those fresh pins are invisible to the resolver for ~two weeks after release, so any install whose venv predates the release bricks on a plain `hermes update`:

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of snowballstemmer==3.1.1 and
    hermes-agent==0.20.6 depends on snowballstemmer==3.1.1, ...
hint: `snowballstemmer` was filtered by `exclude-newer` to only include
packages uploaded before 2026-08-15T12:30:31Z.
```

**Field report, 2026-08-29** — updating three long-running installs from v0.20.0 to v0.20.6 (one Termux/Android, two Linux servers), uv hard-failed in sequence on `snowballstemmer==3.1.1`, `psutil==7.2.2`, `certifi==2026.5.20` ("has no publish time"), then extras pins `fastapi`, `uvicorn`, `cffi`/`pycparser`, `python-telegram-bot`. On the Termux host, `cryptography`'s isolated sdist build also bricked under the same cutoff via its `build-system.requires` (`maturin>=1.9,<2`, `setuptools-rust>=1.11.0`). A second install that had been continuously updated since before the release (venv already holding the pinned versions) sailed through — resolution only breaks when the pinned version must actually be downloaded.

This is the same shape as the existing `setuptools`/`pillow`/`mcp`/`firecrawl-anydoc` exemptions: for an exact pin, the cutoff adds zero float protection (the version cannot move without a reviewed pin bump) and can only brick.

## Change

- Extend `[tool.uv].exclude-newer-package` to cover **every exact-pinned package** in `[project].dependencies` + `optional-dependencies` (13 → 97 entries; table moved to one-key-per-line for reviewability — semantically identical TOML).
- Add `maturin` and `setuptools-rust`: `build-system.requires` of the already-exempted `cryptography` pin, needed on wheel-less platforms (Termux/Android) that must build it from sdist.
- Add `tests/test_packaging_metadata.py::test_exact_pinned_deps_exempt_from_exclude_newer`, mirroring the existing build-system test: adding a `name==version` pin without a matching whitelist entry now fails CI, so this stops being per-release whack-a-mole.

## Notes

- Ranged requirements are intentionally **not** exempted — the cutoff keeps its float protection exactly where a fallback candidate exists.
- `uv sync`/`uv pip` behavior for non-pinned deps is unchanged; only exact pins bypass the cutoff.

## Testing

- `pytest tests/test_packaging_metadata.py` — 8 passed (includes the new test; verified it fails against the un-extended whitelist).
- `ruff check` clean on the touched files.
- Applied locally to the v0.20.6 checkout on all three machines above; `hermes update` then completed end-to-end (deps resolved, gateways restarted, messaging platforms reconnected).