### PR TITLE
fix(relay): Slack force-on unfurl for streamed finals — fresh stamped post + additive delete op cleanup

### DIFF
--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import secrets
 import time
 from collections import OrderedDict
@@ -41,6 +42,12 @@ logger = logging.getLogger(__name__)
 # reader, and ws.close (~3s), the full drain path stays inside 5s.
 _RELAY_GO_IDLE_ON_DISCONNECT_TIMEOUT_S = 2.0
 _RELAY_REVOCATION_MONITOR_TEARDOWN_TIMEOUT_S = 1.0
+
+# Link detection for the fresh-final unfurl route: raw http(s) URLs, Slack
+# mrkdwn link syntax (<https://...|label>), and markdown links. Cheap and
+# permissive on purpose — a false positive costs one fresh (non-edited)
+# final message; a false negative silently loses the preview.
+_URL_RE = re.compile(r"https?://|<https?:|\]\(https?:")
 
 # How many already-answered prompt ids to remember, so a duplicate answer for
 # one of them (a double tap, or a connector redelivery of the same forward) is
@@ -334,6 +341,55 @@ class RelayAdapter(BasePlatformAdapter):
         if self._slack_unfurl_hints(platform):
             return False
         return True
+
+    def prefers_fresh_final_streaming(
+        self,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        chat_id: Optional[str] = None,
+    ) -> bool:
+        """Deliver streamed finals as a FRESH send when Slack unfurl is forced on.
+
+        Slack evaluates link previews exactly once, at ``chat.postMessage``
+        time (live-probed 2026-08-28: URL at post + ``unfurl_links: true``
+        unfurls; a ``chat.update`` that INTRODUCES the URL never does, stamps
+        or not). Edit-based streaming posts its first frame before the model
+        has produced any URL — a tool-progress card or an early text frame —
+        so a configured ``unfurl_links/media: true`` can never surface a
+        preview through the edit lane: the only post Slack evaluates has no
+        link in it.
+
+        Returning True routes the completed reply through the consumer's
+        fresh-final path: one new ``send`` carrying the full content, which
+        ``send()`` stamps with the unfurl hints — URL and flags present at
+        the single moment Slack looks.
+
+        Scope: ONLY when the hints contain an explicit True. False-only
+        hints (the enterprise fail-closed posture) keep the edit lane —
+        suppression rides the placeholder post and an edit can never add a
+        preview afterwards, so ``false`` inherits correctly with zero
+        streaming-UX cost.
+        """
+        platform = None
+        if chat_id is not None:
+            platform = self._platform_by_chat.get(str(chat_id))
+        # The stream consumer's hook call passes (content, metadata=...) only
+        # — no chat_id — so resolve through the turn metadata's platform when
+        # present before falling back to the primary descriptor.
+        if platform is None and isinstance(metadata, dict):
+            platform = metadata.get("platform")
+        if platform is None:
+            platform = getattr(self.descriptor, "platform", None)
+        hints = self._slack_unfurl_hints(platform)
+        if not hints:
+            return False
+        if not any(v is True for v in hints.values()):
+            return False
+        # Only link-bearing finals benefit: without a URL there is nothing to
+        # unfurl, and the relay has no delete op (connector contract v1), so
+        # the streamed preview stays behind the fresh final. Keep the edit
+        # lane for linkless replies to avoid a pointless duplicate message.
+        return bool(_URL_RE.search(content or ""))
 
     def stream_is_message_for_chat(self, chat_id: str) -> bool:
         """Per-chat stream-is-the-message semantic (review r2, finding 2).

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -2298,6 +2298,44 @@ class RelayAdapter(BasePlatformAdapter):
             error=result.get("error"),
         )
 
+    async def delete_message(
+        self,
+        chat_id: str,
+        message_id: str,
+    ) -> bool:
+        """Delete a relayed message through the connector-owned platform API.
+
+        Consumer: the stream consumer's fresh-final cleanup — on the Slack
+        unfurl force-on route the completed reply is re-delivered as a new
+        stamped post and the sealed streamed preview must go away, or the
+        user sees the answer twice.
+
+        Gated on the negotiated descriptor advertising the ``delete`` op
+        (additive within contract_version 1): older connectors never receive
+        an op they can't dispatch, and this returns False so the consumer's
+        best-effort cleanup degrades to leaving the preview in place —
+        exactly the pre-delete behavior.
+        """
+        if self._transport is None:
+            return False
+        desc = self._descriptor_for_chat(str(chat_id))
+        if "delete" not in (desc.supported_ops or ()):
+            return False
+        try:
+            result = await self._transport.send_outbound(
+                {
+                    "op": "delete",
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "metadata": self._with_scope(chat_id, {}),
+                },
+                platform=self._platform_by_chat.get(str(chat_id)),
+            )
+        except Exception:
+            logger.debug("relay delete_message failed", exc_info=True)
+            return False
+        return bool(result.get("success"))
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Egress a typing indicator through the connector.
 

--- a/tests/gateway/relay/test_relay_slack_unfurl.py
+++ b/tests/gateway/relay/test_relay_slack_unfurl.py
@@ -254,3 +254,159 @@ class TestUnfurlDisablesDraftStreaming:
             transport=_CaptureTransport(),
         )
         assert a.supports_draft_streaming() is False
+
+
+class TestFreshFinalForForceOnUnfurl:
+    """Slack evaluates unfurls ONLY at chat.postMessage (live-probed
+    2026-08-28: an edit that introduces a URL never previews, stamped or
+    not). Force-on hints must therefore route streamed finals through the
+    consumer's fresh-final path; false-only hints must NOT (suppression
+    rides the placeholder post and inherits through edits)."""
+
+    def _adapter(self, slack_extra):
+        return RelayAdapter(
+            PlatformConfig(extra={"slack": slack_extra}),
+            make_desc(
+                platform="slack",
+                supports_draft_streaming=True,
+                supported_ops=("send", "draft"),
+            ),
+            transport=_CaptureTransport(),
+        )
+
+    def test_force_on_with_link_prefers_fresh_final(self):
+        a = self._adapter({"unfurl_links": True, "unfurl_media": True})
+        assert (
+            a.prefers_fresh_final_streaming("see https://studiotwin.ai") is True
+        )
+
+    def test_force_on_string_true_prefers_fresh_final(self):
+        # hermes config set / Railway knobs persist YAML strings.
+        a = self._adapter({"unfurl_links": "true"})
+        assert a.prefers_fresh_final_streaming("see https://x.dev") is True
+
+    def test_force_on_mrkdwn_link_prefers_fresh_final(self):
+        a = self._adapter({"unfurl_links": True})
+        assert (
+            a.prefers_fresh_final_streaming("see <https://x.dev|x.dev>") is True
+        )
+
+    def test_force_on_without_link_keeps_edit_lane(self):
+        # No URL => nothing to unfurl; a fresh final would only duplicate
+        # the preview (relay contract v1 has no delete op).
+        a = self._adapter({"unfurl_links": True})
+        assert a.prefers_fresh_final_streaming("plain text answer") is False
+
+    def test_false_only_hints_keep_edit_lane(self):
+        # Enterprise fail-closed posture: suppression is decided at the
+        # placeholder post; the edit lane preserves it. No UX change.
+        a = self._adapter({"unfurl_links": False, "unfurl_media": False})
+        assert (
+            a.prefers_fresh_final_streaming("see https://studiotwin.ai") is False
+        )
+
+    def test_unconfigured_keeps_edit_lane(self):
+        a = self._adapter({})
+        assert (
+            a.prefers_fresh_final_streaming("see https://studiotwin.ai") is False
+        )
+
+    def test_non_slack_platform_keeps_edit_lane(self):
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": True}}),
+            make_desc(
+                platform="telegram",
+                supports_draft_streaming=True,
+                supported_ops=("send", "draft"),
+            ),
+            transport=_CaptureTransport(),
+        )
+        assert (
+            a.prefers_fresh_final_streaming("see https://studiotwin.ai") is False
+        )
+
+
+class _RecordingTransport(_CaptureTransport):
+    """Capture EVERY outbound action in order, not just the last."""
+
+    def __init__(self):
+        super().__init__()
+        self.actions = []
+
+    async def send_outbound(self, action, *, platform=None):
+        self.actions.append(action)
+        self.sent = action
+        self.sent_platform = platform
+        return {"success": True, "message_id": f"m{len(self.actions)}"}
+
+
+class TestConsumerRoutesForceOnFinalAsFreshSend:
+    """End-to-end consumer contract (the lane the live regression hid in):
+    an edit-streamed turn whose URL only exists in the FINAL text must
+    finalize via a fresh `send` op carrying the unfurl stamps — not via an
+    `edit` op, which Slack never re-evaluates for previews."""
+
+    @pytest.mark.asyncio
+    async def test_url_arriving_late_finalizes_as_stamped_fresh_send(self):
+        from gateway.stream_consumer import (
+            GatewayStreamConsumer,
+            StreamConsumerConfig,
+        )
+
+        transport = _RecordingTransport()
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": True, "unfurl_media": True}}),
+            make_desc(platform="slack", supports_edit=True),
+            transport=transport,
+        )
+        consumer = GatewayStreamConsumer(
+            adapter=a,
+            chat_id="D1",
+            config=StreamConsumerConfig(),
+        )
+        # Frame 1: placeholder posts WITHOUT any URL (the task-card /
+        # early-frame shape from the live regression).
+        await consumer._send_or_edit("Working on it…")
+        # Final: the URL exists only now.
+        await consumer._send_or_edit(
+            "see https://studiotwin.ai", finalize=True
+        )
+
+        ops = [x.get("op") for x in transport.actions]
+        # Placeholder went out as a send; the FINAL must be a fresh send
+        # too (not an edit) so Slack evaluates the preview with the URL
+        # present.
+        assert ops[0] == "send"
+        assert ops[-1] == "send", f"final left as {ops[-1]!r}; ops={ops}"
+        final = transport.actions[-1]
+        assert final["content"] == "see https://studiotwin.ai"
+        assert final["metadata"]["unfurl_links"] is True
+        assert final["metadata"]["unfurl_media"] is True
+
+    @pytest.mark.asyncio
+    async def test_false_only_hints_finalize_via_edit_unchanged(self):
+        from gateway.stream_consumer import (
+            GatewayStreamConsumer,
+            StreamConsumerConfig,
+        )
+
+        transport = _RecordingTransport()
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": False, "unfurl_media": False}}),
+            make_desc(platform="slack", supports_edit=True),
+            transport=transport,
+        )
+        consumer = GatewayStreamConsumer(
+            adapter=a,
+            chat_id="D1",
+            config=StreamConsumerConfig(),
+        )
+        await consumer._send_or_edit("Working on it…")
+        await consumer._send_or_edit("see https://studiotwin.ai", finalize=True)
+
+        ops = [x.get("op") for x in transport.actions]
+        # Fail-closed posture keeps the edit lane: placeholder send (which
+        # carries the false stamps at post time) + finalize edit.
+        assert ops[0] == "send"
+        assert transport.actions[0]["metadata"]["unfurl_links"] is False
+        assert ops[-1] == "edit", f"ops={ops}"

--- a/tests/gateway/relay/test_relay_slack_unfurl.py
+++ b/tests/gateway/relay/test_relay_slack_unfurl.py
@@ -410,3 +410,67 @@ class TestConsumerRoutesForceOnFinalAsFreshSend:
         assert ops[0] == "send"
         assert transport.actions[0]["metadata"]["unfurl_links"] is False
         assert ops[-1] == "edit", f"ops={ops}"
+
+
+class TestDeleteOpForFreshFinalCleanup:
+    """Relay delete_message: emitted only when the negotiated descriptor
+    advertises the additive `delete` op; older connectors degrade to the
+    leave-the-preview-behind behavior (return False, no wire traffic)."""
+
+    @pytest.mark.asyncio
+    async def test_delete_emitted_when_advertised(self):
+        transport = _RecordingTransport()
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": True}}),
+            make_desc(
+                platform="slack",
+                supported_ops=("send", "edit", "delete"),
+            ),
+            transport=transport,
+        )
+        ok = await a.delete_message("D1", "1700000000.000200")
+        assert ok is True
+        assert transport.actions[-1]["op"] == "delete"
+        assert transport.actions[-1]["message_id"] == "1700000000.000200"
+
+    @pytest.mark.asyncio
+    async def test_delete_refused_when_not_advertised(self):
+        transport = _RecordingTransport()
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": True}}),
+            make_desc(platform="slack", supported_ops=("send", "edit")),
+            transport=transport,
+        )
+        ok = await a.delete_message("D1", "1700000000.000200")
+        assert ok is False
+        assert transport.actions == []  # no wire traffic for old connectors
+
+    @pytest.mark.asyncio
+    async def test_consumer_fresh_final_deletes_preview_when_supported(self):
+        from gateway.stream_consumer import (
+            GatewayStreamConsumer,
+            StreamConsumerConfig,
+        )
+
+        transport = _RecordingTransport()
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": True, "unfurl_media": True}}),
+            make_desc(
+                platform="slack",
+                supports_edit=True,
+                supported_ops=("send", "edit", "delete"),
+            ),
+            transport=transport,
+        )
+        consumer = GatewayStreamConsumer(
+            adapter=a, chat_id="D1", config=StreamConsumerConfig()
+        )
+        await consumer._send_or_edit("Working on it…")
+        await consumer._send_or_edit("see https://studiotwin.ai", finalize=True)
+
+        ops = [x.get("op") for x in transport.actions]
+        # send (placeholder) ... send (fresh final) ... delete (preview)
+        assert ops[-1] == "delete", f"ops={ops}"
+        deleted = transport.actions[-1]["message_id"]
+        # The deleted message must be the FIRST send's id (m1), not the final.
+        assert deleted == "m1"


### PR DESCRIPTION
## Symptom

With `platforms.relay.extra.slack.unfurl_links/unfurl_media: true` (force-on posture), streamed replies through the relay **never grow link previews** — even though the same knobs work on fresh sends (cron lane, media lane).

## Root cause — Slack evaluates unfurls exactly once, at `chat.postMessage`

Live-probed against the Slack API (same bot, same DM, same stamps, seconds apart):

| Probe | Sequence | Preview? |
|---|---|---|
| A | `postMessage` with URL present + `unfurl_links: true` | **yes** |
| B | placeholder `postMessage` (stamps, no URL) → `chat.update` introduces the URL (stamps) | **no** |
| C | media URL at post time + stamps | **yes** |

An edit that *introduces* a link never gets a preview, stamped or not. Edit-based streaming posts its first frame before the model has produced any URL (on flat DMs with `tool_progress=accumulate` that frame is the task card), so the only post Slack ever evaluates carries no link. The configured `true` can never take effect on the edit lane.

This matches and extends the eb323dd finding (chat.update ignores unfurl fields): the gap is specifically the **edit-introduces-link** cell, which the original probe matrix didn't cover.

## Fix

`RelayAdapter.prefers_fresh_final_streaming()` (hook already shipped for Telegram rich finals, #47048): return True when the Slack unfurl hints contain an explicit `True` **and** the final text carries a link. The stream consumer then delivers the completed reply through its existing fresh-final path — one new `send`, which the relay send lane already stamps with the hints, so URL + flags are present at the single moment Slack looks.

Companion commit adds `delete_message()` over the **additive `delete` op** (contract_version 1) so the fresh-final cleanup removes the sealed streamed preview instead of leaving a duplicate. Gated on the negotiated descriptor advertising `delete`: against an older connector it returns False with zero wire traffic — exact pre-change behavior. Connector half: NousResearch/gateway-gateway (`delete` in `OutboundOp` + Slack descriptor + `chat.delete` sender arm).

**Scope guard:** `false`-only hints (fail-closed enterprise posture) keep the edit lane untouched — suppression rides the placeholder post and probe B shows an edit can never add a preview afterwards, so `false` inherits correctly with zero streaming-UX cost. Linkless finals also keep the edit lane (nothing to unfurl; avoids a pointless duplicate against connectors without `delete`).

## Verification

- Consumer-level contract test drives the exact regression shape (placeholder frame → URL-bearing final) and asserts the final leaves as `op=send` carrying the stamps, not `op=edit`. **Mutation-checked:** RED against the unfixed adapter, GREEN with the hook.
- Delete-op tests: emitted only when advertised; old-connector path produces zero wire traffic; consumer sequence asserts the *original preview id* is what gets deleted.
- Live-verified on enterprise staging (2026-08-29): flat-DM and threaded shapes, toolless + tool-using turns, URL + media cells — previews render, no double delivery, reaction lifecycle completes.

Both commits cherry-pick clean onto main; 106/106 across the touched suites.