### PR TITLE
fix: QQBot long message chunking in delivery and send_message

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -183,6 +183,7 @@ class QQAdapter(BasePlatformAdapter):
     # QQ Bot API does not support editing sent messages.
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+    splits_long_messages = True  # send() chunks via truncate_message()
     _TYPING_INPUT_SECONDS = 60  # input_notify duration reported to QQ
     _TYPING_DEBOUNCE_SECONDS = 50  # refresh before it expires
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2277,34 +2277,32 @@ async def _send_qqbot(pconfig, chat_id, message):
                 "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            payload = {"content": message[:4000], "msg_type": 0}
+            # Chunk long messages (QQ Bot API limit ~4000 chars per message)
+            QQ_MAX = 4000
+            chunks = [message[i:i+QQ_MAX] for i in range(0, len(message), QQ_MAX)] if len(message) > QQ_MAX else [message]
 
-            # Try channel endpoint first (works for guild channels)
-            url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
-            resp = await client.post(url, json=payload, headers=headers)
-            if resp.status_code in {200, 201}:
-                data = resp.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-
-            # If channel endpoint failed (likely "频道不存在"), try C2C endpoint
-            url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
-            resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
-            if resp_c2c.status_code in {200, 201}:
-                data = resp_c2c.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-
-            # If C2C also failed, try group endpoint
-            url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
-            resp_group = await client.post(url_group, json=payload, headers=headers)
-            if resp_group.status_code in {200, 201}:
-                data = resp_group.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-
-            # All endpoints failed — return the most informative error
-            return _error(f"QQBot send failed: channel={resp.status_code} c2c={resp_c2c.status_code} group={resp_group.status_code}")
+            # Determine the correct endpoint (channel, C2C, or group)
+            endpoints = [
+                f"https://api.sgroup.qq.com/channels/{chat_id}/messages",
+                f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages",
+                f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages",
+            ]
+            last_result = None
+            resp = None
+            for chunk in chunks:
+                payload = {"content": chunk, "msg_type": 0}
+                sent = False
+                for url in endpoints:
+                    resp = await client.post(url, json=payload, headers=headers)
+                    if resp.status_code in {200, 201}:
+                        data = resp.json()
+                        last_result = {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                                       "message_id": data.get("id")}
+                        sent = True
+                        break
+                if not sent:
+                    return _error(f"QQBot send failed on all endpoints: {resp.status_code if resp else 'no response'}")
+            return last_result or {"success": True, "platform": "qqbot", "chat_id": chat_id}
     except Exception as e:
         return _error(f"QQBot send failed: {e}")
 


### PR DESCRIPTION
## Summary

Two independent fixes for QQ Bot messages being silently truncated when content exceeds the ~4000 character API limit.

### Problem

QQ Bot has a ~4000 character per-message limit, but Hermes had two code paths that truncated long messages instead of chunking them:

1. **Gateway delivery** (`delivery.py`): Checks `splits_long_messages` on the adapter to decide whether to pre-truncate. The `QQAdapter` already chunks internally via `truncate_message()` in its `send()` method, but without `splits_long_messages = True`, the gateway silently truncated at `MAX_PLATFORM_OUTPUT` (4000 chars) before the adapter ever saw the full content.

2. **Standalone sender** (`send_message_tool.py`): The `_send_qqbot()` function hard-truncated with `message[:4000]`, completely bypassing the adapter. This path is used by `hermes send` CLI and cron job delivery.

**Impact**: Cron jobs delivering reports >4000 chars (e.g. VoIP weekly report at ~13K chars) would silently lose everything after the first ~4000 characters.

### Fix

1. **`QQAdapter.splits_long_messages = True`** — Tells `delivery.py` to pass full content to the adapter instead of pre-truncating. The adapter existing `send()` method handles chunking via `truncate_message()`.

2. **`_send_qqbot()` chunking** — Replaces `message[:4000]` hard-truncation with a loop that splits into 4000-char chunks and sends each via the first working endpoint (channel → C2C → group).

### Testing

Verified with a ~13K character VoIP weekly report — full content delivered as 4 messages on QQ DM.

### Files changed

- `gateway/platforms/qqbot/adapter.py` — Add `splits_long_messages = True` (1 line)
- `tools/send_message_tool.py` — Refactor `_send_qqbot()` to chunk instead of truncate