### PR TITLE
fix(cron): re-resolve hermes_time per profile in multiplex ticker

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -674,6 +674,7 @@ class InProcessCronScheduler(CronScheduler):
             use_cron_store,
         )
         from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+        import hermes_time
 
         logger = logging.getLogger("cron.scheduler_provider")
         logger.info(
@@ -689,6 +690,11 @@ class InProcessCronScheduler(CronScheduler):
         for entry in _existing_profile_homes(profile_homes):
             home = entry[1] if isinstance(entry, tuple) else entry
             home_token = set_hermes_home_override(str(home))
+            # hermes_time caches the resolved timezone process-wide; after
+            # switching to this profile's home, re-resolve so cron instants
+            # persist in the profile's configured zone, not the dashboard
+            # backend's (#97905).
+            hermes_time.reset_cache()
             try:
                 with use_cron_store(home):
                     recovered = self.recover_interrupted()
@@ -713,6 +719,7 @@ class InProcessCronScheduler(CronScheduler):
                     for entry in _existing_profile_homes(profile_homes):
                         home = entry[1] if isinstance(entry, tuple) else entry
                         home_token = set_hermes_home_override(str(home))
+                        hermes_time.reset_cache()
                         try:
                             with use_cron_store(home):
                                 cron_tick(
@@ -736,6 +743,7 @@ class InProcessCronScheduler(CronScheduler):
             for entry in _existing_profile_homes(profile_homes):
                 home = entry[1] if isinstance(entry, tuple) else entry
                 home_token = set_hermes_home_override(str(home))
+                hermes_time.reset_cache()
                 try:
                     with use_cron_store(home):
                         record_ticker_heartbeat(success=ok)

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -190,6 +190,52 @@ def test_inprocess_provider_ticks_and_stops():
     assert calls[0].get("sync") is False
 
 
+def test_multiplex_resets_timezone_cache_per_profile():
+    """The multiplex ticker must re-resolve hermes_time after each profile
+    home override; otherwise next_run_at is persisted in the dashboard
+    backend's timezone, not the ticked profile's configured zone (#97905)."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    resets = []
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+    homes = ["C:/fake/home-a", "C:/fake/home-b"]
+
+    def fake_tick(*args, **kwargs):
+        return 0
+
+    def fake_override(home):
+        return "tok"
+
+    def fake_reset_override(token):
+        return None
+
+    with (
+        patch("cron.scheduler.tick", side_effect=fake_tick),
+        patch("hermes_time.reset_cache", side_effect=lambda: resets.append(1)),
+        patch("hermes_constants.set_hermes_home_override", side_effect=fake_override),
+        patch("hermes_constants.reset_hermes_home_override", side_effect=fake_reset_override),
+        patch("cron.jobs.use_cron_store"),
+        patch("cron.jobs.record_ticker_heartbeat"),
+        patch("cron.jobs.clear_ticker_error"),
+        patch("cron.jobs.record_ticker_error"),
+        patch("cron.scheduler_provider._existing_profile_homes", side_effect=lambda h: h),
+    ):
+        t = threading.Thread(
+            target=prov._start_multiplex,
+            args=(stop,),
+            kwargs={"profile_homes": homes, "interval": 0},
+            daemon=True,
+        )
+        t.start()
+        assert _wait_until(lambda: len(resets) >= 2), "multiplex never reset hermes_time cache"
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive(), "multiplex did not exit after stop_event was set"
+    assert len(resets) >= 2, "hermes_time.reset_cache must be called per profile switch"
+
+
 # ── Phase 2: config key, discovery, resolver ─────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #97905: a profile's cron jobs had `next_run_at` persisted with UTC offsets despite the profile configured `America/New_York`, causing every job to fire 4 hours early (10:00 ET instead of 14:00 ET for `0 14 * * *`).

## Root Cause

`hermes_time.get_timezone()` caches the resolved zone process-wide (resolved once, cached). The desktop multiplex cron ticker (`_start_desktop_cron_ticker` → `_start_multiplex`) switches profiles via `set_hermes_home_override()` but never resets that cache. So `compute_next_run()` / `mark_job_run()` persist `next_run_at` using the dashboard backend's timezone (often UTC), not the ticked profile's configured timezone. On later ticks the correct profile gateway compares the UTC-stored instant against its Eastern-time `now()`, so jobs fire early.

Verified premise with a repro: switching a fake `HERMES_HOME` override with `timezone: America/New_York` does NOT change `hermes_time.get_timezone()` unless `hermes_time.reset_cache()` is called.

## Approach

Add `hermes_time.reset_cache()` after each `set_hermes_home_override()` in the multiplex ticker's three per-profile loops (recovery, tick, heartbeat). After the override, `hermes_time` re-resolves the timezone from the profile's own `config.yaml` `timezone` key (`get_config_path()` follows `get_hermes_home()` which honors the override).

## Test Plan

- New regression test `test_multiplex_resets_timezone_cache_per_profile`: runs the multiplex ticker over two fake profiles, asserts `hermes_time.reset_cache()` is called per profile switch.
- Full file: 33/33 pass. `ruff` + Windows footgun lint clean.

## Risk / Exclusions

- Only touches the multiplex cron ticker's profile-switch points; non-multiplex cron (single gateway per profile) already runs under the correct `HERMES_HOME` and is unaffected.
- `hermes_time.reset_cache()` is a cheap cache clear; it only forces a config re-read on the next `now()` call.

References #97905