### PR TITLE
fix(kanban): make review guidance profile-independent

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1632,9 +1632,11 @@ def init_agent(
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
+    from agent.prompt_builder import kanban_guidance
     agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+        kanban_guidance(review=os.environ.get("HERMES_KANBAN_REVIEW") == "1")
+        if "kanban_show" in agent.valid_tool_names
+        else ""
     )
 
     # Check tool requirements

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -399,6 +399,31 @@ KANBAN_GUIDANCE = (
     "cross-agent handoffs that outlive one API loop."
 )
 
+KANBAN_REVIEW_GUIDANCE = (
+    "# Kanban review-lane protocol\n"
+    "You are the independent reviewer for this task, not its implementer. Treat "
+    "the handoff as a claim to verify, not proof. Read the original task, latest "
+    "handoff, prior requested changes, and actual deliverable. Map every acceptance "
+    "criterion to evidence; for code, inspect the diff and callers, run relevant "
+    "focused tests/lint/type checks, exercise the reported failure and a normal "
+    "control path when practical, and consider error handling, races, data loss, "
+    "security boundaries, and relevant cross-platform behavior.\n"
+    "Choose exactly one terminal verdict. Approve only with concrete evidence via "
+    "`kanban_complete`. For correctable defects, first leave actionable findings "
+    "with locations, reproduction, impact, and minimum correction, then call "
+    "`kanban_request_changes`. Use `kanban_block` only for a genuine external "
+    "prerequisite or human decision. Do not edit the implementation while reviewing; "
+    "preserve role separation and independently re-test the next candidate. Never "
+    "persist secrets, tokens, or raw PII in review summaries or metadata."
+)
+
+
+def kanban_guidance(*, review: bool = False) -> str:
+    """Return the session-static Kanban protocol for this worker lane."""
+    if review:
+        return f"{KANBAN_GUIDANCE}\n\n{KANBAN_REVIEW_GUIDANCE}"
+    return KANBAN_GUIDANCE
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -37,7 +37,6 @@ from agent.prompt_builder import (
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS,
-    KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
     USER_PROFILE_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
@@ -51,6 +50,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
+    kanban_guidance,
 )
 from agent.runtime_cwd import resolve_context_cwd
 from hermes_constants import get_default_hermes_root, get_hermes_home
@@ -513,11 +513,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see
     # this block. Resolved once at __init__ (see _kanban_worker_guidance).
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
+    if _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
+        # Fallback for code paths that bypass agent_init (rare).
+        _kanban_guidance = kanban_guidance(
+            review=os.environ.get("HERMES_KANBAN_REVIEW") == "1"
+        )
+        agent._kanban_worker_guidance = _kanban_guidance
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
-        # Fallback for code paths that bypass agent_init (rare).
-        tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -318,8 +318,9 @@ model:
 # Kanban Review Dispatch
 # =============================================================================
 # First-class review tasks are dispatched automatically by default. The worker
-# is spawned with the bundled sdlc-review skill and can approve, request changes
-# back to the original implementer, or escalate a genuine external blocker.
+# receives native review-lane guidance and can approve, request changes back to
+# the original implementer, or escalate a genuine external blocker. Per-task
+# skills remain opt-in and are not changed by review dispatch.
 # Disable this only when every review is performed manually from the dashboard.
 kanban:
   review_dispatch: true

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1641,8 +1641,8 @@ class GatewayKanbanWatchersMixin:
             PATH, missing venv, credential loss for a real Hermes profile).
             """
             # Only probe the review column when autonomous review dispatch is
-            # actually on. With ``review_dispatch`` off (the default — no
-            # sdlc-review agent), a task parked in 'review' is "correctly idle"
+            # actually on. With ``review_dispatch`` off, a task parked in
+            # 'review' is "correctly idle"
             # waiting for a human, not a stuck dispatcher; probing it here would
             # fire a false "dispatcher stuck" warning that never clears. Shares
             # the exact gate the dispatcher uses so the two can't drift.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2776,7 +2776,7 @@ DEFAULT_CONFIG = {
         # don't want the gateway to spawn workers.
         "dispatch_in_gateway": True,
         # Automatically claim tasks in the first-class review column and spawn
-        # the assigned profile with the bundled sdlc-review skill. Disable for
+        # the assigned profile with native review-lane guidance. Disable for
         # boards where every review is performed manually from the dashboard.
         "review_dispatch": True,
         # Seconds between dispatcher ticks (idle or not). Lower = snappier

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1141,7 +1141,6 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
-
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         keys = set(row.keys())
@@ -9608,9 +9607,10 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
 def review_dispatch_enabled() -> bool:
     """Return whether first-class review tasks should dispatch automatically.
 
-    The default is true because Hermes ships the ``sdlc-review`` skill and the
-    review lifecycle includes a supported reviewer-owned changes-requested
-    transition. Operators can disable it for human-only review boards.
+    The default is true because review workers receive a native review-lane
+    protocol and the lifecycle includes a supported reviewer-owned
+    changes-requested transition. Operators can disable it for human-only
+    review boards.
     """
     try:
         from hermes_cli.config import load_config
@@ -10268,11 +10268,11 @@ def _dispatch_once_locked(
             import inspect
             try:
                 sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
+                sig = None
+            if sig is not None and "board" in sig.parameters:
+                pid = _spawn(claimed, str(workspace), board=board)
+            else:
                 pid = _spawn(claimed, str(workspace))
             if pid:
                 _set_worker_pid(conn, claimed.id, int(pid))
@@ -10308,17 +10308,18 @@ def _dispatch_once_locked(
                 result.auto_blocked.append(claimed.id)
 
     # ---- review column dispatch ----
-    # Review tasks are tasks that a worker moved to 'review' after
-    # creating a PR.  The dispatcher spawns a review agent (loading
-    # sdlc-review skill) that verifies the candidate and either approves
-    # (→ done) or requests changes (→ ready/todo for the implementer).
+    # Review tasks are tasks that a worker moved to 'review' after creating a
+    # PR. The dispatcher marks the transient task context as the review lane;
+    # the default spawn then injects native review guidance without requiring a
+    # bundled skill. The reviewer either approves (→ done) or requests changes
+    # (→ ready/todo for the implementer).
     #
     # Same concurrency model as ready dispatch: review spawns count
     # against max_spawn alongside ready tasks, so the total number of
     # running workers stays bounded.
-    # Auto-dispatch is enabled by default because Hermes bundles the
-    # ``sdlc-review`` skill and reviewer workers can now approve, request
-    # changes without block-loop accounting, or escalate a genuine blocker.
+    # Auto-dispatch is enabled by default because reviewer workers receive the
+    # native review contract and can approve, request changes without
+    # block-loop accounting, or escalate a genuine blocker.
     # Human-only boards can disable it with ``kanban.review_dispatch``.
     #
     # ``review_rows`` was enumerated before the ready loop; when it is
@@ -10368,6 +10369,10 @@ def _dispatch_once_locked(
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
+        # Private, in-memory spawn context. Do not add this to the Task dataclass:
+        # dashboard serialization uses dataclasses.asdict(Task), and lane identity
+        # is per-attempt metadata rather than part of the public task record.
+        setattr(claimed, "_dispatch_lane", "review")
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
@@ -10387,24 +10392,16 @@ def _dispatch_once_locked(
         if claimed.workspace_kind == "worktree":
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load the sdlc-review skill for review agents — it carries
-        # the review logic (AC verification, merge, etc.). The mandatory
-        # kanban lifecycle is already injected into every worker's system
-        # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
-        # review agent needs.
-        claimed.skills = list(
-            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
-        )
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect
             try:
                 sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
+                sig = None
+            if sig is not None and "board" in sig.parameters:
+                pid = _spawn(claimed, str(workspace), board=board)
+            else:
                 pid = _spawn(claimed, str(workspace))
             if pid:
                 _set_worker_pid(conn, claimed.id, int(pid))
@@ -10774,6 +10771,13 @@ def _default_spawn(
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    # Review is a native Kanban lane, not a bundled-skill capability. Mark it
+    # so agent_init injects the review contract into the session-static system
+    # prompt even for profiles that intentionally opt out of bundled skills.
+    if getattr(task, "_dispatch_lane", "ready") == "review":
+        env["HERMES_KANBAN_REVIEW"] = "1"
+    else:
+        env.pop("HERMES_KANBAN_REVIEW", None)
     # Tag the worker's session so it lands in state.db as `kanban`, not as an
     # untitled `cli` row. A worker is a dispatcher-owned run whose transcript is
     # read on the board and in `hermes kanban log` — it is not a conversation

--- a/skills/devops/sdlc-review/SKILL.md
+++ b/skills/devops/sdlc-review/SKILL.md
@@ -37,7 +37,7 @@ Do not use it for a separate downstream review card. A downstream card is ordina
 
 ## How to Run
 
-This skill is loaded automatically by the review dispatcher. Start with `kanban_show` before inspecting files or choosing a verdict.
+The review dispatcher injects the mandatory review-lane protocol directly, so blank-slate profiles do not depend on this bundled skill. Load or assign this skill when the expanded review lenses and examples are useful. Start with `kanban_show` before inspecting files or choosing a verdict.
 
 1. Read the task specification and the latest `review_requested` handoff.
 2. Inspect the actual deliverable and run relevant verification.

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -85,6 +85,19 @@ def _prompt_parts(agent):
         return build_system_prompt_parts(agent)
 
 
+def test_fallback_kanban_guidance_is_session_static(monkeypatch):
+    agent = _make_agent(valid_tool_names=["kanban_show"])
+    del agent._kanban_worker_guidance
+
+    monkeypatch.setenv("HERMES_KANBAN_REVIEW", "1")
+    first = _stable_prompt(agent)
+    monkeypatch.delenv("HERMES_KANBAN_REVIEW")
+    second = _stable_prompt(agent)
+
+    assert "Treat the handoff as a claim" in first
+    assert second == first
+
+
 def _init_code_repo(path):
     """A git repo that actually holds code — the coding posture requires a source
     file (or manifest), not a bare ``.git`` (a prose/notes repo stays general)."""

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -693,7 +693,9 @@ def test_pid_alive_detects_zombie(kanban_home):
 
 
 
-def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
+def test_default_spawn_ready_lane_clears_review_env_and_loads_no_skill(
+    kanban_home, monkeypatch
+):
     """The dispatcher no longer auto-loads a bundled kanban skill.
 
     The kanban lifecycle (formerly the kanban-worker/kanban-orchestrator
@@ -705,6 +707,7 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     hermes subprocess (which would hang trying to call an LLM).
     """
     captured = {}
+    monkeypatch.setenv("HERMES_KANBAN_REVIEW", "1")
 
     class FakeProc:
         def __init__(self):
@@ -741,6 +744,40 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     env = captured["env"]
     assert env.get("HERMES_KANBAN_TASK") == tid
     assert env.get("HERMES_PROFILE") == "some-profile"
+    assert "HERMES_KANBAN_REVIEW" not in env
+
+
+def test_default_spawn_marks_review_lane_without_auto_loading_skill(
+    kanban_home, monkeypatch
+):
+    """Review guidance is native worker protocol, not a profile skill dependency."""
+    captured = {}
+
+    class FakeProc:
+        pid = 99999
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env", {})
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="review protocol test", assignee="blank-slate-reviewer"
+        )
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        workspace = kb.resolve_workspace(task)
+        setattr(task, "_dispatch_lane", "review")
+        from dataclasses import asdict
+        assert "_dispatch_lane" not in asdict(task)
+        pid = kb._default_spawn(task, str(workspace))
+
+    assert pid == 99999
+    assert "--skills" not in captured["cmd"]
+    assert captured["env"].get("HERMES_KANBAN_REVIEW") == "1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -404,8 +404,8 @@ def test_review_dispatch_gate_prevents_phantom_reviewer(
         assert tid not in [s[0] for s in res_off.spawned]
         assert kb.get_task(conn, tid).status == "review"
 
-        # Gate ON (the default; sdlc-review is bundled) -> the review task is
-        # picked up by the dispatcher.
+        # Gate ON (the default) -> native review-lane dispatch picks up the
+        # review task without auto-loading a skill.
         monkeypatch.setattr(
             cfgmod, "load_config",
             lambda *a, **k: {"kanban": {"review_dispatch": True}},
@@ -475,7 +475,7 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         ) == "rate_limit_cooldown"
 
 
-def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
+def test_review_dispatch_preserves_task_skills_and_marks_review_lane(
     kanban_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import hermes_cli.config as cfgmod
@@ -487,11 +487,23 @@ def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
         "load_config",
         lambda *args, **kwargs: {"kanban": {"review_dispatch": True}},
     )
-    captured: list[list[str]] = []
+    captured: list[tuple[list[str], str | None]] = []
 
     def spawn(task, workspace):
-        captured.append(list(task.skills or []))
-        return None
+        """Legacy wrapper must inherit review semantics without a new kwarg."""
+        captured.append((list(task.skills or []), getattr(task, "_dispatch_lane", "")))
+        return kb._default_spawn(task, workspace)
+
+    class FakeProc:
+        pid = 99999
+
+    popen_calls: list[dict] = []
+
+    def fake_popen(_cmd, **kwargs):
+        popen_calls.append(kwargs)
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
 
     with kb.connect() as conn:
         task_id = kb.create_task(
@@ -524,7 +536,49 @@ def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
         result = kb.dispatch_once(conn, spawn_fn=spawn)
 
     assert task_id in [task[0] for task in result.spawned]
-    assert captured == [["domain-specific-review", "sdlc-review"]]
+    assert captured == [(["domain-specific-review"], "review")]
+    assert len(popen_calls) == 1
+    assert popen_calls[0]["env"].get("HERMES_KANBAN_REVIEW") == "1"
+
+
+def test_review_spawn_internal_type_error_is_not_retried(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda _name: True)
+    monkeypatch.setattr(
+        cfgmod,
+        "load_config",
+        lambda *args, **kwargs: {"kanban": {"review_dispatch": True}},
+    )
+    calls: list[str] = []
+
+    def spawn(task, workspace):
+        calls.append(getattr(task, "_dispatch_lane", ""))
+        raise TypeError("inside legacy wrapper")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="review type error", assignee="reviewer")
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="ready",
+            expected_run_id=implementation.current_run_id,
+        )
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn)
+        failed = kb.get_task(conn, task_id)
+
+    assert result.spawned == []
+    assert calls == ["review"]
+    assert failed is not None
+    assert failed.status == "review"
+    assert failed.consecutive_failures == 1
+    assert failed.last_failure_error == "inside legacy wrapper"
 
 
 def test_review_dispatch_honors_global_and_per_profile_caps(

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -579,6 +579,19 @@ def test_kanban_guidance_orchestrator_decision_ownership():
     assert "workers cannot see sibling context" in KANBAN_GUIDANCE
 
 
+def test_review_guidance_is_native_and_review_lane_only():
+    from agent.prompt_builder import kanban_guidance
+
+    worker_guidance = kanban_guidance(review=False)
+    review_guidance = kanban_guidance(review=True)
+
+    assert "Treat the handoff as a claim" not in worker_guidance
+    assert "Treat the handoff as a claim" in review_guidance
+    assert "Do not edit the implementation" in review_guidance
+    assert "kanban_request_changes" in review_guidance
+    assert len(review_guidance) < 10000
+
+
 # ---------------------------------------------------------------------------
 # Worker task-ownership enforcement (regression tests for #19534)
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -51,7 +51,7 @@ For non-Hermes lanes (registered via a plugin), the plugin supplies its own `spa
 Every claim must end in exactly one of:
 
 - `kanban_complete(summary=..., metadata=...)` — task succeeds, status flips to `done`.
-- `kanban_request_review(summary=..., metadata=..., reviewer=...)` — same-card implementation is complete and enters first-class review; status flips to `review`. The dispatcher loads the bundled `sdlc-review` skill unless `kanban.review_dispatch` is disabled. A reviewer approves with `kanban_complete`, returns actionable rework with `kanban_request_changes`, or escalates a genuine external blocker with `kanban_block`.
+- `kanban_request_review(summary=..., metadata=..., reviewer=...)` — same-card implementation is complete and enters first-class review; status flips to `review`. Unless `kanban.review_dispatch` is disabled, the dispatcher starts the assigned profile with native review-lane guidance and leaves per-task skills unchanged. A reviewer approves with `kanban_complete`, returns actionable rework with `kanban_request_changes`, or escalates a genuine external blocker with `kanban_block`.
 - `kanban_block(reason=...)` — task waits for human input, status flips to `blocked`. The dispatcher respawns when `kanban_unblock` runs.
 - The worker process exits without a tool call. The kernel reaps it and emits `crashed` (PID died) or `gave_up` (consecutive-failure breaker tripped) or `timed_out` (max_runtime exceeded). This is the failure path; healthy workers don't end here.
 
@@ -61,7 +61,7 @@ The kanban kernel enforces that exactly one of these terminates each run. A work
 
 For code-changing tasks, pick the review model encoded by the task graph:
 
-- **Same-card review:** call `kanban_request_review(summary=..., metadata=..., reviewer=...)`. The task enters `review` without touching block recurrence accounting. The dispatcher claims it with the bundled `sdlc-review` skill by default. The reviewer approves with `kanban_complete`, calls `kanban_request_changes(reason=...)` to close the review run and route the task back to its original implementer, or blocks only for a genuine external escalation.
+- **Same-card review:** call `kanban_request_review(summary=..., metadata=..., reviewer=...)`. The task enters `review` without touching block recurrence accounting. By default the dispatcher claims it with native review-lane guidance; it does not automatically load `sdlc-review` or any other skill. The reviewer approves with `kanban_complete`, calls `kanban_request_changes(reason=...)` to close the review run and route the task back to its original implementer, or blocks only for a genuine external escalation.
 - **Pre-created downstream review/QA/release card:** `kanban_show` lists child IDs; inspect those cards with `kanban_show(task_id=...)` before choosing the terminal action. When a child is the downstream review/QA/release phase, call `kanban_complete` on the implementation phase. It cannot promote until this parent is `done`/`archived`. Do not additionally request same-card review and never sticky-block the parent with `review-required:` — either choice strands or duplicates the downstream lane.
 - **Human-only boards:** set `kanban.review_dispatch: false`. A task can then remain in `review` until a human approves it or uses `reopen-review`/the dashboard to return it to `ready`/`todo`.
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -227,8 +227,8 @@ kanban:
   dispatch_in_gateway: true        # default
   dispatch_interval_seconds: 60    # default
   review_dispatch: true            # default: spawn the assigned profile with
-                                   # the bundled sdlc-review skill. Set false
-                                   # for human-only review boards.
+                                   # native review-lane guidance. Set false for
+                                   # human-only review boards.
 ```
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban-worker-lanes.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban-worker-lanes.md
@@ -51,7 +51,7 @@ Hermes Kanban 拥有生命周期的真实状态——`ready` → `running` → `
 每次 claim 必须以以下之一结束：
 
 - `kanban_complete(summary=..., metadata=...)` — 任务成功，状态切换为 `done`。
-- `kanban_request_review(summary=..., metadata=..., reviewer=...)` — 同卡实现进入一等审查。默认由内置 `sdlc-review` skill 启动 reviewer；reviewer 可用 `kanban_complete` 批准、用 `kanban_request_changes` 退回原 implementer，或仅在真正需要外部介入时 block。
+- `kanban_request_review(summary=..., metadata=..., reviewer=...)` — 同卡实现已完成并进入一等审查；状态切换为 `review`。除非禁用 `kanban.review_dispatch`，否则调度器会使用原生 review-lane guidance 启动指定 profile，并保持每个任务的 skills 不变。Reviewer 用 `kanban_complete` 批准、用 `kanban_request_changes` 返回可执行的返工要求，或仅在确有外部阻塞时用 `kanban_block` 升级。
 - `kanban_block(reason=...)` — 任务等待人工输入，状态切换为 `blocked`。调度器在 `kanban_unblock` 运行时重新生成。
 - worker 进程退出而未调用任何工具。内核回收该进程并发出 `crashed`（PID 已消亡）、`gave_up`（连续失败断路器触发）或 `timed_out`（超过 max_runtime）。这是失败路径；健康的 worker 不会在此结束。
 
@@ -61,7 +61,7 @@ kanban 内核强制要求每次运行恰好由其中一项终止。既未调用�
 
 代码变更任务必须按照任务图选择审查模型：
 
-- **同卡审查：**调用 `kanban_request_review(summary=..., metadata=..., reviewer=...)`。任务进入 `review`，不会触碰 block 循环计数。默认情况下，调度器使用内置 `sdlc-review` skill 启动 reviewer。Reviewer 用 `kanban_complete` 批准，用 `kanban_request_changes(reason=...)` 关闭审查 run 并将任务退回原 implementer，或只在真正需要外部决策时 block。
+- **同卡审查：**调用 `kanban_request_review(summary=..., metadata=..., reviewer=...)`。任务进入 `review`，不会触碰 block 循环计数。默认情况下，调度器使用原生 review-lane guidance claim 该任务；它不会自动加载 `sdlc-review` 或任何其他 skill。Reviewer 用 `kanban_complete` 批准，用 `kanban_request_changes(reason=...)` 关闭审查 run 并将任务退回原 implementer，或只在确有外部阻塞时 block。
 - **预先创建的下游 review/QA/release 卡：**`kanban_show` 会列出 child ID；选择终止动作前，先用 `kanban_show(task_id=...)` 检查这些卡。如果 child 是下游 review/QA/release 阶段，implementation 阶段必须调用 `kanban_complete`。子卡只有在父卡为 `done`/`archived` 后才能启动。不要再请求同卡审查，也不要用 `review-required:` sticky-block 父卡，否则会让下游通道卡死或重复。
 - **纯人工审查看板：**设置 `kanban.review_dispatch: false`。任务会停在 `review`，直到人工批准，或通过 `reopen-review`/仪表盘退回 `ready`/`todo`。
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -161,8 +161,8 @@ hermes kanban stats
 kanban:
   dispatch_in_gateway: true        # 默认
   dispatch_interval_seconds: 60    # 默认
-  review_dispatch: true            # 默认：使用内置 sdlc-review skill 自动启动 reviewer。
-                                   # 纯人工审查看板可设为 false。
+  review_dispatch: true            # 默认：使用原生 review-lane 指引自动启动 reviewer。
+                                   # 不会自动加载 sdlc-review skill；纯人工审查看板可设为 false。
 ```
 
 通过 `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0` 在运行时覆盖配置标志以进行调试。标准 gateway 监督适用：直接运行 `hermes gateway start`，或将 gateway 配置为 systemd 用户单元（参见 gateway 文档）。没有运行中的 gateway，`ready` 任务会保持原状，直到 gateway 启动 —— `hermes kanban create` 在创建时会对此发出警告。


### PR DESCRIPTION
## Summary

- stop automatic Kanban review dispatch from force-loading the optional bundled `sdlc-review` skill
- carry review-lane identity in task dispatch context so existing two-argument spawn wrappers remain compatible
- inject a compact, session-static review protocol natively for review workers
- preserve explicitly assigned task skills without requiring a bundled skill to exist in the reviewer profile

## Root cause

Profile skill opt-out support predates automatic review dispatch:

- `51f9953e69d303c3d278e41295b1a5c786bf8d87` added `--no-skills` profile creation
- `2ed96372ade3e2f6797b68fb88bf0a53f52f2ee8` made blank-slate profiles durable
- `f55d94a1e0454bc1f2855631d9a0869bc85375dc` later made review dispatch unconditionally append `sdlc-review`

That created a hidden assumption that every reviewer profile can resolve every bundled skill. A valid blank-slate profile instead starts with:

```text
Error: Unknown skill(s): sdlc-review
```

The process exits before its first heartbeat, so ordinary crash reconciliation can only report a dead PID and retries repeat the same deterministic failure.

The repository already established the intended architecture in `84e1d31e5442eeff0bfcf1c2ffab6acf7fe95f45`: mandatory Kanban behavior belongs in native injected guidance, while profile skills remain optional. This change applies that rule to the review lane instead of approximating the runtime skill resolver or silently overriding profile policy.

## Related work

This is narrower than #54100, which makes every Kanban worker continue after missing skill preload, and distinct from #30025/#89601, which filter user-assigned per-task skills at dispatch. This PR preserves strict explicit skill loading and task skill contracts; it removes only the dispatcher's own hidden optional-skill dependency by moving its mandatory protocol to the native prompt path.

## Behavior

Before:

1. a review task is claimed
2. `sdlc-review` is appended to task skills
3. the worker starts with `--skills sdlc-review`
4. a blank-slate reviewer exits before heartbeat

After:

1. review-lane identity is attached to the transient dispatch task
2. legacy spawn wrappers can pass that same task to the default spawner
3. the child receives `HERMES_KANBAN_REVIEW=1`
4. native review guidance is added to the static Kanban system-prompt section
5. no optional skill is force-loaded; explicitly assigned skills are preserved

## Tests

- review dispatch preserves explicit skills and marks the review lane
- default spawn sets review-lane environment without adding `sdlc-review`
- legacy two-argument spawn wrappers preserve review semantics
- ready-lane spawn clears an inherited review marker
- native review guidance is review-only and byte-stable
- focused Kanban, prompt, and bundled-skill suites
- full `tests/hermes_cli/test_kanban*.py` regression surface: `402 passed, 2 skipped`
- Ruff and `git diff --check`

The new regression tests were also run against the pre-fix production path and failed for the expected missing behavior.

## Scope and risk

This does not weaken review verdict handling or independent-review gates. It changes how mandatory review instructions are delivered: native guidance is always available to a review worker, while the larger `sdlc-review` skill remains available when explicitly assigned.

No worker-log persistence, credential handling, board schema, or retry policy is changed.
