### PR TITLE
test(cli): cover SOUL.md legacy-template detection in default_soul

### DIFF
--- a/contributors/emails/salch-cred@users.noreply.github.com
+++ b/contributors/emails/salch-cred@users.noreply.github.com
@@ -1,0 +1,1 @@
+salch-cred

--- a/tests/hermes_cli/test_default_soul.py
+++ b/tests/hermes_cli/test_default_soul.py
@@ -1,0 +1,60 @@
+"""Behavioral tests for hermes_cli.default_soul — SOUL.md template matching.
+
+Covers the legacy-template detection used when upgrading an old comment-only
+SOUL.md (seeded by pre-DEFAULT_SOUL_MD installers) to the default persona,
+without touching user-customized content.
+"""
+
+import pytest
+
+from hermes_cli.default_soul import (
+    DEFAULT_SOUL_MD,
+    _LEGACY_TEMPLATE_SOULS,
+    is_legacy_template_soul,
+)
+
+
+def test_default_soul_is_nonempty_persona():
+    # The default must actually carry a persona, not be empty scaffolding.
+    assert DEFAULT_SOUL_MD.strip()
+    assert "Hermes Agent" in DEFAULT_SOUL_MD
+
+
+def test_legacy_template_matches_verbatim():
+    # A file whose content equals a known legacy template is safe to upgrade.
+    assert is_legacy_template_soul(_LEGACY_TEMPLATE_SOULS[0]) is True
+    assert is_legacy_template_soul(_LEGACY_TEMPLATE_SOULS[1]) is True
+
+
+def test_legacy_template_matches_with_trailing_newline():
+    # Installers may leave a trailing newline; normalization must still match.
+    assert is_legacy_template_soul(_LEGACY_TEMPLATE_SOULS[0] + "\n") is True
+
+
+def test_legacy_template_matches_with_crlf():
+    # Windows installers may write CRLF line endings; normalization unifies them.
+    crlf = _LEGACY_TEMPLATE_SOULS[0].replace("\n", "\r\n")
+    assert is_legacy_template_soul(crlf) is True
+
+
+def test_legacy_template_matches_with_bom():
+    # A leading UTF-8 BOM must be stripped before comparison.
+    assert is_legacy_template_soul("\ufeff" + _LEGACY_TEMPLATE_SOULS[0]) is True
+
+
+def test_user_persona_is_not_matched():
+    # Any user-authored content (even a single line added) must NOT match —
+    # the whole safety guarantee is that legacy templates carry zero user intent.
+    persona = _LEGACY_TEMPLATE_SOULS[0] + "\nYou are a sarcastic pirate."
+    assert is_legacy_template_soul(persona) is False
+
+
+def test_default_soul_is_not_legacy_template():
+    # The current default persona is not one of the old comment-only scaffolds.
+    assert is_legacy_template_soul(DEFAULT_SOUL_MD) is False
+
+
+def test_empty_and_whitespace_input():
+    # Degenerate input — no user persona, but also not a known legacy template.
+    assert is_legacy_template_soul("") is False
+    assert is_legacy_template_soul("   \n  ") is False


### PR DESCRIPTION
Add behavioral regression coverage for `hermes_cli.default_soul` — the SOUL.md template-matching module used to safely upgrade legacy comment-only scaffolds to the default persona.

## Why

`default_soul.py` decides whether an old install's `SOUL.md` is safe to replace in place with `DEFAULT_SOUL_MD`. The whole safety guarantee is that a legacy template carries zero user intent — so a bug in `is_legacy_template_soul()` (e.g. a normalization mismatch that wrongly classifies a user-customized SOUL.md as a safe-to-upgrade template) could silently overwrite a user's persona. It had no dedicated unit coverage (only an incidental reference in `test_config.py`).

## What

`tests/hermes_cli/test_default_soul.py` — behavioral tests:

- The default persona is non-empty and carries identity.
- Known legacy templates match verbatim.
- Matching survives trailing newline, CRLF line endings, and a leading UTF-8 BOM (the normalization `_normalize_soul` exists exactly for these).
- A user-authored persona (even one added line) does NOT match — the critical safety property.
- The current `DEFAULT_SOUL_MD` is not a legacy template.
- Degenerate empty/whitespace input does not match.

## Validation

All assertions verified to pass against the current `default_soul.py` on `main`.
