### PR TITLE
fix(gateway): terminal temp cache keeps its own 72h retention in housekeeping

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30993,7 +30993,10 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         cleanup_video_cache,
     )
     from tools.tool_result_storage import cleanup_spillover_cache
-    from tools.environments.local import cleanup_terminal_temp_cache
+    from tools.environments.local import (
+        cleanup_terminal_temp_cache,
+        TERMINAL_TEMP_MAX_AGE_HOURS,
+    )
     from tools.bot_mode_dm import cleanup_bot_dm_cache
     from tools.bot_relay import cleanup_bot_relay_artifacts
     from hermes_cli.debug import _sweep_expired_pastes
@@ -31046,7 +31049,17 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         if tick_count % IMAGE_CACHE_EVERY == 0:
             for cache_name, cleanup_fn in MEDIA_CACHE_CLEANUPS:
                 try:
-                    removed = cleanup_fn(max_age_hours=24)
+                    # Every other registered cache uses the shared 24h media
+                    # retention; terminal temp artifacts are documented and
+                    # tested at 72h (see TERMINAL_TEMP_MAX_AGE_HOURS) — a
+                    # long-lived cron/background session's log/pid/exit
+                    # files must not be pruned 2 days earlier than promised.
+                    max_age = (
+                        TERMINAL_TEMP_MAX_AGE_HOURS
+                        if cleanup_fn is cleanup_terminal_temp_cache
+                        else 24
+                    )
+                    removed = cleanup_fn(max_age_hours=max_age)
                     if removed:
                         logger.info("%s cache cleanup: removed %d stale file(s)", cache_name, removed)
                 except Exception as e:

--- a/tests/gateway/test_terminal_temp_housekeeping_retention.py
+++ b/tests/gateway/test_terminal_temp_housekeeping_retention.py
@@ -1,0 +1,43 @@
+"""The shared gateway housekeeping loop must not override the terminal-temp
+cache's own 72h retention with the other caches' 24h interval.
+
+``cleanup_terminal_temp_cache`` was folded into ``MEDIA_CACHE_CLEANUPS`` for
+convenience, but that loop calls every entry with a hardcoded
+``max_age_hours=24`` -- silently pruning session temp artifacts (background
+process logs/pid/exit files, code-execution sandboxes) up to 2 days earlier
+than the documented/tested 72h policy (``TERMINAL_TEMP_MAX_AGE_HOURS``).
+"""
+
+import gateway.run as gateway_run
+
+
+class _NTicksStopEvent:
+    """Run exactly ``n`` housekeeping ticks, no sleep or background thread."""
+
+    def __init__(self, n):
+        self.n = n
+        self.count = 0
+
+    def is_set(self):
+        return self.count >= self.n
+
+    def wait(self, timeout=None):
+        self.count += 1
+        return True
+
+
+def test_terminal_temp_cleanup_keeps_its_own_72h_retention(monkeypatch):
+    import tools.environments.local as local_mod
+
+    calls = []
+    monkeypatch.setattr(
+        local_mod,
+        "cleanup_terminal_temp_cache",
+        lambda max_age_hours=None: calls.append(max_age_hours) or 0,
+    )
+
+    # IMAGE_CACHE_EVERY (the media-cache cleanup gate) is 60 ticks.
+    gateway_run._start_gateway_housekeeping(_NTicksStopEvent(60), interval=0)
+
+    assert calls == [local_mod.TERMINAL_TEMP_MAX_AGE_HOURS]
+    assert calls != [24], "terminal temp must not use the other caches' 24h interval"


### PR DESCRIPTION
## What does this PR do?

`95cf7dc9e8` moved the session temp root off tmpfs `/tmp` to
`~/.hermes/cache/terminal`, documenting and testing a 72h retention
(`TERMINAL_TEMP_MAX_AGE_HOURS = 72`, asserted by
`tests/tools/test_local_temp_dir.py::test_cleanup_terminal_temp_cache`).

It wired the new `cleanup_terminal_temp_cache` into the shared
`MEDIA_CACHE_CLEANUPS` tuple the gateway housekeeping loop iterates —
but that loop calls **every** entry with a hardcoded `max_age_hours=24`,
silently overriding the terminal-temp cache's own 72h policy:

```python
# gateway/run.py, before this PR
for cache_name, cleanup_fn in MEDIA_CACHE_CLEANUPS:
    removed = cleanup_fn(max_age_hours=24)   # applies to Terminal temp too
```

Net effect: session temp artifacts (`hermes_bg_*` `.log`/`.pid`/`.exit`
files, code-execution sandboxes) get pruned up to 2 days earlier than
documented. A long-running cron job or delegated background task whose
log is checked between the 24h and 72h mark can find it already gone.

## Related Issue

No existing issue — found via manual audit of the same-day commit
`95cf7dc9e8` plus a repro script (below). Searched for existing PRs/issues
on this specific interaction, found none.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: the housekeeping loop now special-cases the
  terminal-temp entry to use its own `TERMINAL_TEMP_MAX_AGE_HOURS`
  (72) instead of the shared 24h used by the other media caches.
- `tests/gateway/test_terminal_temp_housekeeping_retention.py`: drives
  the housekeeping loop for 60 ticks (the media-cache cleanup gate) and
  asserts `cleanup_terminal_temp_cache` is called with 72, not 24.
  Verified this test fails on the pre-fix code (`assert [24] == [72]`).

## How to Test

```python
import time, os
from pathlib import Path
from tools.environments import local as local_mod

root = Path(tempfile.mkdtemp()) / "cache" / "terminal"
root.mkdir(parents=True)
local_mod._default_terminal_temp_dir = lambda: root

f = root / "hermes-snap-abc123.sh"
f.write_text("x")
t = time.time() - 30 * 3600  # 30h old — should survive under the 72h policy
os.utime(f, (t, t))

# before this PR: removed, because the housekeeping call site hardcodes 24h
# after this PR: survives, because it now uses TERMINAL_TEMP_MAX_AGE_HOURS (72)
```

`pytest tests/gateway/test_terminal_temp_housekeeping_retention.py
tests/gateway/test_memory_trim_housekeeping.py -q` → 2 passed.
`scripts/check-windows-footguns.py gateway/run.py
tests/gateway/test_terminal_temp_housekeeping_retention.py` clean.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added a test for this change
- [x] Platform tested: Windows 11 (dev environment); logic is pure Python control flow, no OS-specific behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)