### PR TITLE
docs(slack): document native markdown blocks

### DIFF
--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -416,6 +416,12 @@ platforms:
       unfurl_links: false
       unfurl_media: false
 
+      # Let Slack render the agent's standard Markdown directly (default: false).
+      # Supports tables, headers, task lists, and syntax-highlighted code fences.
+      # Slack limits markdown blocks to 12,000 characters per message; Hermes
+      # falls back to rich_blocks (when enabled) or flat mrkdwn when necessary.
+      markdown_blocks: false
+
       # Render agent messages as Slack Block Kit blocks (default: false).
       # When true, the final agent message is sent with structured blocks —
       # section headers, dividers, true nested lists (via rich_text), and
@@ -466,6 +472,7 @@ platforms:
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
 | `platforms.slack.extra.unfurl_links` | Slack default | Set to `false` to suppress automatic previews for linked web pages while preserving clickable links. When either unfurl key is set, media captions are posted as a separate message *before* the file (Slack's upload API cannot carry unfurl controls), and native draft streaming falls back to edit-based delivery. |
 | `platforms.slack.extra.unfurl_media` | Slack default | Set to `false` to suppress automatic media previews while preserving clickable links. Same caption-ordering and streaming notes as `unfurl_links`. |
+| `platforms.slack.extra.markdown_blocks` | `false` | When `true`, sends the agent's standard Markdown through Slack's native [`markdown` block](https://docs.slack.dev/reference/block-kit/blocks/markdown-block/), which renders tables, headers, task lists, and syntax-highlighted code fences. Slack caps cumulative markdown-block text at 12,000 characters per message; Hermes falls back safely when content is too long or Slack rejects the block. No app reinstall required. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
 | `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. This is an explicit progress opt-in independent of Slack's default `tool_progress: off`; native API failures fall back to one continuously edited text update. |


### PR DESCRIPTION
## Summary
- document `platforms.slack.extra.markdown_blocks` in the Slack configuration example and option reference
- describe native table/header/task-list/code rendering, Slack's 12,000-character limit, and Hermes's fallback behavior

## Testing
- `npm run build:fast` (passes; reports the pre-existing `/docs/llms.txt` and `/docs/llms-full.txt` broken-link warnings)
