### PR TITLE
fix(docs): run prebuild for fast builds

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
     "start": "docusaurus start",
     "prebuild": "node scripts/prebuild.mjs",
     "build": "docusaurus build",
+    "prebuild:fast": "node scripts/prebuild.mjs",
     "build:fast": "docusaurus build --locale en",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
## Problem

On upstream `main` at `b9dc79033203704841f64e381d564a99299cb3bf`, the English-only docs check emits these warnings from a clean checkout:

```text
[WARNING] Docusaurus found broken links!

Exhaustive list of all broken links found:
- Broken link on source page path = /docs/:
   -> linking to /docs/llms.txt
   -> linking to /docs/llms-full.txt
```

CI runs `npm run build:fast`. npm does not run the existing `prebuild` hook for that script name, so the generated text files are missing when Docusaurus builds the site. The build still exits successfully because broken links are configured as warnings.

The normal deployment build uses `npm run build`, which already runs `prebuild`. The missing generation affects only the fast-build path.

## Change

Add one `prebuild:fast` script that invokes the existing `scripts/prebuild.mjs`. This keeps the English-only build while giving it the same generated assets as the normal build.

Related: #74010 proposes broader website build hardening; this change is limited to restoring generation for the existing `build:fast` script.

## Verification

Tested on macOS with Node 26.5.0, npm 11.17.0, Python 3.11.15 and PyYAML 6.0.3. Webpack's persistent cache was disabled for the disposable worktree.

With `static/llms.txt`, `static/llms-full.txt`, `.docusaurus/` and `build/` absent, run from `website/`:

```sh
npm run build:fast
```

- **Upstream:** reproduces both warnings; both generated text files are absent from the build.
- **This change:** runs `prebuild:fast`, generates both text files, includes them in the build, and produces neither broken-link warning.
- **Control:** generating the files before the unchanged upstream fast build also removes the warnings.
- `git diff --check` passes. One added line in one file.

An unrelated Node 26 `localStorage` experimental warning appears in both builds.
