### PR TITLE
fix(memory): single-source the built-in memory cap defaults + log store provenance

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1880,9 +1880,27 @@ def init_agent(
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
+                from hermes_cli.config_defaults import (
+                    DEFAULT_MEMORY_CHAR_LIMIT,
+                    DEFAULT_USER_CHAR_LIMIT,
+                )
+                _mem_cap = int(mem_config.get("memory_char_limit", DEFAULT_MEMORY_CHAR_LIMIT))
+                _usr_cap = int(mem_config.get("user_char_limit", DEFAULT_USER_CHAR_LIMIT))
+                # Provenance: log the home + caps the store is actually built
+                # against, so a profile/main config-resolution split is
+                # diagnosable from one line instead of silent (#memory-cap-split).
+                try:
+                    from hermes_constants import get_hermes_home
+                    _mem_src = "config" if "memory_char_limit" in mem_config else "default"
+                    logger.info(
+                        "memory store: home=%s mem_cap=%d user_cap=%d source=%s",
+                        get_hermes_home(), _mem_cap, _usr_cap, _mem_src,
+                    )
+                except Exception:
+                    pass
                 agent._memory_store = MemoryStore(
-                    memory_char_limit=mem_config.get("memory_char_limit", 2200),
-                    user_char_limit=mem_config.get("user_char_limit", 1375),
+                    memory_char_limit=_mem_cap,
+                    user_char_limit=_usr_cap,
                     memory_enabled=agent._memory_enabled,
                     user_profile_enabled=agent._user_profile_enabled,
                 )

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -4,6 +4,12 @@ Pure-data leaf module: DEFAULT_CONFIG and OPTIONAL_ENV_VARS, extracted
 verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
 """
 
+# Single source of truth for built-in memory caps. Imported by
+# tools/memory_tool.py and agent/agent_init.py so a missing config section
+# resolves to ONE default, not three drifting copies (#memory-cap-split).
+DEFAULT_MEMORY_CHAR_LIMIT = 2200   # ~800 tokens at 2.75 chars/token
+DEFAULT_USER_CHAR_LIMIT = 1375     # ~500 tokens at 2.75 chars/token
+
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
@@ -2029,8 +2035,8 @@ DEFAULT_CONFIG = {
         #                     /memory reject <id>.
         # To disable memory entirely, use memory_enabled: false instead.
         "write_approval": False,
-        "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
-        "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "memory_char_limit": DEFAULT_MEMORY_CHAR_LIMIT,   # ~800 tokens at 2.75 chars/token
+        "user_char_limit": DEFAULT_USER_CHAR_LIMIT,     # ~500 tokens at 2.75 chars/token
         # Periodic built-in memory review. External providers with automatic
         # turn/session extraction can set this to 0 and keep the small local
         # store reserved for explicit high-frequency operational facts.

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -31,6 +31,10 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
 from hermes_constants import get_hermes_home
+from hermes_cli.config_defaults import (
+    DEFAULT_MEMORY_CHAR_LIMIT,
+    DEFAULT_USER_CHAR_LIMIT,
+)
 from typing import Dict, Any, List, Optional, Tuple
 
 from utils import atomic_write_text, is_truthy_value
@@ -175,8 +179,8 @@ class MemoryStore:
 
     def __init__(
         self,
-        memory_char_limit: int = 2200,
-        user_char_limit: int = 1375,
+        memory_char_limit: int = DEFAULT_MEMORY_CHAR_LIMIT,
+        user_char_limit: int = DEFAULT_USER_CHAR_LIMIT,
         *,
         memory_enabled: bool = True,
         user_profile_enabled: bool = True,
@@ -921,8 +925,8 @@ def load_on_disk_store() -> "MemoryStore":
     Falls back to the built-in defaults if config can't be loaded, so this can
     never raise on a missing/unreadable config.
     """
-    memory_char_limit = 2200
-    user_char_limit = 1375
+    memory_char_limit = DEFAULT_MEMORY_CHAR_LIMIT
+    user_char_limit = DEFAULT_USER_CHAR_LIMIT
     memory_enabled = True
     user_profile_enabled = True
     try:


### PR DESCRIPTION
## Problem

The built-in memory cap defaults (`2200` / `1375`) are hardcoded independently in **three** places:

- `hermes_cli/config_defaults.py` — `DEFAULT_CONFIG["memory"]`
- `tools/memory_tool.py` — `MemoryStore.__init__` and the `/memory` approval-store fallback builder
- `agent/agent_init.py` — live agent memory-store construction

Because the same literal appears in all three, a config-resolution bug that makes the store fall back to the default is **indistinguishable from a legitimate default** — the failure is completely silent.

### How it bit in practice

On a multiplex gateway (`gateway.multiplex_profiles: true`), the memory store is constructed reading the **raw main `config.yaml`** while `hermes config get` reports the **profile-overlaid** value. Result: the store silently enforced `2200` while the CLI showed the raised cap, with no signal anywhere that the two had diverged. Every memory write hit a wall the operator couldn't see.

## Changes

- Add `DEFAULT_MEMORY_CHAR_LIMIT` / `DEFAULT_USER_CHAR_LIMIT` as the single source of truth in `config_defaults.py` (a pure-data leaf module, no new imports).
- Import them in `memory_tool.py` and `agent_init.py`; delete the three duplicate literals.
- Log store provenance at construction (`memory store: home=… mem_cap=… user_cap=… source=…`) so a profile/main resolution split is diagnosable from one log line instead of being silent.

## Risk

Low. No behavior change to the default values themselves (still `2200` / `1375`). This is pure de-duplication plus one observability log line. Explicit config values and the config-override path are unaffected.