### PR TITLE
fix(cron): retry failed monitor changes safely

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1921,6 +1921,7 @@ def _validate_job_mode_invariants(
     monitor_url: Optional[str],
     no_agent: bool,
     script: Optional[str],
+    monitor_retry_on_failure: bool = False,
 ) -> None:
     """Shared create/update validation for job execution-mode invariants.
 
@@ -1938,6 +1939,12 @@ def _validate_job_mode_invariants(
             "monitor_script/monitor_url cannot be combined with no_agent=True — "
             "the whole point of a monitor job is to suppress or wake the AGENT "
             "based on source changes. Use a plain no_agent script job instead."
+        )
+    if monitor_retry_on_failure and not (monitor_script or monitor_url):
+        raise ValueError(
+            "monitor_retry_on_failure requires a monitor source "
+            "(monitor_script or monitor_url) — it changes when the monitor "
+            "hash is committed, which is meaningless without a monitor."
         )
     if no_agent and not script:
         raise ValueError(NO_AGENT_WITHOUT_SCRIPT_ERROR)
@@ -1964,6 +1971,9 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    monitor_retry_on_failure: bool = False,
+    fallback_provider: Optional[str] = None,
+    fallback_model: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2031,6 +2041,20 @@ def create_job(
                 exactly like config-set effort. Inert with ``no_agent=True``
                 (no LLM call to configure). None/empty = unset (job follows
                 config resolution, pre-existing behavior).
+        monitor_retry_on_failure: Opt-in monitor commit-on-success semantics.
+                When True (requires a monitor source), a detected output
+                change is committed to ``monitor_state`` ONLY after the agent
+                run completes successfully; a failed run leaves the change
+                retryable on the next tick (at-least-once). When False/absent
+                (default, legacy), the change is committed at detection time
+                and a failed run consumes it (at-most-once).
+        fallback_provider: Optional per-job fallback provider pin. Must be
+                paired with ``fallback_model``. When set, this single-entry
+                chain REPLACES the global ``fallback_providers`` chain for
+                this job only; other jobs are unaffected. Absent = job
+                follows the global chain (pre-existing behavior).
+        fallback_model: Optional per-job fallback model pin, paired with
+                ``fallback_provider``.
 
     Returns:
         The created job dict
@@ -2068,6 +2092,18 @@ def create_job(
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
     normalized_monitor_url = normalized_monitor_url or None
+    normalized_monitor_retry = bool(monitor_retry_on_failure)
+    normalized_fallback_provider = _normalize_job_optional_text(fallback_provider)
+    normalized_fallback_model = _normalize_job_optional_text(fallback_model)
+
+    # The per-job fallback pin is a PAIR: one axis without the other would
+    # mix a pinned provider with an unrelated model (or vice versa) —
+    # exactly the provider/model non-atomicity the primary pin forbids.
+    if bool(normalized_fallback_provider) != bool(normalized_fallback_model):
+        raise ValueError(
+            "fallback_provider and fallback_model must be set together "
+            "(or both cleared) — the per-job fallback pin is an atomic pair."
+        )
 
     # Monitor-mode validation: exactly one source, and monitor mode only
     # makes sense when there IS an agent to suppress/wake.
@@ -2080,6 +2116,7 @@ def create_job(
         normalized_monitor_url,
         normalized_no_agent,
         normalized_script,
+        normalized_monitor_retry,
     )
 
     # Normalize context_from: accept str or list of str, store as list or None
@@ -2180,6 +2217,16 @@ def create_job(
     # absent key = job follows config resolution (pre-feature behavior).
     if normalized_reasoning_effort is not None:
         job["reasoning_effort"] = normalized_reasoning_effort
+    # Same conditional-persist rule for the monitor commit-on-success
+    # opt-in: absent key = legacy commit-at-detection semantics, and
+    # existing jobs stay byte-identical (no migration).
+    if normalized_monitor_retry:
+        job["monitor_retry_on_failure"] = True
+    # Same conditional-persist rule for the per-job fallback pin pair:
+    # absent keys = job follows the global fallback_providers chain.
+    if normalized_fallback_provider and normalized_fallback_model:
+        job["fallback_provider"] = normalized_fallback_provider
+        job["fallback_model"] = normalized_fallback_model
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -2295,8 +2342,51 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["reasoning_effort"]
                 )
 
+            # Normalize the monitor commit-on-success opt-in: truthy stores
+            # True; falsy CLEARS the key (post-merge pop below) so the
+            # record returns to the legacy absent-key shape (byte-identical
+            # to pre-feature jobs).
+            _monitor_retry_touched = "monitor_retry_on_failure" in updates
+            if _monitor_retry_touched:
+                updates["monitor_retry_on_failure"] = bool(
+                    updates["monitor_retry_on_failure"]
+                )
+
+            # Normalize the per-job fallback pin pair the same way
+            # create_job does (empty string clears the axis; the None-valued
+            # key is popped post-merge below so a cleared pin vanishes from
+            # the record entirely).
+            _fallback_axes_touched = bool(
+                {"fallback_provider", "fallback_model"}.intersection(updates)
+            )
+            for _fb_field in ("fallback_provider", "fallback_model"):
+                if _fb_field in updates:
+                    updates[_fb_field] = _normalize_job_optional_text(
+                        updates[_fb_field]
+                    )
+
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
+
+            if _monitor_retry_touched and not updated.get(
+                "monitor_retry_on_failure"
+            ):
+                updated.pop("monitor_retry_on_failure", None)
+            if _fallback_axes_touched:
+                for _fb_field in ("fallback_provider", "fallback_model"):
+                    if updated.get(_fb_field) is None:
+                        updated.pop(_fb_field, None)
+                # The fallback pin is an atomic pair (same rule as
+                # create_job): one axis without the other would mix a
+                # pinned provider with an unrelated model.
+                if bool(updated.get("fallback_provider")) != bool(
+                    updated.get("fallback_model")
+                ):
+                    raise ValueError(
+                        "fallback_provider and fallback_model must be set "
+                        "together (or both cleared) — the per-job fallback "
+                        "pin is an atomic pair."
+                    )
 
             if (
                 is_terminal_job(job)
@@ -2319,7 +2409,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             # monitor: the scheduler's no_agent short-circuit runs before
             # the monitor gate). Scoped to changed fields so legacy records
             # untouched by this update keep loading.
-            if {"monitor_script", "monitor_url", "no_agent", "script"}.intersection(updates):
+            if {
+                "monitor_script",
+                "monitor_url",
+                "no_agent",
+                "script",
+                "monitor_retry_on_failure",
+            }.intersection(updates):
                 _upd_script = updated.get("script")
                 _upd_script = str(_upd_script).strip() if isinstance(_upd_script, str) else None
                 _validate_job_mode_invariants(
@@ -2327,6 +2423,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updated.get("monitor_url") or None,
                     bool(updated.get("no_agent")),
                     _upd_script or None,
+                    bool(updated.get("monitor_retry_on_failure")),
                 )
 
             if any(k in updates for k in _PAYLOAD_FIELDS):

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -27,6 +27,32 @@ State lives in two places, both durable across scheduler restarts:
 
 Inspired by: ChatGPT Work monitor tasks (idea-level, docs-only);
 enabler: #80774.
+
+Failure-retry semantics (opt-in, ``monitor_retry_on_failure``):
+
+* DEFAULT (field absent/False — legacy): the new hash is committed at
+  DETECTION time, before the agent runs. A failed agent run consumes the
+  change; the next tick sees the same output as ``no_change`` and stays
+  silent. At-most-once alerting per change.
+* OPT-IN (``monitor_retry_on_failure: true``): detection stashes the new
+  hash in a process-local PENDING slot instead of committing it, and
+  ``run_job`` commits it only when the agent run completes successfully
+  (``commit_monitor_change``). A failed agent run leaves the stored hash
+  untouched, so the next tick re-detects the SAME change and retries the
+  agent — at-least-once alerting per change. Opt-in because replay can
+  duplicate side effects for jobs whose agent acts on the world; jobs
+  that do not opt in keep byte-identical legacy behavior.
+* Commit boundary: the hash commits on AGENT-RUN SUCCESS inside
+  ``run_job`` — BEFORE delivery. A delivery error afterwards never
+  un-commits (the agent already acted on the change; replaying it would
+  duplicate side effects, and delivery failure is tracked separately via
+  ``last_delivery_error``). A wake-gate skip (``wakeAgent: false``) does
+  NOT commit — the agent never ran, so the change stays pending.
+* Crash/restart: the pending slot is process-local, so a scheduler crash
+  between detection and commit simply re-detects the change on the next
+  tick (the stored hash was never touched) — correct by construction.
+  A no_change tick (output reverted to the committed output) CLEARS the
+  pending slot so an evaporated change cannot be committed stale later.
 """
 
 from __future__ import annotations
@@ -34,6 +60,7 @@ from __future__ import annotations
 import difflib
 import hashlib
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Optional
 
@@ -49,6 +76,43 @@ URL_TIMEOUT_SECONDS = 30
 MAX_URL_BYTES = 262_144  # 256 KiB
 
 _SNAPSHOT_FILENAME = "monitor_last_output.txt"
+
+
+# Process-local pending commits for ``monitor_retry_on_failure`` jobs:
+# job_id -> (new_hash, output). Detection STASHES here instead of
+# committing; ``commit_monitor_change`` persists after a successful agent
+# run. Process-local by design (see module docstring): a crash simply
+# re-detects the change next tick. Guarded by a lock because the
+# scheduler fires jobs from a parallel thread pool.
+_PENDING_LOCK = threading.Lock()
+_PENDING_COMMITS: dict[str, tuple[str, str]] = {}
+
+
+def job_retries_monitor_on_failure(job: dict) -> bool:
+    """True when the job opted in to commit-on-success monitor semantics."""
+    return bool(job.get("monitor_retry_on_failure"))
+
+
+def commit_monitor_change(job_id: str) -> bool:
+    """Persist a pending monitor change after a successful agent run.
+
+    No-op (returns False) when the job has no pending change — legacy
+    jobs commit at detection time and never populate the slot. Idempotent:
+    a second call after a successful commit finds an empty slot.
+    """
+    with _PENDING_LOCK:
+        pending = _PENDING_COMMITS.pop(str(job_id or ""), None)
+    if pending is None:
+        return False
+    new_hash, output = pending
+    _persist_monitor_state(str(job_id), new_hash, output)
+    return True
+
+
+def clear_pending_monitor_change(job_id: str) -> None:
+    """Drop a pending change without committing (evaporated change)."""
+    with _PENDING_LOCK:
+        _PENDING_COMMITS.pop(str(job_id or ""), None)
 
 
 @dataclass
@@ -147,10 +211,19 @@ def job_has_monitor(job: dict) -> bool:
 def check_monitor(job: dict) -> MonitorOutcome:
     """Run the monitor source and decide whether the agent should run.
 
-    On change (or first run) the new hash + snapshot are persisted BEFORE
-    the agent runs — detection time is the state boundary, so a failed
-    agent run doesn't re-alert on the same content forever.
-    On failure nothing is persisted.
+    On change (or first run) the persistence boundary depends on the
+    job's ``monitor_retry_on_failure`` flag:
+
+    * LEGACY (flag absent/False): the new hash + snapshot are persisted
+      BEFORE the agent runs — detection time is the state boundary, so a
+      failed agent run doesn't re-alert on the same content forever.
+    * OPT-IN (flag True): the new hash + output are stashed in the
+      process-local pending slot instead; ``commit_monitor_change``
+      persists them only after the agent run completes successfully, so
+      a failed run leaves the change retryable on the next tick.
+
+    On source failure nothing is persisted (and any pending change is
+    left in place — the retry is still owed).
     """
     job_id = str(job.get("id") or "")
     ok, output = _run_monitor_source(job)
@@ -163,6 +236,10 @@ def check_monitor(job: dict) -> MonitorOutcome:
     last_hash = state.get("last_output_hash")
 
     if last_hash is not None and new_hash == last_hash:
+        # Unchanged — the previously detected change (if any) evaporated:
+        # the source returned to the committed output, so a stale pending
+        # commit must not be persisted later by an unrelated success.
+        clear_pending_monitor_change(job_id)
         return MonitorOutcome(ok=True, changed=False)
 
     first_run = last_hash is None
@@ -188,7 +265,16 @@ def check_monitor(job: dict) -> MonitorOutcome:
             f"### Current output\n\n```\n{shown_output}\n```"
         )
 
-    _persist_monitor_state(job_id, new_hash, output)
+    if job_retries_monitor_on_failure(job):
+        # Commit-on-success: stash the detected change; run_job persists it
+        # via commit_monitor_change only after the agent completes
+        # successfully. A failed agent run leaves the stored hash untouched
+        # so the next tick re-detects THIS change and retries.
+        with _PENDING_LOCK:
+            _PENDING_COMMITS[job_id] = (new_hash, output)
+    else:
+        # Legacy: detection time is the state boundary — persist now.
+        _persist_monitor_state(job_id, new_hash, output)
     return MonitorOutcome(
         ok=True, changed=True, first_run=first_run, context_block=context_block
     )

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -121,32 +121,106 @@ def _set_cron_session_title(session_db, session_id, base_title):
         return deduped
 
 
-def _fallback_chain_phrase() -> str:
+def _resolve_job_fallback_chain(job: dict, cfg: dict) -> list:
+    """Effective fallback chain for ONE cron job.
+
+    A job pinned with ``fallback_provider`` + ``fallback_model`` (an atomic
+    pair, validated in cron.jobs) runs a single-entry chain of exactly that
+    pin — REPLACING the global ``fallback_providers`` chain for this job
+    only. Every other job keeps the global chain (pre-existing behavior).
+    """
+    if isinstance(job, dict):
+        fb_provider = str(job.get("fallback_provider") or "").strip()
+        fb_model = str(job.get("fallback_model") or "").strip()
+        if fb_provider and fb_model:
+            return [{"provider": fb_provider, "model": fb_model}]
+    return get_fallback_chain(cfg)
+
+
+def _job_backend_identity(job: dict):
+    """Best-effort BackendIdentity of the job's CURRENT (failing) backend.
+
+    Pinned axes win; unpinned axes fall back to the creation-time drift
+    snapshots (what the job actually resolved to). Returns None when the
+    identity is unprovable — callers must then fail to the legacy wording
+    rather than guess.
+    """
+    if not isinstance(job, dict):
+        return None
+    provider = (job.get("provider") or job.get("provider_snapshot") or "")
+    model = (job.get("model") or job.get("model_snapshot") or "")
+    base_url = str(job.get("base_url") or "")
+    provider = str(provider).strip()
+    model = str(model).strip()
+    if not provider or not model:
+        return None
+    from agent.backend_identity import BackendIdentity
+
+    return BackendIdentity.build(provider=provider, model=model, base_url=base_url)
+
+
+def _fallback_chain_phrase(job: dict | None = None) -> str:
     """Wording for the fallback-chain clause of a provider-failure message.
 
     "Fallback chain was exhausted or unavailable." used to fire
     unconditionally on every provider failure, which implies a fallback was
-    attempted and failed. Most installs have fallback_providers: [] (no
-    chain configured at all), so that wording was actively misleading: it
-    sent the operator looking for why a fallback "failed" when none was
-    ever attempted. Distinguish the two cases explicitly.
+    attempted and failed. Two real cases make that wording a lie:
 
-    Fails open to the original ambiguous-but-safe wording if config can't be
-    read (e.g. mid-shutdown, permissions) -- never let a lookup error crash
-    failure-message generation itself.
+    1. Most installs have fallback_providers: [] (no chain at all) — nothing
+       was attempted. Report the no-chain guidance instead.
+    2. The chain exists but EVERY entry resolves to the same backend as the
+       primary, so the agent's skip predicate (agent.backend_identity's
+       should_skip_candidate, MODEL scope — a timeout/429 kills one
+       deployment) skipped them all. Nothing was attempted either, and
+       "exhausted" sends the operator debugging a fallback that was never
+       tried (field-reported: job pinned to zai/glm-5.3 with its only
+       fallback ALSO zai/glm-5.3 → skipped as same-backend, alert still
+       claimed "exhausted or unavailable").
+
+    When at least one entry is a genuinely different backend, the chain was
+    really walked and the legacy wording is honest. When the job's backend
+    identity is unprovable (unpinned, no snapshot), fail open to the legacy
+    ambiguous-but-safe wording. A config-read error fails open the same way
+    — never let a lookup error crash failure-message generation itself.
     """
     try:
         cfg = load_config() or {}
-        chain = get_fallback_chain(cfg)
+        chain = _resolve_job_fallback_chain(job or {}, cfg)
     except Exception:
         return "Fallback chain was exhausted or unavailable."
-    if chain:
-        return "Fallback chain was exhausted or unavailable."
-    return (
-        "No fallback chain configured — add one with `hermes fallback add`, "
-        "or set a cron fleet default via `cron.model` + `cron.model_provider` "
-        "in config.yaml."
-    )
+    if not chain:
+        return (
+            "No fallback chain configured — add one with `hermes fallback add`, "
+            "or set a cron fleet default via `cron.model` + `cron.model_provider` "
+            "in config.yaml."
+        )
+    try:
+        from agent.backend_identity import BackendIdentity, should_skip_candidate
+
+        current = _job_backend_identity(job or {})
+        if current is not None:
+            alternates = 0
+            for entry in chain:
+                if not isinstance(entry, dict):
+                    continue
+                fb_ident = BackendIdentity.build(
+                    provider=entry.get("provider"),
+                    model=entry.get("model"),
+                    base_url=entry.get("base_url") or "",
+                )
+                if not should_skip_candidate(fb_ident, current):
+                    alternates += 1
+            if alternates == 0:
+                return (
+                    "Every configured fallback resolves to the SAME backend as "
+                    "the primary, so no fallback was ever tried — pin a fallback "
+                    "on a different provider/model (e.g. `hermes cron edit "
+                    "<job_id> --fallback-provider <provider> --fallback-model "
+                    "<model>`, or fix the global chain with `hermes fallback`)."
+                )
+    except Exception:
+        pass  # fail open to the legacy wording below
+    return "Fallback chain was exhausted or unavailable."
 
 
 def _failure_streak_nudge(job: dict) -> str:
@@ -282,7 +356,7 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             reason = "quota limit"
         return (
             f"⚠️ Cron '{job_name}' failed: provider {reason}. "
-            f"{_fallback_chain_phrase()} "
+            f"{_fallback_chain_phrase(job)} "
             "Full details saved in cron output."
         )
 
@@ -329,7 +403,7 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
-            f"{_fallback_chain_phrase()} "
+            f"{_fallback_chain_phrase(job)} "
             "Full details saved in cron output."
         )
 
@@ -5088,9 +5162,12 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     auth-fallback path may legitimately rescue a missing primary key, so
     blocking here would break that contract (and burning zero LLM calls is
     already guaranteed by the fallback resolution being config-local).
+    The chain consulted is the JOB's effective chain: a per-job
+    ``fallback_provider`` + ``fallback_model`` pin counts as a configured
+    fallback even when no global ``fallback_providers`` chain exists.
     """
     try:
-        if get_fallback_chain(cfg):
+        if _resolve_job_fallback_chain(job, cfg):
             return None
     except Exception:
         return None  # fail-open: never block on a preflight-internal error
@@ -6155,7 +6232,7 @@ def run_job(
                 reason,
                 resolve_exc,
             )
-            fb_list = get_fallback_chain(_cfg)
+            fb_list = _resolve_job_fallback_chain(job, _cfg)
             runtime = None
             for entry in fb_list:
                 if not isinstance(entry, dict):
@@ -6290,7 +6367,7 @@ def run_job(
                     f"config is pinned or restored. See #44585."
                 )
 
-        fallback_model = get_fallback_chain(_cfg) or None
+        fallback_model = _resolve_job_fallback_chain(job, _cfg) or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()
         if runtime_provider:
@@ -6671,6 +6748,38 @@ def run_job(
 """
         
         logger.info("Job '%s' completed successfully", job_name)
+
+        # Monitor commit-on-success boundary (monitor_retry_on_failure
+        # opt-in): check_monitor only STASHED the detected change; commit
+        # it now that the agent run completed successfully. Deliberately
+        # BEFORE the caller's delivery step: a delivery error afterwards
+        # never un-commits — the agent already consumed the change, and
+        # replaying it would duplicate side effects. No-op for legacy
+        # monitor jobs (committed at detection) and non-monitor jobs.
+        #
+        # Empty-response parity: the caller reclassifies success=True with
+        # an empty final_response as a FAILURE (#8585), so for opt-in retry
+        # jobs an empty response must NOT commit — the change would be
+        # consumed by a run the scheduler contract itself reports as
+        # failed, and the retry would never fire. The pending slot is left
+        # in place so the next identical tick re-detects and re-runs.
+        if job_has_monitor(job):
+            from cron.monitor import (
+                commit_monitor_change,
+                job_retries_monitor_on_failure,
+            )
+
+            if job_retries_monitor_on_failure(job) and not (
+                final_response or ""
+            ).strip():
+                logger.info(
+                    "Job '%s': empty final response — leaving monitor "
+                    "change pending for retry (scheduler treats an empty "
+                    "response as a soft failure)",
+                    job_id,
+                )
+            else:
+                commit_monitor_change(job_id)
 
         # Emit one JSONL line per fire for usage audit.
         _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -545,6 +545,9 @@ def cron_create(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        monitor_retry_on_failure=getattr(args, "monitor_retry_on_failure", None),
+        fallback_provider=getattr(args, "fallback_provider", None),
+        fallback_model=getattr(args, "fallback_model", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -561,6 +564,10 @@ def cron_create(args):
         print(f"  Monitor: {job_data['monitor_script']} (agent runs only on output change)")
     if job_data.get("monitor_url"):
         print(f"  Monitor: {job_data['monitor_url']} (agent runs only on output change)")
+    if job_data.get("monitor_retry_on_failure"):
+        print("  Monitor retry: on (change commits only after a successful agent run)")
+    if job_data.get("fallback_provider"):
+        print(f"  Fallback: {job_data['fallback_provider']} / {job_data.get('fallback_model')} (per-job, replaces global chain)")
     if job_data.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("continuity"):
@@ -620,6 +627,9 @@ def cron_edit(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        monitor_retry_on_failure=getattr(args, "monitor_retry_on_failure", None),
+        fallback_provider=getattr(args, "fallback_provider", None),
+        fallback_model=getattr(args, "fallback_model", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -639,6 +649,10 @@ def cron_edit(args):
         print(f"  Monitor: {updated['monitor_script']} (agent runs only on output change)")
     if updated.get("monitor_url"):
         print(f"  Monitor: {updated['monitor_url']} (agent runs only on output change)")
+    if updated.get("monitor_retry_on_failure"):
+        print("  Monitor retry: on (change commits only after a successful agent run)")
+    if updated.get("fallback_provider"):
+        print(f"  Fallback: {updated['fallback_provider']} / {updated.get('fallback_model')} (per-job, replaces global chain)")
     if updated.get("no_agent"):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("continuity"):

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -120,6 +120,32 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_create.add_argument(
+        "--monitor-retry-on-failure",
+        dest="monitor_retry_on_failure",
+        action="store_true",
+        default=False,
+        help=(
+            "Monitor mode only: commit a detected output change ONLY after "
+            "the agent run succeeds, so a failed run (provider error, "
+            "timeout) retries the SAME change next tick (at-least-once). "
+            "Default off = legacy commit-at-detection (at-most-once)."
+        ),
+    )
+    cron_create.add_argument(
+        "--fallback-provider",
+        dest="fallback_provider",
+        help=(
+            "Per-job fallback provider pin (user-owned; the agent's cronjob "
+            "tool cannot set this). REQUIRES --fallback-model. Replaces the "
+            "global fallback_providers chain for this job only."
+        ),
+    )
+    cron_create.add_argument(
+        "--fallback-model",
+        dest="fallback_model",
+        help="Fallback model paired with --fallback-provider.",
+    )
+    cron_create.add_argument(
         "--continuity",
         dest="continuity",
         action="store_const",
@@ -244,6 +270,37 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--provider",
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--monitor-retry-on-failure",
+        dest="monitor_retry_on_failure",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "Monitor mode only: commit a detected change only after the "
+            "agent run succeeds (failed runs retry the same change)."
+        ),
+    )
+    cron_edit.add_argument(
+        "--no-monitor-retry-on-failure",
+        dest="monitor_retry_on_failure",
+        action="store_const",
+        const=False,
+        help="Restore legacy monitor commit-at-detection semantics.",
+    )
+    cron_edit.add_argument(
+        "--fallback-provider",
+        dest="fallback_provider",
+        help=(
+            "Per-job fallback provider pin (requires --fallback-model). "
+            "Pass empty string together with --fallback-model '' to clear."
+        ),
+    )
+    cron_edit.add_argument(
+        "--fallback-model",
+        dest="fallback_model",
+        help="Fallback model paired with --fallback-provider.",
     )
     cron_edit.add_argument(
         "--reasoning-effort",

--- a/tests/cron/test_cron_fallback_chain_phrase.py
+++ b/tests/cron/test_cron_fallback_chain_phrase.py
@@ -1,0 +1,172 @@
+"""Truthful fallback-chain wording + per-job fallback chain resolution.
+
+Incident (2026-08-29, ufc-watch): the job's only configured fallback
+resolved to the SAME backend as the primary (zai/glm-5.3 on both), so the
+agent's skip predicate skipped it and no fallback was ever tried — yet the
+delivered alert claimed "Fallback chain was exhausted or unavailable.",
+sending the operator to debug a fallback failure that never happened.
+
+Three wording branches, all grounded in agent.backend_identity's
+should_skip_candidate (the same predicate the runtime skip uses):
+
+* same-backend skipped  → every chain entry resolves to the primary's
+  deployment; nothing was tried; say so and give the remediation.
+* no alternate configured → empty chain; existing guidance wording.
+* alternate attempted but failed → at least one genuinely different
+  backend exists; the legacy "exhausted or unavailable." is honest.
+
+Plus the per-job pin (fallback_provider + fallback_model) which REPLACES
+the global chain for that job only.
+"""
+
+import cron.scheduler as scheduler
+from cron.scheduler import (
+    _fallback_chain_phrase,
+    _resolve_job_fallback_chain,
+    _summarize_cron_failure_for_delivery,
+)
+
+ZAI_CHAIN = [{"provider": "zai", "model": "glm-5.3"}]
+REAL_ALT_CHAIN = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-5"}]
+
+
+def _patch_cfg(monkeypatch, chain):
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"fallback_providers": chain})
+    monkeypatch.setattr(scheduler, "get_fallback_chain", lambda cfg: list(chain))
+
+
+# ---------------------------------------------------------------------------
+# Branch 1: same-backend skipped (the incident shape)
+# ---------------------------------------------------------------------------
+
+
+def test_same_backend_fallback_is_not_reported_as_exhausted(monkeypatch):
+    """EXACT incident shape: primary zai/glm-5.3, only fallback zai/glm-5.3."""
+    _patch_cfg(monkeypatch, ZAI_CHAIN)
+    job = {"name": "ufc-watch", "id": "fc73758f1e75",
+           "provider": "zai", "model": "glm-5.3"}
+    msg = _summarize_cron_failure_for_delivery(job, "Request timed out.")
+    assert "provider timeout" in msg
+    assert "same backend" in msg.lower()
+    assert "no fallback was ever tried" in msg.lower()
+    assert "exhausted or unavailable" not in msg
+    assert "No fallback chain configured" not in msg
+
+
+def test_same_backend_all_entries_skipped_wording(monkeypatch):
+    _patch_cfg(
+        monkeypatch,
+        [
+            {"provider": "zai", "model": "glm-5.3"},
+            {"provider": "zai", "model": "glm-5.3", "base_url": ""},
+        ],
+    )
+    job = {"id": "j1", "provider": "zai", "model": "glm-5.3"}
+    phrase = _fallback_chain_phrase(job)
+    assert "same backend" in phrase.lower()
+    assert "exhausted" not in phrase
+
+
+# ---------------------------------------------------------------------------
+# Branch 2: no alternate configured (pre-existing, kept honest)
+# ---------------------------------------------------------------------------
+
+
+def test_no_chain_guidance_unchanged(monkeypatch):
+    _patch_cfg(monkeypatch, [])
+    job = {"id": "j1", "provider": "zai", "model": "glm-5.3"}
+    phrase = _fallback_chain_phrase(job)
+    assert "No fallback chain configured" in phrase
+
+
+# ---------------------------------------------------------------------------
+# Branch 3: alternate attempted but failed (legacy wording is honest)
+# ---------------------------------------------------------------------------
+
+
+def test_real_alternate_keeps_exhausted_wording(monkeypatch):
+    _patch_cfg(monkeypatch, REAL_ALT_CHAIN)
+    job = {"id": "j1", "provider": "zai", "model": "glm-5.3"}
+    phrase = _fallback_chain_phrase(job)
+    assert phrase == "Fallback chain was exhausted or unavailable."
+
+
+def test_mixed_chain_with_one_real_alternate_keeps_exhausted(monkeypatch):
+    _patch_cfg(monkeypatch, ZAI_CHAIN + REAL_ALT_CHAIN)
+    job = {"id": "j1", "provider": "zai", "model": "glm-5.3"}
+    assert _fallback_chain_phrase(job) == "Fallback chain was exhausted or unavailable."
+
+
+def test_unprovable_job_identity_fails_open_to_legacy(monkeypatch):
+    """Unpinned job with no snapshots: identity unknown → legacy wording,
+    never a guess."""
+    _patch_cfg(monkeypatch, ZAI_CHAIN)
+    job = {"id": "j1", "name": "unpinned"}
+    assert _fallback_chain_phrase(job) == "Fallback chain was exhausted or unavailable."
+
+
+def test_snapshot_axes_used_when_unpinned(monkeypatch):
+    """Unpinned job: creation-time drift snapshots supply the identity."""
+    _patch_cfg(monkeypatch, ZAI_CHAIN)
+    job = {
+        "id": "j1",
+        "provider_snapshot": "zai",
+        "model_snapshot": "glm-5.3",
+    }
+    phrase = _fallback_chain_phrase(job)
+    assert "same backend" in phrase.lower()
+
+
+def test_config_error_still_fails_open(monkeypatch):
+    def _raise():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr(scheduler, "load_config", _raise)
+    job = {"id": "j1", "provider": "zai", "model": "glm-5.3"}
+    assert _fallback_chain_phrase(job) == "Fallback chain was exhausted or unavailable."
+
+
+# ---------------------------------------------------------------------------
+# Per-job fallback pin (fix 4): resolution + wording integration
+# ---------------------------------------------------------------------------
+
+
+def test_per_job_pin_replaces_global_chain(monkeypatch):
+    _patch_cfg(monkeypatch, REAL_ALT_CHAIN)
+    job = {"fallback_provider": "openai-codex", "fallback_model": "gpt-5.5"}
+    assert _resolve_job_fallback_chain(job, {}) == [
+        {"provider": "openai-codex", "model": "gpt-5.5"}
+    ]
+
+
+def test_unpinned_job_follows_global_chain(monkeypatch):
+    _patch_cfg(monkeypatch, REAL_ALT_CHAIN)
+    assert _resolve_job_fallback_chain({"id": "j"}, {}) == REAL_ALT_CHAIN
+
+
+def test_per_job_pin_drives_same_backend_wording(monkeypatch):
+    """Global chain has a real alternate, but the job's PIN is same-backend:
+    the job-effective chain decides the wording."""
+    _patch_cfg(monkeypatch, REAL_ALT_CHAIN)
+    job = {
+        "id": "j1",
+        "provider": "zai",
+        "model": "glm-5.3",
+        "fallback_provider": "zai",
+        "fallback_model": "glm-5.3",
+    }
+    phrase = _fallback_chain_phrase(job)
+    assert "same backend" in phrase.lower()
+    assert "exhausted" not in phrase
+
+
+def test_per_job_pin_different_backend_keeps_exhausted(monkeypatch):
+    _patch_cfg(monkeypatch, [])
+    job = {
+        "id": "j1",
+        "provider": "zai",
+        "model": "glm-5.3",
+        "fallback_provider": "openai-codex",
+        "fallback_model": "gpt-5.5",
+    }
+    assert _fallback_chain_phrase(job) == "Fallback chain was exhausted or unavailable."

--- a/tests/cron/test_cron_job_fallback_pin.py
+++ b/tests/cron/test_cron_job_fallback_pin.py
@@ -1,0 +1,159 @@
+"""Per-job fallback pin (fallback_provider + fallback_model) — data layer.
+
+The pin is an ATOMIC pair, conditionally persisted (absent keys = job
+follows the global fallback_providers chain; existing records stay
+byte-identical). Scheduler consumption lives in
+cron.scheduler._resolve_job_fallback_chain (covered in
+test_cron_fallback_chain_phrase.py); these tests pin the
+create/update/persist/validate contract and the cronjob tool wiring.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "scripts").mkdir()
+    (home / "cron").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    return home
+
+
+def test_create_requires_atomic_pair(hermes_env):
+    from cron.jobs import create_job
+
+    with pytest.raises(ValueError, match="atomic pair"):
+        create_job(prompt="p", schedule="every 5m",
+                   fallback_provider="openai-codex")
+    with pytest.raises(ValueError, match="atomic pair"):
+        create_job(prompt="p", schedule="every 5m",
+                   fallback_model="gpt-5.5")
+
+
+def test_create_persists_pair_conditionally(hermes_env):
+    from cron.jobs import create_job, get_job
+
+    pinned = create_job(
+        prompt="p", schedule="every 5m",
+        fallback_provider="openai-codex", fallback_model="gpt-5.5",
+    )
+    reloaded = get_job(pinned["id"])
+    assert reloaded["fallback_provider"] == "openai-codex"
+    assert reloaded["fallback_model"] == "gpt-5.5"
+
+    plain = create_job(prompt="p", schedule="every 5m")
+    reloaded_plain = get_job(plain["id"])
+    assert "fallback_provider" not in reloaded_plain
+    assert "fallback_model" not in reloaded_plain
+
+
+def test_update_set_and_clear_pair(hermes_env):
+    from cron.jobs import create_job, get_job, update_job
+
+    job = create_job(prompt="p", schedule="every 5m")
+    update_job(job["id"], {
+        "fallback_provider": "openai-codex",
+        "fallback_model": "gpt-5.5",
+    })
+    assert get_job(job["id"])["fallback_provider"] == "openai-codex"
+
+    # Clearing both axes removes the keys entirely (legacy shape).
+    update_job(job["id"], {"fallback_provider": "", "fallback_model": ""})
+    reloaded = get_job(job["id"])
+    assert "fallback_provider" not in reloaded
+    assert "fallback_model" not in reloaded
+
+
+def test_update_rejects_half_pair(hermes_env):
+    from cron.jobs import create_job, update_job
+
+    job = create_job(prompt="p", schedule="every 5m")
+    with pytest.raises(ValueError, match="atomic pair"):
+        update_job(job["id"], {"fallback_provider": "openai-codex"})
+    # Failed update leaves the stored record untouched.
+    from cron.jobs import get_job
+    assert "fallback_provider" not in get_job(job["id"])
+
+
+def test_cronjob_tool_create_and_update_fallback_pin(hermes_env):
+    from cron.jobs import get_job
+    from tools.cronjob_tools import cronjob
+
+    created = json.loads(
+        cronjob(
+            action="create",
+            prompt="p",
+            schedule="every 5m",
+            fallback_provider="openai-codex",
+            fallback_model="gpt-5.5",
+            deliver="local",
+        )
+    )
+    assert created.get("success") is True
+    assert created["job"]["fallback_provider"] == "openai-codex"
+    assert created["job"]["fallback_model"] == "gpt-5.5"
+
+    updated = json.loads(
+        cronjob(
+            action="update",
+            job_id=created["job_id"],
+            fallback_provider="",
+            fallback_model="",
+        )
+    )
+    assert updated.get("success") is True
+    reloaded = get_job(created["job_id"])
+    assert "fallback_provider" not in reloaded
+
+
+def test_cronjob_tool_rejects_half_pair(hermes_env):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            prompt="p",
+            schedule="every 5m",
+            fallback_provider="openai-codex",
+            deliver="local",
+        )
+    )
+    assert result.get("success") is False
+    assert "atomic pair" in result.get("error", "")
+
+
+def test_model_dispatch_cannot_set_fallback_pin(hermes_env):
+    """Standing spend-routing policy: like model/provider, the model-facing
+    cronjob handler must NOT accept fallback pins from agent arguments."""
+    from tools.cronjob_tools import _cronjob_handler
+
+    out = json.loads(
+        _cronjob_handler(
+            {
+                "action": "create",
+                "prompt": "p",
+                "schedule": "every 5m",
+                "deliver": "local",
+                # Attempted pin via model args — must be ignored.
+                "fallback_provider": "openai-codex",
+                "fallback_model": "gpt-5.5",
+            }
+        )
+    )
+    assert out.get("success") is True
+    from cron.jobs import get_job
+    reloaded = get_job(out["job_id"])
+    assert "fallback_provider" not in reloaded
+    assert "fallback_model" not in reloaded

--- a/tests/cron/test_cron_preflight_fallback_pin.py
+++ b/tests/cron/test_cron_preflight_fallback_pin.py
@@ -1,0 +1,83 @@
+"""Provider-key preflight must honor the per-job fallback pin.
+
+Finding (engineering review, ufc-watch candidate): the pre-dispatch
+provider-key probe consulted ONLY the global ``fallback_providers`` chain
+(``get_fallback_chain(cfg)``), so a job pinned with an atomic
+``fallback_provider`` + ``fallback_model`` pair was preflight-BLOCKED on a
+missing primary key even though the auth-fallback path would have rescued
+the run via the pin. The probe now consults the job's effective chain via
+``_resolve_job_fallback_chain(job, cfg)`` — the same resolution run_job
+itself uses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME so module reloads never touch the real home."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "cron").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+    return home
+
+
+def _raise_auth_error(monkeypatch):
+    """Make primary-provider resolution fail with a missing credential."""
+    from hermes_cli import runtime_provider as _rtp
+    from hermes_cli.auth import AuthError
+
+    def _boom(**_kw):
+        raise AuthError("No API key found for provider 'test'", provider="test")
+
+    monkeypatch.setattr(_rtp, "resolve_runtime_provider", _boom)
+
+
+def test_pinned_fallback_without_global_chain_not_blocked(hermes_env, monkeypatch):
+    """Pinned fallback + no global chain + missing primary key => the
+    preflight probe must NOT block (the pin is the rescue path)."""
+    import cron.scheduler as sched
+
+    _raise_auth_error(monkeypatch)
+    job = {
+        "id": "j1",
+        "provider": "test",
+        "model": "m1",
+        "fallback_provider": "other",
+        "fallback_model": "m2",
+    }
+    assert sched._preflight_check_provider_key(job, {}) is None
+
+
+def test_no_fallback_anywhere_still_blocks(hermes_env, monkeypatch):
+    """No pin and no global chain + missing primary key => blocked, as
+    before (pre-existing behavior preserved)."""
+    import cron.scheduler as sched
+
+    _raise_auth_error(monkeypatch)
+    job = {"id": "j2", "provider": "test", "model": "m1"}
+    reason = sched._preflight_check_provider_key(job, {})
+    assert reason is not None
+    assert "provider credential missing" in reason
+
+
+def test_unpinned_job_still_follows_global_chain(hermes_env, monkeypatch):
+    """Unrelated jobs keep global/default behavior: a configured global
+    chain still skips the probe for a job without a pin."""
+    import cron.scheduler as sched
+
+    _raise_auth_error(monkeypatch)
+    job = {"id": "j3", "provider": "test", "model": "m1"}
+    cfg = {"fallback_providers": [{"provider": "other", "model": "m2"}]}
+    assert sched._preflight_check_provider_key(job, cfg) is None

--- a/tests/cron/test_monitor_retry_on_failure.py
+++ b/tests/cron/test_monitor_retry_on_failure.py
@@ -1,0 +1,453 @@
+"""Tests for monitor_retry_on_failure — opt-in commit-on-success semantics.
+
+Incident (2026-08-29, ufc-watch): the monitor hash was persisted at
+DETECTION time, so when the agent run then died on provider timeouts the
+change was already consumed and every retry became a silent ``no_change``
+tick. The opt-in field makes the hash commit only after a SUCCESSFUL agent
+run, keeping the change retryable. Legacy jobs (field absent) keep
+commit-at-detection semantics byte-for-byte.
+
+Commit boundary (deliberate): the hash commits on agent-run success inside
+``run_job`` — BEFORE delivery. A delivery error afterwards never un-commits
+(the agent already acted on the change; replay would duplicate side
+effects).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME for each test so jobs/scripts/snapshots don't leak."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "scripts").mkdir()
+    (home / "cron").mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.monitor
+    importlib.reload(cron.monitor)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+def _write_script(home, name: str, body: str) -> str:
+    path = home / "scripts" / name
+    path.write_text(body, encoding="utf-8")
+    return name
+
+
+def _install_agent_stubs(monkeypatch, observed: dict, fail: bool = False,
+                         empty: bool = False):
+    """Stub the agent machinery; fail=True makes every run raise (provider
+    timeout shape); empty=True returns success with an EMPTY final_response
+    (the #8585 soft-failure shape)."""
+    import cron.scheduler as sched
+
+    observed.setdefault("prompts", [])
+    observed.setdefault("agent_runs", 0)
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_conversation(self, prompt, *_a, **_kw):
+            observed["agent_runs"] += 1
+            observed["prompts"].append(prompt)
+            if fail:
+                raise RuntimeError("ReadTimeout: provider request timed out")
+            return {
+                "final_response": "" if empty else "agent done",
+                "messages": [],
+            }
+
+        def get_activity_summary(self):
+            return {"seconds_since_activity": 0.0}
+
+    fake_mod = type(sys)("run_agent")
+    fake_mod.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_mod)
+
+    from hermes_cli import runtime_provider as _rtp
+    monkeypatch.setattr(
+        _rtp,
+        "resolve_runtime_provider",
+        lambda **_kw: {
+            "provider": "test",
+            "api_key": "k",
+            "base_url": "http://test.local",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
+    monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)
+    monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda job, cfg: None)
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+
+    import dotenv
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda *_a, **_kw: True)
+
+
+def _make_job(hermes_env, script_body: str, retry: bool):
+    from cron.jobs import create_job
+
+    _write_script(hermes_env, "mon.sh", script_body)
+    return create_job(
+        prompt="Summarize what changed",
+        schedule="every 5m",
+        monitor_script="mon.sh",
+        deliver="local",
+        monitor_retry_on_failure=retry,
+    )
+
+
+def _stored_state(job_id):
+    from cron.jobs import get_job
+
+    return get_job(job_id).get("monitor_state") or {}
+
+
+# ---------------------------------------------------------------------------
+# data layer: validation + persistence of the opt-in field
+# ---------------------------------------------------------------------------
+
+
+def test_create_retry_flag_requires_monitor_source(hermes_env):
+    from cron.jobs import create_job
+
+    with pytest.raises(ValueError, match="monitor_retry_on_failure requires"):
+        create_job(
+            prompt="p",
+            schedule="every 5m",
+            monitor_retry_on_failure=True,
+        )
+
+
+def test_create_stores_retry_flag_only_when_true(hermes_env):
+    from cron.jobs import create_job, get_job
+
+    _write_script(hermes_env, "mon.sh", "echo stable\n")
+    job_on = create_job(
+        prompt="p", schedule="every 5m", monitor_script="mon.sh",
+        monitor_retry_on_failure=True,
+    )
+    job_off = create_job(
+        prompt="p", schedule="every 5m", monitor_script="mon.sh",
+    )
+    assert get_job(job_on["id"]).get("monitor_retry_on_failure") is True
+    # Legacy shape: key ABSENT (not False) — pre-feature records stay
+    # byte-identical, no migration.
+    assert "monitor_retry_on_failure" not in get_job(job_off["id"])
+
+
+def test_update_door_validation_and_clear(hermes_env):
+    from cron.jobs import create_job, get_job, update_job
+
+    _write_script(hermes_env, "mon.sh", "echo stable\n")
+    plain = create_job(prompt="p", schedule="every 5m")
+    with pytest.raises(ValueError, match="monitor_retry_on_failure requires"):
+        update_job(plain["id"], {"monitor_retry_on_failure": True})
+
+    job = create_job(prompt="p", schedule="every 5m", monitor_script="mon.sh")
+    update_job(job["id"], {"monitor_retry_on_failure": True})
+    assert get_job(job["id"]).get("monitor_retry_on_failure") is True
+    # Clearing returns the record to the absent-key legacy shape.
+    update_job(job["id"], {"monitor_retry_on_failure": False})
+    assert "monitor_retry_on_failure" not in get_job(job["id"])
+
+
+def test_cronjob_tool_create_and_update_retry_flag(hermes_env):
+    from cron.jobs import get_job
+    from tools.cronjob_tools import cronjob
+
+    _write_script(hermes_env, "mon.sh", "echo hi\n")
+    created = json.loads(
+        cronjob(
+            action="create",
+            prompt="React",
+            schedule="every 5m",
+            monitor_script="mon.sh",
+            monitor_retry_on_failure=True,
+            deliver="local",
+        )
+    )
+    assert created.get("success") is True
+    assert created["job"].get("monitor_retry_on_failure") is True
+    assert get_job(created["job_id"]).get("monitor_retry_on_failure") is True
+
+    updated = json.loads(
+        cronjob(
+            action="update",
+            job_id=created["job_id"],
+            monitor_retry_on_failure=False,
+        )
+    )
+    assert updated.get("success") is True
+    assert "monitor_retry_on_failure" not in get_job(created["job_id"])
+
+    rejected = json.loads(
+        cronjob(action="update", job_id=created["job_id"], monitor_script="",
+                monitor_retry_on_failure=True)
+    )
+    assert rejected.get("success") is False
+
+
+# ---------------------------------------------------------------------------
+# scheduler semantics: legacy vs opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_default_consumes_change_on_agent_failure(hermes_env, monkeypatch):
+    """Explicit legacy contract: commit-at-detection. A failed agent run
+    consumes the change; the next tick is no_change. This is exactly the
+    pre-fix behavior non-opted jobs must keep."""
+    from cron.jobs import get_job
+    from cron.scheduler import SILENT_MARKER, run_job
+
+    job = _make_job(hermes_env, "echo 'state A'\n", retry=False)
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed, fail=True)
+
+    success, _doc, _final, error = run_job(job)
+    assert success is False
+    assert error is not None
+    assert observed["agent_runs"] == 1
+    # Hash committed at detection despite the failure (legacy).
+    assert _stored_state(job["id"]).get("last_output_hash")
+
+    job = get_job(job["id"])
+    success, doc, final, error = run_job(job)
+    assert success is True
+    assert final == SILENT_MARKER
+    assert observed["agent_runs"] == 1  # consumed — no retry
+    assert "no_change" in doc
+
+
+def test_optin_failed_run_leaves_change_retryable(hermes_env, monkeypatch):
+    """The incident fix: changed output + provider failure must NOT commit
+    the hash, so the next tick re-detects the SAME change and retries."""
+    from cron.jobs import get_job
+    from cron.scheduler import run_job
+
+    job = _make_job(hermes_env, "echo 'state A'\n", retry=True)
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed, fail=True)
+
+    success, _doc, _final, error = run_job(job)
+    assert success is False
+    assert observed["agent_runs"] == 1
+    # NOTHING committed — first-run baseline never landed.
+    assert _stored_state(job["id"]).get("last_output_hash") is None
+
+
+def test_optin_next_tick_retries_and_success_commits(hermes_env, monkeypatch):
+    from cron.jobs import get_job
+    from cron.scheduler import run_job
+
+    job = _make_job(hermes_env, "echo 'state A'\n", retry=True)
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed, fail=True)
+
+    run_job(job)  # fails, no commit
+    assert observed["agent_runs"] == 1
+
+    # Provider recovers: SAME monitor output, next tick must re-run the
+    # agent (not no_change) and then commit.
+    _install_agent_stubs(monkeypatch, observed, fail=False)
+    job = get_job(job["id"])
+    success, _doc, final, error = run_job(job)
+    assert success is True
+    assert error is None
+    assert observed["agent_runs"] == 2  # retried the same change
+    assert "Monitor Baseline" in observed["prompts"][1]  # still first commit
+    committed = _stored_state(job["id"]).get("last_output_hash")
+    assert committed
+
+    # No-change suppression preserved after the successful commit.
+    from cron.scheduler import SILENT_MARKER
+
+    job = get_job(job["id"])
+    success, doc, final, error = run_job(job)
+    assert success is True
+    assert final == SILENT_MARKER
+    assert observed["agent_runs"] == 2  # unchanged — suppressed
+    assert "no_change" in doc
+
+
+def test_optin_change_after_commit_also_retries(hermes_env, monkeypatch):
+    """A SECOND change (post-commit) is retried the same way when the agent
+    fails on it."""
+    from cron.jobs import get_job
+    from cron.scheduler import run_job
+
+    job = _make_job(hermes_env, "echo 'state A'\n", retry=True)
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed, fail=False)
+    run_job(job)  # baseline A commits
+    hash_a = _stored_state(job["id"])["last_output_hash"]
+
+    _write_script(hermes_env, "mon.sh", "echo 'state B'\n")
+    _install_agent_stubs(monkeypatch, observed, fail=True)
+    job = get_job(job["id"])
+    success, _d, _f, error = run_job(job)
+    assert success is False
+    # B was detected but NOT committed — stored hash is still A's.
+    assert _stored_state(job["id"])["last_output_hash"] == hash_a
+
+    _install_agent_stubs(monkeypatch, observed, fail=False)
+    job = get_job(job["id"])
+    success, _d, _f, error = run_job(job)
+    assert success is True
+    assert observed["agent_runs"] == 3
+    assert "MONITOR CHANGE DETECTED" in observed["prompts"][2]
+    assert _stored_state(job["id"])["last_output_hash"] != hash_a
+
+
+def test_optin_reverted_output_clears_pending(hermes_env, monkeypatch):
+    """Change detected, agent fails, source REVERTS to committed output →
+    no_change tick clears the stale pending commit so a later unrelated
+    success cannot persist it."""
+    from cron.jobs import get_job
+    from cron.scheduler import SILENT_MARKER, run_job
+    import cron.monitor as monitor
+
+    job = _make_job(hermes_env, "echo 'state A'\n", retry=True)
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed, fail=False)
+    run_job(job)  # baseline A commits
+
+    _write_script(hermes_env, "mon.sh", "echo 'state B'\n")
+    _install_agent_stubs(monkeypatch, observed, fail=True)
+    job = get_job(job["id"])
+    run_job(job)  # B detected (pending), agent fails
+    assert monitor._PENDING_COMMITS.get(job["id"]) is not None
+
+    _write_script(hermes_env, "mon.sh", "echo 'state A'\n")  # revert
+    job = get_job(job["id"])
+    success, doc, final, error = run_job(job)
+    assert success is True
+    assert final == SILENT_MARKER  # back at committed output → no_change
+    assert monitor._PENDING_COMMITS.get(job["id"]) is None
+
+
+def test_optin_delivery_error_still_commits(hermes_env, monkeypatch):
+    """Delivery-error boundary (deliberate): the hash commits on agent-run
+    success BEFORE delivery, so a failed delivery never re-arms the change
+    (the agent already acted on it; replay would duplicate side effects)."""
+    from cron.jobs import get_job
+    import cron.scheduler as scheduler
+
+    _write_script(hermes_env, "mon.sh", "echo 'state A'\n")
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt="Summarize what changed",
+        schedule="every 5m",
+        monitor_script="mon.sh",
+        deliver="telegram",
+        name="retry delivery boundary",
+        monitor_retry_on_failure=True,
+    )
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed, fail=False)
+    # Skip the delivery-credential preflight (no gateway config in the test
+    # home) so the run reaches the delivery step itself.
+    monkeypatch.setattr(scheduler, "_preflight_check_delivery", lambda job: None)
+    monkeypatch.setattr(
+        scheduler, "_deliver_result", lambda *a, **kw: "delivery boom"
+    )
+
+    assert scheduler.run_one_job(job) is True
+    assert observed["agent_runs"] == 1
+    # Committed despite the delivery failure.
+    assert _stored_state(job["id"]).get("last_output_hash")
+    reloaded = get_job(job["id"])
+    assert reloaded.get("last_delivery_error") == "delivery boom"
+
+
+def test_optin_empty_response_does_not_commit_and_retries(hermes_env, monkeypatch):
+    """Review finding (HIGH): the agent run SUCCEEDS but returns an empty
+    final_response. The caller reclassifies that run as failed (#8585), so
+    the monitor commit boundary must match scheduler success semantics:
+    no hash commit, the next identical tick re-detects and re-runs; a
+    later GOOD response commits and the tick after that suppresses."""
+    from cron.jobs import get_job
+    import cron.scheduler as scheduler
+
+    job = _make_job(hermes_env, "echo 'state A'\n", retry=True)
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed, empty=True)
+
+    # Full scheduler path (run_one_job) so the caller's empty-response
+    # reclassification is exercised, not just run_job's return tuple.
+    assert scheduler.run_one_job(job) is True
+    assert observed["agent_runs"] == 1
+    reloaded = get_job(job["id"])
+    # Failed by the scheduler contract — last_status is NOT ok.
+    assert reloaded.get("last_status") == "error"
+    assert "empty response" in (reloaded.get("last_error") or "")
+    # Hash NOT committed — the change stays retryable.
+    assert _stored_state(job["id"]).get("last_output_hash") is None
+
+    # Next IDENTICAL tick re-detects the same change and re-runs the agent.
+    job = get_job(job["id"])
+    assert scheduler.run_one_job(job) is True
+    assert observed["agent_runs"] == 2
+    assert _stored_state(job["id"]).get("last_output_hash") is None
+
+    # Agent recovers with a real response: the commit boundary opens.
+    _install_agent_stubs(monkeypatch, observed, empty=False)
+    job = get_job(job["id"])
+    assert scheduler.run_one_job(job) is True
+    assert observed["agent_runs"] == 3
+    assert _stored_state(job["id"]).get("last_output_hash")
+    assert get_job(job["id"]).get("last_status") == "ok"
+
+    # No-change suppression preserved after the successful commit.
+    job = get_job(job["id"])
+    assert scheduler.run_one_job(job) is True
+    assert observed["agent_runs"] == 3  # unchanged — suppressed
+
+
+def test_optin_survives_scheduler_restart(hermes_env, monkeypatch):
+    """Crash/restart correctness: the pending slot is process-local, so a
+    'restart' (module reload) between detection-failure and the next tick
+    simply re-detects the change — the stored hash was never touched."""
+    import importlib
+
+    from cron.jobs import get_job
+    from cron.scheduler import run_job
+
+    job = _make_job(hermes_env, "echo 'state A'\n", retry=True)
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed, fail=True)
+    run_job(job)  # fails; pending only in memory
+    assert _stored_state(job["id"]).get("last_output_hash") is None
+
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.monitor
+    importlib.reload(cron.monitor)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+    _install_agent_stubs(monkeypatch, observed, fail=False)
+
+    job = cron.jobs.get_job(job["id"])
+    success, _d, _f, error = cron.scheduler.run_job(job)
+    assert success is True
+    assert observed["agent_runs"] == 2  # change re-detected and retried
+    assert cron.jobs.get_job(job["id"])["monitor_state"]["last_output_hash"]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -422,6 +422,13 @@ def _mode_guidance_notes(job: Dict[str, Any], user_deliver: Optional[str]) -> Li
             "baseline. The source must emit STABLE output (no timestamps, no "
             "random ordering) or every tick will look changed."
         )
+    if job.get("monitor_retry_on_failure"):
+        notes.append(
+            "monitor_retry_on_failure is ON: a detected change commits only "
+            "after the agent run SUCCEEDS — a failed run re-fires the same "
+            "change next tick (at-least-once; the agent may act on the same "
+            "change more than once)."
+        )
     if job.get("no_agent"):
         notes.append(
             "no_agent mode: stdout is delivered verbatim; EMPTY stdout sends "
@@ -787,6 +794,11 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["monitor_url"] = job["monitor_url"]
     if job.get("monitor_state"):
         result["monitor_state"] = job["monitor_state"]
+    if job.get("monitor_retry_on_failure"):
+        result["monitor_retry_on_failure"] = True
+    if job.get("fallback_provider"):
+        result["fallback_provider"] = job["fallback_provider"]
+        result["fallback_model"] = job.get("fallback_model")
     if job.get("no_agent"):
         result["no_agent"] = True
     if job.get("enabled_toolsets"):
@@ -1371,6 +1383,9 @@ def cronjob(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    monitor_retry_on_failure: Optional[bool] = None,
+    fallback_provider: Optional[str] = None,
+    fallback_model: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1487,6 +1502,14 @@ def cronjob(
                     # dispatch below: models do not make model-config
                     # decisions (standing policy).
                     reasoning_effort=reasoning_effort,
+                    monitor_retry_on_failure=bool(monitor_retry_on_failure),
+                    # fallback_provider/fallback_model reach here from the
+                    # CLI (`hermes cron create/edit --fallback-provider
+                    # --fallback-model`) ONLY — like model/provider they are
+                    # user-owned spend-routing pins and are deliberately not
+                    # read from model arguments in _cronjob_handler.
+                    fallback_provider=_normalize_optional_job_value(fallback_provider),
+                    fallback_model=_normalize_optional_job_value(fallback_model),
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1750,6 +1773,31 @@ def cronjob(
                         "clear one before setting the other.",
                         success=False,
                     )
+            if monitor_retry_on_failure is not None:
+                # Enabling requires a monitor source on the MERGED record —
+                # same invariant create_job enforces, through the update door.
+                if monitor_retry_on_failure:
+                    eff_mon_script = (
+                        updates["monitor_script"] if "monitor_script" in updates else job.get("monitor_script")
+                    )
+                    eff_mon_url = (
+                        updates["monitor_url"] if "monitor_url" in updates else job.get("monitor_url")
+                    )
+                    if not (eff_mon_script or eff_mon_url):
+                        return tool_error(
+                            "monitor_retry_on_failure requires a monitor source "
+                            "(set monitor first, or in the same update).",
+                            success=False,
+                        )
+                updates["monitor_retry_on_failure"] = bool(monitor_retry_on_failure)
+            if fallback_provider is not None:
+                updates["fallback_provider"] = (
+                    _normalize_optional_job_value(fallback_provider) if fallback_provider else None
+                )
+            if fallback_model is not None:
+                updates["fallback_model"] = (
+                    _normalize_optional_job_value(fallback_model) if fallback_model else None
+                )
             if context_from is not None or continuity is not None:
                 # Empty string / empty list clears the field; otherwise validate
                 # each referenced job exists before storing. Normalized to a list
@@ -1885,6 +1933,10 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "default": False,
                 "description": "True = no LLM: the scheduler runs `script` (required) on schedule and delivers its stdout verbatim; empty stdout sends nothing (watchdog pattern). Use for script-only pings with fixed output; keep False for anything needing reasoning."
             },
+            "monitor_retry_on_failure": {
+                "type": "boolean",
+                "description": "Only meaningful with `monitor`. True = a detected output change commits its hash ONLY after the agent run succeeds, so a failed run (provider error, timeout) retries the SAME change next tick (at-least-once — the agent may act on one change more than once). Default false = legacy: the change commits at detection time and a failed run consumes it (at-most-once)."
+            },
             "context_from": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -1975,6 +2027,10 @@ def _cronjob_handler(args, **kw):
         attach_to_session=args.get("attach_to_session"),
         monitor_script=_mon_script,
         monitor_url=_mon_url,
+        # monitor_retry_on_failure is a behavior flag (not spend routing),
+        # so the model MAY set it — unlike fallback_provider/fallback_model,
+        # which stay user-owned like model/provider above.
+        monitor_retry_on_failure=args.get("monitor_retry_on_failure"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     )


### PR DESCRIPTION
## Problem

Cron jobs with a change-detection monitor committed the monitor state at **detection time**, before the agent run finished. If the run then failed (e.g. provider timeouts), the change was already consumed and every subsequent retry ticked as a silent `no_change` — a detected change could be permanently lost to a transient failure.

Related: jobs pinned to a provider/model had no per-job fallback, so a failing pinned backend made retries useless, and the fallback-exhaustion alert could not distinguish "no chain configured" from "chain entries all resolve to the same backend as the primary, so nothing was ever tried".

## Fix

- **Opt-in `monitor_retry_on_failure`** per job: when enabled, the monitor change is committed only after a *successful* agent run (deliberately before delivery — a later delivery error never un-commits, since replay would duplicate side effects). Jobs without the field keep legacy commit-at-detection semantics byte-for-byte.
- **Optional per-job `fallback_provider` + `fallback_model` pair** (atomic, validated in `cron.jobs`): replaces the global `fallback_providers` chain for that job only; all other jobs keep pre-existing global-chain behavior.
- **Fallback-chain alert phrasing** now distinguishes: no chain configured / chain entries all resolve to the same backend as the primary (nothing attempted) / chain genuinely exhausted.
- **CLI + cronjob tool support** for the fallback pair and the retry flag on create/edit, with fail-closed validation (malformed or partial pairs rejected).

## Tests

Focused suites on the head commit — **34 passed in 2.20s** (`pytest -q`):

- `tests/cron/test_monitor_retry_on_failure.py` — 12 passed (commit-on-success, retry-after-failure, legacy semantics preserved, delivery-error boundary)
- `tests/cron/test_cron_fallback_chain_phrase.py` — 12 passed
- `tests/cron/test_cron_job_fallback_pin.py` — 7 passed
- `tests/cron/test_cron_preflight_fallback_pin.py` — 3 passed

## Scope

Single commit, 10 files: `cron/jobs.py`, `cron/monitor.py`, `cron/scheduler.py`, `hermes_cli/cron.py`, `hermes_cli/subcommands/cron.py`, `tools/cronjob_tools.py`, plus the 4 new test files above. No unrelated changes.

---

**DO NOT MERGE** — merge and any deployment are separate maintainer gates.
