### PR TITLE
fix(auth): prevent Codex CLI token fan-out across profiles

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3820,7 +3820,7 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
             auth_store = _load_auth_store()
     else:
         auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "openai-codex")
+    state, source_path = _load_provider_state_with_source(auth_store, "openai-codex")
     if not state:
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
@@ -3855,6 +3855,9 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     return {
         "tokens": tokens,
         "last_refresh": state.get("last_refresh"),
+        # Refresh tokens are single-use. Keep the store that supplied this
+        # pair so rotation does not create a profile-local global fallback.
+        "source_path": source_path,
     }
 
 
@@ -3959,12 +3962,24 @@ def _sync_codex_pool_entries(
         entry["last_error_reset_at"] = None
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
-    """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
+def _save_codex_tokens(
+    tokens: Dict[str, str],
+    last_refresh: str = None,
+    label: str = None,
+    *,
+    source_path: Optional[Path] = None,
+) -> None:
+    """Save Codex OAuth tokens to the supplied Hermes auth store.
+
+    Explicit login/import callers leave ``source_path`` unset and write to the
+    active Hermes scope. Runtime refresh supplies the store that yielded the
+    token pair, preserving profile/global scope.
+    """
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    target_path = source_path or _auth_file_path()
+    with _auth_store_lock(target_path=target_path):
+        auth_store = _load_auth_store(target_path)
         state = _load_provider_state(auth_store, "openai-codex") or {}
         # Capture the previous singleton tokens BEFORE overwriting them.  The
         # pool-sync step uses this to distinguish legacy singleton-aliases
@@ -3984,23 +3999,7 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             last_refresh,
             previous_singleton_tokens=previous_singleton_tokens,
         )
-        _save_auth_store(auth_store)
-
-
-def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
-    """Adopt a valid Codex CLI token pair into Hermes auth, if available."""
-    imported = _import_codex_cli_tokens()
-    # Require BOTH tokens before adopting: persisting a payload without a
-    # usable refresh_token would only break the next refresh cycle.
-    if not (
-        imported
-        and str(imported.get("access_token", "") or "").strip()
-        and str(imported.get("refresh_token", "") or "").strip()
-    ):
-        return None
-    logger.info("Codex auth recovered from Codex CLI auth.json (%s).", reason)
-    _save_codex_tokens(imported)
-    return dict(imported)
+        _save_auth_store(auth_store, target_path)
 
 
 def refresh_codex_oauth_pure(
@@ -4140,45 +4139,38 @@ def refresh_codex_oauth_pure(
 def _refresh_codex_auth_tokens(
     tokens: Dict[str, str],
     timeout_seconds: float,
+    *,
+    source_path: Optional[Path] = None,
 ) -> Dict[str, str]:
-    """Refresh Codex access token using the refresh token.
-    
-    Saves the new tokens to Hermes auth store automatically.
-    """
-    try:
+    """Refresh a Codex token pair and rotate the auth store that supplied it."""
+    # Serialize against the source store, not merely the active profile. A
+    # global fallback credential may be shared by many profile processes.
+    target_path = source_path or _auth_file_path()
+    with _auth_store_lock(target_path=target_path):
+        source_store = _load_auth_store(target_path)
+        providers = source_store.get("providers")
+        source_state = providers.get("openai-codex") if isinstance(providers, dict) else None
+        source_tokens = source_state.get("tokens") if isinstance(source_state, dict) else None
+        if (
+            isinstance(source_tokens, dict)
+            and str(source_tokens.get("access_token", "") or "").strip()
+            and str(source_tokens.get("refresh_token", "") or "").strip()
+            and source_tokens != tokens
+        ):
+            # Another process already consumed and rotated this single-use
+            # chain. Reuse its replacement instead of making a second call.
+            return dict(source_tokens)
+
         refreshed = refresh_codex_oauth_pure(
             str(tokens.get("access_token", "") or ""),
             str(tokens.get("refresh_token", "") or ""),
             timeout_seconds=timeout_seconds,
         )
-    except AuthError as exc:
-        # Self-heal cross-store refresh_token rotation. Hermes keeps its OWN
-        # Codex OAuth token (per profile + top-level), separate from the Codex
-        # CLI's ~/.codex/auth.json. OAuth refresh_tokens are single-use, so when
-        # the Codex CLI (or another Hermes process) rotates the shared token,
-        # this frozen copy's refresh_token goes stale and the refresh fails with
-        # a relogin-required error (invalid_grant / refresh_token_reused / 401).
-        # Before surfacing that as a hard 401 to the turn, adopt the canonical
-        # fresh token from ~/.codex/auth.json (the Codex CLI keeps it current) so
-        # idle profiles / desktop sessions recover automatically instead of
-        # 401'ing until a manual re-auth. Transient failures (e.g. 429 quota)
-        # keep relogin_required=False — the stored token is still valid there, so
-        # we never self-heal those and re-raise unchanged.
-        if not getattr(exc, "relogin_required", False):
-            raise
-        imported = _recover_codex_tokens_from_cli(
-            f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}"
-        )
-        if not imported:
-            raise
-        return imported
-
-    updated_tokens = dict(tokens)
-    updated_tokens["access_token"] = refreshed["access_token"]
-    updated_tokens["refresh_token"] = refreshed["refresh_token"]
-
-    _save_codex_tokens(updated_tokens)
-    return updated_tokens
+        updated_tokens = dict(tokens)
+        updated_tokens["access_token"] = refreshed["access_token"]
+        updated_tokens["refresh_token"] = refreshed["refresh_token"]
+        _save_codex_tokens(updated_tokens, source_path=target_path)
+        return updated_tokens
 
 
 def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
@@ -4237,18 +4229,7 @@ def resolve_codex_runtime_credentials(
         data = _read_codex_tokens()
     except AuthError as exc:
         read_error = exc
-        if getattr(exc, "relogin_required", False) and getattr(exc, "code", None) in {
-            "codex_auth_missing_access_token",
-            "codex_auth_missing_refresh_token",
-            "codex_auth_invalid_shape",
-        }:
-            imported = _recover_codex_tokens_from_cli(str(getattr(exc, "code", None) or "auth_error"))
-            if imported:
-                data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
-            else:
-                data = None
-        else:
-            data = None
+        data = None
 
     if data is None:
         pool_token = _pool_codex_access_token()
@@ -4341,7 +4322,11 @@ def resolve_codex_runtime_credentials(
                 should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
 
             if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                tokens = _refresh_codex_auth_tokens(
+                    tokens,
+                    refresh_timeout_seconds,
+                    source_path=data.get("source_path"),
+                )
                 access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (

--- a/tests/hermes_cli/test_auth_codex_self_heal.py
+++ b/tests/hermes_cli/test_auth_codex_self_heal.py
@@ -1,13 +1,10 @@
-"""Regression tests for Codex refresh_token self-heal (cross-store rotation).
+"""Regression tests for Codex OAuth store isolation.
 
-Hermes keeps its OWN copy of the Codex OAuth token (per profile + top-level),
-separate from the Codex CLI's ``~/.codex/auth.json``. OAuth refresh_tokens are
-single-use, so when the Codex CLI (or another Hermes process) rotates the shared
-token, the frozen copy's refresh_token goes stale and ``refresh_codex_oauth_pure``
-fails with a relogin-required error. ``_refresh_codex_auth_tokens`` must then
-recover by re-importing the canonical token from ``~/.codex/auth.json`` instead of
-surfacing a hard 401 — but ONLY for relogin-required failures, never for transient
-ones (e.g. 429 quota, where the stored token is still valid).
+Hermes runtime credentials are scoped to the Hermes auth store they came from:
+a profile-local store or the global fallback store. Codex CLI credentials are
+only adopted by the explicit interactive import/login flow; runtime resolution
+must never copy ``~/.codex/auth.json`` into a Hermes profile because OAuth
+refresh tokens are single-use.
 """
 
 import json
@@ -20,15 +17,21 @@ from hermes_cli.auth import AuthError, _refresh_codex_auth_tokens, resolve_codex
 STALE = {"access_token": "stale-access", "refresh_token": "stale-refresh"}
 
 
-def test_self_heals_on_stale_refresh_token(monkeypatch):
-    """invalid_grant (relogin-required) → reimport from ~/.codex and persist it."""
-    saved = {}
-    fresh = {
-        "access_token": "fresh-access",
-        "refresh_token": "fresh-refresh",
-        "last_refresh": "2026-06-12T00:00:00Z",
+def _store(tokens):
+    return {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": dict(tokens),
+                "last_refresh": "2026-06-01T00:00:00Z",
+                "auth_mode": "chatgpt",
+            },
+        },
     }
 
+
+def test_rejected_refresh_does_not_adopt_codex_cli_tokens(monkeypatch):
+    """Runtime failures require explicit Hermes re-auth, never a CLI import."""
     def _rejected(*_a, **_k):
         raise AuthError(
             "refresh token rejected",
@@ -38,57 +41,96 @@ def test_self_heals_on_stale_refresh_token(monkeypatch):
         )
 
     monkeypatch.setattr(auth, "refresh_codex_oauth_pure", _rejected)
-    monkeypatch.setattr(auth, "_import_codex_cli_tokens", lambda: dict(fresh))
-    monkeypatch.setattr(auth, "_save_codex_tokens", lambda t, *a, **k: saved.update(t))
+    monkeypatch.setattr(
+        auth,
+        "_import_codex_cli_tokens",
+        lambda: pytest.fail("runtime refresh must not import Codex CLI credentials"),
+    )
 
-    out = _refresh_codex_auth_tokens(STALE, 20.0)
-
-    assert out["access_token"] == "fresh-access"
-    assert out["refresh_token"] == "fresh-refresh"
-    # the recovered token was persisted to the Hermes auth store
-    assert saved["access_token"] == "fresh-access"
-
+    with pytest.raises(AuthError, match="refresh token rejected"):
+        _refresh_codex_auth_tokens(STALE, 20.0)
 
 
-
-
-
-
-
-
-
-def test_self_heals_missing_singleton_access_token_from_codex_cli(tmp_path, monkeypatch):
-    """Exact cron failure path: Hermes auth has refresh_token but missing access_token."""
+def test_missing_profile_token_does_not_adopt_codex_cli_tokens(tmp_path, monkeypatch):
+    """A malformed profile store stays malformed until explicit auth/import."""
     hermes_home = tmp_path / "hermes"
     codex_home = tmp_path / "codex"
     hermes_home.mkdir()
     codex_home.mkdir()
-    (hermes_home / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {
-            "openai-codex": {
-                "tokens": {"refresh_token": "stale-refresh"},
-                "last_refresh": "2026-06-01T00:00:00Z",
-                "auth_mode": "chatgpt",
-            },
-        },
-    }))
+    (hermes_home / "auth.json").write_text(json.dumps(_store({"refresh_token": "stale-refresh"})))
     (codex_home / "auth.json").write_text(json.dumps({
-        "tokens": {
-            "access_token": "fresh-access",
-            "refresh_token": "fresh-refresh",
-        },
+        "tokens": {"access_token": "cli-access", "refresh_token": "cli-refresh"},
     }))
+    before = (hermes_home / "auth.json").read_text()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
 
-    resolved = resolve_codex_runtime_credentials()
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
 
-    assert resolved["api_key"] == "fresh-access"
-    assert resolved["source"] == "hermes-auth-store"
-    stored = json.loads((hermes_home / "auth.json").read_text())
-    tokens = stored["providers"]["openai-codex"]["tokens"]
-    assert tokens["access_token"] == "fresh-access"
-    assert tokens["refresh_token"] == "fresh-refresh"
+    assert exc.value.code == "codex_auth_missing_access_token"
+    assert (hermes_home / "auth.json").read_text() == before
 
 
+def test_refresh_keeps_profile_local_source_store(tmp_path, monkeypatch):
+    profile_home = tmp_path / "profiles" / "darla"
+    global_home = tmp_path / "global"
+    profile_home.mkdir(parents=True)
+    global_home.mkdir()
+    (profile_home / "auth.json").write_text(json.dumps(_store(STALE)))
+    (global_home / "auth.json").write_text(json.dumps(_store({
+        "access_token": "global-access", "refresh_token": "global-refresh",
+    })))
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: global_home / "auth.json")
+    monkeypatch.setattr(auth, "_load_global_auth_store", lambda: json.loads((global_home / "auth.json").read_text()))
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", lambda *_a, **_k: {
+        "access_token": "profile-fresh", "refresh_token": "profile-rotated",
+    })
+
+    resolved = resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == "profile-fresh"
+    assert json.loads((profile_home / "auth.json").read_text())["providers"]["openai-codex"]["tokens"]["refresh_token"] == "profile-rotated"
+    assert json.loads((global_home / "auth.json").read_text())["providers"]["openai-codex"]["tokens"]["refresh_token"] == "global-refresh"
+
+
+def test_global_fallback_refreshes_global_source_store(tmp_path, monkeypatch):
+    profile_home = tmp_path / "profiles" / "darla"
+    global_home = tmp_path / "global"
+    profile_home.mkdir(parents=True)
+    global_home.mkdir()
+    (profile_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    (global_home / "auth.json").write_text(json.dumps(_store(STALE)))
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: global_home / "auth.json")
+    monkeypatch.setattr(auth, "_load_global_auth_store", lambda: json.loads((global_home / "auth.json").read_text()))
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", lambda *_a, **_k: {
+        "access_token": "global-fresh", "refresh_token": "global-rotated",
+    })
+
+    resolved = resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == "global-fresh"
+    assert "openai-codex" not in json.loads((profile_home / "auth.json").read_text())["providers"]
+    assert json.loads((global_home / "auth.json").read_text())["providers"]["openai-codex"]["tokens"]["refresh_token"] == "global-rotated"
+
+
+def test_concurrent_global_fallback_reuses_rotated_source_token(tmp_path, monkeypatch):
+    """A second reader must observe the first writer's rotation, not reuse it."""
+    global_auth = tmp_path / "auth.json"
+    global_auth.write_text(json.dumps(_store(STALE)))
+    calls = []
+
+    def _refresh(*_a, **_k):
+        calls.append(1)
+        return {"access_token": "rotated-access", "refresh_token": "rotated-refresh"}
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", _refresh)
+
+    first = _refresh_codex_auth_tokens(STALE, 20.0, source_path=global_auth)
+    second = _refresh_codex_auth_tokens(STALE, 20.0, source_path=global_auth)
+
+    assert first["refresh_token"] == "rotated-refresh"
+    assert second["refresh_token"] == "rotated-refresh"
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- stop runtime Codex recovery from silently importing `~/.codex/auth.json`
- refresh OAuth tokens back into the profile or global auth store that supplied them
- serialize global-fallback rotation so a concurrent reader reuses the rotated token

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_auth_codex_self_heal.py tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py -q`

Rollout intentionally excluded: this changes no live auth state, does not restart gateways, and must be independently reviewed before Bruno/Ivy-directed rollout.