### PR TITLE
fix(desktop): refresh model picker after gateway reconnect

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -24,6 +24,7 @@ import { sessionTileDelegate } from '@/store/session-states'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 import { ModelCatalogMenu, type ModelMenuController } from './model-catalog-menu'
+import { useGatewayConnected } from './use-gateway-connected'
 
 export { ModelMenuCloseContext } from './model-catalog-menu'
 
@@ -53,6 +54,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
   const copy = t.shell.modelMenu
   const [refreshing, setRefreshing] = useState(false)
   const queryClient = useQueryClient()
+  const gatewayConnected = useGatewayConnected(gateway)
   // Bind to THIS surface's SessionView (primary or tile) so each pane's menu
   // shows/switches its own model — not the primary-only globals.
   const view = useSessionView()
@@ -70,8 +72,11 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
   // dedupes, no second fetch). It must be a live subscription, not a cache
   // peek: with no model in the session store yet, currentPickerSelection falls
   // back to the catalog's reported current, and a non-reactive read would
-  // never repaint that fallback once the catalog resolved.
+  // never repaint that fallback once the catalog resolved. Keep the query
+  // disabled while an explicit gateway socket is down so a reconnect toggles
+  // it back on and gives React Query a clean retry boundary (#83160).
   const modelOptions = useQuery({
+    enabled: gatewayConnected,
     queryKey: modelOptionsQueryKey(profile, activeSessionId),
     queryFn: (): Promise<ModelOptionsResponse> =>
       requestModelOptions({ gateway, profile, request: requestGateway, sessionId: activeSessionId })

--- a/apps/desktop/src/app/shell/use-gateway-connected.test.tsx
+++ b/apps/desktop/src/app/shell/use-gateway-connected.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { HermesGateway } from '@/hermes'
+
+import { useGatewayConnected } from './use-gateway-connected'
+
+describe('useGatewayConnected', () => {
+  it('tracks closed and reopened gateway states', () => {
+    let state: 'closed' | 'open' = 'closed'
+    let listener: ((next: 'closed' | 'open') => void) | undefined
+    const unsubscribe = vi.fn()
+
+    const gateway = {
+      get connectionState() {
+        return state
+      },
+      onState(next: (value: 'closed' | 'open') => void) {
+        listener = next
+        next(state)
+
+        return unsubscribe
+      }
+    } as unknown as HermesGateway
+
+    const { result, unmount } = renderHook(() => useGatewayConnected(gateway))
+
+    expect(result.current).toBe(false)
+
+    act(() => {
+      state = 'open'
+      listener?.('open')
+    })
+    expect(result.current).toBe(true)
+
+    act(() => {
+      state = 'closed'
+      listener?.('closed')
+    })
+    expect(result.current).toBe(false)
+
+    unmount()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('treats the legacy request path without an explicit gateway as connected', () => {
+    const { result } = renderHook(() => useGatewayConnected(undefined))
+
+    expect(result.current).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/shell/use-gateway-connected.ts
+++ b/apps/desktop/src/app/shell/use-gateway-connected.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+
+import type { HermesGateway } from '@/hermes'
+
+/**
+ * React bridge for the gateway's imperative connection-state emitter.
+ *
+ * Model catalog queries must not run while the socket is down: a rejected
+ * `model.options` request is otherwise cached by React Query and the picker can
+ * keep rendering the old "gateway is not connected" error after reconnect.
+ * Toggling the query's `enabled` flag back to true on `open` gives React Query
+ * a clean retry boundary.
+ */
+export function useGatewayConnected(gateway?: HermesGateway): boolean {
+  const [connected, setConnected] = useState(() => !gateway || gateway.connectionState === 'open')
+
+  useEffect(() => {
+    if (!gateway) {
+      setConnected(true)
+
+      return undefined
+    }
+
+    return gateway.onState(state => setConnected(state === 'open'))
+  }, [gateway])
+
+  return connected
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop model picker staying stuck on "Hermes gateway is not connected" after the gateway reconnects.

The model-options query could run while the WebSocket was closed. React Query then retained the rejected request state, while the query itself had no subscription to the gateway's connection lifecycle. This adds a small React bridge for `HermesGateway.onState()` and disables the model-options query while the explicit gateway is down. When the socket returns to `open`, the query becomes enabled again and React Query retries it normally.

The legacy request path where no explicit gateway object is supplied remains enabled.

## Related Issue

Fixes #83160

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/shell/use-gateway-connected.ts` adds a small hook that mirrors the gateway connection state into React.
- `apps/desktop/src/app/shell/model-menu-panel.tsx` gates the `model.options` query on that connection state so reconnecting produces a clean retry.
- `apps/desktop/src/app/shell/use-gateway-connected.test.tsx` covers closed to open to closed transitions, cleanup, and the legacy no-gateway path.

## How to Test

1. Open Desktop while using a gateway-backed model picker.
2. Interrupt the gateway connection, then allow it to reconnect.
3. Open the model picker and verify the provider/model catalog is restored instead of remaining on the stale "gateway is not connected" error.
4. Run `cd apps/desktop && npx vitest run --project ui src/app/shell/use-gateway-connected.test.tsx`.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added regression coverage
- [ ] Full tests were not run locally; GitHub CI will validate the branch
- [x] Documentation/config/tool-schema changes are N/A
- [x] Cross-platform impact considered: the change only follows the existing gateway connection-state API