### PR TITLE
fix(agent): fence compression timeout recovery

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -325,6 +325,93 @@ class AuxiliaryExplicitCancellation(BaseException):
         super().__init__("auxiliary request explicitly cancelled by host")
 
 
+class AuxiliaryCancellationToken:
+    """Monotonic attempt-local cancellation and dispatch admission fence."""
+
+    def __init__(self, source_check: Callable[[], Any]) -> None:
+        self._source_check = source_check
+        self._lock = threading.Lock()
+        self._state = "OPEN"
+        self._cancelled = False
+        self._callbacks: list[Callable[[], None]] = []
+
+    def _source_requested(self) -> bool:
+        try:
+            return bool(self._source_check())
+        except Exception:
+            logger.debug("auxiliary cancellation source check failed", exc_info=True)
+            return False
+
+    def _observe_locked(self) -> list[Callable[[], None]]:
+        if not self._cancelled and self._source_requested():
+            self._cancelled = True
+            if self._state == "OPEN":
+                self._state = "CANCELLED"
+            callbacks = self._callbacks
+            self._callbacks = []
+            return callbacks
+        return []
+
+    @staticmethod
+    def _run_callbacks(callbacks: list[Callable[[], None]]) -> None:
+        for callback in callbacks:
+            try:
+                callback()
+            except Exception:
+                logger.debug("auxiliary cancellation cleanup failed", exc_info=True)
+
+    def is_cancelled(self) -> bool:
+        with self._lock:
+            callbacks = self._observe_locked()
+            cancelled = self._cancelled
+        self._run_callbacks(callbacks)
+        return cancelled
+
+    def raise_if_cancelled(self) -> None:
+        if self.is_cancelled():
+            raise AuxiliaryExplicitCancellation()
+
+    def cancel(self) -> None:
+        with self._lock:
+            self._cancelled = True
+            if self._state == "OPEN":
+                self._state = "CANCELLED"
+            callbacks = self._callbacks
+            self._callbacks = []
+        self._run_callbacks(callbacks)
+
+    def claim_dispatch(self) -> None:
+        """Linearize OPEN -> ADMITTED without holding the lock over RPC."""
+        with self._lock:
+            callbacks = self._observe_locked()
+            admitted = not self._cancelled and self._state != "CANCELLED"
+            if admitted:
+                self._state = "ADMITTED"
+        self._run_callbacks(callbacks)
+        if not admitted:
+            raise AuxiliaryExplicitCancellation()
+
+    def register_cancel_callback(self, callback: Callable[[], None]) -> None:
+        with self._lock:
+            callbacks = self._observe_locked()
+            if not self._cancelled:
+                self._callbacks.append(callback)
+                callbacks = []
+            else:
+                # Registration can lose the acquire -> register race after
+                # cancellation has already won. Deliver the late callback
+                # immediately, but only after leaving the token lock below.
+                callbacks.append(callback)
+        self._run_callbacks(callbacks)
+
+    def unregister_cancel_callback(self, callback: Callable[[], None]) -> None:
+        with self._lock:
+            try:
+                self._callbacks.remove(callback)
+            except ValueError:
+                pass
+
+
 def _aux_interrupt_protected() -> bool:
     return bool(getattr(_aux_interrupt_protection, "active", False))
 
@@ -353,6 +440,7 @@ def aux_interrupt_protection(
     active: bool = True,
     cancel_check=None,
     cancel_event=None,
+    cancellation_token: Optional[AuxiliaryCancellationToken] = None,
 ):
     """Mark the current thread's auxiliary LLM call as interrupt-protected.
 
@@ -365,17 +453,32 @@ def aux_interrupt_protection(
     prev = getattr(_aux_interrupt_protection, "active", False)
     prev_cancel_check = getattr(_aux_interrupt_protection, "cancel_check", None)
     prev_cancel_event = getattr(_aux_interrupt_protection, "cancel_event", None)
+    prev_token = getattr(_aux_interrupt_protection, "cancellation_token", None)
     _aux_interrupt_protection.active = active
     if callable(cancel_check):
         _aux_interrupt_protection.cancel_check = cancel_check
     if cancel_event is not None and callable(getattr(cancel_event, "is_set", None)):
         _aux_interrupt_protection.cancel_event = cancel_event
+    source = None
+    if cancel_event is not None and callable(getattr(cancel_event, "is_set", None)):
+        source = cancel_event.is_set
+    elif callable(cancel_check) and cancellation_token is None:
+        source = cancel_check
+    token = cancellation_token or prev_token
+    if cancellation_token is None and prev_token is not None and callable(source):
+        token = AuxiliaryCancellationToken(
+            lambda: bool(prev_token.is_cancelled() or source())
+        )
+    elif token is None and callable(source):
+        token = AuxiliaryCancellationToken(source)
+    _aux_interrupt_protection.cancellation_token = token
     try:
         yield
     finally:
         _aux_interrupt_protection.active = prev
         _aux_interrupt_protection.cancel_check = prev_cancel_check
         _aux_interrupt_protection.cancel_event = prev_cancel_event
+        _aux_interrupt_protection.cancellation_token = prev_token
 
 
 def _capture_aux_cancel_check() -> Optional[Callable[[], Any]]:
@@ -390,6 +493,11 @@ def _capture_aux_cancel_check() -> Optional[Callable[[], Any]]:
         # methods such as begin_timeout_cleanup() when captured by adapters.
         return check
     return None
+
+
+def _capture_aux_cancellation_token() -> Optional[AuxiliaryCancellationToken]:
+    token = getattr(_aux_interrupt_protection, "cancellation_token", None)
+    return token if isinstance(token, AuxiliaryCancellationToken) else None
 
 
 def _captured_aux_cancel_requested(cancel_check: Callable[[], Any]) -> bool:
@@ -460,6 +568,9 @@ def _notify_aux_progress() -> None:
 
 def _notify_aux_dispatch() -> None:
     """Record an actual provider dispatch without claiming response progress."""
+    token = _capture_aux_cancellation_token()
+    if token is not None:
+        token.claim_dispatch()
     hook = getattr(_aux_dispatch, "hook", None)
     if hook is not None:
         try:
@@ -595,13 +706,18 @@ def _run_protected_sync_provider_call(
     retain the historical direct synchronous path with no extra thread.
     """
     source_cancel_check = _capture_aux_cancel_check()
-    if not _aux_interrupt_protected() or not callable(source_cancel_check):
+    attempt_token = _capture_aux_cancellation_token()
+    if not _aux_interrupt_protected() or (
+        not callable(source_cancel_check) and attempt_token is None
+    ):
         return callback(kwargs)
 
     # Freeze one linearized outcome for this isolated attempt. The host Event is
     # reused and cleared on a later turn, while the Codex timeout Timer may race
     # owner polling. Both paths must decide under the same attempt-local lock.
-    cancel_check = _AuxiliaryCancellationDecision(source_cancel_check)
+    if attempt_token is None:
+        attempt_token = AuxiliaryCancellationToken(source_cancel_check)
+    cancel_check = _AuxiliaryCancellationDecision(attempt_token.is_cancelled)
 
     if cancel_check():
         raise AuxiliaryExplicitCancellation()
@@ -624,7 +740,10 @@ def _run_protected_sync_provider_call(
                 aux_progress_hook(progress_hook),
                 _aux_thread_local_hook(_aux_dispatch, dispatch_hook),
                 _aux_thread_local_hook(_aux_provider_response, provider_response_hook),
-                aux_interrupt_protection(cancel_check=cancel_check),
+                aux_interrupt_protection(
+                    cancel_check=cancel_check,
+                    cancellation_token=attempt_token,
+                ),
             ):
                 outcome["result"] = callback(kwargs)
         except BaseException as exc:
@@ -644,10 +763,12 @@ def _run_protected_sync_provider_call(
         # wins whenever result publication and the host Event become visible in
         # the same polling interval.
         if _captured_aux_cancel_requested(cancel_check):
+            attempt_token.cancel()
             raise AuxiliaryExplicitCancellation()
         if not done.wait(0.02):
             continue
         if _captured_aux_cancel_requested(cancel_check):
+            attempt_token.cancel()
             raise AuxiliaryExplicitCancellation()
         exception = outcome.get("exception")
         if exception is not None:
@@ -3547,6 +3668,34 @@ def _relay_auxiliary_metadata(
     }
 
 
+def _fenced_sync_provider_call(client: Any, kwargs: dict[str, Any]) -> Any:
+    """Claim one physical sync provider handoff before invoking the client."""
+    _notify_aux_dispatch()
+    return client.chat.completions.create(**kwargs)
+
+
+async def _fenced_async_provider_call(client: Any, kwargs: dict[str, Any]) -> Any:
+    """Claim one physical async provider handoff before invoking the client."""
+    _notify_aux_dispatch()
+    return await client.chat.completions.create(**kwargs)
+
+
+def _wait_for_aux_retry(
+    delay_seconds: float,
+    *,
+    cancellation_token: Optional[AuxiliaryCancellationToken] = None,
+) -> None:
+    """Wait for retry backoff while polling the attempt cancellation token."""
+    deadline = time.monotonic() + max(0.0, float(delay_seconds))
+    while True:
+        if cancellation_token is not None:
+            cancellation_token.raise_if_cancelled()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(0.02, remaining))
+
+
 def _relay_sync_completion(
     client: Any,
     kwargs: dict[str, Any],
@@ -3555,7 +3704,7 @@ def _relay_sync_completion(
     api_mode: str | None = None,
     create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
-    callback = create or (lambda request: client.chat.completions.create(**request))
+    callback = create or (lambda request: _fenced_sync_provider_call(client, request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     # Protected compression calls isolate only the provider callback and stream
     # aggregation.  The owning thread remains free to unwind its lease/DB
@@ -3583,7 +3732,7 @@ async def _relay_async_completion(
     api_mode: str | None = None,
     create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
-    callback = create or (lambda request: client.chat.completions.create(**request))
+    callback = create or (lambda request: _fenced_async_provider_call(client, request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
         return await callback(kwargs)
@@ -3609,13 +3758,13 @@ def _relay_sync_stream(
 ) -> Any:
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
-        return client.chat.completions.create(**kwargs)
+        return _fenced_sync_provider_call(client, kwargs)
     provider_name, fallback_model, metadata = route
     from agent import relay_llm
 
     return relay_llm.stream_current(
         kwargs,
-        lambda request: client.chat.completions.create(**request),
+        lambda request: _fenced_sync_provider_call(client, request),
         name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
         finalizer=dict,
@@ -9440,10 +9589,9 @@ def _create_with_progress(
     stream-only provider rejects the plain call by definition, so the
     original error is surfaced to the normal recovery chains instead.
     """
-    _notify_aux_dispatch()
     _notify_aux_progress()  # Preserve the watchdog's historical dispatch tick.
     if (not _aux_progress_active() and not force_stream) or _client_streams_internally(client):
-        response = client.chat.completions.create(**kwargs)
+        response = _fenced_sync_provider_call(client, kwargs)
         if not _client_streams_internally(client):
             _notify_aux_provider_response()
         return response
@@ -9453,7 +9601,7 @@ def _create_with_progress(
     stream_kwargs["stream"] = True
     stream_kwargs["stream_options"] = {"include_usage": True}
     try:
-        chunks = client.chat.completions.create(**stream_kwargs)
+        chunks = _fenced_sync_provider_call(client, stream_kwargs)
     except Exception as exc:
         # Genuine provider failures (auth, credit, rate limit, network) are
         # not streaming's fault — surface them unchanged so the existing
@@ -9475,8 +9623,7 @@ def _create_with_progress(
             "Auxiliary %s: streamed request failed (%s); retrying "
             "non-streaming", task or "call", exc,
         )
-        _notify_aux_dispatch()
-        response = client.chat.completions.create(**kwargs)
+        response = _fenced_sync_provider_call(client, kwargs)
         _notify_aux_provider_response()
         return response
 
@@ -9678,7 +9825,7 @@ async def _acreate_with_stream(
     stream_kwargs = dict(kwargs)
     stream_kwargs["stream"] = True
     stream_kwargs["stream_options"] = {"include_usage": True}
-    chunks = await client.chat.completions.create(**stream_kwargs)
+    chunks = await _fenced_async_provider_call(client, stream_kwargs)
     # Defensive: shims may hand back a complete response despite stream=True.
     if hasattr(chunks, "choices"):
         return chunks
@@ -9713,8 +9860,15 @@ def call_llm(
     """Run an auxiliary LLM request, applying the configured task limit."""
     queue_started_at = time.monotonic()
     semaphore = _acquire_sync_aux_semaphore(task)
+    cancellation_token = _capture_aux_cancellation_token()
+    semaphore_acquired = False
     if semaphore is not None:
-        semaphore.acquire()
+        while True:
+            if cancellation_token is not None:
+                cancellation_token.raise_if_cancelled()
+            if semaphore.acquire(timeout=0.02):
+                semaphore_acquired = True
+                break
     request_started_at = time.monotonic()
     if latency_info is not None:
         latency_info["queue_wait_ms"] = max(
@@ -9733,6 +9887,20 @@ def call_llm(
             latency_info["provider_dispatch_ms"] = max(
                 0, int((time.monotonic() - request_started_at) * 1000)
             )
+
+    release_guard = threading.Lock()
+    permit_released = False
+
+    def _release_permit_once() -> None:
+        nonlocal permit_released
+        with release_guard:
+            if permit_released or semaphore is None or not semaphore_acquired:
+                return
+            permit_released = True
+        semaphore.release()
+
+    if cancellation_token is not None and semaphore_acquired:
+        cancellation_token.register_cancel_callback(_release_permit_once)
 
     try:
         with (
@@ -9774,8 +9942,9 @@ def call_llm(
             latency_info["summary_generation_ms"] = max(
                 0, int((time.monotonic() - request_started_at) * 1000)
             )
-        if semaphore is not None:
-            semaphore.release()
+        if cancellation_token is not None and semaphore_acquired:
+            cancellation_token.unregister_cancel_callback(_release_permit_once)
+        _release_permit_once()
 
 
 def _release_sync_semaphore_after_stream(
@@ -10024,7 +10193,7 @@ def _call_llm_impl(
             # Return the provider call directly; the MoA facade converts a
             # completed response into a one-chunk delta iterator at its
             # boundary.
-            return client.chat.completions.create(**kwargs)
+            return _fenced_sync_provider_call(client, kwargs)
         return _relay_sync_stream(
             client,
             kwargs,
@@ -10097,7 +10266,10 @@ def _call_llm_impl(
                     task or "call", _attempt, _max_transient_retries, _backoff,
                     _last_transient,
                 )
-                time.sleep(_backoff)
+                _wait_for_aux_retry(
+                    _backoff,
+                    cancellation_token=_capture_aux_cancellation_token(),
+                )
                 try:
                     return _validate_llm_response(
                         _relay_sync_completion(
@@ -10831,7 +11003,7 @@ async def _async_call_llm_impl(
         async def _acreate(_kwargs: Dict[str, Any]) -> Any:
             if _force_stream_async:
                 return await _acreate_with_stream(client, _kwargs, task)
-            return await client.chat.completions.create(**_kwargs)
+            return await _fenced_async_provider_call(client, _kwargs)
 
         try:
             return _validate_llm_response(

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2318,6 +2318,11 @@ class ContextCompressor(ContextEngine):
         self._last_compression_telemetry = None
         self._active_compression_telemetry = None
         self._compression_telemetry_seed = None
+        self._automatic_timeout_terminal = False
+        self._automatic_timeout_terminal_turn_id = None
+        self._compression_terminal_outcome = None
+        self._compression_attempt_id = None
+        self._compression_attempt_turn_id = None
         self._proactive_prune_rearm_tokens = 0
 
         # Micro-compaction state reset
@@ -2623,6 +2628,11 @@ class ContextCompressor(ContextEngine):
         self._last_compression_telemetry = None
         self._active_compression_telemetry = None
         self._compression_telemetry_seed = None
+        self._automatic_timeout_terminal = False
+        self._automatic_timeout_terminal_turn_id = None
+        self._compression_terminal_outcome = None
+        self._compression_attempt_id = None
+        self._compression_attempt_turn_id = None
         self._proactive_prune_rearm_tokens = 0
 
     def bind_session_state(self, session_db: Any = None, session_id: str = "") -> None:
@@ -2638,6 +2648,11 @@ class ContextCompressor(ContextEngine):
         self._prellm_skip_count = 0
         self._anti_thrash_recovery_deadline = 0.0
         self._structural_no_op_backoff_until = 0.0
+        self._automatic_timeout_terminal = False
+        self._automatic_timeout_terminal_turn_id = None
+        self._compression_terminal_outcome = None
+        self._compression_attempt_id = None
+        self._compression_attempt_turn_id = None
         self._proactive_prune_rearm_tokens = 0
         self.get_active_compression_failure_cooldown()
         self._load_fallback_compression_streak()
@@ -4756,11 +4771,11 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             n_chunks = _LEAN_DIGEST_MAX_CHUNKS
         digests: list[str] = []
         for ci in range(n_chunks):
+            self._raise_if_compression_cancelled()
             segment = text[ci * chunk_size:(ci + 1) * chunk_size]
             if not segment.strip():
                 continue
             try:
-                from agent.auxiliary_client import call_llm
 
                 # During a stall-fallback retry, follow the summary onto the
                 # pinned healthy route (non-consuming read) instead of
@@ -4774,6 +4789,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
                     max_tokens=_LEAN_DIGEST_MAX_TOKENS,
                     **attempt_summary_route_kwargs(),
                 )
+                self._raise_if_compression_cancelled()
                 body = (
                     resp.choices[0].message.content
                     if hasattr(resp, "choices") else str(resp)
@@ -4803,6 +4819,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         """
         if getattr(self, "tail_mode", "lean") != "lean":
             return summary
+        self._raise_if_compression_cancelled()
         if _LEAN_ANCHOR_HEADING not in summary:
             summary += _redact_compaction_text(
                 _build_anchor_index(turns_to_summarize)
@@ -4811,6 +4828,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             summary += _redact_compaction_text(
                 self._build_chunk_digests(turns_to_summarize)
             )
+        self._raise_if_compression_cancelled()
         if _LEAN_USER_MESSAGES_HEADING not in summary:
             summary += _redact_compaction_text(
                 _build_verbatim_user_section(turns_to_summarize)
@@ -4886,6 +4904,11 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self.summary_model = ""  # empty = use main model
         self._clear_compression_failure_cooldown()  # no cooldown — retry immediately
 
+    def _raise_if_compression_cancelled(self) -> None:
+        check = getattr(self, "_compression_cancelled_check", None)
+        if callable(check) and check():
+            raise AuxiliaryExplicitCancellation()
+
     def _generate_summary(
         self,
         turns_to_summarize: List[Dict[str, Any]],
@@ -4909,6 +4932,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         the middle turns without a summary rather than inject a useless
         placeholder.
         """
+        self._raise_if_compression_cancelled()
         prompt_started_at = time.monotonic()
         now = prompt_started_at
         if now < self._summary_failure_cooldown_until:
@@ -5268,6 +5292,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             # exists, not that it's an object with ``.content``. Some
             # OpenAI-compatible proxies / local backends return a dict- or
             # str-shaped message; coerce defensively instead of crashing.
+            self._raise_if_compression_cancelled()
             if isinstance(response, dict):
                 choices = response.get("choices") or [{}]
                 message = choices[0].get("message") if isinstance(choices[0], dict) else getattr(choices[0], "message", None)
@@ -5313,7 +5338,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             # [SKILL_PRUNED: ...] marker the summarizer paraphrased away.
             summary = _reinject_pruned_skill_markers(summary, _pruned_skill_names)
             summary = self._ground_historical_task_snapshot(summary, turns_to_summarize)
+            self._raise_if_compression_cancelled()
             summary = self._augment_summary_lean(summary, turns_to_summarize)
+            self._raise_if_compression_cancelled()
             self._validate_summary_user_provenance(summary, has_user_turn)
             # Store for iterative updates on next compaction
             self._previous_summary = summary
@@ -5436,6 +5463,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                     _reason = "closed stream prematurely"
                 else:
                     _reason = "timed out"
+                self._raise_if_compression_cancelled()
                 self._fallback_to_main_for_compression(e, _reason)
                 return self._generate_summary(
                     turns_to_summarize,
@@ -5457,6 +5485,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                 and self.summary_model != self.model
                 and not getattr(self, "_summary_model_fallen_back", False)
             ):
+                self._raise_if_compression_cancelled()
                 self._fallback_to_main_for_compression(e, "failed")
                 return self._generate_summary(
                     turns_to_summarize,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -328,6 +328,8 @@ _COMPRESSOR_ATTEMPT_STATE_FIELDS = (
     "_active_compression_telemetry",
     "_compression_telemetry_seed",
     "_proactive_prune_rearm_tokens",
+    "_automatic_timeout_terminal_turn_id",
+    "_compression_terminal_outcome",
 )
 
 _COMPRESSOR_COOLDOWN_STATE_FIELDS = (
@@ -455,6 +457,7 @@ def _restore_compressor_attempt_state(
     durable_cooldown_authoritative: Optional[bool] = None,
     durable_cooldown_state: Optional[dict[str, Any]] = None,
     attempt_generation: Optional[int] = None,
+    attempt_fence: Optional[CompressionCommitFence] = None,
 ) -> None:
     """Restore the safe per-attempt snapshot after a pre-commit hard cancel.
 
@@ -465,6 +468,13 @@ def _restore_compressor_attempt_state(
     primary's unwind must not roll fallback-owned state back to the
     primary's pre-attempt snapshot (#96634 post-merge review, claim 1).
     """
+    if attempt_fence is not None and attempt_fence.host_timeout_won():
+        logger.info(
+            "Skipping compressor rollback: host timeout already owns attempt "
+            "outcome %s",
+            attempt_fence.attempt_id,
+        )
+        return
     if attempt_generation is not None and not _compressor_attempt_is_current(
         compressor, attempt_generation
     ):
@@ -657,6 +667,15 @@ class CompressionCommitFence:
         # still guarantee no FUTURE commit is admitted. Plain bool store —
         # atomic in CPython.
         self._admission_revoked = False
+        # One attempt identity/provenance record is shared by the host and its
+        # detached worker. Host timeout claims this record before recording
+        # cooldown; late unwind consults the same claim and cannot roll it back.
+        self._attempt_id = uuid.uuid4().hex
+        self._attempt_generation: Optional[int] = None
+        self._attempt_turn_id = ""
+        self._terminal_outcome_lock = threading.Lock()
+        self._terminal_outcome: Optional[dict[str, Any]] = None
+        self._host_timeout_recorded = False
         # Holder-qualified durable-lock release hook (#76354 review F4;
         # transplanted from PR #71569 by @ciabata-git). The worker publishes an
         # idempotent, holder-scoped release callable once it owns the durable
@@ -673,6 +692,81 @@ class CompressionCommitFence:
         # not killed by a fixed wall-clock deadline while tokens are moving.
         self._last_progress = time.monotonic()
 
+    @property
+    def attempt_id(self) -> str:
+        return self._attempt_id
+
+    @property
+    def attempt_identity(self) -> dict[str, Any]:
+        """Return this fence's immutable attempt/generation/turn identity."""
+        with self._terminal_outcome_lock:
+            return {
+                "attempt_id": self._attempt_id,
+                "generation": self._attempt_generation,
+                "turn_id": self._attempt_turn_id,
+            }
+
+    def bind_turn(self, turn_id: str = "") -> None:
+        """Bind the first non-empty turn id; never rebind a live fence."""
+        turn_id = str(turn_id or "")
+        if not turn_id:
+            return
+        with self._terminal_outcome_lock:
+            if not self._attempt_turn_id:
+                self._attempt_turn_id = turn_id
+
+    def bind_attempt(self, generation: int, turn_id: str = "") -> None:
+        """Bind the compressor generation and authoritative turn to this fence."""
+        with self._terminal_outcome_lock:
+            if self._attempt_generation is None:
+                self._attempt_generation = generation
+            if not self._attempt_turn_id and turn_id:
+                self._attempt_turn_id = str(turn_id)
+
+    def claim_terminal_outcome(self, failure_class: str, turn_id: str = "") -> bool:
+        """Claim one terminal host outcome; return True only for its winner."""
+        with self._terminal_outcome_lock:
+            if self._terminal_outcome is not None:
+                return False
+            self._terminal_outcome = {
+                "attempt_id": self._attempt_id,
+                "generation": self._attempt_generation,
+                "turn_id": str(self._attempt_turn_id or turn_id or ""),
+                "failure_class": str(failure_class),
+            }
+            return True
+
+    def claim_host_timeout_record(self, turn_id: str = "") -> bool:
+        """Claim the single cooldown write for this attempt's host timeout."""
+        with self._terminal_outcome_lock:
+            if self._terminal_outcome is None:
+                self._terminal_outcome = {
+                    "attempt_id": self._attempt_id,
+                    "generation": self._attempt_generation,
+                    "turn_id": str(self._attempt_turn_id or turn_id or ""),
+                    "failure_class": "host_timeout",
+                }
+            if self._terminal_outcome.get("failure_class") != "host_timeout":
+                return False
+            if self._host_timeout_recorded:
+                return False
+            self._host_timeout_recorded = True
+            return True
+
+    @property
+    def terminal_outcome(self) -> Optional[dict[str, Any]]:
+        with self._terminal_outcome_lock:
+            return copy.deepcopy(self._terminal_outcome)
+
+    def host_timeout_won(self) -> bool:
+        with self._terminal_outcome_lock:
+            return bool(
+                self._terminal_outcome
+                and self._terminal_outcome.get("failure_class") == "host_timeout"
+            )
+
+    # ``begin_commit`` retains the fence lock; this metadata lock is separate
+    # so late outcome inspection never waits behind a SessionDB commit.
     def touch_progress(self) -> None:
         """Record forward progress (e.g. a streamed summary token arriving).
 
@@ -936,6 +1030,140 @@ def _release_compression_admission(_future=None) -> None:
     with _compress_admission_lock:
         if _compress_admitted_count > 0:
             _compress_admitted_count -= 1
+
+
+class _CompressionAdmissionLease:
+    """Idempotent owner for one process-wide compression admission slot."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._released = False
+
+    def release(self, _future=None) -> None:
+        with self._lock:
+            if self._released:
+                return
+            self._released = True
+        _release_compression_admission()
+
+
+def _bind_compression_attempt_identity(
+    telemetry_agent: Any, fence: CompressionCommitFence
+) -> None:
+    """Publish the fence identity before a pooled worker can start."""
+    if telemetry_agent is None:
+        return
+    fence.bind_turn(str(getattr(telemetry_agent, "_current_turn_id", "") or ""))
+    attempt_id = fence.attempt_id
+    turn_id = fence.attempt_identity["turn_id"]
+    compressor = getattr(telemetry_agent, "context_compressor", None)
+    with _COMPRESSOR_ATTEMPT_LOCK:
+        try:
+            telemetry_agent._compression_attempt_id = attempt_id
+            telemetry_agent._compression_attempt_turn_id = turn_id
+        except Exception:
+            pass
+        if compressor is not None:
+            try:
+                compressor._compression_attempt_id = attempt_id
+                compressor._compression_attempt_turn_id = turn_id
+            except Exception:
+                pass
+
+
+def _compression_attempt_identity_matches(
+    telemetry_agent: Any, compressor: Any, outcome: dict[str, Any]
+) -> bool:
+    """Return whether the captured outcome still owns the live compressor."""
+    expected_attempt = outcome.get("attempt_id")
+    if not isinstance(expected_attempt, str) or not expected_attempt:
+        return False
+    for owner in (telemetry_agent, compressor):
+        if owner is None:
+            continue
+        current_attempt = getattr(owner, "_compression_attempt_id", None)
+        if isinstance(current_attempt, str) and current_attempt:
+            if current_attempt != expected_attempt:
+                return False
+    expected_generation = outcome.get("generation")
+    current_generation = (
+        getattr(compressor, "_compression_attempt_generation", None)
+        if compressor is not None
+        else None
+    )
+    if (
+        isinstance(expected_generation, int)
+        and isinstance(current_generation, int)
+        and current_generation != expected_generation
+    ):
+        return False
+    return True
+
+
+def _publish_compression_terminal_outcome(
+    telemetry_agent: Any,
+    fence: CompressionCommitFence,
+    failure_class: str,
+    *,
+    _host_timeout_record_won: bool = False,
+    _latch_automatic_timeout: bool = False,
+) -> Optional[dict[str, Any]]:
+    """Publish a fence-owned outcome without rebinding to mutable turn state."""
+    if telemetry_agent is None:
+        return None
+    fence.claim_terminal_outcome(failure_class)
+    outcome = fence.terminal_outcome
+    if not isinstance(outcome, dict):
+        return None
+    compressor = getattr(telemetry_agent, "context_compressor", None)
+    with _COMPRESSOR_ATTEMPT_LOCK:
+        if not _compression_attempt_identity_matches(
+            telemetry_agent, compressor, outcome
+        ):
+            logger.info(
+                "Skipping stale compression terminal publication for attempt %s",
+                outcome.get("attempt_id"),
+            )
+            return None
+        try:
+            telemetry_agent._compression_attempt_id = outcome["attempt_id"]
+            telemetry_agent._compression_terminal_outcome = copy.deepcopy(outcome)
+        except Exception:
+            pass
+        if compressor is not None:
+            try:
+                compressor._compression_terminal_outcome = copy.deepcopy(outcome)
+                if (
+                    _host_timeout_record_won
+                    and _latch_automatic_timeout
+                    and outcome.get("failure_class") == "host_timeout"
+                ):
+                    compressor._automatic_timeout_terminal = True
+                    compressor._automatic_timeout_terminal_turn_id = str(
+                        outcome.get("turn_id") or ""
+                    )
+            except Exception:
+                pass
+    return outcome
+
+
+def _publish_compression_timeout_outcome(
+    telemetry_agent: Any,
+    fence: CompressionCommitFence,
+    *,
+    latch_automatic_timeout: bool,
+) -> tuple[Optional[dict[str, Any]], bool]:
+    """Claim/publish one timeout and atomically gate its automatic latch."""
+    fence.claim_terminal_outcome("host_timeout")
+    timeout_record_won = fence.claim_host_timeout_record()
+    outcome = _publish_compression_terminal_outcome(
+        telemetry_agent,
+        fence,
+        "host_timeout",
+        _host_timeout_record_won=timeout_record_won,
+        _latch_automatic_timeout=latch_automatic_timeout,
+    )
+    return outcome, bool(outcome is not None and timeout_record_won)
 
 
 def _get_compress_timeout_executor():
@@ -1245,6 +1473,7 @@ def run_compress_context_with_progress_timeout(
         return system_prompt_fallback
 
     fence = fence if fence is not None else CompressionCommitFence()
+    _bind_compression_attempt_identity(telemetry_agent, fence)
     ceiling = max(float(total_ceiling_seconds), float(idle_timeout_seconds))
     idle = float(idle_timeout_seconds)
     # Sync mirror of gateway session-hygiene's run_in_executor(None, ...) +
@@ -1271,6 +1500,9 @@ def run_compress_context_with_progress_timeout(
         # Round-2 #6: saturation refusals must be visible in the same
         # telemetry stream as every other failed attempt, or a wedged pool
         # looks like compression simply stopped being attempted.
+        _publish_compression_terminal_outcome(
+            telemetry_agent, fence, "pool_saturated"
+        )
         if telemetry_agent is not None:
             _emit_compression_attempt_telemetry(
                 telemetry_agent,
@@ -1291,18 +1523,23 @@ def run_compress_context_with_progress_timeout(
                 "Skipping stale compression job: fence cancelled before start"
             )
             return messages, ""
-        return worker(worker_fence)
+        # Make the exact attempt fence ambient for every auxiliary call made by
+        # a plugin or legacy compression engine, not only the built-in path.
+        from agent.auxiliary_client import aux_interrupt_protection
+        with aux_interrupt_protection(cancel_check=lambda: worker_fence.is_cancelled):
+            return worker(worker_fence)
 
     # Bare pool workers start with an empty ContextVar map; propagate the
     # parent conversation/approval context into the worker.
+    admission = _CompressionAdmissionLease()
     try:
         future = executor.submit(
             propagate_context_to_thread(_fence_gated_worker), fence
         )
     except BaseException:
-        _release_compression_admission()
+        admission.release()
         raise
-    future.add_done_callback(_release_compression_admission)
+    future.add_done_callback(admission.release)
     wait_started = time.monotonic()
     # F2: EVERY host unwind (KeyboardInterrupt, task cancellation, unexpected
     # exception while waiting) must revoke future commit admission before the
@@ -1327,6 +1564,7 @@ def run_compress_context_with_progress_timeout(
             )
             try:
                 result = future.result(timeout=wait_slice)
+                admission.release()
                 handled_exit = True
                 return result
             except concurrent.futures.TimeoutError:
@@ -1417,6 +1655,7 @@ def run_compress_context_with_progress_timeout(
                             )
                 try:
                     result = future.result(timeout=remaining)
+                    admission.release()
                     handled_exit = True
                     return result
                 except concurrent.futures.TimeoutError:
@@ -1426,11 +1665,14 @@ def run_compress_context_with_progress_timeout(
                     continue
 
         # Idle-timeout path: cancellation won before the commit boundary.
-        # The fence already blocks any future commit; F4 additionally frees
-        # the timed-out worker's durable lease via the holder-qualified hook
-        # so a NEW compressor can acquire the lock immediately (no ABA: the
-        # DB release is holder-scoped).
+        # Publish the attempt-owned terminal outcome before any detached unwind
+        # or fallback can touch compressor state. The admission lease remains
+        # owned by ``future`` and is released only by its done callback (or a
+        # failed submission), so non-cooperative workers stay bounded.
         handled_exit = True
+        _publish_compression_terminal_outcome(
+            telemetry_agent, fence, "host_timeout"
+        )
         fence.release_cancelled_compression_lock()
         waited = time.monotonic() - wait_started
         since_progress = fence.seconds_since_progress()
@@ -1478,6 +1720,11 @@ def run_compress_context_with_progress_timeout(
             # worker's durable lease via the holder-qualified hook) before
             # the host unwinds, so the detached worker can never publish.
             fence.revoke_commit_admission()
+            # A running future still owns its admission slot. Only release
+            # synchronously when cancel() won before the worker started; a
+            # done-callback owns the running-future release.
+            if future.cancel():
+                admission.release()
 
 class CompressionCheckpointUnavailable(RuntimeError):
     """Raised when required durable pre-compress checkpointing is unavailable."""
@@ -1567,8 +1814,16 @@ def _emit_compression_attempt_telemetry(
             telemetry = {}
         payload = dict(telemetry)
         payload.setdefault("event", "compression_attempt")
-        payload.setdefault("attempt_id", getattr(agent, "_compression_attempt_id", "") or uuid.uuid4().hex)
-        payload.setdefault("session_id", getattr(agent, "session_id", "") or "")
+        current_attempt_id = getattr(agent, "_compression_attempt_id", None)
+        payload["attempt_id"] = str(
+            current_attempt_id or payload.get("attempt_id") or uuid.uuid4().hex
+        )
+        payload["session_id"] = str(
+            getattr(agent, "session_id", "") or payload.get("session_id") or ""
+        )
+        current_turn_id = getattr(agent, "_current_turn_id", None)
+        if isinstance(current_turn_id, str) and current_turn_id:
+            payload["turn_id"] = current_turn_id
         payload["total_duration_ms"] = int((time.monotonic() - started_at) * 1000)
         payload["commit_status"] = commit_status
         payload["split_status"] = split_status
@@ -2773,7 +3028,17 @@ def compress_context(
     agent._compression_skipped_due_to_lock = None
 
     _attempt_started_at = time.monotonic()
-    _attempt_id = uuid.uuid4().hex
+    _attempt_id = (
+        getattr(commit_fence, "attempt_id", None)
+        if commit_fence is not None
+        else None
+    ) or uuid.uuid4().hex
+    if commit_fence is not None:
+        commit_fence.bind_attempt(
+            _attempt_generation,
+            str(getattr(agent, "_current_turn_id", "") or ""),
+        )
+        _bind_compression_attempt_identity(agent, commit_fence)
     _trigger_source = "manual" if force else "auto"
     try:
         agent._compression_attempt_id = _attempt_id
@@ -2814,6 +3079,7 @@ def compress_context(
                 _restore_compressor_attempt_state(
                     agent.context_compressor, _compressor_attempt_snapshot,
                     attempt_generation=_attempt_generation,
+                    attempt_fence=commit_fence,
                 )
                 existing_prompt = getattr(agent, "_cached_system_prompt", None)
                 if not existing_prompt:
@@ -3553,13 +3819,21 @@ def compress_context(
         if commit_fence is not None:
             _install_compression_cancelled_check(
                 agent.context_compressor,
-                lambda: commit_fence.is_cancelled,
+                lambda: _cancel_source(),
                 _attempt_generation,
             )
         # Incoming-message interrupts and active-turn redirects must not tear an
         # atomic summary in half (#23975). Explicit stop surfaces set a separate
         # Event atomically; never infer cause from the racy message fields.
         _hard_cancel_event = getattr(agent, "_hard_interrupt_requested", None)
+        def _cancel_source() -> bool:
+            return bool(
+                (commit_fence is not None and commit_fence.is_cancelled)
+                or (
+                    _hard_cancel_event is not None
+                    and _hard_cancel_event.is_set()
+                )
+            )
         try:
             # F6: never start expensive summary work for an already-cancelled
             # fence (a stale queued job admitted after host departure).
@@ -3572,16 +3846,13 @@ def compress_context(
                 compressed = messages
             else:
                 with aux_progress_hook(_progress_hook), aux_interrupt_protection(
-                    cancel_event=_hard_cancel_event
+                    cancel_check=_cancel_source
                 ):
                     compressed = compress_fn(messages, **compress_kwargs)
                     # Freeze a hard stop that arrived after the final provider
                     # attempt unwound but before this transaction can rotate
                     # session state.
-                    if (
-                        _hard_cancel_event is not None
-                        and _hard_cancel_event.is_set()
-                    ):
+                    if _cancel_source():
                         raise AuxiliaryExplicitCancellation()
         finally:
             if commit_fence is not None:
@@ -3596,6 +3867,7 @@ def compress_context(
                 durable_cooldown_authoritative=_durable_cooldown_authoritative,
                 durable_cooldown_state=_durable_cooldown_state,
                 attempt_generation=_attempt_generation,
+                attempt_fence=commit_fence,
             )
         except BaseException as _rollback_exc:
             # Compensation failure must surface, but it must not strand the
@@ -3755,6 +4027,8 @@ def compress_context(
             _release_lock()
             return messages, _existing_sp
 
+        if _cancel_source():
+            raise AuxiliaryExplicitCancellation()
         if commit_fence is not None:
             _commit_fence_entered = commit_fence.begin_commit(_hard_cancel_event)
             if not _commit_fence_entered:
@@ -3764,6 +4038,7 @@ def compress_context(
                     durable_cooldown_authoritative=_durable_cooldown_authoritative,
                     durable_cooldown_state=_durable_cooldown_state,
                     attempt_generation=_attempt_generation,
+                    attempt_fence=commit_fence,
                 )
                 if (
                     messages_before_compression is not None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -16,6 +16,7 @@ resolved through :func:`_ra` so those patches keep working.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -1513,6 +1514,75 @@ def _compression_deferred_result(
     }
 
 
+def _terminal_compression_overflow_result(
+    agent, messages: List[Dict], api_call_count: int, reason: str,
+) -> Dict[str, Any]:
+    """Fail closed when a blocked terminal compression no-op cannot fit."""
+    compressor = getattr(agent, "context_compressor", None)
+    context_length = int(getattr(compressor, "context_length", 0) or 0)
+    message = (
+        "Context compression is unavailable after a terminal "
+        f"{reason} outcome; the assembled request exceeds the model context "
+        f"window ({context_length:,} tokens). Retry compression manually or "
+        "start a new session."
+    )
+    try:
+        agent._emit_warning(f"⚠ {message}")
+    except Exception:
+        pass
+    try:
+        # Persistence is a sink, not an owner of the live transcript. Pass a
+        # structural snapshot so terminal warning/readback cannot mutate nested
+        # message blocks while the host returns the original request unchanged.
+        agent._persist_session(copy.deepcopy(messages), None)
+    except Exception:
+        pass
+    error = f"retryable_compression_context_overflow:{reason}"
+    return {
+        "final_response": message,
+        "messages": messages,
+        "api_calls": api_call_count,
+        "completed": False,
+        "failed": True,
+        "partial": True,
+        "retryable": True,
+        "compression_context_overflow": True,
+        "compression_failure_class": reason,
+        "compression_attempt_id": getattr(agent, "_compression_attempt_id", ""),
+        "compression_turn_id": getattr(agent, "_current_turn_id", ""),
+        "error": error,
+    }
+
+
+def _compression_terminal_noop_reason(agent, cooldown) -> Optional[str]:
+    """Return only a current-attempt terminal compression provenance."""
+    del cooldown  # terminal state is authoritative; a generic cooldown is not
+    compressor = getattr(agent, "context_compressor", None)
+    attempt_id = getattr(agent, "_compression_attempt_id", None)
+    turn_id = getattr(agent, "_current_turn_id", None)
+    if not isinstance(attempt_id, str) or not isinstance(turn_id, str):
+        return None
+    for owner in (agent, compressor):
+        if owner is None:
+            continue
+        try:
+            outcome = copy.deepcopy(
+                getattr(owner, "_compression_terminal_outcome", None)
+            )
+        except Exception:
+            continue
+        if not isinstance(outcome, dict):
+            continue
+        if outcome.get("attempt_id") != attempt_id:
+            continue
+        if outcome.get("turn_id") != turn_id:
+            continue
+        failure = outcome.get("failure_class")
+        if failure in {"host_timeout", "pool_saturated"}:
+            return str(failure)
+    return None
+
+
 def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool:
     """Rewrite a cache-decorated system message in place, keeping its blocks.
 
@@ -1891,6 +1961,7 @@ def run_conversation(
     agent._last_compaction_in_place = False
     agent._last_compression_attempt_recorded = False
     agent._last_compression_attempt_in_place = None
+    compressor = getattr(agent, "context_compressor", None)
 
     # Adopt any ~/.hermes/.env credential/base-url edits made since the last
     # turn — a Settings save updates .env but not this worker's client, which
@@ -2651,6 +2722,29 @@ def run_conversation(
                 pass
             break
 
+        _early_ctx_len = getattr(
+            getattr(agent, "context_compressor", None), "context_length", None
+        )
+        _early_cooldown = getattr(
+            getattr(agent, "context_compressor", None),
+            "get_active_compression_failure_cooldown",
+            lambda: None,
+        )()
+        _early_reason = _compression_terminal_noop_reason(agent, _early_cooldown)
+        if (
+            agent.compression_enabled
+            and isinstance(_early_ctx_len, int)
+            and _early_ctx_len > 0
+            and request_pressure_tokens > _early_ctx_len
+            and _early_reason
+        ):
+            return _terminal_compression_overflow_result(
+                agent,
+                messages,
+                api_call_count,
+                _early_reason,
+            )
+
         # Pre-API pressure check. The turn-prologue preflight only saw the
         # incoming user message; a single turn can then grow by many large
         # tool results and leave no output budget before the NEXT call (the
@@ -2878,6 +2972,24 @@ def run_conversation(
                 )
                 if callable(_warn_fn):
                     _warn_fn(request_pressure_tokens, _ctx_len)
+
+        _ctx_len = getattr(_compressor, "context_length", None)
+        _terminal_reason = _compression_terminal_noop_reason(
+            agent, _compression_cooldown
+        )
+        if (
+            agent.compression_enabled
+            and isinstance(_ctx_len, int)
+            and _ctx_len > 0
+            and request_pressure_tokens > _ctx_len
+            and _terminal_reason
+        ):
+            return _terminal_compression_overflow_result(
+                agent,
+                messages,
+                api_call_count,
+                _terminal_reason,
+            )
 
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -8029,6 +8029,7 @@ class AIAgent:
         """
         from agent.conversation_compression import (
             CompressionCommitFence,
+            _publish_compression_timeout_outcome,
             compress_context,
             resolve_context_compression_timeouts,
             run_compress_context_with_progress_timeout,
@@ -8057,6 +8058,33 @@ class AIAgent:
             root = self._conversation_root_id()
             if root:
                 token = set_conversation_context(root)
+        # The timeout is terminal for automatic compression retries in this
+        # logical turn. Bind the latch to the turn id that turn_context stamped;
+        # a cached agent must not carry a prior turn's bool forever.
+        _timeout_compressor = getattr(self, "context_compressor", None)
+        _current_turn_id = getattr(self, "_current_turn_id", None)
+        _terminal_turn_id = (
+            getattr(_timeout_compressor, "_automatic_timeout_terminal_turn_id", None)
+            if _timeout_compressor is not None
+            else None
+        )
+        if force:
+            if _timeout_compressor is not None:
+                _timeout_compressor._automatic_timeout_terminal = False
+                _timeout_compressor._automatic_timeout_terminal_turn_id = None
+        elif (
+            _timeout_compressor is not None
+            and getattr(_timeout_compressor, "_automatic_timeout_terminal", False) is True
+            and isinstance(_current_turn_id, str)
+            and _terminal_turn_id == _current_turn_id
+        ):
+            existing_prompt = getattr(self, "_cached_system_prompt", None)
+            if not existing_prompt:
+                existing_prompt = self._build_system_prompt(system_message)
+            if token is not None:
+                reset_conversation_context(token)
+            return messages, existing_prompt
+
         # Every AIAgent compression has a fence, including ordinary in-turn and
         # manual paths. hard_interrupt() uses this exact instance to serialize
         # cancel admission against begin_commit().
@@ -8164,10 +8192,18 @@ class AIAgent:
                                 "compress_context timeout activity touch failed",
                                 exc_info=True,
                             )
-                    # Same timeout cooldown ladder as summary-LLM timeouts
-                    # (#62452): avoid re-burning the full idle budget every turn.
+                    # The fence owns the terminal outcome before the cooldown
+                    # write. This gate is idempotent if a wrapper/caller invokes
+                    # the timeout callback more than once.
+                    _timeout_outcome, _timeout_record_won = (
+                        _publish_compression_timeout_outcome(
+                            self,
+                            active_fence,
+                            latch_automatic_timeout=not force,
+                        )
+                    )
                     compressor = getattr(self, "context_compressor", None)
-                    if compressor is not None:
+                    if compressor is not None and _timeout_record_won:
                         record = getattr(compressor, "record_timeout_failure", None)
                         if callable(record):
                             try:
@@ -8181,6 +8217,7 @@ class AIAgent:
                                     "cooldown",
                                     exc_info=True,
                                 )
+
                     emit = getattr(self, "_emit_warning", None)
                     if callable(emit):
                         emit(

--- a/tests/agent/test_auxiliary_explicit_cancellation.py
+++ b/tests/agent/test_auxiliary_explicit_cancellation.py
@@ -620,3 +620,394 @@ def test_unrelated_interrupted_error_is_not_reclassified_as_explicit_cancel() ->
             aux._relay_sync_completion(client, {"model": "test", "messages": []})
 
     assert not isinstance(caught.value, aux.AuxiliaryExplicitCancellation)
+
+
+def test_every_physical_retry_uses_a_fenced_dispatch_wrapper(monkeypatch):
+    """A cancel after the dispatch snapshot denies a default relay callback."""
+    cancel_event = threading.Event()
+    snapshot_taken = threading.Event()
+    release_snapshot = threading.Event()
+    reads = 0
+    reads_lock = threading.Lock()
+    provider_calls = []
+    outcome = {}
+
+    def _source():
+        nonlocal reads
+        with reads_lock:
+            reads += 1
+            current = reads
+        if current == 1:
+            snapshot_taken.set()
+            assert release_snapshot.wait(timeout=1)
+            return False
+        return cancel_event.is_set()
+
+    def _create(**kwargs):
+        provider_calls.append(kwargs)
+        return SimpleNamespace(choices=[])
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
+    )
+
+    def _run():
+        try:
+            with aux.aux_interrupt_protection(cancel_check=_source):
+                aux._relay_sync_completion(
+                    client,
+                    {"model": "retry", "messages": [], "timeout": 1},
+                )
+        except BaseException as exc:
+            outcome["exc"] = exc
+
+    worker = threading.Thread(target=_run, name="retry-dispatch-fence", daemon=True)
+    worker.start()
+    try:
+        assert snapshot_taken.wait(timeout=1)
+        cancel_event.set()
+        release_snapshot.set()
+        worker.join(timeout=1)
+        assert not worker.is_alive()
+        assert isinstance(outcome.get("exc"), aux.AuxiliaryExplicitCancellation)
+        assert provider_calls == []
+    finally:
+        release_snapshot.set()
+        worker.join(timeout=1)
+
+
+@pytest.mark.parametrize(
+    "branch",
+    ["temperature", "structured_output", "max_tokens", "model_heal"],
+)
+def test_cancel_before_each_named_retry_branch_sends_no_next_rpc(monkeypatch, branch):
+    """Every named retry rung must use the physical dispatch fence."""
+    cancel_event = threading.Event()
+    calls = []
+    first_error = RuntimeError(f"{branch} retry trigger")
+    provider = "nous" if branch == "model_heal" else "test"
+    base_url = (
+        "https://inference-api.nousresearch.com/v1"
+        if branch == "model_heal"
+        else "https://example.test/v1"
+    )
+
+    class _Completions:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                # ``active=False`` keeps the first transport exception visible
+                # to the retry ladder; the next physical handoff must still
+                # consult the token.
+                cancel_event.set()
+                raise first_error
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content="must not be reached")
+                    )
+                ]
+            )
+
+    client = SimpleNamespace(
+        base_url=base_url,
+        chat=SimpleNamespace(completions=_Completions()),
+    )
+    monkeypatch.setattr(
+        aux, "_get_cached_client", lambda *_args, **_kwargs: (client, "stale-model")
+    )
+    monkeypatch.setattr(
+        aux,
+        "_effective_provider_for_client",
+        lambda _client, _provider: provider,
+    )
+    monkeypatch.setattr(aux, "_get_auxiliary_task_config", lambda _task: {})
+
+    call_kwargs = {"temperature": 0.2} if branch == "temperature" else {}
+    max_tokens = 32 if branch == "max_tokens" else None
+    if branch == "temperature":
+        monkeypatch.setattr(
+            aux, "_is_unsupported_temperature_error", lambda exc: exc is first_error
+        )
+    elif branch == "structured_output":
+        monkeypatch.setattr(
+            aux, "_is_structured_output_rejection", lambda exc: exc is first_error
+        )
+        monkeypatch.setattr(
+            aux, "_without_structured_output_format", lambda request: dict(request)
+        )
+    elif branch == "model_heal":
+        monkeypatch.setattr(
+            aux, "_is_model_not_found_error", lambda exc: exc is first_error
+        )
+        monkeypatch.setattr(
+            aux,
+            "_refresh_nous_recommended_model",
+            lambda **_kwargs: "healed-model",
+        )
+
+    with aux.aux_interrupt_protection(
+        active=False, cancel_event=cancel_event
+    ):
+        with pytest.raises(aux.AuxiliaryExplicitCancellation):
+            aux._call_llm_impl(
+                task="compression",
+                provider=provider,
+                model="stale-model",
+                base_url=base_url,
+                api_key="test-key",
+                messages=[],
+                max_tokens=max_tokens,
+                timeout=1,
+                **call_kwargs,
+            )
+
+    assert len(calls) == 1, f"{branch} admitted a cancelled retry: {calls!r}"
+
+
+def test_cancellation_during_auxiliary_backoff_makes_retry_inert_and_releases_permit(
+    monkeypatch,
+):
+    """Backoff polling must stop before the next physical RPC."""
+    cancel_event = threading.Event()
+    first_attempt = threading.Event()
+    release_first = threading.Event()
+    calls = []
+    outcome = {}
+
+    class _Completions:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                first_attempt.set()
+                raise ConnectionError("connection reset")
+            return SimpleNamespace(choices=[])
+
+    client = SimpleNamespace(
+        base_url="https://example.test/v1",
+        chat=SimpleNamespace(completions=_Completions()),
+    )
+    monkeypatch.setattr(
+        aux,
+        "_get_cached_client",
+        lambda *_args, **_kwargs: (client, "retry-model"),
+    )
+    monkeypatch.setattr(aux, "_effective_provider_for_client", lambda *_args: "test")
+    monkeypatch.setattr(aux, "_transient_retry_count", lambda: 1)
+    monkeypatch.setattr(aux, "_TRANSIENT_RETRY_BACKOFF_BASE", 2.0)
+    monkeypatch.setattr(
+        aux,
+        "_get_auxiliary_task_config",
+        lambda _task: {"max_concurrency": 1, "transient_retries": 1},
+    )
+    aux._reset_aux_semaphores()
+
+    def _run():
+        try:
+            with aux.aux_interrupt_protection(
+                active=False, cancel_event=cancel_event
+            ):
+                aux.call_llm(
+                    task="compression",
+                    provider="test",
+                    model="retry-model",
+                    base_url="https://example.test/v1",
+                    api_key="test-key",
+                    messages=[],
+                    timeout=5,
+                )
+        except BaseException as exc:
+            outcome["exc"] = exc
+
+    worker = threading.Thread(target=_run, name="retry-backoff-cancel", daemon=True)
+    worker.start()
+    try:
+        assert first_attempt.wait(timeout=5)
+        cancelled_at = time.monotonic()
+        cancel_event.set()
+        worker.join(timeout=0.75)
+        elapsed = time.monotonic() - cancelled_at
+        assert not worker.is_alive()
+        assert elapsed < 0.75
+        assert isinstance(outcome.get("exc"), aux.AuxiliaryExplicitCancellation)
+        assert len(calls) == 1
+        with aux._aux_sem_lock:
+            semaphore = aux._aux_sync_semaphores["compression"][1]
+            assert semaphore._value == 1
+    finally:
+        release_first.set()
+        worker.join(timeout=1)
+        aux._reset_aux_semaphores()
+
+
+def test_cancelled_token_registration_runs_cleanup_immediately_outside_lock():
+    """Registration after cancellation must invoke cleanup without the lock."""
+    token = aux.AuxiliaryCancellationToken(lambda: False)
+    token.cancel()
+    callback_called = threading.Event()
+    callback_observed_unlocked = threading.Event()
+
+    def _cleanup():
+        acquired = token._lock.acquire(timeout=0.2)
+        if acquired:
+            token._lock.release()
+            callback_observed_unlocked.set()
+        callback_called.set()
+
+    token.register_cancel_callback(_cleanup)
+    assert callback_called.is_set()
+    assert callback_observed_unlocked.is_set()
+
+
+def test_cancel_before_final_provider_dispatch_sends_zero_requests(monkeypatch) -> None:
+    """Cancellation at the final admission seam must deny the provider call."""
+    cancel_event = threading.Event()
+    claim_entered = threading.Event()
+    release_claim = threading.Event()
+    provider_calls: list[dict[str, Any]] = []
+    outcome: dict[str, BaseException] = {}
+
+    original_notify = aux._notify_aux_dispatch
+
+    def _gate_before_claim() -> None:
+        claim_entered.set()
+        assert release_claim.wait(timeout=1)
+        original_notify()
+
+    # The production notify is the deterministic seam immediately before the
+    # short OPEN -> ADMITTED dispatch claim.  Keeping the gate around the real
+    # notify also proves the provider callback is not invoked while a cancel is
+    # waiting to win that claim.
+    monkeypatch.setattr(aux, "_notify_aux_dispatch", _gate_before_claim)
+
+    def _create(**kwargs: Any) -> Any:
+        provider_calls.append(kwargs)
+        return SimpleNamespace(choices=[])
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
+    )
+
+    def _run() -> None:
+        try:
+            with aux.aux_interrupt_protection(cancel_event=cancel_event):
+                aux._relay_sync_completion(
+                    client,
+                    {"model": "test", "messages": [], "timeout": 1},
+                    create=lambda request: aux._create_with_progress(
+                        client, request, "compression", force_stream=True
+                    ),
+                )
+        except BaseException as exc:
+            outcome["exc"] = exc
+
+    worker = threading.Thread(target=_run, name="final-dispatch-cancel", daemon=True)
+    started = time.monotonic()
+    worker.start()
+    try:
+        assert claim_entered.wait(timeout=1), "dispatch claim seam was not reached"
+        cancel_event.set()
+        release_claim.set()
+        worker.join(timeout=1)
+        elapsed = time.monotonic() - started
+        assert not worker.is_alive()
+        assert elapsed < 0.75
+        assert isinstance(outcome.get("exc"), aux.AuxiliaryExplicitCancellation)
+        assert provider_calls == []
+    finally:
+        release_claim.set()
+        worker.join(timeout=1)
+
+
+def test_commit_fence_cancellation_interrupts_aux_semaphore_waiter(monkeypatch) -> None:
+    """A fenced waiter exits without stealing or releasing another permit."""
+    from agent.conversation_compression import CompressionCommitFence
+
+    first_provider_started = threading.Event()
+    release_first_provider = threading.Event()
+    second_semaphore_lookup = threading.Event()
+    outcomes: dict[str, Any] = {}
+    provider_calls: list[str] = []
+    lookup_count = 0
+    lookup_lock = threading.Lock()
+
+    monkeypatch.setattr(
+        aux,
+        "_get_auxiliary_task_config",
+        lambda _task: {"max_concurrency": 1},
+    )
+    original_lookup = aux._acquire_sync_aux_semaphore
+
+    def _tracked_lookup(task: Any) -> Any:
+        nonlocal lookup_count
+        semaphore = original_lookup(task)
+        with lookup_lock:
+            lookup_count += 1
+            if lookup_count == 2:
+                second_semaphore_lookup.set()
+        return semaphore
+
+    monkeypatch.setattr(aux, "_acquire_sync_aux_semaphore", _tracked_lookup)
+
+    def _fake_impl(**kwargs: Any) -> Any:
+        provider_calls.append(str(kwargs.get("model")))
+        first_provider_started.set()
+        assert release_first_provider.wait(timeout=5)
+        return SimpleNamespace(choices=[])
+
+    monkeypatch.setattr(aux, "_call_llm_impl", _fake_impl)
+    aux._reset_aux_semaphores()
+    semaphore = None
+
+    def _first() -> None:
+        try:
+            outcomes["first"] = aux.call_llm(
+                task="compression",
+                provider="test",
+                model="first",
+                messages=[],
+                timeout=1,
+            )
+        except BaseException as exc:
+            outcomes["first"] = exc
+
+    fence = CompressionCommitFence()
+
+    def _second() -> None:
+        try:
+            with aux.aux_interrupt_protection(cancel_check=lambda: fence.is_cancelled):
+                outcomes["second"] = aux.call_llm(
+                    task="compression",
+                    provider="test",
+                    model="second",
+                    messages=[],
+                    timeout=1,
+                )
+        except BaseException as exc:
+            outcomes["second"] = exc
+
+    first = threading.Thread(target=_first, name="compression-semaphore-owner", daemon=True)
+    second = threading.Thread(target=_second, name="compression-semaphore-waiter", daemon=True)
+    first.start()
+    second_started = False
+    try:
+        assert first_provider_started.wait(timeout=1)
+        second.start()
+        assert second_semaphore_lookup.wait(timeout=1)
+        second_started = True
+        assert fence.cancel_before_commit() is True
+        second.join(timeout=0.75)
+        assert not second.is_alive(), "cancelled semaphore waiter did not exit"
+        assert isinstance(outcomes.get("second"), aux.AuxiliaryExplicitCancellation)
+        assert provider_calls == ["first"]
+        with aux._aux_sem_lock:
+            semaphore = aux._aux_sync_semaphores["compression"][1]
+            assert semaphore._value == 0  # first provider still owns it
+    finally:
+        release_first_provider.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+        aux._reset_aux_semaphores()
+    assert not first.is_alive()
+    if second_started:
+        assert not second.is_alive()

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -533,3 +533,69 @@ class TestCompressContextForwarderOwnsTimeout:
         assert seen["fence"] is fence
         assert prompt == "sys"
         assert msgs[0]["content"] == "ok"
+
+
+def test_timeout_cancellation_is_terminal_for_same_turn_automatic_retry(monkeypatch):
+    """Same-turn timeout is terminal; a later turn and force can retry."""
+    from run_agent import AIAgent
+    from agent.context_compressor import ContextCompressor
+
+    agent = object.__new__(AIAgent)
+    agent.session_id = "same-turn-timeout"
+    agent._current_turn_id = "turn-1"
+    agent._cached_system_prompt = "sys"
+    agent._emit_warning = MagicMock()
+    agent._touch_activity = MagicMock()
+    agent._conversation_root_id = MagicMock(return_value=None)
+    agent.context_compressor = MagicMock()
+    agent.context_compressor._consecutive_timeout_failures = 0
+    agent.context_compressor._record_compression_failure_cooldown = MagicMock()
+    agent.context_compressor.record_timeout_failure = ContextCompressor.record_timeout_failure.__get__(
+        agent.context_compressor, MagicMock
+    )
+    release = threading.Event()
+    automatic_calls = []
+    force_calls = []
+
+    def fake_compress(agent_obj, messages, system_message, **kwargs):
+        if kwargs.get("force"):
+            force_calls.append(kwargs)
+            return messages, "forced"
+        automatic_calls.append(kwargs)
+        if len(automatic_calls) == 1:
+            release.wait(timeout=2)
+        return messages, "sys"
+
+    monkeypatch.setattr("agent.conversation_compression.compress_context", fake_compress)
+    monkeypatch.setattr(
+        "agent.conversation_compression.resolve_context_compression_timeouts",
+        lambda compression_cfg=None: (0.05, 0.1),
+    )
+    monkeypatch.setattr("agent.portal_tags.get_conversation_context", lambda: object())
+    original = [{"role": "user", "content": "unchanged"}]
+
+    first = AIAgent._compress_context(agent, original, "sys")
+    assert first[0] is original
+    assert len(automatic_calls) == 1
+    assert agent.context_compressor._record_compression_failure_cooldown.call_count == 1
+    release.set()
+
+    # The same logical turn remains suppressed even after its cooldown timer
+    # has expired; this is the turn-scoped terminal latch, not a time sleep.
+    agent.context_compressor._summary_failure_cooldown_until = time.monotonic() - 1
+    second = AIAgent._compress_context(agent, original, "sys")
+    assert second[0] is original
+    assert len(automatic_calls) == 1
+
+    # The authoritative next turn is admitted once the prior cooldown expires.
+    agent.context_compressor._summary_failure_cooldown_until = time.monotonic() - 1
+    agent._current_turn_id = "turn-2"
+    third = AIAgent._compress_context(agent, original, "sys")
+    assert third[0] is original
+    assert len(automatic_calls) == 2
+    assert agent.context_compressor._record_compression_failure_cooldown.call_count == 1
+
+    forced = AIAgent._compress_context(agent, original, "sys", force=True)
+    assert forced[0] is original
+    assert forced[1] == "forced"
+    assert len(force_calls) == 1

--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -242,6 +242,62 @@ class TestF2HostUnwindRevokesAdmission:
         )
         _drain_admission_slots()
 
+    def test_keyboard_interrupt_keeps_running_future_admission_until_done(
+        self, monkeypatch
+    ):
+        """A host unwind cannot release a slot owned by a running future."""
+        from tools.daemon_pool import DaemonThreadPoolExecutor
+
+        _drain_admission_slots()
+        previous_limit = cc._COMPRESS_EXECUTOR_MAX_WORKERS
+        cc._COMPRESS_EXECUTOR_MAX_WORKERS = 1
+        executor = DaemonThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="c1-fix3-keyboard"
+        )
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        def worker(_fence):
+            started.set()
+            assert release.wait(timeout=10)
+            finished.set()
+            return ([], "done")
+
+        monkeypatch.setattr(
+            cc,
+            "_get_compress_timeout_executor",
+            lambda: _InjectingExecutor(
+                executor, KeyboardInterrupt(), gate=started
+            ),
+        )
+        try:
+            with pytest.raises(KeyboardInterrupt):
+                run_compress_context_with_progress_timeout(
+                    worker=worker,
+                    messages=[{"role": "user", "content": "keep"}],
+                    system_prompt_fallback="fallback",
+                    idle_timeout_seconds=5.0,
+                    total_ceiling_seconds=5.0,
+                )
+
+            assert started.wait(timeout=2)
+            assert not finished.is_set()
+            with cc._compress_admission_lock:
+                assert cc._compress_admitted_count == 1
+
+            release.set()
+            assert finished.wait(timeout=5)
+            _drain_admission_slots()
+            with cc._compress_admission_lock:
+                assert cc._compress_admitted_count == 0
+        finally:
+            release.set()
+            _drain_admission_slots()
+            executor.shutdown(wait=True)
+            cc._COMPRESS_EXECUTOR_MAX_WORKERS = previous_limit
+            _drain_admission_slots()
+
 
 class TestF4CooldownClearOrdering:
     def test_cancelled_attempt_cannot_clear_failure_cooldown(self):
@@ -307,7 +363,8 @@ class TestF6ExecutorSaturation:
                 t.join(timeout=5)  # hosts time out; workers stay wedged
                 assert not t.is_alive()
 
-            # All 4 slots still admitted (workers blocked).
+            # Admission is owned by the future, not by the host timeout. The
+            # four non-cooperative futures remain bounded while detached.
             with cc._compress_admission_lock:
                 assert cc._compress_admitted_count == 4
 
@@ -362,8 +419,8 @@ class TestF6ExecutorSaturation:
                 cc.logger.removeHandler(capture)
                 cc.logger.setLevel(_prev_level)
             elapsed = time.monotonic() - t0
-            # ── Assert while the 4 workers are STILL wedged ───────────────
-            assert not release.is_set()
+            # The pool is still saturated while the original workers are
+            # blocked, so the fifth submission must refuse immediately.
             assert elapsed < 1.0, (
                 f"saturated submission must fail fast, took {elapsed:.2f}s"
             )
@@ -374,22 +431,18 @@ class TestF6ExecutorSaturation:
                 p for p in capture.payloads
                 if p.get("failure_class") == "pool_saturated"
             ]
-            assert saturated, (
-                "fail-fast admission refusal must emit compression-attempt "
-                "telemetry with failure_class='pool_saturated'"
-            )
+            assert saturated
             assert saturated[0]["commit_status"] == "aborted"
             assert saturated[0]["session_id"] == "SATURATED_SESSION"
         finally:
             release.set()
 
-        # Worker recovery: slots free, and the refused fifth job never runs.
+        # Worker recovery: slots free after the owner futures finish.
         _drain_admission_slots()
-        time.sleep(0.1)
         assert not fifth_ran.is_set(), (
-            "recovered workers must not run the refused stale job"
+            "saturated submission must not run later after recovery"
         )
-        # Recovery restores service: a new submission is admitted and runs.
+        # Recovery restores service: a NEW submission is admitted and runs.
         msgs, prompt = run_compress_context_with_progress_timeout(
             worker=lambda fence: ([{"role": "user", "content": "ok"}], "ok"),
             messages=[{"role": "user", "content": "after"}],
@@ -454,6 +507,7 @@ class TestF6ExecutorSaturation:
             assert returned is messages
             # The cancelled attempt must not leave the durable lock held.
             assert db.get_compression_lock_holder(session_id) is None
+            db.close()
 
 
 class TestS3IdleChargedFromLastProgress:
@@ -597,3 +651,182 @@ class TestRound2MidCommitLeaseRelease:
             session_id, "pid:second:contender", ttl_seconds=60
         )
         db.release_compression_lock(session_id, "pid:second:contender")
+
+
+def test_host_timeout_wins_late_same_generation_cooldown_rollback(tmp_path):
+    """Host timeout writes once and late same-generation rollback is inert."""
+    from unittest.mock import patch
+
+    from hermes_state import SessionDB
+    from agent.context_compressor import ContextCompressor
+    from agent.conversation_compression import (
+        _claim_compressor_attempt,
+        _publish_compression_terminal_outcome,
+        _restore_compressor_attempt_state,
+        _snapshot_compressor_attempt_state,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "R2_HOST_TIMEOUT_WINNER"
+    db.create_session(session_id, source="cli")
+    compressor = ContextCompressor(
+        "test/model", quiet_mode=True, config_context_length=1000
+    )
+    compressor.bind_session_state(db, session_id)
+    agent = type(
+        "_Agent",
+        (),
+        {
+            "context_compressor": compressor,
+            "session_id": session_id,
+            "_current_turn_id": "turn-timeout",
+        },
+    )()
+    fence = CompressionCommitFence()
+    generation = _claim_compressor_attempt(compressor)
+    fence.bind_attempt(generation, "turn-timeout")
+    snapshot = _snapshot_compressor_attempt_state(compressor)
+    durable_before = db.get_compression_failure_cooldown_row(session_id)
+    record = db.record_compression_failure_cooldown
+
+    with patch.object(db, "record_compression_failure_cooldown", wraps=record) as recorded:
+        _publish_compression_terminal_outcome(agent, fence, "host_timeout")
+        assert fence.claim_host_timeout_record("turn-timeout") is True
+        compressor.record_timeout_failure("host compress_context timeout (no summary progress)")
+        first_state = {
+            "cooldown": db.get_compression_failure_cooldown_row(session_id),
+            "deadline": compressor._summary_failure_cooldown_until,
+            "error": compressor._last_summary_error,
+            "streak": compressor._consecutive_timeout_failures,
+        }
+        assert recorded.call_count == 1
+
+        # Simulate the late same-generation worker unwind after the host record.
+        _restore_compressor_attempt_state(
+            compressor,
+            snapshot,
+            durable_cooldown_authoritative=True,
+            durable_cooldown_state=durable_before,
+            attempt_generation=generation,
+            attempt_fence=fence,
+        )
+
+    assert db.get_compression_failure_cooldown_row(session_id) == first_state["cooldown"]
+    assert compressor._summary_failure_cooldown_until == first_state["deadline"]
+    assert compressor._last_summary_error == first_state["error"]
+    assert compressor._consecutive_timeout_failures == first_state["streak"]
+    assert fence.claim_host_timeout_record("turn-timeout") is False
+    db.close()
+
+
+def test_host_timeout_releases_compression_pool_slot_before_provider_returns(monkeypatch):
+    """A timed-out owner frees admission while its provider callback remains detached."""
+    from types import SimpleNamespace
+    from agent import auxiliary_client as aux
+
+    from tools.daemon_pool import DaemonThreadPoolExecutor
+
+    _drain_admission_slots()
+    previous_limit = cc._COMPRESS_EXECUTOR_MAX_WORKERS
+    cc._COMPRESS_EXECUTOR_MAX_WORKERS = 1
+    executor = DaemonThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="c1-fix2-fresh"
+    )
+    monkeypatch.setattr(cc, "_get_compress_timeout_executor", lambda: executor)
+    provider_started = threading.Event()
+    release_provider = threading.Event()
+    provider_calls = []
+
+    def _create(**kwargs):
+        provider_calls.append(kwargs)
+        provider_started.set()
+        assert release_provider.wait(timeout=5)
+        return SimpleNamespace(choices=[])
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=_create))
+    )
+
+    def _blocked_worker(_fence):
+        return aux._relay_sync_completion(
+            client, {"model": "compression", "messages": [], "timeout": 1}
+        )
+
+    try:
+        result = run_compress_context_with_progress_timeout(
+            worker=_blocked_worker,
+            messages=[{"role": "user", "content": "keep"}],
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.05,
+            total_ceiling_seconds=0.05,
+        )
+        assert provider_started.wait(timeout=1)
+        assert result[0] is not None
+        with cc._compress_admission_lock:
+            assert cc._compress_admitted_count == 0
+        admitted = threading.Event()
+        fresh = run_compress_context_with_progress_timeout(
+            worker=lambda _fence: (admitted.set() or ([], "new")),
+            messages=[{"role": "user", "content": "new"}],
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=1,
+            total_ceiling_seconds=1,
+        )
+        assert admitted.is_set()
+        assert fresh == ([], "new")
+        assert provider_calls
+    finally:
+        release_provider.set()
+        cc._COMPRESS_EXECUTOR_MAX_WORKERS = previous_limit
+        _drain_admission_slots()
+        executor.shutdown(wait=True)
+
+
+def test_noncooperative_compression_owner_keeps_admission_bounded(monkeypatch):
+    """A legacy worker keeps its owner slot until its future really finishes."""
+    from tools.daemon_pool import DaemonThreadPoolExecutor
+
+    _drain_admission_slots()
+    previous_limit = cc._COMPRESS_EXECUTOR_MAX_WORKERS
+    cc._COMPRESS_EXECUTOR_MAX_WORKERS = 1
+    executor = DaemonThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="c1-fix2-noncooperative"
+    )
+    monkeypatch.setattr(cc, "_get_compress_timeout_executor", lambda: executor)
+    started = threading.Event()
+    release = threading.Event()
+    second_ran = threading.Event()
+
+    def noncooperative(_fence):
+        started.set()
+        assert release.wait(timeout=5)
+        return ([], "late")
+
+    try:
+        result = run_compress_context_with_progress_timeout(
+            worker=noncooperative,
+            messages=[{"role": "user", "content": "keep"}],
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.05,
+            total_ceiling_seconds=0.05,
+        )
+        assert result[0] is not None
+        assert started.wait(timeout=1)
+        with cc._compress_admission_lock:
+            assert cc._compress_admitted_count == 1
+        second = run_compress_context_with_progress_timeout(
+            worker=lambda _fence: (second_ran.set() or ([], "second")),
+            messages=[{"role": "user", "content": "second"}],
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.05,
+            total_ceiling_seconds=0.05,
+        )
+        assert second == ([{"role": "user", "content": "second"}], "fallback")
+        assert not second_ran.is_set()
+        with cc._compress_admission_lock:
+            assert cc._compress_admitted_count == 1
+    finally:
+        release.set()
+        _drain_admission_slots()
+        executor.shutdown(wait=True)
+        cc._COMPRESS_EXECUTOR_MAX_WORKERS = previous_limit

--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -516,14 +516,23 @@ class TestS3IdleChargedFromLastProgress:
         _drain_admission_slots()
         idle = 0.4
         release = threading.Event()
+        progress_at = None
+        timeout_observations = []
 
         def worker(fence: CompressionCommitFence):
+            nonlocal progress_at
             time.sleep(0.05)
             fence.touch_progress()  # early progress, then total silence
+            progress_at = time.monotonic()
             assert release.wait(timeout=10)
             return ([], "late")
 
-        t0 = time.monotonic()
+        def on_timeout(observed_idle, waited, since_progress):
+            timeout_observations.append(
+                (time.monotonic(), observed_idle, waited, since_progress)
+            )
+
+        returned_at = None
         try:
             msgs, prompt = run_compress_context_with_progress_timeout(
                 worker=worker,
@@ -531,17 +540,25 @@ class TestS3IdleChargedFromLastProgress:
                 system_prompt_fallback="fb",
                 idle_timeout_seconds=idle,
                 total_ceiling_seconds=5.0,
+                on_timeout=on_timeout,
+                stall_fallback=False,
             )
+            returned_at = time.monotonic()
         finally:
-            elapsed = time.monotonic() - t0
             release.set()
+
         assert prompt == "fb"
-        # Old behavior waited a full interval from the CHECK (~2x idle ≈
-        # 0.85s+). New behavior times out ~idle after the last progress
-        # (~0.45s). Allow generous slack while still excluding ~2x.
-        assert elapsed < idle * 1.8, (
-            f"silence exceeded ~2x idle budget shape: {elapsed:.2f}s"
-        )
+        assert timeout_observations
+        assert progress_at is not None
+        callback_at, observed_idle, waited, since_progress = timeout_observations[0]
+        assert observed_idle == pytest.approx(idle)
+        assert since_progress >= idle
+        assert since_progress < idle * 1.5
+        assert callback_at - progress_at < idle * 1.5
+
+        # Liveness only; this is not the S3 idle-decision contract.
+        assert returned_at is not None
+        assert returned_at - callback_at < 1.0
         _drain_admission_slots()
 
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2,8 +2,10 @@
 
 import json
 import sqlite3
+import threading
 import pytest
 import time
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import (
@@ -1061,7 +1063,7 @@ class TestSummaryFallbackToMainModel:
         ) as mock_call:
             result = c._generate_summary(self._msgs())
 
-        assert mock_call.call_count == 2
+        assert mock_call.call_count == 3
         # First call used the misconfigured aux model
         assert mock_call.call_args_list[0].kwargs.get("model") == "broken-aux-model"
         # Second call used the main model (no model kwarg → call_llm uses main)
@@ -1097,7 +1099,7 @@ class TestSummaryFallbackToMainModel:
         ) as mock_call:
             result = c._generate_summary(self._msgs())
 
-        assert mock_call.call_count == 2
+        assert mock_call.call_count == 3
         assert mock_call.call_args_list[0].kwargs.get("model") == "flaky-aux-model"
         assert "model" not in mock_call.call_args_list[1].kwargs
         assert result is not None
@@ -1160,7 +1162,7 @@ class TestSummaryFallbackToMainModel:
         ) as mock_call:
             result = c._generate_summary(self._msgs())
 
-        assert mock_call.call_count == 2
+        assert mock_call.call_count == 3
         assert mock_call.call_args_list[0].kwargs.get("model") == "aux-via-broken-proxy"
         assert "model" not in mock_call.call_args_list[1].kwargs
         assert result is not None
@@ -1217,7 +1219,7 @@ class TestStreamingClosedFallback:
         ):
             result = c._generate_summary(self._msgs())
 
-        assert mock_call.call_count == 2
+        assert mock_call.call_count == 3
         assert mock_call.call_args_list[0].kwargs.get("model") == "aux-stream-model"
         assert "model" not in mock_call.call_args_list[1].kwargs
         assert result is not None
@@ -3170,7 +3172,7 @@ class TestSummaryPromptBounding:
         with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
             summary = c._generate_summary(messages)
 
-        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        prompt = mock_call.call_args_list[0].kwargs["messages"][0]["content"]
         assert summary.startswith(SUMMARY_PREFIX)
         # previous summary block + new-turns block each capped, plus the
         # fixed template: well under 3x the cap (unbounded would be ~800K).
@@ -3676,3 +3678,68 @@ class TestSanitizeToolPairsWhitespace:
         tool_call_ids = [m.get("tool_call_id") for m in out if m.get("role") == "tool"]
         assert "call_orphan" not in tool_call_ids, "genuinely orphaned result must be removed"
         assert " call_orphan " not in tool_call_ids, "original whitespace form must also be gone"
+
+
+def test_fence_cancel_after_summary_sends_zero_lean_digest_requests(compressor, monkeypatch):
+    from agent import auxiliary_client as aux
+
+    cancel_event = threading.Event()
+    compressor._compression_cancelled_check = cancel_event.is_set
+    compressor._previous_summary = "previous summary"
+    clear_cooldown = MagicMock()
+    compressor._clear_compression_failure_cooldown = clear_cooldown
+    calls = []
+
+    def _summary_then_cancel(**kwargs):
+        calls.append(kwargs)
+        cancel_event.set()
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="summary body"))]
+        )
+
+    monkeypatch.setattr("agent.context_compressor.call_llm", _summary_then_cancel)
+    with pytest.raises(aux.AuxiliaryExplicitCancellation):
+        compressor._generate_summary(
+            [{"role": "user", "content": "old request"}],
+        )
+
+    assert len(calls) == 1
+    assert compressor._previous_summary == "previous summary"
+    clear_cooldown.assert_not_called()
+
+
+def test_fence_cancel_between_lean_digest_chunks_stops_remaining_chunks(compressor, monkeypatch):
+    from agent import auxiliary_client as aux
+
+    cancel_event = threading.Event()
+    compressor._compression_cancelled_check = cancel_event.is_set
+    compressor._previous_summary = "previous summary"
+    context_calls = []
+    auxiliary_calls = []
+
+    def _summary_and_first_digest(**kwargs):
+        context_calls.append(kwargs)
+        if len(context_calls) == 2:
+            cancel_event.set()
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="summary body"))]
+        )
+
+    def _unexpected_auxiliary_digest(**kwargs):
+        auxiliary_calls.append(kwargs)
+        cancel_event.set()
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="wrong seam"))]
+        )
+
+    monkeypatch.setattr("agent.context_compressor.call_llm", _summary_and_first_digest)
+    # A local re-import would bypass the module seam above. Keep the real
+    # auxiliary symbol patched to a distinct sentinel so that bypass is a
+    # deterministic RED failure without any provider/network call.
+    monkeypatch.setattr(aux, "call_llm", _unexpected_auxiliary_digest)
+    turns = [{"role": "user", "content": "x" * 150_000}]
+    with pytest.raises(aux.AuxiliaryExplicitCancellation):
+        compressor._generate_summary(turns)
+
+    assert len(context_calls) == 2  # summary plus exactly one digest request
+    assert auxiliary_calls == []

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -6,6 +6,10 @@ Verifies that:
 - Preflight compression proactively compresses oversized sessions before API calls
 """
 
+import copy
+import json
+import threading
+import time
 import pytest
 #pytestmark = pytest.mark.skip(reason="Hangs in non-interactive environments")
 
@@ -1212,3 +1216,279 @@ class TestOverflowWithCompactionDisabled:
         assert result.get("failed") is True
         assert result.get("compaction_disabled") is True
         assert "auto-compaction is disabled" in result["error"]
+
+    def _prepare_terminal_noop_overflow(self, agent, estimate):
+        agent.compression_enabled = True
+        agent.tools = []
+        agent._usage_anchor = None
+        agent._try_refresh_env_client_credentials = lambda: None
+        agent.context_compressor.context_length = 900_000
+        agent.context_compressor.threshold_tokens = 850_000
+        agent.context_compressor.get_active_compression_failure_cooldown = (
+            lambda refresh=False: {
+                "remaining_seconds": 60.0,
+                "error": "host compress_context timeout",
+            }
+        )
+        agent.context_compressor._last_compression_telemetry = {
+            "failure_class": "host_timeout"
+        }
+        history = [
+            {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"old {'user' if i % 2 == 0 else 'assistant'} {i}",
+            }
+            for i in range(8)
+        ]
+        warnings = []
+        agent.status_callback = lambda event, message: warnings.append((event, message))
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="provider must not run"
+        )
+        return history, warnings, estimate
+
+    def test_over_context_without_current_terminal_outcome_runs_compression(self, agent):
+        """Stale cooldown/telemetry cannot invent hard-overflow provenance."""
+        history, _warnings, estimate = self._prepare_terminal_noop_overflow(
+            agent, 1_320_689
+        )
+        # Keep the old bookkeeping as a stale fixture, but make the current
+        # compression route available. There is deliberately no current
+        # attempt-bound terminal outcome.
+        agent.context_compressor.get_active_compression_failure_cooldown = (
+            lambda refresh=False: None
+        )
+        agent._compression_attempt_id = "current-attempt"
+        agent._compression_terminal_outcome = None
+        agent.context_compressor._compression_terminal_outcome = None
+        compressed = [{"role": "user", "content": "compacted"}]
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=estimate),
+            patch("agent.conversation_loop.estimate_messages_tokens_rough", return_value=estimate),
+            patch("agent.conversation_loop.estimate_request_tokens_rough", return_value=estimate),
+            patch("agent.conversation_loop.anchored_context_tokens", return_value=None),
+            patch.object(agent, "_compress_context", return_value=(compressed, "compressed")) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=history)
+
+        mock_compress.assert_called()
+        assert agent.client.chat.completions.create.call_count == 1
+        assert result["completed"] is True
+        assert "compression_context_overflow" not in result
+        from agent.conversation_loop import _compression_terminal_noop_reason
+        assert _compression_terminal_noop_reason(agent, None) is None
+
+    def test_cooldown_blocked_request_below_full_context_may_continue(self, agent):
+        history, _warnings, estimate = self._prepare_terminal_noop_overflow(agent, 800_000)
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=estimate),
+            patch("agent.conversation_loop.estimate_messages_tokens_rough", return_value=estimate),
+            patch("agent.conversation_loop.estimate_request_tokens_rough", return_value=estimate),
+            patch("agent.conversation_loop.anchored_context_tokens", return_value=None),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=history)
+
+        assert agent.client.chat.completions.create.call_count == 1
+        assert result["completed"] is True
+
+
+def test_terminal_timeout_keeps_fence_identity_when_next_turn_wins(monkeypatch, agent):
+    """A late timeout cannot publish or latch the mutable next turn."""
+    from agent.conversation_compression import (
+        CompressionCommitFence,
+        _claim_compressor_attempt,
+    )
+    from agent.conversation_loop import _compression_terminal_noop_reason
+
+    compressor = agent.context_compressor
+    agent._current_turn_id = "turn-1"
+    agent._compression_terminal_outcome = None
+    compressor._automatic_timeout_terminal = False
+    compressor._automatic_timeout_terminal_turn_id = None
+    compressor._compression_terminal_outcome = None
+    compressor._compression_attempt_generation = 7
+    publication_entered = threading.Event()
+    release_publication = threading.Event()
+    finished = threading.Event()
+    fence_box = {}
+    result_box = {}
+
+    def fake_timeout_wrapper(**kwargs):
+        fence = kwargs["fence"]
+        fence_box["fence"] = fence
+        fence.bind_attempt(7, "turn-1")
+        attempt_id = fence.attempt_id
+        agent._compression_attempt_id = attempt_id
+        compressor._compression_attempt_id = attempt_id
+        original_claim = fence.claim_terminal_outcome
+
+        def delayed_claim(*args, **claim_kwargs):
+            publication_entered.set()
+            assert release_publication.wait(timeout=5)
+            return original_claim(*args, **claim_kwargs)
+
+        fence.claim_terminal_outcome = delayed_claim
+        kwargs["on_timeout"](0.01, 0.01, 0.01)
+        finished.set()
+        return kwargs["messages"], "sys"
+
+    monkeypatch.setattr(
+        "agent.conversation_compression.run_compress_context_with_progress_timeout",
+        fake_timeout_wrapper,
+    )
+    monkeypatch.setattr(
+        "agent.conversation_compression.resolve_context_compression_timeouts",
+        lambda compression_cfg=None: (0.01, 0.01),
+    )
+    monkeypatch.setattr("agent.portal_tags.get_conversation_context", lambda: object())
+    agent._emit_warning = MagicMock()
+    agent._touch_activity = MagicMock()
+
+    def run():
+        result_box["value"] = AIAgent._compress_context(
+            agent, [{"role": "user", "content": "keep"}], "sys"
+        )
+
+    thread = threading.Thread(target=run, name="stale-timeout-publication")
+    thread.start()
+    assert publication_entered.wait(timeout=2)
+
+    # New-turn ownership advances while the old fence is paused before its
+    # terminal publication/latch transition.
+    agent._current_turn_id = "turn-2"
+    _claim_compressor_attempt(compressor)
+    agent._compression_attempt_id = "turn-2-attempt"
+    compressor._compression_attempt_id = "turn-2-attempt"
+    release_publication.set()
+
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert finished.is_set()
+    assert result_box["value"][0]
+    outcome = fence_box["fence"].terminal_outcome
+    assert outcome["turn_id"] == "turn-1"
+    assert compressor._automatic_timeout_terminal is False
+    assert compressor._automatic_timeout_terminal_turn_id is None
+    assert _compression_terminal_noop_reason(agent, None) is None
+
+
+def test_real_host_timeout_terminal_outcome_preserves_deep_transcript(agent):
+    """Host timeout provenance is current-attempt bound and persistence sees a copy."""
+    from agent.conversation_compression import (
+        CompressionCommitFence,
+        run_compress_context_with_progress_timeout,
+    )
+    from agent.conversation_loop import (
+        _compression_terminal_noop_reason,
+        _terminal_compression_overflow_result,
+    )
+
+    agent._current_turn_id = "turn-host-timeout"
+    agent.context_compressor.context_length = 100
+    agent.context_compressor._last_compression_telemetry = {
+        "attempt_id": "stale",
+        "failure_class": "host_timeout",
+    }
+    agent._preflight_compression_blocked = True
+    messages = [
+        {
+            "role": "user",
+            "content": {"blocks": [{"type": "text", "text": "keep"}]},
+        }
+    ]
+    before = copy.deepcopy(messages)
+    before_bytes = json.dumps(
+        before, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    persisted = []
+
+    def _persist(snapshot, _history):
+        persisted.append(snapshot)
+        snapshot[0]["content"]["blocks"].append({"type": "text", "text": "sink-only"})
+
+    agent._persist_session = MagicMock(side_effect=_persist)
+    release = threading.Event()
+    started = threading.Event()
+
+    def blocked_worker(_fence):
+        started.set()
+        assert release.wait(timeout=5)
+        return ([], "late")
+
+    try:
+        result = run_compress_context_with_progress_timeout(
+            worker=blocked_worker,
+            messages=messages,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.03,
+            total_ceiling_seconds=0.03,
+            fence=CompressionCommitFence(),
+            telemetry_agent=agent,
+            stall_fallback=False,
+        )
+        assert started.wait(timeout=1)
+        assert result[0] is messages
+        assert _compression_terminal_noop_reason(agent, None) == "host_timeout"
+        terminal = _terminal_compression_overflow_result(
+            agent, messages, 0, "host_timeout"
+        )
+        assert terminal["compression_failure_class"] == "host_timeout"
+        assert terminal["compression_attempt_id"] == agent._compression_attempt_id
+        assert terminal["compression_turn_id"] == agent._current_turn_id
+        assert messages == before
+        assert persisted
+        assert persisted[0] != messages
+        assert json.dumps(
+            messages, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8") == before_bytes
+    finally:
+        release.set()
+
+
+def test_real_pool_saturated_terminal_outcome_is_not_stale_local_flag(monkeypatch, agent):
+    """A genuine admission refusal binds pool_saturated to the active attempt."""
+    from agent.conversation_compression import (
+        run_compress_context_with_progress_timeout,
+    )
+    from agent.conversation_loop import _compression_terminal_noop_reason
+    import agent.conversation_compression as cc
+
+    agent._current_turn_id = "turn-pool-saturated"
+    agent._preflight_compression_blocked = True
+    agent.context_compressor._last_compression_telemetry = {
+        "attempt_id": "old-attempt",
+        "failure_class": "host_timeout",
+    }
+    previous_limit = cc._COMPRESS_EXECUTOR_MAX_WORKERS
+    try:
+        cc._COMPRESS_EXECUTOR_MAX_WORKERS = 1
+        with cc._compress_admission_lock:
+            cc._compress_admitted_count = 1
+        messages = [{"role": "user", "content": "unchanged"}]
+        result = run_compress_context_with_progress_timeout(
+            worker=lambda _fence: (_ for _ in ()).throw(
+                AssertionError("saturated path must not start a worker")
+            ),
+            messages=messages,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=1,
+            total_ceiling_seconds=1,
+            telemetry_agent=agent,
+            stall_fallback=False,
+        )
+        assert result == (messages, "fallback")
+        assert _compression_terminal_noop_reason(agent, None) == "pool_saturated"
+        assert agent._compression_terminal_outcome["failure_class"] == "pool_saturated"
+        assert agent._compression_terminal_outcome["turn_id"] == "turn-pool-saturated"
+        agent._compression_attempt_id = "different-attempt"
+        assert _compression_terminal_noop_reason(agent, None) is None
+    finally:
+        with cc._compress_admission_lock:
+            cc._compress_admitted_count = 0
+        cc._COMPRESS_EXECUTOR_MAX_WORKERS = previous_limit


### PR DESCRIPTION
## Summary
- bound compression timeout/cancellation effects to attempt, generation, and turn ownership
- prevent stale workers, late callbacks, and superseded retries from publishing into newer turns
- serialize outbound dispatch admission without holding coordination locks across RPCs
- preserve non-cooperative admitted work while returning bounded terminal outcomes
- suppress same-turn automatic retries after timeout while allowing explicit forced retries

## Verification
- canonical focused runner: **235 passed, 0 failed**
- independent Sol review: **APPROVE**, 0 Critical / 0 Important
- `py_compile`: all 10 changed Python paths
- `git diff --check`: pass
- rebased by clean cherry-pick onto current upstream main `3f36c87e1ebdfbf7d14a88229dc9be222c12ea89`

## Runtime
No live Hermes/Desktop restart or activation was performed.