### PR TITLE
fix(kanban): honor dispatcher failure limit in reapers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4519,7 +4519,7 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
 
 
 def recompute_ready(
-    conn: sqlite3.Connection, failure_limit: int = None,
+    conn: sqlite3.Connection, failure_limit: Optional[int] = None,
 ) -> int:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
@@ -8139,7 +8139,7 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     * ``"clean_exit"`` — ``WIFEXITED`` with ``WEXITSTATUS == 0``. When the
       task is still ``running`` in the DB, this is a protocol violation
       (worker exited without calling ``kanban_complete`` / ``kanban_block``)
-      and should be auto-blocked immediately — retrying will just loop.
+      accounted against a dedicated bounded retry streak.
     * ``"rate_limited"`` — ``WIFEXITED`` with status
       ``KANBAN_RATE_LIMIT_EXIT_CODE``. The worker bailed because the
       provider rate-limited / exhausted quota, NOT because the task failed.
@@ -8434,6 +8434,7 @@ def heartbeat_worker(
 def enforce_max_runtime(
     conn: sqlite3.Connection,
     *,
+    failure_limit: Optional[int] = None,
     signal_fn=None,
 ) -> list[str]:
     """Terminate workers whose per-task ``max_runtime_seconds`` has elapsed.
@@ -8442,7 +8443,10 @@ def enforce_max_runtime(
     ``timed_out`` event and restores the task's source phase so the next
     dispatcher tick re-spawns the same kind of worker — unless the circuit
     breaker has already given up, in which case the task stays blocked
-    where ``_record_spawn_failure`` parked it.
+    where ``_record_task_failure`` parked it.
+
+    ``failure_limit`` is the dispatcher's configured unified retry budget;
+    ``None`` preserves the default used by direct callers.
 
     Runs host-local: only tasks claimed by this host are candidates
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
@@ -8540,6 +8544,7 @@ def enforce_max_runtime(
                 conn, tid,
                 error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
                 outcome="timed_out",
+                failure_limit=failure_limit,
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={
@@ -8860,7 +8865,11 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection,
+    *,
+    failure_limit: Optional[int] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and restores the task's source phase.
@@ -8875,9 +8884,9 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     When the reap registry shows the worker exited cleanly (rc=0) but
     the task was still ``running`` in the DB, treat it as a protocol
     violation (worker answered conversationally without calling
-    ``kanban_complete`` / ``kanban_block``) and trip the circuit breaker
-    on the first occurrence — retrying a worker whose CLI keeps
-    returning 0 without a terminal transition just loops forever.
+    ``kanban_complete`` / ``kanban_block``) and account it against a
+    dedicated bounded retry streak. This prevents unbounded loops without
+    consuming the ordinary crash budget on the first occurrence.
 
     When the reap registry shows the worker exited with the rate-limit
     sentinel (``KANBAN_RATE_LIMIT_EXIT_CODE``), the worker bailed on a
@@ -8887,6 +8896,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     ``check_respawn_guard`` defers their respawn until the window clears.
     The ids are returned via the ``_last_rate_limited`` function attribute
     (the public return stays the crashed-only ``list[str]``).
+
+    ``failure_limit`` governs ordinary crashes through the unified failure
+    counter. Protocol-violation and systemic-crash threshold selection is
+    handled separately below.
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
@@ -9128,7 +9141,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 conn, tid,
                 error=error_text,
                 outcome="crashed",
-                failure_limit=1 if is_systemic else None,
+                failure_limit=1 if is_systemic else failure_limit,
                 release_claim=False,
                 end_run=False,
                 event_payload_extra={"pid": pid, "claimer": claimer},
@@ -9166,7 +9179,7 @@ def _record_task_failure(
     error: str,
     *,
     outcome: str,
-    failure_limit: int = None,
+    failure_limit: Optional[int] = None,
     force_trip: bool = False,
     release_claim: bool = False,
     end_run: bool = False,
@@ -9343,7 +9356,7 @@ def _record_spawn_failure(
     task_id: str,
     error: str,
     *,
-    failure_limit: int = None,
+    failure_limit: Optional[int] = None,
 ) -> bool:
     return _record_task_failure(
         conn, task_id, error,
@@ -9925,9 +9938,10 @@ def _dispatch_once_locked(
          return value (if any) is recorded as ``worker_pid`` so subsequent
          ticks can detect crashes before the TTL expires.
 
-    Spawn failures are counted per-task. After ``failure_limit`` consecutive
-    failures the task is auto-blocked with the last error as its reason —
-    prevents the dispatcher from thrashing forever on an unfixable task.
+    Non-success attempts are counted per-task. After ``failure_limit``
+    consecutive failures the task is auto-blocked with the last error as its
+    reason — preventing the dispatcher from thrashing forever on an
+    unfixable task.
 
     ``max_spawn`` is a **live concurrency cap**, not a per-tick spawn budget:
     it counts tasks already in ``status='running'`` plus this tick's spawns
@@ -9962,7 +9976,9 @@ def _dispatch_once_locked(
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(
+        conn, failure_limit=failure_limit,
+    )
     # detect_crashed_workers stashes protocol-violation auto-blocks on
     # itself so the public list-return stays stable. Pull them into the
     # DispatchResult here so telemetry / tests see the trip.
@@ -9979,7 +9995,9 @@ def _dispatch_once_locked(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
-    result.timed_out = enforce_max_runtime(conn)
+    result.timed_out = enforce_max_runtime(
+        conn, failure_limit=failure_limit,
+    )
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
     # Count tasks already running so max_spawn enforces concurrency rather

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import signal
 import subprocess
 import threading
 import time
@@ -312,6 +313,62 @@ def test_max_runtime_terminates_overrun_worker(kanban_home):
             conn.close()
     finally:
         _kb._pid_alive = original_alive
+
+
+def test_max_runtime_honours_dispatcher_failure_limit(kanban_home, monkeypatch):
+    """A dispatcher failure limit of one blocks on the first timeout."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="single-timeout budget",
+            assignee="worker",
+            max_runtime_seconds=1,
+        )
+        kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 999_991)
+        old_started = int(time.time()) - 30
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET started_at = ? WHERE id = ?",
+                (old_started, tid),
+            )
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? "
+                "WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
+                (old_started, tid),
+            )
+
+        # The crash reaper runs before timeout enforcement. Keep this fresh
+        # claim inside its launch grace so only the timeout path handles it.
+        monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "86400")
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        killed = []
+        # dispatch_once does not expose enforce_max_runtime's signal_fn test
+        # hook, so patch the process-global kill function for this short scope.
+        monkeypatch.setattr(
+            os, "kill", lambda pid, sig: killed.append((pid, sig)),
+        )
+        result = _kb.dispatch_once(
+            conn, max_spawn=0,
+            failure_limit=1,
+        )
+        assert tid in result.timed_out
+        assert killed == [(999_991, signal.SIGTERM)]
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 1
+        gave_up = [
+            event for event in kb.list_events(conn, tid)
+            if event.kind == "gave_up"
+        ]
+        assert len(gave_up) == 1
+        assert gave_up[0].payload["effective_limit"] == 1
+        assert gave_up[0].payload["limit_source"] == "dispatcher"
+    finally:
+        conn.close()
 
 
 
@@ -1320,6 +1377,86 @@ def _drive_nonzero_crash(conn, tid, fake_pid):
     return _drive_worker_exit(conn, tid, fake_pid, 256)
 
 
+def test_crash_honours_dispatcher_failure_limit(kanban_home, monkeypatch):
+    """The configured unified failure budget applies to plain crashes."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="single-crash budget", assignee="worker")
+        pid = 991_099
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        assert _kb.claim_task(conn, tid, claimer=f"{host_prefix}:mock")
+        _kb._set_worker_pid(conn, tid, pid)
+        _kb._record_worker_exit(pid, 256)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET started_at = ? WHERE id = ?",
+                (int(time.time()) - 30, tid),
+            )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+        result = _kb.dispatch_once(conn, max_spawn=0, failure_limit=1)
+        assert tid in result.crashed
+        assert tid in result.auto_blocked
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 1
+        gave_up = [
+            event for event in kb.list_events(conn, tid)
+            if event.kind == "gave_up"
+        ]
+        assert len(gave_up) == 1
+        assert gave_up[0].payload["effective_limit"] == 1
+        assert gave_up[0].payload["limit_source"] == "dispatcher"
+    finally:
+        conn.close()
+
+
+def test_crash_breaker_agrees_with_lenient_dispatcher_limit(
+    kanban_home, monkeypatch,
+):
+    """A lenient dispatcher limit must not trip at the built-in default."""
+    import hermes_cli.kanban_db as _kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="lenient crash budget", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+        for attempt, pid in enumerate((991_101, 991_102, 991_103), start=1):
+            assert _kb.claim_task(conn, tid, claimer=f"{host_prefix}:mock")
+            _kb._set_worker_pid(conn, tid, pid)
+            _kb._record_worker_exit(pid, 256)
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET started_at = ? WHERE id = ?",
+                    (int(time.time()) - 30, tid),
+                )
+
+            result = _kb.dispatch_once(conn, max_spawn=0, failure_limit=3)
+            assert tid in result.crashed
+            task = kb.get_task(conn, tid)
+            assert task.consecutive_failures == attempt
+            gave_up = [
+                event for event in kb.list_events(conn, tid)
+                if event.kind == "gave_up"
+            ]
+            if attempt < 3:
+                assert task.status == "ready"
+                assert tid not in result.auto_blocked
+                assert gave_up == []
+            else:
+                assert task.status == "blocked"
+                assert tid in result.auto_blocked
+                assert len(gave_up) == 1
+                assert gave_up[0].payload["effective_limit"] == 3
+                assert gave_up[0].payload["limit_source"] == "dispatcher"
+    finally:
+        conn.close()
+
+
 def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
     """Mixed failure kinds must not consume the violation retry budget.
 
@@ -1406,5 +1543,3 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
-


### PR DESCRIPTION
## Summary

- propagate the dispatcher `failure_limit` into max-runtime timeout accounting
- propagate the same limit into ordinary worker-crash accounting
- preserve the dedicated systemic-crash and protocol-violation thresholds
- cover strict and lenient limits through full dispatcher ticks

## Bug

The dispatcher passed its configured failure limit to spawn-failure accounting and `recompute_ready`, but the timeout and crash reapers omitted it. Those paths silently fell back to `DEFAULT_FAILURE_LIMIT`.

With a strict limit, tasks received more retries than configured. With a lenient limit, the breaker could trip at the built-in default and `recompute_ready` could immediately promote the task under the configured limit, producing a block/promote retry loop.

## Validation

- reproduced both affected paths on upstream `main` before the fix
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py -q`
- 316 passed, 2 platform-specific skips on macOS
- adversarial Claude Code review converged after four bounded passes; unsafe real-signal behavior in the dispatcher-level timeout test was removed before submission

The production change is keyword-only and default-preserving: the dispatcher default and direct-call fallback both remain `DEFAULT_FAILURE_LIMIT`.