### PR TITLE
fix(cli): don't resolve venv python into Linux desktop Exec=

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -76,14 +76,20 @@ def resolve_exec_command() -> str:
             # installer's bash wrapper). Launched from the .desktop entry that
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
-            # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # Prefix the running interpreter. Do NOT Path.resolve() it:
+            # venv/bin/python is often a symlink to /usr/bin/python3.N, and
+            # following that drops the venv (ModuleNotFoundError: hermes_cli).
+            argv = [_running_interpreter(), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [_running_interpreter(), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _running_interpreter() -> str:
+    """``sys.executable`` as the DE should invoke it — never follow venv symlinks."""
+    return str(Path(sys.executable))
 
 
 def _needs_interpreter(bin_path: Path) -> bool:
@@ -99,15 +105,24 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # loader is self-sufficient.
         return False
     shebang = head.decode("utf-8", errors="replace").strip().lower()
-    if "python" not in shebang:
+    if not shebang.startswith("#!"):
+        return False
+    rest = shebang[2:].strip()
+    if "python" not in rest:
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
+    prog = rest.split()[0]
+    # ``#!/usr/bin/env python3`` always escapes the venv when the DE spawns
+    # it. Do not substring-match the interpreter dir against the shebang:
+    # ``/usr/bin`` is inside ``/usr/bin/env python3`` and would skip the
+    # prefix (#90292) *and* is the follow-symlink target of venv/bin/python.
+    if Path(prog).name == "env":
+        return True
     # A python shebang pointing INSIDE the running interpreter's environment
-    # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    # already resolves correctly; a system path would not.
+    exe_dir = str(Path(sys.executable).parent)
+    return exe_dir not in prog
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,7 +107,7 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(Path(sys.executable))
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -135,7 +135,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(Path(sys.executable))
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
@@ -146,6 +146,35 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
 
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
+    assert exec_line == f"{hermes_bin} desktop"
+
+
+def test_exec_does_not_follow_venv_python_symlink(tmp_path, xdg_home, monkeypatch):
+    """venv/bin/python is often a symlink to /usr/bin/python3.N.
+
+    Resolving that into Exec= launches system Python, which cannot import
+    hermes_cli — silent menu death because Terminal=false.
+    """
+    root = _make_project(tmp_path)
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    system_py = tmp_path / "usr" / "bin" / "python3.11"
+    system_py.parent.mkdir(parents=True)
+    system_py.write_text("#!/bin/sh\n", encoding="utf-8")
+    system_py.chmod(0o755)
+    venv_py = venv_bin / "python"
+    venv_py.symlink_to(system_py)
+    hermes_bin = venv_bin / "hermes"
+    hermes_bin.write_text(f"#!{venv_py}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr(lde.sys, "executable", str(venv_py))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert str(system_py) not in exec_line
     assert exec_line == f"{hermes_bin} desktop"
 
 


### PR DESCRIPTION
## Bug Description

After `hermes desktop` (and after every rebuild/update), the Linux menu entry is rewritten with an `Exec=` that launches **system Python**. The icon does nothing. `hermes desktop` from a TTY still works.

Reproduced on EndeavourOS / Hyprland, git install, `venv/bin/python -> /usr/bin/python3.11`:

```
Exec=/usr/bin/python3.11 ~/.hermes/hermes-agent/venv/bin/hermes desktop
```

That command exits 1 with `ModuleNotFoundError: No module named 'hermes_cli'`. `Terminal=false`, so the DE shows nothing.

Related: #90292 (partially addressed by #90492), #92095, #94110, #94058.

There are already open PRs on the same class of bug (#92090, #94051, #96685). This one is the smallest delta that also closes a `#90292` hole the others still have: substring-matching the interpreter dir against the shebang, so `/usr/bin` matches `#!/usr/bin/env python3` and skips the venv prefix.

## Root Cause

1. `Path(sys.executable).resolve()` follows `venv/bin/python` (symlink) to `/usr/bin/python3.N` or the uv store. CPython only activates a venv via the *unresolved* argv[0] + `pyvenv.cfg`.
2. `_needs_interpreter` used `exe_dir not in shebang`. After (1), `exe_dir` is `/usr/bin`, which is **not** in `#!…/venv/bin/python3`, so a *correct* venv console-script was classified as foreign and got the system interpreter prefixed. The same substring also matches `#!/usr/bin/env python3`, which would skip the #90292 prefix.

## Fix

- Prefix `sys.executable` **without** following the symlink.
- Treat `env` shebangs as always needing that prefix.
- Compare the unresolved interpreter dir against the shebang *program*, not the whole line.

## How to Verify

1. Linux git/uv install where `venv/bin/python` is a symlink to a base interpreter.
2. Run `hermes desktop` once from a TTY.
3. `awk -F= '/^Exec=/{print substr($0,6)}' ~/.local/share/applications/hermes.desktop`
   - must **not** start with `/usr/bin/python` or `~/.local/share/uv/python/…`
   - good: `…/venv/bin/hermes desktop` or `~/.local/bin/hermes desktop` or `…/venv/bin/python …/hermes desktop`
4. Launch from the app menu. Window opens.

## Test Plan

- [x] Added regression test: venv python symlink must not appear as the resolved base interpreter in `Exec=`
- [x] Existing tests still pass (`tests/hermes_cli/test_linux_desktop_entry.py`: 16 passed, 2 skipped)
- [x] Manual verification of the fix (menu Exec rewritten; `~/.local/bin/hermes --version` works)

## Risk Assessment

Low — Linux `.desktop` writer only. macOS/Windows unchanged. Shell-wrapper launchers still left alone. `#90292` env-shebang prefix still applied, now with the venv path instead of the base interpreter.