### PR TITLE
fix(website): abort a stalled skills catalog fetch and show a retryable error card

### DIFF
--- a/website/src/pages/skills/index.tsx
+++ b/website/src/pages/skills/index.tsx
@@ -481,6 +481,9 @@ const PAGE_SIZE = 60;
 // place that needs to follow.
 const SKILLS_URL = "/docs/api/skills.json";
 const META_URL = "/docs/api/skills-meta.json";
+// Idle timeout for the catalog fetch — abort only when the transfer has
+// produced no bytes for this long, so slow-but-alive downloads survive.
+const CATALOG_STALL_TIMEOUT_MS = 45_000;
 
 function buildSearchHaystack(s: Skill): string {
   // Pre-compute the lowercase blob the search filter scans. Done once at
@@ -535,6 +538,8 @@ export default function SkillsDashboard() {
   // mount from the same CDN that serves the docs.
   const [data, setData] = useState<{ skills: Skill[]; meta: IndexMeta } | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  // Bumped by the error card's Retry button to re-run the catalog load.
+  const [reloadKey, setReloadKey] = useState(0);
 
   const [search, setSearch] = useState("");
   // Debounced copy of `search` — used by the filter. Without the debounce,
@@ -550,16 +555,41 @@ export default function SkillsDashboard() {
   const searchRef = useRef<HTMLInputElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
 
+  // The catalog comes from the docs CDN (skills.json 301s onto GitHub
+  // Pages, ~50 MB raw). A connection that silently hangs — polluted DNS,
+  // TLS resets — would otherwise leave the page on "Loading the
+  // catalog…" forever, so read the body as a stream and abort only when
+  // no bytes have arrived for CATALOG_STALL_TIMEOUT_MS. Slow-but-alive
+  // transfers keep resetting the timer and are never cut off (#97861).
   useEffect(() => {
+    const ctrl = new AbortController();
+    let stallTimer: ReturnType<typeof setTimeout> | null = null;
+    const armStallTimer = () => {
+      if (stallTimer) clearTimeout(stallTimer);
+      stallTimer = setTimeout(() => ctrl.abort(), CATALOG_STALL_TIMEOUT_MS);
+    };
     let cancelled = false;
+    const readJson = async (url: string): Promise<unknown> => {
+      const res = await fetch(url, { signal: ctrl.signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
+      if (!res.body) return res.json();
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let text = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        armStallTimer();
+        text += decoder.decode(value, { stream: true });
+      }
+      return JSON.parse(text);
+    };
     (async () => {
       try {
+        armStallTimer();
         const [sk, mt] = await Promise.all([
-          fetch(SKILLS_URL).then((r) => {
-            if (!r.ok) throw new Error(`skills.json HTTP ${r.status}`);
-            return r.json();
-          }),
-          fetch(META_URL).then((r) => (r.ok ? r.json() : {})).catch(() => ({})),
+          readJson(SKILLS_URL),
+          readJson(META_URL).catch(() => ({})),
         ]);
         if (cancelled) return;
         const skillsArr = Array.isArray(sk) ? (sk as Skill[]) : [];
@@ -568,13 +598,26 @@ export default function SkillsDashboard() {
         setData({ skills: skillsArr, meta: mt || {} });
       } catch (err) {
         if (cancelled) return;
+        if (ctrl.signal.aborted) {
+          setLoadError(
+            `catalog fetch stalled — no data received for ${CATALOG_STALL_TIMEOUT_MS / 1000}s`,
+          );
+          return;
+        }
         setLoadError(err instanceof Error ? err.message : String(err));
       }
     })();
     return () => {
       cancelled = true;
+      ctrl.abort();
+      if (stallTimer) clearTimeout(stallTimer);
     };
-  }, []);
+  }, [reloadKey]);
+
+  const retryCatalogLoad = () => {
+    setLoadError(null);
+    setReloadKey((k) => k + 1);
+  };
 
   // Debounce the search input — 150ms feels instant while preventing the
   // filter from running on every individual keystroke.
@@ -692,11 +735,6 @@ export default function SkillsDashboard() {
                 {data ? allSkillsLocal.length.toLocaleString() : "…"}
               </strong>{" "}
               skills across {sources.length - 1} registries
-              {loadError && (
-                <span style={{ color: "#f87171", marginLeft: 8 }}>
-                  · failed to load catalog ({loadError})
-                </span>
-              )}
             </p>
             {(indexMetaLocal?.indexGeneratedAt || indexMetaLocal?.extractedAt) && (
               <p className={styles.heroSub} style={{ fontSize: "0.85rem", opacity: 0.75 }}>
@@ -895,6 +933,19 @@ export default function SkillsDashboard() {
                 <p className={styles.emptyDesc}>
                   Fetching 88k+ skills across every registry. One moment.
                 </p>
+              </div>
+            ) : loadError ? (
+              <div className={styles.empty}>
+                <div className={styles.emptyIcon}>{"\u26A0\uFE0F"}</div>
+                <h3 className={styles.emptyTitle}>Couldn't load the catalog</h3>
+                <p className={styles.emptyDesc}>
+                  {loadError}. The catalog is served from a public CDN —
+                  restricted networks may need a working proxy. Check your
+                  connection and retry.
+                </p>
+                <button className={styles.emptyReset} onClick={retryCatalogLoad}>
+                  Retry
+                </button>
               </div>
             ) : visible.length > 0 ? (
               <>


### PR DESCRIPTION
## What does this PR do?

The Skills Hub page (`website/src/pages/skills/index.tsx`) lazy-loads the catalog from the docs CDN on mount with a bare `fetch` and no timeout. On a network where that connection silently hangs (DNS pollution, TLS resets — the environment in #97861), the page stays on "Loading the catalog…" indefinitely. Worse, when the fetch *does* error out, the main grid falls through to the generic "No skills found — try a different search term" empty state, misrepresenting a network failure as an empty catalog, with no way to retry.

This PR fixes both halves of that UX:

1. **Stall-aware abort instead of a hard timeout.** The catalog bodies are now read as streams, and the fetch is aborted only when **no bytes have arrived for 45 seconds** (`CATALOG_STALL_TIMEOUT_MS`). A hard total-duration timeout would misfire here: the raw `skills.json` is ~50 MB and a legitimate slow transfer can run for minutes — every received chunk re-arms the timer, so slow-but-alive downloads are never cut off, while a hung connection (zero bytes flowing) is aborted within the stall window and surfaces as `catalog fetch stalled — no data received for 45s`.
2. **A dedicated error card with a Retry button.** When loading fails and no data is present, the main area now renders an error card (message + guidance + Retry) instead of the misleading "No skills found" empty state. Retry clears the error and re-runs the load (a `reloadKey` bumps the effect). The small inline red note in the hero is removed in favor of the card, so the failure is reported once, where the catalog would be.

The Electron system-proxy aspect raised in the issue (embedded browser not honoring OS proxy) is intentionally **not** addressed here — it is a separate concern in `apps/desktop/electron/main.ts` with its own design questions, and this PR stays scoped to the page's own resilience.

## Related Issue

Fixes #97861

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `website/src/pages/skills/index.tsx`
  - Added `CATALOG_STALL_TIMEOUT_MS = 45_000` and replaced the bare `fetch(...).then(r => r.json())` pair with a `readJson()` helper that streams the response body and re-arms an idle timer on every chunk, aborting via a shared `AbortController` only when the transfer goes silent.
  - Abort during load now surfaces as a dedicated `catalog fetch stalled — no data received for 45s` error message; other errors keep their existing message form (`HTTP <status> from <url>`).
  - Added a `reloadKey` state; the load effect depends on it, and a `retryCatalogLoad()` (wired to the error card's Retry button) re-runs the load.
  - Load failure with no data now renders an error card (⚠️ + message + guidance + Retry) in the main area instead of falling through to the "No skills found" empty state; removed the now-redundant inline red error note under the hero subtitle.
  - Effect cleanup now also aborts the in-flight fetch (component unmount / StrictMode double-invoke).

## How to Test

1. `cd website && npx tsc -p . --noEmit` (with `"ignoreDeprecations": "6.0"` temporarily added locally to get past the pre-existing `baseUrl` deprecation error on main — that error and the 5 pre-existing `JSX` namespace / generated-JSON errors are unchanged by this diff; `src/pages/skills/index.tsx` itself type-checks clean).
2. Behavior verification of the exact `readJson` logic with a local HTTP server (scaled stall window of 2s):
   - hung connection (server accepts, sends nothing): aborts after the stall window (`aborted=true`, AbortError, ~2.0s) — **Observed result: PASS, 2004ms**
   - slow-but-alive transfer (one chunk every 600ms): completes and parses, never aborts — **Observed result: PASS, 2421ms**
   - normal response: parses correctly — **Observed result: PASS, 7ms**
   - HTTP 502: surfaces as a non-abort `HTTP 502` error — **Observed result: PASS, 2ms**
3. Manual page check: `cd website && npm ci && npm run build:fast` should build; blocking the catalog host (e.g. `/etc/hosts` pointing `nousresearch.github.io` at a blackhole IP) then loading `/skills/` should show the spinner, then the error card with Retry after ~45s, and clearing the block + Retry should load the catalog.
4. Existing python suites are unaffected (website-only change); CI's `docs-site-checks` build is the gate for this path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this change: website-only, no python code touched; CI runs the python suites on the untouched tree
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A as a unit test: the `website/` package has no test runner at all (no test script, no test framework, no `*.test.*` files; CI covers it via `build:fast` + typecheck), and introducing one is out of scope for this fix. The fetch logic was verified with the 4-scenario local-server harness described in "How to Test" (hung / slow-alive / normal / HTTP-error).
- [x] I've tested on my platform: macOS 26.6 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no docs describe the skills-page fetch internals)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — browser/Electron-webview code only; uses standard `fetch` streaming (`ReadableStream`, `TextDecoder`, `AbortController`) available in every Chromium build and modern browsers, with a `res.json()` fallback when `res.body` is absent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Behavior-verification harness output (local HTTP server, 2s scaled stall window):

```
PASS  hung connection aborts after stall window :: aborted=true err=AbortError in 2004ms
PASS  slow-but-alive transfer completes :: result={"ok":"slow-alive"} in 2421ms
PASS  normal response parses :: result={"ok":"fast"} in 7ms
PASS  HTTP 502 surfaces as error :: aborted=false err=Error in 2ms
```
