### PR TITLE
fix(honcho): switching setup to API-key auth retires the OAuth grant

### DIFF
--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -277,6 +277,30 @@ def _write_config(cfg: dict, path: Path | None = None) -> None:
     atomic_json_write(path, cfg, mode=0o600)
 
 
+def _apply_api_key_to_host(cfg: dict, host: str, api_key: str) -> None:
+    """Make ``api_key`` the effective credential for ``host``.
+
+    Choosing API-key auth has to retire the OAuth grant, not sit beside it
+    (#97990).  The OAuth path persists *two* things into the host block —
+    ``apiKey`` (the access token) and ``oauth`` — while readers prefer the
+    host block over the top level: ``_resolve_api_key`` reads
+    ``hosts.<host>.apiKey`` first, and ``client._credential_fingerprint``
+    keys on ``oauth.refreshToken`` whenever that block exists.  Writing only
+    the top-level ``apiKey`` therefore leaves a revoked grant winning both
+    lookups, and ``hermes honcho status`` keeps reporting ``Auth: OAuth``
+    across repeated, fully completed setup runs.
+
+    So write the key where the resolver actually reads it, keep the
+    top-level copy for the legacy/global readers, and drop the superseded
+    ``oauth`` block.  Identity/workspace settings and other hosts are left
+    untouched — only the credential for this host is replaced.
+    """
+    cfg["apiKey"] = api_key
+    block = cfg.setdefault("hosts", {}).setdefault(host, {})
+    block["apiKey"] = api_key
+    block.pop("oauth", None)
+
+
 def _resolve_api_key(cfg: dict) -> str:
     """Resolve API key with host -> root -> env fallback.
 
@@ -746,13 +770,19 @@ def cmd_setup(args) -> None:
             masked = f"...{current_key[-8:]}" if len(current_key) > 8 else ("set" if current_key else "not set")
             print(f"\n  Current API key: {masked}")
             new_key = _prompt("Honcho API key (leave blank to keep current)", secret=True)
-            if new_key:
-                cfg["apiKey"] = new_key
 
-            if not cfg.get("apiKey"):
+            effective_key = new_key or current_key
+            if not effective_key:
                 print("\n  No API key configured. Get yours at https://app.honcho.dev")
                 print("  Run 'hermes honcho setup' again once you have a key.\n")
                 return
+
+            # Choosing API-key auth retires any OAuth grant on this host: the
+            # host block outranks the top level in every reader, so a
+            # top-level-only write leaves a revoked grant deciding auth
+            # (#97990).  Done for a kept key too — the shadowing survives
+            # config rewrites, so re-running setup has to be able to clear it.
+            _apply_api_key_to_host(cfg, _host_key(), effective_key)
 
     # --- 3. Identity ---
     current_peer = hermes_host.get("peerName") or cfg.get("peerName", "")

--- a/tests/honcho_plugin/test_apikey_retires_revoked_oauth.py
+++ b/tests/honcho_plugin/test_apikey_retires_revoked_oauth.py
@@ -1,0 +1,178 @@
+"""Switching `hermes honcho setup` to API-key auth must retire the OAuth grant.
+
+Reported in #97990: after a Honcho OAuth grant is revoked server-side
+(`invalid_grant`), running `hermes honcho setup` -> `apikey` and pasting a
+valid key leaves authentication broken. `hermes honcho status` keeps
+reporting `Auth: OAuth (...)` across repeated, fully completed setup runs.
+
+Root cause is a write/read asymmetry in the host block:
+
+  * the OAuth path persists BOTH `hosts.<host>.apiKey` (the access token) and
+    `hosts.<host>.oauth` (`oauth._persist_credential`),
+  * the API-key path writes only the TOP-LEVEL `cfg["apiKey"]`,
+  * every reader prefers the host block: `cli._resolve_api_key` reads
+    `hosts.<host>.apiKey` before `cfg["apiKey"]`, and
+    `client._credential_fingerprint` keys on `hosts.<host>.oauth.refreshToken`
+    whenever it is present.
+
+So the dead grant keeps shadowing the new key: the stale access token wins the
+key lookup, and the revoked refresh token still decides the client cache
+identity. Both survive `honcho.json` rewrites because nothing on the API-key
+path clears them.
+
+Behaviour contract asserted here:
+  * choosing API-key auth writes the key where the resolver actually reads it
+  * choosing API-key auth removes the superseded `oauth` block
+  * the new key, not the retired access token, is what resolves afterwards
+  * the client's credential identity changes, so a cached OAuth client for the
+    old grant cannot be reused
+  * an untouched OAuth host is left alone (no collateral retirement)
+"""
+
+import json
+
+import pytest
+
+from plugins.memory.honcho import cli as honcho_cli
+from plugins.memory.honcho import client as honcho_client
+
+
+HOST = "hermes"
+
+REVOKED_ACCESS_TOKEN = "hon_oauth_access_REVOKED"
+REVOKED_REFRESH_TOKEN = "hon_oauth_refresh_REVOKED"
+NEW_API_KEY = "hon_sk_freshly_pasted_key"
+
+
+def _config_with_revoked_grant() -> dict:
+    """The on-disk shape after an OAuth login whose grant was later revoked."""
+    return {
+        "enabled": True,
+        "hosts": {
+            HOST: {
+                "apiKey": REVOKED_ACCESS_TOKEN,
+                "oauth": {
+                    "accessToken": REVOKED_ACCESS_TOKEN,
+                    "refreshToken": REVOKED_REFRESH_TOKEN,
+                    "expiresAt": 0,
+                },
+                "peerName": "operator",
+                "aiPeer": "hermes",
+                "workspace": "hermes",
+            }
+        },
+    }
+
+
+@pytest.fixture
+def cfg_path(tmp_path, monkeypatch):
+    path = tmp_path / "honcho.json"
+    path.write_text(json.dumps(_config_with_revoked_grant()), encoding="utf-8")
+    monkeypatch.setattr(honcho_cli, "_host_key", lambda: HOST, raising=False)
+    return path
+
+
+class TestApiKeyRetiresRevokedGrant:
+    def test_api_key_lands_where_the_resolver_reads_it(self, cfg_path):
+        """The key must reach the host block, not only the top level.
+
+        `_resolve_api_key` prefers `hosts.<host>.apiKey`, so a top-level-only
+        write is invisible to it while the OAuth access token sits there.
+        """
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+
+        honcho_cli._apply_api_key_to_host(cfg, HOST, NEW_API_KEY)
+
+        assert cfg["hosts"][HOST]["apiKey"] == NEW_API_KEY
+        assert cfg.get("apiKey") == NEW_API_KEY
+        assert honcho_cli._resolve_api_key(cfg) == NEW_API_KEY, (
+            "the retired OAuth access token is still shadowing the new key"
+        )
+
+    def test_superseded_oauth_block_is_removed(self, cfg_path):
+        """A revoked grant must not survive an explicit switch to API-key auth."""
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+
+        honcho_cli._apply_api_key_to_host(cfg, HOST, NEW_API_KEY)
+
+        assert "oauth" not in cfg["hosts"][HOST], (
+            "the dead grant survived; status will keep reporting Auth: OAuth"
+        )
+
+    def test_unrelated_host_settings_are_preserved(self, cfg_path):
+        """Retiring the grant must not disturb identity/workspace settings."""
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+
+        honcho_cli._apply_api_key_to_host(cfg, HOST, NEW_API_KEY)
+
+        block = cfg["hosts"][HOST]
+        assert block["peerName"] == "operator"
+        assert block["aiPeer"] == "hermes"
+        assert block["workspace"] == "hermes"
+
+    def test_other_hosts_keep_their_grants(self, cfg_path):
+        """Only the host being reconfigured is retired."""
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        cfg["hosts"]["hermes_other"] = {
+            "apiKey": "other_access",
+            "oauth": {"refreshToken": "other_refresh", "expiresAt": 0},
+        }
+
+        honcho_cli._apply_api_key_to_host(cfg, HOST, NEW_API_KEY)
+
+        assert cfg["hosts"]["hermes_other"]["oauth"]["refreshToken"] == "other_refresh"
+
+
+class TestCredentialIdentityMovesOffTheDeadGrant:
+    def test_fingerprint_changes_when_the_grant_is_retired(self, cfg_path):
+        """The client cache must not reuse the revoked grant's slot.
+
+        `_credential_fingerprint` keys on `oauth.refreshToken` whenever the
+        block is present, so leaving it behind pins the cache to the dead
+        grant no matter which key the user pasted.  `api_key` is passed
+        alongside `raw` because that mirrors how the config is built — the
+        fingerprint reads the resolved key from the config field and the
+        grant from `raw`, and only the OAuth branch is `raw`-only.
+        """
+        raw_before = json.loads(cfg_path.read_text(encoding="utf-8"))
+        before = honcho_client._credential_fingerprint(
+            honcho_client.HonchoClientConfig(
+                raw=raw_before, host=HOST, api_key=REVOKED_ACCESS_TOKEN
+            )
+        )
+
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        honcho_cli._apply_api_key_to_host(cfg, HOST, NEW_API_KEY)
+        after = honcho_client._credential_fingerprint(
+            honcho_client.HonchoClientConfig(
+                raw=cfg, host=HOST, api_key=honcho_cli._resolve_api_key(cfg)
+            )
+        )
+
+        assert before, "precondition: the revoked grant has an identity"
+        assert after, "the reconfigured host must still have a credential identity"
+        assert after != before, (
+            "identity still derives from the revoked refresh token; a cached "
+            "OAuth client would be reused for the new key"
+        )
+
+    def test_identity_follows_the_key_not_the_retired_token(self, cfg_path):
+        """After retirement the identity must be the pasted key's, not the
+        access token the OAuth path had parked in the same field."""
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+        honcho_cli._apply_api_key_to_host(cfg, HOST, NEW_API_KEY)
+
+        actual = honcho_client._credential_fingerprint(
+            honcho_client.HonchoClientConfig(
+                raw=cfg, host=HOST, api_key=honcho_cli._resolve_api_key(cfg)
+            )
+        )
+        expected = honcho_client._credential_fingerprint(
+            honcho_client.HonchoClientConfig(
+                raw={"hosts": {HOST: {"apiKey": NEW_API_KEY}}},
+                host=HOST,
+                api_key=NEW_API_KEY,
+            )
+        )
+
+        assert actual == expected


### PR DESCRIPTION
Fixes #97990 — `hermes honcho setup` → `apikey` now actually takes effect after an OAuth grant is revoked.

The reporter's diagnosis was right, and the mechanism turns out to be a **write/read asymmetry on the host block** rather than anything in the wizard's prompt flow:

| | writes `hosts.<host>.apiKey` | writes `hosts.<host>.oauth` | writes top-level `apiKey` |
|---|---|---|---|
| OAuth path (`oauth._persist_credential`) | ✅ (the access token) | ✅ | — |
| API-key path (before this PR) | — | — | ✅ |

Every reader prefers the host block:

- `cli._resolve_api_key` reads `_host_block(cfg, _host_key()).get("apiKey")` **before** `cfg["apiKey"]`
- `client._credential_fingerprint` keys on `hosts.<host>.oauth.refreshToken` whenever that block is present, so the client cache identity is pinned to the grant

So the pasted key was written somewhere nothing reads first. The revoked access token kept winning the key lookup, the revoked refresh token kept deciding cache identity, and both survived every `honcho.json` rewrite because nothing on the API-key path cleared them — which is exactly why repeated completed setup runs changed nothing and only a manual edit worked.

### The fix

`_apply_api_key_to_host()` writes the key where the resolver actually reads it (host block **and** top level, the latter kept for legacy/global readers) and drops the superseded `oauth` block. Identity/workspace settings and other hosts are untouched — only this host's credential is replaced.

One deliberate scope decision worth review: it runs for a **kept** key too (blank prompt = keep current), not only for a newly pasted one. The shadowing survives config rewrites, so re-running setup has to be able to clear it; requiring the user to re-paste a key they already have in order to escape a dead grant would be a strange recovery path. That also repairs a smaller pre-existing case — a blank prompt with a valid top-level key previously left the host block untouched entirely.

I deliberately did **not** change the resolution order itself. Host-over-root precedence is load-bearing for profile isolation, and the defect is that the API-key path never wrote at that level — not that the precedence is wrong.

### Verification

Sabotage-checked rather than assumed. Reverting the helper to the previous top-level-only write reproduces the reported symptom exactly, in all three of its observable forms:

```
AssertionError: assert 'hon_oauth_access_REVOKED' == 'hon_sk_freshly_pasted_key'
AssertionError: the dead grant survived; status will keep reporting Auth: OAuth
AssertionError: identity still derives from the revoked refresh token; a cached
                OAuth client would be reused for the new key
4 failed, 2 passed
```

Restored: 6 passed. The six regressions assert behaviour contracts rather than the config's shape — that the key resolves through `_resolve_api_key`, that the credential fingerprint moves off the dead grant and lands on the pasted key's identity, that peer/workspace settings survive, and that an unrelated OAuth host keeps its grant.

`tests/honcho_plugin`: **311 passed, 16 skipped**. `tests -k honcho`: **375 passed, 20 skipped**.

### Not covered

I could not reproduce the original server-side revocation end to end — I have no revoked Honcho grant to hand, so the starting state is reconstructed from the on-disk shape the OAuth path writes (`apiKey` + `oauth` with a stale `expiresAt`) rather than captured from a live `invalid_grant`. What is proven here is that the config the reporter described resolves to the wrong credential before this change and the right one after. If a maintainer would rather see the wizard exercised end to end than the helper it delegates to, I am happy to add that.
