### PR TITLE
fix(custom): omit Ollama-only think=false on strict OpenAI-compat endpoints

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -6,16 +6,39 @@ Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
   - reasoning_config disabled → top-level reasoning_effort="none"
     (Ollama /v1/chat/completions ignores think=False — ollama#14820)
-    + extra_body.think = False for /api/chat and proxies
+    + extra_body.think = False only on Ollama URLs (/api/chat and proxies)
   - reasoning_config enabled + effort → top-level reasoning_effort
     (the native OpenAI-compatible format GLM/ARK expect; unset omits it
     so the endpoint's server default applies)
 """
 
 from typing import Any
+from urllib.parse import urlparse
 
 from providers import register_provider
 from providers.base import ProviderProfile
+
+
+def _looks_like_ollama_endpoint(base_url: str | None) -> bool:
+    """True when ``base_url`` is an Ollama host, not a generic OpenAI-compat relay.
+
+    ``think`` is an Ollama-native extra_body field. Strict hosts (Mistral
+    ``extra=forbid``, Groq, …) reject it with HTTP 422. Match only explicit
+    Ollama signatures — default port 11434, or ``ollama`` as a hostname
+    label — not arbitrary localhost (llama.cpp / vLLM / LM Studio).
+    """
+    raw = (base_url or "").strip()
+    if not raw:
+        return False
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    if parsed.port == 11434:
+        return True
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        return False
+    if host == "ollama.com" or host.endswith(".ollama.com"):
+        return True
+    return "ollama" in host.split(".")
 
 
 class CustomProfile(ProviderProfile):
@@ -40,7 +63,8 @@ class CustomProfile(ProviderProfile):
         # Reasoning / thinking control for custom OpenAI-compatible endpoints
         # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, …).
         #
-        #   - disabled  → extra_body.think = False (Ollama's thinking-off flag)
+        #   - disabled  → top-level reasoning_effort="none"; extra_body.think
+        #     = False only on Ollama URLs (Ollama's thinking-off flag)
         #   - enabled + effort set → TOP-LEVEL reasoning_effort string, the
         #     format GLM-5.2/ARK and other OpenAI-compatible reasoning APIs
         #     expect (GLM documents "high" and "max"; "max" is its default).
@@ -50,19 +74,22 @@ class CustomProfile(ProviderProfile):
         # We deliberately do NOT emit ``think=True`` on enable: it is an
         # Ollama-only flag and thinking is already server-default-on for these
         # backends, so forcing it risks a 400 on GLM/vLLM endpoints that don't
-        # recognize it. Mirrors the DeepSeek/Zai profile precedent.
+        # recognize it. Mirrors the DeepSeek/Zai profile precedent. The same
+        # constraint applies to ``think=False`` on disable — Mistral/Groq
+        # reject unknown fields (HTTP 422 extra_forbidden) rather than ignoring
+        # them, so that flag stays Ollama-URL-gated.
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
                 # Ollama's /v1/chat/completions silently ignores
                 # extra_body.think (only /api/chat honours it — ollama#14820)
-                # but respects the top-level reasoning_effort field, so both
-                # are needed to actually stop a thinking-capable model from
-                # reasoning (#25758). Endpoints that recognize neither simply
-                # ignore them.
+                # but respects the top-level reasoning_effort field (#25758).
+                # Always emit reasoning_effort="none"; only add think=False
+                # when the URL is actually Ollama.
                 top_level["reasoning_effort"] = "none"
-                extra_body["think"] = False
+                if _looks_like_ollama_endpoint(ctx.get("base_url")):
+                    extra_body["think"] = False
             elif _effort:
                 # Clamp the internal ladder onto the widest OpenAI-compatible
                 # wire vocabulary (shared policy in agent.reasoning_effort) —

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -34,8 +34,8 @@ def _looks_like_ollama_endpoint(base_url: str | None) -> bool:
     # urlparse raises ValueError for non-integer / out-of-range ports
     # ("http://host:99999/v1" parses fine in the OpenAI client, so the URL
     # is reachable here). Treat a malformed port as "not Ollama" instead of
-    # killing the whole kwargs build — mirrors the same guard around the
-    # 11434 check in hermes_cli/models.py should_use_ollama_native_catalog.
+    # killing the whole kwargs build — same try/except shape the 11434
+    # check in hermes_cli/models.py uses, not the same detection logic.
     try:
         if parsed.port == 11434:
             return True

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -31,8 +31,16 @@ def _looks_like_ollama_endpoint(base_url: str | None) -> bool:
     if not raw:
         return False
     parsed = urlparse(raw if "://" in raw else f"//{raw}")
-    if parsed.port == 11434:
-        return True
+    # urlparse raises ValueError for non-integer / out-of-range ports
+    # ("http://host:99999/v1" parses fine in the OpenAI client, so the URL
+    # is reachable here). Treat a malformed port as "not Ollama" instead of
+    # killing the whole kwargs build — mirrors the same guard around the
+    # 11434 check in hermes_cli/models.py should_use_ollama_native_catalog.
+    try:
+        if parsed.port == 11434:
+            return True
+    except ValueError:
+        return False
     host = (parsed.hostname or "").lower().rstrip(".")
     if not host:
         return False

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -297,8 +297,23 @@ class TestChatCompletionsBuildKwargs:
             model="qwen3", messages=msgs,
             provider_profile=profile,
             reasoning_config={"effort": "none"},
+            base_url="http://127.0.0.1:11434/v1",
         )
         assert kw["extra_body"]["think"] is False
+
+    def test_custom_omits_think_on_mistral(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="mistral-small-latest",
+            messages=msgs,
+            provider_profile=profile,
+            reasoning_config={"effort": "none"},
+            base_url="https://api.mistral.ai/v1",
+        )
+        assert kw.get("extra_body", {}).get("think") is None
+        assert kw.get("reasoning_effort") == "none"
 
 
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -309,7 +309,7 @@ class TestChatCompletionsBuildKwargs:
             model="mistral-small-latest",
             messages=msgs,
             provider_profile=profile,
-            reasoning_config={"effort": "none"},
+            reasoning_config={"enabled": False, "effort": "none"},
             base_url="https://api.mistral.ai/v1",
         )
         assert kw.get("extra_body", {}).get("think") is None

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -7,12 +7,13 @@ nothing when reasoning was *enabled*, so a configured ``reasoning_effort``
 was silently dropped for every custom endpoint.
 
 These tests pin the wire-shape contract:
-  - disabled            → extra_body.think = False
-  - enabled + effort    → top-level reasoning_effort (native OpenAI-compat
+    - disabled on Ollama  → extra_body.think = False + reasoning_effort=none
+    - disabled elsewhere  → reasoning_effort=none, no think (strict APIs 422)
+    - enabled + effort    → top-level reasoning_effort (native OpenAI-compat
                           format GLM/ARK expect), passed through verbatim
                           including ``max``/``xhigh``
-  - enabled + no effort → nothing emitted (endpoint's server default applies)
-  - ollama_num_ctx      → extra_body.options.num_ctx, orthogonal to reasoning
+    - enabled + no effort → nothing emitted (endpoint's server default applies)
+    - ollama_num_ctx      → extra_body.options.num_ctx, orthogonal to reasoning
 """
 
 from __future__ import annotations
@@ -49,23 +50,71 @@ class TestCustomReasoningWireShape:
         assert tl == {}
 
     def test_disabled_sends_think_false(self, custom_profile):
-        """enabled=False → reasoning_effort='none' top-level + think=False.
+        """enabled=False on an Ollama URL → reasoning_effort='none' + think=False.
 
-        Both fields are required: Ollama's /v1/chat/completions silently
+        Both fields are required on Ollama: /v1/chat/completions silently
         ignores extra_body.think (only /api/chat honours it — ollama#14820)
         but respects top-level reasoning_effort (#25758). think=False stays
         for proxies and the native /api/chat path.
         """
         eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": False}, model="glm-5.2"
+            reasoning_config={"enabled": False},
+            model="qwen3",
+            base_url="http://127.0.0.1:11434/v1",
         )
         assert eb == {"think": False}
         assert tl == {"reasoning_effort": "none"}
 
     def test_effort_none_sends_think_false(self, custom_profile):
-        """effort='none' is the disable alias → same dual emission."""
+        """effort='none' is the disable alias → same dual emission on Ollama."""
         eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "none"}, model="glm-5.2"
+            reasoning_config={"enabled": True, "effort": "none"},
+            model="qwen3",
+            base_url="http://localhost:11434/v1",
+        )
+        assert eb == {"think": False}
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_disabled_omits_think_on_mistral(self, custom_profile):
+        """Strict OpenAI-compat hosts forbid extra ``think`` (HTTP 422)."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"},
+            model="mistral-small-latest",
+            base_url="https://api.mistral.ai/v1",
+        )
+        assert "think" not in eb
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_disabled_omits_think_without_base_url(self, custom_profile):
+        """Unknown custom endpoint — do not send the Ollama-only flag."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}, model="glm-5.2"
+        )
+        assert "think" not in eb
+        assert tl == {"reasoning_effort": "none"}
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "http://127.0.0.1:8080/v1",
+            "http://localhost:1234/v1",
+            "https://api.groq.com/openai/v1",
+        ],
+    )
+    def test_disabled_omits_think_on_non_ollama_relays(self, custom_profile, base_url):
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"effort": "none"},
+            model="llama3",
+            base_url=base_url,
+        )
+        assert "think" not in eb
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_disabled_sends_think_false_on_ollama_cloud_host(self, custom_profile):
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="qwen3",
+            base_url="https://ollama.com/v1",
         )
         assert eb == {"think": False}
         assert tl == {"reasoning_effort": "none"}

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -120,6 +120,30 @@ class TestCustomReasoningWireShape:
         assert tl == {"reasoning_effort": "none"}
 
     @pytest.mark.parametrize(
+        "base_url",
+        [
+            "http://myhost:99999/v1",  # out-of-range port: OpenAI client accepts it
+            "http://localhost:80a/v1",  # non-integer port
+            "http://localhost:11434./v1",  # trailing-dot port
+        ],
+    )
+    def test_malformed_port_does_not_raise(self, custom_profile, base_url):
+        """Malformed ports must not raise — urlparse's ``port`` is ValueError-happy.
+
+        The OpenAI client accepts ``http://myhost:99999/v1`` at construction
+        (only httpx fails later), so these URLs reach ``build_api_kwargs_extras``
+        in production. The heuristic must treat them as non-Ollama rather than
+        killing the kwargs build.
+        """
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="qwen3",
+            base_url=base_url,
+        )
+        assert "think" not in eb
+        assert tl == {"reasoning_effort": "none"}
+
+    @pytest.mark.parametrize(
         "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]
     )
     def test_enabled_effort_goes_top_level(self, custom_profile, effort):

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -168,5 +168,18 @@ class TestCustomOllamaParity:
             tools=None,
             provider_profile=get_provider_profile("custom"),
             reasoning_config={"enabled": False, "effort": "none"},
+            base_url="http://127.0.0.1:11434/v1",
         )
         assert kw["extra_body"]["think"] is False
+
+    def test_think_omitted_for_mistral_custom(self, transport):
+        kw = transport.build_kwargs(
+            model="mistral-small-latest",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("custom"),
+            reasoning_config={"enabled": False, "effort": "none"},
+            base_url="https://api.mistral.ai/v1",
+        )
+        assert kw.get("extra_body", {}).get("think") is None
+        assert kw.get("reasoning_effort") == "none"


### PR DESCRIPTION
## Summary
Turning reasoning off (`reasoning_effort: none`) no longer sends Ollama's `think: false` to non-Ollama custom endpoints — strict hosts like Mistral (`extra=forbid`) rejected it with HTTP 422, killing every chat request. `think=false` now goes out only for Ollama URLs (port 11434, `ollama` hostname label, ollama.com); everyone else still gets top-level `reasoning_effort: "none"`, which those endpoints accept.

Fixes #11237.

## Root cause
The `custom` provider profile emitted `extra_body.think = False` for EVERY custom endpoint whenever reasoning was disabled. `think` is an Ollama-native field; Mistral-style strict validators reject unknown body fields (`extra_forbidden` → HTTP 422).

## Changes
- `plugins/model-providers/custom/__init__.py`: `_looks_like_ollama_endpoint(base_url)` gates `think=false` on Ollama URL signatures (port 11434 / `ollama` hostname label / ollama.com). Top-level `reasoning_effort: "none"` stays unconditional — Ollama's `/v1/chat/completions` ignores `extra_body.think` (ollama#14820) and honors `reasoning_effort` (#25758), so the dual-emission contract on real Ollama is unchanged.
- Follow-up hardening: the port check wraps `parsed.port` in `try/except ValueError` — `urlparse` raises on non-integer/out-of-range ports, and `http://myhost:99999/v1` passes OpenAI-client construction, so the crash was reachable from `build_kwargs` on every request. Mirrors the guard `hermes_cli.models` already uses around its 11434 check.
- Tests at 3 layers (profile unit incl. parametrized malformed-port cases, transport parity, chat-completions integration): Ollama URL → dual emission; Mistral/Groq/LM Studio/no-base_url → `think` omitted, `reasoning_effort=none` kept.

## Validation
| Scenario | Before | After |
|---|---|---|
| Mistral custom + reasoning off | HTTP 422 (`extra_forbidden: body.think`) | request succeeds, no `think` in body |
| Ollama 11434 / ollama.com + reasoning off | `think=False` + `reasoning_effort=none` | same (unchanged, #25758 contract) |
| Malformed port (`http://myhost:99999/v1`) | `ValueError` from `build_kwargs` (client construction accepts it) | treated as non-Ollama, no crash |
| Targeted suites | — | 291 passed (profile, parity, transport, provider-profiles, aux client) |
| Mutation check | — | reverting the fix fails 7 guard tests; removing the port guard fails 3 new tests |

## Credit
Salvaged from #97984 by @xxxigm — both commits cherry-picked with authorship preserved; the malformed-port guard is a follow-up on top. Related earlier attempts that did not land: #11520, #11296, #11362 (edit the pre-plugin emission site in `run_agent.py` that no longer exists), #64286, #63315.
