### PR TITLE
fix(desktop): stop a mirrored composer effort pinning every new chat

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -4,7 +4,14 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import type { ChatBarState } from '@/app/chat/composer/types'
 import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
-import { $activeSessionId, $currentModel, setCurrentModel, setCurrentModelSource } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentModel,
+  setCurrentModel,
+  setCurrentModelSource,
+  setCurrentReasoningEffort,
+  setDefaultReasoningEffort
+} from '@/store/session'
 
 import { ModelPill } from './model-pill'
 
@@ -20,6 +27,49 @@ afterEach(() => {
   $activeSessionId.set(null)
   setCurrentModel('')
   setCurrentModelSource('')
+  setCurrentReasoningEffort('')
+  setDefaultReasoningEffort('')
+})
+
+// A draft sends its sticky effort only when the user picked it; otherwise the
+// gateway resolves the target profile's `agent.reasoning_effort`. The pill must
+// show what the chat will actually start on.
+describe('ModelPill reasoning-effort label', () => {
+  it('shows the profile default when the sticky effort is only a mirror', () => {
+    setCurrentModel('gpt-6')
+    setCurrentModelSource('default')
+    setCurrentReasoningEffort('medium')
+    setDefaultReasoningEffort('high')
+    $activeSessionId.set(null)
+
+    render(<ModelPill disabled={false} model={modelState()} />)
+
+    expect(screen.getByText(/· High$/)).toBeTruthy()
+  })
+
+  it('shows the sticky effort for a real user pick', () => {
+    setCurrentModel('gpt-6')
+    setCurrentModelSource('manual')
+    setCurrentReasoningEffort('medium')
+    setDefaultReasoningEffort('high')
+    $activeSessionId.set(null)
+
+    render(<ModelPill disabled={false} model={modelState()} />)
+
+    expect(screen.getByText(/· Med$/)).toBeTruthy()
+  })
+
+  it('keeps showing a live session own effort, pick or not', () => {
+    setCurrentModel('gpt-6')
+    setCurrentModelSource('default')
+    setCurrentReasoningEffort('medium')
+    setDefaultReasoningEffort('high')
+    $activeSessionId.set('live-1')
+
+    render(<ModelPill disabled={false} model={modelState()} />)
+
+    expect(screen.getByText(/· Med$/)).toBeTruthy()
+  })
 })
 
 // #62055: a manual composer pick is sticky and silently overrides the

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -92,6 +92,13 @@ export function ModelPill({
   const pinnedOverride =
     view.kind === 'primary' && !runtimeId && modelSource === 'manual' && Boolean(currentModel.trim())
 
+  // A draft only sends its sticky effort when the user actually picked it
+  // (see `desktopSessionCreateParams`); otherwise the gateway resolves the
+  // target profile's `agent.reasoning_effort`. Show that profile default rather
+  // than a mirror we are not going to send, so the pill cannot promise Medium
+  // and then start the chat on High. A live session keeps showing its own.
+  const displayedEffort = !runtimeId && modelSource !== 'manual' ? '' : reasoningEffort
+
   // The model resolves a beat after the gateway/session comes up. Rather than
   // flash a literal "No model", show a quiet loader (inherits the pill text
   // color at half opacity) until a model lands.
@@ -101,7 +108,7 @@ export function ModelPill({
     <>
       {currentModel.trim() ? (
         <span className="truncate">
-          {formatModelStatusLabel(currentModel, { defaultEffort, fastMode, reasoningEffort })}
+          {formatModelStatusLabel(currentModel, { defaultEffort, fastMode, reasoningEffort: displayedEffort })}
         </span>
       ) : (
         <GlyphSpinner className="opacity-50" spinner="braille" />

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -60,6 +60,7 @@ import {
   setCurrentCwd,
   setCurrentFastMode,
   setCurrentModel,
+  setCurrentModelSource,
   setCurrentProvider,
   setCurrentReasoningEffort,
   setMessages,
@@ -568,6 +569,7 @@ describe('createBackendSessionForSend profile routing', () => {
     $currentModel.set('')
     $currentProvider.set('')
     $currentReasoningEffort.set('')
+    setCurrentModelSource('')
     setNewChatWorkspaceTarget(undefined)
     vi.restoreAllMocks()
   })
@@ -652,10 +654,56 @@ describe('createBackendSessionForSend profile routing', () => {
     expect(ambientRequest).not.toHaveBeenCalledWith('session.create', expect.anything())
   })
 
+  it('omits reasoning_effort when the composer only MIRRORS a profile default', async () => {
+    // The composer seeds its effort from `agent.reasoning_effort`, but only
+    // while no session is active — so in app-global remote mode it keeps the
+    // seed of whatever profile the app happened to be scoped to, and a chat
+    // started on another profile was born with THAT profile's effort pinned.
+    const params = await createWith(() => {
+      setCurrentModelSource('default')
+      setCurrentReasoningEffort('medium')
+    })
+
+    expect(params).not.toHaveProperty('reasoning_effort')
+  })
+
+  it('omits reasoning_effort when the selection source is unset', async () => {
+    const params = await createWith(() => {
+      setCurrentModelSource('')
+      setCurrentReasoningEffort('medium')
+    })
+
+    expect(params).not.toHaveProperty('reasoning_effort')
+  })
+
+  it('still sends reasoning_effort for a real user pick', async () => {
+    const params = await createWith(() => {
+      setCurrentModelSource('manual')
+      setCurrentReasoningEffort('high')
+    })
+
+    expect(params).toMatchObject({ reasoning_effort: 'high' })
+  })
+
+  it('keeps sending the composer model when the effort is withheld', async () => {
+    // The two are gated independently here: this change is scoped to effort so
+    // it composes with the model-side fix rather than duplicating it.
+    const params = await createWith(() => {
+      setCurrentModelSource('default')
+      setCurrentModel('openai/gpt-5.6-sol')
+      setCurrentProvider('openai-codex')
+      setCurrentReasoningEffort('medium')
+    })
+
+    expect(params).toMatchObject({ model: 'openai/gpt-5.6-sol', provider: 'openai-codex' })
+    expect(params).not.toHaveProperty('reasoning_effort')
+  })
+
   it('freezes the visible selector state before profile readiness and sends fast: false explicitly', async () => {
     const profileReady = deferred<void>()
     vi.mocked(ensureGatewayProfile).mockReturnValueOnce(profileReady.promise)
 
+    setCurrentModelSource('manual')
     setCurrentModel('anthropic/claude-sonnet-4.6')
     setCurrentProvider('anthropic')
     setCurrentReasoningEffort('high')

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -71,6 +71,7 @@ import {
   $newChatWorkspaceTarget,
   $sessions,
   $yoloActive,
+  getCurrentModelSource,
   getSessionOwnerHint,
   type NewChatWorkspaceTarget,
   resolveComposerSessionKey,
@@ -241,8 +242,9 @@ function reconcileAuthoritativeMessages(
 // mode one backend serves every profile, so an omitted profile silently lands the
 // chat on the launch (default) profile — the "rubberbands back to default" bug.
 // A no-op for single-profile/local-pooled users (a backend resolves its own launch
-// profile to None). The sticky UI model/effort/fast ride as per-session overrides,
-// never the profile default (that lives in Settings → Model).
+// profile to None). The sticky UI model/fast ride as per-session overrides, never
+// the profile default (that lives in Settings → Model); the sticky effort rides
+// only when the user actually picked it (see `isManualSelection` below).
 async function desktopSessionCreateParams(
   cwd: string,
   capturedRoute = resolveNewChatOwnerRoute()
@@ -251,8 +253,18 @@ async function desktopSessionCreateParams(
   // profile handshake below can yield long enough for background config/model
   // refreshes to finish; reading atoms afterward would silently create the
   // session with a different selection than the one the user submitted.
+  //
+  // Only a real user pick may override the target profile's configured effort.
+  // `'default'`/unset means the composer is MIRRORING some profile's
+  // `agent.reasoning_effort` — and in app-global remote mode that is routinely a
+  // DIFFERENT profile than this chat's, because one backend serves them all and
+  // the composer only reseeds while no session is active. Sending the mirror as
+  // an explicit per-session override therefore transplants profile A's default
+  // onto profile B; omitting it lets the gateway resolve the target profile's.
+  const isManualSelection = getCurrentModelSource() === 'manual'
+
   const selection = {
-    effort: $currentReasoningEffort.get().trim(),
+    effort: isManualSelection ? $currentReasoningEffort.get().trim() : '',
     fast: $currentFastMode.get(),
     model: $currentModel.get().trim(),
     provider: $currentProvider.get().trim()


### PR DESCRIPTION
## What

A new desktop chat is created with an explicit `reasoning_effort` per-session override taken from the composer's sticky selection — **even when that selection was never a user pick**. It is often just a *mirror* of some profile's `agent.reasoning_effort`, and in app-global remote mode routinely a **different** profile than the one the chat is being created against.

Result: a profile configured `agent.reasoning_effort: high` runs its desktop chats at `medium`, and the configured value is never consulted.

## Why it happens

The composer seeds its effort from config in `useHermesConfig`, but only while **no session is active**:

```ts
const shouldSeedComposer =
  !activeSessionIdRef.current &&
  getComposerSelectionGeneration() === selectionGeneration &&
  (force || getCurrentModelSource() !== 'manual')
```

In app-global remote mode one backend serves every profile. With a chat open — the normal state — switching to another bot never reseeds the pill, so it keeps the effort of whichever profile the app was last scoped to. `desktopSessionCreateParams` then ships that stale mirror as an explicit override:

```ts
...(selection.effort ? { reasoning_effort: selection.effort } : {}),
```

and `session.create` honours it as a per-session override, short-circuiting the target profile's configured value.

The value is also persisted to `localStorage` (`hermes.desktop.composer.reasoning-effort`) and re-written from `session.info` heartbeats, so once one `medium` chat exists the wrong effort sticks across restarts and spreads to new chats on every profile.

Observed on a 60-profile remote deployment: profiles pinned to `gpt-5.6-sol` / `high` in `config.yaml` had every desktop-created session persisted with `"reasoning_config": {"effort": "medium"}`, while `cron`-created sessions on the same profiles were correctly `high`.

## Why this fix

The selection source already distinguishes the two cases — this change just honours it, exactly as #91482 does for model/provider:

- `'manual'` → a real user pick → send it as a per-session override (unchanged)
- `'default'` / unset → a mirror of profile config → omit it, let the backend resolve the target profile's value

```ts
const isManualSelection = getCurrentModelSource() === 'manual'

const selection = {
  effort: isManualSelection ? $currentReasoningEffort.get().trim() : '',
  fast: $currentFastMode.get(),
  model: $currentModel.get().trim(),
  provider: $currentProvider.get().trim()
}
```

A manual effort pick still overrides: `patchReasoning` calls `markComposerSelectionManual()`, so the user's choice sets the source before it is read here.

## Scope

Deliberately scoped to `reasoning_effort` so it **composes with #91482** (same gate, model/provider half) rather than duplicating its diff. If #91482 lands first this rebases to the one `effort:` line — happy to squash them if you'd prefer a single PR.

`fast` still rides unconditionally, because the gateway documents its *presence* as an explicit pin contract ("omitted means inherit the profile, true pins priority, and false pins normal") and an existing test asserts `fast: false` is sent explicitly. Worth a separate look, but it is a deliberate contract rather than a leak.

## Reproduction

On a multi-profile backend:

1. Profile **A** has `agent.reasoning_effort: medium`, profile **B** has `high`.
2. Open a chat on **A** (the composer pill now reads Medium).
3. With that chat still open, switch to **B** and start a **new** chat.

**Before:** the new chat on **B** runs at `medium`; `hermes config get reasoning` for that session reports `medium` while B's `config.yaml` says `high`.
**After:** the new chat runs at **B**'s configured `high`.

### Second commit: the pill must not advertise what it will not send

Withholding the mirror from `session.create` left the composer free to display a
level the new chat would not use — it renders `reasoningEffort || defaultEffort`,
and on a draft `reasoningEffort` is that same mirror. It could read "Med" and
then start the chat on the profile's High.

A draft that is not running a manual pick now falls through to
`$defaultReasoningEffort`, which `useHermesConfig` publishes from profile config
on every refresh regardless of whether the composer is reseeded ("Publish the
profile default regardless of whether the composer is reseeded below"). A live
session still shows its own effort; a manual pick still shows the pick. This
matches the existing `pinnedOverride` badge, which already treats
`modelSource === 'manual'` as "this will override".

## How to test

Automated coverage — 4 new cases in the `createBackendSessionForSend profile routing` suite:

| Case | Asserts |
|---|---|
| `'default'`-sourced selection | `reasoning_effort` omitted |
| unset source (first run / cleared) | `reasoning_effort` omitted |
| manual pick | still sent as an override |
| model independence | `model` / `provider` still sent while effort is withheld |

…plus 3 in `ModelPill reasoning-effort label`: a mirror shows the profile
default, a manual pick shows the pick, and a live session keeps showing its own.

Three of them fail against the previous code with `expected { … } to not have property "reasoning_effort"`.

One existing test (`freezes the visible selector state before profile readiness`) now sets the selection source explicitly — it drives the atoms directly rather than going through a composer pick, so it opts into `'manual'` to keep asserting override behavior. Same adjustment #91482 needed.

## Verification

Run against this branch on `3f36c87e1e`:

- `npx vitest run` (entire desktop suite) — **8689 passed / 816 files**, 6 skipped
- `npx tsc -p tsconfig.json --noEmit` — clean
- `npx eslint` on all changed files — clean

## Platforms

Reproduced against a Windows (x64) packaged Electron build talking to a Linux backend over a remote gateway. The change is platform-independent renderer logic — no file I/O, process, or terminal handling — so no cross-platform impact is expected.
