### PR TITLE
fix(guardrails): add crash-class hint to terminal failure recovery

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -759,6 +759,10 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
             "For terminal failures, run a small diagnostic such as `pwd && ls -la` "
             "in the same tool, then try an absolute path, a simpler command, a different "
             "working directory, or a different tool such as read_file/write_file/patch."
+            " If the error is an import crash (ModuleNotFoundError, ABI mismatch, "
+            "a compiled .so built for another CPython), check the environment first: "
+            "a PYTHONPATH-poisoned interpreter re-reports the same crash no matter "
+            "how many times the command is re-run — fix the env, not the command."
         )
     return common + (
         "Try different arguments, a narrower query/path, an absolute path when relevant, "

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1725,7 +1725,7 @@ tool_loop_guardrails:
     max_subagents: 50          # max subagents spawned per turn (0 = unlimited)
 ```
 
-`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
+`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. The counters reset at the start of every turn, so a legitimate multi-turn session is never starved — a single turn that spirals into unbounded repetition is stopped. See also [Docker / unattended deployments](docker.md).
 
 ### Per-turn runaway-loop caps
 


### PR DESCRIPTION
## Problem

When a terminal command fails with an import crash — `ModuleNotFoundError`, ABI mismatch from a compiled `.so` built for another CPython, PYTHONPATH-poisoned interpreter — the agent re-runs the same failing command repeatedly (observed: 46× in one session) because the failure reads as "need to search more" rather than "environment is broken".

Bead: worktracker-676.4.22.175.57

## Change

- `_tool_failure_recovery_hint` (terminal branch) now appends a crash-class hint: check the environment first; a PYTHONPATH-poisoned interpreter re-reports the same crash no matter how many times the command is re-run.
- `configuration.md` clarifies that `tool_loop_guardrails` counters reset at the start of every turn, so a legitimate multi-turn session is never starved.

## Verification

- `python3 -m pytest tests/agent/test_tool_guardrails.py -q` → 7 passed
- Manual check: `_tool_failure_recovery_hint('terminal', 4)` includes the crash hint; non-terminal tools unchanged.