### PR TITLE
fix(codex): nudge the second continuation of a compaction-only turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7044,7 +7044,29 @@ def run_conversation(
                         or interim_has_codex_reasoning
                         or interim_has_codex_message_items
                     )
-                    if not interim_replayable:
+                    # A replayable interim is not the same thing as a retry
+                    # that DIFFERS.  When the interim replays but carries no
+                    # new instruction, the continuation is byte-identical to
+                    # the request that just failed and returns the same empty
+                    # response until the budget is gone.  Live case (gpt-5.6
+                    # on the Codex backend, Aug 2026): the model answers with
+                    # a server-side ``compaction`` checkpoint and no message.
+                    # The checkpoint lands in ``codex_reasoning_items``, so
+                    # ``interim_replayable`` is True and no nudge is added —
+                    # meanwhile the checkpoint makes the wire converter prune
+                    # every pre-checkpoint item, so all three attempts send
+                    # the same checkpoint + retained user messages and end on
+                    # an empty assistant turn with nothing to answer.  The
+                    # provider's own prefix cache reports 99-100% on the
+                    # repeats, and the turn dies with "Codex response
+                    # remained incomplete after 3 continuation attempts",
+                    # losing the whole turn's work.
+                    #
+                    # One bare retry is still worth trying (the model often
+                    # just needs another turn).  Once THAT has also come back
+                    # incomplete, a bare retry is proven not to work for this
+                    # turn, so every remaining attempt carries the nudge.
+                    if not interim_replayable or agent._codex_incomplete_retries >= 2:
                         _last_msg = messages[-1] if messages else None
                         _already_nudged = (
                             isinstance(_last_msg, dict)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -10,6 +10,7 @@ sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
 sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
 import run_agent
+from agent.conversation_loop import _CODEX_INCOMPLETE_NUDGE
 
 
 @pytest.fixture(autouse=True)
@@ -2407,3 +2408,97 @@ def test_consume_codex_stream_leaves_unindexed_reasoning_untouched():
     )
 
     assert "".join(reasoning_streamed) == "Need to inspect files."
+
+
+def _codex_compaction_checkpoint_response(blob: str = "compaction_blob_1"):
+    """A turn that returns ONLY a server-side native-compaction checkpoint.
+
+    This is what gpt-5.6 on the Codex backend sends when it compacts a long
+    conversation: a ``compaction`` output item carrying the encrypted
+    stand-in for the pruned history, with no ``message`` and no
+    ``function_call``. It normalizes to ``finish_reason="incomplete"``, and
+    the checkpoint rides the ``codex_reasoning_items`` sidecar.
+    """
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="compaction",
+                encrypted_content=blob,
+            ),
+        ],
+        usage=SimpleNamespace(input_tokens=9, output_tokens=1, total_tokens=10),
+        status="completed",
+        model="gpt-5-codex",
+    )
+
+
+def test_codex_compaction_only_continuation_gets_nudged_before_budget_runs_out(monkeypatch):
+    """A compaction-checkpoint-only turn must not burn the retry budget on
+    byte-identical continuations.
+
+    The checkpoint lands in ``codex_reasoning_items``, so the interim looks
+    "replayable" and the old gate suppressed the continuation nudge. But a
+    checkpoint carries no answer and no new instruction, and — because a
+    replayed checkpoint makes the wire converter prune every pre-checkpoint
+    item — the continuation re-sends the same checkpoint plus the same
+    retained user messages and ends on an empty assistant turn. Every attempt
+    is then identical (the provider's prefix cache reports 99-100% on the
+    repeats) and returns the same empty response, so the turn dies with
+    "Codex response remained incomplete after 3 continuation attempts" and
+    the whole turn's work is lost.
+
+    One bare retry is still allowed. Once that has also come back incomplete,
+    every remaining attempt must carry the nudge so the request differs and
+    states what is wanted.
+    """
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_compaction_checkpoint_response("blob_1"),
+        _codex_compaction_checkpoint_response("blob_2"),
+        _codex_message_response("Here is the answer."),
+    ]
+    sent_message_counts: list = []
+    original_call = agent._interruptible_api_call
+
+    def _fake_call(api_kwargs):
+        sent_message_counts.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_call)
+
+    result = agent.run_conversation("summarize the investigation")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Here is the answer."
+
+    nudges = [
+        m for m in result["messages"]
+        if m.get("role") == "user"
+        and m.get("content") == _CODEX_INCOMPLETE_NUDGE
+    ]
+    assert len(nudges) == 1, (
+        "the second continuation of a compaction-only turn must carry the "
+        "incomplete nudge so the retry is not byte-identical"
+    )
+
+
+def test_codex_first_compaction_continuation_is_still_a_bare_retry(monkeypatch):
+    """The first continuation stays bare — the model often just needs another
+    turn, and nudging it immediately would cut multi-phase work short."""
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_compaction_checkpoint_response("blob_1"),
+        _codex_message_response("Done."),
+    ]
+    monkeypatch.setattr(
+        agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0)
+    )
+
+    result = agent.run_conversation("short turn")
+
+    assert result["completed"] is True
+    assert not [
+        m for m in result["messages"]
+        if m.get("role") == "user"
+        and m.get("content") == _CODEX_INCOMPLETE_NUDGE
+    ]


### PR DESCRIPTION
## The failure

Turns on the Codex backend die with:

> Codex response remained incomplete after 3 continuation attempts

and the whole turn's work is lost. Reproduced live on `gpt-5.6-sol` and
`gpt-5.6-terra` via `provider: openai-codex`, with
`compression.codex_responses_native: true`.

## Cause

gpt-5.6 answers a large turn with a server-side `compaction` checkpoint and
no `message` item. `normalize_codex_response` correctly returns
`finish_reason="incomplete"` — the turn has no answer yet — and the
checkpoint is captured onto the interim assistant message's
`codex_reasoning_items` sidecar.

The continuation path then declines to nudge, because the checkpoint makes
`interim_replayable` true:

```python
interim_replayable = (
    interim_has_content
    or interim_has_codex_reasoning      # <- the compaction checkpoint
    or interim_has_codex_message_items
)
if not interim_replayable:
    ...append _CODEX_INCOMPLETE_NUDGE...
```

But *replayable* is not the same as *different*. A checkpoint carries no
answer and no new instruction, and replaying one makes
`prune_pre_checkpoint_items` treat the whole conversation as pre-checkpoint
history. Measured by running a real 262-message session through
`_chat_messages_to_responses_input(..., native_compaction_eligible=True)`:

| | items | `function_call` | `function_call_output` |
|---|---|---|---|
| checkpoint not replayed | 489 | 186 | 186 |
| checkpoint replayed | **12** | **0** | **0** |

The 12 remaining items are the checkpoint, nine retained `role="user"`
messages, a reasoning item, and an empty assistant message — in that order.
The wire ends on `{"role": "assistant", "content": ""}` with no tool results
and no live instruction, so the model returns another empty response.

Because nothing was appended, the next attempt sends the same bytes. The
provider's own prefix cache confirms it — from the failing turn:

```
API call #427: in=141409 out=60  latency=53.3s
    Native Responses compaction item captured (44300 chars encrypted).
API call #428: in=102684 out=14  cache=25088/102684  (24%)
API call #429: in=102638 out=47  cache=101888/102638 (99%)
    turn finished: status=error duration=460.6s
```

Three byte-identical attempts, three empty responses, turn dead.

This is the same failure shape the `not interim_replayable` branch was
added for (grok-4.20 on xai-oauth, whose reasoning items carry no
`encrypted_content`) — the compaction checkpoint just slips past the
predicate.

## Fix

Keep the first continuation bare: the model often genuinely needs one more
turn, and nudging immediately would cut multi-phase/commentary work short.
Once that bare retry has *also* come back incomplete, it is proven not to
work for this turn, so every remaining attempt carries the nudge.

```python
if not interim_replayable or agent._codex_incomplete_retries >= 2:
```

The nudge is a trailing `role="user"` message, so it survives pruning and
lands last on the wire — the model gets an explicit, live instruction
instead of an empty assistant turn.

## Tests

Two regression tests in `tests/run_agent/test_run_agent_codex_responses.py`,
built on a new `_codex_compaction_checkpoint_response` helper:

- `test_codex_compaction_only_continuation_gets_nudged_before_budget_runs_out`
  — two compaction-only turns then an answer; asserts exactly one nudge.
  **Fails on `main`** (no nudge is ever appended), passes with the fix.
- `test_codex_first_compaction_continuation_is_still_a_bare_retry` — one
  compaction-only turn then an answer; asserts no nudge, pinning the
  unchanged happy path.

`tests/run_agent/test_run_agent_codex_responses.py`,
`tests/agent/test_codex_responses_adapter.py` and
`tests/gateway/test_incomplete_gateway_turns.py`: 87 passed.

## Note, not fixed here

Even with the fix the continuation answers from the checkpoint blob with
every `function_call_output` pruned off the wire. That is native
compaction's intended contract (the blob stands in for the pruned history),
so it is left alone — but it does mean a post-checkpoint answer rests on
the server's compaction rather than on the replayed tool results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)