### PR TITLE
fix(cli): apply --in DIR for one-shot (-z) runs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -174,6 +174,45 @@ def _cleanup_oneshot_runtime() -> None:
         pass
 
 
+def _enter_in_dir(in_dir: object, *, stream=None) -> str | None:
+    """Apply ``--in DIR``: chdir into DIR, or exit(1) with a clear message.
+
+    Shared by ``cmd_chat`` and ``_run_and_exit_oneshot`` so ``--in`` means the
+    same thing for every launch mode. The process cwd is the LAST anchor the
+    file tools fall back to when resolving a relative path
+    (``tools.file_tools._resolve_base_dir``, step 4), so a launch mode that
+    parsed ``--in`` but never chdir'd wrote relative paths into the launcher's
+    cwd instead of the assigned workspace.
+
+    ``stream`` selects where the error text goes; defaults to stdout to match
+    the rest of the CLI. ``-z`` passes stderr because one-shot reserves stdout
+    for the final response.
+
+    Returns the absolute directory entered, or ``None`` when *in_dir* is unset.
+    """
+    if not in_dir:
+        return None
+    # Git Bash / MSYS hands the CLI POSIX-style paths (`--in ~` expands to
+    # `/c/Users/x` before Python ever sees it; MSYS2's path conversion is
+    # disabled for native executables). Translate the MSYS/Cygwin/WSL
+    # drive-root spellings to native Windows form first — no-op elsewhere.
+    from tools.environments.local import _msys_to_windows_path
+
+    _target_dir = os.path.abspath(
+        os.path.expanduser(_msys_to_windows_path(str(in_dir)))
+    )
+    _out = stream or sys.stdout
+    if not os.path.isdir(_target_dir):
+        print(f"Error: --in directory not found: {in_dir}", file=_out)
+        sys.exit(1)
+    try:
+        os.chdir(_target_dir)
+    except OSError as e:
+        print(f"Error: cannot enter --in directory {in_dir}: {e}", file=_out)
+        sys.exit(1)
+    return _target_dir
+
+
 def _run_and_exit_oneshot(
     prompt: str,
     *,
@@ -182,8 +221,17 @@ def _run_and_exit_oneshot(
     toolsets: object = None,
     skills: object = None,
     usage_file: object = None,
+    in_dir: object = None,
 ) -> None:
     try:
+        # --in DIR must take effect BEFORE the agent is constructed: the run's
+        # session cwd record and the file tools' relative-path anchor are both
+        # seeded from the process cwd. Without this, `-z ... --in WS` parsed
+        # the flag and silently ignored it, so "create SUMMARY.md" landed in
+        # the launcher's cwd. Errors go to stderr — one-shot reserves stdout
+        # for the final response.
+        _enter_in_dir(in_dir, stream=sys.stderr)
+
         from hermes_cli.oneshot import run_oneshot
 
         rc = run_oneshot(
@@ -3132,25 +3180,7 @@ def cmd_chat(args):
     # workspace-scoped "latest"/-c lookups key off DIR, and it pins the
     # session there — an explicit --in wins over a resumed session's
     # recorded cwd (so the restore step below is skipped).
-    in_dir = getattr(args, "in_dir", None)
-    if in_dir:
-        # Git Bash / MSYS hands the CLI POSIX-style paths (`--in ~` expands to
-        # `/c/Users/x` before Python ever sees it; MSYS2's path conversion is
-        # disabled for native executables). Translate the MSYS/Cygwin/WSL
-        # drive-root spellings to native Windows form first — no-op elsewhere.
-        from tools.environments.local import _msys_to_windows_path
-
-        _target_dir = os.path.abspath(
-            os.path.expanduser(_msys_to_windows_path(in_dir))
-        )
-        if not os.path.isdir(_target_dir):
-            print(f"Error: --in directory not found: {in_dir}")
-            sys.exit(1)
-        try:
-            os.chdir(_target_dir)
-        except OSError as e:
-            print(f"Error: cannot enter --in directory {in_dir}: {e}")
-            sys.exit(1)
+    if _enter_in_dir(getattr(args, "in_dir", None)) is not None:
         args.no_restore_cwd = True
 
     # --resume latest: keyword for "most recent session" — same resolution
@@ -12679,6 +12709,7 @@ def _try_fast_chat_launch() -> bool:
             toolsets=getattr(args, "toolsets", None),
             skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
+            in_dir=getattr(args, "in_dir", None),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -12737,6 +12768,7 @@ def _try_termux_fast_cli_launch() -> bool:
             toolsets=getattr(args, "toolsets", None),
             skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
+            in_dir=getattr(args, "in_dir", None),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -14734,6 +14766,7 @@ def main():
             toolsets=getattr(args, "toolsets", None),
             skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
+            in_dir=getattr(args, "in_dir", None),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/tests/hermes_cli/test_resume_latest_and_in_dir.py
+++ b/tests/hermes_cli/test_resume_latest_and_in_dir.py
@@ -229,3 +229,100 @@ def test_in_dir_expands_user_home(main_mod, launched, monkeypatch, tmp_path):
         assert os.getcwd() == str((home / "proj").resolve())
     finally:
         os.chdir(start)
+
+
+# ---------------------------------------------------------------------------
+# --in DIR for one-shot (-z)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def oneshot_harness(main_mod, monkeypatch):
+    """Drive _run_and_exit_oneshot without os._exit() or a real agent."""
+    seen = {}
+
+    def fake_run_oneshot(prompt, **kwargs):
+        import os
+
+        seen["cwd"] = os.getcwd()
+        seen["prompt"] = prompt
+        seen["kwargs"] = kwargs
+        return 0
+
+    # _run_and_exit_oneshot imports this lazily, inside the call.
+    monkeypatch.setattr("hermes_cli.oneshot.run_oneshot", fake_run_oneshot)
+    monkeypatch.setattr(main_mod, "_cleanup_oneshot_runtime", lambda: None)
+
+    def fake_exit(rc):
+        raise SystemExit(rc)
+
+    monkeypatch.setattr(main_mod, "_exit_after_oneshot", fake_exit)
+    return seen
+
+
+def test_oneshot_in_dir_chdirs_before_agent_runs(main_mod, oneshot_harness, tmp_path):
+    """`hermes -z ... --in WS` must run with WS as the process cwd.
+
+    Regression: --in was consumed only by cmd_chat, so a one-shot parsed the
+    flag and silently ignored it — "create SUMMARY.md" landed in the
+    launcher's cwd (the repo root) instead of the assigned workspace.
+    """
+    import os
+
+    target = tmp_path / "workspace"
+    target.mkdir()
+    start = os.getcwd()
+
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main_mod._run_and_exit_oneshot("create SUMMARY.md", in_dir=str(target))
+    finally:
+        os.chdir(start)
+
+    assert exc.value.code == 0
+    assert oneshot_harness["cwd"] == str(target.resolve())
+
+
+def test_oneshot_without_in_dir_keeps_process_cwd(main_mod, oneshot_harness):
+    import os
+
+    start = os.getcwd()
+    with pytest.raises(SystemExit) as exc:
+        main_mod._run_and_exit_oneshot("hello")
+
+    assert exc.value.code == 0
+    assert oneshot_harness["cwd"] == start
+
+
+def test_oneshot_in_dir_missing_directory_exits_1_on_stderr(
+    main_mod, oneshot_harness, tmp_path, capsys
+):
+    """A bad --in fails the run, and the message must not pollute -z's stdout."""
+    with pytest.raises(SystemExit) as exc:
+        main_mod._run_and_exit_oneshot("x", in_dir=str(tmp_path / "nope"))
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "--in directory not found" in captured.err
+    assert captured.out == ""
+    assert "cwd" not in oneshot_harness  # the agent never ran
+
+
+def test_every_oneshot_dispatch_site_forwards_in_dir():
+    """Every `-z` dispatch site must forward --in.
+
+    There are three (fast-CLI, Termux fast-CLI, full dispatch); a new one that
+    forgets the kwarg silently reintroduces the wrong-workspace bug.
+    """
+    import inspect
+
+    import hermes_cli.main as mod
+
+    # Split on the call marker; a dispatch site is the one whose first
+    # argument is ``args.oneshot`` (the helper's own def line is not).
+    chunks = inspect.getsource(mod).split("_run_and_exit_oneshot(")[1:]
+    sites = [c for c in chunks if c.lstrip().startswith("args.oneshot,")]
+    assert sites, "no -z dispatch sites found"
+    # The call ends at the first dedented closing paren.
+    missing = [c for c in sites if "in_dir=" not in c.split("        )")[0]]
+    assert not missing, f"{len(missing)} of {len(sites)} -z dispatch site(s) drop --in"


### PR DESCRIPTION
`--in` parses to `args.in_dir`, but its only consumer is `cmd_chat`, which chdirs into the directory. All three `-z`/`--oneshot` dispatch sites call `_run_and_exit_oneshot()` and exit without ever reaching `cmd_chat`, so the flag is parsed, validated, and then silently discarded.

With no chdir and no registered workspace override, relative paths in the file tools fall through to their last anchor, `os.getcwd()`. A one-shot asked to create a file at a relative path writes it into the launcher's working directory instead of the assigned workspace — while still reporting success.

## Repro

```
hermes -z "Create a file named SUMMARY.md here" --in /tmp/workspace
```

replies `DONE`, and `SUMMARY.md` lands in the launcher's cwd.

## Fix

Lift the existing chdir out of `cmd_chat` into a shared `_enter_in_dir()` helper, call it from `_run_and_exit_oneshot` before the agent is constructed, and forward `in_dir` from all three dispatch sites.

`cmd_chat` behaviour is unchanged: same messages, same stdout stream, same `no_restore_cwd` side effect. The one-shot path sends its error to stderr because `-z` reserves stdout for the final response.

I considered registering a workspace override into the file tools instead of chdir'ing, but the CLI one-shot is always a dedicated, short-lived process (`_run_and_exit_oneshot` ends in `os._exit()` in a `finally`), so a process-global chdir cannot leak into another session. It also matches the established `--in` semantics for `chat`, and fixes reads, edits, globs and the terminal tool in one move.

## Tests

Four added, including a source-level guard that fails if a new `-z` dispatch site is added without forwarding `in_dir`.

Measured on `tests/hermes_cli/test_resume_latest_and_in_dir.py` at this branch's merge base:

| | result |
|---|---|
| without the fix | 4 failed, 12 passed |
| with the fix | 1 failed, 15 passed |

The remaining failure, `test_in_dir_expands_user_home`, is **pre-existing and unrelated** — it monkeypatches `HOME`, but `os.path.expanduser` on native Windows reads `USERPROFILE`. It fails identically with and without this change, and I left it alone rather than widen the scope.

## Behaviour changes for external `-z --in` callers

- A bogus `--in` now fails the run (exit 1, stderr) instead of silently running in the wrong directory.
- A *relative* `--usage-file` now resolves inside the `--in` workspace.

No caller inside the repo is affected: every internal `--in` use goes through the `chat` subcommand, which already chdirs and is unchanged.