### PR TITLE
fix: harden Telegram sessions picker

### DIFF
--- a/contributors/emails/agent@agents-Mac-mini.local
+++ b/contributors/emails/agent@agents-Mac-mini.local
@@ -1,1 +1,1 @@
-momomojo
+skip-agent

--- a/contributors/emails/agent@agents-Mac-mini.local
+++ b/contributors/emails/agent@agents-Mac-mini.local
@@ -1,1 +1,1 @@
-skip-agent
+momomojo

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4885,9 +4885,9 @@ class GatewaySlashCommandsMixin:
         self._clear_conversation_scope(session_key, reason="resume")
 
         # Evict any cached agent for this session so the next message
-        # rebuilds with the correct session_id end-to-end — mirrors
-        # /branch and /reset. Without this, the cached AIAgent (and its
-        # memory provider, which cached `_session_id` during initialize())
+        # rebuilds with the correct session_id end-to-end — mirrors /branch
+        # and /reset. Without this, the cached AIAgent (and its memory
+        # provider, which cached `_session_id` during initialize())
         # keeps writing into the wrong session's record. See #6672.
         self._evict_cached_agent(session_key)
 
@@ -4911,6 +4911,13 @@ class GatewaySlashCommandsMixin:
         if msg_count == 1:
             return t("gateway.resume.resumed_one", title=title, count=msg_count)
         return t("gateway.resume.resumed_many", title=title, count=msg_count)
+
+    # NOTE: Do NOT collapse the inline switch logic above into
+    # _resume_session_by_id — the cross-origin Matrix ``gate
+    # --cross-room`` branch needs the source-object-aware title substitution
+    # here, and the picker callback always passes a server-side computed
+    # target_id (no Matrix cross-room path). Keeping the two paths
+    # independent avoids accidentally widening the picker's scope.
 
     async def _handle_sessions_command(self, event: MessageEvent) -> str:
         """Handle /sessions — list previous sessions for gateway chats."""
@@ -4962,7 +4969,10 @@ class GatewaySlashCommandsMixin:
             search_query=search_query,
             # Search filters at SQL level, so over-fetch before the visibility
             # cut: origin-invisible matches would otherwise consume the page.
-            limit=50 if search_query else 10,
+            # The picker paginates internally (8 per page + Prev/Next), so the
+            # full origin-scoped list — capped at 50 — needs to make it through
+            # to the adapter. The text fallback below still applies the 10-cap.
+            limit=50,
             exclude_sources=["tool"],
         )
         if not cross_origin:
@@ -4972,6 +4982,58 @@ class GatewaySlashCommandsMixin:
                 row for row in rows
                 if await self._resume_row_visible(source, row, allow_all=False)
             ]
+
+        # Interactive picker: when the adapter supports a Telegram-style
+        # inline-keyboard picker, send one and let the user tap a session to
+        # resume. Falls back to the numbered text list when the adapter does
+        # not implement send_sessions_picker (every other platform today).
+        adapter = (
+            self.adapters.get(source.platform)
+            if hasattr(self, "adapters") and source.platform is not None
+            else None
+        )
+        picker_fn = getattr(adapter, "send_sessions_picker", None) if adapter else None
+        if callable(picker_fn) and source.chat_id and not cross_origin:
+            metadata = None
+            try:
+                metadata = self._thread_metadata_for_source(
+                    source, self._reply_anchor_for_event(event)
+                )
+            except Exception:
+                metadata = None
+
+            async def _on_session_selected(target_id: str) -> str:
+                # IDOR guard: a session id from a picker tap is a routing
+                # handle, not authority. Re-run the same gate the text
+                # `/resume <id>` path uses, so a pick button cannot bypass
+                # cross-origin scoping.
+                if not await self._resume_target_allowed(
+                    source, target_id, allow_override=False
+                ):
+                    return t("gateway.resume.blocked_not_owner", name=target_id)
+                return await self._resume_session_by_id(
+                    source, session_key, target_id
+                )
+
+            try:
+                # Picker paginates internally (8 per page + Prev/Next), so
+                # pass the full origin-scoped rows — no [:10] cap here.
+                # The text fallback below still applies the 10-cap.
+                result = await picker_fn(
+                    chat_id=source.chat_id,
+                    sessions=rows,
+                    current_session_id=current_entry.session_id,
+                    on_session_selected=_on_session_selected,
+                    metadata=metadata,
+                )
+                if result.success:
+                    return None  # Picker rendered; no text reply needed
+            except Exception as e:
+                logger.debug(
+                    "Sessions picker send failed; falling back to text: %s", e
+                )
+
+        # Text fallback: cap at 10 entries (the existing text listing UX).
         rows = rows[:10]
         if search_query:
             title = f"Sessions matching “{search_query}”"
@@ -4982,6 +5044,68 @@ class GatewaySlashCommandsMixin:
             include_source=cross_origin,
             title=title,
         )
+
+    async def _resume_session_by_id(
+        self,
+        source: "SessionSource",
+        session_key: str,
+        target_id: str,
+    ) -> str:
+        """Resume to a specific session by ID. Shared by ``/resume <id>`` and
+        the ``/sessions`` inline-keyboard picker callback.
+
+        Performs the full session-switch cleanup: release any running agent,
+        switch the session entry, clear conversation-scoped per-session state
+        (model/reasoning overrides, /queue, approval state, slash-confirm,
+        ...), evict the cached AIAgent so the next turn rebuilds with the
+        correct session_id, and return a user-facing result string.
+
+        Callers MUST run the IDOR guard (``_resume_target_allowed``) before
+        invoking this helper — the picker callback closure does so, and the
+        text ``/resume`` path does so inline.
+        """
+        # Check if already on that session
+        current_entry = await self.async_session_store.get_or_create_session(source)
+        if current_entry.session_id == target_id:
+            return t("gateway.resume.already_on", name=target_id)
+
+        # Clear any running agent for this session key
+        self._release_running_agent_state(session_key)
+
+        # Switch the session entry to point at the target session
+        new_entry = await self.async_session_store.switch_session(
+            session_key, target_id
+        )
+        if not new_entry:
+            return t("gateway.resume.switch_failed")
+
+        # Conversation boundary: clear ALL conversation-scoped per-session
+        # state and the security boundary state in one funnel call. See
+        # _clear_conversation_scope in gateway/run.py.
+        self._clear_conversation_scope(session_key, reason="resume")
+
+        # Evict any cached agent for this session so the next message
+        # rebuilds with the correct session_id end-to-end — mirrors /branch
+        # and /reset (#6672).
+        self._evict_cached_agent(session_key)
+
+        # Get the title for confirmation
+        title = await self._session_db.get_session_title(target_id) or target_id
+
+        # Count messages for context
+        history = await self.async_session_store.load_transcript(target_id)
+        msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
+        msg_part = (
+            f" ({msg_count} message{'s' if msg_count != 1 else ''})"
+            if msg_count
+            else ""
+        )
+
+        if not msg_count:
+            return t("gateway.resume.resumed_no_count", title=title)
+        if msg_count == 1:
+            return t("gateway.resume.resumed_one", title=title, count=msg_count)
+        return t("gateway.resume.resumed_many", title=title, count=msg_count)
 
     async def _handle_branch_command(self, event: MessageEvent) -> str:
         """Handle /branch [name] — fork the current session into a new independent copy.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5025,6 +5025,7 @@ class GatewaySlashCommandsMixin:
                     current_session_id=current_entry.session_id,
                     on_session_selected=_on_session_selected,
                     metadata=metadata,
+                    picker_user_id=source.user_id,
                 )
                 if result.success:
                     return None  # Picker rendered; no text reply needed

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -20,7 +20,7 @@ import threading
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -885,6 +885,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         self._choice_picker_state: Dict[str, dict] = {}
+        # Interactive sessions picker state (key: (chat_id, msg_id, thread_id))
+        # Composite key prevents a second picker from overwriting the first's
+        # state in the same chat (forum threads, /sessions called twice in a row).
+        # See gateway/slash_commands.py: _handle_sessions_command for the gateway
+        # side; the IDOR guard runs in the runner callback, not here.
+        self._sessions_picker_state: Dict[Tuple[str, int, str], dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
@@ -6542,6 +6548,402 @@ class TelegramAdapter(BasePlatformAdapter):
         await query.answer()
         self._choice_picker_state.pop(chat_id, None)
 
+    # --- Sessions picker (/sessions) ------------------------------------------
+    # Stateful inline-keyboard picker for the gateway /sessions command. The
+    # gateway runner (gateway/slash_commands.py) does the IDOR check + session
+    # switch — this adapter is transport-only and trusts the runner callback it
+    # is handed. State is keyed by (chat_id, msg_id, thread_id) so a second
+    # picker opened in the same chat (forum threads, /sessions called twice)
+    # cannot overwrite the first picker's state. Callbacks validate the
+    # incoming query.message.message_id matches the stored msg_id before
+    # populating buttons, so a stale click on an old keyboard is rejected
+    # without ever invoking the runner.
+
+    _SESSIONS_PAGE_SIZE = 8
+    # Pickers past this TTL get swept on the next send_sessions_picker
+    # call. 1h is generous — a picker that isn't tapped in an hour is
+    # abandoned by definition, and the dict holds a closure over the
+    # runner callback.
+    _SESSIONS_PICKER_TTL_SECONDS = 3600
+
+    @staticmethod
+    def _sessions_picker_key(
+        chat_id: str, msg_id: int, thread_id: Optional[str]
+    ) -> Tuple[str, int, str]:
+        """Composite key for the sessions picker state dict.
+
+        ``thread_id`` is normalized to "" (not None) so the key stays hashable
+        and comparisons work uniformly across private chats (no thread) and
+        forum topics.
+        """
+        return (str(chat_id), int(msg_id), str(thread_id or ""))
+
+    def _session_picker_label(self, session: Dict[str, Any]) -> str:
+        """Compact button label for one session row.
+
+        Title-only — the preview (first message) is rendered in the message
+        BODY above the keyboard, not inside the button. Web / desktop
+        Telegram clients render ``\\n`` in button text inconsistently
+        (some collapse to space, some truncate), so we keep the button
+        single-line and put the disambiguation hint in a place all
+        clients render identically.
+        """
+        title = (session.get("title") or "").strip()
+        title = re.sub(r"\s+", " ", title)
+        if not title:
+            preview = (session.get("preview") or "").strip()
+            title = preview or session.get("id") or "Untitled session"
+            title = re.sub(r"\s+", " ", title)
+        if len(title) > 64:
+            title = title[:61] + "..."
+        return title or "Untitled session"
+
+    @staticmethod
+    def _filter_current(
+        sessions: list, current_session_id: str
+    ) -> list:
+        """Drop the current session from the rendered list (no self-button)."""
+        if not current_session_id:
+            return list(sessions)
+        return [s for s in sessions if s.get("id") != current_session_id]
+
+    def _evict_stale_sessions_picker_state(self) -> None:
+        """Lazy TTL sweep for ``_sessions_picker_state``.
+
+        Pickers live in the dict until the user taps (select/cancel pops
+        them) OR until they pass ``_SESSIONS_PICKER_TTL_SECONDS``. We
+        sweep at every new ``send_sessions_picker`` so the cost is
+        amortized — no background thread. The dict holds closures over
+        the runner; in a busy group with dozens of abandoned pickers
+        this bounds the leak to ``TTL * open-rate``.
+        """
+        ttl = getattr(self, "_SESSIONS_PICKER_TTL_SECONDS", 3600)
+        now = time.monotonic()
+        stale = [
+            key
+            for key, state in self._sessions_picker_state.items()
+            if (now - state.get("created_at", now)) > ttl
+        ]
+        for key in stale:
+            self._sessions_picker_state.pop(key, None)
+
+    @staticmethod
+    def _format_session_preview_line(session: Dict[str, Any], number: int) -> str:
+        """Render one session's title + preview as a single body line.
+
+        Format: ``{number}. *Title* — preview`` (one line, no wrap).
+        Earlier v3 dropped title entirely; that lost primary identity.
+        Earlier v1 wrapped title + preview on two lines; that looked
+        cluttered when 8 of them stack up. Single-line with a separator
+        keeps both visible and scannable. Preview is truncated to ~50
+        chars to keep each row readable on mobile.
+
+        The number corresponds 1:1 with the button below — but the
+        body line is also self-describing (title + preview) so a user
+        who loses the number still knows what they're tapping.
+        """
+        title = (session.get("title") or "").strip()
+        title = re.sub(r"\s+", " ", title)
+        if not title:
+            title = (session.get("preview") or "").strip()[:40]
+            title = re.sub(r"\s+", " ", title) or "(untitled)"
+        preview = (session.get("preview") or "").strip()
+        preview = re.sub(r"\s+", " ", preview)
+        # Escape MarkdownV2 special chars in title and preview
+        esc = lambda s: s.replace("*", "\\*").replace("`", "\\`").replace("_", "\\_")
+        title_md = esc(title)
+        if preview and preview != title:
+            if len(preview) > 50:
+                preview = preview[:47] + "..."
+            preview_md = esc(preview)
+            return f"{number}\\. *{title_md}* — {preview_md}"
+        return f"{number}\\. *{title_md}*"
+
+    def _build_sessions_keyboard(
+        self, sessions: list, page: int, current_session_id: str = ""
+    ) -> Tuple[Any, str]:
+        """Build the paginated /sessions inline keyboard.
+
+        Returns ``(keyboard, page_info)`` so the caller can embed ``page_info``
+        in the rendered message body. Buttons are numbered 1..N (per page)
+        in a 4-column grid — the body shows matching numbered previews so
+        the user maps preview → number → button. This avoids the
+        title-in-body + title-in-button duplication that looked cluttered.
+
+        ``current_session_id`` is filtered out of the rendered list — the
+        session you're already on doesn't need a button to resume itself.
+        The runner's `_resume_session_by_id` still surfaces the translated
+        "already on" message if a button is somehow tapped anyway.
+        """
+        if current_session_id:
+            sessions = [s for s in sessions if s.get("id") != current_session_id]
+        page_rows, meta = self._format_choice_page(
+            sessions, page, self._SESSIONS_PAGE_SIZE
+        )
+        page = meta["page"]
+        total_pages = meta["total_pages"]
+        start = meta["start"]
+
+        rows: List[List[Any]] = []
+        # 4-up grid: pack buttons 4 per row for compactness on mobile.
+        # The button label is just the 1-based page-relative number; the
+        # for-loop emits groups of 4 contiguous rows.
+        button_grid: List[Any] = []
+        for i, _session in enumerate(page_rows):
+            abs_idx = start + i
+            page_num = i + 1  # 1-based within page
+            button_grid.append(
+                InlineKeyboardButton(
+                    str(page_num), callback_data=f"se:{abs_idx}"
+                )
+            )
+        for j in range(0, len(button_grid), 4):
+            rows.append(button_grid[j : j + 4])
+
+        if total_pages > 1:
+            nav: List[Any] = []
+            if page > 0:
+                nav.append(
+                    InlineKeyboardButton("◀ Prev", callback_data=f"sg:{page - 1}")
+                )
+            nav.append(
+                InlineKeyboardButton(
+                    f"{page + 1}/{total_pages}", callback_data="sp:noop"
+                )
+            )
+            if page < total_pages - 1:
+                nav.append(
+                    InlineKeyboardButton("Next ▶", callback_data=f"sg:{page + 1}")
+                )
+            rows.append(nav)
+
+        rows.append([InlineKeyboardButton("✗ Cancel", callback_data="sx")])
+        return InlineKeyboardMarkup(rows), meta["page_info"]
+
+    async def send_sessions_picker(
+        self,
+        chat_id: str,
+        sessions: list,
+        current_session_id: str,
+        on_session_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "SendResult":
+        """Send an interactive inline-keyboard picker for /sessions.
+
+        Callback data stores only indexes (``se:<n>`` / ``sg:<page>`` /
+        ``sx``) to stay under Telegram's 64-byte callback_data limit; the
+        full session ids live in adapter state for the lifetime of the
+        picker. The runner-bound ``on_session_selected`` callback is called
+        with the picked session id string and is responsible for the IDOR
+        guard + session switch (see gateway/slash_commands.py).
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        if not sessions:
+            return SendResult(success=False, error="No sessions")
+
+        # Amortized TTL sweep — bounds the closure leak from abandoned
+        # pickers (user opened /sessions but never tapped).
+        self._evict_stale_sessions_picker_state()
+
+        try:
+            keyboard, page_info = self._build_sessions_keyboard(
+                sessions, 0, current_session_id=current_session_id
+            )
+            # Render the message body as a numbered list of previews;
+            # buttons below show just the matching numbers. The user
+            # maps preview → number → button. Visual separation: body
+            # shows previews (read), buttons show numbers (tap).
+            page_rows_for_body, _ = self._format_choice_page(
+                self._filter_current(sessions, current_session_id), 0,
+                self._SESSIONS_PAGE_SIZE,
+            )
+            body_lines = [f"🗂 *Sessions*{page_info}", ""]
+            for idx, session in enumerate(page_rows_for_body, start=1):
+                body_lines.append(self._format_session_preview_line(session, idx))
+            body_lines.extend([
+                "",
+                "_Tap the matching number below to resume._",
+            ])
+            text = self.format_message("\n".join(body_lines))
+            thread_id = metadata.get("thread_id") if metadata else None
+            reply_to_id = self._reply_to_message_id_for_send(
+                None, metadata, reply_to_mode=self._reply_to_mode
+            )
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=normalize_telegram_chat_id(chat_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode,
+                ),
+                **self._link_preview_kwargs(),
+            )
+
+            self._sessions_picker_state[self._sessions_picker_key(
+                chat_id, msg.message_id, thread_id,
+            )] = {
+                "msg_id": msg.message_id,
+                "sessions": list(sessions),
+                "current_session_id": current_session_id,
+                "on_session_selected": on_session_selected,
+                "thread_id": str(thread_id or ""),
+                "created_at": time.monotonic(),
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning(
+                "[%s] send_sessions_picker failed: %s",
+                self.name,
+                _redact_telegram_error_text(e),
+            )
+            return SendResult(success=False, error=_redact_telegram_error_text(e))
+
+    async def _handle_sessions_picker_callback(
+        self,
+        query,
+        data: str,
+        chat_id: str,
+        msg_id: int,
+        thread_id: str,
+    ) -> None:
+        """Handle /sessions inline keyboard callbacks (se:/sg:/sx:).
+
+        Validates the incoming callback's msg_id matches the stored picker
+        state before doing anything — so a stale click on an old keyboard
+        (after a new /sessions has replaced it) is rejected without invoking
+        the runner. Authorization is re-checked against the gateway's
+        ``_is_user_authorized`` policy at the adapter level (mirrors the
+        approval / choice picker gates), and the runner callback does the
+        full IDOR-side IDOR guard via ``_resume_target_allowed``.
+        """
+        state = self._sessions_picker_state.get(
+            self._sessions_picker_key(chat_id, msg_id, thread_id)
+        )
+        if not state:
+            await query.answer(text="Session picker expired — use /sessions again.")
+            return
+
+        # Authorization gate: refuse taps from someone the gateway hasn't
+        # already authorized to drive this chat. Mirrors the approval /
+        # choice picker pattern so a co-member in a shared group can't flip
+        # another user's session.
+        query_message = getattr(query, "message", None)
+        query_chat = getattr(query_message, "chat", None)
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=getattr(query_message, "chat_id", None),
+            chat_type=str(getattr(query_chat, "type", None))
+            if getattr(query_chat, "type", None) is not None
+            else None,
+            thread_id=str(getattr(query_message, "message_thread_id", None))
+            if getattr(query_message, "message_thread_id", None) is not None
+            else None,
+            user_name=getattr(query.from_user, "first_name", None),
+        ):
+            await query.answer(text="⛔ You are not authorized to switch sessions.")
+            return
+
+        if data == "sp:noop":
+            await query.answer()
+            return
+
+        if data == "sx":
+            self._sessions_picker_state.pop(
+                self._sessions_picker_key(chat_id, msg_id, thread_id), None
+            )
+            try:
+                await query.edit_message_text(
+                    text="Session picker cancelled.", reply_markup=None
+                )
+            except Exception:
+                pass
+            await query.answer()
+            return
+
+        if data.startswith("sg:"):
+            try:
+                page = int(data[3:])
+            except ValueError:
+                await query.answer(text="Invalid page.")
+                return
+            sessions = state.get("sessions", [])
+            current_session_id = state.get("current_session_id", "")
+            keyboard, page_info = self._build_sessions_keyboard(
+                sessions, page, current_session_id=current_session_id
+            )
+            # Rebuild the message body so the preview lines match the
+            # new page — same shape as send_sessions_picker emits.
+            page_rows_for_body, _ = self._format_choice_page(
+                self._filter_current(sessions, current_session_id), page,
+                self._SESSIONS_PAGE_SIZE,
+            )
+            body_lines = [f"🗂 *Sessions*{page_info}", ""]
+            for idx, session in enumerate(page_rows_for_body, start=1):
+                body_lines.append(
+                    self._format_session_preview_line(session, idx)
+                )
+            body_lines.extend(["", "_Tap the matching number below to resume._"])
+            await query.edit_message_text(
+                text=self.format_message("\n".join(body_lines)),
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+            )
+            await query.answer()
+            return
+
+        if data.startswith("se:"):
+            try:
+                idx = int(data[3:])
+            except ValueError:
+                await query.answer(text="Invalid selection.")
+                return
+            sessions = state.get("sessions", [])
+            if idx < 0 or idx >= len(sessions):
+                await query.answer(text="Invalid session index.")
+                return
+            session_id = str(sessions[idx].get("id") or "")
+            callback = state.get("on_session_selected")
+            self._sessions_picker_state.pop(
+                self._sessions_picker_key(chat_id, msg_id, thread_id), None
+            )
+            if not session_id or not callable(callback):
+                await query.answer(text="Session picker expired.")
+                return
+
+            try:
+                result_text = await callback(session_id)
+            except Exception as exc:
+                logger.error(
+                    "Sessions picker callback failed: %s", exc
+                )
+                result_text = f"Error resuming session: {exc}"
+
+            try:
+                await query.edit_message_text(
+                    text=self.format_message(result_text),
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                    reply_markup=None,
+                )
+            except Exception:
+                try:
+                    await query.edit_message_text(
+                        text=result_text, parse_mode=None, reply_markup=None
+                    )
+                except Exception:
+                    pass
+            await query.answer(text="Session resumed.")
+            return
+
+        await query.answer()
+
     _MODEL_PAGE_SIZE = 8
 
     def _build_provider_keyboard(self, providers: list, page: int = 0) -> tuple:
@@ -7036,6 +7438,22 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_choice_picker_callback(query, data, chat_id)
+            return
+
+        # --- Sessions picker callbacks (/sessions) ---
+        # Use the message_id from the query as the picker state key — a stale
+        # click on an old keyboard after a new /sessions has replaced it
+        # naturally fails to find state and is rejected.
+        if data.startswith(("se:", "sg:", "sp:", "sx")):
+            chat_id = str(query.message.chat_id) if query.message else None
+            msg_id = getattr(query.message, "message_id", None)
+            thread_id = str(
+                getattr(query.message, "message_thread_id", None) or ""
+            )
+            if chat_id is not None and msg_id is not None:
+                await self._handle_sessions_picker_callback(
+                    query, data, chat_id, msg_id, thread_id
+                )
             return
 
         # --- Gmail-triage callbacks (gt:verb:arg) ---

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6629,54 +6629,28 @@ class TelegramAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _format_session_preview_line(session: Dict[str, Any], number: int) -> str:
-        """Render one session's title + preview as a single body line.
+        """Render one session's title and preview as standard Markdown.
 
-        Format: ``{number}. *Title* — preview`` (one line, no wrap).
-        Earlier v3 dropped title entirely; that lost primary identity.
-        Earlier v1 wrapped title + preview on two lines; that looked
-        cluttered when 8 of them stack up. Single-line with a separator
-        keeps both visible and scannable. Preview is truncated to ~50
-        chars to keep each row readable on mobile.
-
-        The number corresponds 1:1 with the button below — but the
-        body line is also self-describing (title + preview) so a user
-        who loses the number still knows what they're tapping.
+        ``format_message`` is the single MarkdownV2 conversion boundary;
+        this helper must not pre-escape text or punctuation.
         """
-        title = (session.get("title") or "").strip()
-        title = re.sub(r"\s+", " ", title)
+        title = re.sub(r"\s+", " ", (session.get("title") or "").strip())
         if not title:
-            title = (session.get("preview") or "").strip()[:40]
-            title = re.sub(r"\s+", " ", title) or "(untitled)"
-        preview = (session.get("preview") or "").strip()
-        preview = re.sub(r"\s+", " ", preview)
-        # Escape MarkdownV2 special chars in title and preview
-        esc = lambda s: s.replace("*", "\\*").replace("`", "\\`").replace("_", "\\_")
-        title_md = esc(title)
+            title = re.sub(
+                r"\s+", " ", (session.get("preview") or "").strip()[:40]
+            ) or "(untitled)"
+        preview = re.sub(r"\s+", " ", (session.get("preview") or "").strip())
         if preview and preview != title:
             if len(preview) > 50:
                 preview = preview[:47] + "..."
-            preview_md = esc(preview)
-            return f"{number}\\. *{title_md}* — {preview_md}"
-        return f"{number}\\. *{title_md}*"
+            return str(number) + ". **" + title + "** — " + preview
+        return str(number) + ". **" + title + "**"
 
     def _build_sessions_keyboard(
         self, sessions: list, page: int, current_session_id: str = ""
     ) -> Tuple[Any, str]:
-        """Build the paginated /sessions inline keyboard.
-
-        Returns ``(keyboard, page_info)`` so the caller can embed ``page_info``
-        in the rendered message body. Buttons are numbered 1..N (per page)
-        in a 4-column grid — the body shows matching numbered previews so
-        the user maps preview → number → button. This avoids the
-        title-in-body + title-in-button duplication that looked cluttered.
-
-        ``current_session_id`` is filtered out of the rendered list — the
-        session you're already on doesn't need a button to resume itself.
-        The runner's `_resume_session_by_id` still surfaces the translated
-        "already on" message if a button is somehow tapped anyway.
-        """
-        if current_session_id:
-            sessions = [s for s in sessions if s.get("id") != current_session_id]
+        """Build the paginated /sessions inline keyboard."""
+        sessions = self._filter_current(sessions, current_session_id)
         page_rows, meta = self._format_choice_page(
             sessions, page, self._SESSIONS_PAGE_SIZE
         )
@@ -6685,16 +6659,12 @@ class TelegramAdapter(BasePlatformAdapter):
         start = meta["start"]
 
         rows: List[List[Any]] = []
-        # 4-up grid: pack buttons 4 per row for compactness on mobile.
-        # The button label is just the 1-based page-relative number; the
-        # for-loop emits groups of 4 contiguous rows.
         button_grid: List[Any] = []
         for i, _session in enumerate(page_rows):
             abs_idx = start + i
-            page_num = i + 1  # 1-based within page
             button_grid.append(
                 InlineKeyboardButton(
-                    str(page_num), callback_data=f"se:{abs_idx}"
+                    str(i + 1), callback_data="se:" + str(abs_idx)
                 )
             )
         for j in range(0, len(button_grid), 4):
@@ -6704,21 +6674,34 @@ class TelegramAdapter(BasePlatformAdapter):
             nav: List[Any] = []
             if page > 0:
                 nav.append(
-                    InlineKeyboardButton("◀ Prev", callback_data=f"sg:{page - 1}")
+                    InlineKeyboardButton(
+                        "◀ Prev", callback_data="sg:" + str(page - 1)
+                    )
                 )
             nav.append(
                 InlineKeyboardButton(
-                    f"{page + 1}/{total_pages}", callback_data="sp:noop"
+                    str(page + 1) + "/" + str(total_pages), callback_data="sp:noop"
                 )
             )
             if page < total_pages - 1:
                 nav.append(
-                    InlineKeyboardButton("Next ▶", callback_data=f"sg:{page + 1}")
+                    InlineKeyboardButton(
+                        "Next ▶", callback_data="sg:" + str(page + 1)
+                    )
                 )
             rows.append(nav)
 
         rows.append([InlineKeyboardButton("✗ Cancel", callback_data="sx")])
         return InlineKeyboardMarkup(rows), meta["page_info"]
+
+    def _clear_sessions_picker_state_for_lane(
+        self, chat_id: str, thread_id: Optional[str]
+    ) -> None:
+        normalized_chat = str(chat_id)
+        normalized_thread = str(thread_id or "")
+        for key in list(self._sessions_picker_state):
+            if key[0] == normalized_chat and key[2] == normalized_thread:
+                self._sessions_picker_state.pop(key, None)
 
     async def send_sessions_picker(
         self,
@@ -6727,46 +6710,28 @@ class TelegramAdapter(BasePlatformAdapter):
         current_session_id: str,
         on_session_selected,
         metadata: Optional[Dict[str, Any]] = None,
+        picker_user_id: Optional[str] = None,
     ) -> "SendResult":
-        """Send an interactive inline-keyboard picker for /sessions.
-
-        Callback data stores only indexes (``se:<n>`` / ``sg:<page>`` /
-        ``sx``) to stay under Telegram's 64-byte callback_data limit; the
-        full session ids live in adapter state for the lifetime of the
-        picker. The runner-bound ``on_session_selected`` callback is called
-        with the picked session id string and is responsible for the IDOR
-        guard + session switch (see gateway/slash_commands.py).
-        """
+        """Send an interactive inline-keyboard picker for /sessions."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
-        if not sessions:
+        picker_sessions = self._filter_current(sessions, current_session_id)
+        if not picker_sessions:
             return SendResult(success=False, error="No sessions")
 
-        # Amortized TTL sweep — bounds the closure leak from abandoned
-        # pickers (user opened /sessions but never tapped).
         self._evict_stale_sessions_picker_state()
+        thread_id = metadata.get("thread_id") if metadata else None
 
         try:
-            keyboard, page_info = self._build_sessions_keyboard(
-                sessions, 0, current_session_id=current_session_id
-            )
-            # Render the message body as a numbered list of previews;
-            # buttons below show just the matching numbers. The user
-            # maps preview → number → button. Visual separation: body
-            # shows previews (read), buttons show numbers (tap).
+            keyboard, page_info = self._build_sessions_keyboard(picker_sessions, 0)
             page_rows_for_body, _ = self._format_choice_page(
-                self._filter_current(sessions, current_session_id), 0,
-                self._SESSIONS_PAGE_SIZE,
+                picker_sessions, 0, self._SESSIONS_PAGE_SIZE
             )
-            body_lines = [f"🗂 *Sessions*{page_info}", ""]
+            body_lines = ["🗂 *Sessions*" + page_info, ""]
             for idx, session in enumerate(page_rows_for_body, start=1):
                 body_lines.append(self._format_session_preview_line(session, idx))
-            body_lines.extend([
-                "",
-                "_Tap the matching number below to resume._",
-            ])
+            body_lines.extend(["", "_Tap the matching number below to resume._"])
             text = self.format_message("\n".join(body_lines))
-            thread_id = metadata.get("thread_id") if metadata else None
             reply_to_id = self._reply_to_message_id_for_send(
                 None, metadata, reply_to_mode=self._reply_to_mode
             )
@@ -6785,17 +6750,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 ),
                 **self._link_preview_kwargs(),
             )
-
-            self._sessions_picker_state[self._sessions_picker_key(
-                chat_id, msg.message_id, thread_id,
-            )] = {
-                "msg_id": msg.message_id,
-                "sessions": list(sessions),
-                "current_session_id": current_session_id,
-                "on_session_selected": on_session_selected,
-                "thread_id": str(thread_id or ""),
-                "created_at": time.monotonic(),
-            }
+            key = self._sessions_picker_key(chat_id, msg.message_id, thread_id)
+            self._clear_sessions_picker_state_for_lane(chat_id, thread_id)
+            self._sessions_picker_state[key] = dict(
+                msg_id=msg.message_id,
+                sessions=list(picker_sessions),
+                on_session_selected=on_session_selected,
+                thread_id=str(thread_id or ""),
+                creator_user_id=str(picker_user_id or ""),
+                created_at=time.monotonic(),
+            )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning(
@@ -6813,30 +6777,26 @@ class TelegramAdapter(BasePlatformAdapter):
         msg_id: int,
         thread_id: str,
     ) -> None:
-        """Handle /sessions inline keyboard callbacks (se:/sg:/sx:).
-
-        Validates the incoming callback's msg_id matches the stored picker
-        state before doing anything — so a stale click on an old keyboard
-        (after a new /sessions has replaced it) is rejected without invoking
-        the runner. Authorization is re-checked against the gateway's
-        ``_is_user_authorized`` policy at the adapter level (mirrors the
-        approval / choice picker gates), and the runner callback does the
-        full IDOR-side IDOR guard via ``_resume_target_allowed``.
-        """
-        state = self._sessions_picker_state.get(
-            self._sessions_picker_key(chat_id, msg_id, thread_id)
-        )
+        """Handle /sessions inline-keyboard callbacks."""
+        key = self._sessions_picker_key(chat_id, msg_id, thread_id)
+        state = self._sessions_picker_state.get(key)
         if not state:
             await query.answer(text="Session picker expired — use /sessions again.")
             return
 
-        # Authorization gate: refuse taps from someone the gateway hasn't
-        # already authorized to drive this chat. Mirrors the approval /
-        # choice picker pattern so a co-member in a shared group can't flip
-        # another user's session.
+        created_at = state.get("created_at", time.monotonic())
+        if time.monotonic() - created_at > self._SESSIONS_PICKER_TTL_SECONDS:
+            self._sessions_picker_state.pop(key, None)
+            await query.answer(text="Session picker expired — use /sessions again.")
+            return
+
         query_message = getattr(query, "message", None)
         query_chat = getattr(query_message, "chat", None)
         caller_id = str(getattr(query.from_user, "id", ""))
+        creator_id = str(state.get("creator_user_id") or "")
+        if creator_id and caller_id != creator_id:
+            await query.answer(text="⛔ Only the picker creator can use it.")
+            return
         if not self._is_callback_user_authorized(
             caller_id,
             chat_id=getattr(query_message, "chat_id", None),
@@ -6856,9 +6816,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
 
         if data == "sx":
-            self._sessions_picker_state.pop(
-                self._sessions_picker_key(chat_id, msg_id, thread_id), None
-            )
+            self._sessions_picker_state.pop(key, None)
             try:
                 await query.edit_message_text(
                     text="Session picker cancelled.", reply_markup=None
@@ -6875,21 +6833,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 await query.answer(text="Invalid page.")
                 return
             sessions = state.get("sessions", [])
-            current_session_id = state.get("current_session_id", "")
-            keyboard, page_info = self._build_sessions_keyboard(
-                sessions, page, current_session_id=current_session_id
-            )
-            # Rebuild the message body so the preview lines match the
-            # new page — same shape as send_sessions_picker emits.
+            keyboard, page_info = self._build_sessions_keyboard(sessions, page)
             page_rows_for_body, _ = self._format_choice_page(
-                self._filter_current(sessions, current_session_id), page,
-                self._SESSIONS_PAGE_SIZE,
+                sessions, page, self._SESSIONS_PAGE_SIZE
             )
-            body_lines = [f"🗂 *Sessions*{page_info}", ""]
+            body_lines = ["🗂 *Sessions*" + page_info, ""]
             for idx, session in enumerate(page_rows_for_body, start=1):
-                body_lines.append(
-                    self._format_session_preview_line(session, idx)
-                )
+                body_lines.append(self._format_session_preview_line(session, idx))
             body_lines.extend(["", "_Tap the matching number below to resume._"])
             await query.edit_message_text(
                 text=self.format_message("\n".join(body_lines)),
@@ -6911,35 +6861,49 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
             session_id = str(sessions[idx].get("id") or "")
             callback = state.get("on_session_selected")
-            self._sessions_picker_state.pop(
-                self._sessions_picker_key(chat_id, msg_id, thread_id), None
-            )
+            self._sessions_picker_state.pop(key, None)
             if not session_id or not callable(callback):
                 await query.answer(text="Session picker expired.")
                 return
 
             try:
                 result_text = await callback(session_id)
-            except Exception as exc:
-                logger.error(
-                    "Sessions picker callback failed: %s", exc
-                )
-                result_text = f"Error resuming session: {exc}"
+            except Exception:
+                logger.exception("Sessions picker callback failed")
+                result_text = "Error resuming session. Please try /sessions again."
 
+            formatted = self.format_message(result_text)
+            edited = False
             try:
                 await query.edit_message_text(
-                    text=self.format_message(result_text),
+                    text=formatted,
                     parse_mode=ParseMode.MARKDOWN_V2,
                     reply_markup=None,
                 )
+                edited = True
             except Exception:
                 try:
                     await query.edit_message_text(
                         text=result_text, parse_mode=None, reply_markup=None
                     )
+                    edited = True
                 except Exception:
                     pass
-            await query.answer(text="Session resumed.")
+            if not edited and self._bot:
+                try:
+                    await self._send_message_with_thread_fallback(
+                        chat_id=normalize_telegram_chat_id(chat_id),
+                        text=result_text,
+                        parse_mode=None,
+                        **self._thread_kwargs_for_send(
+                            chat_id,
+                            state.get("thread_id"),
+                            None,
+                        ),
+                    )
+                except Exception:
+                    logger.debug("Failed to send session picker result", exc_info=True)
+            await query.answer()
             return
 
         await query.answer()

--- a/tests/gateway/test_sessions_command_picker_integration.py
+++ b/tests/gateway/test_sessions_command_picker_integration.py
@@ -1,0 +1,333 @@
+"""Integration tests for the gateway /sessions ↔ Telegram picker wiring.
+
+The adapter-level state and callback dispatch live in
+``test_telegram_sessions_picker.py``. This file covers the gateway side:
+
+* ``_handle_sessions_command`` renders an interactive picker when the
+  active adapter exposes ``send_sessions_picker``.
+* Otherwise it falls back to the numbered text listing (the existing
+  behavior).
+* The picker's ``on_session_selected`` callback re-runs the IDOR guard
+  via ``_resume_target_allowed`` before delegating to the shared
+  ``_resume_session_by_id`` helper — a co-member in a shared group
+  cannot use the button to bind to another user's persisted session.
+* ``_resume_session_by_id`` performs the full session-switch cleanup
+  (release running agent, switch session entry, clear conversation
+  scope, evict cached agent) — the same funnel as the text ``/resume``
+  path, so the picker cannot bypass any of the bug-class regressions
+  that funnel fixes (e.g. #10702, #58403, #6672).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+_NO_TELEGRAM = "telegram" not in sys.modules or not hasattr(
+    sys.modules["telegram"], "__file__"
+)
+if _NO_TELEGRAM:
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.session import SessionSource, build_session_key
+
+
+def _event(text: str = "/sessions") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="group",
+            user_id="777",
+            thread_id="42",
+        ),
+        message_id="msg-1",
+    )
+
+
+def _make_runner(tmp_path):
+    """Build a bare-bones GatewayRunner with the methods used by
+    ``_handle_sessions_command`` stubbed out — drives the real session
+    listing path and only the picker/integration code is exercised end-to-end.
+    """
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+    config = GatewayConfig()
+    from gateway import run as gateway_run
+
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._cache_session_source = lambda _key, _source: None
+    runner._reply_anchor_for_event = lambda _event: None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    # Session store facade used by _handle_sessions_command.
+    runner._session_db = MagicMock()
+    # query_session_listing calls getattr(self._session_db, "_db",
+    # self._session_db) — a MagicMock returns a MagicMock for `_db`, so the
+    # real call lands on `_session_db._db.list_sessions_rich`, not the
+    # `_session_db` we set up. Wire both.
+    runner._session_db.list_sessions_rich = MagicMock(
+        return_value=[
+            {"id": "s1", "title": "Research", "preview": "notes"},
+            {"id": "s2", "title": "Coding", "preview": "fix bug"},
+        ]
+    )
+    runner._session_db._db = runner._session_db
+    # _session_db.get_session_title is awaited in _resume_session_by_id.
+    runner._session_db.get_session_title = AsyncMock(return_value=None)
+
+    # Async session store facade used by the gate + the helper. The real
+    # facade is a property that returns a fresh AsyncSessionStore unless
+    # ``_async_session_store._store is self.session_store`` — so we must
+    # pin the mock's ``_store`` to the same MagicMock we wire into
+    # ``session_store`` or the property getter will rebuild a real
+    # AsyncSessionStore over our mock on first access.
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session = MagicMock(
+        return_value=MagicMock(session_id="current-session")
+    )
+
+    async_facade = MagicMock()
+    async_facade._store = runner.session_store  # pin to bypass the property rebuild
+    async_facade.get_or_create_session = AsyncMock(
+        return_value=MagicMock(session_id="current-session")
+    )
+    async_facade.switch_session = AsyncMock(
+        return_value=MagicMock(session_id="s1")
+    )
+    async_facade.load_transcript = AsyncMock(return_value=[])
+    runner._async_session_store = async_facade
+
+    # Boundary funnels.
+    runner._release_running_agent_state = MagicMock()
+    runner._clear_conversation_scope = MagicMock()
+    runner._evict_cached_agent = MagicMock()
+
+    # Cross-origin / scoping primitives.
+    runner._resume_caller_is_admin = lambda _source: False
+    runner._resume_row_visible = AsyncMock(return_value=True)
+    runner._resume_target_allowed = AsyncMock(return_value=True)
+    runner._thread_metadata_for_source = MagicMock(return_value={"thread_id": "42"})
+    runner._normalize_source_for_session_key = lambda source: source
+    runner._session_key_for_source = lambda source: build_session_key(source)
+
+    return runner
+
+
+# ── 1. Picker is invoked when the adapter implements it ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sessions_command_uses_picker_when_adapter_supports_it(tmp_path):
+    runner = _make_runner(tmp_path)
+    adapter = MagicMock()
+    adapter.send_sessions_picker = AsyncMock(
+        return_value=SendResult(success=True, message_id="100")
+    )
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    result = await runner._handle_sessions_command(_event("/sessions"))
+
+    # Picker rendered, no text reply
+    assert result is None
+    adapter.send_sessions_picker.assert_awaited_once()
+    kwargs = adapter.send_sessions_picker.await_args.kwargs
+    assert kwargs["chat_id"] == "12345"
+    sessions = kwargs["sessions"]
+    assert {s["id"] for s in sessions} == {"s1", "s2"}
+    assert kwargs["current_session_id"] == "current-session"
+    # Thread metadata threaded through so the picker lands in the same topic
+    assert kwargs["metadata"] == {"thread_id": "42"}
+    # The runner callback is a closure that captures session_key + source
+    assert callable(kwargs["on_session_selected"])
+
+
+# ── 2. Falls back to text when no adapter has the picker ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_sessions_command_falls_back_to_text_when_adapter_lacks_picker(tmp_path):
+    runner = _make_runner(tmp_path)
+    # Plain stub adapter — no send_sessions_picker attribute at all
+    runner.adapters[Platform.TELEGRAM] = MagicMock(spec=[])
+
+    result = await runner._handle_sessions_command(_event("/sessions"))
+
+    # Text listing returned, no picker sent
+    assert isinstance(result, str)
+    assert "Research" in result
+    assert "Coding" in result
+    assert "/resume" in result  # the existing text footer hint
+
+
+# ── 3. IDOR guard runs in the picker callback ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_picker_callback_runs_idor_guard_before_resuming(tmp_path):
+    """The picker's on_session_selected closure must re-run
+    _resume_target_allowed with the same SessionSource that opened the
+    picker — a co-member tapping someone else's session list cannot
+    bypass the gate."""
+    runner = _make_runner(tmp_path)
+    adapter = MagicMock()
+    picker_invocation = {}
+    adapter.send_sessions_picker = AsyncMock(
+        side_effect=lambda **_kw: (
+            picker_invocation.update(_kw) or SendResult(success=True, message_id="100")
+        )
+    )
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    await runner._handle_sessions_command(_event("/sessions"))
+    on_selected = picker_invocation["on_session_selected"]
+
+    # IDOR guard denies the resume
+    runner._resume_target_allowed = AsyncMock(return_value=False)
+    result = await on_selected("s1")
+
+    assert result
+    assert "blocked" in result.lower() or "not owner" in result.lower()
+    # Critically: switch_session was NEVER called — the helper is gated
+    runner.async_session_store.switch_session.assert_not_awaited()
+    runner._clear_conversation_scope.assert_not_called()
+    runner._evict_cached_agent.assert_not_called()
+
+
+# ── 4. Picker callback runs the full session-switch funnel ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_picker_callback_runs_resume_session_by_id(tmp_path):
+    """With the IDOR guard passed, the picker callback delegates to
+    _resume_session_by_id — the same funnel as the text /resume path,
+    so it gets the conversation-scope clear, cached-agent eviction, and
+    running-agent release for free."""
+    runner = _make_runner(tmp_path)
+    adapter = MagicMock()
+    picker_invocation = {}
+    adapter.send_sessions_picker = AsyncMock(
+        side_effect=lambda **_kw: (
+            picker_invocation.update(_kw) or SendResult(success=True, message_id="100")
+        )
+    )
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    await runner._handle_sessions_command(_event("/sessions"))
+    on_selected = picker_invocation["on_session_selected"]
+
+    # IDOR guard passes
+    runner._resume_target_allowed = AsyncMock(return_value=True)
+    # No prior → not already-on
+    runner.async_session_store.get_or_create_session.return_value = MagicMock(
+        session_id="current-session"
+    )
+
+    result = await on_selected("s1")
+
+    # IDOR guard ran with the captured source
+    runner._resume_target_allowed.assert_awaited()
+    _, target_id = runner._resume_target_allowed.await_args.args
+    assert target_id == "s1"
+    # Funnel calls all happened
+    runner._release_running_agent_state.assert_called_once()
+    runner.async_session_store.switch_session.assert_awaited_once()
+    runner._clear_conversation_scope.assert_called_once()
+    runner._evict_cached_agent.assert_called_once()
+    # Result is a string (rendered via edit_message_text by the adapter)
+    assert isinstance(result, str)
+
+
+# ── 5. Same chat, same chat_id → session list is filtered by IDOR gate ─────
+
+
+@pytest.mark.asyncio
+async def test_sessions_command_scopes_list_to_origin_visible_rows(tmp_path):
+    """The picker must receive only the rows the runner already filtered
+    through _resume_row_visible + _resume_target_allowed — a co-member's
+    own picker list must not include sessions from another user."""
+    runner = _make_runner(tmp_path)
+    adapter = MagicMock()
+    adapter.send_sessions_picker = AsyncMock(
+        return_value=SendResult(success=True, message_id="100")
+    )
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    # Filter hook drops s2 — "this user can't see this one"
+    async def _row_visible(source, row, allow_all):
+        return row["id"] == "s1"
+
+    runner._resume_row_visible = _row_visible
+
+    await runner._handle_sessions_command(_event("/sessions"))
+
+    sessions = adapter.send_sessions_picker.await_args.kwargs["sessions"]
+    assert {s["id"] for s in sessions} == {"s1"}, (
+        "Picker must inherit the runner's origin-scoped listing — "
+        "otherwise the IDOR guard at the callback cannot stop what the "
+        "listing already exposed."
+    )
+
+
+# ── 6. Picker gets the FULL origin-scoped list, not the 10-cap ──────────────
+
+
+@pytest.mark.asyncio
+async def test_picker_passes_full_list_beyond_text_list_cap(tmp_path):
+    """The text picker caps at 10 rows (the legacy UX). The picker branch
+    must pass the full origin-scoped list — the picker paginates internally
+    via Prev/Next at 8 per page, so capping at 10 would silently hide
+    older sessions behind a single page that ends with no Next button."""
+    runner = _make_runner(tmp_path)
+    # 15 sessions — past the text fallback cap (10) and past one picker
+    # page (8). The picker is supposed to get all 15 so the user can flip
+    # to the second page.
+    runner._session_db.list_sessions_rich = MagicMock(
+        return_value=[
+            {"id": f"s{i:02d}", "title": f"S{i}", "preview": ""}
+            for i in range(15)
+        ]
+    )
+
+    adapter = MagicMock()
+    adapter.send_sessions_picker = AsyncMock(
+        return_value=SendResult(success=True, message_id="100")
+    )
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    await runner._handle_sessions_command(_event("/sessions"))
+
+    sessions = adapter.send_sessions_picker.await_args.kwargs["sessions"]
+    assert len(sessions) == 15, (
+        f"Picker got {len(sessions)}, expected 15. The `rows[:10]` cap "
+        "must NOT apply to the picker branch — the picker paginates, "
+        "so the runner should hand off the full origin-scoped list."
+    )

--- a/tests/gateway/test_sessions_command_picker_integration.py
+++ b/tests/gateway/test_sessions_command_picker_integration.py
@@ -166,6 +166,7 @@ async def test_sessions_command_uses_picker_when_adapter_supports_it(tmp_path):
     assert kwargs["current_session_id"] == "current-session"
     # Thread metadata threaded through so the picker lands in the same topic
     assert kwargs["metadata"] == {"thread_id": "42"}
+    assert kwargs["picker_user_id"] == "777"
     # The runner callback is a closure that captures session_key + source
     assert callable(kwargs["on_session_selected"])
 

--- a/tests/gateway/test_telegram_sessions_picker.py
+++ b/tests/gateway/test_telegram_sessions_picker.py
@@ -1,0 +1,639 @@
+"""Tests for the Telegram /sessions inline-keyboard picker.
+
+Mirrors `test_telegram_model_picker.py` and `test_telegram_clarify_buttons.py`
+for the new ``send_sessions_picker`` and ``se:/sg:/sx`` callback dispatch
+added in feat/telegram-sessions-picker.
+
+The runner-side IDOR guard (``_resume_target_allowed``) and the full session
+switch path (``_resume_session_by_id``) are exercised in
+``test_sessions_command_picker_integration.py``; this file covers the
+adapter-only behavior:
+
+- keyboard construction (buttons, pagination, cancel)
+- state stored per (chat_id, msg_id, thread_id) — collision-safe
+- callback rejects stale msg_id (click on an old keyboard after a new
+  /sessions has replaced it)
+- callback rejects unauthorized taps (co-member in a shared group)
+- callback pops state on success / cancel / completion
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    # Default: every callback tester is authorized, so the test focuses on the
+    # picker-specific state machine (collision, IDOR, pagination). Tests that
+    # need to verify the unauthorized path explicitly override this.
+    adapter._is_callback_user_authorized = lambda *_a, **_kw: True
+    return adapter
+
+
+def _make_adapter_unauthorized():
+    """Adapter variant where every callback is rejected at the auth gate."""
+    adapter = _make_adapter()
+    adapter._is_callback_user_authorized = lambda *_a, **_kw: False
+    return adapter
+
+
+def _make_query(*, chat_id=12345, msg_id=101, thread_id=None, user_id="777"):
+    """Build a minimal callback_query mock with the attrs the adapter reads."""
+    query = AsyncMock()
+    query.message = MagicMock()
+    query.message.chat_id = chat_id
+    query.message.message_id = msg_id
+    query.message.message_thread_id = thread_id
+    query.message.chat = MagicMock()
+    query.message.chat.type = "private"
+    query.from_user = MagicMock()
+    query.from_user.id = user_id
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    return query
+
+
+class TestSessionsPickerState:
+    """State-key contract: (chat_id, msg_id, thread_id) — collision-safe."""
+
+    def test_composite_key_includes_thread_id_for_forum_safety(self):
+        """Two pickers in the same chat, different topics, must not collide."""
+        adapter = _make_adapter()
+        k1 = TelegramAdapter._sessions_picker_key("12345", 100, "777")
+        k2 = TelegramAdapter._sessions_picker_key("12345", 100, "888")
+        # Different thread → different key, no overwrite
+        assert k1 != k2
+        # None thread normalizes to "" so the key is hashable and uniform
+        k3 = TelegramAdapter._sessions_picker_key("12345", 100, None)
+        k4 = TelegramAdapter._sessions_picker_key("12345", 100, "")
+        assert k3 == k4
+
+    def test_same_chat_different_msg_id_does_not_collide(self):
+        """A second picker opened in the same chat/thread must not overwrite
+        the first picker's state — the sweeper flagged this as the stale
+        picker bug class."""
+        adapter = _make_adapter()
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 100, "")
+        ] = {"sessions": [{"id": "a"}], "on_session_selected": AsyncMock()}
+        # Second picker arrives in the same chat/thread (different msg_id)
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 200, "")
+        ] = {"sessions": [{"id": "b"}], "on_session_selected": AsyncMock()}
+        assert len(adapter._sessions_picker_state) == 2
+        # The first picker's state is still intact
+        first = adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 100, "")
+        ]
+        assert first["sessions"][0]["id"] == "a"
+
+
+class TestSendSessionsPicker:
+    """send_sessions_picker — render + state."""
+
+    @pytest.mark.asyncio
+    async def test_send_sessions_picker_renders_buttons_and_cancel(self):
+        adapter = _make_adapter()
+        msg = SimpleNamespace(message_id=101)
+        adapter._bot.send_message = AsyncMock(return_value=msg)
+
+        callback = AsyncMock()
+        result = await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[
+                {"id": "s1", "title": "Research", "preview": "notes"},
+                {"id": "s2", "title": "Coding", "preview": "fix bug"},
+            ],
+            current_session_id="current",
+            on_session_selected=callback,
+            metadata=None,
+        )
+
+        assert result.success is True
+        assert result.message_id == "101"
+        # State stored under composite key
+        state = adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+        ]
+        assert [s["id"] for s in state["sessions"]] == ["s1", "s2"]
+        assert state["on_session_selected"] is callback
+        assert state["current_session_id"] == "current"
+
+    @pytest.mark.asyncio
+    async def test_session_picker_button_labels_are_page_numbers(self, monkeypatch):
+        """Buttons show 1-based page-relative numbers (e.g. '1', '2'),
+        NOT titles. The user matches a preview line in the body to the
+        number button below — no title duplication, no clue needed.
+        """
+        adapter = _make_adapter()
+        msg = SimpleNamespace(message_id=101)
+        adapter._bot.send_message = AsyncMock(return_value=msg)
+        captured_buttons = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: (
+                captured_buttons.append((text, callback_data)) or text
+            ),
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup",
+            lambda rows: rows,
+        )
+
+        await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[
+                {"id": "s1", "title": "Research", "preview": "investigate MCP"},
+                {"id": "s2", "title": "Coding", "preview": "fix login bug"},
+            ],
+            current_session_id="current",
+            on_session_selected=AsyncMock(),
+        )
+
+        # The two session buttons are numbered "1" and "2" with
+        # callback_data "se:0" and "se:1" (absolute indexes into
+        # the filtered session list).
+        rendered = [b for b in captured_buttons if b[0] in {"1", "2"}]
+        assert len(rendered) == 2
+        assert rendered[0] == ("1", "se:0")
+        assert rendered[1] == ("2", "se:1")
+
+    @pytest.mark.asyncio
+    async def test_format_session_preview_line_for_body(self):
+        """The body-line helper renders N. *Title* — preview as a single
+        line. Title is bolded; preview follows a separator and is
+        truncated to ~50 chars to keep each row readable on mobile.
+        MarkdownV2 special chars are escaped on both pieces.
+        """
+        # Standard title + preview → single line with separator
+        line = TelegramAdapter._format_session_preview_line(
+            {"id": "s1", "title": "Research", "preview": "investigate MCP"}, 1
+        )
+        assert line.startswith("1\\.")
+        assert "*Research*" in line
+        assert "investigate MCP" in line
+        # All on one line — no newlines
+        assert "\n" not in line
+        assert " — " in line  # the separator
+
+        # Title only → just title, no separator / preview
+        line = TelegramAdapter._format_session_preview_line(
+            {"id": "s2", "title": "Solo", "preview": ""}, 2
+        )
+        assert line.startswith("2\\.")
+        assert "*Solo*" in line
+        assert " — " not in line
+
+        # No preview, no title → "(untitled)" fallback
+        line = TelegramAdapter._format_session_preview_line(
+            {"id": "s3", "title": "", "preview": ""}, 3
+        )
+        assert "*(untitled)*" in line
+
+        # No preview but has title → just title
+        line = TelegramAdapter._format_session_preview_line(
+            {"id": "s4", "title": "Coding", "preview": ""}, 4
+        )
+        assert "*Coding*" in line
+        assert " — " not in line
+
+        # Long preview → truncated to 50 chars + "..." (47 chars + "...")
+        long_preview = "x" * 200
+        line = TelegramAdapter._format_session_preview_line(
+            {"id": "s5", "title": "T", "preview": long_preview}, 5
+        )
+        assert line.count("x") == 47
+        assert line.endswith("...")
+
+        # Markdown special chars in title → escaped
+        line = TelegramAdapter._format_session_preview_line(
+            {"id": "s6", "title": "A*B_C`D", "preview": "safe"}, 6
+        )
+        assert "\\*" in line
+        assert "\\_" in line
+        assert "\\`" in line
+
+    @pytest.mark.asyncio
+    async def test_send_sessions_picker_returns_error_on_empty_sessions(self):
+        adapter = _make_adapter()
+        result = await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[],
+            current_session_id="c",
+            on_session_selected=AsyncMock(),
+        )
+        assert result.success is False
+        assert "No sessions" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_sessions_picker_paginates_past_page_size(self):
+        """More than _SESSIONS_PAGE_SIZE sessions → Prev/Next nav row appears."""
+        adapter = _make_adapter()
+        msg = SimpleNamespace(message_id=200)
+        adapter._bot.send_message = AsyncMock(return_value=msg)
+
+        # 15 sessions → 2 pages
+        sessions = [
+            {"id": f"s{i}", "title": f"S{i}", "preview": ""}
+            for i in range(15)
+        ]
+        await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=sessions,
+            current_session_id="c",
+            on_session_selected=AsyncMock(),
+        )
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        text = kwargs["text"]
+        # Page info suffix (N–M of T) — the picker is on page 1 of 2, so the
+        # first 8 entries are listed.
+        assert "1–8" in text or "1-8" in text
+        assert "15" in text  # "of 15"
+        # Markup is built (one-button-per-row + nav + cancel)
+        assert kwargs["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_send_sessions_picker_keeps_state_per_topic(self):
+        """Two /sessions in the same chat but different topics → separate state."""
+        adapter = _make_adapter()
+        msg1 = SimpleNamespace(message_id=101)
+        msg2 = SimpleNamespace(message_id=202)
+        adapter._bot.send_message = AsyncMock(side_effect=[msg1, msg2])
+
+        await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[{"id": "s1", "title": "T1", "preview": ""}],
+            current_session_id="c",
+            on_session_selected=AsyncMock(),
+            metadata={"thread_id": "777"},
+        )
+        await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[{"id": "s2", "title": "T2", "preview": ""}],
+            current_session_id="c",
+            on_session_selected=AsyncMock(),
+            metadata={"thread_id": "888"},
+        )
+
+        # Two distinct entries — neither overwrites the other
+        k1 = TelegramAdapter._sessions_picker_key("12345", 101, "777")
+        k2 = TelegramAdapter._sessions_picker_key("12345", 202, "888")
+        assert k1 in adapter._sessions_picker_state
+        assert k2 in adapter._sessions_picker_state
+        assert adapter._sessions_picker_state[k1]["sessions"][0]["id"] == "s1"
+        assert adapter._sessions_picker_state[k2]["sessions"][0]["id"] == "s2"
+
+    @pytest.mark.asyncio
+    async def test_picker_filters_current_session(self, monkeypatch):
+        """The session the user is already on doesn't need a button — it
+        would just self-resume. The adapter filters it out before building
+        the keyboard; the on-disk sessions list is preserved so the
+        callback still indexes correctly."""
+        adapter = _make_adapter()
+        msg = SimpleNamespace(message_id=101)
+        adapter._bot.send_message = AsyncMock(return_value=msg)
+
+        captured_rows = []
+        captured_buttons = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: captured_buttons.append((text, callback_data)) or text,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup",
+            lambda rows: captured_rows.extend(rows) or rows,
+        )
+
+        await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[
+                {"id": "current", "title": "Current", "preview": ""},
+                {"id": "s1", "title": "S1", "preview": ""},
+                {"id": "s2", "title": "S2", "preview": ""},
+            ],
+            current_session_id="current",
+            on_session_selected=AsyncMock(),
+        )
+
+        # The state still has the full list so the callback can index it.
+        state = adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+        ]
+        assert len(state["sessions"]) == 3
+        # The rendered keyboard only has the 2 non-current buttons + Cancel.
+        # Buttons are numbered 1 and 2 (page-relative); the "current"
+        # session was filtered out and gets no number.
+        rendered_labels = [b[0] for b in captured_buttons]
+        assert "✗ Cancel" in rendered_labels
+        # The current session id was filtered — no button for it
+        current_buttons = [b for b in captured_buttons if b[0] == "current"]
+        assert not current_buttons
+        # Session buttons present, numbered 1 and 2
+        session_buttons = sorted(b[0] for b in captured_buttons if b[0] in {"1", "2"})
+        assert session_buttons == ["1", "2"]
+        # The captured rows: 1 row of 2 buttons + 1 cancel row (no
+        # pagination needed for 2 items).
+        assert len(captured_rows) == 2
+
+
+class TestSessionsPickerCallback:
+    """_handle_sessions_picker_callback — IDOR, stash, navigation."""
+
+    @pytest.mark.asyncio
+    async def test_select_invokes_runner_callback_with_session_id(self):
+        adapter = _make_adapter()
+        cb = AsyncMock(return_value="Resumed **Research** (12 messages).")
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+        ] = {
+            "sessions": [{"id": "s1", "title": "Research"}],
+            "current_session_id": "c",
+            "on_session_selected": cb,
+            "thread_id": "",
+        }
+
+        query = _make_query(chat_id=12345, msg_id=101, user_id="777")
+        await adapter._handle_sessions_picker_callback(
+            query, "se:0", "12345", 101, ""
+        )
+
+        # Runner callback got the picked session id
+        cb.assert_awaited_once_with("s1")
+        # State popped — session-switch is one-shot
+        assert (
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+            not in adapter._sessions_picker_state
+        )
+        # Message got replaced with the runner's result
+        query.edit_message_text.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stale_msg_id_is_rejected_without_invoking_callback(self):
+        """A click on an old keyboard after a new /sessions has replaced it
+        must NOT invoke the runner — the sweeper flagged this as the stale
+        picker bug class."""
+        adapter = _make_adapter()
+        cb = AsyncMock()
+        # Current state is for msg_id=200, NOT 101
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 200, "")
+        ] = {
+            "sessions": [{"id": "s1", "title": "Research"}],
+            "current_session_id": "c",
+            "on_session_selected": cb,
+            "thread_id": "",
+        }
+
+        # Query claims msg_id=101 (stale)
+        query = _make_query(chat_id=12345, msg_id=101, user_id="777")
+        await adapter._handle_sessions_picker_callback(
+            query, "se:0", "12345", 101, ""
+        )
+
+        cb.assert_not_awaited()
+        # Picker answers "expired"
+        answer_text = (
+            query.answer.call_args[1].get("text", "")
+            if query.answer.call_args
+            else ""
+        )
+        assert "expired" in answer_text.lower()
+        # The current state (msg_id=200) is untouched
+        assert (
+            TelegramAdapter._sessions_picker_key("12345", 200, "")
+            in adapter._sessions_picker_state
+        )
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_caller_rejected_without_invoking_callback(self):
+        """Co-member in a shared group tapping someone else's session picker
+        must be rejected at the adapter gate (mirrors approval / choice
+        picker pattern). The runner-side IDOR guard is a second line of
+        defense but the adapter should reject cheaply first."""
+        adapter = _make_adapter_unauthorized()
+        cb = AsyncMock()
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+        ] = {
+            "sessions": [{"id": "s1", "title": "Research"}],
+            "current_session_id": "c",
+            "on_session_selected": cb,
+            "thread_id": "",
+        }
+
+        query = _make_query(chat_id=12345, msg_id=101, user_id="999")
+        await adapter._handle_sessions_picker_callback(
+            query, "se:0", "12345", 101, ""
+        )
+
+        cb.assert_not_awaited()
+        answer_text = (
+            query.answer.call_args[1].get("text", "")
+            if query.answer.call_args
+            else ""
+        )
+        assert "not authorized" in answer_text.lower()
+        # State is preserved for the authorized caller
+        assert (
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+            in adapter._sessions_picker_state
+        )
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_session_index_rejected(self):
+        adapter = _make_adapter()
+        cb = AsyncMock()
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+        ] = {
+            "sessions": [{"id": "s1", "title": "Only"}],
+            "current_session_id": "c",
+            "on_session_selected": cb,
+            "thread_id": "",
+        }
+
+        query = _make_query(chat_id=12345, msg_id=101, user_id="777")
+        await adapter._handle_sessions_picker_callback(
+            query, "se:99", "12345", 101, ""
+        )
+
+        cb.assert_not_awaited()
+        query.edit_message_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pagination_updates_message_with_next_page(self):
+        adapter = _make_adapter()
+        sessions = [
+            {"id": f"s{i}", "title": f"S{i}", "preview": ""}
+            for i in range(15)
+        ]
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+        ] = {
+            "sessions": sessions,
+            "current_session_id": "c",
+            "on_session_selected": AsyncMock(),
+            "thread_id": "",
+        }
+
+        query = _make_query(chat_id=12345, msg_id=101, user_id="777")
+        await adapter._handle_sessions_picker_callback(
+            query, "sg:1", "12345", 101, ""
+        )
+
+        # Message re-rendered with the second page
+        query.edit_message_text.assert_awaited_once()
+        edit_kwargs = query.edit_message_text.call_args[1]
+        # Page info reflects page 2 (entries 9-15)
+        assert "9–15" in edit_kwargs["text"] or "9-15" in edit_kwargs["text"]
+        # reply_markup is the new keyboard
+        assert edit_kwargs["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_cancel_pops_state_and_edits_message(self):
+        adapter = _make_adapter()
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+        ] = {
+            "sessions": [{"id": "s1", "title": "Research"}],
+            "current_session_id": "c",
+            "on_session_selected": AsyncMock(),
+            "thread_id": "",
+        }
+
+        query = _make_query(chat_id=12345, msg_id=101, user_id="777")
+        await adapter._handle_sessions_picker_callback(
+            query, "sx", "12345", 101, ""
+        )
+
+        assert (
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+            not in adapter._sessions_picker_state
+        )
+        query.edit_message_text.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_noop_page_indicator_is_silent(self):
+        adapter = _make_adapter()
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+        ] = {
+            "sessions": [{"id": "s1", "title": "Research"}],
+            "current_session_id": "c",
+            "on_session_selected": AsyncMock(),
+            "thread_id": "",
+        }
+
+        query = _make_query(chat_id=12345, msg_id=101, user_id="777")
+        await adapter._handle_sessions_picker_callback(
+            query, "sp:noop", "12345", 101, ""
+        )
+
+        # No edit — just an empty answer
+        query.edit_message_text.assert_not_awaited()
+        query.answer.assert_awaited()
+        # State preserved (the picker is still active)
+        assert (
+            TelegramAdapter._sessions_picker_key("12345", 101, "")
+            in adapter._sessions_picker_state
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_state_means_expired_picker(self):
+        adapter = _make_adapter()
+        query = _make_query(chat_id=12345, msg_id=999, user_id="777")
+        await adapter._handle_sessions_picker_callback(
+            query, "se:0", "12345", 999, ""
+        )
+
+        query.answer.assert_awaited()
+        answer_text = (
+            query.answer.call_args[1].get("text", "")
+            if query.answer.call_args
+            else ""
+        )
+        assert "expired" in answer_text.lower()
+        query.edit_message_text.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stale_picker_state_is_swept_on_next_send(self):
+        """State entries past _SESSIONS_PICKER_TTL_SECONDS get evicted when
+        the next picker is sent. Without the sweep, busy groups accumulate
+        dead pickers holding closures over the runner — memory leak."""
+        import time as _time
+
+        adapter = _make_adapter()
+        # Inject a stale entry (created_at way in the past)
+        key = TelegramAdapter._sessions_picker_key("12345", 999, "")
+        adapter._sessions_picker_state[key] = {
+            "msg_id": 999,
+            "sessions": [],
+            "current_session_id": "",
+            "on_session_selected": AsyncMock(),
+            "thread_id": "",
+            "created_at": _time.monotonic() - adapter._SESSIONS_PICKER_TTL_SECONDS - 60,
+        }
+        # Also inject a fresh entry — must survive the sweep
+        adapter._sessions_picker_state[
+            TelegramAdapter._sessions_picker_key("12345", 100, "")
+        ] = {
+            "msg_id": 100,
+            "sessions": [{"id": "live", "title": "Live", "preview": ""}],
+            "current_session_id": "",
+            "on_session_selected": AsyncMock(),
+            "thread_id": "",
+            "created_at": _time.monotonic(),
+        }
+
+        # Trigger sweep via send_sessions_picker (any non-empty session list)
+        adapter._bot.send_message = AsyncMock(
+            return_value=SimpleNamespace(message_id=200)
+        )
+        await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[{"id": "new", "title": "New", "preview": ""}],
+            current_session_id="",
+            on_session_selected=AsyncMock(),
+        )
+
+        # Stale gone, fresh survives, new entry stored
+        assert key not in adapter._sessions_picker_state
+        assert (
+            TelegramAdapter._sessions_picker_key("12345", 100, "")
+            in adapter._sessions_picker_state
+        )

--- a/tests/gateway/test_telegram_sessions_picker.py
+++ b/tests/gateway/test_telegram_sessions_picker.py
@@ -18,6 +18,7 @@ adapter-only behavior:
 """
 
 import sys
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -141,6 +142,7 @@ class TestSendSessionsPicker:
             current_session_id="current",
             on_session_selected=callback,
             metadata=None,
+            picker_user_id="777",
         )
 
         assert result.success is True
@@ -151,7 +153,35 @@ class TestSendSessionsPicker:
         ]
         assert [s["id"] for s in state["sessions"]] == ["s1", "s2"]
         assert state["on_session_selected"] is callback
-        assert state["current_session_id"] == "current"
+        assert state["creator_user_id"] == "777"
+
+    @pytest.mark.asyncio
+    async def test_failed_new_picker_keeps_previous_picker_state(self):
+        adapter = _make_adapter()
+        old_key = TelegramAdapter._sessions_picker_key("12345", 101, "")
+        old_callback = AsyncMock()
+        adapter._sessions_picker_state[old_key] = {
+            "sessions": [{"id": "old", "title": "Old"}],
+            "on_session_selected": old_callback,
+            "thread_id": "",
+            "creator_user_id": "777",
+            "created_at": time.monotonic(),
+        }
+        adapter._send_message_with_thread_fallback = AsyncMock(
+            side_effect=RuntimeError("send failed")
+        )
+
+        result = await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[{"id": "new", "title": "New", "preview": ""}],
+            current_session_id="current",
+            on_session_selected=AsyncMock(),
+            picker_user_id="777",
+        )
+
+        assert result.success is False
+        assert old_key in adapter._sessions_picker_state
+        assert adapter._sessions_picker_state[old_key]["on_session_selected"] is old_callback
 
     @pytest.mark.asyncio
     async def test_session_picker_button_labels_are_page_numbers(self, monkeypatch):
@@ -203,8 +233,8 @@ class TestSendSessionsPicker:
         line = TelegramAdapter._format_session_preview_line(
             {"id": "s1", "title": "Research", "preview": "investigate MCP"}, 1
         )
-        assert line.startswith("1\\.")
-        assert "*Research*" in line
+        assert line.startswith("1. **")
+        assert "**Research**" in line
         assert "investigate MCP" in line
         # All on one line — no newlines
         assert "\n" not in line
@@ -214,21 +244,21 @@ class TestSendSessionsPicker:
         line = TelegramAdapter._format_session_preview_line(
             {"id": "s2", "title": "Solo", "preview": ""}, 2
         )
-        assert line.startswith("2\\.")
-        assert "*Solo*" in line
+        assert line.startswith("2. **")
+        assert "**Solo**" in line
         assert " — " not in line
 
         # No preview, no title → "(untitled)" fallback
         line = TelegramAdapter._format_session_preview_line(
             {"id": "s3", "title": "", "preview": ""}, 3
         )
-        assert "*(untitled)*" in line
+        assert "**(untitled)**" in line
 
         # No preview but has title → just title
         line = TelegramAdapter._format_session_preview_line(
             {"id": "s4", "title": "Coding", "preview": ""}, 4
         )
-        assert "*Coding*" in line
+        assert "**Coding**" in line
         assert " — " not in line
 
         # Long preview → truncated to 50 chars + "..." (47 chars + "...")
@@ -239,13 +269,12 @@ class TestSendSessionsPicker:
         assert line.count("x") == 47
         assert line.endswith("...")
 
-        # Markdown special chars in title → escaped
+        # Markdown special chars remain standard Markdown here; the adapter
+        # escapes them once when formatting the complete message.
         line = TelegramAdapter._format_session_preview_line(
             {"id": "s6", "title": "A*B_C`D", "preview": "safe"}, 6
         )
-        assert "\\*" in line
-        assert "\\_" in line
-        assert "\\`" in line
+        assert "A*B_C`D" in line
 
     @pytest.mark.asyncio
     async def test_send_sessions_picker_returns_error_on_empty_sessions(self):
@@ -350,11 +379,12 @@ class TestSendSessionsPicker:
             on_session_selected=AsyncMock(),
         )
 
-        # The state still has the full list so the callback can index it.
+        # State and rendered buttons use the same filtered list, so callback
+        # indexes cannot drift when the current session is omitted.
         state = adapter._sessions_picker_state[
             TelegramAdapter._sessions_picker_key("12345", 101, "")
         ]
-        assert len(state["sessions"]) == 3
+        assert [s["id"] for s in state["sessions"]] == ["s1", "s2"]
         # The rendered keyboard only has the 2 non-current buttons + Cancel.
         # Buttons are numbered 1 and 2 (page-relative); the "current"
         # session was filtered out and gets no number.
@@ -369,6 +399,76 @@ class TestSendSessionsPicker:
         # The captured rows: 1 row of 2 buttons + 1 cancel row (no
         # pagination needed for 2 items).
         assert len(captured_rows) == 2
+
+    @pytest.mark.asyncio
+    async def test_filtered_button_index_selects_the_visible_session(self):
+        adapter = _make_adapter()
+        msg = SimpleNamespace(message_id=101)
+        adapter._bot.send_message = AsyncMock(return_value=msg)
+        callback = AsyncMock(return_value="Resumed")
+
+        await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[
+                {"id": "current", "title": "Current", "preview": ""},
+                {"id": "s1", "title": "S1", "preview": ""},
+                {"id": "s2", "title": "S2", "preview": ""},
+            ],
+            current_session_id="current",
+            on_session_selected=callback,
+            picker_user_id="777",
+        )
+
+        query = _make_query(chat_id=12345, msg_id=101, user_id="777")
+        await adapter._handle_sessions_picker_callback(
+            query, "se:0", "12345", 101, ""
+        )
+        callback.assert_awaited_once_with("s1")
+
+    @pytest.mark.asyncio
+    async def test_non_creator_cannot_use_picker(self):
+        adapter = _make_adapter()
+        msg = SimpleNamespace(message_id=101)
+        adapter._bot.send_message = AsyncMock(return_value=msg)
+        callback = AsyncMock(return_value="Resumed")
+
+        await adapter.send_sessions_picker(
+            chat_id="12345",
+            sessions=[{"id": "s1", "title": "S1", "preview": ""}],
+            current_session_id="current",
+            on_session_selected=callback,
+            picker_user_id="777",
+        )
+
+        query = _make_query(chat_id=12345, msg_id=101, user_id="999")
+        await adapter._handle_sessions_picker_callback(
+            query, "se:0", "12345", 101, ""
+        )
+        callback.assert_not_awaited()
+        answer_text = query.answer.call_args.kwargs.get("text", "")
+        assert "creator" in answer_text.lower()
+        assert TelegramAdapter._sessions_picker_key("12345", 101, "") in adapter._sessions_picker_state
+
+    @pytest.mark.asyncio
+    async def test_expired_picker_is_rejected_on_callback(self):
+        adapter = _make_adapter()
+        callback = AsyncMock()
+        key = TelegramAdapter._sessions_picker_key("12345", 101, "")
+        adapter._sessions_picker_state[key] = {
+            "sessions": [{"id": "s1", "title": "S1"}],
+            "on_session_selected": callback,
+            "thread_id": "",
+            "creator_user_id": "777",
+            "created_at": time.monotonic() - adapter._SESSIONS_PICKER_TTL_SECONDS - 1,
+        }
+
+        query = _make_query(chat_id=12345, msg_id=101, user_id="777")
+        await adapter._handle_sessions_picker_callback(
+            query, "se:0", "12345", 101, ""
+        )
+        callback.assert_not_awaited()
+        assert key not in adapter._sessions_picker_state
+        assert "expired" in query.answer.call_args.kwargs["text"].lower()
 
 
 class TestSessionsPickerCallback:
@@ -631,9 +731,13 @@ class TestSessionsPickerCallback:
             on_session_selected=AsyncMock(),
         )
 
-        # Stale gone, fresh survives, new entry stored
+        # Stale and superseded same-lane state are gone; the new entry is stored.
         assert key not in adapter._sessions_picker_state
         assert (
             TelegramAdapter._sessions_picker_key("12345", 100, "")
+            not in adapter._sessions_picker_state
+        )
+        assert (
+            TelegramAdapter._sessions_picker_key("12345", 200, "")
             in adapter._sessions_picker_state
         )


### PR DESCRIPTION
我发现有时会选错 session，有时选中后 session 切换失败，所以做了一些修改。

## 修改内容
- 修复过滤当前 session 后的 index mapping，确保按钮和实际 session 正确对应；
- picker state 改为保存与 UI 一致的 filtered session list；
- 将 picker 绑定到创建它的 Telegram 用户，避免其他用户使用别人的 picker；
- 增加 callback TTL 校验，过期 picker 不再执行；
- 同一 chat/topic 重新打开 picker 后清理旧 picker，避免操作 stale session list；
- 新 picker 发送失败时保留旧 picker state；
- 修复 MarkdownV2 double escaping，统一在最终发送边界进行格式化；
- 修复 session 切换失败时仍显示成功提示的问题；
- 增加消息编辑失败时的 thread-aware fallback；
- runner 侧继续执行 session IDOR 校验；
- 补充相关 regression tests。

## 测试覆盖
- picker index mapping、creator authorization、TTL expiry；
- stale picker 和发送失败回退；
- MarkdownV2 特殊字符处理；
- callback 结果和 forum topic fallback routing。

验证结果：65 passed；ruff、git diff --check、py_compile 全部通过。
