### PR TITLE
feat(moa): add native conditional routing

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -362,7 +362,9 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
     if entry is not None:
         stamped_at, cached = entry
         if now - stamped_at < _RUNTIME_CACHE_TTL_SECONDS:
-            return cached
+            # Callers consume request-local fields (notably extra_body) with
+            # pop(). Never expose the cached dictionary itself.
+            return dict(cached)
     out: dict[str, Any] = {"provider": provider, "model": model}
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -387,8 +389,8 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
         # provider/model kwargs for a full TTL.
         return out
     with _runtime_cache_lock:
-        _runtime_cache[cache_key] = (now, out)
-    return out
+        _runtime_cache[cache_key] = (now, dict(out))
+    return dict(out)
 
 
 def _merge_slot_extra_body(
@@ -1159,6 +1161,32 @@ def _reference_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return rendered
 
 
+def _route_turn_identity(messages: list[dict[str, Any]]) -> tuple[str, str]:
+    """Return latest user text and a cache-decoration-stable turn signature.
+
+    Only canonical visible user text participates. Assistant/tool growth,
+    prompt-cache metadata, key ordering, ephemeral MoA guidance, and provider
+    request decoration therefore cannot flip the route inside one user turn.
+    The complete user-message sequence distinguishes consecutive identical
+    prompts without depending on compressible assistant history.
+    """
+    user_texts: list[str] = []
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+        text = flatten_message_text(message.get("content"))
+        if text == _ADVISORY_INSTRUCTION:
+            continue
+        if not text.strip() and isinstance(message.get("content"), list):
+            text = "[user sent non-text content (e.g. an image attachment)]"
+        user_texts.append(text)
+    latest = user_texts[-1] if user_texts else ""
+    signature = hashlib.sha256(
+        "\u0000".join(user_texts).encode("utf-8", "replace")
+    ).hexdigest()
+    return latest, signature
+
+
 
 def _extract_text(response: Any) -> str:
     try:
@@ -1614,6 +1642,11 @@ class MoAChatCompletions:
         # Normalized moa.privacy_filter mode for the current turn ('' |
         # 'display' | 'full'), refreshed from config on every create().
         self._privacy_mode: str = ""
+        # Explainable request-local decision from the conditional router. Kept
+        # on the facade for UI/observability consumers; it never changes the
+        # acting aggregator or the conversation's provider identity.
+        self.last_route_decision: Any = None
+        self._route_turn_sig: str | None = None
 
     def consume_reference_usage(self) -> tuple[Any, Any]:
         """Pop pending reference-fan-out usage + cost, resetting both to empty.
@@ -1750,7 +1783,12 @@ class MoAChatCompletions:
         agg_messages = [dict(message) for message in messages]
         if guidance:
             _attach_reference_guidance(agg_messages, str(guidance))
-        return {**prepared, "messages": agg_messages}
+        _, rebased_turn_sig = _route_turn_identity(messages)
+        return {
+            **prepared,
+            "messages": agg_messages,
+            "_route_turn_sig": rebased_turn_sig,
+        }
 
     def _call_prepared_aggregator(
         self, prepared: dict[str, Any], api_kwargs: dict[str, Any]
@@ -1908,6 +1946,11 @@ class MoAChatCompletions:
         if prepared_request is not None:
             if not isinstance(prepared_request, dict):
                 raise TypeError("_moa_prepared_request must be a dict")
+            prepared_decision = prepared_request.get("_route_decision")
+            prepared_turn_sig = prepared_request.get("_route_turn_sig")
+            if prepared_decision is not None and isinstance(prepared_turn_sig, str):
+                self.last_route_decision = prepared_decision
+                self._route_turn_sig = prepared_turn_sig
             return self._call_prepared_aggregator(prepared_request, api_kwargs)
 
         from hermes_cli.config import get_config_path, load_config
@@ -1952,6 +1995,28 @@ class MoAChatCompletions:
             if slot.get("enabled", True)
         ]
         aggregator = preset.get("aggregator") or {}
+        from agent.moa_router import decide_moa_route
+
+        latest_user_prompt, route_turn_sig = _route_turn_identity(messages)
+        if route_turn_sig == self._route_turn_sig and self.last_route_decision is not None:
+            route_decision = self.last_route_decision
+        else:
+            route_decision = decide_moa_route(
+                latest_user_prompt,
+                preset.get("routing"),
+            )
+            self._route_turn_sig = route_turn_sig
+        self.last_route_decision = route_decision
+        if not route_decision.fanout:
+            reference_models = []
+        logger.info(
+            "MoA route: preset=%s mode=%s fanout=%s score=%s reasons=%s",
+            self.preset_name,
+            route_decision.mode,
+            route_decision.fanout,
+            route_decision.score,
+            ",".join(route_decision.reasons) or "none",
+        )
         # Expose the resolved aggregator slot so session cost accounting can
         # price the aggregator's acting turn at its REAL model/provider. The
         # agent's model/provider on the MoA path are the virtual preset name
@@ -2310,6 +2375,8 @@ class MoAChatCompletions:
             "guidance": guidance,
             "aggregator": aggregator,
             "aggregator_temperature": aggregator_temperature,
+            "_route_decision": route_decision,
+            "_route_turn_sig": route_turn_sig,
         }
         if api_kwargs.pop("_moa_prepare_only", False):
             return prepared_request

--- a/agent/moa_router.py
+++ b/agent/moa_router.py
@@ -1,0 +1,97 @@
+"""Deterministic, dependency-free routing for conditional MoA fan-out.
+
+The router decides only whether a configured MoA preset should consult its
+reference models.  The aggregator remains the acting model in both branches,
+so a decision never swaps providers, tools, or the cached system prompt.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+_DELIBERATION = re.compile(
+    r"\b(compare|contrast|evaluate|assess|critique|review|recommend|trade[ -]?offs?|"
+    r"pros and cons|multiple perspectives?|second opinion)\b",
+    re.IGNORECASE,
+)
+_HIGH_STAKES = re.compile(
+    r"\b(security|privacy|legal|contract|medical|financial|production|architecture|"
+    r"migration|incident|risk|threat model)\b",
+    re.IGNORECASE,
+)
+_MULTI_PART = re.compile(r"(?:^|\n)\s*(?:\d+[.)]|[-*])\s+", re.MULTILINE)
+_SIMPLE = re.compile(
+    r"^\s*(?:what time|what date|translate|rephrase|format|spell|define|convert)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class MoARouteDecision:
+    """Explainable result of one request-local routing decision."""
+
+    fanout: bool
+    mode: str
+    score: int
+    reasons: tuple[str, ...]
+
+
+def decide_moa_route(
+    prompt: str,
+    routing: Mapping[str, Any] | None = None,
+) -> MoARouteDecision:
+    """Choose direct aggregator-only execution or advisor fan-out.
+
+    ``always`` preserves historical MoA behaviour and is the default.
+    ``never`` makes the preset an aggregator-only route. ``auto`` applies a
+    small explainable intent/complexity scorer without an embedding service or
+    extra billable model call.
+    """
+
+    config = routing if isinstance(routing, Mapping) else {}
+    mode = str(config.get("mode") or "always").strip().lower()
+    if mode not in {"always", "never", "auto"}:
+        mode = "always"
+    if mode == "always":
+        return MoARouteDecision(True, mode, 0, ("configured-always",))
+    if mode == "never":
+        return MoARouteDecision(False, mode, 0, ("configured-never",))
+
+    text = str(prompt or "").strip()
+    score = 0
+    reasons: list[str] = []
+    if _DELIBERATION.search(text):
+        score += 2
+        reasons.append("deliberation")
+    if _HIGH_STAKES.search(text):
+        score += 3
+        reasons.append("high-stakes")
+    if _MULTI_PART.search(text) or len(re.findall(r"\b(?:and|then|also)\b", text, re.I)) >= 2:
+        score += 1
+        reasons.append("multi-part")
+    word_count = len(text.split())
+    if word_count >= 120:
+        score += 1
+        reasons.append("long-context")
+    if word_count >= 300:
+        score += 1
+        reasons.append("very-long-context")
+    simple_evidence = bool(_SIMPLE.search(text))
+    if simple_evidence:
+        reasons.append("simple-utility")
+
+    try:
+        threshold = int(config.get("threshold", 3))
+    except (TypeError, ValueError):
+        threshold = 3
+    threshold = max(1, threshold)
+    # Fail safe: auto-routing may bypass advisors only when the prompt carries
+    # affirmative evidence of being a simple utility request. Unknown,
+    # ambiguous, empty, and non-English intent keeps historical MoA fan-out.
+    fanout = score >= threshold or not simple_evidence
+    if fanout and score < threshold and not simple_evidence:
+        reasons.append("ambiguous")
+    return MoARouteDecision(fanout, mode, score, tuple(reasons))

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -79,7 +79,7 @@ def _coerce_int(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         try:
             return int(float(value))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             return default
 
 
@@ -134,6 +134,16 @@ def _coerce_fanout(value: Any) -> str:
         if n == 1:
             return "per_iteration"
     return "user_turn"
+
+
+def _coerce_routing(value: Any) -> dict[str, Any]:
+    """Normalize request-local direct-versus-fan-out routing policy."""
+    raw = value if isinstance(value, dict) else {}
+    mode = str(raw.get("mode") or "always").strip().lower()
+    if mode not in {"always", "never", "auto"}:
+        mode = "always"
+    threshold = max(1, _coerce_int(raw.get("threshold"), 3))
+    return {"mode": mode, "threshold": threshold}
 
 
 def coerce_privacy_filter(value: Any) -> str:
@@ -306,6 +316,7 @@ def _default_preset() -> dict[str, Any]:
         "max_tokens": 4096,
         "reference_max_tokens": None,
         "fanout": "user_turn",
+        "routing": {"mode": "always", "threshold": 3},
         "enabled": True,
     }
 
@@ -366,6 +377,7 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # last advisor run. Also accepts the mapping form
         # {mode: every_n, n: N}, normalized to the canonical string.
         "fanout": _coerce_fanout(raw.get("fanout")),
+        "routing": _coerce_routing(raw.get("routing")),
     }
 
 
@@ -415,6 +427,7 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
         "max_tokens": active["max_tokens"],
         "reference_max_tokens": active.get("reference_max_tokens"),
         "fanout": active.get("fanout", "user_turn"),
+        "routing": deepcopy(active["routing"]),
         "enabled": active["enabled"],
         # MoA-level (not per-preset) toggles ride at the top level alongside
         # save_traces. privacy_filter: '' (off, default) | 'display' | 'full'

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -182,6 +182,18 @@ class _MoaReferenceControls(BaseModel):
         return timeout
 
 
+class MoaRoutingPayload(BaseModel):
+    mode: Literal["always", "never", "auto"] = "always"
+    threshold: int = 3
+
+    @field_validator("threshold")
+    @classmethod
+    def threshold_must_be_positive(cls, value: int) -> int:
+        if value < 1:
+            raise ValueError("routing threshold must be at least 1")
+        return value
+
+
 class MoaPresetPayload(_MoaReferenceControls):
     reference_models: list[MoaModelSlot] = []
     aggregator: MoaModelSlot = MoaModelSlot()
@@ -195,6 +207,9 @@ class MoaPresetPayload(_MoaReferenceControls):
     # that round-trip the GET payload don't silently erase hand-set values.
     reference_max_tokens: Optional[int] = None
     fanout: Optional[str] = None
+    # None means an older client omitted this field. The PUT path preserves an
+    # existing policy instead of silently resetting it to historical "always".
+    routing: Optional[MoaRoutingPayload] = None
     enabled: bool = True
 
 
@@ -211,6 +226,7 @@ class MoaConfigPayload(_MoaReferenceControls):
     max_tokens: int = 4096
     reference_max_tokens: Optional[int] = None
     fanout: Optional[str] = None
+    routing: Optional[MoaRoutingPayload] = None
     enabled: bool = True
     profile: Optional[str] = None
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1710,6 +1710,7 @@ from hermes_cli.web_models import (  # noqa: F401
     ModelAssignment,
     MoaModelSlot,
     _MoaReferenceControls,
+    MoaRoutingPayload,
     MoaPresetPayload,
     MoaConfigPayload,
     FsWriteText,
@@ -7625,7 +7626,7 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
             return {k: v for k, v in slot.dict().items() if v is not None}
 
         def _preset_dict(preset: MoaPresetPayload) -> dict:
-            return {
+            result = {
                 "reference_models": [_slot_dict(slot) for slot in preset.reference_models],
                 "aggregator": _slot_dict(preset.aggregator),
                 "reference_temperature": preset.reference_temperature,
@@ -7637,14 +7638,45 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                 "fanout": preset.fanout,
                 "enabled": preset.enabled,
             }
+            if preset.routing is not None:
+                result["routing"] = preset.routing.model_dump()
+            return result
 
         with _profile_scope(body.profile or profile):
             cfg = load_config()
+            existing_moa = cfg.get("moa") if isinstance(cfg.get("moa"), dict) else {}
+            existing_presets = (
+                existing_moa.get("presets")
+                if isinstance(existing_moa.get("presets"), dict)
+                else {}
+            )
             if body.presets:
+                raw_presets = {}
+                for name, preset in body.presets.items():
+                    saved_preset = _preset_dict(preset)
+                    existing_preset = existing_presets.get(name)
+                    existing_routing = (
+                        existing_preset.get("routing")
+                        if isinstance(existing_preset, dict)
+                        else None
+                    )
+                    if (
+                        not isinstance(existing_routing, dict)
+                        and not existing_presets
+                        and name == body.default_preset
+                        and isinstance(existing_moa.get("routing"), dict)
+                    ):
+                        existing_routing = existing_moa["routing"]
+                    if (
+                        "routing" not in saved_preset
+                        and isinstance(existing_routing, dict)
+                    ):
+                        saved_preset["routing"] = dict(existing_routing)
+                    raw_presets[name] = saved_preset
                 raw = {
                     "default_preset": body.default_preset,
                     "active_preset": body.active_preset,
-                    "presets": {name: _preset_dict(preset) for name, preset in body.presets.items()},
+                    "presets": raw_presets,
                 }
             else:
                 raw = _preset_dict(
@@ -7658,9 +7690,24 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                         max_tokens=body.max_tokens,
                         reference_max_tokens=body.reference_max_tokens,
                         fanout=body.fanout,
+                        routing=body.routing,
                         enabled=body.enabled,
                     )
                 )
+                if "routing" not in raw:
+                    existing_routing = existing_moa.get("routing")
+                    if not isinstance(existing_routing, dict):
+                        existing_name = str(
+                            existing_moa.get("default_preset") or body.default_preset or ""
+                        )
+                        existing_preset = existing_presets.get(existing_name)
+                        existing_routing = (
+                            existing_preset.get("routing")
+                            if isinstance(existing_preset, dict)
+                            else None
+                        )
+                    if isinstance(existing_routing, dict):
+                        raw["routing"] = dict(existing_routing)
 
             # Reject-don't-repair: normalize_moa_config() silently swaps any
             # preset containing incomplete slots for the hardcoded defaults —

--- a/tests/agent/test_moa_conditional_router.py
+++ b/tests/agent/test_moa_conditional_router.py
@@ -1,0 +1,456 @@
+"""Behavioural tests for the native conditional MoA router."""
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from agent.moa_router import decide_moa_route
+from hermes_cli.moa_config import normalize_moa_config
+
+
+def _response(content: str):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        usage=None,
+        model="fake-model",
+    )
+
+
+def test_auto_router_escalates_deliberative_prompt_and_keeps_simple_prompt_direct():
+    config = {"mode": "auto", "threshold": 3}
+
+    direct = decide_moa_route("What time is the meeting?", config)
+    fused = decide_moa_route(
+        "Compare the two architectures, identify security risks, and recommend "
+        "which design we should use with reasons.",
+        config,
+    )
+
+    assert direct.fanout is False
+    assert direct.mode == "auto"
+    assert fused.fanout is True
+    assert fused.score >= 3
+    assert "deliberation" in fused.reasons
+
+
+def test_auto_router_fails_safe_for_ambiguous_and_non_english_prompts():
+    ambiguous = decide_moa_route("Explain the implications.", {"mode": "auto"})
+    non_english = decide_moa_route("请分析这个方案。", {"mode": "auto"})
+
+    assert ambiguous.fanout is True
+    assert non_english.fanout is True
+    assert "ambiguous" in ambiguous.reasons
+
+
+def test_explicit_modes_are_backward_compatible_and_deterministic():
+    assert decide_moa_route("hello", {"mode": "always"}).fanout is True
+    assert decide_moa_route("review every security risk", {"mode": "never"}).fanout is False
+
+
+def test_simple_prefix_does_not_bypass_high_stakes_deliberation():
+    decision = decide_moa_route(
+        "Translate this legal contract and assess the risk.",
+        {"mode": "auto", "threshold": 3},
+    )
+
+    assert decision.fanout is True
+    assert "high-stakes" in decision.reasons
+
+
+def test_moa_config_normalizes_per_preset_router_without_changing_default_behaviour():
+    configured = normalize_moa_config(
+        {
+            "presets": {
+                "review": {
+                    "routing": {"mode": "auto", "threshold": "4"},
+                }
+            }
+        }
+    )
+    defaulted = normalize_moa_config({})
+
+    assert configured["presets"]["review"]["routing"] == {
+        "mode": "auto",
+        "threshold": 4,
+    }
+    assert defaulted["presets"]["default"]["routing"] == {
+        "mode": "always",
+        "threshold": 3,
+    }
+
+
+def test_normalized_flattened_view_exposes_active_routing_policy():
+    cfg = normalize_moa_config(
+        {
+            "default_preset": "review",
+            "presets": {
+                "review": {
+                    "routing": {"mode": "auto", "threshold": 5},
+                }
+            },
+        }
+    )
+
+    assert cfg["routing"] == {"mode": "auto", "threshold": 5}
+
+
+def test_auto_router_skips_advisors_for_simple_turn_but_fans_out_for_deliberation(
+    monkeypatch, tmp_path
+):
+    from agent.moa_loop import MoAClient
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      routing:
+        mode: auto
+        threshold: 3
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: bedrock
+        model: anthropic.claude-opus
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("advice" if kwargs["task"] == "moa_reference" else "answer")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    simple = MoAClient("review")
+    simple.chat.completions.create(
+        messages=[{"role": "user", "content": "What time is the meeting?"}]
+    )
+    assert [call["task"] for call in calls] == ["moa_aggregator"]
+    assert calls[0]["provider"] == "bedrock"
+
+    calls.clear()
+    complex_turn = MoAClient("review")
+    complex_turn.chat.completions.create(
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    "Compare both architectures, identify the security risks, "
+                    "and recommend the best production design."
+                ),
+            }
+        ]
+    )
+    assert [call["task"] for call in calls] == [
+        "moa_reference",
+        "moa_aggregator",
+    ]
+    assert [call["provider"] for call in calls] == ["openai-codex", "bedrock"]
+
+
+def test_dashboard_payload_round_trips_router_configuration():
+    from hermes_cli.web_models import MoaPresetPayload
+
+    payload = MoaPresetPayload(routing={"mode": "auto", "threshold": 5})
+
+    assert payload.model_dump()["routing"] == {"mode": "auto", "threshold": 5}
+
+
+def test_dashboard_rejects_invalid_router_policy():
+    from hermes_cli.web_models import MoaPresetPayload
+
+    with pytest.raises(ValidationError):
+        MoaPresetPayload(routing={"mode": "guess", "threshold": 3})
+    with pytest.raises(ValidationError):
+        MoaPresetPayload(routing={"mode": "auto", "threshold": 0})
+
+
+def test_malformed_on_disk_router_policy_fails_to_historical_fanout():
+    cfg = normalize_moa_config(
+        {"presets": {"review": {"routing": {"mode": "guess", "threshold": 0}}}}
+    )
+
+    assert cfg["presets"]["review"]["routing"] == {
+        "mode": "always",
+        "threshold": 1,
+    }
+
+
+def test_non_finite_on_disk_router_threshold_falls_back_safely():
+    cfg = normalize_moa_config(
+        {"presets": {"review": {"routing": {"mode": "auto", "threshold": "inf"}}}}
+    )
+
+    assert cfg["presets"]["review"]["routing"] == {
+        "mode": "auto",
+        "threshold": 3,
+    }
+
+
+def test_route_decision_is_pinned_for_retries_within_one_user_turn(monkeypatch, tmp_path):
+    from agent.moa_loop import MoAClient
+    from agent.moa_router import MoARouteDecision
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  presets:
+    review:
+      routing: {mode: auto, threshold: 3}
+      reference_models:
+        - {provider: openai-codex, model: gpt-5.5}
+      aggregator: {provider: bedrock, model: anthropic.claude-opus}
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    decisions = []
+
+    def unstable_router(*_args, **_kwargs):
+        decisions.append(True)
+        return MoARouteDecision(
+            fanout=len(decisions) == 1,
+            mode="auto",
+            score=3,
+            reasons=("test",),
+        )
+
+    monkeypatch.setattr("agent.moa_router.decide_moa_route", unstable_router)
+    monkeypatch.setattr("agent.moa_loop.call_llm", lambda **_kwargs: _response("ok"))
+    client = MoAClient("review")
+    messages = [{"role": "user", "content": "Review this architecture."}]
+
+    client.chat.completions.create(messages=messages)
+    client.chat.completions.create(messages=messages)
+
+    assert len(decisions) == 1
+    assert client.chat.completions.last_route_decision.fanout is True
+
+
+def test_route_identity_ignores_cache_decoration(monkeypatch, tmp_path):
+    from agent.moa_loop import MoAClient
+    from agent.moa_router import MoARouteDecision
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  presets:
+    review:
+      routing: {mode: auto, threshold: 3}
+      reference_models: [{provider: openai-codex, model: gpt-5.5}]
+      aggregator: {provider: bedrock, model: anthropic.claude-opus}
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    decisions = []
+
+    def router(*_args, **_kwargs):
+        decisions.append(True)
+        return MoARouteDecision(True, "auto", 3, ("test",))
+
+    monkeypatch.setattr("agent.moa_router.decide_moa_route", router)
+    monkeypatch.setattr("agent.moa_loop.call_llm", lambda **_kwargs: _response("ok"))
+    client = MoAClient("review")
+    client.chat.completions.create(messages=[{"role": "user", "content": "Review this."}])
+    client.chat.completions.create(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Review this.",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert len(decisions) == 1
+
+
+def test_prepared_request_restores_route_pin_on_fresh_client(monkeypatch, tmp_path):
+    from agent.moa_loop import MoAClient
+    from agent.moa_router import MoARouteDecision
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  presets:
+    review:
+      routing: {mode: auto, threshold: 3}
+      reference_models: [{provider: openai-codex, model: gpt-5.5}]
+      aggregator: {provider: bedrock, model: anthropic.claude-opus}
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    decisions = []
+
+    def unstable_router(*_args, **_kwargs):
+        decisions.append(True)
+        return MoARouteDecision(len(decisions) == 1, "auto", 3, ("test",))
+
+    monkeypatch.setattr("agent.moa_router.decide_moa_route", unstable_router)
+    monkeypatch.setattr("agent.moa_loop.call_llm", lambda **_kwargs: _response("ok"))
+    messages = [{"role": "user", "content": "Review this architecture."}]
+    prepared = MoAClient("review").chat.completions.create(
+        messages=messages,
+        _moa_prepare_only=True,
+    )
+    rebuilt = MoAClient("review")
+    rebuilt.chat.completions.create(_moa_prepared_request=prepared)
+    rebuilt.chat.completions.create(messages=messages)
+
+    assert len(decisions) == 1
+    assert rebuilt.chat.completions.last_route_decision.fanout is True
+
+
+def test_rebased_prepared_request_rekeys_route_pin_to_compacted_transcript(
+    monkeypatch, tmp_path
+):
+    from agent.moa_loop import MoAClient
+    from agent.moa_router import MoARouteDecision
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  presets:
+    review:
+      routing: {mode: auto, threshold: 3}
+      reference_models: [{provider: openai-codex, model: gpt-5.5}]
+      aggregator: {provider: bedrock, model: anthropic.claude-opus}
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    decisions = []
+
+    def unstable_router(*_args, **_kwargs):
+        decisions.append(True)
+        return MoARouteDecision(len(decisions) == 1, "auto", 3, ("test",))
+
+    monkeypatch.setattr("agent.moa_router.decide_moa_route", unstable_router)
+    monkeypatch.setattr("agent.moa_loop.call_llm", lambda **_kwargs: _response("ok"))
+    original = [
+        {"role": "user", "content": "Earlier context."},
+        {"role": "assistant", "content": "Acknowledged."},
+        {"role": "user", "content": "Review this architecture."},
+    ]
+    compacted = [
+        {"role": "system", "content": "Compacted earlier context."},
+        {"role": "user", "content": "Review this architecture."},
+    ]
+    client = MoAClient("review")
+    prepared = client.chat.completions.create(
+        messages=original,
+        _moa_prepare_only=True,
+    )
+    rebased = client.chat.completions.rebase_prepared_request(prepared, compacted)
+    client.chat.completions.create(_moa_prepared_request=rebased)
+    client.chat.completions.create(messages=compacted)
+
+    assert len(decisions) == 1
+    assert client.chat.completions.last_route_decision.fanout is True
+
+
+def test_conditional_routes_preserve_canonical_provider_oauth_runtime(monkeypatch, tmp_path):
+    from agent import moa_loop
+    from agent.moa_loop import MoAClient
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  presets:
+    direct:
+      routing: {mode: never}
+      reference_models: [{provider: openai-codex, model: gpt-5.5}]
+      aggregator: {provider: azure-foundry, model: gpt-5.5}
+    fused:
+      routing: {mode: always}
+      reference_models: [{provider: openai-codex, model: gpt-5.5}]
+      aggregator: {provider: azure-foundry, model: gpt-5.5}
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    token_callable = lambda: "oauth-token"  # noqa: E731 - identity is asserted below
+    resolved = []
+
+    def resolve_runtime_provider(*, requested, target_model):
+        resolved.append((requested, target_model))
+        return {
+            "provider": requested,
+            "model": target_model,
+            "base_url": f"https://{requested}.internal.example/v1",
+            "api_key": token_callable,
+            "api_mode": "responses" if requested == "azure-foundry" else "chat_completions",
+            "request_overrides": {"extra_body": {"tenant": "internal"}},
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        resolve_runtime_provider,
+    )
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("ok")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    with moa_loop._runtime_cache_lock:
+        moa_loop._runtime_cache.clear()
+
+    MoAClient("direct").chat.completions.create(
+        messages=[{"role": "user", "content": "Review this."}]
+    )
+    assert resolved == [("azure-foundry", "gpt-5.5")]
+    assert calls[0]["api_key"] is token_callable
+    assert calls[0]["base_url"] == "https://azure-foundry.internal.example/v1"
+    assert calls[0]["api_mode"] == "responses"
+    assert calls[0]["extra_body"] == {"tenant": "internal"}
+
+    # The cached runtime must be immutable from a caller's perspective. MoA's
+    # aggregator path consumes request overrides from its request-local copy;
+    # a second call must still receive the resolver-supplied extra_body.
+    MoAClient("direct").chat.completions.create(
+        messages=[{"role": "user", "content": "Review this again."}]
+    )
+    assert resolved == [("azure-foundry", "gpt-5.5")]
+    assert calls[1]["extra_body"] == {"tenant": "internal"}
+    assert calls[1]["api_key"] is token_callable
+
+    resolved.clear()
+    calls.clear()
+    with moa_loop._runtime_cache_lock:
+        moa_loop._runtime_cache.clear()
+    MoAClient("fused").chat.completions.create(
+        messages=[{"role": "user", "content": "Review this."}]
+    )
+    assert resolved == [
+        ("openai-codex", "gpt-5.5"),
+        ("azure-foundry", "gpt-5.5"),
+    ]
+    assert calls[-1]["api_key"] is token_callable
+    assert calls[-1]["api_mode"] == "responses"

--- a/tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py
+++ b/tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py
@@ -9,7 +9,13 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from hermes_cli.web_server import MoaConfigPayload, MoaModelSlot, MoaPresetPayload, set_moa_models
+from hermes_cli.web_server import (
+    MoaConfigPayload,
+    MoaModelSlot,
+    MoaPresetPayload,
+    MoaRoutingPayload,
+    set_moa_models,
+)
 
 
 def _base_payload(**overrides) -> MoaConfigPayload:
@@ -24,6 +30,7 @@ def _base_payload(**overrides) -> MoaConfigPayload:
                 ],
                 aggregator=MoaModelSlot(provider="openrouter", model="anthropic/claude-opus-4.8"),
                 max_tokens=4096,
+                routing=MoaRoutingPayload(mode="auto", threshold=5),
                 enabled=True,
             ),
         },
@@ -73,6 +80,10 @@ class TestSetMoaModelsPreservesUndeclaredKeys:
             set_moa_models(payload)
 
         moa = saved_cfg["moa"]
+        assert moa["presets"]["default"]["routing"] == {
+            "mode": "auto",
+            "threshold": 5,
+        }
         assert moa.get("save_traces") is True, (
             "save_traces was dropped by set_moa_models"
         )
@@ -80,4 +91,93 @@ class TestSetMoaModelsPreservesUndeclaredKeys:
             "trace_dir was dropped by set_moa_models"
         )
 
+    def test_legacy_put_omitting_routing_preserves_existing_policy(self):
+        existing_cfg = {
+            "moa": {
+                "default_preset": "default",
+                "presets": {
+                    "default": {
+                        "reference_models": [
+                            {"provider": "openai-codex", "model": "gpt-5.5"},
+                        ],
+                        "aggregator": {
+                            "provider": "openrouter",
+                            "model": "anthropic/claude-opus-4.8",
+                        },
+                        "routing": {"mode": "auto", "threshold": 5},
+                    }
+                },
+            }
+        }
+        payload = MoaConfigPayload.model_validate(
+            {
+                "default_preset": "default",
+                "presets": {
+                    "default": {
+                        "reference_models": [
+                            {"provider": "openai-codex", "model": "gpt-5.5"},
+                        ],
+                        "aggregator": {
+                            "provider": "openrouter",
+                            "model": "anthropic/claude-opus-4.8",
+                        },
+                    }
+                },
+            }
+        )
+        saved_cfg = {}
 
+        with (
+            patch("hermes_cli.web_server.load_config", return_value=existing_cfg),
+            patch("hermes_cli.web_server.save_config", side_effect=lambda cfg: saved_cfg.update(cfg)),
+            patch("hermes_cli.web_server._profile_scope"),
+        ):
+            set_moa_models(payload)
+
+        assert saved_cfg["moa"]["presets"]["default"]["routing"] == {
+            "mode": "auto",
+            "threshold": 5,
+        }
+
+    def test_named_put_omitting_routing_preserves_legacy_flat_policy(self):
+        existing_cfg = {
+            "moa": {
+                "routing": {"mode": "auto", "threshold": 5},
+                "reference_models": [
+                    {"provider": "openai-codex", "model": "gpt-5.5"},
+                ],
+                "aggregator": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-opus-4.8",
+                },
+            }
+        }
+        payload = MoaConfigPayload.model_validate(
+            {
+                "default_preset": "default",
+                "presets": {
+                    "default": {
+                        "reference_models": [
+                            {"provider": "openai-codex", "model": "gpt-5.5"},
+                        ],
+                        "aggregator": {
+                            "provider": "openrouter",
+                            "model": "anthropic/claude-opus-4.8",
+                        },
+                    }
+                },
+            }
+        )
+        saved_cfg = {}
+
+        with (
+            patch("hermes_cli.web_server.load_config", return_value=existing_cfg),
+            patch("hermes_cli.web_server.save_config", side_effect=lambda cfg: saved_cfg.update(cfg)),
+            patch("hermes_cli.web_server._profile_scope"),
+        ):
+            set_moa_models(payload)
+
+        assert saved_cfg["moa"]["presets"]["default"]["routing"] == {
+            "mode": "auto",
+            "threshold": 5,
+        }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2458,6 +2458,8 @@ export interface MoaConfigResponse {
     reference_max_tokens?: number | null;
     /** Fan-out cadence (user_turn default | per_iteration | every_n:N) — round-tripped. */
     fanout?: string;
+    /** Conditional direct-versus-advisor routing. */
+    routing?: { mode: "always" | "never" | "auto"; threshold: number };
     enabled: boolean;
   }>;
   reference_models: MoaModelSlot[];

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -768,6 +768,7 @@ function MoaModelsModal({
       reference_timeout: draft.reference_timeout,
       degraded_reference_policy: draft.degraded_reference_policy,
       max_tokens: draft.max_tokens,
+      routing: { mode: "always", threshold: 3 },
       enabled: draft.enabled,
     };
     setDraft((prev) => ({
@@ -889,6 +890,50 @@ function MoaModelsModal({
             <div className="flex items-center gap-2 border border-border/50 bg-muted/20 px-3 py-2">
               <div className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary">{slotLabel(preset.aggregator)}</div>
               <Button size="sm" outlined onClick={() => setPicker({ kind: "aggregator" })}>Change</Button>
+            </div>
+          </div>
+
+          <div className="space-y-2 border border-border/50 bg-muted/20 px-3 py-3">
+            <div className="text-display text-xs font-medium tracking-wider">Conditional routing</div>
+            <p className="text-xs text-text-secondary">
+              Always preserves classic MoA. Auto consults reference models only for prompts that benefit from deliberation. Aggregator only skips reference models.
+            </p>
+            <div className="flex items-center gap-3">
+              <select
+                aria-label="MoA routing mode"
+                className="border border-border bg-background px-2 py-1 text-xs"
+                value={preset.routing?.mode ?? "always"}
+                onChange={(event) => updateSelectedPreset((prev) => ({
+                  ...prev,
+                  routing: {
+                    mode: event.target.value as "always" | "never" | "auto",
+                    threshold: prev.routing?.threshold ?? 3,
+                  },
+                }))}
+              >
+                <option value="always">Always fan out</option>
+                <option value="auto">Auto</option>
+                <option value="never">Aggregator only</option>
+              </select>
+              {(preset.routing?.mode ?? "always") === "auto" && (
+                <label className="flex items-center gap-2 text-xs text-text-secondary">
+                  Threshold
+                  <input
+                    aria-label="MoA routing threshold"
+                    className="w-16 border border-border bg-background px-2 py-1 text-xs"
+                    type="number"
+                    min={1}
+                    value={preset.routing?.threshold ?? 3}
+                    onChange={(event) => updateSelectedPreset((prev) => ({
+                      ...prev,
+                      routing: {
+                        mode: prev.routing?.mode ?? "auto",
+                        threshold: Math.max(1, Number(event.target.value) || 1),
+                      },
+                    }))}
+                  />
+                </label>
+              )}
             </div>
           </div>
 

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -91,6 +91,9 @@ moa:
       # reference_temperature: 0.6
       # aggregator_temperature: 0.4
       max_tokens: 4096
+      routing:
+        mode: auto       # always | auto | never
+        threshold: 3     # lower values fan out more readily
       enabled: true
 ```
 
@@ -99,6 +102,26 @@ Default preset:
 - reference: `openai-codex:gpt-5.5`
 - reference: `openrouter:deepseek/deepseek-v4-pro`
 - aggregator / acting model: `openrouter:anthropic/claude-opus-4.8`
+
+### Conditional Fusion-style routing
+
+Each preset can decide locally whether a turn needs its reference models. The
+aggregator remains the acting model on both paths, so Hermes keeps the same
+provider-specific runtime, OAuth credentials, tools, fallback behaviour, and
+conversation cache identity.
+
+- `routing.mode: always` is the backward-compatible default and runs the
+  configured advisors according to `fanout`.
+- `routing.mode: auto` uses a dependency-free, explainable intent score. It
+  favours deliberation for comparison, review, recommendation, research,
+  architecture, code, and high-stakes prompts; short lookup-style requests go
+  directly to the aggregator.
+- `routing.mode: never` skips advisors and uses the aggregator directly.
+- `routing.threshold` is a positive integer used by `auto` (default `3`). A
+  lower threshold invokes advisors more often.
+
+The route is request-local and never swaps the acting model mid-conversation.
+Every decision is logged with its score and reasons for diagnosis.
 
 ### Tuning advisor speed with `reference_max_tokens`
 


### PR DESCRIPTION
## What does this PR do?

Adds native conditional direct-versus-Mixture-of-Agents routing to each MoA preset. Simple requests can stay on the existing authenticated aggregator client, while deliberative requests fan out through the existing advisor pipeline.

The design stays inside Hermes' current MoA loop. It does not add a proxy, duplicate provider authentication, mutate conversation history, inject synthetic messages, or switch the session's provider/model. The routing decision only chooses between the preset's existing aggregator-only path and its existing advisor fan-out path.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added deterministic `always`, `auto`, and aggregator-only `never` routing policies.
- Added conservative prompt scoring and configurable escalation thresholds.
- Kept direct execution on the already-resolved aggregator client, preserving OAuth/API-key handling.
- Added API models, dashboard controls, config persistence, and user documentation.
- Preserved routing policy across legacy flat config and older dashboard save shapes.
- Made malformed and non-finite on-disk thresholds degrade safely.
- Exposed the active routing policy in the flattened compatibility response.

## How to Test

1. Configure an MoA preset with `routing.mode: auto` and a threshold.
2. Send a simple prompt and confirm the response is produced directly by the aggregator without advisor fan-out.
3. Send a multi-constraint analysis prompt and confirm the existing advisor fan-out and aggregator path run.
4. Save the policy through the dashboard, reload `/api/model/moa`, and confirm the policy persists.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run the complete repository test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this extends the existing `moa.presets` shape
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A
- [x] I've considered cross-platform impact; the implementation is pure Python/TypeScript with no platform-specific calls
- [x] Tool descriptions/schemas are N/A

## Verification

- 25 MoA test files: 134 passed
- Web suite: 278 passed
- Web typecheck, lint, and production build passed
- `git diff --check` passed
- Staging dashboard write/persist/restore probe passed: threshold `3 -> 4 -> 3`

The full repository runner was launched, but unrelated timing-sensitive tests failed under the heavily parallel local run before completion. The focused feature suite and complete web suite are green; CI remains the authoritative full-suite gate.
