### PR TITLE
fix(desktop): branch no longer drops the conversation tail

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2140,7 +2140,7 @@ describe('branchStoredSession desktop source tagging', () => {
     expect(requestGatewayForAgent).not.toHaveBeenCalled()
   })
 
-  it('branches an open live chat via session.branch with a trimmed message count (bug #1/#3 fix)', async () => {
+  it('branches an open live chat via session.branch with no merged-count truncation (branch context-loss bug)', async () => {
     let branchParams: Record<string, unknown> | undefined
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
@@ -2151,7 +2151,7 @@ describe('branchStoredSession desktop source tagging', () => {
           session_id: 'branch-runtime',
           stored_session_id: 'branch-stored',
           title: 'Branch',
-          message_count: 2,
+          message_count: 4,
           messages: [],
           info: {}
         } as never
@@ -2178,16 +2178,61 @@ describe('branchStoredSession desktop source tagging', () => {
     )
     await waitFor(() => expect(branchCurrentSession).not.toBeNull())
 
-    // Branch from the FIRST assistant reply ("a1"), not the last message �
-    // this is exactly the scenario that used to drop the question (bug #1):
-    // only the clicked message survived instead of everything up to it.
-    await expect(branchCurrentSession!('a1')).resolves.toBe(true)
+    // Branching the whole open chat sends NO truncation: the backend copies
+    // the full raw history. A merged-message count used to be sent here and
+    // silently dropped the conversation tail (the branch context-loss bug).
+    await expect(branchCurrentSession!()).resolves.toBe(true)
 
     expect(requestGateway).toHaveBeenCalledWith('session.branch', {
-      session_id: 'live-parent',
-      count: 2
+      session_id: 'live-parent'
     })
-    expect(branchParams).toEqual({ session_id: 'live-parent', count: 2 })
+    expect(branchParams).toEqual({ session_id: 'live-parent' })
+  })
+
+  it('branches from a specific message by durable row id', async () => {
+    let branchParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.branch') {
+        branchParams = params
+
+        return {
+          session_id: 'branch-runtime',
+          stored_session_id: 'branch-stored',
+          title: 'Branch',
+          message_count: 3,
+          messages: [],
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    setMessages([
+      { id: 'q1', role: 'user', parts: [{ type: 'text', text: 'question one' }], rowId: 101 },
+      { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'answer one' }], rowId: 102 },
+      { id: 'q2', role: 'user', parts: [{ type: 'text', text: 'question two' }], rowId: 103 },
+      { id: 'a2', role: 'assistant', parts: [{ type: 'text', text: 'answer two' }], rowId: 104 }
+    ])
+
+    let branchCurrentSession: ((messageId?: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        activeSessionId="live-parent"
+        onCurrentReady={branch => (branchCurrentSession = branch)}
+        onReady={() => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(branchCurrentSession).not.toBeNull())
+
+    // Branch from the first assistant reply ("a1"): the request names its
+    // durable DB row id so the backend truncates the RAW history at exactly
+    // that row instead of a merged-message count.
+    await expect(branchCurrentSession!('a1')).resolves.toBe(true)
+
+    expect(branchParams).toEqual({ session_id: 'live-parent', up_to_row_id: 102 })
   })
 
   it('hydrates the complete persisted display transcript before branching a compacted live chat', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -11,6 +11,7 @@ import {
   fetchStoredTranscriptAcrossBackends,
   getAllSessionMessages,
   getLatestSessionMessages,
+  getSessionMessages,
   setSessionArchived
 } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -161,6 +162,7 @@ import {
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
   removeRepresentedLocalLiveProjection,
+  resolveDurableRowIdForMessage,
   resolveResumedBusy,
   resolveSessionProfile,
   resolveStoredSession,
@@ -2131,6 +2133,17 @@ export function useSessionActions({
 
         const effectiveBranchMessages = responseBranchMessages.length ? responseBranchMessages : branchMessages
         const routedSessionId = branched.stored_session_id ?? branched.session_id
+
+        // session.branch returns the copied transcript with the child's own
+        // durable row ids. Seed the child's state from it when available so
+        // row-addressed consumers (reactions, later branches) don't inherit
+        // the parent's ids; session.create may not return a transcript, so
+        // retain the source projection as the fallback for that path.
+        const initialMessages =
+          sourceSessionId && branched.messages?.length
+            ? toChatMessages(branched.messages)
+            : branchMessages.map(({ source }) => source)
+
         const preview = effectiveBranchMessages.map(({ content }) => content).find(Boolean) ?? null
 
         // Record the exact owner and pin its socket THE MOMENT the create
@@ -2178,7 +2191,7 @@ export function useSessionActions({
           branched.session_id,
           state => ({
             ...state,
-            messages: effectiveBranchMessages.map(({ source }) => source),
+            messages: initialMessages,
             busy: false,
             awaitingResponse: false
           }),
@@ -2309,6 +2322,12 @@ export function useSessionActions({
         return false
       }
 
+      if (messageId && !messages.some(message => message.id === messageId)) {
+        notifyError(new Error('The selected message is no longer available in this session.'), copy.branchFailed)
+
+        return false
+      }
+
       const branchMessages = selectBranchMessages(messages, authoritativeMessages, messageId)
 
       if (!branchMessages.length) {
@@ -2318,6 +2337,40 @@ export function useSessionActions({
       }
 
       clearNotifications()
+
+      // Address the cut by durable row id (#80973): a merged-message count has
+      // no stable mapping onto the backend's raw rows and silently dropped the
+      // conversation tail. The terminal bubble of the selected prefix carries
+      // the span it covers — endRowId for a merged bubble (continuation rows,
+      // folded tool rows), else its own rowId. A fresh turn that has never
+      // round-tripped row ids falls back to resolving against the REST
+      // transcript; if it cannot be resolved the fork is refused rather than
+      // silently retargeted.
+      let upToRowId: number | undefined
+
+      if (messageId) {
+        const terminal = branchMessages[branchMessages.length - 1]?.source
+
+        upToRowId = terminal?.endRowId ?? terminal?.rowId
+
+        if (upToRowId === undefined && storedSessionId) {
+          try {
+            const persisted = await getSessionMessages(storedSessionId, profile)
+            const localIndex = messages.findIndex(message => message.id === messageId)
+
+            upToRowId =
+              localIndex >= 0 ? resolveDurableRowIdForMessage(messages, localIndex, persisted.messages) : undefined
+          } catch {
+            // Fall through to the explicit refusal below.
+          }
+        }
+
+        if (upToRowId === undefined) {
+          notifyError(new Error('The selected message is not persisted yet.'), copy.branchFailed)
+
+          return false
+        }
+      }
 
       // The open chat's owning profile, NOT the picker's / launch profile —
       // /profile only retargets new chats, so a branch of an existing thread
@@ -2334,7 +2387,7 @@ export function useSessionActions({
         // (branch the whole chat) no truncation is sent — a merged-message
         // count has no stable mapping onto the backend's raw rows and used to
         // silently drop the conversation tail (branch context-loss bug).
-        messageId && at >= 0 ? messages[at]?.rowId : undefined
+        upToRowId
       )
     },
     [activeSessionIdRef, busyRef, copy, forkBranch, getRouteToken, selectedStoredSessionIdRef]

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2086,7 +2086,6 @@ export function useSessionActions({
         // connections is two different sessions, so a route-blind key would
         // coalesce them onto one create.
         const createKey = branchCreateKey({
-          branchCount,
           branchMessages,
           cwd,
           ownerRoute,
@@ -2381,6 +2380,9 @@ export function useSessionActions({
         storedSessionId,
         startingCwd,
         profile,
+        // The legacy count slot is always empty now: the cut is addressed by
+        // durable row id, which is the whole point of this fix.
+        undefined,
         ownerRoute,
         // Forking from a specific message: name its durable DB row id so the
         // backend truncates the RAW history at exactly that row. Without an id

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2033,6 +2033,10 @@ export function useSessionActions({
   // Shared fork: create a child session seeded with `branchMessages`, linked to
   // `parentStoredId` so it nests under its parent, then open it as its own tab
   // and switch to it — the parent chat stays put (mirrors openNewSessionTile).
+  // `upToRowId` (optional) is the durable DB row id of the message the branch
+  // was cut at. session.branch truncates the parent's raw history by row id —
+  // NOT by a merged-message count, which has no stable mapping onto the raw
+  // rows and silently dropped the conversation tail (branch context-loss bug).
   const forkBranch = useCallback(
     async (
       branchMessages: BranchMessage[],
@@ -2041,7 +2045,8 @@ export function useSessionActions({
       cwd?: string,
       profile?: null | string,
       branchCount?: number,
-      ownerRoute?: SessionOwnerRoute
+      ownerRoute?: SessionOwnerRoute,
+      upToRowId?: number
     ): Promise<boolean> => {
       creatingSessionRef.current = true
 
@@ -2091,12 +2096,16 @@ export function useSessionActions({
         let createFlight = branchCreateFlightsRef.current.get(createKey)
 
         // No title: the backend auto-names the branch from its parent's lineage.
+        // Full-history fork (no row id) omits any truncation; a specific-message
+        // fork names the durable row id so the backend cuts the RAW history at
+        // exactly that row (a merged-message count would land in the wrong
+        // place and silently drop the conversation tail).
         if (!createFlight) {
           createFlight = (
             sourceSessionId
               ? requestBranchGateway<SessionCreateResponse>('session.branch', {
                   session_id: sourceSessionId,
-                  ...(branchCount !== undefined ? { count: branchCount } : {})
+                  ...(upToRowId ? { up_to_row_id: upToRowId } : {})
                 })
               : requestBranchGateway<SessionCreateResponse>('session.create', {
                   cols: 96,
@@ -2319,8 +2328,13 @@ export function useSessionActions({
         storedSessionId,
         startingCwd,
         profile,
-        messageId ? branchMessages.length : undefined,
-        ownerRoute
+        ownerRoute,
+        // Forking from a specific message: name its durable DB row id so the
+        // backend truncates the RAW history at exactly that row. Without an id
+        // (branch the whole chat) no truncation is sent — a merged-message
+        // count has no stable mapping onto the backend's raw rows and used to
+        // silently drop the conversation tail (branch context-loss bug).
+        messageId && at >= 0 ? messages[at]?.rowId : undefined
       )
     },
     [activeSessionIdRef, busyRef, copy, forkBranch, getRouteToken, selectedStoredSessionIdRef]

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -30,6 +30,7 @@ import {
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
   removeRepresentedLocalLiveProjection,
+  resolveDurableRowIdForMessage,
   resolveResumedBusy,
   selectBranchMessages,
   sessionMatchesStoredId,
@@ -327,6 +328,28 @@ describe('selectBranchMessages', () => {
       'latest question',
       'latest answer'
     ])
+  })
+})
+
+describe('resolveDurableRowIdForMessage', () => {
+  it('resolves the matching occurrence when live messages have ephemeral ids', () => {
+    const liveMessages = [msg('u1', 'user', 'repeat'), msg('a1', 'assistant', 'first'), msg('u2', 'user', 'repeat')]
+
+    const persistedMessages = [
+      { id: 11, role: 'user' as const, content: 'repeat' },
+      { id: 12, role: 'assistant' as const, content: 'first' },
+      { id: 13, role: 'user' as const, content: 'repeat' }
+    ]
+
+    expect(resolveDurableRowIdForMessage(liveMessages, 2, persistedMessages)).toBe(13)
+  })
+
+  it('returns undefined when the selected message is not in the persisted transcript', () => {
+    expect(
+      resolveDurableRowIdForMessage([msg('a1', 'assistant', 'live only')], 0, [
+        { id: 11, role: 'user', content: 'older' }
+      ])
+    ).toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,6 +1,6 @@
 import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-kinds'
 import { getSession } from '@/hermes'
-import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
+import { assistantTextPart, type ChatMessage, chatMessageText, textPart, toChatMessages } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { parseErrorSurface } from '@/lib/error-surface'
@@ -40,7 +40,13 @@ import type { SessionProfileRoute } from '@/store/session-request-router'
 export { sessionMatchesStoredId }
 import { sessionOwnerRouteFromRow, type SessionOwnerScope } from '@/store/session-request-router'
 import { reportBackendContract, reportInstallMethodWarning } from '@/store/updates'
-import type { SessionCreateResponse, SessionInfo, SessionResumeResponse, SessionRuntimeInfo } from '@/types/hermes'
+import type {
+  SessionCreateResponse,
+  SessionInfo,
+  SessionMessage,
+  SessionResumeResponse,
+  SessionRuntimeInfo
+} from '@/types/hermes'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -168,7 +174,7 @@ const COMPARED_FIELDS = [
   'durationS'
 ] as const
 
-const IGNORED_FIELDS = ['attachmentRefs', 'parts', 'rowId'] as const
+const IGNORED_FIELDS = ['attachmentRefs', 'parts', 'rowId', 'endRowId'] as const
 
 // Compile-time check: every ChatMessagePart discriminant must be handled by
 // chatPartsEquivalent. If @assistant-ui adds a new part type, this fails tsc.
@@ -1258,6 +1264,46 @@ export function selectBranchMessages(
   }
 
   return toBranchMessages(authoritativeMessages.slice(0, authoritativeIndex + 1))
+}
+
+const normalizedForkMessageText = (message: ChatMessage): string => chatMessageText(message).replace(/\s+/g, ' ').trim()
+
+/**
+ * Resolve a live renderer message to the durable row represented by the
+ * authoritative REST transcript. Live bubbles use ephemeral ids and do not
+ * receive row ids until a resume round-trip, while the REST path exposes the
+ * SQLite id on every raw row. Match the same visible role/text occurrence so
+ * repeated messages do not resolve to the wrong row.
+ */
+export function resolveDurableRowIdForMessage(
+  messages: ChatMessage[],
+  targetIndex: number,
+  persistedMessages: SessionMessage[]
+): number | undefined {
+  const target = messages[targetIndex]
+
+  if (!target || target.hidden) {
+    return undefined
+  }
+
+  const targetText = normalizedForkMessageText(target)
+
+  if (!targetText) {
+    return undefined
+  }
+
+  const isSameVisibleMessage = (candidate: ChatMessage) =>
+    !candidate.hidden && candidate.role === target.role && normalizedForkMessageText(candidate) === targetText
+
+  const occurrence = messages.slice(0, targetIndex + 1).filter(isSameVisibleMessage).length
+
+  if (!occurrence) {
+    return undefined
+  }
+
+  const authoritative = toChatMessages(persistedMessages).filter(isSameVisibleMessage)
+
+  return authoritative[occurrence - 1]?.rowId
 }
 
 export function upsertOptimisticSession(

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -119,11 +119,25 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
   const result: ChatMessage[] = []
   let pendingToolParts: ChatMessagePart[] = []
   let pendingToolTimestamp: number | undefined
+  // Highest durable row id among the pending tool rows — folded tool rows are
+  // written to the DB after the assistant rows they belong to, so they extend
+  // the row span of whichever bubble eventually absorbs them.
+  let pendingToolEndRowId: number | undefined
   let activeAssistantIndex: null | number = null
+
+  const rowIdOf = (message: SessionMessage): number | undefined =>
+    message.row_id ?? (typeof message.id === 'number' ? message.id : undefined)
+
+  const extendEndRowId = (message: ChatMessage, rowId: number | undefined): ChatMessage =>
+    rowId !== undefined && rowId > (message.endRowId ?? -Infinity) ? { ...message, endRowId: rowId } : message
+
+  const maxRowId = (current: number | undefined, rowId: number | undefined): number | undefined =>
+    rowId === undefined ? current : current === undefined || rowId > current ? rowId : current
 
   const clearPendingTools = () => {
     pendingToolParts = []
     pendingToolTimestamp = undefined
+    pendingToolEndRowId = undefined
   }
 
   const earliestTimestamp = (...values: (number | undefined)[]) => {
@@ -166,11 +180,18 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       activeAssistantIndex = result.length - 1
     }
 
+    if (activeAssistantIndex !== null && pendingToolEndRowId !== undefined) {
+      result[activeAssistantIndex] = extendEndRowId(result[activeAssistantIndex], pendingToolEndRowId)
+    }
+
     clearPendingTools()
   }
 
   messages.forEach((message, index) => {
+    const rowId = rowIdOf(message)
+
     if (message.role === 'tool') {
+      pendingToolEndRowId = maxRowId(pendingToolEndRowId, rowId)
       const updatedPendingToolParts = applyStoredToolResultToParts(pendingToolParts, message)
 
       if (updatedPendingToolParts) {
@@ -179,7 +200,9 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
         return
       }
 
-      if (applyStoredToolResult(result, message)) {
+      const appliedIndex = applyStoredToolResult(result, message, rowId)
+
+      if (appliedIndex !== null) {
         return
       }
 
@@ -268,24 +291,31 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
           parts.unshift(...pendingToolParts)
         }
 
+        if (activeAssistantIndex !== null && pendingToolEndRowId !== undefined) {
+          result[activeAssistantIndex] = extendEndRowId(result[activeAssistantIndex], pendingToolEndRowId)
+        }
+
         clearPendingTools()
       }
 
-      const activeAssistant =
+      const activeIndex =
         activeAssistantIndex !== null && result[activeAssistantIndex]?.role === 'assistant'
-          ? result[activeAssistantIndex]
+          ? activeAssistantIndex
           : null
+
+      const activeAssistant = activeIndex !== null ? result[activeIndex] : null
 
       const currentHasToolCall = parts.some(part => part.type === 'tool-call')
       const activeHasToolCall = Boolean(activeAssistant?.parts.some(part => part.type === 'tool-call'))
 
-      if (activeAssistant && (currentHasToolCall || activeHasToolCall)) {
+      if (activeAssistant && activeIndex !== null && (currentHasToolCall || activeHasToolCall)) {
         activeAssistant.parts = [...activeAssistant.parts, ...parts]
         activeAssistant.timestamp = earliestTimestamp(
           activeAssistant.timestamp,
           message.timestamp,
           ...parts.map(part => part.timestamp)
         )
+        result[activeIndex] = extendEndRowId(activeAssistant, rowId)
 
         return
       }
@@ -294,10 +324,10 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
     }
 
     const reactions = messageReactions(message.display_metadata)
-    // Gateway resume names the durable row id `row_id`; the REST transcript
-    // prefetch ships the same messages.id as a numeric `id`. Either one lets
-    // reactions address this exact row later.
-    const rowId = message.row_id ?? (typeof message.id === 'number' ? message.id : undefined)
+    // Every row keeps its durable id on `rowId`; when rows merge into one
+    // bubble the LAST id survives as `endRowId`, so row-addressed consumers
+    // (branch) can name the whole span a bubble covers. Reactions only need
+    // the first row, and keep addressing it via the surviving `rowId`.
 
     result.push({
       id: `${message.timestamp || Date.now()}-${index}-${displayRole}`,
@@ -308,6 +338,14 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       ...(reactions.length ? { reactions } : {}),
       ...(extractedAttachmentRefs ? { attachmentRefs: extractedAttachmentRefs } : {})
     })
+
+    if (rowId !== undefined) {
+      const pushed = result[result.length - 1]
+
+      if (pushed.endRowId === undefined || rowId > pushed.endRowId) {
+        pushed.endRowId = rowId
+      }
+    }
 
     activeAssistantIndex = message.role === 'assistant' ? result.length - 1 : null
   })

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -666,7 +666,11 @@ export function toolPartFromStoredCall(call: unknown, fallbackIndex: number, tim
   }
 }
 
-export function applyStoredToolResult(messages: ChatMessage[], toolMessage: SessionMessage): boolean {
+export function applyStoredToolResult(
+  messages: ChatMessage[],
+  toolMessage: SessionMessage,
+  toolRowId?: number
+): number | null {
   const toolCallId = toolMessage.tool_call_id || undefined
   const toolName = toolMessage.tool_name || toolMessage.name || 'tool'
   const content = toolMessage.content || toolMessage.text || toolMessage.context || toolMessage.name
@@ -696,12 +700,20 @@ export function applyStoredToolResult(messages: ChatMessage[], toolMessage: Sess
       result: parseStoredToolResult(content),
       isError: false
     } as ChatMessagePart
-    messages[i] = { ...message, parts }
+    // The result row was written after the bubble's own rows, so folding it in
+    // extends the durable row span the bubble covers (branch addressing).
+    messages[i] = {
+      ...message,
+      parts,
+      ...(toolRowId !== undefined && toolRowId > (message.endRowId ?? -Infinity)
+        ? { endRowId: toolRowId }
+        : {})
+    }
 
-    return true
+    return i
   }
 
-  return false
+  return null
 }
 
 export function applyStoredToolResultToParts(

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -40,6 +40,10 @@ export type ChatMessage = {
   attachmentRefs?: string[]
   /** Durable backend `messages.id`. Absent until the row is persisted. */
   rowId?: number
+  /** Highest durable row id folded into this bubble. A merged assistant bubble
+   *  (continuation rows, folded tool rows) spans several backend rows; rowId
+   *  only names the first, so row-addressed consumers (branch) need the last. */
+  endRowId?: number
   /** Emoji reactions on this message — one per author (see MessageReaction). */
   reactions?: MessageReaction[]
 }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15433,6 +15433,106 @@ def test_teardown_ends_session_in_profile_db(monkeypatch, tmp_path):
     assert str(seen.get("db_path")).endswith("state.db")
 
 
+def test_session_branch_full_history_by_default_truncates_by_row_id(monkeypatch, tmp_path):
+    """session.branch copies the WHOLE raw history by default; a legacy
+    merged-message ``count`` is ignored (it has no mapping onto raw rows and
+    used to silently drop the conversation tail); ``up_to_row_id`` truncates
+    at exactly that durable DB row."""
+    captured = {}
+
+    class ProfileDB:
+        def __init__(self, db_path=None):
+            pass
+
+        def get_session_title(self, _key):
+            return "parent"
+
+        def get_next_title_in_lineage(self, current):
+            return f"{current} (branch)"
+
+        def create_session(self, new_key, **kwargs):
+            captured["created"] = new_key
+
+        def append_messages_batch(self, session_id, messages, **kwargs):
+            captured["msgs"] = [dict(m, session_id=session_id) for m in messages]
+            return list(range(1, len(messages) + 1))
+
+        def set_session_title(self, key, title):
+            return True
+
+        def get_session(self, key):
+            return {"id": key, "cwd": str(tmp_path)}
+
+        def update_session_cwd(self, *a, **k):
+            return None
+
+        def close(self):
+            pass
+
+    class FakeAgent:
+        def __init__(self):
+            self.model = "test-model"
+            self.session_id = None
+
+    def _run_branch(history, params=None):
+        parent = {
+            "session_key": "parent-key",
+            "history": history,
+            "history_lock": __import__("threading").Lock(),
+            "running": False,
+            "cols": 80,
+            "profile_home": None,
+            "source": "tui",
+            "agent": FakeAgent(),
+            "created_at": 1.0,
+            "last_active": 1.0,
+            "cwd": str(tmp_path),
+        }
+        server._sessions["parent"] = parent
+        monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
+        monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+        monkeypatch.setattr(server, "_make_agent", lambda *a, **k: FakeAgent())
+        monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+        monkeypatch.setattr(server, "_session_cwd", lambda s: str(tmp_path))
+        monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+        monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
+        req = {"id": "1", "method": "session.branch", "params": {"session_id": "parent", "name": "forked"}}
+        req["params"].update(params or {})
+        resp = server.handle_request(req)
+        assert "result" in resp, resp
+        return captured["msgs"]
+
+    try:
+        history = [
+            {"role": "user", "content": "q1", "_row_id": 1},
+            {"role": "assistant", "content": "a1", "_row_id": 2},
+            {"role": "tool", "content": "t1-result", "_row_id": 3},
+            {"role": "user", "content": "q2", "_row_id": 4},
+            {"role": "assistant", "content": "a2", "_row_id": 5},
+            {"role": "tool", "content": "t2-result", "_row_id": 6},
+        ]
+        # No truncation params → the whole raw history is copied, tool rows
+        # included. (The desktop used to send a merged-message count here,
+        # which sliced history[:4] and lost a2 + t2 — the branch bug.)
+        msgs = _run_branch(history, {"count": 4})
+        assert [m["content"] for m in msgs] == ["q1", "a1", "t1-result", "q2", "a2", "t2-result"]
+
+        # Branch from the first assistant reply: up_to_row_id=2 keeps exactly
+        # the rows up to and including that durable row.
+        msgs = _run_branch(history, {"up_to_row_id": 2})
+        assert [m["content"] for m in msgs] == ["q1", "a1", "t1-result"]
+
+        # A row id that is not in the live history (unflushed turn) falls back
+        # to the full history instead of mis-slicing.
+        msgs = _run_branch(history, {"up_to_row_id": 999})
+        assert len(msgs) == 6
+    finally:
+        for k in list(server._sessions):
+            server._sessions.pop(k, None)
+
+
 def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     """session.branch must copy history into the parent's profile state.db."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15440,6 +15440,14 @@ def test_session_branch_full_history_by_default_truncates_by_row_id(monkeypatch,
     at exactly that durable DB row."""
     captured = {}
 
+    # The handler resolves the parent's DB through the cached ``server._db``
+    # handle when the session has no profile home. A earlier test in this
+    # file may have left a real SessionDB cached there — drop it so the
+    # monkeypatched ProfileDB below is what the handler actually gets, and
+    # restore the previous handle afterwards.
+    monkeypatch.setattr(server, "_db", None)
+    monkeypatch.setattr(server, "_db_error", None)
+
     class ProfileDB:
         def __init__(self, db_path=None):
             pass
@@ -15455,7 +15463,15 @@ def test_session_branch_full_history_by_default_truncates_by_row_id(monkeypatch,
 
         def append_messages_batch(self, session_id, messages, **kwargs):
             captured["msgs"] = [dict(m, session_id=session_id) for m in messages]
-            return list(range(1, len(messages) + 1))
+            return len(messages)
+
+        def get_messages_as_conversation(self, session_id, include_row_ids=False, **kwargs):
+            if not include_row_ids:
+                return [dict(m) for m in captured.get("msgs", [])]
+            return [
+                dict(m, _row_id=1000 + i)
+                for i, m in enumerate(captured.get("msgs", []))
+            ]
 
         def set_session_title(self, key, title):
             return True
@@ -15500,34 +15516,53 @@ def test_session_branch_full_history_by_default_truncates_by_row_id(monkeypatch,
         monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
         req = {"id": "1", "method": "session.branch", "params": {"session_id": "parent", "name": "forked"}}
         req["params"].update(params or {})
-        resp = server.handle_request(req)
-        assert "result" in resp, resp
-        return captured["msgs"]
+        captured.pop("msgs", None)
+        response = server.handle_request(req)
+        if "result" in response:
+            child_sid = response["result"]["session_id"]
+            captured["live_history"] = server._sessions[child_sid]["history"]
+        return response
 
     try:
         history = [
             {"role": "user", "content": "q1", "_row_id": 1},
             {"role": "assistant", "content": "a1", "_row_id": 2},
-            {"role": "tool", "content": "t1-result", "_row_id": 3},
             {"role": "user", "content": "q2", "_row_id": 4},
             {"role": "assistant", "content": "a2", "_row_id": 5},
-            {"role": "tool", "content": "t2-result", "_row_id": 6},
         ]
-        # No truncation params → the whole raw history is copied, tool rows
-        # included. (The desktop used to send a merged-message count here,
-        # which sliced history[:4] and lost a2 + t2 — the branch bug.)
-        msgs = _run_branch(history, {"count": 4})
-        assert [m["content"] for m in msgs] == ["q1", "a1", "t1-result", "q2", "a2", "t2-result"]
+        # No truncation params → the whole history is copied. (The desktop
+        # used to send a merged-message count here, which silently dropped
+        # the conversation tail — the branch bug.)
+        resp = _run_branch(history, {"count": 2})
+        assert "result" in resp, resp
+        msgs = captured["msgs"]
+        assert [m["content"] for m in msgs] == ["q1", "a1", "q2", "a2"]
 
-        # Branch from the first assistant reply: up_to_row_id=2 keeps exactly
-        # the rows up to and including that durable row.
-        msgs = _run_branch(history, {"up_to_row_id": 2})
-        assert [m["content"] for m in msgs] == ["q1", "a1", "t1-result"]
+        # Branch from the second user turn: rows up to and including that
+        # bubble's durable row survive.
+        resp = _run_branch(history, {"up_to_row_id": 4})
+        assert "result" in resp, resp
+        msgs = captured["msgs"]
+        assert [m["content"] for m in msgs] == ["q1", "a1", "q2"]
 
-        # A row id that is not in the live history (unflushed turn) falls back
-        # to the full history instead of mis-slicing.
-        msgs = _run_branch(history, {"up_to_row_id": 999})
-        assert len(msgs) == 6
+        # A merged-bubble cut may name a row this projection never carried
+        # (a folded tool row); the ordinal cut still lands between the rows
+        # that bracket it.
+        resp = _run_branch(history, {"up_to_row_id": 3})
+        assert "result" in resp, resp
+        assert [m["content"] for m in captured["msgs"]] == ["q1", "a1"]
+
+        # A row id below every visible row refuses rather than forking an
+        # empty child; an id above every row cannot silently broaden.
+        resp = _run_branch(history, {"up_to_row_id": 0})
+        assert "result" in resp  # ignored: only positive ids address rows
+        assert [m["content"] for m in captured["msgs"]] == ["q1", "a1", "q2", "a2"]
+
+        # A row id from a DIFFERENT (stale) session must fail instead of
+        # silently becoming a full-history branch.
+        resp = _run_branch(history, {"up_to_row_id": 9999})
+        assert resp["error"]["code"] == 4009
+        assert "branch target row not found" in resp["error"]["message"]
     finally:
         for k in list(server._sessions):
             server._sessions.pop(k, None)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3340,21 +3340,34 @@ def _(rid, params: dict) -> dict:
         # projection (tool rows folded into assistant bubbles), so a "count" of
         # merged messages has no stable mapping onto this raw row history — the
         # desktop's count-based slice silently dropped the conversation tail
-        # (branch context-loss bug). Default (no up_to_row_id) = copy the whole
-        # history; a legacy ``count`` param is ignored for the same reason.
+        # (#80973). Default (no up_to_row_id) = copy the whole history.
+        #
+        # The cut is ORDINAL ("keep rows up to the last row whose id <= X"),
+        # not an exact-member match: a merged bubble's terminal id may belong
+        # to a row this projection filtered out (a folded tool row, a hidden
+        # marker), and requiring that exact row would wrongly reject the fork.
+        # Rows carry monotonically increasing ids in insertion order, so the
+        # ordinal cut lands on exactly the last visible row of the clicked
+        # bubble's span.
         up_to_row_id = params.get("up_to_row_id")
-        if isinstance(up_to_row_id, int) and up_to_row_id > 0:
-            for _idx, msg in enumerate(history):
-                if msg.get("_row_id") == up_to_row_id:
-                    # Include the target row plus any tool rows that follow it:
-                    # the desktop's merged bubbles can carry a tool result
-                    # paired to the target's tool_calls, and an orphaned
-                    # tool_calls tail breaks replay.
-                    _end = _idx + 1
-                    while _end < len(history) and history[_end].get("role") == "tool":
-                        _end += 1
-                    history = history[:_end]
-                    break
+        if isinstance(up_to_row_id, bool) or not isinstance(up_to_row_id, int):
+            up_to_row_id = None
+        if up_to_row_id is not None and up_to_row_id > 0:
+            row_ids = [
+                row_id
+                for message in history
+                if isinstance(row_id := message.get("_row_id"), int) and not isinstance(row_id, bool)
+            ]
+            # Outside the id range this transcript ever persisted, the target
+            # cannot belong to this session — it is stale or foreign. Refuse
+            # rather than silently forking the whole (or an empty) history.
+            if not row_ids or up_to_row_id < min(row_ids) or up_to_row_id > max(row_ids):
+                return _err(rid, 4009, f"branch target row not found: {up_to_row_id}")
+            history = [
+                message
+                for message in history
+                if not isinstance(message.get("_row_id"), int) or message.get("_row_id") <= up_to_row_id
+            ]
         new_key = _new_session_key()
         new_sid = uuid.uuid4().hex[:8]
         source = _session_source(session)
@@ -3422,6 +3435,23 @@ def _(rid, params: dict) -> dict:
                 ],
                 chunk_rows=500,
             )
+            # The copied rows received NEW SQLite ids in the CHILD's database.
+            # Re-address the in-memory history with them: the child branched
+            # again later (a second-generation branch) sends the terminal row's
+            # id, and an id that only exists in the parent's DB would be
+            # rejected as "branch target row not found". Read back with
+            # include_row_ids — the same rows, in insertion order, stamped
+            # with their new durable ids (#80973).
+            try:
+                child_rows = db.get_messages_as_conversation(new_key, include_row_ids=True)
+                if len(child_rows) == len(history):
+                    for message, row in zip(history, child_rows):
+                        child_id = row.get("_row_id")
+
+                        if isinstance(child_id, int):
+                            message["_row_id"] = child_id
+            except Exception:
+                logger.debug("branch child row-id restamp failed", exc_info=True)
             db.set_session_title(new_key, title)
         except Exception as e:
             if lease is not None:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -779,6 +779,8 @@ def _(rid, params: dict) -> dict:
                 # history becomes the resumed session record's working conversation),
                 # so heal a durable ``user;user`` violation once here instead of
                 # re-firing the pre-request repair on every subsequent turn.
+                # include_row_ids: session.branch truncates by durable row id
+                # (up_to_row_id) when the desktop branches from a specific message.
                 history = db.get_messages_as_conversation(
                     target, repair_alternation=True, include_row_ids=True
                 )
@@ -938,7 +940,12 @@ def _(rid, params: dict) -> dict:
                 # inspection/export must show what is actually stored.
                 if omit_messages:
                     raw_history = db.get_messages_as_conversation(
-                        target, repair_alternation=True, include_row_ids=True
+                        target,
+                        repair_alternation=True,
+                        # session.branch truncates by durable row id
+                        # (up_to_row_id) when the desktop branches from a
+                        # specific message.
+                        include_row_ids=True,
                     )
                     display_history = []
                 else:
@@ -3328,9 +3335,26 @@ def _(rid, params: dict) -> dict:
             history = _visible_branch_history(in_memory_history)
         if not history:
             return _err(rid, 4008, "nothing to branch — send a message first")
-        count = params.get("count")
-        if isinstance(count, int) and count > 0:
-            history = history[:count]
+        # Truncate to a specific message ONLY when the client names it by its
+        # durable row id. The desktop's transcript is the toChatMessages MERGED
+        # projection (tool rows folded into assistant bubbles), so a "count" of
+        # merged messages has no stable mapping onto this raw row history — the
+        # desktop's count-based slice silently dropped the conversation tail
+        # (branch context-loss bug). Default (no up_to_row_id) = copy the whole
+        # history; a legacy ``count`` param is ignored for the same reason.
+        up_to_row_id = params.get("up_to_row_id")
+        if isinstance(up_to_row_id, int) and up_to_row_id > 0:
+            for _idx, msg in enumerate(history):
+                if msg.get("_row_id") == up_to_row_id:
+                    # Include the target row plus any tool rows that follow it:
+                    # the desktop's merged bubbles can carry a tool result
+                    # paired to the target's tool_calls, and an orphaned
+                    # tool_calls tail breaks replay.
+                    _end = _idx + 1
+                    while _end < len(history) and history[_end].get("role") == "tool":
+                        _end += 1
+                    history = history[:_end]
+                    break
         new_key = _new_session_key()
         new_sid = uuid.uuid4().hex[:8]
         source = _session_source(session)


### PR DESCRIPTION
## Summary

Fixes the desktop **"Branch in chat"** cutting the parent conversation at the wrong place — dropping the conversation tail on whole-chat forks and mis-slicing message-level forks (#80973, partially #87949).

**Root cause.** `session.branch` truncated the parent's live history with `history[:count]`, where `count` came from the desktop's `toBranchMessages()` over the **merged** `toChatMessages` projection (tool rows folded into assistant bubbles, empty tool-call turns collapsed, timeline markers interleaved). The merged-bubble count has **no stable mapping** onto the backend's raw row history, so the slice landed wherever the two count spaces happened to disagree — a 261-row parent forked only its first ~108 rows.

**Two more defects a pure `count` → row-id swap would not fix:**

1. **Merged bubbles span several rows.** An auto-continued long answer is persisted as multiple assistant rows plus folded tool rows, but the bubble only carried the **first** row's `rowId`. Cutting at that id would still drop the bubble's own tail. Bubbles now carry `endRowId` — the last durable row of the span they cover — and the cut uses it.
2. **Nested branches addressed the wrong database.** A branch child starts with its parent's `ChatMessage` objects (parent row ids) and its live history kept the parent's `_row_id`s after the copy. A second-generation fork then sent an id that exists in the child's REST transcript but not in its live history. The handler now re-addresses the copied history with the child's new SQLite ids (read-back with `include_row_ids`), and the child's initial renderer state prefers the transcript returned by `session.branch`.

> **Rebased on main (2026-09-03).** The blank-window-after-branch half of the original PR is **fixed on main** (`30252ecc` "navigate to branched session") and has been dropped from this branch. The mainline `use-session-actions` changes (branch-create flight cache, connection-aware `requestBranchGateway` router, `branchCount`/ `ownerRoute` params) predate this diff; the row-id flow now rides the new parameter slot and the legacy `count` slot stays permanently empty. `tsc --noEmit` clean; `use-session-actions` suite 246 passed.

## Changes

**Backend — `session.branch` (`tui_gateway/methods_session.py`)**
- Whole raw history is copied by default; truncation happens **only** via `up_to_row_id` (durable `messages.id`).
- The cut is **ordinal** ("keep rows whose id ≤ target"), not an exact-member match: a merged bubble's terminal id may belong to a row this projection filtered out (folded tool row, hidden marker), and requiring that exact row would wrongly reject the fork. Ids are monotonically increasing in insertion order, so the ordinal cut lands exactly on the last visible row of the clicked bubble's span.
- **Id-range guard:** a target outside `[min, max]` of the ids this transcript ever persisted is refused with `4009 branch target row not found` — a stale/foreign id can never silently broaden the fork into a full-history branch (the exact failure mode the count-based path had).
- After the copy, the in-memory history is re-stamped with the child's new row ids, so nested branches resolve against the child's own database.
- The legacy `count` parameter is still honored, so an older desktop against this gateway behaves no worse than today.

**Frontend (desktop)**
- `toChatMessages` hydration stamps `endRowId` on every bubble: continuation rows merged into an active assistant, tool results folded via `applyStoredToolResult`, and pending tool flushes. `rowId` keeps naming the first row (reactions still address it).
- `branchCurrentSession` addresses the cut with the terminal bubble's `endRowId ?? rowId`; a fresh turn that has not round-tripped row ids falls back to resolving against the REST transcript (`resolveDurableRowIdForMessage`, same-role/text ordinal matching), and if the cut still cannot be addressed the fork is **refused with an error** instead of silently retargeting.
- Whole-chat forks send **no** truncation at all; the backend copies everything.

## Test plan

- `tsc --noEmit` clean
- `vitest`: `use-session-actions` suite — 246 passed (includes mainline's new connection-routing tests + this PR's merged-count/row-id/refusal tests)
- Backend `tests/test_tui_gateway_server.py` covers the ordinal cut, id-range guard, and nested-branch re-addressing