### PR TITLE
fix(setup): Blank Slate must remove installer-seeded bundled skills

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3602,8 +3602,18 @@ def _run_blank_slate_setup(config: dict, hermes_home, is_existing: bool):
         # `hermes update` runs don't re-inject them. Essential skills (the
         # `hermes-agent` operating manual) are still seeded by the sync.
         try:
-            from tools.skills_sync import set_bundled_skills_opt_out, sync_skills
+            from tools.skills_sync import (
+                remove_pristine_bundled_skills,
+                set_bundled_skills_opt_out,
+                sync_skills,
+            )
             set_bundled_skills_opt_out(True)
+            # The installer seeds the full bundled catalog before this wizard
+            # runs, so opt-out alone is not enough: delete the already-seeded
+            # bundled skills (only pristine, manifest-tracked, unmodified ones
+            # are removed — user/hub/local skills are preserved), then re-sync
+            # to restore just the essential `hermes-agent` operating manual.
+            remove_pristine_bundled_skills(dry_run=False)
             sync_skills(quiet=True)
         except Exception as exc:
             logger.debug("blank-slate skill opt-out error: %s", exc)
@@ -3636,7 +3646,11 @@ def _blank_slate_walkthrough(config: dict, hermes_home):
         default=False,
     )
     try:
-        from tools.skills_sync import set_bundled_skills_opt_out, sync_skills
+        from tools.skills_sync import (
+            remove_pristine_bundled_skills,
+            set_bundled_skills_opt_out,
+            sync_skills,
+        )
         if seed_skills:
             # Make sure no stale opt-out marker blocks the seed, then sync.
             set_bundled_skills_opt_out(False)
@@ -3645,11 +3659,18 @@ def _blank_slate_walkthrough(config: dict, hermes_home):
             print_success(f"Seeded {copied} bundled skills.")
         else:
             set_bundled_skills_opt_out(True)
+            # The installer seeds the full bundled catalog before this wizard
+            # runs, so opt-out alone is not enough: delete the already-seeded
+            # bundled skills (only pristine, manifest-tracked, unmodified ones
+            # are removed — user/hub/local skills are preserved), then re-sync
+            # to restore just the essential `hermes-agent` operating manual.
+            remove_pristine_bundled_skills(dry_run=False)
             # Essential skills (the `hermes-agent` operating manual) are
             # still seeded even for an opted-out profile.
             sync_skills(quiet=True)
             print_info("No skills seeded (except the essential `hermes-agent`")
-            print_info("skill). A .no-bundled-skills marker keeps future")
+            print_info("skill). Bundled skills seeded earlier by the installer")
+            print_info("were removed. A .no-bundled-skills marker keeps future")
             print_info("`hermes update` runs from re-injecting them. Opt back in any")
             print_info("time with `hermes skills opt-in --sync`.")
     except Exception as exc:

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -120,3 +120,40 @@ class TestBlankSlateFork:
         # Finish-now path records the skill opt-out (no bundled skills).
         assert opted_out["value"] is True
 
+    def test_finish_now_removes_already_seeded_bundled_skills(self, monkeypatch, tmp_path):
+        """Regression: Blank Slate must delete the bundled skills the installer
+        already seeded, not just write the opt-out marker.
+
+        The installer (`setup-hermes.sh`) seeds the full bundled catalog into
+        ~/.hermes/skills/ *before* the first-run wizard runs. Selecting Blank
+        Slate therefore used to only write .no-bundled-skills and re-sync
+        (which seeds nothing new but leaves the 80+ installer-seeded skills on
+        disk), so the user still saw every bundled skill — and blamed the next
+        `hermes update` for "re-injecting" them. The finish-now path must also
+        call remove_pristine_bundled_skills() so a Blank Slate is actually blank.
+        """
+        import hermes_cli.setup as s
+        self._patch_common(monkeypatch)
+        # Fork prompt returns 0 = finish now.
+        monkeypatch.setattr(s, "prompt_choice", lambda *a, **k: 0)
+        monkeypatch.setattr(
+            s, "_blank_slate_walkthrough", lambda cfg, home: None
+        )
+
+        calls = {"opt_out": [], "remove_dry_run": [], "sync": 0}
+        import tools.skills_sync as ss
+        monkeypatch.setattr(ss, "set_bundled_skills_opt_out",
+                            lambda enabled: calls["opt_out"].append(enabled))
+        monkeypatch.setattr(ss, "remove_pristine_bundled_skills",
+                            lambda dry_run: calls["remove_dry_run"].append(dry_run))
+        monkeypatch.setattr(ss, "sync_skills",
+                            lambda quiet: calls.__setitem__("sync", calls["sync"] + 1))
+
+        s._run_blank_slate_setup({}, tmp_path, is_existing=False)
+
+        # Wrote the opt-out marker, removed the already-seeded bundled skills
+        # (destructive, dry_run=False), then re-synced (restores essential only).
+        assert calls["opt_out"] == [True]
+        assert calls["remove_dry_run"] == [False]
+        assert calls["sync"] == 1
+

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -817,6 +817,54 @@ class TestOptOutToggleAndRemove:
             # non-bundled local skill never considered
             assert (skills_dir / "mine" / "SKILL.md").exists()
 
+    def test_remove_always_keeps_essential_skills(self, tmp_path):
+        """Regression: `hermes skills opt-out --remove` (and blank-slate
+        cleanup) must NEVER remove essential skills like `hermes-agent`,
+        even when they are pristine and manifest-tracked. The essential
+        `hermes-agent` operating manual is required to run the agent at all
+        and must survive a blank-slate cleanup (#98027).
+        """
+        from tools.skills_sync import (
+            _essential_names,
+            sync_skills, remove_pristine_bundled_skills,
+        )
+        bundled = tmp_path / "bundled"
+        for n in ("alpha", *sorted(_essential_names())):
+            d = bundled / n
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(f"---\nname: {n}\n---\nbody {n}\n")
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        home = tmp_path / "home"
+        home.mkdir()
+        with patch("tools.skills_sync._get_bundled_dir", return_value=bundled), \
+             patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"), \
+             patch("tools.skills_sync.SKILLS_DIR", skills_dir), \
+             patch("tools.skills_sync.MANIFEST_FILE", manifest_file), \
+             patch("tools.skills_sync.HERMES_HOME", home):
+            sync_skills(quiet=True)
+            essential_names = sorted(_essential_names())
+            # essential skill is seeded and tracked
+            for n in essential_names:
+                assert (skills_dir / n / "SKILL.md").exists()
+
+            preview = remove_pristine_bundled_skills(dry_run=True)
+            assert "alpha" in preview["removed"]
+            # essential skills never listed for removal
+            for n in essential_names:
+                assert n not in preview["removed"]
+
+            result = remove_pristine_bundled_skills(dry_run=False)
+            assert "alpha" in result["removed"]
+            assert not (skills_dir / "alpha").exists()
+            # essential skill survives the destructive removal
+            for n in essential_names:
+                assert (skills_dir / n / "SKILL.md").exists()
+                # and its manifest entry is preserved
+            kept_reasons = {s["name"]: s["reason"] for s in result["skipped"]}
+            for n in essential_names:
+                assert kept_reasons.get(n) == "essential (kept)"
+
 
 class TestUpdateBackupRecovery:
     """Regression tests for backup handling in the bundled-update path.

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -1392,8 +1392,11 @@ def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:
         (so the user has not edited it).
 
     Anything user-modified, hub-installed, or locally authored is left
-    untouched and reported under ``skipped``. The manifest entry for each
-    removed skill is dropped so a later opt-in re-seed treats it as new.
+    untouched and reported under ``skipped``. Essential skills
+    (``_essential_names()``, e.g. the ``hermes-agent`` operating manual) are
+    ALWAYS kept — they are required to run the agent at all and must survive
+    even a blank-slate cleanup. The manifest entry for each removed skill is
+    dropped so a later opt-in re-seed treats it as new.
 
     Args:
         dry_run: When True, compute what would be removed without deleting.
@@ -1406,11 +1409,16 @@ def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:
     manifest = _read_manifest()
     bundled_dir = _get_bundled_dir()
     bundled_by_name = dict(_discover_bundled_skills(bundled_dir))
+    essential = _essential_names()
 
     removed: List[str] = []
     skipped: List[dict] = []
 
     for name, origin_hash in sorted(manifest.items()):
+        if name in essential:
+            # Essential skills are always required; never remove them.
+            skipped.append({"name": name, "reason": "essential (kept)"})
+            continue
         src = bundled_by_name.get(name)
         if src is None:
             # Tracked but no longer bundled upstream — leave it; not ours to judge.


### PR DESCRIPTION
## Summary

Picking **Blank Slate** in first-time setup only wrote the `.no-bundled-skills` opt-out marker and re-ran `sync_skills()`. That prevents *future* seeding but never deleted the skills the installer (`setup-hermes.sh`) already copied in *before* the wizard ran — so the user was left with the entire 80+ skill catalog after explicitly choosing a blank profile.

This explains the recurring report: user selects Blank Slate, then every `hermes update` is blamed for "re-injecting" skills — but updates already honor the marker and re-inject nothing. The skills were never removed in the first place.

## Root cause (reproduced)

1. `setup-hermes.sh` line ~431 runs `sync_skills` and seeds the full catalog into `~/.hermes/skills/` before setup.
2. Selecting Blank Slate wrote the marker + `sync_skills` — which, with the marker present, seeds only the essential `hermes-agent` skill and leaves everything already on disk untouched.

Repro against a temp `HERMES_HOME`: after a full installer-style sync (82 skills + manifest), Blank Slate's old code left **82 skills** on disk. `hermes update` was never the culprit.

## Fix

The Blank Slate path now calls `remove_pristine_bundled_skills()` after writing the marker, then re-syncs. It deletes only pristine, manifest-tracked, unmodified bundled skills (user-modified, hub-installed, and locally-authored skills are preserved), leaving the profile with just the essential `hermes-agent` operating manual.

After the fix, the same repro ends with **1 skill** (`hermes-agent`) — a genuinely blank slate.

## Test Plan

- New regression test `test_finish_now_removes_already_seeded_bundled_skills` verifies the finish-now path writes the marker, calls `remove_pristine_bundled_skills(dry_run=False)`, then re-syncs.
- `pytest tests/hermes_cli/test_setup_blank_slate.py` → 5 passed
- `pytest tests/tools/test_skills_sync.py` → 34 passed
- Manual E2E repro of the installer→Blank-Slate flow on a temp `HERMES_HOME` confirms 82 → 1 skills.