### PR TITLE
feat(delegation): per-task model selection and profile identity for delegate_task

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2118,6 +2118,25 @@ DEFAULT_CONFIG = {
                                      # (floor 30s) to enforce a hard cap.
         "reasoning_effort": "",  # subagent effort: "ultra", "max", "xhigh", "high",
                                  # "medium", "low", "minimal", "none" (empty = inherit)
+        # Allow the agent to pick a per-task model when fanning out work, e.g.
+        # comparing the same task across several models. When True, each
+        # delegate_task entry may carry a `model` field naming a model
+        # ("opus", "gpt-5", "glm") — resolved leniently against the parent's
+        # current provider (aggregator-aware), falling back to delegation.provider.
+        # Off by default: the documented contract is that subagents inherit the
+        # parent model, and per-task model selection can route work to a more
+        # expensive model than the user expects. Opt in deliberately.
+        "allow_model_selection": False,
+        # Allow the agent to name a per-task Hermes profile when fanning out
+        # work. When True, each delegate_task entry may carry a `profile` field
+        # naming a profile under the Hermes profiles root. The child loads that
+        # profile's SOUL.md, IDENTITY.md, and AGENTS.md as its system prompt
+        # identity, and reads model/provider from its config.yaml when not
+        # explicitly overridden — so the child "becomes" the named bot rather
+        # than a generic subagent. Off by default: loading arbitrary profile
+        # files into a child prompt is a trust boundary that should be
+        # deliberate.
+        "allow_profile_identity": False,
         "max_concurrent_children": 10,  # unified concurrency cap: max parallel children per batch
                                        # AND max concurrent background (background=true)
                                        # delegation units. New async dispatches beyond the cap

--- a/tests/tools/test_delegate_model_selection.py
+++ b/tests/tools/test_delegate_model_selection.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Integration tests for per-task model selection in delegate_task.
+
+Mirrors the test file name and structure from Kilo-Org/kilocode#11786
+(upstream kilocode-port/per-task-delegation-model branch). These tests
+exercise _resolve_task_model_creds with REAL switch_model() calls rather
+than mocks, complementing the mocked unit tests in
+test_delegate_per_task_overrides.py.
+
+Run with:  python -m pytest tests/tools/test_delegate_model_selection.py -v
+"""
+
+import unittest
+from unittest.mock import patch
+
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_dynamic_schema_overrides,
+    _get_allow_model_selection,
+    _resolve_task_model_creds,
+)
+
+
+class _FakeParent:
+    """Minimal parent agent for credential anchoring."""
+
+    provider = "openrouter"
+    model = "anthropic/claude-opus-4.8"
+    base_url = "https://openrouter.ai/api/v1"
+    api_key = "sk-test"
+
+
+_BASE_CREDS = {
+    "model": None,
+    "provider": None,
+    "base_url": None,
+    "api_key": None,
+    "api_mode": None,
+    "command": None,
+    "args": None,
+}
+
+
+class TestSchemaGating(unittest.TestCase):
+    """The per-task model field only appears when the flag is enabled."""
+
+    def test_flag_off_no_model_field(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertNotIn("model", props)
+        self.assertNotIn("model", props["tasks"]["items"]["properties"])
+
+    def test_flag_on_adds_model_field(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ):
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertEqual(props["model"]["type"], "string")
+        self.assertIn("model", props["tasks"]["items"]["properties"])
+
+    def test_static_schema_never_mutated(self):
+        """Dynamic overrides must not leak the model field into the static schema."""
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ):
+            _build_dynamic_schema_overrides()
+        static_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertNotIn("model", static_props)
+        self.assertNotIn(
+            "model", static_props["tasks"]["items"]["properties"]
+        )
+
+
+class TestFlagGetter(unittest.TestCase):
+    def test_default_off(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            self.assertFalse(_get_allow_model_selection())
+
+    def test_truthy_on(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ):
+            self.assertTrue(_get_allow_model_selection())
+
+
+class TestModelResolutionIntegration(unittest.TestCase):
+    """Integration tests with real switch_model() calls.
+
+    These mirror the kilocode branch's test approach: exercise the actual
+    model_switch pipeline rather than mocking it. Tests may be skipped if
+    the model_switch module cannot resolve models in the test environment
+    (e.g. no provider config available).
+    """
+
+    def test_empty_name_returns_base_unchanged(self):
+        out = _resolve_task_model_creds("", _FakeParent(), _BASE_CREDS)
+        self.assertIs(out, _BASE_CREDS)
+
+    def test_base_creds_not_mutated(self):
+        before = dict(_BASE_CREDS)
+        try:
+            _resolve_task_model_creds("sonnet", _FakeParent(), _BASE_CREDS)
+        except (ValueError, Exception):
+            # Resolution may fail in test env; mutation check is independent
+            pass
+        self.assertEqual(_BASE_CREDS, before)
+
+    def test_full_slug_passthrough(self):
+        """A full vendor/model slug should pass through resolution."""
+        try:
+            out = _resolve_task_model_creds(
+                "openai/gpt-5.4", _FakeParent(), _BASE_CREDS
+            )
+            self.assertEqual(out["model"], "openai/gpt-5.4")
+        except (ValueError, Exception):
+            self.skipTest("model_switch cannot resolve in this environment")
+
+    def test_unresolvable_name_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_task_model_creds(
+                "zzznotarealmodel-xyz-123", _FakeParent(), _BASE_CREDS
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_delegate_per_task_overrides.py
+++ b/tests/tools/test_delegate_per_task_overrides.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+Tests for per-task model selection and profile identity in delegate_task.
+
+Two opt-in features, both gated behind config flags (default off):
+
+1. **Per-task model selection** (``delegation.allow_model_selection``):
+   The agent names a model per task ("opus", "gpt-5", "glm") when fanning
+   work out; resolution reuses the shared ``model_switch`` pipeline so names
+   are matched leniently and the provider is resolved (not dictated).
+
+2. **Per-task profile identity** (``delegation.allow_profile_identity``):
+   The agent names a Hermes profile per task; the child loads that profile's
+   SOUL.md, IDENTITY.md, and AGENTS.md as its system prompt identity, and
+   reads model/provider from its config.yaml when not explicitly overridden.
+   The child "becomes" the named bot rather than a generic subagent.
+
+Both flags are off by default to preserve the "subagents inherit the parent
+model and use a generic identity" contract. The schema fields only appear
+when the corresponding flag is enabled (keeping the tool surface minimal).
+
+Run with:  python3 -m pytest tests/tools/test_delegate_per_task_overrides.py -v
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_dynamic_schema_overrides,
+    _get_allow_model_selection,
+    _get_allow_profile_identity,
+    _resolve_task_model_creds,
+    _load_profile_identity,
+    _build_child_system_prompt,
+)
+
+
+class _FakeParent:
+    """Minimal parent agent for credential anchoring."""
+
+    provider = "openrouter"
+    model = "anthropic/claude-opus-4.8"
+    base_url = "https://openrouter.ai/api/v1"
+    api_key = "sk-test"
+
+
+_BASE_CREDS = {
+    "model": None,
+    "provider": None,
+    "base_url": None,
+    "api_key": None,
+    "api_mode": None,
+    "command": None,
+    "args": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Schema gating: fields only appear when the flag is on
+# ---------------------------------------------------------------------------
+
+class TestSchemaGating(unittest.TestCase):
+    """Per-task fields only appear when the corresponding flag is enabled."""
+
+    def test_both_flags_off_no_extra_fields(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertNotIn("model", props)
+        self.assertNotIn("profile", props)
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertNotIn("model", task_props)
+        self.assertNotIn("profile", task_props)
+
+    def test_model_flag_on_adds_model_field(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ):
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertEqual(props["model"]["type"], "string")
+        self.assertIn("model", props["tasks"]["items"]["properties"])
+
+    def test_profile_flag_on_adds_profile_field(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_profile_identity": True},
+        ):
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertIn("profile", props)
+        self.assertEqual(props["profile"]["type"], "string")
+        self.assertIn("profile", props["tasks"]["items"]["properties"])
+
+    def test_both_flags_on_adds_both_fields(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={
+                "allow_model_selection": True,
+                "allow_profile_identity": True,
+            },
+        ):
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertIn("profile", props)
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("model", task_props)
+        self.assertIn("profile", task_props)
+
+    def test_static_schema_never_mutated(self):
+        """Dynamic overrides must not leak into the static schema."""
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={
+                "allow_model_selection": True,
+                "allow_profile_identity": True,
+            },
+        ):
+            _build_dynamic_schema_overrides()
+        static_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertNotIn("model", static_props)
+        self.assertNotIn("profile", static_props)
+        self.assertNotIn(
+            "model", static_props["tasks"]["items"]["properties"]
+        )
+        self.assertNotIn(
+            "profile", static_props["tasks"]["items"]["properties"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Flag getters
+# ---------------------------------------------------------------------------
+
+class TestFlagGetters(unittest.TestCase):
+    def test_model_selection_default_off(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            self.assertFalse(_get_allow_model_selection())
+
+    def test_model_selection_truthy_on(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ):
+            self.assertTrue(_get_allow_model_selection())
+
+    def test_profile_identity_default_off(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            self.assertFalse(_get_allow_profile_identity())
+
+    def test_profile_identity_truthy_on(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_profile_identity": True},
+        ):
+            self.assertTrue(_get_allow_profile_identity())
+
+
+# ---------------------------------------------------------------------------
+# Model resolution
+# ---------------------------------------------------------------------------
+
+class TestModelResolution(unittest.TestCase):
+    """`_resolve_task_model_creds` reuses the model_switch pipeline."""
+
+    def test_empty_name_returns_base_unchanged(self):
+        out = _resolve_task_model_creds("", _FakeParent(), _BASE_CREDS)
+        self.assertIs(out, _BASE_CREDS)
+
+    def test_base_creds_not_mutated(self):
+        before = dict(_BASE_CREDS)
+        _resolve_task_model_creds("", _FakeParent(), _BASE_CREDS)
+        self.assertEqual(_BASE_CREDS, before)
+
+
+# ---------------------------------------------------------------------------
+# Profile identity loading
+# ---------------------------------------------------------------------------
+
+class TestProfileIdentityLoading(unittest.TestCase):
+    """`_load_profile_identity` reads identity files from a profile directory."""
+
+    def test_nonexistent_profile_returns_none(self):
+        import pathlib
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create the profiles root but not the named profile
+            pathlib.Path(tmpdir, "profiles").mkdir(parents=True)
+            with patch(
+                "hermes_constants.get_default_hermes_root",
+                return_value=pathlib.Path(tmpdir),
+            ):
+                result = _load_profile_identity("nonexistent-profile")
+        self.assertIsNone(result)
+
+    def test_loads_identity_files_and_config(self):
+        """A well-formed profile returns soul, identity, agents, model, provider."""
+        import pathlib
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            profile_dir = pathlib.Path(tmpdir) / "profiles" / "test-bot"
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "SOUL.md").write_text("You are a test bot.")
+            (profile_dir / "IDENTITY.md").write_text("Name: TestBot")
+            (profile_dir / "AGENTS.md").write_text("# Test Agent Rules")
+            (profile_dir / "config.yaml").write_text(
+                "model:\n  default: glm-5.3\n  provider: ollama-cloud\n"
+            )
+
+            with patch(
+                "hermes_constants.get_default_hermes_root",
+                return_value=pathlib.Path(tmpdir),
+            ):
+                result = _load_profile_identity("test-bot")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["soul"], "You are a test bot.")
+        self.assertEqual(result["identity"], "Name: TestBot")
+        self.assertEqual(result["agents"], "# Test Agent Rules")
+        self.assertEqual(result["model"], "glm-5.3")
+        self.assertEqual(result["provider"], "ollama-cloud")
+
+    def test_partial_profile_still_loads(self):
+        """A profile with only SOUL.md still returns a valid dict."""
+        import pathlib
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            profile_dir = pathlib.Path(tmpdir) / "profiles" / "partial-bot"
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "SOUL.md").write_text("You are partial.")
+
+            with patch(
+                "hermes_constants.get_default_hermes_root",
+                return_value=pathlib.Path(tmpdir),
+            ):
+                result = _load_profile_identity("partial-bot")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["soul"], "You are partial.")
+        self.assertIsNone(result["identity"])
+        self.assertIsNone(result["agents"])
+        self.assertIsNone(result["model"])
+        self.assertIsNone(result["provider"])
+
+
+# ---------------------------------------------------------------------------
+# System prompt with profile identity
+# ---------------------------------------------------------------------------
+
+class TestChildSystemPromptWithProfile(unittest.TestCase):
+    """`_build_child_system_prompt` uses profile identity when provided."""
+
+    def test_profile_identity_replaces_generic_preamble(self):
+        identity = {
+            "soul": "You are a code reviewer.",
+            "identity": "Name: ReviewerBot",
+            "agents": "# Review Rules",
+            "model": None,
+            "provider": None,
+        }
+        prompt = _build_child_system_prompt(
+            "Review the PR", profile_identity=identity
+        )
+        self.assertIn("You are a code reviewer.", prompt)
+        self.assertIn("Name: ReviewerBot", prompt)
+        self.assertIn("# Review Rules", prompt)
+        self.assertIn("YOUR TASK:\nReview the PR", prompt)
+        self.assertNotIn("You are a focused subagent", prompt)
+
+    def test_no_profile_identity_uses_generic_preamble(self):
+        prompt = _build_child_system_prompt("Fix the tests")
+        self.assertIn("You are a focused subagent", prompt)
+        self.assertIn("YOUR TASK:\nFix the tests", prompt)
+
+    def test_partial_profile_warns_and_uses_agents(self):
+        """Profile with only AGENTS.md (no SOUL/IDENTITY) falls back gracefully."""
+        identity = {
+            "soul": None,
+            "identity": None,
+            "agents": "# Agent Rules Only",
+            "model": None,
+            "provider": None,
+        }
+        with patch("tools.delegate_tool.logger") as mock_logger:
+            prompt = _build_child_system_prompt(
+                "Do the work", profile_identity=identity
+            )
+        mock_logger.warning.assert_called_once()
+        self.assertIn("You are a focused subagent", prompt)
+        self.assertIn("# Agent Rules Only", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_delegate_per_task_overrides.py
+++ b/tests/tools/test_delegate_per_task_overrides.py
@@ -227,7 +227,7 @@ class TestProfileIdentityLoading(unittest.TestCase):
         self.assertEqual(result["provider"], "ollama-cloud")
 
     def test_partial_profile_still_loads(self):
-        """A profile with only SOUL.md still returns a valid dict."""
+        """A profile with only SOUL.md (no IDENTITY) still returns a valid dict."""
         import pathlib
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -247,6 +247,40 @@ class TestProfileIdentityLoading(unittest.TestCase):
         self.assertIsNone(result["agents"])
         self.assertIsNone(result["model"])
         self.assertIsNone(result["provider"])
+
+    def test_path_traversal_rejected(self):
+        """Profile names with slashes or dots are rejected to prevent traversal."""
+        import pathlib
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a directory outside profiles that a traversal would hit
+            secret_dir = pathlib.Path(tmpdir) / "secret"
+            secret_dir.mkdir()
+            (secret_dir / "SOUL.md").write_text("SECRET DATA")
+
+            with patch(
+                "hermes_constants.get_default_hermes_root",
+                return_value=pathlib.Path(tmpdir),
+            ):
+                # All of these should return None, never reading the secret
+                for bad_name in [
+                    "../../secret",
+                    "../secret",
+                    "foo/../../secret",
+                    ".../.../secret",
+                    "foo/../bar",
+                    "a/b",
+                    "a.b",
+                    ".hidden",
+                    "trailing/",
+                    "/absolute",
+                ]:
+                    with self.subTest(name=bad_name):
+                        result = _load_profile_identity(bad_name)
+                        self.assertIsNone(
+                            result,
+                            f"Path traversal with '{bad_name}' should return None",
+                        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate_per_task_overrides.py
+++ b/tests/tools/test_delegate_per_task_overrides.py
@@ -22,8 +22,10 @@ when the corresponding flag is enabled (keeping the tool surface minimal).
 Run with:  python3 -m pytest tests/tools/test_delegate_per_task_overrides.py -v
 """
 
+import json
 import os
 import tempfile
+import threading
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -35,6 +37,8 @@ from tools.delegate_tool import (
     _resolve_task_model_creds,
     _load_profile_identity,
     _build_child_system_prompt,
+    delegate_task,
+    set_spawn_paused,
 )
 
 
@@ -328,6 +332,217 @@ class TestChildSystemPromptWithProfile(unittest.TestCase):
         mock_logger.warning.assert_called_once()
         self.assertIn("You are a focused subagent", prompt)
         self.assertIn("# Agent Rules Only", prompt)
+
+
+# ---------------------------------------------------------------------------
+# P1 regressions (PR #98031 review)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_parent():
+    """Mock parent with every field delegate_task / _build_child_agent touch.
+
+    Mirrors the established pattern from tests/tools/test_delegate_test_gap.py.
+    """
+    parent = MagicMock()
+    parent.session_id = "parent-session-overrides"
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "***"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-opus-4.8"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent.provider_require_parameters = False
+    parent.provider_data_collection = None
+    parent.request_overrides = {}
+    parent.max_tokens = None
+    parent.enabled_toolsets = None
+    parent.valid_tool_names = []
+    parent.disabled_toolsets = None
+    parent._session_db = None
+    parent._delegate_depth = 0
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._subagent_finalization_lock = threading.RLock()
+    parent._current_task_id = None
+    parent._current_turn_id = ""
+    parent._memory_manager = None
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    return parent
+
+
+# Long enough to clear the batch goal-quality gate (_MIN_BATCH_GOAL_LEN=10).
+_GOAL_A = "Do the first delegated task end to end"
+_GOAL_B = "Do the second delegated task end to end"
+
+
+class TestAtomicBatchPreflight(unittest.TestCase):
+    """P1 #1: a mid-batch resolution failure must construct ZERO children.
+
+    The dispatcher preflights every task (model resolution, profile
+    loading, credential bundling) before constructing any child, so a
+    failure on task 1 can never orphan task 0's already-constructed child
+    (open SessionDB, registration in _active_children) with no cleanup.
+    """
+
+    def setUp(self):
+        set_spawn_paused(False)
+
+    def test_invalid_profile_in_later_task_constructs_no_children(self):
+        """Task 0 valid + task 1 invalid profile → error, zero children,
+        no SessionDB construction side effect."""
+        parent = _make_mock_parent()
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_profile_identity": True},
+        ), patch(
+            "tools.delegate_tool._load_profile_identity",
+            side_effect=lambda name: (
+                {
+                    "soul": "You are Devbot.",
+                    "identity": None,
+                    "agents": None,
+                    "model": None,
+                    "provider": None,
+                    "_profile_name": name,
+                }
+                if name == "devbot"
+                else None
+            ),
+        ), patch("run_agent.AIAgent") as MockAgent, patch(
+            "hermes_state.SessionDB"
+        ) as MockSessionDB:
+            out = delegate_task(
+                tasks=[
+                    {"goal": _GOAL_A, "profile": "devbot"},
+                    {"goal": _GOAL_B, "profile": "no-such-profile-xyz"},
+                ],
+                parent_agent=parent,
+            )
+        payload = json.loads(out)
+        # The whole batch is refused with a per-task error...
+        self.assertIn("error", payload)
+        self.assertIn("Task 1", payload["error"])
+        self.assertIn("no-such-profile-xyz", payload["error"])
+        # ...with ZERO children constructed.
+        MockAgent.assert_not_called()
+        self.assertEqual(len(parent._active_children), 0)
+        # And no child SessionDB handle was opened (construction never ran).
+        MockSessionDB.assert_not_called()
+
+
+class TestProfileProviderRouting(unittest.TestCase):
+    """P1 #2: a profile's model+provider resolve as one routing unit —
+    against the PROFILE's provider, never the parent's."""
+
+    def setUp(self):
+        set_spawn_paused(False)
+
+    def test_profile_provider_used_not_parent_provider(self):
+        """Parent on openrouter + profile configured for openai/gpt-5 →
+        the child receives openai credentials, not openrouter's."""
+        parent = _make_mock_parent()
+
+        fake_runtime = {
+            "provider": "openai",
+            "model": "gpt-5",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "sk-openai",
+            "api_mode": "chat_completions",
+            "request_overrides": {},
+            "max_output_tokens": None,
+            "command": None,
+            "args": [],
+        }
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={
+                "allow_profile_identity": True,
+                "allow_model_selection": True,
+            },
+        ), patch(
+            "tools.delegate_tool._load_profile_identity",
+            return_value={
+                "soul": "You are Devbot.",
+                "identity": None,
+                "agents": None,
+                "model": "gpt-5",
+                "provider": "openai",
+                "_profile_name": "devbot",
+            },
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ) as mock_rrp, patch("run_agent.AIAgent") as MockAgent:
+            child = MagicMock()
+            child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "tokens": {"input": 1, "output": 1},
+            }
+            MockAgent.return_value = child
+            out = delegate_task(
+                tasks=[{"goal": _GOAL_A, "profile": "devbot"}],
+                parent_agent=parent,
+            )
+        payload = json.loads(out)
+        self.assertNotIn("error", payload)
+        # Resolution anchored on the PROFILE's provider...
+        mock_rrp.assert_called_once()
+        self.assertEqual(
+            mock_rrp.call_args.kwargs.get("requested"), "openai"
+        )
+        # ...and the child was constructed with the openai routing unit.
+        kwargs = MockAgent.call_args.kwargs
+        self.assertEqual(kwargs["provider"], "openai")
+        self.assertEqual(kwargs["model"], "gpt-5")
+        self.assertEqual(kwargs["base_url"], "https://api.openai.com/v1")
+        self.assertEqual(kwargs["api_key"], "sk-openai")
+        self.assertNotEqual(kwargs["provider"], "openrouter")
+        # Identity still applied alongside the provider routing.
+        self.assertIn("You are Devbot", kwargs["ephemeral_system_prompt"])
+
+
+class TestOverlongProfileName(unittest.TestCase):
+    """P1 #3: a regex-valid name longer than the filesystem component
+    limit returns None (profile not found), never an OSError."""
+
+    def test_overlong_valid_name_returns_none_without_raising(self):
+        long_name = "a" * 256  # matches ^[A-Za-z0-9_-]+$ but > 255 bytes
+        import pathlib
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "hermes_constants.get_default_hermes_root",
+                return_value=pathlib.Path(tmpdir),
+            ) as mock_root:
+                # Must return None, not raise OSError(ENAMETOOLONG).
+                result = _load_profile_identity(long_name)
+            self.assertIsNone(result)
+            # Rejected at the guard — no filesystem access needed.
+            mock_root.assert_not_called()
+
+    def test_name_at_255_limit_still_accepted_by_guard(self):
+        """A 255-char name is legal: it passes the guard and fails the
+        directory lookup gracefully (None, no crash)."""
+        name_255 = "a" * 255
+        import pathlib
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "hermes_constants.get_default_hermes_root",
+                return_value=pathlib.Path(tmpdir),
+            ) as mock_root:
+                result = _load_profile_identity(name_255)
+            self.assertIsNone(result)  # no such profile on disk
+            mock_root.assert_called_once()  # guard let it through
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate_test_gap.py
+++ b/tests/tools/test_delegate_test_gap.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""
+Test-gap closure for per-task model selection + profile identity (Card 4).
+
+Four categories, all test-only (no production changes):
+
+  1. Property-based (Hypothesis) fuzzing of the profile-name path traversal
+     guard ``^[A-Za-z0-9_-]+$`` in ``_load_profile_identity`` — arbitrary
+     strings, adversarial unicode / null bytes / control chars / extremely
+     long names / path separators on both POSIX and Windows.
+  2. Regression: ``allow_model_selection=False`` + ``allow_profile_identity=True``
+     must gate the schema (profile advertised, model NOT) and must NOT let a
+     profile's config.yaml model trigger a model switch.
+  3. Fallback chain semantics: unresolvable models raise ValueError (fail
+     loudly, never silently inherit); None/"" model names are no-ops that
+     return the base creds untouched.
+  4. Integration with mock child spawns (the test_delegate_usage_ledger.py
+     pattern): profile identity reaches the child system prompt, no profile
+     uses the generic preamble, explicit model beats the profile model,
+     fork snapshots attach to children, and the usage ledger is populated.
+
+Run with:  python3 -m pytest tests/tools/test_delegate_test_gap.py -v
+"""
+
+import json
+import pathlib
+import re
+import shutil
+import tempfile
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from hypothesis import given, settings, strategies as st
+
+from tools.delegate_tool import (
+    _build_dynamic_schema_overrides,
+    _get_allow_model_selection,
+    _get_allow_profile_identity,
+    _load_profile_identity,
+    _resolve_task_model_creds,
+    delegate_task,
+    set_spawn_paused,
+)
+from tools.delegation_fork import INHERITANCE_NOTICE
+
+# The exact guard regex _load_profile_identity enforces (delegate_tool.py).
+_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# Shared goal for integration dispatches (long enough to clear the batch
+# goal-quality gate even if the shape ever changes to multi-task).
+GOAL = "Do the delegated integration work end to end"
+
+
+# ── Shared fixtures ───────────────────────────────────────────────────────
+
+
+class _FakeParent:
+    """Minimal parent agent for credential anchoring (model_switch path)."""
+
+    provider = "openrouter"
+    model = "anthropic/claude-opus-4.8"
+    base_url = "https://openrouter.ai/api/v1"
+    api_key = "sk-test"
+
+
+def _base_creds():
+    """Fresh base credential bundle shaped like _resolve_delegation_credentials."""
+    return {
+        "model": None,
+        "provider": None,
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "command": None,
+        "args": None,
+    }
+
+
+def _make_switch_result(
+    new_model="gpt-5x",
+    target_provider="openai",
+    success=True,
+    error_message=None,
+):
+    """Fake ModelSwitchResult like hermes_cli.model_switch returns."""
+    r = MagicMock()
+    r.success = success
+    r.error_message = error_message
+    r.new_model = new_model
+    r.target_provider = target_provider
+    r.base_url = "https://api.openai.com/v1"
+    r.api_key = "sk-openai"
+    r.api_mode = "chat_completions"
+    return r
+
+
+def _identity_stub(
+    soul="You are Devbot — a build agent.",
+    identity="Name: Devbot",
+    agents=None,
+    model=None,
+    provider=None,
+    profile_name="devbot",
+):
+    """Profile identity dict shaped like _load_profile_identity output."""
+    return {
+        "soul": soul,
+        "identity": identity,
+        "agents": agents,
+        "model": model,
+        "provider": provider,
+        "_profile_name": profile_name,
+    }
+
+
+def _make_mock_parent():
+    """Mock parent with every field delegate_task / _build_child_agent touch.
+
+    Mirrors the established pattern from tests/tools/test_delegate.py's
+    _make_mock_parent plus the ledger fields from test_delegate_usage_ledger.
+    """
+    parent = MagicMock()
+    parent.session_id = "parent-session-gap"
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "***"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-opus-4.8"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent.provider_require_parameters = False
+    parent.provider_data_collection = None
+    parent.request_overrides = {}
+    parent.max_tokens = None
+    parent.enabled_toolsets = None
+    parent.valid_tool_names = []
+    parent.disabled_toolsets = None
+    parent._session_db = None
+    parent._delegate_depth = 0
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._subagent_finalization_lock = threading.RLock()
+    parent._current_task_id = None
+    parent._current_turn_id = ""
+    parent._memory_manager = None
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    # Usage-ledger fields (Card 2 contract).
+    parent.session_delegation_usage = []
+    parent.session_estimated_cost_usd = 0.0
+    parent.session_cost_source = "none"
+    parent.session_cost_status = "unknown"
+    return parent
+
+
+def _make_mock_child():
+    """Mock child AIAgent whose run_conversation completes immediately."""
+    child = MagicMock()
+    child.run_conversation.return_value = {
+        "final_response": "done",
+        "completed": True,
+        "interrupted": False,
+        "api_calls": 2,
+        "tokens": {"input": 100, "output": 50},
+    }
+    child._credential_pool = None
+    return child
+
+
+# ── Category 1: Property-based path traversal tests (Hypothesis) ─────────
+
+
+class TestPathTraversalPropertyBased(unittest.TestCase):
+    """Property-based fuzzing of the ^[A-Za-z0-9_-]+$ profile-name guard."""
+
+    @settings(max_examples=100, deadline=None)
+    @given(st.text(max_size=100))
+    def test_invalid_names_rejected_before_filesystem_access(self, name):
+        """Any string with characters outside [A-Za-z0-9_-] must return None,
+        and must be rejected BEFORE the profiles root is ever consulted (the
+        guard is the security control; the directory check is not)."""
+        if _SAFE_NAME_RE.match(name or ""):
+            return  # valid names are covered by the next property
+        with patch(
+            "hermes_constants.get_default_hermes_root"
+        ) as mock_root:
+            result = _load_profile_identity(name)
+            self.assertIsNone(
+                result,
+                f"profile name {name!r} contains characters outside "
+                "[A-Za-z0-9_-] and must be rejected",
+            )
+            mock_root.assert_not_called()
+
+    @settings(max_examples=50, deadline=None)
+    @given(st.from_regex(r"[A-Za-z0-9_-]{1,64}", fullmatch=True))
+    def test_valid_names_pass_guard_and_load(self, name):
+        """Names matching the safe regex must never be rejected by the guard:
+        a real on-disk profile with that exact name loads successfully."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            profile_dir = pathlib.Path(tmpdir) / "profiles" / name
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "SOUL.md").write_text(
+                "gap-test soul", encoding="utf-8"
+            )
+            with patch(
+                "hermes_constants.get_default_hermes_root",
+                return_value=pathlib.Path(tmpdir),
+            ):
+                result = _load_profile_identity(name)
+            self.assertIsNotNone(
+                result,
+                f"valid profile name {name!r} must not be rejected "
+                "by the guard (false positive)",
+            )
+            self.assertEqual(result["soul"], "gap-test soul")
+            self.assertEqual(result["_profile_name"], name)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_adversarial_traversal_names_rejected(self):
+        """Hand-picked adversarial inputs (spec list) must all return None,
+        with a real secret directory sitting outside the profiles root that a
+        broken guard would read."""
+        adversarial = [
+            "../", "..\\", ".../", "./", ".\\", "/etc", "\\windows",
+            "foo/../../bar", "a/b/c", "a.b.c", " ", "  ", "\t", "\n",
+            "null\x00byte",
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            secret = pathlib.Path(tmpdir) / "secret"
+            secret.mkdir()
+            (secret / "SOUL.md").write_text("SECRET DATA", encoding="utf-8")
+            with patch(
+                "hermes_constants.get_default_hermes_root",
+                return_value=pathlib.Path(tmpdir),
+            ) as mock_root:
+                for bad in adversarial:
+                    with self.subTest(name=bad):
+                        self.assertIsNone(
+                            _load_profile_identity(bad),
+                            f"adversarial name {bad!r} must be rejected",
+                        )
+                mock_root.assert_not_called()
+
+    def test_unicode_names_rejected(self):
+        """Non-ASCII codepoints must never satisfy the guard."""
+        for bad in ["böt", "日本語", "🤖-bot", "pro\u00e9file", "профиль", "‮rtl"]:
+            with self.subTest(name=bad):
+                with patch(
+                    "hermes_constants.get_default_hermes_root"
+                ) as mock_root:
+                    self.assertIsNone(_load_profile_identity(bad))
+                    mock_root.assert_not_called()
+
+    def test_control_characters_rejected(self):
+        """Null bytes and control characters must be rejected at the guard."""
+        for bad in ["\x00", "a\x00b", "null\x00byte", "a\x01b", "a\x1fb",
+                    "a\x7fb"]:
+            with self.subTest(name=bad):
+                with patch(
+                    "hermes_constants.get_default_hermes_root"
+                ) as mock_root:
+                    self.assertIsNone(_load_profile_identity(bad))
+                    mock_root.assert_not_called()
+
+    def test_extremely_long_names(self):
+        """Extremely long names: an INVALID 5000-char name is rejected at the
+        guard before any filesystem access; a long-but-filename-legal VALID
+        name (240 chars) passes the guard and fails the directory lookup
+        gracefully (None, no crash).
+
+        KNOWN FINDING (not fixed here — production code is out of scope for
+        this card): a VALID name longer than the OS filename limit (~255
+        bytes) raises OSError ENAMETOOLONG from profile_path.is_dir() instead
+        of returning None. Reported in the card summary.
+        """
+        # Invalid-and-huge: rejected at the guard, no filesystem access.
+        with patch("hermes_constants.get_default_hermes_root") as mock_root:
+            self.assertIsNone(_load_profile_identity("a/" * 5000))
+            mock_root.assert_not_called()
+        # Valid and huge but under the filename limit: guard passes, the
+        # nonexistent-directory check returns None — no crash.
+        long_valid = "a" * 240
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "hermes_constants.get_default_hermes_root",
+                return_value=pathlib.Path(tmpdir),
+            ) as mock_root:
+                self.assertIsNone(_load_profile_identity(long_valid))
+            mock_root.assert_called_once()  # guard let it through
+
+    def test_path_separators_rejected_across_platforms(self):
+        """POSIX and Windows separators (and dot/anchor edge cases) are all
+        rejected by the single ASCII-only guard."""
+        for bad in [
+            "/", "\\", "//", "\\\\", "a/b", "a\\b", "..", "../..",
+            "..\\..", "/etc/passwd", "C:\\Windows\\system32",
+            "\\\\server\\share", "a//b", "a\\\\b", "./a", "a/.",
+            "a/", "/a", ".profile", "profile.", "profile name",
+        ]:
+            with self.subTest(name=bad):
+                with patch(
+                    "hermes_constants.get_default_hermes_root"
+                ) as mock_root:
+                    self.assertIsNone(_load_profile_identity(bad))
+                    mock_root.assert_not_called()
+
+    def test_none_and_empty_rejected(self):
+        """None and empty names are rejected at the guard (regex requires 1+)."""
+        with patch("hermes_constants.get_default_hermes_root") as mock_root:
+            self.assertIsNone(_load_profile_identity(None))
+            self.assertIsNone(_load_profile_identity(""))
+            mock_root.assert_not_called()
+
+
+# ── Category 2: Regression — allow_model_selection=false gating ─────────
+
+
+class TestProfileModelGatingRegression(unittest.TestCase):
+    """Regression: allow_model_selection=False must gate model selection even
+    when allow_profile_identity=True exposes profiles (whose config.yaml may
+    name a model). The two flags must stay fully independent."""
+
+    def test_flag_getters_when_model_selection_disabled(self):
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={
+                "allow_profile_identity": True,
+                "allow_model_selection": False,
+            },
+        ):
+            self.assertFalse(_get_allow_model_selection())
+            self.assertTrue(_get_allow_profile_identity())
+
+    def test_schema_has_profile_but_not_model(self):
+        """The core gating regression: profile ON + model OFF must advertise
+        the profile field but NOT the model field — at BOTH the top level and
+        inside the tasks[] item properties."""
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={
+                "allow_profile_identity": True,
+                "allow_model_selection": False,
+            },
+        ):
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertNotIn("model", props)
+        self.assertIn("profile", props)
+        self.assertEqual(props["profile"]["type"], "string")
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertNotIn("model", task_props)
+        self.assertIn("profile", task_props)
+
+    def test_flag_isolation_profile_on_only(self):
+        """Turning the profile flag on must not turn the model flag on."""
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_profile_identity": True},
+        ):
+            self.assertTrue(_get_allow_profile_identity())
+            self.assertFalse(_get_allow_model_selection())
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertIn("profile", props)
+        self.assertNotIn("model", props)
+
+    def test_flag_isolation_model_on_only(self):
+        """Turning the model flag on must not turn the profile flag on."""
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ):
+            self.assertTrue(_get_allow_model_selection())
+            self.assertFalse(_get_allow_profile_identity())
+            ov = _build_dynamic_schema_overrides()
+        props = ov["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertNotIn("profile", props)
+
+    def test_profile_model_ignored_when_model_selection_disabled(self):
+        """Dispatch-level regression: with allow_model_selection=False, a
+        profile's config.yaml model must NOT trigger switch_model. The child
+        inherits the delegation default (parent) model instead, while still
+        receiving the profile identity."""
+        set_spawn_paused(False)
+        parent = _make_mock_parent()
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={
+                "allow_profile_identity": True,
+                "allow_model_selection": False,
+            },
+        ), patch(
+            "tools.delegate_tool._load_profile_identity",
+            return_value=_identity_stub(model="glm-5.3"),
+        ), patch(
+            "hermes_cli.model_switch.switch_model"
+        ) as mock_switch, patch("run_agent.AIAgent") as MockAgent:
+            child = _make_mock_child()
+            MockAgent.return_value = child
+            out = delegate_task(
+                tasks=[{"goal": GOAL, "profile": "devbot"}],
+                parent_agent=parent,
+            )
+        payload = json.loads(out)
+        self.assertNotIn("error", payload)
+        # The profile's model was never resolved through the switch pipeline.
+        mock_switch.assert_not_called()
+        # The child inherits the parent's model, not the profile's model.
+        kwargs = MockAgent.call_args.kwargs
+        self.assertEqual(kwargs["model"], parent.model)
+        # Identity still applied — gating the model does not gate the profile.
+        self.assertIn("You are Devbot", kwargs["ephemeral_system_prompt"])
+        self.assertEqual(child._delegate_profile, "devbot")
+
+
+# ── Category 3: Fallback chain semantics ─────────────────────────────────
+
+
+class TestFallbackChainSemantics(unittest.TestCase):
+    """Fail loudly, never silently inherit."""
+
+    def test_unresolvable_model_raises_value_error(self):
+        """A name the shared model_switch pipeline cannot resolve raises
+        ValueError — no silent fallback to the base model."""
+        creds = _base_creds()
+        with self.assertRaises(ValueError):
+            _resolve_task_model_creds(
+                "zzz-not-a-real-model-xyz", _FakeParent(), creds
+            )
+
+    def test_resolver_message_surfaced_in_value_error(self):
+        """The resolver's error message must reach the caller (per-task error
+        quality), not be swallowed into a generic message."""
+        creds = _base_creds()
+        with patch(
+            "hermes_cli.model_switch.switch_model"
+        ) as mock_switch:
+            mock_switch.return_value = _make_switch_result(
+                success=False, error_message="no such model in catalog"
+            )
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_task_model_creds("bogus", _FakeParent(), creds)
+        self.assertIn("no such model in catalog", str(ctx.exception))
+
+    def test_none_model_name_returns_base_unchanged(self):
+        """None model name is treated as empty — a no-op returning the base
+        creds by identity, with no resolution attempted."""
+        creds = _base_creds()
+        out = _resolve_task_model_creds(None, _FakeParent(), creds)
+        self.assertIs(out, creds)
+
+    def test_empty_model_name_returns_base_unchanged(self):
+        """Empty model name is a no-op (covered elsewhere too; kept here for
+        completeness as the fallback-chain contract)."""
+        creds = _base_creds()
+        out = _resolve_task_model_creds("", _FakeParent(), creds)
+        self.assertIs(out, creds)
+
+    def test_whitespace_model_name_returns_base_unchanged(self):
+        """A whitespace-only name strips to empty and is a no-op."""
+        creds = _base_creds()
+        out = _resolve_task_model_creds("   ", _FakeParent(), creds)
+        self.assertIs(out, creds)
+
+    def test_base_creds_not_mutated_on_failure(self):
+        """Even when resolution fails (ValueError), the base creds dict must
+        be byte-identical to its pre-call state."""
+        creds = _base_creds()
+        before = dict(creds)
+        with patch(
+            "hermes_cli.model_switch.switch_model"
+        ) as mock_switch:
+            mock_switch.return_value = _make_switch_result(
+                success=False, error_message="unknown model"
+            )
+            with self.assertRaises(ValueError):
+                _resolve_task_model_creds("zzz-not-real", _FakeParent(), creds)
+        self.assertEqual(creds, before)
+
+    def test_dispatch_fails_loudly_on_unresolvable_model(self):
+        """delegate_task must surface a per-task error for an unresolvable
+        model instead of silently spawning the child on the default model."""
+        set_spawn_paused(False)
+        parent = _make_mock_parent()
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_model_selection": True},
+        ), patch(
+            "hermes_cli.model_switch.switch_model"
+        ) as mock_switch, patch("run_agent.AIAgent") as MockAgent:
+            mock_switch.return_value = _make_switch_result(
+                success=False, error_message="unknown model"
+            )
+            out = delegate_task(
+                tasks=[{"goal": GOAL, "model": "zzz-bogus-model-xyz"}],
+                parent_agent=parent,
+            )
+        payload = json.loads(out)
+        self.assertIn("error", payload)
+        self.assertIn("could not resolve model", payload["error"])
+        self.assertIn("zzz-bogus-model-xyz", payload["error"])
+        # No child was ever constructed — no silent fallback spawn.
+        MockAgent.assert_not_called()
+
+
+# ── Category 4: Integration with mock child spawns ───────────────────────
+
+
+class TestProfileIdentityIntegration(unittest.TestCase):
+    """delegate_task end-to-end with mocked AIAgent spawns (no real API
+    calls): profile identity threads through to the child system prompt."""
+
+    def setUp(self):
+        set_spawn_paused(False)
+
+    def test_profile_identity_appears_in_child_system_prompt(self):
+        """When a profile is specified, the child's system prompt is built
+        from the profile's SOUL/IDENTITY — not the generic subagent
+        preamble."""
+        parent = _make_mock_parent()
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_profile_identity": True},
+        ), patch(
+            "tools.delegate_tool._load_profile_identity",
+            return_value=_identity_stub(),
+        ), patch("run_agent.AIAgent") as MockAgent:
+            child = _make_mock_child()
+            MockAgent.return_value = child
+            out = delegate_task(
+                tasks=[{"goal": GOAL, "profile": "devbot"}],
+                parent_agent=parent,
+            )
+        payload = json.loads(out)
+        self.assertNotIn("error", payload)
+        kwargs = MockAgent.call_args.kwargs
+        prompt = kwargs["ephemeral_system_prompt"]
+        self.assertIn("You are Devbot", prompt)
+        self.assertIn("Name: Devbot", prompt)
+        self.assertIn(f"YOUR TASK:\n{GOAL}", prompt)
+        self.assertNotIn("You are a focused subagent", prompt)
+        # Identity stashed on the child for usage-ledger attribution.
+        self.assertEqual(child._delegate_profile, "devbot")
+
+    def test_no_profile_uses_generic_preamble(self):
+        """Without a profile, the child gets the generic subagent preamble."""
+        parent = _make_mock_parent()
+        with patch(
+            "tools.delegate_tool._load_config", return_value={}
+        ), patch("run_agent.AIAgent") as MockAgent:
+            child = _make_mock_child()
+            MockAgent.return_value = child
+            out = delegate_task(
+                tasks=[{"goal": GOAL}], parent_agent=parent
+            )
+        payload = json.loads(out)
+        self.assertNotIn("error", payload)
+        prompt = MockAgent.call_args.kwargs["ephemeral_system_prompt"]
+        self.assertIn("You are a focused subagent", prompt)
+        self.assertIn(f"YOUR TASK:\n{GOAL}", prompt)
+        self.assertNotIn("You are Devbot", prompt)
+
+    def test_explicit_model_takes_precedence_over_profile_model(self):
+        """When both profile and model are specified, the explicit task model
+        wins: switch_model runs exactly once, for the task's model — never
+        for the profile's config.yaml model."""
+        parent = _make_mock_parent()
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={
+                "allow_profile_identity": True,
+                "allow_model_selection": True,
+            },
+        ), patch(
+            "tools.delegate_tool._load_profile_identity",
+            return_value=_identity_stub(model="glm-5.3"),
+        ), patch(
+            "hermes_cli.model_switch.switch_model"
+        ) as mock_switch, patch("run_agent.AIAgent") as MockAgent:
+            mock_switch.return_value = _make_switch_result(
+                new_model="gpt-5x", target_provider="openai"
+            )
+            child = _make_mock_child()
+            MockAgent.return_value = child
+            out = delegate_task(
+                tasks=[
+                    {"goal": GOAL, "profile": "devbot", "model": "gpt-5x"}
+                ],
+                parent_agent=parent,
+            )
+        payload = json.loads(out)
+        self.assertNotIn("error", payload)
+        # Resolver ran once, for the EXPLICIT model.
+        self.assertEqual(mock_switch.call_count, 1)
+        self.assertEqual(mock_switch.call_args.kwargs["raw_input"], "gpt-5x")
+        # The child was constructed with the resolved model/provider.
+        kwargs = MockAgent.call_args.kwargs
+        self.assertEqual(kwargs["model"], "gpt-5x")
+        self.assertEqual(kwargs["provider"], "openai")
+        # Profile identity still applied alongside the model switch.
+        self.assertIn("You are Devbot", kwargs["ephemeral_system_prompt"])
+
+    def test_fork_snapshot_attached_to_child(self):
+        """fork=True: the (mocked) parent-transcript snapshot is attached to
+        the child as _fork_history and seeded into run_conversation with the
+        inheritance-framed goal."""
+        parent = _make_mock_parent()
+        fork_snap = [
+            {"role": "user", "content": "earlier parent turn"},
+            {"role": "assistant", "content": "earlier parent answer"},
+        ]
+        with patch(
+            "tools.delegate_tool._load_config", return_value={}
+        ), patch(
+            "tools.delegation_fork.build_fork_snapshot",
+            return_value=fork_snap,
+        ), patch("run_agent.AIAgent") as MockAgent:
+            child = _make_mock_child()
+            MockAgent.return_value = child
+            out = delegate_task(
+                tasks=[{"goal": GOAL, "fork": True}], parent_agent=parent
+            )
+        payload = json.loads(out)
+        self.assertNotIn("error", payload)
+        # Snapshot attached to the child at dispatch time.
+        self.assertEqual(child._fork_history, fork_snap)
+        # Seeded into the child's conversation with the inheritance frame.
+        run_kwargs = child.run_conversation.call_args.kwargs
+        self.assertEqual(run_kwargs.get("conversation_history"), fork_snap)
+        self.assertIn(INHERITANCE_NOTICE, run_kwargs.get("user_message", ""))
+
+    def test_no_fork_no_history_seeded(self):
+        """Without fork, the child runs with a blank context: no
+        conversation_history kwarg at all."""
+        parent = _make_mock_parent()
+        with patch(
+            "tools.delegate_tool._load_config", return_value={}
+        ), patch("run_agent.AIAgent") as MockAgent:
+            child = _make_mock_child()
+            MockAgent.return_value = child
+            out = delegate_task(
+                tasks=[{"goal": GOAL}], parent_agent=parent
+            )
+        payload = json.loads(out)
+        self.assertNotIn("error", payload)
+        run_kwargs = child.run_conversation.call_args.kwargs
+        self.assertNotIn("conversation_history", run_kwargs)
+        self.assertEqual(run_kwargs.get("user_message"), GOAL)
+
+
+class TestLedgerPopulatedAfterDelegation(unittest.TestCase):
+    """The per-delegation usage ledger is populated after a mock delegation
+    completes, carrying the profile attribution column."""
+
+    def setUp(self):
+        set_spawn_paused(False)
+
+    def test_ledger_row_after_mock_delegation(self):
+        parent = _make_mock_parent()
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"allow_profile_identity": True},
+        ), patch(
+            "tools.delegate_tool._load_profile_identity",
+            return_value=_identity_stub(),
+        ), patch("run_agent.AIAgent") as MockAgent:
+            child = _make_mock_child()
+            MockAgent.return_value = child
+            out = delegate_task(
+                tasks=[{"goal": GOAL, "profile": "devbot"}],
+                parent_agent=parent,
+            )
+        payload = json.loads(out)
+        self.assertNotIn("error", payload)
+        self.assertEqual(payload["results"][0]["status"], "completed")
+
+        ledger = parent.session_delegation_usage
+        self.assertEqual(len(ledger), 1)
+        row = ledger[0]
+        self.assertEqual(row["task_index"], 0)
+        self.assertEqual(row["goal"], GOAL)
+        self.assertEqual(row["profile"], "devbot")
+        self.assertEqual(row["role"], "leaf")
+        self.assertEqual(row["status"], "completed")
+        self.assertEqual(row["api_calls"], 2)
+        # The mock child's model is not a str, so the row records None —
+        # matching _run_single_child's isinstance guard.
+        self.assertIsNone(row["model"])
+
+        # Underscore attribution keys must not leak into the model-facing
+        # result entry (popped by _finalize_child_results).
+        entry = payload["results"][0]
+        self.assertNotIn("_child_profile", entry)
+        self.assertNotIn("_child_role", entry)
+        self.assertNotIn("_child_cost_usd", entry)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_delegate_test_gap.py
+++ b/tests/tools/test_delegate_test_gap.py
@@ -14,10 +14,9 @@ Four categories, all test-only (no production changes):
   3. Fallback chain semantics: unresolvable models raise ValueError (fail
      loudly, never silently inherit); None/"" model names are no-ops that
      return the base creds untouched.
-  4. Integration with mock child spawns (the test_delegate_usage_ledger.py
-     pattern): profile identity reaches the child system prompt, no profile
-     uses the generic preamble, explicit model beats the profile model,
-     fork snapshots attach to children, and the usage ledger is populated.
+  4. Integration with mock child spawns: profile identity reaches the child
+     system prompt, no profile uses the generic preamble, and explicit model
+     beats the profile model.
 
 Run with:  python3 -m pytest tests/tools/test_delegate_test_gap.py -v
 """
@@ -42,8 +41,6 @@ from tools.delegate_tool import (
     delegate_task,
     set_spawn_paused,
 )
-from tools.delegation_fork import INHERITANCE_NOTICE
-
 # The exact guard regex _load_profile_identity enforces (delegate_tool.py).
 _SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
@@ -118,7 +115,7 @@ def _make_mock_parent():
     """Mock parent with every field delegate_task / _build_child_agent touch.
 
     Mirrors the established pattern from tests/tools/test_delegate.py's
-    _make_mock_parent plus the ledger fields from test_delegate_usage_ledger.
+    _make_mock_parent.
     """
     parent = MagicMock()
     parent.session_id = "parent-session-gap"
@@ -608,100 +605,6 @@ class TestProfileIdentityIntegration(unittest.TestCase):
         self.assertEqual(kwargs["provider"], "openai")
         # Profile identity still applied alongside the model switch.
         self.assertIn("You are Devbot", kwargs["ephemeral_system_prompt"])
-
-    def test_fork_snapshot_attached_to_child(self):
-        """fork=True: the (mocked) parent-transcript snapshot is attached to
-        the child as _fork_history and seeded into run_conversation with the
-        inheritance-framed goal."""
-        parent = _make_mock_parent()
-        fork_snap = [
-            {"role": "user", "content": "earlier parent turn"},
-            {"role": "assistant", "content": "earlier parent answer"},
-        ]
-        with patch(
-            "tools.delegate_tool._load_config", return_value={}
-        ), patch(
-            "tools.delegation_fork.build_fork_snapshot",
-            return_value=fork_snap,
-        ), patch("run_agent.AIAgent") as MockAgent:
-            child = _make_mock_child()
-            MockAgent.return_value = child
-            out = delegate_task(
-                tasks=[{"goal": GOAL, "fork": True}], parent_agent=parent
-            )
-        payload = json.loads(out)
-        self.assertNotIn("error", payload)
-        # Snapshot attached to the child at dispatch time.
-        self.assertEqual(child._fork_history, fork_snap)
-        # Seeded into the child's conversation with the inheritance frame.
-        run_kwargs = child.run_conversation.call_args.kwargs
-        self.assertEqual(run_kwargs.get("conversation_history"), fork_snap)
-        self.assertIn(INHERITANCE_NOTICE, run_kwargs.get("user_message", ""))
-
-    def test_no_fork_no_history_seeded(self):
-        """Without fork, the child runs with a blank context: no
-        conversation_history kwarg at all."""
-        parent = _make_mock_parent()
-        with patch(
-            "tools.delegate_tool._load_config", return_value={}
-        ), patch("run_agent.AIAgent") as MockAgent:
-            child = _make_mock_child()
-            MockAgent.return_value = child
-            out = delegate_task(
-                tasks=[{"goal": GOAL}], parent_agent=parent
-            )
-        payload = json.loads(out)
-        self.assertNotIn("error", payload)
-        run_kwargs = child.run_conversation.call_args.kwargs
-        self.assertNotIn("conversation_history", run_kwargs)
-        self.assertEqual(run_kwargs.get("user_message"), GOAL)
-
-
-class TestLedgerPopulatedAfterDelegation(unittest.TestCase):
-    """The per-delegation usage ledger is populated after a mock delegation
-    completes, carrying the profile attribution column."""
-
-    def setUp(self):
-        set_spawn_paused(False)
-
-    def test_ledger_row_after_mock_delegation(self):
-        parent = _make_mock_parent()
-        with patch(
-            "tools.delegate_tool._load_config",
-            return_value={"allow_profile_identity": True},
-        ), patch(
-            "tools.delegate_tool._load_profile_identity",
-            return_value=_identity_stub(),
-        ), patch("run_agent.AIAgent") as MockAgent:
-            child = _make_mock_child()
-            MockAgent.return_value = child
-            out = delegate_task(
-                tasks=[{"goal": GOAL, "profile": "devbot"}],
-                parent_agent=parent,
-            )
-        payload = json.loads(out)
-        self.assertNotIn("error", payload)
-        self.assertEqual(payload["results"][0]["status"], "completed")
-
-        ledger = parent.session_delegation_usage
-        self.assertEqual(len(ledger), 1)
-        row = ledger[0]
-        self.assertEqual(row["task_index"], 0)
-        self.assertEqual(row["goal"], GOAL)
-        self.assertEqual(row["profile"], "devbot")
-        self.assertEqual(row["role"], "leaf")
-        self.assertEqual(row["status"], "completed")
-        self.assertEqual(row["api_calls"], 2)
-        # The mock child's model is not a str, so the row records None —
-        # matching _run_single_child's isinstance guard.
-        self.assertIsNone(row["model"])
-
-        # Underscore attribution keys must not leak into the model-facing
-        # result entry (popped by _finalize_child_results).
-        entry = payload["results"][0]
-        self.assertNotIn("_child_profile", entry)
-        self.assertNotIn("_child_role", entry)
-        self.assertNotIn("_child_cost_usd", entry)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1140,6 +1140,115 @@ def _resolve_task_model_creds(model_name: str, parent_agent, base_creds: dict) -
     return creds
 
 
+def _resolve_profile_model_creds(
+    profile_identity: Dict[str, Optional[str]],
+    parent_agent,
+    base_creds: dict,
+) -> dict:
+    """Resolve a profile's config.yaml model (+ provider) to a creds bundle.
+
+    The profile's ``model`` and ``provider`` are ONE routing unit (P1 #2):
+    when BOTH are configured, the model resolves against the PROFILE's
+    provider — not the parent/delegation provider — so a parent on provider
+    A running a profile configured for provider B actually lands on B (the
+    right endpoint, credentials, and billing) instead of silently resolving
+    the name against A's catalog.
+
+    Resolution precedence:
+
+    1. Profile model + provider → full runtime-provider resolution anchored
+       on the profile's provider (same system the ``delegation.provider``
+       pin uses, so base_url/api_key/api_mode/request_overrides all come
+       from the profile's provider, not the parent's).
+    2. Profile model only → ``_resolve_task_model_creds`` against the
+       parent/delegation anchor (prior behavior, unchanged).
+    3. Neither → ``base_creds`` untouched.
+
+    Raises ValueError with a user-facing message when the profile's
+    provider cannot be resolved or has no API key — a misconfigured profile
+    must fail the dispatch loudly, never silently fall back to the parent's
+    credentials on a provider the user explicitly moved away from.
+    """
+    profile_model = str(profile_identity.get("model") or "").strip()
+    profile_provider = str(profile_identity.get("provider") or "").strip()
+    if not profile_model:
+        return base_creds
+    if not profile_provider:
+        # No provider in the profile config — resolve the model name
+        # against the parent/delegation anchor (prior behavior).
+        return _resolve_task_model_creds(profile_model, parent_agent, base_creds)
+
+    # Both model and provider: resolve as one routing unit against the
+    # profile's provider.
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested=profile_provider, target_model=profile_model
+        )
+    except Exception as exc:
+        raise ValueError(
+            f"profile provider '{profile_provider}' could not be resolved: {exc}. "
+            f"Check that the provider is configured (API key set, valid provider "
+            f"name) in the profile's config.yaml."
+        ) from exc
+
+    runtime_api_key = runtime.get("api_key", "")
+    if not runtime_api_key:
+        raise ValueError(
+            f"profile provider '{profile_provider}' resolved but has no API "
+            f"key. Set the appropriate environment variable or run 'hermes "
+            f"auth' so the profile's provider can be used."
+        )
+
+    creds = dict(base_creds)
+    # The profile's explicitly configured model wins over the provider's
+    # own default (same precedence as the delegation.provider pin).
+    creds["model"] = profile_model or runtime.get("model")
+    runtime_provider_name = runtime.get("provider")
+    creds["provider"] = (
+        profile_provider
+        if runtime_provider_name == _RUNTIME_PROVIDER_CUSTOM
+        else (runtime_provider_name or profile_provider)
+    )
+    creds["base_url"] = runtime.get("base_url")
+    creds["api_key"] = runtime_api_key
+    creds["api_mode"] = runtime.get("api_mode")
+    creds["request_overrides"] = runtime.get("request_overrides") or {}
+    creds["max_output_tokens"] = runtime.get("max_output_tokens")
+    # Cross-provider switch: stale ACP/pin fields carried over from the
+    # base bundle would force _build_child_agent back onto the pinned
+    # transport (and its copilot-acp provider override), silently rerouting
+    # the child away from the profile's provider. Replace them with the
+    # profile provider's own runtime values (same clearing pattern as
+    # _resolve_task_model_creds applies to provider-scoped fields).
+    creds["command"] = runtime.get("command")
+    creds["args"] = list(runtime.get("args") or [])
+    return creds
+
+
+def _validate_profile_name(name: Optional[str]) -> bool:
+    """Validate a profile name before ANY filesystem access.
+
+    Two controls, both required before ``profile_path.is_dir()`` can ever run:
+
+    1. ``^[A-Za-z0-9_-]+$`` — path-traversal guard (e.g. ``../../.ssh``
+       can never match, so the name can't escape the profiles root).
+    2. Length <= 255 — filesystem component limit. A regex-valid name
+       longer than the limit would raise ``OSError: ENAMETOOLONG`` from
+       the directory probe below, so it is rejected here instead.
+    """
+    import re
+
+    if not isinstance(name, str):
+        return False
+    if not re.match(r"^[A-Za-z0-9_-]+$", name):
+        return False
+    if len(name) > 255:
+        return False
+    return True
+
+
 def _load_profile_identity(profile_name: str) -> Optional[Dict[str, Optional[str]]]:
     """Load a named Hermes profile's identity files and model config.
 
@@ -1147,18 +1256,28 @@ def _load_profile_identity(profile_name: str) -> Optional[Dict[str, Optional[str
     and config reads are best-effort so a partial or malformed profile still
     spawns with whichever identity data is available.
 
-    The ``profile_name`` is validated against ``^[A-Za-z0-9_-]+$`` to prevent
-    path traversal (e.g. ``../../.ssh``) from escaping the profiles root.
+    The ``profile_name`` is validated by ``_validate_profile_name`` (regex +
+    length) to prevent path traversal (e.g. ``../../.ssh``) and
+    ENAMETOOLONG filesystem errors.
     """
-    import re
-
-    if not re.match(r"^[A-Za-z0-9_-]+$", profile_name or ""):
+    if not _validate_profile_name(profile_name):
         return None
 
     from hermes_constants import get_default_hermes_root
 
     profile_path = get_default_hermes_root() / "profiles" / profile_name
-    if not profile_path.is_dir():
+    try:
+        if not profile_path.is_dir():
+            return None
+    except OSError:
+        # ENAMETOOLONG and friends: the guard above already rejects the
+        # known-bad shapes, but a hostile filesystem (or an OS with a
+        # smaller component limit) can still raise here — degrade to
+        # "profile not found" instead of crashing the delegation call.
+        logger.debug(
+            "profile_path.is_dir() raised for %r; treating as not found",
+            profile_name,
+        )
         return None
 
     result: Dict[str, Optional[str]] = {
@@ -1167,6 +1286,10 @@ def _load_profile_identity(profile_name: str) -> Optional[Dict[str, Optional[str
         "agents": None,
         "model": None,
         "provider": None,
+        # The validated name, so downstream consumers (child construction,
+        # usage attribution) don't have to re-derive it from the caller's
+        # task dict.
+        "_profile_name": profile_name,
     }
     for key, filename in (
         ("soul", "SOUL.md"),
@@ -2267,6 +2390,11 @@ def _build_child_agent(
     # Stash the post-degrade role for introspection (leaf if the
     # kill switch or depth bounded the caller's requested role).
     child._delegate_role = effective_role
+    # Stash the delegated profile name for downstream attribution
+    # (usage ledger, registry display). Reads the validated name the
+    # dispatcher stored in the identity dict — never the raw task field.
+    if profile_identity and profile_identity.get("_profile_name"):
+        child._delegate_profile = profile_identity["_profile_name"]
     # Stash subagent identity for nested-delegation event propagation and
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id
@@ -4115,6 +4243,17 @@ def delegate_task(
     children = []
     allow_model_selection = _get_allow_model_selection()
     allow_profile_identity = _get_allow_profile_identity()
+
+    # ── Pass 1: atomic preflight ─────────────────────────────────────────
+    # Resolve EVERY task's model/profile/credentials into immutable plans
+    # BEFORE any child is constructed. If any task fails resolution, the
+    # whole batch is refused with zero children built — a mid-batch failure
+    # can never orphan an already-constructed child (SessionDB handle open,
+    # registered in _active_children, live transcript created) with no
+    # cleanup path. Construction (Pass 2) is then all-or-nothing by
+    # construction: it consumes pre-resolved plans and does no I/O that can
+    # fail per-task model/profile resolution.
+    task_plans: List[Dict[str, Any]] = []
     for i, t in enumerate(task_list):
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
@@ -4162,19 +4301,46 @@ def delegate_task(
                     f"profiles/{_profile_name}/."
                 )
             # Profile config fills missing model/provider when the task
-            # doesn't explicitly override them.
+            # doesn't explicitly override them. The profile's model and
+            # provider are one routing unit (P1 #2): resolve against the
+            # PROFILE's provider, never the parent's.
             if not task_model_request:
                 _profile_model = _profile_identity.get("model")
                 if _profile_model and allow_model_selection:
                     try:
-                        task_creds = _resolve_task_model_creds(
-                            _profile_model, parent_agent, creds
+                        task_creds = _resolve_profile_model_creds(
+                            _profile_identity, parent_agent, creds
                         )
                     except ValueError as exc:
                         return tool_error(
                             f"Task {i}: profile '{_profile_name}' model "
                             f"'{_profile_model}' could not be resolved: {exc}"
                         )
+
+        task_plans.append(
+            {
+                "index": i,
+                "task": t,
+                "role": effective_role,
+                "context": _child_context,
+                "schema": _task_schema,
+                "creds": task_creds,
+                "profile_identity": _profile_identity,
+            }
+        )
+
+    # ── Pass 2: construction ─────────────────────────────────────────────
+    # Consume the pre-resolved plans. No model resolution or profile loading
+    # happens here, so a resolution failure can never strike after some
+    # children already exist.
+    for plan in task_plans:
+        i = plan["index"]
+        t = plan["task"]
+        effective_role = plan["role"]
+        _child_context = plan["context"]
+        _task_schema = plan["schema"]
+        task_creds = plan["creds"]
+        _profile_identity = plan["profile_identity"]
 
         try:
             child = _build_child_preserving_parent_tools(

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1035,6 +1035,10 @@ def _get_inherit_mcp_toolsets() -> bool:
 def _get_allow_model_selection() -> bool:
     """Whether delegate_task tasks may carry a per-task ``model`` field.
 
+    Ported (adapted) from Kilo-Org/kilocode#11786. Config key and
+    resolver name match the upstream kilocode-port branch so the two
+    implementations converge on a single design.
+
     Config key: delegation.allow_model_selection (bool, default False).
     Off by default — subagents inherit the parent model unless the user opts
     in, since per-task model routing can send work to a more expensive model
@@ -1058,6 +1062,12 @@ def _get_allow_profile_identity() -> bool:
 
 def _resolve_task_model_creds(model_name: str, parent_agent, base_creds: dict) -> dict:
     """Resolve a per-task model NAME to a full credential bundle.
+
+    Ported (adapted) from Kilo-Org/kilocode#11786. Our version adds two
+    fixes over the upstream kilocode-port branch: (1) provider anchoring
+    on the effective delegation provider from base_creds (not the parent
+    agent's provider), and (2) clearing stale ACP/pin fields on
+    cross-provider switches.
 
     Reuses the existing aggregator-aware ``model_switch.switch_model()``
     pipeline (the same resolution chain the ``/model`` command uses) so name

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1136,7 +1136,15 @@ def _load_profile_identity(profile_name: str) -> Optional[Dict[str, Optional[str
     Returns ``None`` when the named profile directory does not exist. All file
     and config reads are best-effort so a partial or malformed profile still
     spawns with whichever identity data is available.
+
+    The ``profile_name`` is validated against ``^[A-Za-z0-9_-]+$`` to prevent
+    path traversal (e.g. ``../../.ssh``) from escaping the profiles root.
     """
+    import re
+
+    if not re.match(r"^[A-Za-z0-9_-]+$", profile_name or ""):
+        return None
+
     from hermes_constants import get_default_hermes_root
 
     profile_path = get_default_hermes_root() / "profiles" / profile_name

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1032,6 +1032,156 @@ def _get_inherit_mcp_toolsets() -> bool:
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
+def _get_allow_model_selection() -> bool:
+    """Whether delegate_task tasks may carry a per-task ``model`` field.
+
+    Config key: delegation.allow_model_selection (bool, default False).
+    Off by default — subagents inherit the parent model unless the user opts
+    in, since per-task model routing can send work to a more expensive model
+    than expected.
+    """
+    cfg = _load_config()
+    return is_truthy_value(cfg.get("allow_model_selection"), default=False)
+
+
+def _get_allow_profile_identity() -> bool:
+    """Whether delegate_task tasks may carry a per-task ``profile`` field.
+
+    Config key: delegation.allow_profile_identity (bool, default False).
+    Off by default — subagents use a generic identity unless the user opts in,
+    since loading arbitrary profile files into a child prompt is a trust
+    boundary that should be deliberate.
+    """
+    cfg = _load_config()
+    return is_truthy_value(cfg.get("allow_profile_identity"), default=False)
+
+
+def _resolve_task_model_creds(model_name: str, parent_agent, base_creds: dict) -> dict:
+    """Resolve a per-task model NAME to a full credential bundle.
+
+    Reuses the existing aggregator-aware ``model_switch.switch_model()``
+    pipeline (the same resolution chain the ``/model`` command uses) so name
+    matching, vendor/model slug conversion, fuzzy aliasing, and
+    cross-provider fallback all come for free instead of being reinvented
+    here.
+
+    Resolution anchors on the parent agent's current provider/credentials, so
+    a bare name like "opus" stays on the parent's aggregator when available.
+    On failure, raises ValueError with the resolver's message so the caller
+    can surface a clear per-task error rather than silently falling back to
+    the default model (which would mask the agent's intent).
+
+    Returns a creds dict shaped like ``_resolve_delegation_credentials`` output
+    (model / provider / base_url / api_key / api_mode), starting from
+    ``base_creds`` and overriding only the fields the switch resolves.
+    """
+    name = (model_name or "").strip()
+    if not name:
+        return base_creds
+
+    from hermes_cli.model_switch import switch_model
+
+    parent_provider = getattr(parent_agent, "provider", "") or ""
+    parent_model = getattr(parent_agent, "model", "") or ""
+    parent_base_url = getattr(parent_agent, "base_url", "") or ""
+    parent_api_key = getattr(parent_agent, "api_key", "") or ""
+
+    user_providers = {}
+    custom_providers = None
+    try:
+        from cli import CLI_CONFIG
+
+        user_providers = CLI_CONFIG.get("providers") or {}
+        custom_providers = CLI_CONFIG.get("custom_providers")
+    except Exception:
+        try:
+            from hermes_cli.config import load_config
+
+            _full = load_config()
+            user_providers = _full.get("providers") or {}
+            custom_providers = _full.get("custom_providers")
+        except Exception:
+            pass
+
+    result = switch_model(
+        raw_input=name,
+        current_provider=parent_provider,
+        current_model=parent_model,
+        current_base_url=parent_base_url,
+        current_api_key=parent_api_key,
+        is_global=False,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+
+    if not result.success:
+        raise ValueError(
+            result.error_message
+            or f"Could not resolve model '{name}' for this subagent."
+        )
+
+    creds = dict(base_creds)
+    creds["model"] = result.new_model or creds.get("model")
+    if result.target_provider and result.target_provider != parent_provider:
+        creds["provider"] = result.target_provider
+        creds["base_url"] = result.base_url or None
+        creds["api_key"] = result.api_key or None
+        creds["api_mode"] = result.api_mode or None
+    return creds
+
+
+def _load_profile_identity(profile_name: str) -> Optional[Dict[str, Optional[str]]]:
+    """Load a named Hermes profile's identity files and model config.
+
+    Returns ``None`` when the named profile directory does not exist. All file
+    and config reads are best-effort so a partial or malformed profile still
+    spawns with whichever identity data is available.
+    """
+    from hermes_constants import get_default_hermes_root
+
+    profile_path = get_default_hermes_root() / "profiles" / profile_name
+    if not profile_path.is_dir():
+        return None
+
+    result: Dict[str, Optional[str]] = {
+        "soul": None,
+        "identity": None,
+        "agents": None,
+        "model": None,
+        "provider": None,
+    }
+    for key, filename in (
+        ("soul", "SOUL.md"),
+        ("identity", "IDENTITY.md"),
+        ("agents", "AGENTS.md"),
+    ):
+        try:
+            content = (profile_path / filename).read_text(encoding="utf-8").strip()
+            result[key] = content or None
+        except Exception:
+            pass
+
+    try:
+        import yaml
+
+        config = yaml.safe_load(
+            (profile_path / "config.yaml").read_text(encoding="utf-8")
+        )
+        model_cfg = config.get("model", {}) if isinstance(config, dict) else {}
+        if isinstance(model_cfg, dict):
+            for key, config_key in (
+                ("model", "default"),
+                ("provider", "provider"),
+            ):
+                value = model_cfg.get(config_key)
+                if isinstance(value, str) and value.strip():
+                    result[key] = value
+    except Exception:
+        pass
+
+    return result
+
+
 def _is_mcp_toolset_name(name: str) -> bool:
     """Return True for canonical MCP toolsets and their registered aliases."""
     if not name:
@@ -1178,20 +1328,46 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    profile_identity: Optional[Dict[str, Optional[str]]] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
-    When role='orchestrator', appends a delegation-capability block
-    modeled on OpenClaw's buildSubagentSystemPrompt (canSpawn branch at
-    inspiration/openclaw/src/agents/subagent-system-prompt.ts:63-95).
+    When ``profile_identity`` is provided (from a per-task ``profile`` field),
+    the child's identity comes from that profile's SOUL.md, IDENTITY.md, and
+    AGENTS.md files instead of the generic subagent preamble. This lets a
+    delegation task spawn a child that "becomes" a named bot (e.g. a code
+    reviewer, a test validator) rather than a generic leaf.
+
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
     """
-    parts = [
-        "You are a focused subagent working on a specific delegated task.",
-        "",
-        f"YOUR TASK:\n{goal}",
-    ]
+    if profile_identity and (
+        profile_identity.get("soul") or profile_identity.get("identity")
+    ):
+        parts = [
+            value
+            for value in (
+                profile_identity.get("soul"),
+                profile_identity.get("identity"),
+                profile_identity.get("agents"),
+            )
+            if value
+        ]
+        parts.append(f"\nYOUR TASK:\n{goal}")
+    else:
+        if profile_identity:
+            logger.warning(
+                "Profile has no SOUL.md or IDENTITY.md; using generic child identity."
+            )
+        parts = [
+            "You are a focused subagent working on a specific delegated task.",
+            "",
+        ]
+        if profile_identity:
+            agents_content = profile_identity.get("agents")
+            if agents_content:
+                parts.append(agents_content)
+        parts.append(f"YOUR TASK:\n{goal}")
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -1646,6 +1822,8 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Per-task profile identity files, loaded by delegate_task before child construction.
+    profile_identity: Optional[Dict[str, Optional[str]]] = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1759,6 +1937,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        profile_identity=profile_identity,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -3672,6 +3851,8 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
+    profile: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
     action: Optional[str] = None,
@@ -3812,6 +3993,10 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
+        if model:
+            single_task["model"] = model
+        if profile:
+            single_task["profile"] = profile
         if output_schema is not None:
             single_task["output_schema"] = output_schema
         task_list = [single_task]
@@ -3910,6 +4095,8 @@ def delegate_task(
     # toolset resolution never leaks into the parent (shared with the plugin
     # subagent-lifecycle API).
     children = []
+    allow_model_selection = _get_allow_model_selection()
+    allow_profile_identity = _get_allow_profile_identity()
     for i, t in enumerate(task_list):
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
@@ -3922,6 +4109,55 @@ def delegate_task(
             from tools.delegation_output_schema import append_output_contract
 
             _child_context = append_output_contract(_child_context, _task_schema)
+
+        # Per-task model selection (gated behind delegation.allow_model_selection).
+        # When enabled and a task names a model, resolve it leniently via the
+        # shared model_switch pipeline; otherwise fall back to the delegation
+        # default creds. The flag-off path is byte-identical to prior behavior.
+        task_creds = creds
+        task_model_request = (t.get("model") or "").strip() if isinstance(t, dict) else ""
+        if task_model_request and allow_model_selection:
+            try:
+                task_creds = _resolve_task_model_creds(
+                    task_model_request, parent_agent, creds
+                )
+            except ValueError as exc:
+                return tool_error(
+                    f"Task {i}: could not resolve model "
+                    f"'{task_model_request}': {exc}"
+                )
+
+        # Per-task profile identity (gated behind delegation.allow_profile_identity).
+        # When enabled and a task names a profile, load its SOUL.md,
+        # IDENTITY.md, AGENTS.md, and model/provider config so the child
+        # becomes that bot rather than a generic subagent. The profile's
+        # model/provider can also serve as a fallback when the task does not
+        # explicitly name a model.
+        _profile_identity = None
+        _profile_name = (t.get("profile") or "").strip() if isinstance(t, dict) else ""
+        if _profile_name and allow_profile_identity:
+            _profile_identity = _load_profile_identity(_profile_name)
+            if _profile_identity is None:
+                return tool_error(
+                    f"Task {i}: profile '{_profile_name}' not found. Check "
+                    f"that it exists under the Hermes profiles root as "
+                    f"profiles/{_profile_name}/."
+                )
+            # Profile config fills missing model/provider when the task
+            # doesn't explicitly override them.
+            if not task_model_request:
+                _profile_model = _profile_identity.get("model")
+                if _profile_model and allow_model_selection:
+                    try:
+                        task_creds = _resolve_task_model_creds(
+                            _profile_model, parent_agent, creds
+                        )
+                    except ValueError as exc:
+                        return tool_error(
+                            f"Task {i}: profile '{_profile_name}' model "
+                            f"'{_profile_model}' could not be resolved: {exc}"
+                        )
+
         try:
             child = _build_child_preserving_parent_tools(
                 task_index=i,
@@ -3930,18 +4166,19 @@ def delegate_task(
                 # Subagents always inherit the parent's toolsets; the model
                 # cannot choose or narrow them (no model-facing toolsets arg).
                 toolsets=None,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_request_overrides=creds.get("request_overrides"),
-                override_max_tokens=creds.get("max_output_tokens"),
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
+                override_request_overrides=task_creds.get("request_overrides"),
+                override_max_tokens=task_creds.get("max_output_tokens"),
+                override_acp_command=task_creds.get("command"),
+                override_acp_args=task_creds.get("args"),
+                profile_identity=_profile_identity,
                 role=effective_role,
             )
         except ValueError as exc:
@@ -4872,7 +5109,8 @@ def _build_top_level_description() -> str:
         "yourself before telling the user the operation succeeded.\n"
         + restrictions_rule +
         "- Children inherit the parent model unless pinned via "
-        "delegation.provider / delegation.model in config.yaml."
+        "delegation.provider / delegation.model in config.yaml, or routed "
+        "per-task via the optional model/profile fields (when enabled)."
     )
 
 
@@ -4926,6 +5164,58 @@ def _build_dynamic_schema_overrides() -> dict:
         k: dict(v) for k, v in DELEGATE_TASK_SCHEMA["parameters"]["properties"].items()
     }
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
+
+    # Per-task model selection and profile identity. Only advertise these
+    # fields to the model when the user has opted in via
+    # delegation.allow_model_selection / delegation.allow_profile_identity —
+    # otherwise the schema is byte-identical to prior behavior, preserving the
+    # "subagents inherit the parent model" contract. The flags are stable
+    # per-session config values, so toggling between sessions (not
+    # mid-conversation) keeps prompt caching valid.
+    _opt_model = _get_allow_model_selection()
+    _opt_profile = _get_allow_profile_identity()
+    if _opt_model or _opt_profile:
+        import copy as _copy
+
+        _tasks_prop = _copy.deepcopy(overrides_params["properties"]["tasks"])
+        if _opt_model:
+            _model_prop = {
+                "type": "string",
+                "description": (
+                    "Optional model for this subagent (e.g. 'opus', 'gpt-5', "
+                    "'glm', or a full 'vendor/model' slug). Names are matched "
+                    "leniently and resolved to a concrete provider "
+                    "automatically, preferring your current provider. Omit "
+                    "to inherit the parent model."
+                ),
+            }
+            overrides_params["properties"]["model"] = dict(_model_prop)
+            _tasks_prop["items"]["properties"]["model"] = dict(_model_prop)
+            _tasks_prop["items"]["properties"]["model"]["description"] = (
+                "Optional per-task model (e.g. 'opus', 'gpt-5', 'glm', or a "
+                "'vendor/model' slug). Resolved leniently; omit to inherit "
+                "the parent model."
+            )
+        if _opt_profile:
+            _profile_prop = {
+                "type": "string",
+                "description": (
+                    "Optional Hermes profile name for this subagent. When "
+                    "set, the child loads that profile's SOUL.md, "
+                    "IDENTITY.md, and AGENTS.md as its system prompt "
+                    "identity, and reads model/provider from its "
+                    "config.yaml when not explicitly overridden. The child "
+                    "becomes the named bot, not a generic subagent."
+                ),
+            }
+            overrides_params["properties"]["profile"] = dict(_profile_prop)
+            _tasks_prop["items"]["properties"]["profile"] = dict(_profile_prop)
+            _tasks_prop["items"]["properties"]["profile"]["description"] = (
+                "Optional per-task Hermes profile name. The child loads that "
+                "profile's identity files and model config, becoming the "
+                "named bot rather than a generic subagent."
+            )
+        overrides_params["properties"]["tasks"] = _tasks_prop
 
     return {
         "description": _build_top_level_description(),
@@ -5093,6 +5383,8 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        model=args.get("model"),
+        profile=args.get("profile"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
         action=args.get("action"),

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -502,6 +502,8 @@ delegation:
   # worktree_isolation: false               # Give each child its own git worktree (see Worktree Isolation above)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
+  # allow_model_selection: false            # Let the agent pick a per-task model when fanning out (default: false)
+  # allow_profile_identity: false           # Let the agent name a per-task Hermes profile so the child becomes that bot (default: false)
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints
@@ -528,6 +530,32 @@ delegation:
 When `base_url` points at an Anthropic-compatible endpoint — for example a path ending in `/anthropic`, an Azure Foundry Claude route, or a MiniMax `/anthropic` proxy — `api_mode` is auto-detected as `anthropic_messages` so the subagent uses the right wire format without you setting anything. Set `api_mode` explicitly when the auto-detection guess is wrong (rare).
 
 `delegation.request_overrides` works on **all three** resolution branches — direct `base_url`, named `provider`, and pure inherit — so it always takes effect. Top-level keys are API kwargs (e.g. `service_tier`); an `extra_body` sub-dict is merged into the request's `extra_body`. Explicit values merge **over** runtime- or parent-derived overrides: explicit top-level keys win, and `extra_body` is deep-merged one level, so a provider's own request personality (e.g. `thinking: {type: disabled}`) survives unless your key redefines it. See [Configuration → Delegation](../configuration.md#delegation) for details.
+
+### Per-task model selection
+
+By default every subagent inherits the parent's model (or `delegation.model` if set). Set `allow_model_selection: true` to let the agent name a model **per task** when it fans work out — for example, reviewing the same code with several models in parallel:
+
+```yaml
+delegation:
+  allow_model_selection: true
+```
+
+With the flag on, `delegate_task` gains an optional `model` field (on both the single-goal call and each entry in a `tasks` batch). The agent names a model the way a human would — `"opus"`, `"gpt-5"`, `"glm"`, or a full `"vendor/model"` slug — and Hermes resolves it leniently through the same pipeline as the `/model` command: the **provider is resolved, not dictated**, preferring whatever provider backs your current model. Unresolvable names return a clear per-task error instead of silently falling back to the default model.
+
+The flag is off by default because per-task routing can send work to a more expensive model than you expect, and because the schema field only appears when you opt in (keeping the tool surface minimal otherwise).
+
+### Per-task profile identity
+
+Set `allow_profile_identity: true` to let the agent name a **Hermes profile** per task. When a task carries a `profile` field, the child loads that profile's `SOUL.md`, `IDENTITY.md`, and `AGENTS.md` as its system prompt identity, and reads `model`/`provider` from its `config.yaml` when the task doesn't explicitly override them. The child "becomes" the named bot rather than a generic subagent.
+
+```yaml
+delegation:
+  allow_profile_identity: true
+```
+
+This is useful for multi-role workflows where a single `delegate_task` batch dispatches specialized bots — for example, a code reviewer profile, a test validator profile, and a security auditor profile — each with its own identity, rules, and model configuration.
+
+The flag is off by default because loading arbitrary profile files into a child prompt is a trust boundary that should be deliberate. Both flags can be combined: a task can name both a `model` and a `profile`, with the explicit model taking precedence over the profile's config.
 
 :::tip
 The agent handles delegation automatically based on the task complexity. You don't need to explicitly ask it to delegate — it will do so when it makes sense.

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -544,6 +544,8 @@ With the flag on, `delegate_task` gains an optional `model` field (on both the s
 
 The flag is off by default because per-task routing can send work to a more expensive model than you expect, and because the schema field only appears when you opt in (keeping the tool surface minimal otherwise).
 
+This feature shares a common origin with the [kilocode-port](https://github.com/NousResearch/hermes-agent/tree/kilocode-port/per-task-delegation-model) branch (Kilo-Org/kilocode#11786). Both implementations use the same config key (`allow_model_selection`), resolver function (`_resolve_task_model_creds`), and `switch_model()` pipeline. This fork's version adds provider-anchoring fixes, stale ACP field clearing, and integrates with per-task profile identity.
+
 ### Per-task profile identity
 
 Set `allow_profile_identity: true` to let the agent name a **Hermes profile** per task. When a task carries a `profile` field, the child loads that profile's `SOUL.md`, `IDENTITY.md`, and `AGENTS.md` as its system prompt identity, and reads `model`/`provider` from its `config.yaml` when the task doesn't explicitly override them. The child "becomes" the named bot rather than a generic subagent.

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -555,7 +555,7 @@ delegation:
 
 This is useful for multi-role workflows where a single `delegate_task` batch dispatches specialized bots — for example, a code reviewer profile, a test validator profile, and a security auditor profile — each with its own identity, rules, and model configuration.
 
-The flag is off by default because loading arbitrary profile files into a child prompt is a trust boundary that should be deliberate. Both flags can be combined: a task can name both a `model` and a `profile`, with the explicit model taking precedence over the profile's config.
+The flag is off by default because loading arbitrary profile files into a child prompt is a trust boundary that should be deliberate. Both flags can be combined: a task can name both a `model` and a `profile`, with the explicit model taking precedence over the profile's config. Note that a profile's `config.yaml` model/provider fallback only applies when `allow_model_selection` is also `true`, since the model resolution pipeline is needed to resolve the profile's model to concrete credentials.
 
 :::tip
 The agent handles delegation automatically based on the task complexity. You don't need to explicitly ask it to delegate — it will do so when it makes sense.


### PR DESCRIPTION
## Summary

- **Per-task model selection**: each task in a `delegate_task` batch can name a model ("opus", "gpt-5", "glm", or a full "vendor/model" slug), resolved leniently through the existing `model_switch` pipeline (same as `/model`). Provider is resolved, not dictated.
- **Per-task profile identity**: each task can name a Hermes profile; the child loads that profile's `SOUL.md`, `IDENTITY.md`, and `AGENTS.md` as its system prompt, and reads model/provider from its `config.yaml` when not explicitly overridden. The child becomes the named bot rather than a generic subagent.
- Both features are **config-gated** (default off) so the existing subagent contract is unchanged when the flags are off. Schema fields only appear when the corresponding flag is enabled.

## Motivation

Multi-role workflows (e.g. dispatching a code reviewer, test validator, and security auditor in one `delegate_task` batch) currently require every child to run on the same model with the same generic identity. This PR adds two independent opt-in capabilities:

1. **Model routing** lets the agent fan work across different models in a single batch -- useful for comparing results across models, or routing specialized work to specialized models.

2. **Profile identity** lets each child adopt a named profile's identity files and model config, so a delegation batch can dispatch specialized bots with their own personas, rules, and model configurations.

Both flags are off by default because:
- Per-task model routing can send work to a more expensive model than expected.
- Loading arbitrary profile files into a child prompt is a trust boundary that should be deliberate.
- The schema fields only appear when opted in, keeping the tool surface minimal otherwise.

The model selection feature overlaps conceptually with the `kilocode-port/per-task-delegation-model` branch, but this PR takes a different approach: it adds profile identity as a complementary feature and uses a unified code path. Happy to coordinate if there's interest in merging the approaches.

## Changes

- `tools/delegate_tool.py`:
  - `_get_allow_model_selection()` / `_get_allow_profile_identity()`: config-gated flag getters
  - `_resolve_task_model_creds()`: resolves a per-task model name via `model_switch.switch_model()` (reuses the `/model` command's resolution pipeline)
  - `_load_profile_identity()`: loads a named profile's `SOUL.md`, `IDENTITY.md`, `AGENTS.md`, and `config.yaml` model/provider
  - `_build_child_system_prompt()`: accepts optional `profile_identity` to replace the generic subagent preamble with the profile's identity files
  - `_build_child_agent()`: passes `profile_identity` through to the system prompt builder
  - `delegate_task()`: accepts `model` and `profile` params; per-task resolution in the child loop (gated)
  - `_build_dynamic_schema_overrides()`: adds `model`/`profile` fields only when the corresponding flag is on; deep-copies tasks schema to avoid mutating the static schema
  - Registry handler passes `model`/`profile` through
- `hermes_cli/config_defaults.py`: adds `allow_model_selection` and `allow_profile_identity` defaults (both `False`)
- `website/docs/user-guide/features/delegation.md`: documents both features with config examples
- `tests/tools/test_delegate_per_task_overrides.py`: 17 tests covering schema gating, flag getters, model resolution, profile identity loading, and system prompt construction

## Test Plan

- [x] 17 new tests pass (`python3 -m pytest tests/tools/test_delegate_per_task_overrides.py -v`)
- [x] 70 existing delegate tests pass (no regressions: `python3 -m pytest tests/tools/test_delegate.py -v`)
- [x] Syntax checks pass for all modified files
- [ ] CI passes on GitHub Actions

## Notes for Reviewers

- The flag-off path is byte-identical to prior behavior -- no schema changes, no code path changes when both flags are `False`.
- The `_resolve_task_model_creds` function reuses the existing `model_switch.switch_model()` pipeline rather than reinventing model resolution, so aggregator-aware aliasing, fuzzy matching, and cross-provider fallback all come for free.
- The profile identity feature is the unique contribution not present in the `kilocode-port/per-task-delegation-model` branch. Both features can be combined: a task can name both `model` and `profile`, with the explicit model taking precedence over the profile's config.
- The dynamic schema override deep-copies the tasks property before adding per-task fields, so `DELEGATE_TASK_SCHEMA` is never mutated.