### PR TITLE
fix(ci): bind label reruns to trusted run evidence

### DIFF
--- a/.github/workflows/label-rerun.yml
+++ b/.github/workflows/label-rerun.yml
@@ -1,23 +1,15 @@
 name: Label rerun
 
-# When the ``ci-reviewed`` label is added to a PR, rerun all failed jobs in
-# the latest CI run. This re-evaluates ``review-labels`` (which now sees the
-# label) and GitHub reruns the dependent ``all-checks-pass`` gate.
-#
-# ``gh run rerun`` only works on a completed run. Thus this waits when the
-# run is still in progress. The wait is now short. The two slowest jobs are
-# the 40-minute comment poller and the 45-minute image build. Each one moved
-# to its own workflow, so a CI run ends when its required jobs end.
-#
-# The review comment updates without help. The poller in
-# ci-review-comment.yml watches the CI run through the API. It gets the
-# rerun results.
+# Trusted control-plane workflow. The workflow and checkout are pinned to the
+# pull request base; the PR head is used only as an API data selector.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 permissions:
+  contents: read
+  checks: read
   actions: write
   pull-requests: read
 
@@ -30,58 +22,29 @@ jobs:
     name: Rerun review-labels job
     if: github.event.label.name == 'ci-reviewed'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 15
     steps:
-      - name: Wait for CI run to finish, then rerun failed jobs
+      - name: Checkout trusted pull request base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Read exact provider state and rerun when eligible
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          WORKFLOW_FILE: ci.yaml
+          REQUIRED_CONTEXT: All required checks pass
         run: |
-          set -uo pipefail
-
-          # Find the latest CI run for this PR's head SHA.
-          RUN_INFO=$(gh run list \
+          set -euo pipefail
+          python3 scripts/ci/pipeline_state.py \
             --repo "$REPO" \
-            --commit "$HEAD_SHA" \
-            --workflow ci.yaml \
-            --limit 1 \
-            --json databaseId,status \
-            --jq '.[0] | "\(.databaseId) \(.status)"' 2>/dev/null || true)
-
-          if [ -z "$RUN_INFO" ]; then
-            echo "No CI run found for this PR — nothing to rerun."
-            exit 0
-          fi
-
-          # Split "RUN_ID STATUS" into two vars. Read STATUS from RUN_INFO,
-          # not from the truncated RUN_ID. Both values came from the same
-          # var before, which made STATUS the run id. Thus the wait branch
-          # always ran.
-          RUN_ID="${RUN_INFO%% *}"
-          STATUS="${RUN_INFO##* }"
-
-          echo "Latest CI run: $RUN_ID (status: $STATUS)"
-
-          # If the run is still in progress, wait for it to finish.
-          # gh run rerun only works on completed runs — if we try while it's
-          # running, GitHub rejects with "cannot be rerun; This workflow is
-          # already running".
-          if [ "$STATUS" != "completed" ]; then
-            echo "Run is $STATUS — waiting for completion (this may take a while)..."
-            # gh run watch --exit-status exits non-zero if the run fails,
-            # which is expected (the label gate fails). Don't let that kill
-            # the workflow — we WANT to rerun failed jobs.
-            timeout 2100 gh run watch "$RUN_ID" --repo "$REPO" --interval 15 || true
-
-            # Verify it's actually completed now.
-            STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status' 2>/dev/null || echo "unknown")
-            if [ "$STATUS" != "completed" ]; then
-              echo "Run is still $STATUS after wait — giving up."
-              exit 0
-            fi
-          fi
-
-          echo "Run completed. Rerunning all failed jobs..."
-          gh run rerun "$RUN_ID" --repo "$REPO" --failed || true
-          echo "Done. GitHub will rerun review-labels and all dependent jobs."
+            --pr "$PR_NUMBER" \
+            --workflow "$WORKFLOW_FILE" \
+            --required-context "$REQUIRED_CONTEXT" \
+            --event-head-sha "$EVENT_HEAD_SHA" \
+            --json

--- a/scripts/ci/pipeline_state.py
+++ b/scripts/ci/pipeline_state.py
@@ -484,7 +484,7 @@ def request_exactly_one_rerun(
         raise RerunCommandError("PR head changed before rerun")
     args = ["run", "rerun", bound_run_id, "--repo", repo, "--failed"]
     try:
-        outcome = subprocess.run(["gh", *args], check=True, capture_output=True, text=True) if runner is None else runner(args)
+        outcome = subprocess.run(["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8") if runner is None else runner(args)
     except Exception as exc:
         if isinstance(exc, RerunCommandError):
             raise
@@ -585,7 +585,7 @@ def build_fixture_from_api(
 
 def _gh_json(args: list[str]) -> Any:
     try:
-        result = subprocess.run(["gh", *args], check=True, capture_output=True, text=True)
+        result = subprocess.run(["gh", *args], check=True, capture_output=True, text=True, encoding="utf-8")
         return json.loads(result.stdout)
     except Exception as exc:
         raise EvidenceError(str(exc)) from exc

--- a/scripts/ci/pipeline_state.py
+++ b/scripts/ci/pipeline_state.py
@@ -1,0 +1,729 @@
+#!/usr/bin/env python3
+"""Fail-closed provider adapter for the ``ci-reviewed`` label.
+
+The fixture and diagnosis result mirror the reviewed P1 schema.  This module
+has no runtime dependency on the P1 repository.  The live path reads the
+current PR head, exact ``ci.yaml`` run and attempt, jobs, the exact required
+check, its annotations, and compare/merge-base evidence through ``gh`` before
+it can issue one failed-jobs rerun.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+DIAGNOSIS_CLASSES = (
+    "BLOCKED_PROVIDER_BILLING",
+    "BLOCKED_PROVIDER_POLICY",
+    "BLOCKED_LINEAGE",
+    "TRANSIENT_PROVIDER_FAILURE",
+    "WORKFLOW_OR_HARNESS_FAILURE",
+    "CODE_OR_TEST_FAILURE",
+    "LOCAL_GREEN_AWAITING_HOSTED",
+    "HOSTED_GREEN",
+    "EVIDENCE_INCOMPLETE",
+)
+
+GITHUB_ACTIONS_APP_ID = "15368"
+GITHUB_ACTIONS_APP_SLUG = "github-actions"
+TRUSTED_GITHUB_ACTIONS_APP = {"id": GITHUB_ACTIONS_APP_ID, "slug": GITHUB_ACTIONS_APP_SLUG}
+
+_REASONS = {
+    "INVALID_INPUT_SCHEMA", "REPOSITORY_MISMATCH", "HEAD_MISMATCH", "CONTEXT_MISMATCH",
+    "PROVIDER_APP_MISMATCH", "FOREIGN_PROVIDER", "LATEST_ATTEMPT_MISMATCH", "STALE_HEAD",
+    "OLD_ATTEMPT", "MISSING_REQUIRED_CONTEXT", "DUPLICATE_REQUIRED_CONTEXT", "DUPLICATE_CONTEXT",
+    "DUPLICATE_JOB", "PAGINATION_INCOMPLETE", "JOBS_INCOMPLETE", "ANNOTATIONS_INCOMPLETE",
+    "MISSING_JOBS", "NO_MERGE_BASE", "POST_WRITE_HEAD_CHANGED", "POST_WRITE_READBACK_INCOMPLETE",
+    "BILLING_ANNOTATION", "POLICY_ANNOTATION", "TRANSIENT_ANNOTATION", "WORKFLOW_ANNOTATION",
+    "CODE_TEST_ANNOTATION", "ACTION_REQUIRED", "PYTEST_EXIT_5", "EMPTY_SELECTOR",
+    "PROVIDER_FAILURE_AFTER_STARTED", "LOCAL_FAILURE", "PROVIDER_NOT_GREEN",
+}
+_EVIDENCE_REASONS = {
+    "INVALID_INPUT_SCHEMA", "REPOSITORY_MISMATCH", "HEAD_MISMATCH", "CONTEXT_MISMATCH",
+    "PROVIDER_APP_MISMATCH", "FOREIGN_PROVIDER", "LATEST_ATTEMPT_MISMATCH", "STALE_HEAD",
+    "OLD_ATTEMPT", "MISSING_REQUIRED_CONTEXT", "DUPLICATE_REQUIRED_CONTEXT", "DUPLICATE_CONTEXT",
+    "DUPLICATE_JOB", "PAGINATION_INCOMPLETE", "JOBS_INCOMPLETE", "ANNOTATIONS_INCOMPLETE",
+    "MISSING_JOBS", "POST_WRITE_HEAD_CHANGED", "POST_WRITE_READBACK_INCOMPLETE",
+}
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_ZERO_SHA = "0" * 40
+_STATUSES = {"queued", "in_progress", "completed"}
+_CONCLUSIONS = {"success", "failure", "cancelled", "skipped", "neutral", "timed_out", "action_required", None}
+_ANNOTATION_CATEGORIES = {"billing", "policy", "transient", "workflow", "code_test"}
+_WRAPPER_KEYS = {"jobs", "check_runs", "annotations", "workflow_runs"}
+_WORKFLOW_RUN_KEYS = {"run_id", "head_sha", "attempt", "status", "conclusion"}
+_ROUTING_FALSE = {
+    "retry_allowed": False,
+    "code_fix_allowed": False,
+    "local_repro_required": False,
+    "source_branch_loop_allowed": False,
+}
+
+
+class RerunCommandError(RuntimeError):
+    """The provider rejected the one allowed rerun request or head fence."""
+
+
+class EvidenceError(RuntimeError):
+    """Provider data cannot be converted to bounded P1 evidence."""
+
+
+def _sha(value: Any, *, allow_zero: bool = False) -> bool:
+    return isinstance(value, str) and _SHA_RE.fullmatch(value) is not None and (allow_zero or value != _ZERO_SHA)
+
+
+def _text(value: Any, limit: int = 1024, *, allow_empty: bool = False) -> bool:
+    return isinstance(value, str) and len(value) <= limit and (allow_empty or bool(value.strip())) and not any(ord(char) < 32 for char in value)
+
+
+def _app(value: Any) -> bool:
+    return isinstance(value, dict) and set(value) == {"id", "slug"} and all(_text(value[key], 128) for key in ("id", "slug"))
+
+
+def _official_app(value: Any) -> bool:
+    return _app(value) and value == TRUSTED_GITHUB_ACTIONS_APP
+
+
+def _repository(value: Any) -> bool:
+    return isinstance(value, dict) and set(value) == {"owner", "repo"} and all(_text(value[key], 100) for key in ("owner", "repo"))
+
+
+def _result(classification: str, reasons: list[str], evidence: dict[str, Any]) -> dict[str, Any]:
+    """Build the exact five-key P1 result shape."""
+    return {
+        "schema": 1,
+        "classification": classification,
+        "reason_codes": list(dict.fromkeys(reason for reason in reasons if reason in _REASONS)),
+        "routing": dict(_ROUTING_FALSE),
+        "evidence": evidence,
+    }
+
+
+def _empty_evidence() -> dict[str, Any]:
+    return {
+        "repository": None,
+        "head_sha": None,
+        "context": None,
+        "provider_app": None,
+        "latest_attempt": None,
+        "merge_base": None,
+        "real_started_step": False,
+        "post_write_valid": False,
+    }
+
+
+def _evidence(data: dict[str, Any]) -> dict[str, Any]:
+    target = data["target"]
+    post = data["post_write"]
+    post_valid = post["readback_complete"] and (post["head_sha"] is None or post["head_sha"] == target["head_sha"])
+    return {
+        "repository": dict(target["repository"]),
+        "head_sha": target["head_sha"],
+        "context": target["context"],
+        "provider_app": dict(target["provider_app"]),
+        "latest_attempt": target["latest_attempt"],
+        "merge_base": data["lineage"]["merge_base"],
+        "real_started_step": False,
+        "post_write_valid": post_valid,
+    }
+
+
+def _valid_step(value: Any) -> bool:
+    return isinstance(value, dict) and set(value) == {"name", "status", "conclusion"} and _text(value["name"], 256) and value["status"] in _STATUSES and value["conclusion"] in _CONCLUSIONS
+
+
+def _valid_annotation(value: Any) -> bool:
+    return isinstance(value, dict) and set(value) == {"category", "message"} and value["category"] in _ANNOTATION_CATEGORIES and _text(value["message"])
+
+
+def _valid_job(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and set(value) == {"job_id", "head_sha", "attempt", "status", "conclusion", "runner_id", "steps", "annotations"}
+        and _text(value["job_id"], 256)
+        and _sha(value["head_sha"])
+        and isinstance(value["attempt"], int) and not isinstance(value["attempt"], bool) and value["attempt"] >= 1
+        and value["status"] in _STATUSES and value["conclusion"] in _CONCLUSIONS
+        and isinstance(value["runner_id"], int) and not isinstance(value["runner_id"], bool) and value["runner_id"] >= 0
+        and isinstance(value["steps"], list) and len(value["steps"]) <= 256 and all(_valid_step(step) for step in value["steps"])
+        and isinstance(value["annotations"], list) and len(value["annotations"]) <= 128 and all(_valid_annotation(annotation) for annotation in value["annotations"])
+    )
+
+
+def _valid_context(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and set(value) == {"context", "head_sha", "app", "attempt", "status", "conclusion", "jobs"}
+        and _text(value["context"], 256) and _sha(value["head_sha"])
+        and _official_app(value["app"])
+        and isinstance(value["attempt"], int) and not isinstance(value["attempt"], bool) and value["attempt"] >= 1
+        and value["status"] in _STATUSES and value["conclusion"] in _CONCLUSIONS
+        and isinstance(value["jobs"], list) and len(value["jobs"]) <= 128 and all(_valid_job(job) for job in value["jobs"])
+    )
+
+
+def _valid_fixture_shape(data: Any) -> bool:
+    if not isinstance(data, dict) or set(data) != {"schema", "target", "provider_snapshot", "lineage", "local", "post_write"} or data["schema"] != 1:
+        return False
+    target, snapshot, lineage, local, post = (data[key] for key in ("target", "provider_snapshot", "lineage", "local", "post_write"))
+    if not all(isinstance(value, dict) for value in (target, snapshot, lineage, local, post)):
+        return False
+    if set(target) != {"repository", "head_sha", "context", "provider_app", "latest_attempt"}:
+        return False
+    if set(snapshot) != {"repository", "head_sha", "required_context", "provider_app", "latest_attempt", "workflow_run", "pagination", "contexts"}:
+        return False
+    if set(lineage) != {"merge_base", "source_branch", "target_branch"} or set(local) != {"status", "exit_code", "selector"} or set(post) != {"head_sha", "readback_complete"}:
+        return False
+    if not _repository(target["repository"]) or not _repository(snapshot["repository"]):
+        return False
+    if not _official_app(target["provider_app"]) or not _official_app(snapshot["provider_app"]):
+        return False
+    if not _sha(target["head_sha"]) or not _sha(snapshot["head_sha"]):
+        return False
+    if not _text(target["context"], 256) or not _text(snapshot["required_context"], 256):
+        return False
+    if any(isinstance(value, bool) or not isinstance(value, int) or value < 1 for value in (target["latest_attempt"], snapshot["latest_attempt"])):
+        return False
+    pagination = snapshot["pagination"]
+    if not isinstance(pagination, dict) or set(pagination) != {"contexts_complete", "jobs_complete", "annotations_complete"} or not all(isinstance(value, bool) for value in pagination.values()):
+        return False
+    if not isinstance(snapshot["contexts"], list) or len(snapshot["contexts"]) > 128 or not all(_valid_context(context) for context in snapshot["contexts"]):
+        return False
+    workflow_run = snapshot["workflow_run"]
+    if not isinstance(workflow_run, dict) or set(workflow_run) != _WORKFLOW_RUN_KEYS:
+        return False
+    if not _text(workflow_run["run_id"], 128) or not _sha(workflow_run["head_sha"]):
+        return False
+    if isinstance(workflow_run["attempt"], bool) or not isinstance(workflow_run["attempt"], int) or workflow_run["attempt"] < 1:
+        return False
+    if not _text(workflow_run["status"], 64) or workflow_run["conclusion"] is not None and not _text(workflow_run["conclusion"], 64):
+        return False
+    if lineage["merge_base"] is not None and not _sha(lineage["merge_base"]):
+        return False
+    if not _text(lineage["source_branch"], 255) or not _text(lineage["target_branch"], 255):
+        return False
+    if local["status"] not in {"NOT_RUN", "PASS", "FAIL"}:
+        return False
+    if local["exit_code"] is not None and (isinstance(local["exit_code"], bool) or not isinstance(local["exit_code"], int) or local["exit_code"] < 0):
+        return False
+    if local["selector"] is not None and not _text(local["selector"], 256, allow_empty=True):
+        return False
+    if local["status"] == "NOT_RUN" and (local["exit_code"] is not None or local["selector"] is not None):
+        return False
+    if local["status"] == "PASS" and (local["exit_code"] != 0 or not _text(local["selector"], 256)):
+        return False
+    if local["status"] == "FAIL" and (not isinstance(local["exit_code"], int) or not _text(local["selector"], 256, allow_empty=True)):
+        return False
+    return type(post["readback_complete"]) is bool and (post["head_sha"] is None or _sha(post["head_sha"]))
+
+
+def _real_started_step(step: dict[str, Any]) -> bool:
+    return step["status"] == "in_progress" or (step["status"] == "completed" and step["conclusion"] not in {None, "skipped"})
+
+
+def _job_executed_failure(job: dict[str, Any]) -> bool:
+    return job["status"] == "completed" and job["conclusion"] == "failure" and job["runner_id"] > 0 and any(_real_started_step(step) for step in job["steps"])
+
+
+def _category(annotation: dict[str, Any]) -> str | None:
+    category = annotation.get("category")
+    message = annotation.get("message", "").lower()
+    if category == "billing" or "billing" in message or "spending" in message:
+        return "billing"
+    return category if category in {"policy", "transient", "workflow", "code_test"} else None
+
+
+def _diagnose_valid(data: dict[str, Any], *, require_post_write: bool) -> dict[str, Any]:
+    target = data["target"]
+    snapshot = data["provider_snapshot"]
+    evidence = _evidence(data)
+    reasons: list[str] = []
+    if snapshot["repository"] != target["repository"]:
+        reasons.append("REPOSITORY_MISMATCH")
+    if snapshot["head_sha"] != target["head_sha"]:
+        reasons.append("HEAD_MISMATCH")
+    if snapshot["required_context"] != target["context"]:
+        reasons.append("CONTEXT_MISMATCH")
+    if snapshot["provider_app"] != target["provider_app"]:
+        reasons.append("PROVIDER_APP_MISMATCH")
+    if snapshot["latest_attempt"] != target["latest_attempt"]:
+        reasons.append("LATEST_ATTEMPT_MISMATCH")
+    pagination = snapshot["pagination"]
+    if not pagination["contexts_complete"]:
+        reasons.append("PAGINATION_INCOMPLETE")
+    if not pagination["jobs_complete"]:
+        reasons.append("JOBS_INCOMPLETE")
+    if not pagination["annotations_complete"]:
+        reasons.append("ANNOTATIONS_INCOMPLETE")
+    contexts = snapshot["contexts"]
+    counts: dict[str, int] = {}
+    for context in contexts:
+        counts[context["context"]] = counts.get(context["context"], 0) + 1
+        if context["head_sha"] != target["head_sha"]:
+            reasons.append("STALE_HEAD")
+        if context["app"] != target["provider_app"]:
+            reasons.append("FOREIGN_PROVIDER")
+        if context["attempt"] != target["latest_attempt"]:
+            reasons.append("OLD_ATTEMPT")
+        for job in context["jobs"]:
+            if job["head_sha"] != target["head_sha"]:
+                reasons.append("STALE_HEAD")
+            if job["attempt"] != target["latest_attempt"]:
+                reasons.append("OLD_ATTEMPT")
+    required_count = counts.get(target["context"], 0)
+    if required_count == 0:
+        reasons.append("MISSING_REQUIRED_CONTEXT")
+    elif required_count > 1:
+        reasons.append("DUPLICATE_REQUIRED_CONTEXT")
+    for name, count in counts.items():
+        if name != target["context"] and count > 1:
+            reasons.append("DUPLICATE_CONTEXT")
+    required = next((context for context in contexts if context["context"] == target["context"]), None)
+    jobs = required["jobs"] if required else []
+    if required and not jobs and required["conclusion"] != "action_required":
+        reasons.append("MISSING_JOBS")
+    job_ids = [job["job_id"] for job in jobs]
+    if len(set(job_ids)) != len(job_ids):
+        reasons.append("DUPLICATE_JOB")
+    if data["lineage"]["merge_base"] is None:
+        reasons.append("NO_MERGE_BASE")
+    workflow_run = snapshot["workflow_run"]
+    if workflow_run["head_sha"] != target["head_sha"]:
+        reasons.append("HEAD_MISMATCH")
+    if workflow_run["attempt"] != target["latest_attempt"]:
+        reasons.append("OLD_ATTEMPT")
+    post = data["post_write"]
+    if require_post_write:
+        if not post["readback_complete"]:
+            reasons.append("POST_WRITE_READBACK_INCOMPLETE")
+            evidence["post_write_valid"] = False
+        if post["head_sha"] is not None and post["head_sha"] != target["head_sha"]:
+            reasons.append("POST_WRITE_HEAD_CHANGED")
+            evidence["post_write_valid"] = False
+    else:
+        evidence["post_write_valid"] = False
+        if post["head_sha"] is not None and post["head_sha"] != target["head_sha"]:
+            reasons.append("POST_WRITE_HEAD_CHANGED")
+    action_required = bool(required and (required["conclusion"] == "action_required" or any(job["conclusion"] == "action_required" for job in jobs)))
+    if action_required and not jobs and not reasons:
+        return _result("BLOCKED_PROVIDER_POLICY", ["ACTION_REQUIRED"], evidence)
+    if workflow_run["status"] != "completed" or workflow_run["conclusion"] != "failure":
+        return _result("EVIDENCE_INCOMPLETE", [*reasons, "PROVIDER_NOT_GREEN"], evidence)
+    if required and (required["status"] != "completed" or required["conclusion"] != "failure") and not reasons:
+        if required["status"] in {"queued", "in_progress"}:
+            result = _result("TRANSIENT_PROVIDER_FAILURE", ["PROVIDER_NOT_GREEN"], evidence)
+            result["routing"]["retry_allowed"] = True
+            return result
+        return _result("EVIDENCE_INCOMPLETE", ["PROVIDER_NOT_GREEN"], evidence)
+    non_lineage_evidence = [reason for reason in reasons if reason != "NO_MERGE_BASE"]
+    if any(reason in _EVIDENCE_REASONS for reason in non_lineage_evidence):
+        return _result("EVIDENCE_INCOMPLETE", reasons, evidence)
+    if data["lineage"]["merge_base"] is None:
+        return _result("BLOCKED_LINEAGE", reasons, evidence)
+    annotations = [annotation for job in jobs for annotation in job["annotations"]]
+    categories = [_category(annotation) for annotation in annotations]
+    # Billing/spending is a hard provider block even when the job did execute.
+    if "billing" in categories:
+        return _result("BLOCKED_PROVIDER_BILLING", [*reasons, "BILLING_ANNOTATION"], evidence)
+    if action_required or "policy" in categories:
+        return _result("BLOCKED_PROVIDER_POLICY", [*reasons, "ACTION_REQUIRED" if action_required else "POLICY_ANNOTATION"], evidence)
+    failed_jobs = [job for job in jobs if job["conclusion"] == "failure"]
+    failed_executed = [job for job in failed_jobs if _job_executed_failure(job)]
+    evidence["real_started_step"] = bool(failed_executed)
+    local = data["local"]
+    if local["status"] == "FAIL" and local["exit_code"] == 5:
+        reasons.append("PYTEST_EXIT_5")
+    if local["status"] == "FAIL" and local["selector"] == "":
+        reasons.append("EMPTY_SELECTOR")
+    if local["status"] == "FAIL" and (local["exit_code"] == 5 or local["selector"] == ""):
+        return _result("WORKFLOW_OR_HARNESS_FAILURE", reasons, evidence)
+    for category, classification, reason in (
+        ("transient", "TRANSIENT_PROVIDER_FAILURE", "TRANSIENT_ANNOTATION"),
+        ("workflow", "WORKFLOW_OR_HARNESS_FAILURE", "WORKFLOW_ANNOTATION"),
+        ("code_test", "CODE_OR_TEST_FAILURE", "CODE_TEST_ANNOTATION"),
+    ):
+        if category in categories:
+            result = _result(classification, [*reasons, reason], evidence)
+            if classification == "TRANSIENT_PROVIDER_FAILURE":
+                result["routing"]["retry_allowed"] = True
+            elif classification == "WORKFLOW_OR_HARNESS_FAILURE":
+                result["routing"]["local_repro_required"] = bool(failed_executed and local["status"] != "FAIL")
+            else:
+                result["routing"].update(code_fix_allowed=True, local_repro_required=bool(failed_executed and local["status"] != "FAIL"), source_branch_loop_allowed=True)
+            return result
+    if required and required["status"] == "completed" and required["conclusion"] == "failure":
+        if failed_jobs and len(failed_executed) == len(failed_jobs):
+            result = _result("CODE_OR_TEST_FAILURE", [*reasons, "PROVIDER_FAILURE_AFTER_STARTED"], evidence)
+            result["routing"].update(code_fix_allowed=True, local_repro_required=local["status"] != "FAIL", source_branch_loop_allowed=True)
+            return result
+        return _result("WORKFLOW_OR_HARNESS_FAILURE", reasons, evidence)
+    if local["status"] == "FAIL":
+        result = _result("CODE_OR_TEST_FAILURE", [*reasons, "LOCAL_FAILURE"], evidence)
+        result["routing"].update(code_fix_allowed=True, source_branch_loop_allowed=True)
+        return result
+    if local["status"] == "PASS":
+        return _result("LOCAL_GREEN_AWAITING_HOSTED", reasons, evidence)
+    if required and required["status"] in {"queued", "in_progress"}:
+        result = _result("TRANSIENT_PROVIDER_FAILURE", [*reasons, "PROVIDER_NOT_GREEN"], evidence)
+        result["routing"]["retry_allowed"] = True
+        return result
+    if require_post_write and required and required["status"] == "completed" and required["conclusion"] == "success" and jobs and all(job["status"] == "completed" and job["conclusion"] == "success" for job in jobs):
+        return _result("HOSTED_GREEN", reasons, evidence)
+    return _result("EVIDENCE_INCOMPLETE", [*reasons, "PROVIDER_NOT_GREEN"], evidence)
+
+
+def diagnose_pipeline(data: Any, *, require_post_write: bool = True) -> dict[str, Any]:
+    """Return exact P1 diagnosis; malformed evidence never escapes an exception."""
+    try:
+        if not _valid_fixture_shape(data):
+            return _result("EVIDENCE_INCOMPLETE", ["INVALID_INPUT_SCHEMA"], _empty_evidence())
+        return _diagnose_valid(data, require_post_write=require_post_write)
+    except Exception:
+        return _result("EVIDENCE_INCOMPLETE", ["INVALID_INPUT_SCHEMA"], _empty_evidence())
+
+
+def can_request_rerun(data: Any) -> bool:
+    """Allow one rerun only when every failed job is a completed executed failure."""
+    try:
+        decision = diagnose_pipeline(data, require_post_write=False)
+        if decision["classification"] != "CODE_OR_TEST_FAILURE" or not _valid_fixture_shape(data):
+            return False
+        workflow_run = data["provider_snapshot"]["workflow_run"]
+        if workflow_run["status"] != "completed" or workflow_run["conclusion"] != "failure":
+            return False
+        context = next(context for context in data["provider_snapshot"]["contexts"] if context["context"] == data["target"]["context"])
+        failed = [job for job in context["jobs"] if job["conclusion"] == "failure"]
+        return bool(failed) and all(_job_executed_failure(job) for job in failed) and decision["evidence"]["real_started_step"]
+    except Exception:
+        return False
+
+
+def _workflow_matches(run_workflow: Any, requested: str) -> bool:
+    if run_workflow == requested:
+        return True
+    return isinstance(run_workflow, str) and requested.lower().endswith((".yml", ".yaml")) and run_workflow.lower() == Path(requested).stem.lower()
+
+
+def select_exact_workflow_run(runs: list[dict[str, Any]], *, workflow: str, head_sha: str) -> dict[str, Any] | None:
+    """Select the newest run whose workflow and head both match."""
+    if not _sha(head_sha):
+        return None
+    candidates = [run for run in runs if isinstance(run, dict) and run.get("headSha", run.get("head_sha")) == head_sha and _workflow_matches(run.get("workflowName", run.get("workflow_name")), workflow)]
+    return max(candidates, key=lambda run: (str(run.get("createdAt", run.get("created_at", ""))), int(run.get("databaseId", run.get("id", 0)) or 0)), default=None)
+
+
+def parse_paginated_response(value: Any, key: str) -> list[dict[str, Any]] | None:
+    """Unwrap REST objects/pages and reject every non-object item."""
+    if isinstance(value, dict):
+        if any(wrapper_key in value for wrapper_key in _WRAPPER_KEYS if wrapper_key != key) or not isinstance(value.get(key), list):
+            return None
+        items = value[key]
+    elif isinstance(value, list):
+        if all(isinstance(page, list) for page in value):
+            items = [item for page in value for item in page]
+        elif any(isinstance(page, dict) and key in page for page in value):
+            if not all(
+                isinstance(page, dict)
+                and key in page
+                and isinstance(page[key], list)
+                and not any(wrapper_key in page for wrapper_key in _WRAPPER_KEYS if wrapper_key != key)
+                for page in value
+            ):
+                return None
+            items = [item for page in value for item in page[key]]
+        elif all(isinstance(page, dict) for page in value):
+            if any(wrapper_key in page for page in value for wrapper_key in _WRAPPER_KEYS):
+                return None
+            items = value
+        else:
+            return None
+    else:
+        return None
+    return items if all(isinstance(item, dict) for item in items) else None
+
+
+def request_exactly_one_rerun(
+    decision: dict[str, Any], *, repo: str, run_id: str, runner: Callable[[list[str]], Any] | None = None,
+    eligible: bool | None = None, expected_run_id: str | None = None, expected_attempt: int | None = None,
+    expected_head_sha: str | None = None, head_reader: Callable[[], str] | None = None,
+    workflow_run_reader: Callable[[], dict[str, Any]] | None = None,
+    required_check_reader: Callable[[], dict[str, Any]] | None = None,
+) -> dict[str, str]:
+    """Fence the head, then issue exactly one rerun request."""
+    allowed = (decision.get("classification") == "CODE_OR_TEST_FAILURE" and decision.get("evidence", {}).get("real_started_step") is True) if eligible is None else eligible
+    if not allowed:
+        return {"status": decision.get("classification", "EVIDENCE_INCOMPLETE")}
+    if expected_run_id is None or expected_attempt is None or expected_head_sha is None or head_reader is None or workflow_run_reader is None or required_check_reader is None:
+        raise RerunCommandError("missing mandatory pre-rerun evidence fences")
+    if str(run_id) != str(expected_run_id):
+        raise RerunCommandError("rerun target does not match selected run")
+    bound_run_id = str(expected_run_id)
+    try:
+        workflow_run = workflow_run_reader()
+    except Exception as exc:
+        raise RerunCommandError(str(exc)) from exc
+    if not isinstance(workflow_run, dict) or str(workflow_run.get("run_id")) != bound_run_id or workflow_run.get("head_sha") != expected_head_sha or workflow_run.get("attempt") != expected_attempt or workflow_run.get("status") != "completed" or workflow_run.get("conclusion") != "failure":
+        raise RerunCommandError("workflow run is not the exact completed failure")
+    try:
+        check = required_check_reader()
+    except Exception as exc:
+        raise RerunCommandError(str(exc)) from exc
+    if not isinstance(check, dict) or check.get("head_sha") != expected_head_sha or check.get("status") != "completed" or check.get("conclusion") != "failure":
+        raise RerunCommandError("required check is not an exact completed failure")
+    try:
+        current = head_reader()
+    except Exception as exc:
+        raise RerunCommandError(str(exc)) from exc
+    if current != expected_head_sha:
+        raise RerunCommandError("PR head changed before rerun")
+    args = ["run", "rerun", bound_run_id, "--repo", repo, "--failed"]
+    try:
+        outcome = subprocess.run(["gh", *args], check=True, capture_output=True, text=True) if runner is None else runner(args)
+    except Exception as exc:
+        if isinstance(exc, RerunCommandError):
+            raise
+        raise RerunCommandError(str(exc)) from exc
+    if getattr(outcome, "returncode", 0) not in (0, None):
+        raise RerunCommandError("gh run rerun returned non-zero")
+    return {"status": "RERUN_REQUESTED"}
+
+
+def build_fixture_from_api(
+    *, repo: str, head_sha: str, run: dict[str, Any], jobs: list[dict[str, Any]], check_runs: list[dict[str, Any]], annotations_by_check: dict[Any, list[dict[str, Any]]], base_sha: str, source_branch: str, target_branch: str, merge_base: str | None, required_context: str = "All required checks pass"
+) -> dict[str, Any] | None:
+    """Bind raw provider data to one trusted check and its aggregate job."""
+    try:
+        if not _sha(head_sha) or not _sha(base_sha) or not isinstance(run, dict) or "headSha" not in run or run["headSha"] != head_sha:
+            return None
+        if run.get("databaseId") is None or not _text(str(run["databaseId"]), 128):
+            return None
+        attempt = run["attempt"]
+        if isinstance(attempt, bool) or not isinstance(attempt, int) or attempt < 1:
+            return None
+        if run.get("status") != "completed" or run.get("conclusion") != "failure":
+            return None
+        selected = [check for check in check_runs if isinstance(check, dict) and check.get("name") == required_context and "head_sha" in check and check["head_sha"] == head_sha]
+        if len(selected) != 1:
+            return None
+        check = selected[0]
+        check_id = check["id"]
+        if check.get("status") not in _STATUSES or check.get("conclusion") not in _CONCLUSIONS or not _official_app({"id": str((check.get("app") or {}).get("id")), "slug": (check.get("app") or {}).get("slug")}):
+            return None
+        raw_annotations = annotations_by_check[check_id]
+        if not isinstance(raw_annotations, list) or not all(isinstance(annotation, dict) for annotation in raw_annotations):
+            return None
+        normalized_jobs: list[dict[str, Any]] = []
+        raw_by_id: dict[str, dict[str, Any]] = {}
+        aggregate_raw: list[dict[str, Any]] = []
+        for raw in jobs:
+            if not isinstance(raw, dict) or raw.get("id") is None or str(raw["id"]) in raw_by_id:
+                return None
+            if "head_sha" not in raw or raw["head_sha"] != head_sha or "run_attempt" not in raw or raw["run_attempt"] != attempt:
+                return None
+            if "steps" not in raw or not isinstance(raw["steps"], list):
+                return None
+            raw_by_id[str(raw["id"])] = raw
+            if raw.get("name") == required_context or raw.get("check_run_id") == check_id:
+                aggregate_raw.append(raw)
+            normalized_jobs.append({
+                "job_id": str(raw["id"]),
+                "head_sha": raw["head_sha"],
+                "attempt": attempt,
+                "status": raw.get("status"),
+                "conclusion": raw.get("conclusion"),
+                "runner_id": raw.get("runner_id", 0) or 0,
+                "steps": [{"name": step.get("name"), "status": step.get("status"), "conclusion": step.get("conclusion")} for step in raw["steps"]],
+                "annotations": [],
+            })
+        if len(aggregate_raw) != 1:
+            return None
+        if aggregate_raw[0].get("status") != check["status"] or aggregate_raw[0].get("conclusion") != check["conclusion"]:
+            return None
+        by_id = {job["job_id"]: job for job in normalized_jobs}
+        aggregate_destination = by_id[str(aggregate_raw[0]["id"])]
+        for raw_annotation in raw_annotations:
+            if not isinstance(raw_annotation.get("message"), str) or not raw_annotation["message"]:
+                return None
+            destination = by_id.get(str(raw_annotation["job_id"])) if raw_annotation.get("job_id") is not None else aggregate_destination
+            if destination is None:
+                return None
+            message = raw_annotation["message"]
+            raw_category = raw_annotation.get("category")
+            if raw_category in _ANNOTATION_CATEGORIES:
+                category = raw_category
+            elif any(word in message.lower() for word in ("billing", "spending")):
+                category = "billing"
+            elif "policy" in message.lower() or "action_required" in message.lower():
+                category = "policy"
+            else:
+                category = "code_test"
+            destination["annotations"].append({"category": category, "message": message})
+        raw_app = check.get("app") or {}
+        app = {"id": str(raw_app.get("id")), "slug": raw_app.get("slug")}
+        owner, name = repo.split("/", 1)
+        if not _official_app(app) or not _repository({"owner": owner, "repo": name}) or not _text(source_branch, 255) or not _text(target_branch, 255):
+            return None
+        target = {"repository": {"owner": owner, "repo": name}, "head_sha": head_sha, "context": required_context, "provider_app": dict(TRUSTED_GITHUB_ACTIONS_APP), "latest_attempt": attempt}
+        context = {"context": required_context, "head_sha": head_sha, "app": dict(TRUSTED_GITHUB_ACTIONS_APP), "attempt": attempt, "status": check["status"], "conclusion": check["conclusion"], "jobs": normalized_jobs}
+        return {
+            "schema": 1,
+            "target": target,
+            "provider_snapshot": {"repository": dict(target["repository"]), "head_sha": head_sha, "required_context": required_context, "provider_app": dict(TRUSTED_GITHUB_ACTIONS_APP), "latest_attempt": attempt, "workflow_run": {"run_id": str(run["databaseId"]), "head_sha": head_sha, "attempt": attempt, "status": run["status"], "conclusion": run["conclusion"]}, "pagination": {"contexts_complete": True, "jobs_complete": True, "annotations_complete": True}, "contexts": [context]},
+            "lineage": {"merge_base": merge_base, "source_branch": source_branch, "target_branch": target_branch},
+            "local": {"status": "NOT_RUN", "exit_code": None, "selector": None},
+            "post_write": {"head_sha": None, "readback_complete": False},
+        }
+    except Exception:
+        return None
+
+
+def _gh_json(args: list[str]) -> Any:
+    try:
+        result = subprocess.run(["gh", *args], check=True, capture_output=True, text=True)
+        return json.loads(result.stdout)
+    except Exception as exc:
+        raise EvidenceError(str(exc)) from exc
+
+
+def read_current_pr_head(repo: str, pr_number: str) -> str:
+    value = _gh_json(["pr", "view", pr_number, "--repo", repo, "--json", "headRefOid"])
+    head = value.get("headRefOid") if isinstance(value, dict) else None
+    if not _sha(head):
+        raise EvidenceError("invalid current PR head")
+    return head
+
+
+def read_exact_workflow_run(repo: str, run_id: str) -> dict[str, Any]:
+    """Read the exact run identity and state at the mutation boundary."""
+    value = _gh_json(["run", "view", run_id, "--repo", repo, "--json", "databaseId,headSha,attempt,status,conclusion"])
+    if not isinstance(value, dict) or value.get("databaseId") is None:
+        raise EvidenceError("workflow run readback is not an object")
+    return {
+        "run_id": str(value["databaseId"]),
+        "head_sha": value.get("headSha"),
+        "attempt": value.get("attempt"),
+        "status": value.get("status"),
+        "conclusion": value.get("conclusion"),
+    }
+
+
+def read_exact_required_check(repo: str, head_sha: str, required_context: str) -> dict[str, Any]:
+    """Read and validate the required check again at the mutation boundary."""
+    checks = parse_paginated_response(
+        _gh_json(["api", "--paginate", "--slurp", f"repos/{repo}/commits/{head_sha}/check-runs?per_page=100"]),
+        "check_runs",
+    )
+    if checks is None:
+        raise EvidenceError("required-check readback is malformed")
+    selected = [check for check in checks if check.get("name") == required_context and check.get("head_sha") == head_sha]
+    if len(selected) != 1:
+        raise EvidenceError("required-check readback is missing or duplicated")
+    check = selected[0]
+    app = check.get("app") or {}
+    if not _official_app({"id": str(app.get("id")), "slug": app.get("slug")}):
+        raise EvidenceError("required-check provider identity changed")
+    return {"status": check.get("status"), "conclusion": check.get("conclusion"), "head_sha": head_sha}
+
+
+def verify_exact_head_run_readback(*, expected_head_sha: str, expected_run_id: str, head_reader: Callable[[], str], run_reader: Callable[[], dict[str, Any]]) -> bool:
+    """Validate the exact head and run only after the mutation returns."""
+    try:
+        run = run_reader()
+        return head_reader() == expected_head_sha and isinstance(run, dict) and str(run.get("databaseId", run.get("id"))) == str(expected_run_id) and run.get("headSha", run.get("head_sha")) == expected_head_sha
+    except Exception:
+        return False
+
+
+def collect_provider_fixture(*, repo: str, pr_number: str, workflow: str, required_context: str = "All required checks pass", event_head_sha: str | None = None) -> tuple[str, str, dict[str, Any]]:
+    """Read exact provider evidence; malformed evidence is fatal to the run."""
+    pr = _gh_json(["pr", "view", pr_number, "--repo", repo, "--json", "headRefOid,baseRefOid,headRefName,baseRefName"])
+    if not isinstance(pr, dict):
+        raise EvidenceError("PR view is not an object")
+    head, base = pr.get("headRefOid"), pr.get("baseRefOid")
+    if not _sha(head) or (event_head_sha is not None and event_head_sha != head):
+        raise EvidenceError("current PR head does not match label event")
+    runs = parse_paginated_response(_gh_json(["run", "list", "--repo", repo, "--workflow", workflow, "--commit", head, "--limit", "100", "--json", "databaseId,status,conclusion,headSha,workflowName,createdAt"]), "workflow_runs")
+    if runs is None:
+        raise EvidenceError("workflow run response is malformed")
+    run = select_exact_workflow_run(runs, workflow=workflow, head_sha=head)
+    if run is None:
+        raise EvidenceError("no exact-head workflow run")
+    selected_run_id = run.get("databaseId")
+    if selected_run_id is None or not _text(str(selected_run_id), 128):
+        raise EvidenceError("selected workflow run lacks an ID")
+    run_id = str(selected_run_id)
+    details = _gh_json(["run", "view", run_id, "--repo", repo, "--json", "databaseId,status,conclusion,headSha,workflowName,attempt"])
+    if not isinstance(details, dict) or str(details.get("databaseId")) != run_id or details.get("headSha") != head or not isinstance(details.get("attempt"), int) or isinstance(details.get("attempt"), bool) or details["attempt"] < 1:
+        raise EvidenceError("run view lacks exact identity, head, or attempt")
+    run = {**run, **details, "databaseId": run_id}
+    jobs = parse_paginated_response(_gh_json(["api", "--paginate", "--slurp", f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"]), "jobs")
+    checks = parse_paginated_response(_gh_json(["api", "--paginate", "--slurp", f"repos/{repo}/commits/{head}/check-runs?per_page=100"]), "check_runs")
+    if jobs is None or checks is None:
+        raise EvidenceError("jobs or check-runs response is malformed")
+    required = [check for check in checks if check.get("name") == required_context and check.get("head_sha") == head]
+    if len(required) != 1 or required[0].get("id") is None:
+        raise EvidenceError("required check is missing or duplicated")
+    check_id = required[0]["id"]
+    annotations = parse_paginated_response(_gh_json(["api", "--paginate", "--slurp", f"repos/{repo}/check-runs/{check_id}/annotations?per_page=100"]), "annotations")
+    if annotations is None:
+        raise EvidenceError("annotations response is malformed")
+    compare = _gh_json(["api", f"repos/{repo}/compare/{base}...{head}"]) if _sha(base) else {}
+    merge = compare.get("merge_base_commit", {}).get("sha") if isinstance(compare, dict) else None
+    fixture = build_fixture_from_api(repo=repo, head_sha=head, run=run, jobs=jobs, check_runs=checks, annotations_by_check={check_id: annotations}, base_sha=base, source_branch=pr.get("headRefName"), target_branch=pr.get("baseRefName"), merge_base=merge if _sha(merge) else None, required_context=required_context)
+    if fixture is None:
+        raise EvidenceError("provider evidence failed bounded schema binding")
+    return head, run_id, fixture
+
+
+def _print_json(value: dict[str, Any]) -> None:
+    print(json.dumps(value, separators=(",", ":"), sort_keys=False))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path)
+    parser.add_argument("--repo")
+    parser.add_argument("--pr")
+    parser.add_argument("--workflow", default="ci.yaml")
+    parser.add_argument("--required-context", default="All required checks pass")
+    parser.add_argument("--event-head-sha")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        if args.fixture:
+            decision = diagnose_pipeline(json.loads(args.fixture.read_text(encoding="utf-8")))
+            _print_json(decision)
+            return 1 if decision["classification"] == "EVIDENCE_INCOMPLETE" else 0
+        if not args.repo or not args.pr:
+            raise EvidenceError("--repo and --pr are required without --fixture")
+        head, selected_run_id, fixture = collect_provider_fixture(repo=args.repo, pr_number=args.pr, workflow=args.workflow, required_context=args.required_context, event_head_sha=args.event_head_sha)
+        decision = diagnose_pipeline(fixture, require_post_write=False)
+        if not can_request_rerun(fixture):
+            _print_json({"status": decision["classification"], "head_sha": head})
+            return 1 if decision["classification"] == "EVIDENCE_INCOMPLETE" else 0
+        workflow_run = fixture["provider_snapshot"]["workflow_run"]
+        bound_run_id = str(selected_run_id)
+        if str(workflow_run["run_id"]) != bound_run_id:
+            raise EvidenceError("bounded fixture changed selected workflow run ID")
+        result = request_exactly_one_rerun(decision, repo=args.repo, run_id=bound_run_id, eligible=True, expected_run_id=bound_run_id, expected_attempt=workflow_run["attempt"], expected_head_sha=head, head_reader=lambda: read_current_pr_head(args.repo, args.pr), workflow_run_reader=lambda: read_exact_workflow_run(args.repo, bound_run_id), required_check_reader=lambda: read_exact_required_check(args.repo, head, args.required_context))
+        if not verify_exact_head_run_readback(expected_head_sha=head, expected_run_id=bound_run_id, head_reader=lambda: read_current_pr_head(args.repo, args.pr), run_reader=lambda: _gh_json(["run", "view", bound_run_id, "--repo", args.repo, "--json", "databaseId,headSha"])):
+            raise EvidenceError("post-rerun exact-head readback failed")
+        _print_json(result)
+        return 0
+    except RerunCommandError as exc:
+        print(f"label-rerun: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        _print_json({"status": "EVIDENCE_INCOMPLETE", "reason_codes": ["EVIDENCE_INCOMPLETE"]})
+        print(f"label-rerun: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_label_rerun_workflow.py
+++ b/tests/ci/test_label_rerun_workflow.py
@@ -1,0 +1,163 @@
+"""Workflow-level trust-boundary and exact-selection tests."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "label-rerun.yml"
+EXPECTED_WORKFLOW = "ci.yaml"
+EXPECTED_RUN = """set -euo pipefail
+python3 scripts/ci/pipeline_state.py \\
+  --repo \"$REPO\" \\
+  --pr \"$PR_NUMBER\" \\
+  --workflow \"$WORKFLOW_FILE\" \\
+  --required-context \"$REQUIRED_CONTEXT\" \\
+  --event-head-sha \"$EVENT_HEAD_SHA\" \\
+  --json"""
+
+
+def _workflow():
+    yaml = pytest.importorskip("yaml")
+    data = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # PyYAML 1.1 parses an unquoted GitHub `on` key as True.
+    return data, data.get("on", data.get(True))
+
+
+def _job(workflow):
+    return workflow["jobs"]["rerun-review-labels"]
+
+
+def _run_step(workflow):
+    return next(step for step in _job(workflow)["steps"] if "run" in step)
+
+
+def _assert_trusted_control_plane(workflow):
+    """Strict oracle: only the known base-owned control steps are permitted."""
+    _, trigger = _workflow_from(workflow)
+    assert set(trigger) == {"pull_request_target"}
+    job = _job(workflow)
+    assert set(job) == {"name", "if", "runs-on", "timeout-minutes", "steps"}
+    assert len(job["steps"]) == 2
+    checkout, run = job["steps"]
+    assert set(checkout) == {"name", "uses", "with"}
+    assert checkout["uses"].startswith("actions/checkout@")
+    assert checkout["with"] == {
+        "ref": "${{ github.event.pull_request.base.sha }}",
+        "persist-credentials": False,
+    }
+    assert set(run) == {"name", "env", "run"}
+    assert run["name"] == "Read exact provider state and rerun when eligible"
+    assert run["run"].strip() == EXPECTED_RUN
+    assert set(run["env"]) == {
+        "GH_TOKEN", "REPO", "PR_NUMBER", "EVENT_HEAD_SHA", "BASE_SHA", "WORKFLOW_FILE", "REQUIRED_CONTEXT"
+    }
+    assert "head.sha" not in str(checkout)
+    assert "git fetch" not in run["run"]
+    assert "git checkout" not in run["run"]
+
+
+def _workflow_from(workflow):
+    yaml = pytest.importorskip("yaml")
+    return workflow, workflow.get("on", workflow.get(True))
+
+
+def test_workflow_is_base_owned_and_uses_the_real_ci_yaml():
+    workflow, trigger = _workflow()
+    assert "pull_request_target" in trigger
+    assert (ROOT / ".github" / "workflows" / EXPECTED_WORKFLOW).is_file()
+    assert not (ROOT / ".github" / "workflows" / "ci.yml").exists()
+    job = _job(workflow)
+    checkout = job["steps"][0]
+    assert checkout["with"]["ref"] == "${{ github.event.pull_request.base.sha }}"
+    assert "head.sha" not in str(checkout)
+    env = _run_step(workflow)["env"]
+    assert env["WORKFLOW_FILE"] == EXPECTED_WORKFLOW
+    assert env["REQUIRED_CONTEXT"] == "All required checks pass"
+
+
+def test_workflow_grants_minimum_explicit_checks_read_permission():
+    workflow, _ = _workflow()
+    assert workflow["permissions"] == {
+        "contents": "read",
+        "checks": "read",
+        "actions": "write",
+        "pull-requests": "read",
+    }
+
+
+def test_workflow_command_body_is_exact_and_no_pr_head_execution_surface_exists():
+    workflow, _ = _workflow()
+    _assert_trusted_control_plane(workflow)
+    run = _run_step(workflow)
+    assert run["env"]["EVENT_HEAD_SHA"] == "${{ github.event.pull_request.head.sha }}"
+    assert "github.event.pull_request.head.sha" not in str(workflow["jobs"]["rerun-review-labels"]["steps"][0])
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda w: w["jobs"]["rerun-review-labels"]["steps"].append({"run": "git fetch origin \"$EVENT_HEAD_SHA\""}),
+        lambda w: w["jobs"]["rerun-review-labels"]["steps"][1].update({"run": EXPECTED_RUN + "\ngit fetch origin \\\"$EVENT_HEAD_SHA\\\""}),
+    ],
+)
+def test_mutation_oracle_rejects_appended_pr_head_paths(mutate):
+    workflow, _ = _workflow()
+    mutated = deepcopy(workflow)
+    if mutate.__name__ == "<lambda>":
+        # The second mutation is applied explicitly below; this branch keeps
+        # the parametrized cases readable without source-text assertions.
+        pass
+    mutate(mutated)
+    with pytest.raises(AssertionError):
+        _assert_trusted_control_plane(mutated)
+
+
+def test_appended_checkout_and_execution_commands_are_rejected():
+    workflow, _ = _workflow()
+    for payload in (
+        {"run": "git checkout \"$EVENT_HEAD_SHA\""},
+        {"run": "python3 /tmp/pr-head.py"},
+        {"run": "git fetch origin \"$EVENT_HEAD_SHA\""},
+    ):
+        mutated = deepcopy(workflow)
+        mutated["jobs"]["rerun-review-labels"]["steps"].append(payload)
+        with pytest.raises(AssertionError):
+            _assert_trusted_control_plane(mutated)
+
+
+def test_job_level_pr_head_execution_surfaces_are_rejected():
+    workflow, _ = _workflow()
+    for key, value in (
+        ("container", {"image": "${{ github.event.pull_request.head.label }}"}),
+        ("services", {"hostile": {"image": "${{ github.event.pull_request.head.label }}"}}),
+    ):
+        mutated = deepcopy(workflow)
+        mutated["jobs"]["rerun-review-labels"][key] = value
+        with pytest.raises(AssertionError):
+            _assert_trusted_control_plane(mutated)
+
+
+def test_step_uses_and_head_checkout_mutants_are_rejected():
+    workflow, _ = _workflow()
+    uses_mutant = deepcopy(workflow)
+    uses_mutant["jobs"]["rerun-review-labels"]["steps"].append({"uses": "actions/checkout@deadbeef"})
+    with pytest.raises(AssertionError):
+        _assert_trusted_control_plane(uses_mutant)
+
+    head_checkout = deepcopy(workflow)
+    head_checkout["jobs"]["rerun-review-labels"]["steps"][0]["with"]["ref"] = "${{ github.event.pull_request.head.sha }}"
+    with pytest.raises(AssertionError):
+        _assert_trusted_control_plane(head_checkout)
+
+
+def test_no_error_swallowing_or_done_status_in_workflow_body():
+    workflow, _ = _workflow()
+    text = str(workflow)
+    assert "|| true" not in text
+    assert "set -euo pipefail" in text
+    assert "Done" not in text
+    assert "RERUN_REQUESTED" not in text

--- a/tests/ci/test_pipeline_state.py
+++ b/tests/ci/test_pipeline_state.py
@@ -1,0 +1,674 @@
+"""Strict fail-closed tests for the label-rerun provider adapter.
+
+Fixtures mirror the reviewed P1 schema.  These tests use deterministic
+provider-shaped data only; they never call GitHub or mutate a run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "pipeline_state.py"
+_spec = importlib.util.spec_from_file_location("pipeline_state", _PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("failed to load pipeline_state.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+HEAD = "a" * 40
+BASE = "b" * 40
+OTHER = "c" * 40
+APP = {"id": "15368", "slug": "github-actions"}
+
+
+def _step(name="pytest", status="completed", conclusion="failure"):
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+def _job(
+    *,
+    job_id="job-1",
+    name="All required checks pass",
+    status="completed",
+    conclusion="failure",
+    runner_id=42,
+    steps=None,
+    annotations=None,
+):
+    return {
+        "job_id": job_id,
+        "head_sha": HEAD,
+        "attempt": 3,
+        "status": status,
+        "conclusion": conclusion,
+        "runner_id": runner_id,
+        "steps": [_step()] if steps is None else steps,
+        "annotations": [] if annotations is None else annotations,
+    }
+
+
+def fixture(*, run_status="completed", run_conclusion="failure", jobs=None, merge_base=BASE):
+    context = {
+        "context": "All required checks pass",
+        "head_sha": HEAD,
+        "app": dict(APP),
+        "attempt": 3,
+        "status": run_status,
+        "conclusion": run_conclusion,
+        "jobs": [_job()] if jobs is None else jobs,
+    }
+    return {
+        "schema": 1,
+        "target": {
+            "repository": {"owner": "example-org", "repo": "example-repo"},
+            "head_sha": HEAD,
+            "context": "All required checks pass",
+            "provider_app": dict(APP),
+            "latest_attempt": 3,
+        },
+        "provider_snapshot": {
+            "repository": {"owner": "example-org", "repo": "example-repo"},
+            "head_sha": HEAD,
+            "required_context": "All required checks pass",
+            "provider_app": dict(APP),
+            "latest_attempt": 3,
+            "workflow_run": {
+                "run_id": "run-123",
+                "head_sha": HEAD,
+                "attempt": 3,
+                "status": "completed",
+                "conclusion": "failure",
+            },
+            "pagination": {
+                "contexts_complete": True,
+                "jobs_complete": True,
+                "annotations_complete": True,
+            },
+            "contexts": [context],
+        },
+        "lineage": {
+            "merge_base": merge_base,
+            "source_branch": "feature/label-rerun",
+            "target_branch": "main",
+        },
+        "local": {"status": "NOT_RUN", "exit_code": None, "selector": None},
+        "post_write": {"head_sha": HEAD, "readback_complete": True},
+    }
+
+
+def _context(data):
+    return data["provider_snapshot"]["contexts"][0]
+
+
+def _job0(data):
+    return _context(data)["jobs"][0]
+
+
+def _assert_all_routing_false(result):
+    assert result["routing"] == {
+        "retry_allowed": False,
+        "code_fix_allowed": False,
+        "local_repro_required": False,
+        "source_branch_loop_allowed": False,
+    }
+
+
+def test_p1_result_has_exact_keys_and_does_not_invent_retry_routing():
+    result = _mod.diagnose_pipeline(fixture())
+    assert list(result) == ["schema", "classification", "reason_codes", "routing", "evidence"]
+    assert result["classification"] == "CODE_OR_TEST_FAILURE"
+    assert result["routing"] == {
+        "retry_allowed": False,
+        "code_fix_allowed": True,
+        "local_repro_required": True,
+        "source_branch_loop_allowed": True,
+    }
+    assert _mod.can_request_rerun(fixture()) is True
+
+
+def test_billing_spending_prestart_is_blocked_without_rerun():
+    data = fixture(jobs=[_job(runner_id=0, steps=[], annotations=[
+        {"category": "billing", "message": "provider spending limit"},
+    ])])
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "BLOCKED_PROVIDER_BILLING"
+    assert result["reason_codes"] == ["BILLING_ANNOTATION"]
+    _assert_all_routing_false(result)
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_action_required_with_no_jobs_is_provider_policy_block():
+    data = fixture(run_conclusion="action_required", jobs=[])
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "BLOCKED_PROVIDER_POLICY"
+    assert result["reason_codes"] == ["ACTION_REQUIRED"]
+    _assert_all_routing_false(result)
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_started_step_from_another_job_cannot_authorize_unstarted_failure():
+    data = fixture(jobs=[
+        _job(job_id="executed-success", conclusion="success", steps=[_step(conclusion="success")]),
+        _job(job_id="unstarted-failure", runner_id=0, steps=[], conclusion="failure"),
+    ])
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "WORKFLOW_OR_HARNESS_FAILURE"
+    assert result["evidence"]["real_started_step"] is False
+    assert _mod.can_request_rerun(data) is False
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda d: d["provider_snapshot"]["contexts"].clear(),
+        lambda d: d["provider_snapshot"]["pagination"].update({"jobs_complete": False}),
+        lambda d: d["provider_snapshot"]["pagination"].update({"annotations_complete": False}),
+        lambda d: d["provider_snapshot"]["contexts"][0].update({"status": "mystery"}),
+    ],
+)
+def test_missing_unknown_or_incomplete_evidence_never_requests_rerun(mutate):
+    data = fixture()
+    mutate(data)
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "EVIDENCE_INCOMPLETE"
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_malformed_identity_types_fail_closed_without_exception():
+    data = fixture()
+    data["target"]["head_sha"] = 7
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "EVIDENCE_INCOMPLETE"
+    assert result["reason_codes"] == ["INVALID_INPUT_SCHEMA"]
+    _assert_all_routing_false(result)
+
+
+def test_blocked_lineage_precedes_failure_and_never_authorizes_rerun():
+    data = fixture(merge_base=None)
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "BLOCKED_LINEAGE"
+    assert result["reason_codes"] == ["NO_MERGE_BASE"]
+    _assert_all_routing_false(result)
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_zero_synthetic_merge_base_is_not_accepted_as_real_evidence():
+    data = fixture(merge_base="0" * 40)
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "EVIDENCE_INCOMPLETE"
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_failed_rerun_is_red_and_makes_one_command_attempt():
+    decision = _mod.diagnose_pipeline(fixture())
+    calls = []
+
+    def fail_runner(args):
+        calls.append(args)
+        raise _mod.RerunCommandError("gh run rerun failed")
+
+    with pytest.raises(_mod.RerunCommandError):
+        _mod.request_exactly_one_rerun(
+            decision, repo="example-org/example-repo", run_id="123", runner=fail_runner,
+            expected_run_id="123", expected_attempt=3,
+            expected_head_sha=HEAD, head_reader=lambda: HEAD,
+            workflow_run_reader=lambda: {"run_id": "123", "head_sha": HEAD, "attempt": 3, "status": "completed", "conclusion": "failure"},
+            required_check_reader=lambda: {"status": "completed", "conclusion": "failure", "head_sha": HEAD},
+        )
+    assert calls == [["run", "rerun", "123", "--repo", "example-org/example-repo", "--failed"]]
+
+
+def test_successful_rerun_emits_only_rerun_requested():
+    decision = _mod.diagnose_pipeline(fixture())
+    result = _mod.request_exactly_one_rerun(
+        decision,
+        repo="example-org/example-repo",
+        run_id="123",
+        runner=lambda args: None,
+        expected_run_id="123",
+        expected_attempt=3,
+        expected_head_sha=HEAD,
+        head_reader=lambda: HEAD,
+        workflow_run_reader=lambda: {"run_id": "123", "head_sha": HEAD, "attempt": 3, "status": "completed", "conclusion": "failure"},
+        required_check_reader=lambda: {"status": "completed", "conclusion": "failure", "head_sha": HEAD},
+    )
+    assert result == {"status": "RERUN_REQUESTED"}
+
+
+def test_exact_workflow_and_head_selection_rejects_foreign_runs():
+    runs = [
+        {"databaseId": 1, "workflowName": "CI", "headSha": OTHER, "status": "completed"},
+        {"databaseId": 2, "workflowName": "Other", "headSha": HEAD, "status": "completed"},
+        {"databaseId": 3, "workflowName": "CI", "headSha": HEAD, "status": "completed"},
+    ]
+    assert _mod.select_exact_workflow_run(runs, workflow="CI", head_sha=HEAD)["databaseId"] == 3
+    assert _mod.select_exact_workflow_run(runs, workflow="CI", head_sha="d" * 40) is None
+
+
+def _raw_run(*, attempt=4):
+    return {
+        "databaseId": 123,
+        "headSha": HEAD,
+        "workflowName": "CI",
+        "status": "completed",
+        "conclusion": "failure",
+        "attempt": attempt,
+    }
+
+
+def _raw_job(job_id="job-1", name="All required checks pass", **overrides):
+    return {
+        "id": job_id,
+        "name": name,
+        "head_sha": HEAD,
+        "run_attempt": 4,
+        "status": "completed",
+        "conclusion": "failure",
+        "runner_id": 42,
+        "steps": [{"name": "pytest", "status": "completed", "conclusion": "failure"}],
+        **overrides,
+    }
+
+
+def _raw_check(check_id=9, name="All required checks pass", **overrides):
+    return {"id": check_id, "name": name, "head_sha": HEAD, "status": "completed", "conclusion": "failure", "app": dict(APP), **overrides}
+
+
+def test_provider_builder_binds_only_required_check_and_never_smears_annotations():
+    data = _mod.build_fixture_from_api(
+        repo="example-org/example-repo",
+        head_sha=HEAD,
+        run=_raw_run(attempt=4),
+        jobs=[_raw_job()],
+        check_runs=[_raw_check(8, "Foreign unrelated check"), _raw_check(9)],
+        annotations_by_check={
+            8: [{"category": "billing", "message": "foreign spending"}],
+            9: [{"category": "code_test", "message": "required failure"}],
+        },
+        base_sha=BASE,
+        source_branch="feature/label-rerun",
+        target_branch="main",
+        merge_base=BASE,
+    )
+    assert data is not None
+    assert data["target"]["latest_attempt"] == 4
+    assert [c["context"] for c in data["provider_snapshot"]["contexts"]] == ["All required checks pass"]
+    assert data["provider_snapshot"]["contexts"][0]["jobs"][0]["annotations"] == [
+        {"category": "code_test", "message": "required failure"}
+    ]
+
+
+def test_provider_builder_rejects_missing_required_check_without_synthesizing_it():
+    data = _mod.build_fixture_from_api(
+        repo="example-org/example-repo",
+        head_sha=HEAD,
+        run=_raw_run(),
+        jobs=[_raw_job(name="Foreign unrelated check")],
+        check_runs=[_raw_check(8, "Foreign unrelated check")],
+        annotations_by_check={8: []},
+        base_sha=BASE,
+        source_branch="feature/label-rerun",
+        target_branch="main",
+        merge_base=BASE,
+    )
+    assert data is None
+
+
+def test_post_write_readback_head_change_invalidates_old_failure():
+    data = fixture()
+    data["post_write"]["head_sha"] = OTHER
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "EVIDENCE_INCOMPLETE"
+    assert "POST_WRITE_HEAD_CHANGED" in result["reason_codes"]
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_missing_provider_head_shas_are_not_substituted():
+    run = _raw_run()
+    jobs = [_raw_job()]
+    check = _raw_check()
+    check.pop("head_sha")
+    assert _mod.build_fixture_from_api(
+        repo="example-org/example-repo", head_sha=HEAD, run=run, jobs=jobs,
+        check_runs=[check], annotations_by_check={9: []}, base_sha=BASE,
+        source_branch="feature/label-rerun", target_branch="main", merge_base=BASE,
+    ) is None
+    check = _raw_check()
+    jobs[0].pop("head_sha")
+    assert _mod.build_fixture_from_api(
+        repo="example-org/example-repo", head_sha=HEAD, run=run, jobs=jobs,
+        check_runs=[check], annotations_by_check={9: []}, base_sha=BASE,
+        source_branch="feature/label-rerun", target_branch="main", merge_base=BASE,
+    ) is None
+
+
+def test_required_check_status_and_conclusion_override_workflow_run_status():
+    run = _raw_run()
+    check = _raw_check(status="completed", conclusion="success")
+    data = _mod.build_fixture_from_api(
+        repo="example-org/example-repo", head_sha=HEAD, run=run, jobs=[_raw_job(conclusion="success")],
+        check_runs=[check], annotations_by_check={9: []}, base_sha=BASE,
+        source_branch="feature/label-rerun", target_branch="main", merge_base=BASE,
+    )
+    assert data is not None
+    context = data["provider_snapshot"]["contexts"][0]
+    assert context["status"] == "completed"
+    assert context["conclusion"] == "success"
+    result = _mod.diagnose_pipeline(data, require_post_write=False)
+    assert result["classification"] == "EVIDENCE_INCOMPLETE"
+    assert "PROVIDER_NOT_GREEN" in result["reason_codes"]
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_selected_check_must_be_the_trusted_github_actions_app():
+    check = _raw_check(app={"id": "foreign", "slug": "foreign-provider"})
+    data = _mod.build_fixture_from_api(
+        repo="example-org/example-repo", head_sha=HEAD, run=_raw_run(), jobs=[_raw_job()],
+        check_runs=[check], annotations_by_check={9: []}, base_sha=BASE,
+        source_branch="feature/label-rerun", target_branch="main", merge_base=BASE,
+    )
+    assert data is None
+
+
+def test_any_billing_or_spending_annotation_blocks_even_executed_failure():
+    data = fixture(jobs=[_job(runner_id=42, steps=[_step()], annotations=[
+        {"category": "billing", "message": "spending limit"},
+    ])])
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "BLOCKED_PROVIDER_BILLING"
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_paginated_response_accepts_rest_wrappers_and_rejects_non_objects():
+    item = {"id": 1}
+    assert _mod.parse_paginated_response({"jobs": [item]}, "jobs") == [item]
+    assert _mod.parse_paginated_response({"check_runs": [item]}, "check_runs") == [item]
+    assert _mod.parse_paginated_response({"jobs": [item, "HOSTILE_NON_OBJECT"]}, "jobs") is None
+    assert _mod.parse_paginated_response([{"jobs": [item]}, {"jobs": ["HOSTILE_NON_OBJECT"]}], "jobs") is None
+
+
+def test_each_job_run_attempt_must_equal_the_exact_run_attempt():
+    jobs = [_raw_job(run_attempt=3)]
+    assert _mod.build_fixture_from_api(
+        repo="example-org/example-repo", head_sha=HEAD, run=_raw_run(attempt=4), jobs=jobs,
+        check_runs=[_raw_check()], annotations_by_check={9: []}, base_sha=BASE,
+        source_branch="feature/label-rerun", target_branch="main", merge_base=BASE,
+    ) is None
+    jobs = [_raw_job()]
+    jobs[0].pop("run_attempt")
+    assert _mod.build_fixture_from_api(
+        repo="example-org/example-repo", head_sha=HEAD, run=_raw_run(attempt=4), jobs=jobs,
+        check_runs=[_raw_check()], annotations_by_check={9: []}, base_sha=BASE,
+        source_branch="feature/label-rerun", target_branch="main", merge_base=BASE,
+    ) is None
+
+
+def test_real_ci_yaml_failed_aggregate_path_binds_annotations_to_aggregate_job():
+    jobs = [
+        _raw_job(job_id="unit", name="Python tests", conclusion="success", steps=[_step(conclusion="success")]),
+        _raw_job(job_id="aggregate", name="All required checks pass"),
+    ]
+    data = _mod.build_fixture_from_api(
+        repo="example-org/example-repo", head_sha=HEAD, run=_raw_run(), jobs=jobs,
+        check_runs=[_raw_check(9, "All required checks pass")],
+        annotations_by_check={9: [{"message": "::error::1 job failed"}]}, base_sha=BASE,
+        source_branch="feature/label-rerun", target_branch="main", merge_base=BASE,
+    )
+    assert data is not None
+    bound_jobs = data["provider_snapshot"]["contexts"][0]["jobs"]
+    assert bound_jobs[0]["annotations"] == []
+    assert bound_jobs[1]["annotations"] == [{"category": "code_test", "message": "::error::1 job failed"}]
+    assert _mod.can_request_rerun(data) is True
+
+
+def test_rerun_rechecks_original_head_immediately_before_command():
+    decision = _mod.diagnose_pipeline(fixture())
+    calls = []
+    with pytest.raises(_mod.RerunCommandError):
+        _mod.request_exactly_one_rerun(
+            decision, repo="example-org/example-repo", run_id="123", runner=lambda args: calls.append(args),
+            expected_head_sha=HEAD, head_reader=lambda: OTHER,
+            expected_run_id="123", expected_attempt=3,
+            workflow_run_reader=lambda: {"run_id": "123", "head_sha": HEAD, "attempt": 3, "status": "completed", "conclusion": "failure"},
+            required_check_reader=lambda: {"status": "completed", "conclusion": "failure", "head_sha": HEAD},
+    )
+    assert calls == []
+
+
+def test_post_mutation_readback_requires_exact_head_and_run():
+    assert _mod.verify_exact_head_run_readback(
+        expected_head_sha=HEAD, expected_run_id="123",
+        head_reader=lambda: HEAD, run_reader=lambda: {"databaseId": 123, "headSha": HEAD},
+    ) is True
+    assert _mod.verify_exact_head_run_readback(
+        expected_head_sha=HEAD, expected_run_id="123",
+        head_reader=lambda: OTHER, run_reader=lambda: {"databaseId": 123, "headSha": HEAD},
+    ) is False
+
+
+@pytest.mark.parametrize(
+    "status,conclusion",
+    [("completed", "success"), ("in_progress", None)],
+)
+def test_non_failed_required_check_cannot_enter_annotation_or_rerun_route(status, conclusion):
+    data = fixture(run_status=status, run_conclusion=conclusion, jobs=[_job(annotations=[
+        {"category": "code_test", "message": "ordinary failure annotation"},
+    ])])
+    result = _mod.diagnose_pipeline(data, require_post_write=False)
+    assert result["classification"] != "CODE_OR_TEST_FAILURE"
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_mixed_paginated_wrapper_and_bare_items_are_rejected():
+    item = {"id": 1}
+    assert _mod.parse_paginated_response([{"jobs": [item]}, item], "jobs") is None
+    assert _mod.parse_paginated_response([{"jobs": [item]}, {"check_runs": [item]}], "jobs") is None
+    assert _mod.parse_paginated_response([{"jobs": [item]}, {"jobs": ["bad"]}], "jobs") is None
+
+
+def test_paginated_response_rejects_mixed_wrapper_keys_in_one_shape():
+    item = {"id": 1}
+    assert _mod.parse_paginated_response({"jobs": [item], "check_runs": []}, "jobs") is None
+    assert _mod.parse_paginated_response([{"jobs": [item], "check_runs": []}], "jobs") is None
+
+
+def test_aggregate_job_state_must_match_selected_required_check():
+    check = _raw_check(status="completed", conclusion="failure")
+    jobs = [_raw_job(status="completed", conclusion="success")]
+    assert _mod.build_fixture_from_api(
+        repo="example-org/example-repo", head_sha=HEAD, run=_raw_run(), jobs=jobs,
+        check_runs=[check], annotations_by_check={9: []}, base_sha=BASE,
+        source_branch="feature/label-rerun", target_branch="main", merge_base=BASE,
+    ) is None
+
+
+def test_truthy_non_boolean_post_write_flag_fails_closed():
+    data = fixture()
+    data["post_write"]["readback_complete"] = "HOSTILE_TRUTHY"
+    result = _mod.diagnose_pipeline(data)
+    assert result["classification"] == "EVIDENCE_INCOMPLETE"
+    assert result["reason_codes"] == ["INVALID_INPUT_SCHEMA"]
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_mutation_authorization_reasserts_required_check_failure():
+    decision = _mod.diagnose_pipeline(fixture())
+    calls = []
+    with pytest.raises(_mod.RerunCommandError):
+        _mod.request_exactly_one_rerun(
+            decision, repo="example-org/example-repo", run_id="123",
+            runner=lambda args: calls.append(args), eligible=True,
+            expected_head_sha=HEAD, head_reader=lambda: HEAD,
+            expected_run_id="123", expected_attempt=3,
+            workflow_run_reader=lambda: {"run_id": "123", "head_sha": HEAD, "attempt": 3, "status": "completed", "conclusion": "failure"},
+            required_check_reader=lambda: {"status": "completed", "conclusion": "success", "head_sha": HEAD},
+        )
+    assert calls == []
+
+
+def test_mutation_without_fresh_head_and_required_check_fences_is_rejected():
+    decision = _mod.diagnose_pipeline(fixture())
+    calls = []
+    with pytest.raises(_mod.RerunCommandError):
+        _mod.request_exactly_one_rerun(
+            decision, repo="example-org/example-repo", run_id="123",
+            runner=lambda args: calls.append(args), eligible=True,
+        )
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "status,conclusion",
+    [("in_progress", None), ("mystery", "failure"), ("completed", "success")],
+)
+def test_target_workflow_run_state_must_be_completed_failure(status, conclusion):
+    data = fixture()
+    data["provider_snapshot"]["workflow_run"].update({"status": status, "conclusion": conclusion})
+    result = _mod.diagnose_pipeline(data, require_post_write=False)
+    assert result["classification"] == "EVIDENCE_INCOMPLETE"
+    assert _mod.can_request_rerun(data) is False
+
+
+def test_builder_carries_exact_workflow_run_identity_and_state():
+    data = _mod.build_fixture_from_api(
+        repo="example-org/example-repo", head_sha=HEAD, run=_raw_run(attempt=4), jobs=[_raw_job()],
+        check_runs=[_raw_check()], annotations_by_check={9: []}, base_sha=BASE,
+        source_branch="feature/label-rerun", target_branch="main", merge_base=BASE,
+    )
+    assert data is not None
+    assert data["provider_snapshot"]["workflow_run"] == {
+        "run_id": "123", "head_sha": HEAD, "attempt": 4,
+        "status": "completed", "conclusion": "failure",
+    }
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        {"run_id": "other", "head_sha": HEAD, "attempt": 4, "status": "completed", "conclusion": "failure"},
+        {"run_id": "123", "head_sha": OTHER, "attempt": 4, "status": "completed", "conclusion": "failure"},
+        {"run_id": "123", "head_sha": HEAD, "attempt": 2, "status": "completed", "conclusion": "failure"},
+        {"run_id": "123", "head_sha": HEAD, "attempt": 4, "status": "in_progress", "conclusion": None},
+        {"run_id": "123", "head_sha": HEAD, "attempt": 4, "status": "completed", "conclusion": "success"},
+    ],
+)
+def test_mutation_rejects_changed_workflow_run_identity_or_state(mutate):
+    decision = _mod.diagnose_pipeline(fixture())
+    calls = []
+    with pytest.raises(_mod.RerunCommandError):
+        _mod.request_exactly_one_rerun(
+            decision, repo="example-org/example-repo", run_id="123",
+            runner=lambda args: calls.append(args), eligible=True,
+            expected_run_id="123", expected_attempt=3, expected_head_sha=HEAD,
+            head_reader=lambda: HEAD,
+            workflow_run_reader=lambda: mutate,
+            required_check_reader=lambda: {"status": "completed", "conclusion": "failure", "head_sha": HEAD},
+        )
+    assert calls == []
+
+
+def test_collection_rejects_detail_run_id_mismatch_before_downstream_calls(monkeypatch):
+    downstream_calls = []
+
+    def fake_gh(args):
+        if args[:3] == ["pr", "view", "77"]:
+            return {
+                "headRefOid": HEAD,
+                "baseRefOid": BASE,
+                "headRefName": "feature/label-rerun",
+                "baseRefName": "main",
+            }
+        if args[:2] == ["run", "list"]:
+            return {
+                "workflow_runs": [{
+                    "databaseId": 123,
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "headSha": HEAD,
+                    "workflowName": "CI",
+                    "createdAt": "2026-08-29T18:00:00Z",
+                }]
+            }
+        if args[:3] == ["run", "view", "123"]:
+            return {
+                "databaseId": 999,
+                "status": "completed",
+                "conclusion": "failure",
+                "headSha": HEAD,
+                "workflowName": "CI",
+                "attempt": 4,
+            }
+        downstream_calls.append(args)
+        if args[:3] == ["api", "--paginate", "--slurp"] and "/actions/runs/123/jobs" in args[3]:
+            return {"jobs": [_raw_job()]}
+        if args[:3] == ["api", "--paginate", "--slurp"] and "/check-runs?" in args[3]:
+            return {"check_runs": [_raw_check()]}
+        if args[:3] == ["api", "--paginate", "--slurp"] and "/check-runs/9/annotations" in args[3]:
+            return {"annotations": []}
+        if args[:2] == ["api", f"repos/example-org/example-repo/compare/{BASE}...{HEAD}"]:
+            return {"merge_base_commit": {"sha": BASE}}
+        raise AssertionError(f"unexpected provider call: {args}")
+
+    monkeypatch.setattr(_mod, "_gh_json", fake_gh)
+    with pytest.raises(_mod.EvidenceError):
+        _mod.collect_provider_fixture(
+            repo="example-org/example-repo",
+            pr_number="77",
+            workflow="CI",
+            event_head_sha=HEAD,
+        )
+    assert downstream_calls == []
+
+
+def test_mutation_target_run_id_substitution_is_rejected_before_runner():
+    decision = _mod.diagnose_pipeline(fixture())
+    calls = []
+    with pytest.raises(_mod.RerunCommandError):
+        _mod.request_exactly_one_rerun(
+            decision,
+            repo="example-org/example-repo",
+            run_id="ATTACKER-CHANGED-RUN",
+            runner=lambda args: calls.append(args),
+            eligible=True,
+            expected_run_id="123",
+            expected_attempt=3,
+            expected_head_sha=HEAD,
+            head_reader=lambda: HEAD,
+            workflow_run_reader=lambda: {
+                "run_id": "123",
+                "head_sha": HEAD,
+                "attempt": 3,
+                "status": "completed",
+                "conclusion": "failure",
+            },
+            required_check_reader=lambda: {
+                "status": "completed",
+                "conclusion": "failure",
+                "head_sha": HEAD,
+            },
+        )
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "status,conclusion",
+    [("in_progress", None), ("unknown", "mystery"), ("completed", "success")],
+)
+def test_bounded_builder_rejects_non_completed_failure_run_state(status, conclusion):
+    run = _raw_run()
+    run.update({"status": status, "conclusion": conclusion})
+    assert _mod.build_fixture_from_api(
+        repo="example-org/example-repo",
+        head_sha=HEAD,
+        run=run,
+        jobs=[_raw_job()],
+        check_runs=[_raw_check()],
+        annotations_by_check={9: []},
+        base_sha=BASE,
+        source_branch="feature/label-rerun",
+        target_branch="main",
+        merge_base=BASE,
+    ) is None


### PR DESCRIPTION
## Summary
- replace blind label-triggered reruns with a fail-closed provider adapter
- bind PR head, workflow, run ID/attempt/state, jobs, required check/provider, annotations, compare/merge-base, and billing evidence
- require one immutable selected run ID from collection through final rerun command/readback
- reject incomplete, mixed, paginated, drifted, or non-`completed/failure` evidence with zero mutation

## Verification
- focused canonical runner: **57 passed, 0 failed**
- independent Sol review: **APPROVE_LOCAL_AWAITING_HOSTED**, 0 Critical / 0 Important
- hostile W6 probes: **5 RED → 5 GREEN**
- Python AST: 3/3
- workflow YAML parse: pass
- `git diff --check`: pass
- clean cherry-pick onto current upstream main `835a913ffd599e52b7843334c8abb74726c6aeeb`

## Hosted gate
No live rerun was dispatched. Hosted GitHub evidence and any real rerun remain external gates.