### PR TITLE
fix(moa): report actual reference fallback routes

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -170,6 +170,7 @@ class _RefAccounting:
     model: str | None = None
     provider: str | None = None
     temperature: Any = None
+    rerouted: bool = False
 
 
 # Per-tool-result char budget for the advisory view: tool CALLS are kept in full,
@@ -384,16 +385,38 @@ def _run_reference(
         slot_max_tokens = slot.get("max_tokens")
         # Copilot gates premium models on request attribution; MoA fan-out serves the
         # user's current turn, so mirror the main agent's x-initiator header.
-        from agent.auxiliary_client import _normalize_aux_provider
+        from agent.auxiliary_client import _normalize_aux_provider, _normalize_resolved_model
         is_copilot = _normalize_aux_provider(str(runtime.get("provider") or "")) in ("copilot", "copilot-acp")
+        route_info: dict[str, str] = {}
         response = call_llm(
             task="moa_reference", messages=trimmed, temperature=temperature,
             max_tokens=slot_max_tokens if slot_max_tokens is not None else max_tokens,
             timeout=reference_timeout, reasoning_config=_slot_reasoning_config(slot),
-            extra_headers={"x-initiator": "user"} if is_copilot else None, **runtime,
+            extra_headers={"x-initiator": "user"} if is_copilot else None,
+            route_info=route_info, **runtime,
         )
+        requested_provider = str(runtime.get("provider") or slot.get("provider") or "")
+        requested_model = str(runtime.get("model") or slot.get("model") or "")
+        actual_provider = route_info.get("provider") or requested_provider
+        actual_model = route_info.get("model") or requested_model
+        normalized_requested_provider = _normalize_aux_provider(requested_provider)
+        expected_model = _normalize_resolved_model(requested_model, actual_provider)
+        rerouted = normalized_requested_provider != "auto" and (
+            _normalize_aux_provider(actual_provider) != normalized_requested_provider
+            or actual_model != expected_model
+        )
+        if rerouted:
+            label = f"{label} -> {_slot_label({**slot, 'provider': actual_provider, 'model': actual_model})}"
+        actual_slot = {**slot, "model": actual_model}
+        actual_runtime = {**runtime, "provider": actual_provider}
+        if rerouted:
+            actual_runtime.update(api_mode=None, base_url=None, api_key=None)
         output_text = _extract_text(response) or "(empty response)"
-        acct = _RefAccounting(*_price_reference_response(response, slot, runtime), messages=trimmed, output=output_text, **trace_fields)
+        acct = _RefAccounting(
+            *_price_reference_response(response, actual_slot, actual_runtime),
+            messages=trimmed, output=output_text, model=actual_model,
+            provider=actual_provider, temperature=temperature, rerouted=rerouted,
+        )
         return label, output_text, acct
     except Exception as exc:
         logger.warning("MoA reference model %s failed: %s", label, exc)
@@ -753,10 +776,17 @@ def _sum_reference_accounting(outputs: list[tuple[str, str, Any]]) -> tuple[Any,
     return usage, cost
 
 
-def _degraded_notice(failed_labels: list[str], policy: str) -> str:
-    if not failed_labels or policy.strip().lower() == "silent":
+def _degraded_notice(
+    failed_labels: list[str], policy: str, *, rerouted_labels: list[str] | None = None,
+) -> str:
+    if policy.strip().lower() == "silent":
         return ""
-    return f"[Reference models unavailable: {', '.join(failed_labels)}]"
+    notices = []
+    if failed_labels:
+        notices.append(f"Reference models unavailable: {', '.join(failed_labels)}")
+    if rerouted_labels:
+        notices.append(f"Reference models rerouted: {', '.join(rerouted_labels)}")
+    return f"[{'; '.join(notices)}]" if notices else ""
 
 
 def _slot_labels(slots: list[dict[str, Any]]) -> str:
@@ -773,8 +803,16 @@ def _guidance_inputs(
     """
     successful = [o for o in reference_outputs if not _is_failed_reference(o[1])]
     failed_labels = [label for label, text, _acct in reference_outputs if _is_failed_reference(text)]
+    rerouted_labels = [
+        label for label, _text, acct in reference_outputs
+        if isinstance(acct, _RefAccounting) and acct.rerouted
+    ]
     agg_refs = _redact_reference_outputs(successful) if privacy_full else successful
-    return agg_refs, _degraded_notice(failed_labels, policy), bool(reference_outputs) and not successful
+    return (
+        agg_refs,
+        _degraded_notice(failed_labels, policy, rerouted_labels=rerouted_labels),
+        bool(reference_outputs) and not successful,
+    )
 
 
 def aggregate_moa_context(
@@ -850,7 +888,7 @@ def aggregate_moa_context(
         "normal Hermes agent loop. You may call tools, continue reasoning, or "
         "finish normally.]\n"
         f"Aggregator: {agg_label}\n"
-        f"References: {_slot_labels(reference_models)}\n\n"
+        f"References: {', '.join(label for label, _, _ in reference_outputs)}\n\n"
         f"{(synthesis or joined).strip()}"
     )
 

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -791,6 +791,85 @@ def test_run_reference_captures_usage_and_cost(monkeypatch):
     assert acct.cost_usd == 0.0123
 
 
+@pytest.mark.parametrize(
+    ("requested_provider", "actual_provider", "actual_model", "rerouted"),
+    [
+        ("nous", "openai-codex", "gpt-5.6-sol", True),
+        ("anthropic", "anthropic", "claude-opus-4-8", False),
+        ("auto", "openai-codex", "gpt-5.6-sol", False),
+    ],
+)
+def test_moa_reference_route_reporting(
+    monkeypatch, requested_provider, actual_provider, actual_model, rerouted
+):
+    from agent import moa_loop
+
+    aggregator_calls = []
+    priced_routes = []
+    reference_outputs = []
+
+    def fake_call_llm(**kwargs):
+        if kwargs["task"] == "moa_reference":
+            route_info = kwargs.get("route_info")
+            if route_info is not None:
+                route_info.update(provider=actual_provider, model=actual_model)
+            return _response_with_usage()
+        aggregator_calls.append(kwargs)
+        return _response("synthesized guidance")
+
+    def fake_estimate(model, _usage, *, provider=None, base_url=None, **_kwargs):
+        priced_routes.append((provider, model, base_url))
+        return SimpleNamespace(amount_usd=0.01, status="estimated", source="table")
+
+    run_references = moa_loop._run_references_parallel
+
+    def capture_reference_outputs(*args, **kwargs):
+        outputs = run_references(*args, **kwargs)
+        reference_outputs.extend(outputs)
+        return outputs
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(
+        moa_loop, "_run_references_parallel", capture_reference_outputs
+    )
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": slot["provider"],
+            "model": slot["model"],
+            "base_url": "https://example.test/v1",
+        },
+    )
+    monkeypatch.setattr("agent.usage_pricing.estimate_usage_cost", fake_estimate)
+
+    result = moa_loop.aggregate_moa_context(
+        user_prompt="review this",
+        api_messages=[{"role": "user", "content": "review this"}],
+        reference_models=[
+            {"provider": requested_provider, "model": "anthropic/claude-opus-4.8"}
+        ],
+        aggregator={"provider": "openrouter", "model": "aggregator"},
+        degraded_reference_policy="loud",
+    )
+
+    requested = f"{requested_provider}:anthropic/claude-opus-4.8"
+    actual = f"{actual_provider}:{actual_model}"
+    label = f"{requested} -> {actual}" if rerouted else requested
+    private_prompt = aggregator_calls[0]["messages"][0]["content"]
+    assert f"Reference 1 — {label}" in private_prompt
+    assert f"References: {label}" in result
+    accounting = reference_outputs[0][2]
+    assert accounting.provider == actual_provider
+    assert accounting.model == actual_model
+    assert accounting.rerouted is rerouted
+    if rerouted:
+        assert f"Reference models rerouted: {label}" in private_prompt
+    else:
+        assert "Reference models rerouted" not in private_prompt
+    assert priced_routes == [
+        (actual_provider, actual_model, None if rerouted else "https://example.test/v1")
+    ]
 
 
 def test_canonical_usage_add():


### PR DESCRIPTION
## What does this PR do?

MoA reference requests can be rerouted by the auxiliary router when their configured route fails. `_run_reference()` still attributed successful fallback responses to the originally configured provider and model.

This change uses the concrete route reported by `call_llm()` for labels, traces, usage normalization, and pricing. Rerouted references are shown as `requested -> actual` and reported when `degraded_reference_policy` is set to `loud`. Provider-specific model normalization and normal `provider: auto` resolution are not treated as fallbacks.

## Related Issue

Fixes #97936

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Attribute successful MoA fallbacks to the provider and model that served the request.
- Use the actual route for labels, trace data, usage normalization, and pricing.
- Report rerouted references when `degraded_reference_policy` is set to `loud`.
- Add regression coverage for fallback attribution, model normalization, and automatic provider resolution.

## How to Test

1. `scripts/run_tests.sh -j 1 tests/run_agent/test_moa_loop_mode.py -q` — 30 passed
2. `scripts/run_tests.sh -j 4 'tests/agent/test_moa*.py' -q` — 54 passed
3. `scripts/run_tests.sh -j 1 tests/agent/test_plugin_llm_task_routing.py -q` — 31 passed
4. `uvx ruff check agent/moa_loop.py tests/run_agent/test_moa_loop_mode.py` — passed
5. `python scripts/check-windows-footguns.py agent/moa_loop.py tests/run_agent/test_moa_loop_mode.py` — passed
6. `git diff --check` — passed

Tested on Windows using the repository test wrapper.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Full-suite coverage is left to GitHub CI. The focused tests above pass.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no documented interface or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added or changed config keys — N/A, no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is platform-neutral Python
- [x] I've updated tool descriptions or schemas if I changed tool behavior — N/A, no tool interface or schema change

## AI assistance

I used Codex to investigate the issue and assist with validation.