### PR TITLE
fix(models): accept live Nous Portal recommendations in /model validation (salvage #71315)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -7060,6 +7060,42 @@ def validate_requested_model(
                     ),
                 }
 
+            # Nous provider: also check the Portal's live
+            # /api/nous/recommended-models feed. That feed can list a model
+            # (e.g. a newly-promoted free/paid recommendation) before it's
+            # been added to the hardcoded _PROVIDER_MODELS["nous"] curated
+            # list or the docs-hosted catalog manifest has been rebuilt.
+            # `hermes chat` already accepts these models via
+            # union_with_portal_free/paid_recommendations() at model-list
+            # build time; this mirrors that same source of truth for the
+            # per-message /model validation path (messaging platform
+            # pickers, /model command), which previously only checked the
+            # curated catalog and rejected valid Portal-recommended models.
+            if normalized == "nous":
+                try:
+                    portal_payload = fetch_nous_recommended_models(
+                        _resolve_nous_portal_url()
+                    )
+                    portal_model_names = {
+                        str(entry.get("modelName", "")).strip().lower()
+                        for tier in ("freeRecommendedModels", "paidRecommendedModels")
+                        for entry in (portal_payload.get(tier) or [])
+                        if isinstance(entry, dict)
+                    }
+                    portal_model_names.discard("")
+                except Exception:
+                    portal_model_names = set()
+                if requested_for_lookup.lower() in portal_model_names:
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "message": (
+                            f"Note: `{requested}` was not found in the live /v1/models "
+                            f"listing but is a current Nous Portal recommendation — accepted."
+                        ),
+                    }
+
         return {
             "accepted": False,
             "persist": False,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -7077,12 +7077,11 @@ def validate_requested_model(
                         _resolve_nous_portal_url()
                     )
                     portal_model_names = {
-                        str(entry.get("modelName", "")).strip().lower()
+                        name.lower()
                         for tier in ("freeRecommendedModels", "paidRecommendedModels")
                         for entry in (portal_payload.get(tier) or [])
-                        if isinstance(entry, dict)
+                        if (name := _extract_model_name(entry))
                     }
-                    portal_model_names.discard("")
                 except Exception:
                     portal_model_names = set()
                 if requested_for_lookup.lower() in portal_model_names:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -749,6 +749,26 @@ class TestValidateRequestedModelNousPortalRecommendations:
         )
         assert result["accepted"] is False  # fails closed, doesn't crash
 
+    def test_non_string_model_name_entries_ignored(self):
+        """Malformed Portal entries (non-string / empty modelName) must be
+        skipped via _extract_model_name -- never stringified into garbage
+        matches (e.g. an int modelName 5 must not accept a model named "5")."""
+        payload = {
+            "freeRecommendedModels": [
+                {"modelName": 5},
+                {"modelName": ""},
+                {"modelName": None},
+                "not-a-dict",
+                {"modelName": "inclusionai/ling-3.0-flash:free"},
+            ],
+            "paidRecommendedModels": [],
+        }
+        assert self._validate_nous("5", portal_payload=payload)["accepted"] is False
+        result = self._validate_nous(
+            "inclusionai/ling-3.0-flash:free", portal_payload=payload
+        )
+        assert result["accepted"] is True
+
     def test_non_nous_provider_does_not_consult_portal_feed(self):
         """This fallback tier is Nous-specific; a non-Nous provider must
         not have its rejection changed by (or trigger a call to) the Nous

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -676,3 +676,111 @@ class TestValidateOpenRouterVariantSuffixes:
         assert result["accepted"] is True
         assert result["recognized"] is True
         assert result.get("corrected_model") is None
+
+
+class TestValidateRequestedModelNousPortalRecommendations:
+    """Regression tests for issue #71312: the Nous Telegram picker (and any
+    other messaging-platform /model validation, since they all share
+    validate_requested_model()) rejected models that are live Nous Portal
+    recommendations (/api/nous/recommended-models) but not yet in the
+    hardcoded curated catalog -- even though `hermes chat` already accepts
+    these via union_with_portal_free/paid_recommendations() at model-list
+    build time. The per-message validation path now checks the same Portal
+    feed as a fallback tier before rejecting, so Telegram/CLI agree.
+    """
+
+    PORTAL_PAYLOAD = {
+        "freeRecommendedModels": [
+            {"modelName": "inclusionai/ling-3.0-flash:free"},
+        ],
+        "paidRecommendedModels": [
+            {"modelName": "inclusionai/ling-3.0-pro"},
+        ],
+    }
+
+    def _validate_nous(self, model, api_models=None, portal_payload=None, portal_raises=False):
+        api_models = api_models if api_models is not None else ["inclusionai/ling-2.6-flash"]
+        probe_payload = {
+            "models": api_models,
+            "probed_url": "https://portal.nousresearch.com/v1/models",
+            "resolved_base_url": "https://portal.nousresearch.com/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+
+        def _fetch_portal(*a, **kw):
+            if portal_raises:
+                raise RuntimeError("portal unreachable")
+            return portal_payload if portal_payload is not None else self.PORTAL_PAYLOAD
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=api_models), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload), \
+             patch("hermes_cli.models.fetch_nous_recommended_models", side_effect=_fetch_portal), \
+             patch("hermes_cli.models._resolve_nous_portal_url", return_value="https://portal.nousresearch.com"), \
+             patch("hermes_cli.models._model_in_provider_catalog", return_value=False):
+            return validate_requested_model(model, "nous")
+
+    def test_free_portal_recommendation_accepted(self):
+        """The exact scenario from #71312: a free-tier Portal recommendation
+        missing from the curated catalog and the live /v1/models listing
+        must be accepted, not rejected."""
+        result = self._validate_nous("inclusionai/ling-3.0-flash:free")
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert "Portal recommendation" in (result["message"] or "")
+
+    def test_paid_portal_recommendation_accepted(self):
+        result = self._validate_nous("inclusionai/ling-3.0-pro")
+        assert result["accepted"] is True
+
+    def test_model_absent_from_portal_and_catalog_still_rejected(self):
+        """A model that's genuinely nowhere (not live, not curated, not a
+        Portal recommendation) must still be rejected -- this fallback
+        tier must not make validation permissive for everything."""
+        result = self._validate_nous("totally-made-up-model-xyz")
+        assert result["accepted"] is False
+        assert result["recognized"] is False
+
+    def test_portal_fetch_failure_falls_through_to_rejection_not_crash(self):
+        """A network/parse failure fetching the Portal feed must not crash
+        validation -- it degrades to the existing rejection path."""
+        result = self._validate_nous(
+            "inclusionai/ling-3.0-flash:free", portal_raises=True
+        )
+        assert result["accepted"] is False  # fails closed, doesn't crash
+
+    def test_non_nous_provider_does_not_consult_portal_feed(self):
+        """This fallback tier is Nous-specific; a non-Nous provider must
+        not have its rejection changed by (or trigger a call to) the Nous
+        Portal feed."""
+        probe_payload = {
+            "models": ["some/other-model"],
+            "probed_url": "https://api.example.com/v1/models",
+            "resolved_base_url": "https://api.example.com/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=["some/other-model"]), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload), \
+             patch("hermes_cli.models.fetch_nous_recommended_models") as mock_portal, \
+             patch("hermes_cli.models._model_in_provider_catalog", return_value=False):
+            result = validate_requested_model("inclusionai/ling-3.0-flash:free", "openrouter")
+        mock_portal.assert_not_called()
+        assert result["accepted"] is False
+
+    def test_curated_catalog_hit_short_circuits_before_portal_check(self):
+        """When the curated-catalog fallback already accepts the model, the
+        Portal feed should not need to be consulted at all (cheaper, and
+        avoids an unnecessary network call on the common path)."""
+        api_models = ["inclusionai/ling-2.6-flash"]
+        probe_payload = {
+            "models": api_models, "probed_url": "x", "resolved_base_url": "x",
+            "suggested_base_url": None, "used_fallback": False,
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=api_models), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload), \
+             patch("hermes_cli.models._model_in_provider_catalog", return_value=True), \
+             patch("hermes_cli.models.fetch_nous_recommended_models") as mock_portal:
+            result = validate_requested_model("inclusionai/ling-2.6-flash", "nous")
+        mock_portal.assert_not_called()
+        assert result["accepted"] is True


### PR DESCRIPTION
## Summary

Salvage of #71315 by @ygd58 (fixes #71312; closes duplicate #71313), rebased onto current main with the author's commit and authorship preserved, plus a follow-up refactor commit addressing review findings.

## Real-world impact (WHO/WHEN/WHY)

WHO: any user selecting a Nous Portal model from a GUI picker (desktop app, TUI, dashboard, Telegram/Discord `/model`) when that model is a live Portal recommendation but not yet in the hardcoded curated catalog or the provider's `/v1/models` listing.

WHEN: every time the Portal promotes a new free/paid recommendation before a Hermes release catches up — e.g. `inclusionai/ling-3.0-flash-fin:free`, promoted in the `freeRecommendedModels`/`paidRecommendedModels` feed but absent from `_PROVIDER_MODELS["nous"]` and the live listing.

WHY it breaks: the picker MENU is built through `list_authenticated_providers()`, which merges the Portal feed via `union_with_portal_free/paid_recommendations()` — so the model is offered. But SELECTING it goes through `config.set` → `switch_model()` → `validate_requested_model()`, which only consulted the live `/v1/models` listing and the static curated catalog. The menu offers a model the validator then rejects.

## Verbatim before/after

Before (current main, live repro against the real Portal feed + real Nous credentials):

```
switch_model('inclusionai/ling-3.0-flash-fin:free', explicit_provider='nous')
-> success=False
   Model `inclusionai/ling-3.0-flash-fin:free` was not found in this provider's model listing.
   Similar models: `inclusionai/ling-3.0-flash`, `stepfun/step-3.7-flash:free`, `meituan/longcat-2.0:free`
```

Desktop app (CDP-driven repro): the model shows in the picker, selecting it mid-session pops "Model switch failed — Model `inclusionai/ling-3.0-flash-fin:free` was not found in this provider's model listing" and rolls the pill back. The model genuinely serves inference on the Nous API (verified with a real completion) — validation was the only blocker. Meanwhile `hermes model` (wizard) and `hermes chat -m ... --provider nous` accept and run it, hence the "works in CLI, not in desktop" reports.

After (this branch, same live probe):

```
switch_model('inclusionai/ling-3.0-flash-fin:free', explicit_provider='nous')
-> success=True
   Note: `inclusionai/ling-3.0-flash-fin:free` was not found in the live /v1/models
   listing but is a current Nous Portal recommendation — accepted.
```

Desktop E2E on this branch (dev app, backend pinned to this checkout): mid-session switch commits cleanly, session store records the session on `inclusionai/ling-3.0-flash-fin:free` via provider `nous`, and the next turn genuinely runs on it.

## Commits

1. `fix(models): accept live Nous Portal recommendations in /model validation` — @ygd58's fix from #71315, rebased. Adds a Nous-only fallback tier in `validate_requested_model()`: after the live-listing miss and the curated-catalog miss, consult the same `fetch_nous_recommended_models()` feed the CLI union helpers already use (TTL + disk-cached, 5s bounded, fails closed when unreachable, short-circuits when an earlier tier accepted).
2. `refactor(models): reuse _extract_model_name in the Portal-recommendation validation tier` — review follow-up: the inline set-comprehension re-implemented modelName extraction that `_extract_model_name()` (used by both union helpers) already provides, and its `str(...)` would stringify a malformed non-string `modelName` (int `5` → garbage `"5"` match). Routed through the helper; added a regression test locking the behavior.

## Verification

- Reproduced the bug live on current main (rejection) and verified the fix live on this branch (acceptance), including a full desktop-app E2E where the previously-failing mid-session switch now succeeds and the turn runs on the model.
- `tests/hermes_cli/test_model_validation.py`: 52/52 pass; + `test_models.py`: 131 combined pass.
- Full `tests/hermes_cli/`: 303 passed / 1 failed — the failure (`test_approval_transport.py::test_cli_selected_transport_replaces_builtin_prompt`) reproduces identically on upstream/main (test-ordering artifact, passes in isolation): pre-existing, unrelated.
- Mutation checks: with `hermes_cli/models.py` reverted to pre-fix main, the accepted-path tests + the new non-string guard fail (3 failed / 4 passed); restored, all green. The new guard also fails against the raw-stringify comprehension specifically, proving it binds the refactor's semantic change.
- `ruff check` clean on both changed files.
- The original PR's CI failures were against its Jul-30 base: slice 2 was a setup-uv infra fetch failure, slice 7's `test_update_eol_churn` failure is unrelated to this diff and passes on current main.

## Provenance

Original work: #71315 by @ygd58 (authorship preserved on the fix commit; the original branch's second commit repaired a rebase corruption in the test file and is obsoleted by the clean rebase here). Original issue #71312 and duplicate #71313 by the same reporter.

Closes #71312. Closes #71313.
