### PR TITLE
feat(skills): sepia — de-AI writing via narrative-structure repair (port of Nanako0129/sepia, MIT)

### DIFF
--- a/optional-skills/creative/sepia/LICENSE.txt
+++ b/optional-skills/creative/sepia/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nanako Tsai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/optional-skills/creative/sepia/SKILL.md
+++ b/optional-skills/creative/sepia/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: sepia
+description: "De-AI writing: fix narrative structure, not just style."
+version: 1.0.0
+author: 'Nanako0129 (upstream sepia), ported by Hermes Agent'
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [writing, de-ai, humanize, fiction, prose, storyscope]
+    category: creative
+    homepage: https://github.com/Nanako0129/sepia
+    related_skills: [humanizer]
+---
+
+# Sepia — de-AI writing
+
+Make AI-generated writing read as human-written, in fiction and in professional
+prose. Repairs the narrative architecture of fiction and stories (based on
+StoryScope, arXiv:2604.03136); routes professional text through domain rules for
+release notes, announcements, PR and issue replies, code-review comments,
+incident postmortems, tickets, work orders, technical articles, and blog posts.
+Four operations — write, review (diagnose AI tells without editing), refactor
+(minimal in-place edits), recreate (full rewrite). Use when asked to humanize,
+de-AI, unslop, or strip AI flavor from any text; when writing or revising any of
+these document types; or whenever output must not read as machine-written.
+
+*Ported from upstream sepia v0.2.0. The upstream `research/` directory (evidence
+notes behind each rule) is not vendored in this port — see
+https://github.com/Nanako0129/sepia/tree/main/research for provenance.*
+
+Every rule here is backed by a measured human-vs-AI gap. The load-bearing facts: in fiction, a classifier using only **narrative-structure features** detects AI at 93.2% macro-F1 and style editing barely moves it — so structure is fixed before style, always. In professional prose, the measured tells are different — filler density, missing stance, chatbot residue, register mismatch, format uniformity — and the fix is domain-specific. Route first, then operate.
+
+## Sepia vs humanizer
+
+Hermes also bundles **humanizer** (Wikipedia signs-of-AI-writing): a fast,
+style-level de-AI pass for any text — word swaps, tone, surface tells.
+**Sepia** is structural repair: fiction narrative architecture (StoryScope —
+structure alone detects AI at 93.2% macro-F1; style editing barely moves it),
+domain-routed professional prose rules (release notes, PR replies, postmortems,
+tickets, tech articles), and four operation contracts (write / review /
+refactor / recreate). Recommendation: quick de-slop → humanizer; fiction,
+domain documents, or text that *still reads as AI after style edits* → sepia.
+
+## Loading references in Hermes
+
+Load the pass files on demand with
+`skill_view(name='sepia', file_path='references/narrative-pass.md')` (and
+likewise for any path in the routing table below).
+
+## Routing
+
+| Text type | Load, in order |
+|---|---|
+| Fiction / stories / narrative essays | `references/narrative-pass.md` → `references/discourse-pass.md` → `references/style-pass.md`; diagnose with `references/rubric.md` |
+| Release notes, changelogs, announcements | `references/professional-pass.md` + `references/domains/release-notes.md` |
+| PR replies, issue replies, review comments | `references/professional-pass.md` + `references/domains/dev-replies.md` |
+| Incident postmortems / RCA | `references/professional-pass.md` + `references/domains/postmortems.md` |
+| Tickets, work orders, bug reports | `references/professional-pass.md` + `references/domains/tickets.md` |
+| Technical articles, blog posts, tutorials | `references/professional-pass.md` + `references/domains/tech-articles.md` + `references/discourse-pass.md` §1–3 |
+| Any other prose | `references/professional-pass.md` + `references/style-pass.md` |
+
+Every non-fiction route ends with the vocabulary/syntax scan in `references/style-pass.md` §2–3, and long professional pieces take the whole style pass — in both cases skipping its fiction-slop table. If the text was produced by a known model, add `references/model-fingerprints.md` (fiction-centric; use as priors).
+
+## Operations
+
+Any request maps to one of four operations:
+
+| Operation | Contract |
+|---|---|
+| **write** | New content. Read the domain file *before* drafting — architecture and register decisions come first, they cannot be retrofitted cheaply. For fiction, follow Workflow A below. |
+| **review** | Diagnose only — no edits. Produce the defect list (fiction: rubric report; professional: checklist findings with quoted evidence) and stop. Report findings; apply nothing until asked. |
+| **refactor** | Minimal in-place revision preserving structure, voice, and intent. Two-stage: full defect list first, then fix item by item, deepest layer first. Skew replace/delete over insert (measured editor ratio 74/18/8). |
+| **recreate** | Full rewrite. Extract the facts, claims, and intent from the original into a bare list; verify nothing invented; write fresh under the domain rules. Use when defects are structural and the text is short enough that surgery costs more than rebuilding. |
+
+The two-stage protocol is not optional for refactor/recreate: paraphrasing without a defect list makes AI fingerprints *more* visible, not less (measured on expert detectors).
+
+## Fiction workflows
+
+**A — writing new fiction:** (1) premise, genre, length — genre sets calibration targets; (2) fill the architecture sheet in `references/narrative-pass.md`; (3) select 3–5 human-leaning moves + one rarity move; (4) outline, run the outline/QUD checks in `references/discourse-pass.md` and the echo test in `references/narrative-pass.md` §2; (5) draft; (6) self-diagnose with `references/rubric.md`, one group at a time; (7) style pass last.
+
+**B — revising existing fiction:** (1) diagnose completely first (rubric → discourse → style), no edits; (2) triage — architecture defects need scene-level surgery, tell the user how deep before cutting; (3) fix deepest first; (4) verify: re-run changed rubric groups, read key passages aloud, echo-test any added twist.
+
+## Calibration — the rule that governs all rules
+
+| Principle | Meaning |
+|---|---|
+| Aim at the band, not the opposite pole | Human values are moderate (chronological discontinuity 2.4/5, not 5). Inverting every AI tell creates a new fingerprint. In professional prose the equivalent: match the venue's register, don't overshoot into forced casualness — informality alone fools no trained reader. |
+| Select, don't accumulate | Human writing is diverse. Fiction: 3–5 moves per story, chosen for the premise, varied across works. Professional: fix what the checklist actually flags, nothing more. |
+| Leave slack | Ordinary sentences, an underdeveloped thought, a plain paragraph. Do not sand every surface. |
+
+## Hard guardrails
+
+- **Never invent specifics.** Fiction: intertextual references, brands, places must be real and correct. Professional: versions, numbers, timestamps, benchmarks, quotes come from the actual change/incident/data — missing info means ask the user or leave an explicit TODO, never fill. Confident wrong facts are themselves a top-tier tell.
+- **Deletion beats addition** (74% replace / 18% delete / 8% insert). The only additive fix is real specificity.
+- **Respect the author's voice and the venue's corpus.** Extract habits from the user's samples or the venue's recent artifacts before editing; edit toward *that* profile. Do not remove a mannerism they actually use.
+- **Dialogue quotes and quoted material are load-bearing** — do not regularize them.
+- **Check the whitelists** (`references/style-pass.md` §7, `references/professional-pass.md` last section) before flagging: clean grammar, formal tone in formal venues, and conventional templates are not evidence of AI.

--- a/optional-skills/creative/sepia/references/discourse-pass.md
+++ b/optional-skills/creative/sepia/references/discourse-pass.md
@@ -1,0 +1,53 @@
+# Pass 2 — Discourse flow
+
+The layer between plot and sentences: how paragraphs advance, where the energy sags, and where things sit on the page. Evidence: QUDsim/COLM 2025 (Q), Tripto et al. EMNLP 2025 (T), Russell et al. ACL 2025 (R), Beguš 2024 (B), asavvin's outline test (A).
+
+## 1 The QUD check — what question does each paragraph answer?
+
+Every paragraph implicitly answers a question. LLM narratives walk a template of questions regardless of surface wording — two models given the same premise independently produced the identical sequence *scene briefing → justifying the deception → social consequences → the weight of responsibility* (Q). Rewording sentences cannot hide this; only reordering and replacing the questions can.
+
+**Check:** List one implicit question per paragraph/scene of the outline or draft. Flags:
+
+| Flag | Symptom |
+|---|---|
+| Linear interview | Each question follows administratively from the last (what happened → why → what resulted → what it means) |
+| The reflection tail | Final paragraphs answer "what does this mean / how does she feel about it now" — the machine's closing move |
+| Missing move types | No paragraph *compares* (two times, two characters, two versions of an event), none *verifies* (doubts or contradicts an earlier paragraph's account), none *digresses* (memory or association that earns its place later) |
+
+**Fix:** Reorder so at least one question arrives before its setup. Replace one consequence-paragraph with a comparison or a contradiction — LLMs use consequence/procedure moves ~19% of the time and comparison/verification moves ~0.2–0.3% (Q); a single "but that isn't how her sister remembers it" paragraph does more de-AI work than a page of rewording.
+
+**Outline test (A):** extract the first sentence of every paragraph and read them as a list. If they form a clean summary of the piece, the structure is machine-shaped — a human outline has gaps, jumps, and sentences that make no sense out of context.
+
+## 2 The middle is the choke point
+
+Detectors and human judges find AI text most identifiable in the **body**, least in openings and endings — models imitate the formulaic bookends well and expose themselves in the long middle (T). LLM stories also show a measured mid-story collapse into predictable filler, rushing pace and leaving suspense unexplored (X, cited in narrative pass). Though this section speaks in fiction terms, the choke-point evidence was measured on news, essays, and email as well — for non-fiction, read "scene" as section and "event" as claim or finding.
+
+**Fix, aimed at the middle third:**
+
+- Put at least one event there that the opening does not predict.
+- Vary texture between adjacent scenes: a dense scene then a fast one, a dialogue-heavy stretch then summary narration. Human writing shows high cross-paragraph variance ("burstiness"); models hold one register for the whole text (T).
+- Let one thread slow down instead of resolving on schedule — the machine failure mode is acceleration past the interesting part.
+
+## 3 Structural positions on the page
+
+Position patterns survive paraphrase better than word choice does — after full paraphrasing, position tells became *more* visible to expert detectors, not less (R).
+
+| Position tell | Machine habit | Human habit |
+|---|---|---|
+| Paragraph lengths | Uniform | Ragged — including a one-sentence paragraph |
+| Quoted speech / key lines | Always closing a paragraph | Anywhere, including mid-paragraph |
+| Lists of qualities, reasons, images | Exactly three items | Two, four, one — three sometimes |
+| Scene transitions | Same connective formula each time | Varied: hard cut, time skip, dialogue pickup |
+| Emphasis | Evenly distributed | Clustered where it matters, absent elsewhere |
+
+## 4 Openings
+
+The machine opening: establish time + place + weather, introduce the character with description, then start the story (B: "Once upon a time"-style detachment; R: the "On a drab November morning" scene-setting lead; S: AI over-grounds the opening spatially, 2.33 vs 2.12).
+
+**Fix:** open inside the situation — mid-conflict, mid-conversation, mid-error ("Sam didn't know she wasn't human"). Ground space with one working detail, not a establishing shot. Delay the character's appearance-and-backstory paragraph indefinitely; most stories never need it.
+
+## 5 Names
+
+Models converge on the same character names — Elara, Ava, Amelia; Emily and Sarah appeared in 63–70% of tested AI articles, everyone titled "Dr." (B, R).
+
+**Fix:** name characters from the story's specific world (ethnicity, region, generation, class), let surnames and nicknames do social work, drop titles except where the fiction needs them, and let different characters call the same person different things.

--- a/optional-skills/creative/sepia/references/domains/dev-replies.md
+++ b/optional-skills/creative/sepia/references/domains/dev-replies.md
@@ -1,0 +1,29 @@
+# Domain — PR replies, issue replies, review comments
+
+Covers replies on pull requests and issues, code-review comments, and discussion-thread responses. Run with `professional-pass.md` (short-answer weighting: factuality, specificity, templatedness).
+
+## Human baseline
+
+Direct, specific, proportional. Maintainers answer the point in the first sentence, quote the exact code or error, disagree plainly, and say "I don't know" or "won't fix" when that's the truth. Terseness is the norm, not rudeness. **Read the thread and the maintainer's other replies first — match that register**, not a universal politeness standard. With no thread to sample, this baseline applies.
+
+## AI tells in this domain
+
+| Tell | Fix |
+|---|---|
+| Praise/thanks opener by default: "Great catch!", "Thanks for the detailed report!" | Open with the answer. Thank people when it's genuinely warranted (first contribution, unusual effort) — not as a reflex |
+| Restating the question/issue back before answering | Delete; the thread already contains it |
+| A wall of bullets for a one-sentence answer | One sentence. Length proportional to stakes |
+| Hedged non-answers: "There could be several factors…", both-sides mush | Commit: the most likely cause, the check to confirm it, or an honest "I don't know" |
+| Boilerplate empathy on bug reports: "I understand how frustrating this must be" | Ask for the repro detail you actually need |
+| Sign-offs: "Hope this helps!", "Let me know if you have any questions!" | End at the content |
+| Promising work in the reply instead of doing it ("I'll look into this") when the fix is at hand | Do it, then link the commit |
+| Perfectly uniform comment structure across a review (every comment: praise + issue + suggestion) | Vary; some comments are one word ("nit: typo"), some are paragraphs |
+
+## Rules
+
+1. **Answer first.** Verdict/answer in sentence one; reasoning after, only as needed.
+2. Cite artifacts: `file.py:214`, the commit SHA, the error text verbatim, the doc link. A claim about code points at the code.
+3. Disagree plainly with a reason ("This breaks the retry path — see #388") — no apology wrapper, no praise sandwich.
+4. State uncertainty honestly and cheaply: "not sure — does it reproduce on 2.4?" beats three hedged paragraphs.
+5. Wontfix/out-of-scope: say so, one reason, link the policy or issue where it was decided. Don't soften it into ambiguity the reporter must decode.
+6. In review comments, distinguish severity explicitly (blocking vs nit) the way the repo already does.

--- a/optional-skills/creative/sepia/references/domains/postmortems.md
+++ b/optional-skills/creative/sepia/references/domains/postmortems.md
@@ -1,0 +1,28 @@
+# Domain — incident postmortems
+
+Covers incident reports, outage retrospectives, RCA documents. Run with `professional-pass.md` (article-like weighting: relevance, density, stance) plus the outline test in `discourse-pass.md`.
+
+## Human baseline
+
+Blameless toward people, merciless toward mechanisms. The real document has absolute timestamps, exact failure mechanics (the query, the config line, the race window), honest dead ends ("we spent 40 minutes on the wrong hypothesis"), and action items someone actually owns. A team's incident template is a fine container — the tell is filler inside it.
+
+## AI tells in this domain
+
+| Tell | Fix |
+|---|---|
+| Agentless fog: "mistakes were made", "the change was deployed" with no actor anywhere | Blameless ≠ agentless. Name systems and roles: "the deploy pipeline promoted the config before validation ran" |
+| Generic lessons: "we will improve monitoring and communication" | An action item is a change with an owner and a date: "add alert on queue depth > 10k (owner: infra, due 09-15)" |
+| Every template section filled to similar length for completeness | Sections earn their length; "What went well: N/A-grade prose" → one honest line or delete |
+| Self-praise adverbs: "the team swiftly identified…" | Timestamps carry the speed judgment; let them |
+| Hedged root cause: "a combination of factors may have contributed" | Commit to the causal chain you believe, and mark the genuinely unknown part as unknown |
+| Moralizing conclusion about reliability culture | End at the action items |
+| Round, sourceless numbers | Real duration, real blast radius, real user/request counts — from the actual incident data, never estimated to sound complete |
+
+## Rules
+
+1. **Timeline with absolute times and timezone**, including the wrong turns — the 40 minutes on the bad hypothesis is the most instructive part; models systematically omit failure-within-the-failure.
+2. The failure mechanism at code/config level: the exact query, flag, limit, or race. If you (the writer) don't know it, that's a question for the team, not a blank to prose over.
+3. Counterfactuals stated honestly: what would have caught it, and why it didn't exist. No "the system worked as designed" face-saving.
+4. Contributing factors as a causal chain, not a bullet cloud — each factor says what it enabled.
+5. Impact in numbers first (duration, requests failed, users affected, money if known), narrative second.
+6. Stance check (professional-pass #4): a postmortem that admits no wrong judgment anywhere hasn't been written yet.

--- a/optional-skills/creative/sepia/references/domains/release-notes.md
+++ b/optional-skills/creative/sepia/references/domains/release-notes.md
@@ -1,0 +1,26 @@
+# Domain — release notes & announcements
+
+Covers changelogs, GitHub Releases, version announcements, and short launch posts. Run with `professional-pass.md`; add `style-pass.md` for anything longer than a changelog.
+
+## Human baseline
+
+Terse, factual, user-impact-first. The reader is deciding **whether to upgrade and what will break** — everything serves that decision. Conventional structure (Keep a Changelog categories: Added / Changed / Fixed / Removed / Security; or the repo's own habit) is expected, not a tell.
+
+## AI tells in this domain
+
+| Tell | Fix |
+|---|---|
+| Marketing inflation: "We're thrilled/excited to announce", "powerful new features", "seamless experience", "supercharge your workflow" | State what changed. The feature is the news; enthusiasm is not |
+| Benefit claims with no mechanism: "improved performance", "enhanced stability" | The number or the change itself: "cold start 1.8s → 0.4s", "fixed a race in the retry queue (#412)" |
+| Every change narrated as a sentence-long story | One line per change, verb-first, no adjectives |
+| Emoji headers and exclamation marks throughout | Match the repo's existing notes; default to none |
+| An intro paragraph about the journey and a closing paragraph about the road ahead | Delete both. Version, date, changes, done |
+| Symmetric prose for every item regardless of importance | Order by user impact; breaking changes first, one-word fixes last |
+
+## Rules
+
+1. **Breaking changes first**, with the exact migration step (the command, the config key, the renamed flag).
+2. Every claim carries its artifact: issue/PR numbers, commit ranges, exact version strings, real benchmark numbers with conditions. No artifact → no claim.
+3. Credit people plainly ("thanks @name for #398") — no gratitude paragraphs.
+4. Length follows the release: a patch release is three lines; do not inflate it to look substantial.
+5. Humor and voice are allowed if the repo's history has them; never inject them fresh into a repo that doesn't.

--- a/optional-skills/creative/sepia/references/domains/tech-articles.md
+++ b/optional-skills/creative/sepia/references/domains/tech-articles.md
@@ -1,0 +1,30 @@
+# Domain — technical articles & blog posts
+
+Covers engineering blog posts, tutorials, architecture write-ups, experience reports. The richest domain: run `professional-pass.md` (article-like weighting), the outline/QUD checks in `discourse-pass.md` §1–3, and `style-pass.md` (skip its fiction-slop table).
+
+## Human baseline
+
+Motivated by a real problem the author actually hit. Uneven by design — deep where it got interesting, one line where it didn't. Contains at least one dead end, at least one opinion the reader could disagree with, and numbers with their conditions attached. First person and contractions are normal.
+
+## AI tells in this domain
+
+| Tell | Fix |
+|---|---|
+| The topic-survey opening: "In the world of distributed systems…" / definition of the thing everyone reading already knows | Open at the incident, the bug, the number that made you look |
+| Listicle in a trench coat: prose that is secretly "The first… The second… The third…" | Either honest structure (a real list/table) or real prose with an argument |
+| Fractal summaries: every section announces, tells, recaps | Say it once, at the level where it lives |
+| Invented concept labels: "the observability paradox", "configuration drift syndrome" coined mid-post | Plain description, or an established term |
+| Symmetric coverage: every alternative gets a paragraph, none gets a verdict | Commit to a recommendation and give the case that would change your mind |
+| No failure anywhere: every step worked, benchmarks confirm the thesis | Include what broke, what you tried first, what you'd skip next time — models systematically omit the dead end, and it's the part readers trust |
+| Generic code examples (`foo`, `my_service`) that were never run | Real, runnable, tested snippets from the actual work — or say explicitly they're sketches |
+| Benchmarks with no conditions | Machine, version, dataset size, number of runs — or don't print the number |
+| The both-sides conclusion + future outlook | End on the recommendation or the open question you actually have |
+
+## Rules
+
+1. **The problem before the topic.** First paragraph: the concrete situation that forced the question. If there is no real situation, the honest genre is "notes on X", not a war story — never fabricate the incident.
+2. One opinion minimum, stated as yours, with the disagreement condition ("if your writes are under 1k/s, ignore all of this").
+3. Depth budget by interest, not symmetry: the section that surprised you gets 5× the words of the setup steps.
+4. Numbers carry conditions; claims carry links; code carries a "this runs" guarantee or a disclaimer.
+5. QUD check: if the section-question sequence reads *what is X → why X matters → how to X → conclusion*, restructure around what actually happened.
+6. Voice: first person, contractions, an aside or two. The measured human markers (stance, unevenness, lived specifics) are the same ones expert readers use to judge "a person wrote this."

--- a/optional-skills/creative/sepia/references/domains/tickets.md
+++ b/optional-skills/creative/sepia/references/domains/tickets.md
@@ -1,0 +1,26 @@
+# Domain — tickets & work orders
+
+Covers issue tickets, tasks, work orders, bug reports you file (not replies — that's `dev-replies.md`). Run with `professional-pass.md` (short-answer weighting).
+
+## Human baseline
+
+Imperative, minimal, complete-enough. The assignee should be able to start without asking a question, and know when they're done. A tracker's field template is a container, not a tell.
+
+## AI tells in this domain
+
+| Tell | Fix |
+|---|---|
+| Novel-length background before the ask | Context is only what the assignee doesn't already know; link the rest |
+| Description that restates the title in sentences | The description starts where the title stops |
+| Obvious steps enumerated ("1. Open the repository. 2. Locate the file…") | Only the non-obvious steps and the exact commands |
+| Vague acceptance: "works correctly", "improved performance" | Testable criteria: the command to run and the output that means done ("p95 < 200ms on the staging load test") |
+| Every template field filled with prose for completeness | Empty is a valid value; "N/A" beats a paragraph of nothing |
+| Round scope words: "refactor the module", "clean up" | The concrete boundary: which files/functions in, which explicitly out |
+
+## Rules
+
+1. **Title = outcome**, not activity ("Retry queue drops jobs on redeploy" not "Investigate queue issue").
+2. Bug tickets: exact repro (versions, commands, input), expected vs actual with real output pasted, frequency. If you can't reproduce it, say what you tried.
+3. Acceptance criteria are testable or they aren't criteria.
+4. Link, don't repeat: prior tickets, the design doc, the alert. One source of truth.
+5. Priority/estimate honest and bare — no justification paragraphs.

--- a/optional-skills/creative/sepia/references/model-fingerprints.md
+++ b/optional-skills/creative/sepia/references/model-fingerprints.md
@@ -1,0 +1,59 @@
+# Per-model fingerprints
+
+Each frontier model diverges from the *other AIs* on its own signature features (StoryScope §5, Table 16; 6-way attribution 68.4% macro-F1 from narrative features alone). When you know which model wrote — or is writing — the text, push against its specific defaults **in addition to** the shared corrections in the three passes. These are tendencies measured on specific model versions (Sonnet 4.6, GPT-5.4, Gemini 3 Flash, DeepSeek V3.2, Kimi K2.5, 2026); treat them as priors to verify against the draft, not certainties.
+
+## Claude — the most identifiable AI (26 fingerprint features)
+
+| Default | Correction |
+|---|---|
+| Flattest event escalation of any source; uniform narrative voice throughout | Build real escalation: let stakes and intensity *jump*, unevenly. Allow the voice to strain, speed up, or coarsen at pressure points |
+| Reverent/continuist toward literary tradition (62% of stories vs 39–56%) | Permit one convention to be broken or mocked rather than honored |
+| Favors epilogues and flash-forward endings; quiet endings over "avalanche" endings | Ban the epilogue by default; end in motion. An avalanche ending is allowed |
+| Avoids dream sequences entirely | A dream is available if the story wants one (do not force it — absence is only a tell in aggregate) |
+| Setting mood drifts to uncanny/haunted | Vary the atmospheric register |
+
+## GPT — the gossip and the long lens
+
+| Default | Correction |
+|---|---|
+| Gossip/rumor as plot mechanism (64% vs 44–55%) | Let information move by observation, documents, or accident — not through the town talking |
+| Distant retrospective narrator ("years later, she would…") | Narrate closer to the event; drop the decades-later frame |
+| Subverts reader expectations more than any other AI (41%) | Do not add another twist; earn the one you have |
+| Reconciliations left partial/ambiguous, habitually | Resolve one relationship fully — in either direction |
+| Ensemble-heavy social webs (human-level density but formulaic) | Prune the ensemble to the characters the story uses |
+
+## Gemini — the tidy pessimist
+
+| Default | Correction |
+|---|---|
+| Tidiest endings + extended denouements | Cut the last scene; leave accounts unsettled |
+| Bleak/oppressive settings in 88% of stories | Vary — let some settings be neutral or warm even when events are not |
+| Frequent flashbacks as a reflex; over-indexes on dream sequences | Keep anachrony purposeful (staging disclosure), not decorative |
+| Protagonist's social circle always expands | Allow shrinking or static trajectories |
+| Direct speech dominates exchanges | Mix in indirect and summarized speech |
+
+## DeepSeek — the front-loader
+
+| Default | Correction |
+|---|---|
+| Crucial context delivered before the story moves | Withhold; leak backstory mid-motion (see narrative pass §4) |
+| Visible, present narrator | Recede; let scenes run unhosted |
+| Emotions via behavioral cues almost exclusively | Blend in plain naming and occasional interiority |
+| Backstory evenly interleaved, metronomically | Cluster it irregularly |
+| Embedded storytelling scenes (tales within the tale) | Use at most one, if any |
+
+## Kimi — the generic center
+
+Fewest fingerprints (3) — it sits at the centroid of AI narrative space, which *is* its tell: no distinctive choices at all. Corrections: it opens in medias res with in-action introductions by reflex (vary the entry), and never labels traits explicitly (allowed to). Mostly, apply the shared passes at full strength and make the rarity move count.
+
+## Human fingerprints — the positive targets
+
+The features on which human authors diverge from every model, usable as direct recipes:
+
+| Human marker | Recipe |
+|---|---|
+| Protagonist introduced in-dialogue (uniqueness 21.4 — the strongest single marker in the study) | First appearance: the character speaking, unannotated |
+| Single focal perspective held | Depth over head-hopping |
+| Narrator never addresses, then occasionally does | No system to the asides |
+| Back-loaded revelation pacing | The biggest thing lands late |
+| Crossover-genre literary ambition | Let the genre piece want to be something else too |

--- a/optional-skills/creative/sepia/references/narrative-pass.md
+++ b/optional-skills/creative/sepia/references/narrative-pass.md
@@ -1,0 +1,130 @@
+# Pass 1 — Narrative architecture
+
+Seven decision groups. Each lists the measured human-vs-AI gap, what to do when **generating**, and what to check when **revising**. Numbers are from StoryScope (S), Beguš 2024 (B), Xu et al. PNAS 2025 (X), Nonaka & Perry 2025 (N), and QUDsim (Q); percentages read *human vs AI*.
+
+Work through all seven groups when filling the architecture sheet, but **enact only 3–5 human-leaning moves per story** (see SKILL.md Calibration). The groups marked ⚑ are zero-covered by every existing humanizer tool — they carry the most signal per unit of effort.
+
+## Architecture sheet template
+
+Fill this before drafting (Workflow A) or as the diagnosis summary (Workflow B):
+
+| Decision | Choice for this story | Target band |
+|---|---|---|
+| Theme handling | stated / implied / withheld | implied by default |
+| Subplot | none / parallel / contrasting / independent | one subplot, ~40% of stories |
+| Resolution driver | protagonist choice / mixed / external | mixed or external ~50% |
+| Ending mode | external act / internal acceptance / partial / open / catastrophic | avoid internal-acceptance default |
+| Time structure | linear / moderate anachrony / braided | moderate (2–3 on a 1–5 scale) |
+| Revelation pacing | front-loaded / even / back-loaded | back-loaded |
+| Emotion strategy | mix of: explicit labels / behavior / embodied / ambiguous | behavior-led mix; embodied only at peaks |
+| Protagonist introduction | description / in-action / in-dialogue / thought / others' reports | in-dialogue or in-action |
+| Moral stance on protagonist | affirmative / tragic-flaw / ambivalent / antiheroic | ambivalent ~60% |
+| Real-world anchors | list actual works, places, brands to name | ≥1 explicit named reference |
+| Network shape | who never meets whom; who dislikes whom | sparse, net-neutral affect |
+| Rarity move | the one structural choice atypical for this premise | exactly one |
+
+## 1 ⚑ Theme: stop explaining it
+
+| Feature | Human | AI |
+|---|---|---|
+| Narrator explicitly states the theme (S) | 52% | 77% |
+| Thematic explicitness, 1–5 (S) | 3.28 | 3.94 |
+| Dialogue used for philosophical debate (S) | 34% | 59% |
+| Moral/philosophical weighting, 1–5 (S) | 3.26 | 3.68 |
+| Thematic unity, 1–5 (S) | 4.41 | 4.74 |
+
+**Generate:** Decide the theme, then trust the events to carry it. The narrator never summarizes the lesson; the grieving character's arc does **not** end with what she learned. Dialogue does plot and relationship work — characters argue about the rent, not about the nature of grief. Let one scene or image exist for texture alone, serving no theme (humans score 4.4/5 on unity, not 5/5 — near-total unity is the tell, total unity is worse).
+
+**Revise:** Search the last three paragraphs and any narrator generalization ("That is how people are", "It was then she learned…", "In the end, what mattered was…") — cut or convert to a concrete action or image. Where dialogue debates ideas, rewrite so the disagreement is about something specific the characters want. If a symbol is explained in-text, delete the explanation and keep the symbol.
+
+> The moralizing final line is the single most reliable AI ending (B: "love knows no boundaries" appears as a matter of routine). An ending that just stops is human; an ending that concludes is machine.
+
+## 2 ⚑ Plot: loosen the single track
+
+| Feature | Human | AI |
+|---|---|---|
+| No subplots at all (S) | 57% | 79% |
+| Subplot thematically parallel to main plot (S) | 42% | 21% |
+| Causal-chain continuity, 1–5 (S) | 3.92 | 4.20 |
+| Plot elements that reappear on regeneration — "drop ratio" (X) | 3.7% | 9–11% |
+
+**Generate:** Give roughly two in five stories a subplot; when present, let it echo the main theme obliquely rather than restate it. Allow the causal chain to break once: an episode that isn't caused by the inciting incident, a consequence that arrives from offstage. Plant one detail that never fires — humans leave loose ends; the fully-paid-off setup inventory is machine bookkeeping.
+
+**Revise:** Outline the draft as a beat list. If every beat is caused by the previous beat in one unbroken line to the climax, sever one link: move a cause offstage, or insert an event with its own origin. If the story has no second thread and its length can carry one, braid one in.
+
+**Echo test (X):** for each turning point ask — *if this premise were regenerated twenty times, would this same turn appear again?* The helpful stranger, the problem that solves cleanly, the reconciliation on schedule: these reappear. Replace inevitable turns with one that requires this story's particulars. Kafka's traffic cop says "Give it up!" and walks away; twenty regenerations produce twenty cops giving directions.
+
+## 3 Endings and resolution
+
+| Feature | Human | AI |
+|---|---|---|
+| Resolution driven by protagonist's own choice (S) | 46% | 69% |
+| Resolution via internal understanding/acceptance (S) | 27% | 47% |
+| Morally ambivalent protagonist (S) | 59% | 38% |
+
+**Generate:** Do not default to the arc where the protagonist, having grown, chooses the resolution and makes peace with it — that compound default (agency + acceptance + growth) is the strongest ending fingerprint in the data. Half the time, let chance, other people, or institutions decide the outcome. Endings may be partial, open, or catastrophic. The protagonist's final moral position can stay mixed: vindicated in the event, wrong in the act.
+
+**Revise:** If the draft ends with the protagonist deciding + accepting + understanding, change at least one leg of the tripod. Cut denouement paragraphs that settle every account; ending one beat *earlier* than feels complete is usually the fix.
+
+## 4 ⚑ Time: linearity is a choice, not a default
+
+| Feature | Human | AI |
+|---|---|---|
+| Chronological discontinuity, 1–5 (S) | 2.40 | 2.12 |
+| Anachrony (flashback/flash-forward) intensity, 1–5 (S) | 2.58 | 2.31 |
+| Nonlinear framing used to delay disclosure, 1–5 (S) | 1.96 | 1.68 |
+| Recontextualization depth after a reveal, 1–5 (S) | 3.28 | 2.95 |
+| Revelation pacing (human fingerprint, S) | back-loaded | even/front-loaded |
+
+**Generate:** The human band is *moderate* nonlinearity — a story that opens at the funeral and spirals back through decades, not a shuffled puzzle-box. Use time jumps to **stage information**: hold back the cause, open with the effect. Aim reveals so they force rereading — the best twist recolors earlier scenes (target 3/5, not a twist that changes nothing and not a total inversion). Keep the biggest disclosure late (back-loaded pacing is a measured human fingerprint).
+
+**Revise:** If the draft narrates first-cause-to-final-effect in order, find the scene whose impact grows when withheld and move it. Check that DeepSeek-style front-loading (all context delivered before the story starts moving) isn't present: cut the briefing, let context leak out mid-motion.
+
+## 5 ⚑ Emotion and senses: break the show-don't-tell dogma
+
+| Feature | Human | AI |
+|---|---|---|
+| Emotion conveyed mainly via embodied sensation/metaphor (S) | 38% | 81% |
+| Emotion conveyed mainly via explicit labels (S) | 29% | 8% |
+| Olfactory imagery among dominant senses (S) | 57% | 82% |
+| Setting mirrors characters' inner states, 1–5 (S) | 3.58 | 4.07 |
+| Sensory density, 1–5 (S) | 3.66 | 3.93 |
+| Depth of interior access, 1–5 (S) | 3.67 | 3.93 |
+
+**Generate:** AI executes "show don't tell" as dogma: fear is always a tightening chest, cold sweat, dimming lamplight. Humans mix four modes and lean on the plainest two — behavior first, plain naming second ("She was afraid" is a human sentence; models almost never write it). Reserve embodied rendering for one or two peaks per story. Let weather be weather: not every storm carries the marriage. Ration smell — it has become the connoisseur sense of machine prose.
+
+**Revise:** Inventory every emotion beat and classify its mode. If embodied dominates, convert most to behavior (what she does) or plain statement (what she feels, named), keeping the strongest one or two embodied. Strip pathetic fallacy where the environment shadows mood scene after scene. Thin sensory description toward moderate density — cut the third sense in three-sense sentences.
+
+## 6 ⚑ Characters and the social network
+
+| Feature | Human | AI |
+|---|---|---|
+| Protagonist introduced via external description (S) | 30% | 52% |
+| Human fingerprint: introduced in-dialogue (S) | strongest human marker | rare |
+| Network density — share of character pairs that interact (N) | 0.18 | 0.34–0.47 |
+| Mean relationship affect (N) | −0.06 (net neutral) | +0.24 to +0.66 (all positive) |
+| Clustering among antagonistic ties (N) | 0.395 | 0.07–0.21 |
+| Investment built before putting a character in danger, 1–5 (S) | 2.76 | 2.99 |
+
+**Generate:** Bring the protagonist on stage talking or doing, not described ("The dog arrived on a Tuesday" beats a paragraph of appearance-and-backstory). Keep the cast graph sparse: some characters never meet; some know each other only through a third. Sum of relationship affect should sit near neutral — real casts contain dislike that has nothing to do with the plot. Give antagonism *structure*: the antagonist has allies, internal rifts, their own network — not a lone hostile node pointed at the hero. It's fine to endanger a character the reader barely knows.
+
+**Revise:** Draw the cast graph with signed edges. If everyone connects to everyone, delete edges. If every edge is warm, cool several. If the villain is isolated, give them one relationship that doesn't involve the protagonist.
+
+## 7 ⚑ The outside world and the reader
+
+| Feature | Human | AI |
+|---|---|---|
+| Explicit named references to real texts/authors (S) | 47% | 24% |
+| Balanced mix of explicit + implicit reference (S) | 37% | 16% |
+| Any fourth-wall permeability (S) | 67% | 39% |
+| Direct reader address (S) | 28% | 7% |
+| Distinct meaningful locations (S, ordinal) | 1.34 | 1.08 |
+| Dialogue-to-narration proportion, 1–5 (S) | 2.95 | 2.70 |
+
+**Generate:** Name real things — an actual novel on the shelf, a real band, the specific highway (accuracy rule in SKILL.md applies: only real, correct references; ask the user for material if needed). Mix named references with unnamed echoes. An occasional aside that admits a reader exists ("you know the kind of house") is a human move — *occasional*: an aside or two, not a metafictional frame. Let scenes happen in one or two more places than the premise strictly needs. Give dialogue slightly more floor than exposition.
+
+**Revise:** If the draft gestures at "a famous poet" or "an old song," make one of them specific and real. If the story visits a single room for 5,000 words and the premise doesn't demand confinement, move one scene. Vague allusion everywhere = machine caution.
+
+## The rarity move
+
+Human stories are structurally *rarer* than AI stories (rarity percentile 0.71 vs 0.49; the five models cluster in one region of narrative space and humans scatter). Beyond the band-calibrated rules above, make **exactly one** structural choice that is genuinely atypical for the premise — an unexpected narrator distance, a resolution mode the genre rarely uses, a frame that recasts the genre (crossover literary ambition is a measured human fingerprint). One. More than one reads as performance.

--- a/optional-skills/creative/sepia/references/professional-pass.md
+++ b/optional-skills/creative/sepia/references/professional-pass.md
@@ -1,0 +1,62 @@
+# Professional pass — shared layer for non-fiction
+
+Applies to every non-fiction domain (release notes, PR/issue replies, postmortems, tickets, technical articles, and anything else that isn't narrative). Evidence: the slop taxonomy (Shaib et al., S), expert AI-detector studies (Russell et al., R), genre-alignment findings (Reinhart et al., P), and the Wikipedia/humanizer corpus of documented tells (W).
+
+> In professional genres the goal is not "fool a detector" — it is that the text carries information, has a stance, and sounds like it came from the person whose name is on it. Conventional structure is *fine* here; slop is the filler inside the structure.
+
+## Read the venue first
+
+Before writing or editing, sample 2–3 recent human-written artifacts from the same venue — the repo's past release notes, the maintainer's recent replies, the team's last postmortem — and match their register, length norms, and formatting habits. Half of measured AI-ness is register mismatch: models emit one evenly-polished, noun-heavy prose regardless of venue (P). The venue corpus, not this skill, defines the target voice. When no corpus exists, the domain file's baseline applies.
+
+## The checklist
+
+Run these one at a time (a combined pass goes blind — measured on this very taxonomy). Slop is **cumulative**: one hit means nothing; clusters mean rewrite.
+
+| # | Check | What to hunt |
+|---|---|---|
+| 1 | Chatbot residue | "Great question", "Thanks for raising this!", "I hope this helps", "Certainly!", "You're absolutely right", offers of further help, apology openers, "Let's dive in". Delete — a colleague doesn't talk like a support desk. |
+| 2 | Density | Could this say the same at half the length? Generic statements true in any context ("in today's fast-paced world", "it's important to note") carry zero information — cut. Length must be proportional to stakes. |
+| 3 | Relevance | Does every paragraph serve *the reader's task* — the thing they came to find out? Background the reader already has, restated questions, and scope tours are filler. |
+| 4 | Stance | Where a judgment is required, commit to one. Absent subjectivity is a measured slop dimension (S): a review without a verdict, a comparison without a recommendation, a postmortem without an admitted mistake. Hedge once per genuinely fragile claim, not per sentence. |
+| 5 | Specificity | Versions, numbers, file:line, commands, error text verbatim, names — present and **real**. Never pad with invented specifics; a wrong fact stated confidently is itself a top-tier tell (R). Missing info → ask or leave an explicit TODO. |
+| 6 | Formatting tells | Bold-mini-heading bullet lists where prose would do; emoji as decoration; Title Case headings; every section the same length; lists of exactly three, everywhere; a heading restated by its first sentence; fractal summaries (announce → say → recap at every level) (W). |
+| 7 | Conclusion residue | "In conclusion/summary" sections, restating what was said, generic future outlook ("we will continue to improve…"). End when the content ends. |
+| 8 | Templatedness | The same sentence frame recycled ("X, a Y at Z, said that…" three times); every item phrased identically. Vary or tabulate. |
+| 9 | Sameness of rhythm | Uniform paragraph and sentence lengths throughout. Human professional prose is uneven — depth where it matters, one-liners where it doesn't. |
+| 10 | Fluency | Grammatically correct but unsayable ("the earthen area that formerly held the puddle"). Read it aloud; if no one would say or write it in an email, redo it in speech-shaped syntax. |
+
+Then finish with the vocabulary/syntax scan in `style-pass.md` §2–3 (the ban tables apply to professional prose too; the fiction-slop table does not).
+
+## Domain weighting
+
+Which checks dominate depends on document shape (measured: S):
+
+| Document shape | Weight first |
+|---|---|
+| Article-like (postmortem, tech article, announcement) | Relevance, density, stance/tone, coherence |
+| Short answers (PR/issue replies, review comments, tickets) | Factuality, specificity, templatedness — density and tone matter less at short length |
+
+Weighting sets the order and depth of attention, not an exemption: a short reply drowning in filler still fails density.
+
+For long-form (articles, postmortems), also run the outline test and QUD check in `discourse-pass.md` §1–3: extract first sentences per paragraph; a clean-summary outline and a briefing→justification→consequences→reflection question-sequence are both machine shapes.
+
+## Report format (review operation)
+
+```text
+SEPIA REVIEW — <document type, venue>
+Loaded: <files used>
+Venue corpus: <artifacts sampled, or "none — using domain baseline">
+Failed: <#n check-name — quoted evidence>   (one line per failed check)
+Passed: <check numbers only>
+Verdict: <clean / isolated hits / cluster> → <ship / refactor / recreate>
+```
+
+## Whitelist — conventional ≠ slop
+
+| Do not flag | Why |
+|---|---|
+| Changelog categories, issue/PR templates, RFC sections, runbook formats | Formulaic containers by convention; the community expects them |
+| Formal register in a formal venue | Register match beats forced casualness |
+| Bullets for genuinely enumerable items | Tables and lists are correct for enumerable facts |
+| Terse, unadorned replies | Brevity is the human default in dev venues, not a tell |
+| The author's own verified habits | Edit toward their voice, not a generic "human" |

--- a/optional-skills/creative/sepia/references/rubric.md
+++ b/optional-skills/creative/sepia/references/rubric.md
@@ -1,0 +1,99 @@
+# Diagnosis rubric — the 30 core features
+
+The 30 narrative features that most reliably separate human from AI fiction (StoryScope Tables 13–15; scoring criteria adapted from its released taxonomy). Alone they detect AI at 84.8% macro-F1 — this checklist *is* the detector, run in reverse.
+
+## Protocol
+
+1. Score **one group at a time**, in five separate passes. Never assess the whole rubric in one read: models self-evaluating text collapse onto one or two salient dimensions and go blind to the rest (measured on the slop taxonomy — span precision 0.13 when given the full guide at once).
+2. For each feature, quote the short passage that justifies the score. No quote, no score.
+3. Apply the scoring rules below mechanically — no judgment calls about what counts as drift.
+4. Scales are 1–5 unless a row notes otherwise. "Target" is the human mean.
+
+## Scoring rules
+
+| Case | Rule |
+|---|---|
+| Numeric rows (scale/ordinal) | **Drifted** when the story's score sits on the AI side of the midpoint between the Target and AI values. Example: thematic explicitness Target 3.3 / AI 3.9 → midpoint 3.6 → a story scoring 4 is drifted, 3.5 is not. |
+| Percentage rows (categorical/binary) | **Drifted** when the story exhibits the AI-column option **and** AI% ÷ Target% ≥ 1.4. (The ratios are precomputed: every percentage row in groups A–C and E qualifies except *Subplots*, which is cumulative evidence only and never counts alone.) Absence of a human-leaning option is never drift by itself — most individual human stories also lack any given one. |
+| Group D | Human-positive markers, scored as **one unit**: +1 drifted only if *none* of its three markers appears anywhere in the story; 0 otherwise. |
+| Not applicable | A feature with no occasion in the text (no jeopardy → pre-threat investment; no reveal → recontextualization) scores **n/a** and leaves the assessable count. Reference explicitness is n/a only when the story makes no allusive gesture at all — an unnamed borrowed quotation or a recognizable unattributed retelling *is* an occasion (score it implicit). Short texts produce several n/a — that is expected, not a defect of the story. |
+| Over-correction | A numeric score at the far extreme *away* from the AI direction (e.g. discontinuity 5/5, thematic explicitness 1/5) → flag as **over-correction advisory**. Report it (it is the humanizer-fingerprint failure mode) but don't count it in the drift share. |
+
+**Triage:** assessable = 26 units maximum — 25 scored rows (groups A, B, C, E minus the two advisory rows *Subplots* and *Location variety*) plus 1 unit for group D — minus any n/a. Compute drift share = drifted ÷ assessable:
+
+| Drift share | Action |
+|---|---|
+| ≥ 20% | Structural revision (Workflow B, all three passes) |
+| 10–20% | Targeted fixes on the drifted features |
+| < 10% | Style pass only |
+
+## Group A — Thematic over-determination (AI drifts high)
+
+| Feature | How to judge | Target | AI |
+|---|---|---|---|
+| Thematic explicitness | 1 = themes stay implicit; 5 = thesis-like statements tell the reader how to interpret events | ~3.3 | 3.9 |
+| Moral/philosophical weighting | How far ethical debate and thematic exposition outweigh story pleasure; check narrator commentary and climactic speeches | ~3.3 | 3.7 |
+| Thematic unity | 5 = every scene, subplot, image reinforces one thematic core | ~4.4 | 4.7 |
+| Narrator thematic commentary | Does the narrating voice generalize about what events mean ("That is how people are")? | yes in ~52% | 77% |
+| Dialogue as philosophical debate | Do key dialogues argue ideas rather than advance want/conflict? | dominant in ~34% | 59% |
+| Reference explicitness | Vague unnamed allusion as the dominant intertext mode (the human-leaning state is a balanced mix of named + implicit, 37% vs 16%) | implicit-only ~50% | 72% |
+
+## Group B — Sensory & embodied performativity (AI drifts high)
+
+| Feature | How to judge | Target | AI |
+|---|---|---|---|
+| Dominant emotion mode | Classify strong-affect scenes: explicit label / embodied sensation / behavior / ambiguous; drifted when embodied dominates | embodied dominant in ~38% | 81% |
+| Setting as psychological mirror | Do weather/landscape/architecture consistently externalize inner states? | ~3.6 | 4.1 |
+| Environmental emphasis | Landscape and ecology beyond backdrop | ~2.8 | 3.2 |
+| Olfactory imagery | Smell among regularly engaged senses — judge salience relative to length (one prominent instance counts in flash-length text; recurring use in longer work) | ~57% | 82% |
+| Sensory density | Proportion of text doing multi-sense description; 5 = lush, pace-slowing | ~3.7 | 3.9 |
+| Depth of interior access | 1 = external only; 5 = stream of consciousness | ~3.7 | 3.9 |
+
+## Group C — Structural streamlining (AI drifts high/tidy)
+
+| Feature | How to judge | Target | AI |
+|---|---|---|---|
+| Causal-chain continuity | 5 = every event tightly linked in one line from incitement to end | ~3.9 | 4.2 |
+| Subplots *(advisory — cumulative evidence only)* | Absence of any subplot; too common in human stories (57%) to count alone | no-subplot ~57% | 79% |
+| Resolution agency | Turning point triggered by protagonist choice vs chance/others | choice ~46% | 69% |
+| Resolution mode | External act / internal acceptance / partial / open / catastrophic; drifted on internal acceptance | internal ~27% | 47% |
+| Protagonist introduction | Device at first substantial appearance — one of: external description / in-action / in-dialogue / inner thought / others' reports. Drifted only on external description; the other four are never drift (in-dialogue is the strongest human marker) | description ~30% | 52% |
+| Opening spatial grounding | How completely the first scene fixes local + global place (1–4) | ~2.1 | 2.3 |
+| Spatial granularity | Density of place names, rooms, routes (1–4) | ~2.3 | 2.5 |
+| Pre-threat investment | Interiority/backstory built before jeopardy | ~2.8 | 3.0 |
+
+## Group D — Human-positive markers (one unit: +1 only if all three absent)
+
+| Marker | How to judge | Human | AI |
+|---|---|---|---|
+| Named intertextuality | Any real text/author/work explicitly named | present in ~47% | 24% |
+| Fourth-wall gesture | Any wink, aside, or reader acknowledgement anywhere | present in ~67% | 39% |
+| Direct reader address | Any "you"/"dear reader" moment | present in ~28% | 7% |
+
+## Group E — Temporal complexity & diversity (AI drifts low/tidy)
+
+| Feature | How to judge | Target | AI |
+|---|---|---|---|
+| Chronological discontinuity | Frequency/sharpness of time jumps | ~2.4 | 2.1 |
+| Anachrony intensity | Scene-level flashbacks/flash-forwards as structure | ~2.6 | 2.3 |
+| Nonlinear framing for disclosure | Time devices used to stage revelations | ~2.0 | 1.7 |
+| Recontextualization after surprise | How much earlier text a reveal recolors | ~3.3 | 3.0 |
+| Location variety *(advisory — not counted)* | Flag when a 3,000+ word story never leaves one locale without the premise demanding confinement | 2+ full-scene locales common | single-location bias |
+| Dialogue proportion | Fraction of text in quoted speech (1 = none, 3 = balanced, 5 = dominates) | ~3.0 | 2.7 |
+| Moral polarity toward protagonist | Narrative's final stance; drifted when clearly affirmative or clearly condemning | ambivalent ~59% | clear 62% |
+
+## Report format
+
+Cite by quoting a short phrase, not by paragraph number:
+
+```text
+SEPIA DIAGNOSIS — <title>
+Group A: 3 drifted, 1 n/a (narrator commentary — "It was then she learned…"; …)
+Group B: 2 drifted (…)
+Group C: 1 drifted, 1 n/a (…)
+Group D: 0 (named intertextuality present — "…")
+Group E: 2 drifted (…)
+Advisories: over-correction none; subplots absent; single-location
+Drift share: 8 / 24 assessable = 33% → structural revision
+Plan: <ordered fixes, deepest layer first, each tied to a quoted passage>
+```

--- a/optional-skills/creative/sepia/references/style-pass.md
+++ b/optional-skills/creative/sepia/references/style-pass.md
@@ -1,0 +1,84 @@
+# Pass 3 — Surface style
+
+Run last, after structure is fixed. Evidence: LAMP/CHI 2025 (L), Reinhart et al. PNAS 2025 (P), Russell et al. ACL 2025 (R), Shaib et al. slop taxonomy (S), fiction/RP community ban lists (F). Editing operations should skew **replace 74% / delete 18% / insert 8%** (L) — when in doubt, cut. The one exception that may grow text: adding concrete specificity.
+
+## 1 The seven artifacts (professional-editor taxonomy, L)
+
+Ordered by how often professional writers actually fixed each, which is the priority order:
+
+| # | Artifact | Fix |
+|---|---|---|
+| 1 | Awkward word choice (28%) | Replace misused or off-register words. "Seem to + verb" → the verb itself, unless uncertainty is real. Fix unclear pronouns and excess passives. |
+| 2 | Poor sentence structure (20%) | Split run-ons into two sentences. One tangled thought = two plain ones. |
+| 3 | Redundant exposition (18%) | Delete what the scene already implies. The pattern "[main clause], [trailing participial phrase restating it]" → delete after the comma ("cast long shadows over the desolate landscape" → "cast a long shadow"). |
+| 4 | Cliché (17%) | Replace with fresh, scene-specific language — **never with a blander paraphrase** (that is the documented machine failure). If nothing fresh is available, delete the line. |
+| 5 | Lack of specificity | The only additive fix: real names, objects, numbers, actions from lived detail. If you lack the material, ask the user — filling in more generic description makes it worse. |
+| 6 | Purple prose | Simplify. Long abstract-noun sentences conveying one feeling → short concrete sentences ("She cried. She cried for unfairness. She cried without relief."). |
+| 7 | Tense inconsistency | Pin the tense; hunt drift inside paragraphs. |
+
+## 2 Syntax templates to hunt
+
+These part-of-speech shapes are 2–5× overrepresented in LLM prose and heavily edited out by professionals (L, P):
+
+| Template | Examples | Fix |
+|---|---|---|
+| a/the [abstract noun] of [noun] (and [noun]) | a mix of pride and fear · a sense of wonder · a pang of nostalgia · the weight of expectation | Name the concrete thing or cut the wrapper noun |
+| the [adj] [noun] of [possessive] | the intricate tapestry of its · the unspoken plea in her | Rewrite from scratch |
+| Trailing/leading participial clause | "…, evading Show's heavy blows" · "Stuffing his mouth, Joe ran" | Break into its own short sentence with a finite verb (LLM usage: up to 5× human) |
+| Nominalization | realization, determination, transformation as sentence subjects | Turn back into verbs (2× human rate) |
+| Paired abstractions "X and Y" | desperation and resolve · curiosity and caution | Keep one |
+| not only X but also Y · it's not X, it's Y | — | Say the one thing you mean |
+| Rule of three | three parallel adjectives/clauses/images, everywhere | Two or four; break the rhythm |
+
+## 3 Vocabulary
+
+Merged ban list (R Table 12 + P excess-vocab + L signature phrases + F fiction slop). A single hit is not a verdict — **slop is cumulative** (S): count hits, and rewrite when they cluster.
+
+| Class | Words/phrases |
+|---|---|
+| Abstract-grandeur nouns | tapestry, testament, symphony, kaleidoscope, landscape, realm, journey, beacon, camaraderie, solace, resilience, nuance, myriad |
+| Performance verbs | delve, underscore, foster, harness, navigate, resonate, elevate, embrace, transcend, unravel, ignite, grapple, weave/weaving |
+| Inflation adjectives | intricate, vibrant, palpable, profound, pivotal, crucial, seamless, robust, transformative, multifaceted, fleeting, bustling |
+| Fiction slop (F) | ozone, petrichor, shimmering, thrums, gossamer, "barely above a whisper", "eyes gleam/glint/alight", "despite herself", "breath catches", "heart skips", "shivers down the spine", "voice like [material]" |
+| Signature phrases (L) | unspoken, the weight of, hung in the air, the air was thick, in the pit of her/my stomach, a constant reminder of |
+| Formula phrases (R) | paving the way, it's important to note, in a world of/where, a testament to, cautionary tale, "amidst" |
+| Filter words (F) | felt, seemed, realized, noticed, knew, watched as — delete the filter, render the thing directly |
+
+## 4 What to add back — the underused human register
+
+Instruct-tuned models systematically suppress these (P: usage 13–80% of human rate). Restore them *to the degree the genre and the author's voice allow* — sprinkled, not poured:
+
+| Restore | Examples |
+|---|---|
+| Contractions | don't, it's, wouldn't |
+| Discourse particles and fillers | well, anyway, just, really, actually |
+| Plain causal connectives | because (GPT-4o uses it at 20% of human rate), so |
+| Hedges and emphatics | almost, sort of, for sure, obviously |
+| Negation | "no answer was good enough" — synthetic negation runs at half human rate |
+| Pro-verb do | "and she did" |
+| Plain speech tags | *says/said* on repeat is human; rotating *notes, observes, remarks, muses* is machine elegance |
+| First/second person, direct questions | where POV permits |
+| Coarse or blunt language | where the register genuinely calls for it |
+
+## 5 Genre alignment
+
+Half of surface AI-ness is register mismatch: instruct models write one noun-heavy, information-dense, evenly-polished prose regardless of genre (P). Before editing, state the target register (literary / pulp / YA / essayistic) and edit toward *that* — a de-AI'd thriller and a de-AI'd literary story should not end up in the same voice. Sentence length variance, contraction rate, and vocabulary plainness are genre parameters, not universal constants.
+
+## 6 The read-aloud test
+
+Grammatically correct but unsayable is a distinct slop dimension (S: "the earthen area that formerly held the puddle was now dry"). Read dialogue and any sentence you rewrote aloud (mentally): if no native speaker would say it or write it in a letter, redo it in speech-shaped syntax.
+
+## 7 False-positive whitelist
+
+Do **not** flag or "fix" these — over-correction is its own fingerprint:
+
+| Not evidence of AI | Why |
+|---|---|
+| Correct grammar and clean punctuation | Plenty of humans write cleanly; imperfection-injection is a detectable gimmick |
+| A single em-dash, semicolon, or "delve" | One hit means nothing; only clusters count |
+| Neutral or formal tone in a formal genre | Register match beats forced casualness |
+| A banned word inside quoted dialogue or an in-world document | Quoted material keeps its texture |
+| The author's own verified habits | If the user's samples use em-dashes or "moreover," those stay |
+| Moderate ordinary sentences | Slack is human; do not polish every line to distinctiveness |
+
+> Informality is not a disguise. Current-generation models already fake casual registers, and expert detectors read "informal but otherwise fully machine-patterned" as AI instantly (R). Surface fixes only hold when passes 1–2 were done first.

--- a/tests/skills/test_sepia_skill.py
+++ b/tests/skills/test_sepia_skill.py
@@ -1,0 +1,104 @@
+"""Tests for the ported sepia optional skill (de-AI writing)."""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+STAGING_ROOT = Path(__file__).resolve().parents[2]
+FALLBACK_ROOT = Path.home() / ".hermes" / "hermes-agent"
+
+
+def _skill_dir() -> Path:
+    staged = STAGING_ROOT / "optional-skills" / "creative" / "sepia"
+    if staged.is_dir():
+        return staged
+    fallback = FALLBACK_ROOT / "optional-skills" / "creative" / "sepia"
+    if fallback.is_dir():
+        return fallback
+    pytest.skip("sepia skill directory not found in staging or fallback")
+
+
+SKILL_DIR = _skill_dir()
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+REFERENCE_FILES = [
+    "references/discourse-pass.md",
+    "references/narrative-pass.md",
+    "references/professional-pass.md",
+    "references/style-pass.md",
+    "references/rubric.md",
+    "references/model-fingerprints.md",
+    "references/domains/dev-replies.md",
+    "references/domains/postmortems.md",
+    "references/domains/release-notes.md",
+    "references/domains/tech-articles.md",
+    "references/domains/tickets.md",
+]
+
+
+def _frontmatter() -> dict:
+    text = SKILL_MD.read_text(encoding="utf-8")
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match, "SKILL.md missing YAML frontmatter"
+    data = yaml.safe_load(match.group(1))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_frontmatter_parses():
+    fm = _frontmatter()
+    assert fm["name"] == "sepia"
+
+
+def test_description_length_and_period():
+    desc = _frontmatter()["description"]
+    assert isinstance(desc, str)
+    assert len(desc) <= 60, f"description is {len(desc)} chars"
+    assert desc.endswith("."), "description must end with a period"
+
+
+def test_platforms_present():
+    platforms = _frontmatter().get("platforms")
+    assert platforms, "platforms field is mandatory for optional skills"
+    assert set(platforms) == {"linux", "macos", "windows"}
+
+
+def test_license_mit_and_license_file():
+    assert _frontmatter()["license"] == "MIT"
+    lic = SKILL_DIR / "LICENSE.txt"
+    assert lic.is_file(), "LICENSE.txt missing"
+    assert "MIT License" in lic.read_text(encoding="utf-8")
+
+
+def test_routing_table_reference_paths_exist():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    paths = set(re.findall(r"`(references/[\w\-/]+\.md)`", text))
+    assert paths, "no reference paths found in SKILL.md"
+    for rel in sorted(paths):
+        assert (SKILL_DIR / rel).is_file(), f"missing: {rel}"
+
+
+def test_all_eleven_reference_files_exist_nonempty():
+    for rel in REFERENCE_FILES:
+        p = SKILL_DIR / rel
+        assert p.is_file(), f"missing: {rel}"
+        assert p.stat().st_size > 0, f"empty: {rel}"
+
+
+def test_no_upstream_harness_residue():
+    pattern = re.compile(r"allowed-tools|\.claude-plugin|AskUserQuestion", re.IGNORECASE)
+    for i, line in enumerate(SKILL_MD.read_text(encoding="utf-8").splitlines(), 1):
+        assert not pattern.search(line), f"harness residue on line {i}: {line!r}"
+
+
+def test_related_skills_resolve():
+    related = _frontmatter().get("metadata", {}).get("hermes", {}).get("related_skills", [])
+    assert "humanizer" in related
+    search_roots = [STAGING_ROOT, FALLBACK_ROOT / "skills"]
+    found = any(
+        root.is_dir() and any(p.name == "humanizer" and p.is_dir() for p in root.rglob("humanizer"))
+        for root in search_roots
+    )
+    assert found, "related skill 'humanizer' not found under staging root or ~/.hermes/hermes-agent/skills"

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -66,6 +66,7 @@ hermes skills uninstall <skill-name>
 | [**kanban-video-orchestrator**](/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator) | Plan and run multi-agent video production pipelines. |
 | [**meme-generation**](/docs/user-guide/skills/optional/creative/creative-meme-generation) | Create meme PNGs from templates with Pillow text overlay. |
 | [**pixel-art**](/docs/user-guide/skills/optional/creative/creative-pixel-art) | Pixel art w/ era palettes (NES, Game Boy, PICO-8). |
+| [**sepia**](/docs/user-guide/skills/optional/creative/creative-sepia) | De-AI writing: fix narrative structure, not just style. |
 | [**simple-english**](/docs/user-guide/skills/optional/creative/creative-simple-english) | Rewrite technical text to ASD-STE100 Simplified Technical English. |
 | [**social-media-content-calendar**](/docs/user-guide/skills/optional/creative/creative-social-media-content-calendar) | Plan multi-platform social campaigns: briefs to posting. |
 | [**tldraw-offline**](/docs/user-guide/skills/optional/creative/creative-tldraw-offline) | Drive and script tldraw offline canvases with an agent. |

--- a/website/docs/user-guide/skills/optional/creative/creative-sepia.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-sepia.md
@@ -1,0 +1,114 @@
+---
+title: "Sepia — De-AI writing: fix narrative structure, not just style"
+sidebar_label: "Sepia"
+description: "De-AI writing: fix narrative structure, not just style"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Sepia
+
+De-AI writing: fix narrative structure, not just style.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/creative/sepia` |
+| Path | `optional-skills/creative/sepia` |
+| Version | `1.0.0` |
+| Author | Nanako0129 (upstream sepia), ported by Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `writing`, `de-ai`, `humanize`, `fiction`, `prose`, `storyscope` |
+| Related skills | [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Sepia — de-AI writing
+
+Make AI-generated writing read as human-written, in fiction and in professional
+prose. Repairs the narrative architecture of fiction and stories (based on
+StoryScope, arXiv:2604.03136); routes professional text through domain rules for
+release notes, announcements, PR and issue replies, code-review comments,
+incident postmortems, tickets, work orders, technical articles, and blog posts.
+Four operations — write, review (diagnose AI tells without editing), refactor
+(minimal in-place edits), recreate (full rewrite). Use when asked to humanize,
+de-AI, unslop, or strip AI flavor from any text; when writing or revising any of
+these document types; or whenever output must not read as machine-written.
+
+*Ported from upstream sepia v0.2.0. The upstream `research/` directory (evidence
+notes behind each rule) is not vendored in this port — see
+https://github.com/Nanako0129/sepia/tree/main/research for provenance.*
+
+Every rule here is backed by a measured human-vs-AI gap. The load-bearing facts: in fiction, a classifier using only **narrative-structure features** detects AI at 93.2% macro-F1 and style editing barely moves it — so structure is fixed before style, always. In professional prose, the measured tells are different — filler density, missing stance, chatbot residue, register mismatch, format uniformity — and the fix is domain-specific. Route first, then operate.
+
+## Sepia vs humanizer
+
+Hermes also bundles **humanizer** (Wikipedia signs-of-AI-writing): a fast,
+style-level de-AI pass for any text — word swaps, tone, surface tells.
+**Sepia** is structural repair: fiction narrative architecture (StoryScope —
+structure alone detects AI at 93.2% macro-F1; style editing barely moves it),
+domain-routed professional prose rules (release notes, PR replies, postmortems,
+tickets, tech articles), and four operation contracts (write / review /
+refactor / recreate). Recommendation: quick de-slop → humanizer; fiction,
+domain documents, or text that *still reads as AI after style edits* → sepia.
+
+## Loading references in Hermes
+
+Load the pass files on demand with
+`skill_view(name='sepia', file_path='references/narrative-pass.md')` (and
+likewise for any path in the routing table below).
+
+## Routing
+
+| Text type | Load, in order |
+|---|---|
+| Fiction / stories / narrative essays | `references/narrative-pass.md` → `references/discourse-pass.md` → `references/style-pass.md`; diagnose with `references/rubric.md` |
+| Release notes, changelogs, announcements | `references/professional-pass.md` + `references/domains/release-notes.md` |
+| PR replies, issue replies, review comments | `references/professional-pass.md` + `references/domains/dev-replies.md` |
+| Incident postmortems / RCA | `references/professional-pass.md` + `references/domains/postmortems.md` |
+| Tickets, work orders, bug reports | `references/professional-pass.md` + `references/domains/tickets.md` |
+| Technical articles, blog posts, tutorials | `references/professional-pass.md` + `references/domains/tech-articles.md` + `references/discourse-pass.md` §1–3 |
+| Any other prose | `references/professional-pass.md` + `references/style-pass.md` |
+
+Every non-fiction route ends with the vocabulary/syntax scan in `references/style-pass.md` §2–3, and long professional pieces take the whole style pass — in both cases skipping its fiction-slop table. If the text was produced by a known model, add `references/model-fingerprints.md` (fiction-centric; use as priors).
+
+## Operations
+
+Any request maps to one of four operations:
+
+| Operation | Contract |
+|---|---|
+| **write** | New content. Read the domain file *before* drafting — architecture and register decisions come first, they cannot be retrofitted cheaply. For fiction, follow Workflow A below. |
+| **review** | Diagnose only — no edits. Produce the defect list (fiction: rubric report; professional: checklist findings with quoted evidence) and stop. Report findings; apply nothing until asked. |
+| **refactor** | Minimal in-place revision preserving structure, voice, and intent. Two-stage: full defect list first, then fix item by item, deepest layer first. Skew replace/delete over insert (measured editor ratio 74/18/8). |
+| **recreate** | Full rewrite. Extract the facts, claims, and intent from the original into a bare list; verify nothing invented; write fresh under the domain rules. Use when defects are structural and the text is short enough that surgery costs more than rebuilding. |
+
+The two-stage protocol is not optional for refactor/recreate: paraphrasing without a defect list makes AI fingerprints *more* visible, not less (measured on expert detectors).
+
+## Fiction workflows
+
+**A — writing new fiction:** (1) premise, genre, length — genre sets calibration targets; (2) fill the architecture sheet in `references/narrative-pass.md`; (3) select 3–5 human-leaning moves + one rarity move; (4) outline, run the outline/QUD checks in `references/discourse-pass.md` and the echo test in `references/narrative-pass.md` §2; (5) draft; (6) self-diagnose with `references/rubric.md`, one group at a time; (7) style pass last.
+
+**B — revising existing fiction:** (1) diagnose completely first (rubric → discourse → style), no edits; (2) triage — architecture defects need scene-level surgery, tell the user how deep before cutting; (3) fix deepest first; (4) verify: re-run changed rubric groups, read key passages aloud, echo-test any added twist.
+
+## Calibration — the rule that governs all rules
+
+| Principle | Meaning |
+|---|---|
+| Aim at the band, not the opposite pole | Human values are moderate (chronological discontinuity 2.4/5, not 5). Inverting every AI tell creates a new fingerprint. In professional prose the equivalent: match the venue's register, don't overshoot into forced casualness — informality alone fools no trained reader. |
+| Select, don't accumulate | Human writing is diverse. Fiction: 3–5 moves per story, chosen for the premise, varied across works. Professional: fix what the checklist actually flags, nothing more. |
+| Leave slack | Ordinary sentences, an underdeveloped thought, a plain paragraph. Do not sand every surface. |
+
+## Hard guardrails
+
+- **Never invent specifics.** Fiction: intertextual references, brands, places must be real and correct. Professional: versions, numbers, timestamps, benchmarks, quotes come from the actual change/incident/data — missing info means ask the user or leave an explicit TODO, never fill. Confident wrong facts are themselves a top-tier tell.
+- **Deletion beats addition** (74% replace / 18% delete / 8% insert). The only additive fix is real specificity.
+- **Respect the author's voice and the venue's corpus.** Extract habits from the user's samples or the venue's recent artifacts before editing; edit toward *that* profile. Do not remove a mannerism they actually use.
+- **Dialogue quotes and quoted material are load-bearing** — do not regularize them.
+- **Check the whitelists** (`references/style-pass.md` §7, `references/professional-pass.md` last section) before flagging: clean grammar, formal tone in formal venues, and conventional templates are not evidence of AI.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -390,6 +390,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/creative/creative-kanban-video-orchestrator',
                     'user-guide/skills/optional/creative/creative-meme-generation',
                     'user-guide/skills/optional/creative/creative-pixel-art',
+                    'user-guide/skills/optional/creative/creative-sepia',
                     'user-guide/skills/optional/creative/creative-simple-english',
                     'user-guide/skills/optional/creative/creative-social-media-content-calendar',
                     'user-guide/skills/optional/creative/creative-tldraw-offline',


### PR DESCRIPTION
## Summary
Hermes users can now install `official/creative/sepia` — de-AI writing that repairs *narrative structure* first, based on StoryScope (arXiv:2604.03136): a classifier using only narrative-structure features detects AI fiction at 93.2% macro-F1, and style editing barely moves it. Style-only humanizing leaves the strongest tell untouched; sepia fixes the layer that matters.

## What it is
Port of [Nanako0129/sepia](https://github.com/Nanako0129/sepia) (MIT, 584★ within ~36h of its Aug 28 creation). Routes fiction through narrative→discourse→style passes and professional prose through domain rules (release notes, PR/issue replies, postmortems, tickets, tech articles), under four operation contracts: write / review / refactor / recreate.

## vs the bundled `humanizer`
Documented in the SKILL.md: `humanizer` = fast style-level de-AI pass for any text; `sepia` = structural repair for fiction + domain-routed professional documents + "still reads as AI after style edits". Cross-linked via `related_skills: [humanizer]` (resolves — humanizer is bundled at `skills/creative/humanizer`).

## Changes
- `optional-skills/creative/sepia/`: SKILL.md (~200 lines: routing table, operations, differentiation, Hermes loading notes) + 11 reference files verbatim (6 pass docs + 5 domain files) + LICENSE.txt (MIT verbatim)
- `tests/skills/test_sepia_skill.py`: frontmatter, routing-table path resolution, reference presence, de-Claude grep, related_skills resolution
- Docs: skill page + catalog row + sidebar entry (scope-disciplined regen)

## Validation
| Check | Result |
|---|---|
| Staging + repo `test_authoring_standards.py` | 1234 passed |
| Routing-table references resolve on disk | 11/11 |
| ruff on staged test | clean |
| De-Claude residue grep | clean (model-fingerprints.md discusses models as data, kept) |

## Why now (trend evidence)
Created Aug 28, 584★ in under two days — steepest star velocity in this week's created-30d sweep. Research-grounded (StoryScope) rather than vibes-based, which is what separates it from the dozens of "humanize" skills already ruled out in prior scout runs.

## Infographic

![sepia skill](https://v3b.fal.media/files/b/0aa84eaf/9rlYBCmkzyze7fTlojaDY_Rw3LMDu4.png)
