### PR TITLE
fix(desktop): keep long task lists scrollable

### DIFF
--- a/apps/desktop/src/components/chat/composer-dock.test.ts
+++ b/apps/desktop/src/components/chat/composer-dock.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { composerDockCard } from './composer-dock'
+
+describe('composerDockCard', () => {
+  it('does not shrink inside the capped status-stack scroll container', () => {
+    expect(composerDockCard('top').split(/\s+/)).toContain('shrink-0')
+  })
+})

--- a/apps/desktop/src/components/chat/composer-dock.ts
+++ b/apps/desktop/src/components/chat/composer-dock.ts
@@ -19,9 +19,13 @@ const composerDockEdge = (edge: 'bottom' | 'top') =>
 
 /** Glassy docked card — the status stack / queue. Paints the SAME
  *  `--composer-fill` as the surface, so rest / scrolled / focused / drawer-open
- *  all match the composer by construction. */
+ *  all match the composer by construction.
+ *
+ * Keep the card non-shrinking inside capped flex scroll containers. Otherwise
+ * flexbox compresses the card to the cap and its own overflow-hidden clips
+ * later status rows before the outer status stack gets anything to scroll. */
 export const composerDockCard = (edge: 'bottom' | 'top' = 'top') =>
-  cn(composerDockEdge(edge), composerFill, composerSurfaceGlass)
+  cn('shrink-0', composerDockEdge(edge), composerFill, composerSurfaceGlass)
 
 /** Floating composer panel skin — the `/`·`@`·`?` completion drawer and the
  *  attach (`+`) menu. Glassy translucent card, hairline border, full radius,


### PR DESCRIPTION
## Summary

- keep the composer status card from flex-shrinking inside the capped status stack
- let the outer `overflow-y-auto` container own overflow so every task row remains reachable
- add a focused regression test for the non-shrinking dock-card contract

## Root cause

The status stack is a capped flex column with `overflow-y-auto`, but its inner dock card was still a shrinkable flex child and also used `overflow-hidden`. With enough task rows, flexbox shrank that card to the height cap and clipped the later rows inside it, so the outer container had no overflow left to scroll.

Adding `shrink-0` keeps the card at its content height, which makes the existing outer scroll container work as intended.

## Testing

- added `composer-dock.test.ts` covering the non-shrinking card contract
- tests not run locally

Closes #97997
