### PR TITLE
feat(memory): make external provider prefetch timeout configurable

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1902,7 +1902,17 @@ def init_agent(
             if _mem_provider_name and _mem_provider_name.strip():
                 from agent.memory_manager import MemoryManager as _MemoryManager
                 from plugins.memory import load_memory_provider as _load_mem
-                agent._memory_manager = _MemoryManager()
+                # Prefetch timeout is provider-latency dependent, hence
+                # configurable. A junk value must not break startup: fall back
+                # to MemoryManager's own default.
+                try:
+                    _raw = (mem_config or {}).get("external_prefetch_timeout")
+                    _prefetch_timeout = float(_raw) if _raw and float(_raw) > 0 else None
+                except (TypeError, ValueError):
+                    _prefetch_timeout = None
+                agent._memory_manager = _MemoryManager(
+                    external_prefetch_timeout=_prefetch_timeout
+                )
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2040,6 +2040,14 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Seconds a turn waits for an EXTERNAL provider's prefetch (recall)
+        # before continuing without injected memory; the built-in local
+        # provider is unaffected. A timed-out worker is NOT cancelled and
+        # later turns skip while it lives, so a provider slower than this
+        # never gets applied at all. Measure your provider's real p95 and
+        # keep this above it; a local reranker or large graph can push a
+        # single recall past 20s.
+        "external_prefetch_timeout": 8.0,
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/tests/agent/test_memory_prefetch_timeout_config.py
+++ b/tests/agent/test_memory_prefetch_timeout_config.py
@@ -1,0 +1,94 @@
+"""memory.external_prefetch_timeout must reach MemoryManager.
+
+Guards the config -> runtime chain for the external memory prefetch timeout.
+The value is latency dependent (a provider whose recall exceeds it has its
+prefetch effectively never applied, because the timed-out worker thread keeps
+running and later turns skip while it is alive), so it must stay configurable
+and must degrade safely when the configured value is junk.
+"""
+import pytest
+
+from agent.memory_manager import _EXTERNAL_PREFETCH_TIMEOUT_S, MemoryManager
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+
+def resolve(mem_config):
+    """Mirror agent_init's resolution of memory.external_prefetch_timeout."""
+    try:
+        raw = (mem_config or {}).get("external_prefetch_timeout")
+        timeout = float(raw) if raw and float(raw) > 0 else None
+    except (TypeError, ValueError):
+        timeout = None
+    return MemoryManager(external_prefetch_timeout=timeout)
+
+
+def test_default_is_declared_in_config_defaults():
+    assert "external_prefetch_timeout" in DEFAULT_CONFIG["memory"]
+
+
+def test_documented_default_matches_runtime_fallback():
+    # A drifting pair would make the documented default a lie.
+    assert DEFAULT_CONFIG["memory"]["external_prefetch_timeout"] == pytest.approx(
+        _EXTERNAL_PREFETCH_TIMEOUT_S
+    )
+
+
+@pytest.mark.parametrize(
+    "configured,expected",
+    [
+        (30.0, 30.0),
+        (45, 45.0),
+        ("25", 25.0),   # YAML may hand back a string
+        (0.5, 0.5),
+    ],
+)
+def test_configured_value_reaches_manager(configured, expected):
+    mgr = resolve({"external_prefetch_timeout": configured})
+    assert mgr._external_prefetch_timeout == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [None, 0, -5, "abc", "", [], {}],
+)
+def test_invalid_values_fall_back_without_raising(configured):
+    # Startup must survive a bad config value rather than crash on it.
+    mgr = resolve({"external_prefetch_timeout": configured})
+    assert mgr._external_prefetch_timeout == pytest.approx(
+        _EXTERNAL_PREFETCH_TIMEOUT_S
+    )
+
+
+@pytest.mark.parametrize("mem_config", [None, {}])
+def test_absent_config_uses_default(mem_config):
+    mgr = resolve(mem_config)
+    assert mgr._external_prefetch_timeout == pytest.approx(
+        _EXTERNAL_PREFETCH_TIMEOUT_S
+    )
+
+
+def test_manager_still_rejects_non_positive_when_passed_directly():
+    # The guard inside MemoryManager must remain, independent of the caller.
+    with pytest.raises(ValueError):
+        MemoryManager(external_prefetch_timeout=0)
+
+
+def test_agent_init_actually_passes_the_timeout():
+    """Guard the real call site, not just a mirrored copy of its logic.
+
+    The parametrised tests above exercise resolve(), which reproduces
+    agent_init's logic. That cannot catch agent_init reverting to a bare
+    MemoryManager() call, so assert on the construction site itself.
+    """
+    import inspect
+
+    from agent import agent_init
+
+    src = inspect.getsource(agent_init)
+    assert "external_prefetch_timeout=_prefetch_timeout" in src, (
+        "agent_init must pass the configured timeout into MemoryManager; "
+        "a bare MemoryManager() call silently restores the hardcoded default"
+    )
+    assert '"external_prefetch_timeout"' in src, (
+        "agent_init must read memory.external_prefetch_timeout from config"
+    )


### PR DESCRIPTION
## Problem

`agent/memory_manager.py` hardcodes `_EXTERNAL_PREFETCH_TIMEOUT_S = 8.0`, but the correct value depends on the external memory provider's recall latency — something the core cannot know.

This is not only a "memory arrives late" issue. In `MemoryManager._prefetch_external` (`memory_manager.py:611-632`) a timed-out worker thread is **not** cancelled:

```python
thread.join(self._external_prefetch_timeout)
if thread.is_alive():
    logger.warning("Memory provider '%s' prefetch timed out after %.1fs; ...")
    return ""
```

The thread keeps running, and lines 611-619 skip prefetch on any later turn while it is still alive. So when a provider's recall reliably exceeds the timeout, prefetch is **never applied at all** — not merely delayed. The only symptom is a repeating warning, which reads like noise rather than "your memory provider is switched off."

Observed with the Hindsight provider against a bank whose local CPU cross-encoder reranked 300 candidates per recall: recall measured 15-22s against the 8s ceiling, 135 warnings accumulated, and prefetch was effectively disabled for the entire period. Raising the timeout restored it immediately.

## Change

Adds `memory.external_prefetch_timeout` (default `8.0`, so existing behaviour is unchanged) and threads it from `agent_init` into `MemoryManager`.

Deliberate choices:

- **`config.yaml`, not an env var** — this is a behavioural setting, not a credential.
- **Invalid values fall back, they do not raise.** A non-numeric or non-positive value in user config must not break startup, so it degrades to the existing default. `MemoryManager`'s own positive-value guard is left intact for direct callers.

## Tests

`tests/agent/test_memory_prefetch_timeout_config.py`:

- Resolution chain: configured float / int / numeric string, absent key, `None`, zero, negative, garbage, empty config.
- Asserts the documented default in `config_defaults.py` matches `_EXTERNAL_PREFETCH_TIMEOUT_S`, so the two cannot silently drift.
- Guards the real `agent_init` call site. The parametrised cases mirror `agent_init`'s resolution logic, which means they would stay green if `agent_init` reverted to a bare `MemoryManager()` — so that case is asserted separately against the source.

Mutation-verified: breaking the wiring fails the guard test (exit 1); restoring it passes (exit 0). 88 tests pass alongside the existing `tests/agent/test_memory_provider.py` suite.

## Verification

Exercised on a live install rather than only in tests: set to `15`, restarted the gateway, confirmed the value resolves through `load_config()` → `MemoryManager` as `15.0`, and confirmed real `hindsight_recall` calls now complete instead of being discarded. Zero timeout warnings from sessions created after the restart.

One behaviour worth noting for reviewers: the timeout is read when a session's agent is constructed, so already-running long-lived sessions keep their previous value until they end. That is consistent with how other `memory.*` settings behave.
