### PR TITLE
fix(skills): keep underscore-archived skills inactive

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -464,8 +464,6 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                 else iter_skill_index_files(scan_dir, "SKILL.md")
             )
             for skill_md in _iter:
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
-                    continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')
                     frontmatter, body = _parse_frontmatter(content)

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -31,6 +31,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".github",
         ".hub",
         ".archive",
+        "_archive",
         ".venv",
         "venv",
         "node_modules",

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -51,12 +51,16 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
 
 
 class TestScanSkillCommands:
+    def test_skips_skills_under_underscore_archive_directory(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        _make_skill(skills_root, "active-skill")
+        _make_skill(skills_root / "_archive", "archived-skill")
 
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            result = scan_skill_commands()
 
-
-
-
-
+        assert "/active-skill" in result
+        assert "/archived-skill" not in result
 
     def test_loads_skill_invocation_from_symlinked_skill_dir(self, tmp_path):
         """Slash commands should load skills symlinked under the local skills dir."""


### PR DESCRIPTION
## What does this PR do?

Skills stored under a user-created `_archive/` directory currently remain discoverable and continue registering slash commands. This change makes `_archive` part of the shared inactive-directory convention and removes the smaller, duplicated exclusion check from the slash-command scanner so all scan paths use one source of truth.

### Symptom

A `SKILL.md` stored below `skills/_archive/` appears in `scan_skill_commands()` and remains invocable through its generated slash command. The equivalent `.archive/` layout is already inactive.

### Impact

Manually archived skills can remain active, collide with core slash commands, and be reread during scans. The affected population is users who archive skill packages under the visible `_archive/` convention rather than the Curator-managed `.archive/` directory.

### Bug Cause

**Trigger:** `agent/skill_utils.py:28` / `EXCLUDED_SKILL_DIRS`

**Causal chain:**
1. A user moves a skill package below `skills/_archive/`.
2. `iter_skill_index_files()` prunes only names in `EXCLUDED_SKILL_DIRS`, which omitted `_archive`.
3. `scan_skill_commands()` receives the archived `SKILL.md` and registers its slash command as active.

**Why it is wrong:** Archive location spelling changed whether inactive content stayed loadable, while `agent/skill_commands.py` also carried a redundant four-entry exclusion set that could drift from the shared scanner semantics.

**Working sibling / contrast:** `.archive/` is already present in `EXCLUDED_SKILL_DIRS`, so the same package under that directory is pruned before command registration.

**Ruled out:** Existing virtualenv, dependency, VCS, and cache exclusions were not bypassed by `iter_skill_index_files()`; they were already pruned through the shared set. The reproducible gap was the missing `_archive` convention.

### Fix

Add `_archive` to `EXCLUDED_SKILL_DIRS` and rely on `iter_skill_index_files()` as the single exclusion chokepoint instead of rechecking a smaller inline set in `scan_skill_commands()`. A regression test verifies that an active sibling still registers while an underscore-archived skill does not.

## Related Issue

Closes #98044

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py` - treat `_archive` as an excluded inactive skill directory.
- `agent/skill_commands.py` - remove the duplicate inline exclusion set.
- `tests/agent/test_skill_commands.py` - cover active and underscore-archived command discovery together.

## How to Test

1. Create one skill under `skills/active-skill/` and another under `skills/_archive/archived-skill/`.
2. Run `scan_skill_commands()` and confirm only `/active-skill` is returned.
3. Run the focused suites:

```bash
scripts/run_tests.sh tests/agent/test_skill_commands.py -k 'not supporting_files_shown_with_absolute_paths and not inline_shell_runs_in_skill_directory' -q
scripts/run_tests.sh tests/agent/test_skill_utils.py -q
```

The focused runs pass 28 and 23 tests respectively. The two excluded Windows assertions also fail unchanged on upstream `main`: one expects a generated supporting-file example to contain the fixture filename, and one compares Git Bash `pwd` output against a Windows-native path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A; this aligns an existing archive convention
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] I've considered cross-platform impact; the exclusion is path-component based
- [x] Tool description and schema updates are N/A; no tool contract changed

## Screenshots / Logs

N/A - the regression is covered by filesystem-backed automated tests.
