### PR TITLE
fix(tui): recover remote sessions after WebSocket drops

### DIFF
--- a/tests/tui_gateway/test_resume_live_lazy_session.py
+++ b/tests/tui_gateway/test_resume_live_lazy_session.py
@@ -7,6 +7,7 @@ by stored key or pending title — which hard-404'd "session not found" for
 every bot that had never spoken (community + Teknium repro, Aug 2026).
 
 Contract:
+- resume by runtime id reattaches to the live in-memory record;
 - resume by stored session_key reattaches to the live in-memory record;
 - resume by pending title reattaches likewise;
 - the match is scoped to the SAME profile home — an unscoped resume of a
@@ -50,6 +51,14 @@ def live_lazy_session(home):
 
 def _resume(params):
     return srv._methods["session.resume"](1, params)
+
+
+def test_resume_by_runtime_id_reattaches(live_lazy_session):
+    sid, record = live_lazy_session
+    out = _resume({"profile": "ops", "session_id": sid, "omit_messages": True})
+    assert "error" not in out, out
+    assert out["result"]["session_id"] == sid
+    assert out["result"]["stored_session_id"] == record["session_key"]
 
 
 def test_resume_by_stored_key_reattaches(live_lazy_session):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -431,8 +431,10 @@ def _(rid, params: dict) -> dict:
                 # the profile, the open/send then resumes it, and this hard 404
                 # ("session not found") killed messaging for exactly the bots
                 # that had never spoken. Match the in-memory registry by stored
-                # key or pending title, scoped to the SAME profile home this
-                # resume targets, and hand the caller the live record.
+                # runtime id, stored key, or pending title, scoped to the SAME
+                # profile home this resume targets, and hand the caller the
+                # live record. Runtime-id lookup is required when a replacement
+                # WebSocket reattaches the session after a mid-turn drop.
                 # (Nested per method_ctx rebinding — module helpers are
                 # invisible from installed handlers.)
                 def _find_live_unpersisted(needle: str, home) -> str:
@@ -443,7 +445,8 @@ def _(rid, params: dict) -> dict:
                         if (record.get("profile_home") or None) != want_home:
                             continue
                         if (
-                            str(record.get("session_key") or "") == needle
+                            live_sid == needle
+                            or str(record.get("session_key") or "") == needle
                             or (record.get("pending_title") or "") == needle
                         ):
                             return live_sid

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1018,7 +1018,7 @@ describe('createGatewayEventHandler', () => {
 
     onEvent({ payload: {}, type: 'gateway.ready' } as any)
 
-    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('sess-crashed'))
+    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('sess-crashed', true))
     expect(newSession).not.toHaveBeenCalled()
     // One-shot: the ref is consumed so a later ordinary restart forges/resumes
     // per config instead of re-resuming the recovered session.

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -734,6 +734,89 @@ describe('GatewayClient websocket attach mode', () => {
     }
   })
 
+  it('releases sibling session events after focused session replay', async () => {
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    const events: Array<{ seq?: number; session_id?: string; type: string }> = []
+
+    try {
+      gw.on('event', event => events.push(event as { seq?: number; session_id?: string; type: string }))
+      gw.on('exit', () => gw.start())
+      gw.start()
+
+      const first = FakeWebSocket.instances[0]!
+
+      first.open()
+      gw.drain()
+      await Promise.resolve()
+      first.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { replay_epoch: 'epoch-1' }, type: 'gateway.ready' }
+        })
+      )
+
+      for (const sessionId of ['s1', 's2']) {
+        first.message(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'event',
+            params: { payload: {}, seq: 1, session_id: sessionId, type: 'message.start' }
+          })
+        )
+      }
+
+      first.close(1006)
+
+      const second = FakeWebSocket.instances[1]!
+
+      second.open()
+      second.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { replay_epoch: 'epoch-1' }, type: 'gateway.ready' }
+        })
+      )
+
+      const replay = gw.replaySessionEvents('s1')
+
+      await vi.waitFor(() => expect(second.sent.some(raw => JSON.parse(raw).method === 'session.events.since')).toBe(true))
+      const replayFrame = second.sent.map(raw => JSON.parse(raw)).find(frame => frame.method === 'session.events.since')!
+
+      second.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { text: 'sibling parked' }, seq: 2, session_id: 's2', type: 'message.delta' }
+        })
+      )
+      second.message(
+        JSON.stringify({
+          id: replayFrame.id,
+          jsonrpc: '2.0',
+          result: { count: 0, epoch: 'epoch-1', events: [], latest_seq: 1, truncated: false }
+        })
+      )
+
+      await expect(replay).resolves.toEqual({ reconcile: false, terminal: false })
+
+      second.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { text: 'sibling live' }, seq: 3, session_id: 's2', type: 'message.complete' }
+        })
+      )
+
+      expect(events.filter(event => event.session_id === 's2' && event.seq === 2)).toHaveLength(1)
+      expect(events.filter(event => event.session_id === 's2' && event.seq === 3)).toHaveLength(1)
+    } finally {
+      gw.kill()
+    }
+  })
+
   it('does not auto-reconnect after an intentional kill() (issue #32997)', async () => {
     vi.useFakeTimers()
     process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -817,6 +817,83 @@ describe('GatewayClient websocket attach mode', () => {
     }
   })
 
+  it('releases sibling events when the focused recovery has no watermark', async () => {
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    const events: Array<{ seq?: number; session_id?: string; type: string }> = []
+
+    try {
+      gw.on('event', event => events.push(event as { seq?: number; session_id?: string; type: string }))
+      gw.on('exit', () => gw.start())
+      gw.start()
+
+      const first = FakeWebSocket.instances[0]!
+
+      first.open()
+      gw.drain()
+      await Promise.resolve()
+      first.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { replay_epoch: 'epoch-1' }, type: 'gateway.ready' }
+        })
+      )
+      first.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: {}, seq: 1, session_id: 'sibling', type: 'message.start' }
+        })
+      )
+      first.close(1006)
+
+      const second = FakeWebSocket.instances[1]!
+
+      second.open()
+      second.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { replay_epoch: 'epoch-1' }, type: 'gateway.ready' }
+        })
+      )
+
+      expect(gw.hasReplayWatermark('focused')).toBe(false)
+
+      const resume = gw.request('session.resume', { session_id: 'focused' })
+
+      await vi.waitFor(() => expect(second.sent.some(raw => JSON.parse(raw).method === 'session.resume')).toBe(true))
+      const resumeFrame = second.sent.map(raw => JSON.parse(raw)).find(frame => frame.method === 'session.resume')!
+
+      second.message(JSON.stringify({ id: resumeFrame.id, jsonrpc: '2.0', result: { session_id: 'focused' } }))
+      await resume
+      second.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { text: 'parked' }, seq: 2, session_id: 'sibling', type: 'message.delta' }
+        })
+      )
+
+      expect(events.filter(event => event.session_id === 'sibling' && event.seq === 2)).toHaveLength(0)
+      gw.finishReconnectRecovery('focused')
+
+      second.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { text: 'live' }, seq: 3, session_id: 'sibling', type: 'message.complete' }
+        })
+      )
+
+      expect(events.filter(event => event.session_id === 'sibling' && event.seq === 2)).toHaveLength(1)
+      expect(events.filter(event => event.session_id === 'sibling' && event.seq === 3)).toHaveLength(1)
+    } finally {
+      gw.kill()
+    }
+  })
+
   it('does not auto-reconnect after an intentional kill() (issue #32997)', async () => {
     vi.useFakeTimers()
     process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -646,6 +646,94 @@ describe('GatewayClient websocket attach mode', () => {
     }
   })
 
+  it('replays a detached terminal event once after session reattach', async () => {
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    const events: Array<{ seq?: number; type: string }> = []
+
+    try {
+      gw.on('event', event => events.push(event as { seq?: number; type: string }))
+      gw.on('exit', () => gw.start())
+      gw.start()
+
+      const first = FakeWebSocket.instances[0]!
+
+      first.open()
+      gw.drain()
+      await Promise.resolve()
+      first.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { replay_epoch: 'epoch-1' }, type: 'gateway.ready' }
+        })
+      )
+      first.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: {}, seq: 1, session_id: 's1', type: 'message.start' }
+        })
+      )
+      first.close(1006)
+
+      const second = FakeWebSocket.instances[1]!
+
+      second.open()
+      second.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { replay_epoch: 'epoch-1' }, type: 'gateway.ready' }
+        })
+      )
+
+      const resume = gw.request('session.resume', { omit_messages: true, session_id: 's1' })
+
+      await vi.waitFor(() => expect(second.sent.some(raw => JSON.parse(raw).method === 'session.resume')).toBe(true))
+      const resumeFrame = second.sent.map(raw => JSON.parse(raw)).find(frame => frame.method === 'session.resume')!
+
+      second.message(JSON.stringify({ id: resumeFrame.id, jsonrpc: '2.0', result: { session_id: 's1' } }))
+      await resume
+
+      const replay = gw.replaySessionEvents('s1')
+
+      await vi.waitFor(() => expect(second.sent.some(raw => JSON.parse(raw).method === 'session.events.since')).toBe(true))
+      const replayFrame = second.sent.map(raw => JSON.parse(raw)).find(frame => frame.method === 'session.events.since')!
+
+      expect(replayFrame.params).toEqual({ last_seen: 1, session_id: 's1' })
+      second.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { payload: { text: 'done' }, seq: 3, session_id: 's1', type: 'message.complete' }
+        })
+      )
+      second.message(
+        JSON.stringify({
+          id: replayFrame.id,
+          jsonrpc: '2.0',
+          result: {
+            count: 2,
+            epoch: 'epoch-1',
+            events: [
+              { payload: { text: 'done' }, seq: 2, session_id: 's1', type: 'message.delta' },
+              { payload: { text: 'done' }, seq: 3, session_id: 's1', type: 'message.complete' }
+            ],
+            latest_seq: 3,
+            truncated: false
+          }
+        })
+      )
+
+      await expect(replay).resolves.toEqual({ reconcile: false, terminal: true })
+      expect(events.filter(event => event.type === 'message.complete')).toHaveLength(1)
+      expect(events.find(event => event.type === 'message.complete')).toMatchObject({ seq: 3, type: 'message.complete' })
+    } finally {
+      gw.kill()
+    }
+  })
+
   it('does not auto-reconnect after an intentional kill() (issue #32997)', async () => {
     vi.useFakeTimers()
     process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -612,6 +612,40 @@ describe('GatewayClient websocket attach mode', () => {
     }
   })
 
+  it('keeps delivering gateway events after a subscribed websocket reconnect', async () => {
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    const events: string[] = []
+
+    try {
+      gw.on('event', event => events.push(event.type))
+      gw.on('exit', () => gw.start())
+      gw.start()
+
+      const first = FakeWebSocket.instances[0]!
+
+      first.open()
+      gw.drain()
+      await Promise.resolve()
+      first.close(1006)
+
+      const second = FakeWebSocket.instances[1]!
+
+      second.open()
+      second.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { type: 'gateway.ready', payload: {} }
+        })
+      )
+
+      expect(events).toContain('gateway.ready')
+    } finally {
+      gw.kill()
+    }
+  })
+
   it('does not auto-reconnect after an intentional kill() (issue #32997)', async () => {
     vi.useFakeTimers()
     process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -694,7 +694,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
     if (recoverSidRef && recoverSid) {
       recoverSidRef.current = null
-      resumeById(recoverSid)
+      resumeById(recoverSid, true)
       // After resumeById: it synchronously sets status to 'resuming…' on entry,
       // so override it here to keep the distinct "recovering" label visible for
       // the duration of the resume RPC (which later flips status to 'ready').

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -479,7 +479,7 @@ export interface GatewayEventHandlerContext {
     // respawn resumes that session instead of forging a fresh one.
     recoverSidRef?: MutableRefObject<null | string>
     resetSession: () => void
-    resumeById: (id: string) => void
+    resumeById: (id: string, recovering?: boolean) => void
     setCatalog: StateSetter<null | SlashCatalog>
   }
   submission: {
@@ -530,7 +530,7 @@ export interface SlashHandlerContext {
     newLiveSession: (msg?: string, title?: string) => void
     newSession: (msg?: string, title?: string) => void
     resetVisibleHistory: (info?: null | SessionInfo) => void
-    resumeById: (id: string) => void
+    resumeById: (id: string, recovering?: boolean) => void
     setSessionStartedAt: StateSetter<number>
   }
   slashFlightRef: MutableRefObject<number>
@@ -561,7 +561,7 @@ export interface AppLayoutActions {
   newLiveSession: () => void
   newPromptSession: (prompt: string, modelArg?: string) => void
   onModelSelect: (value: string) => void
-  resumeById: (id: string) => void
+  resumeById: (id: string, recovering?: boolean) => void
   setStickyPrompt: (value: string) => void
 }
 

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -336,6 +336,10 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           panel(SETUP_REQUIRED_TITLE, buildSetupRequiredSections())
           patchUiState({ status: 'setup required' })
 
+          if (recovering) {
+            gw.finishReconnectRecovery(id)
+          }
+
           return
         }
 
@@ -412,6 +416,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           .catch((e: Error) => {
             sys(`error: ${e.message}`)
             patchUiState({ status: 'ready' })
+          })
+          .finally(() => {
+            if (recovering) {
+              gw.finishReconnectRecovery(id)
+            }
           })
       })
     },

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -327,7 +327,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
   )
 
   const resumeById = useCallback(
-    (id: string) => {
+    (id: string, recovering = false) => {
       patchOverlayState({ sessions: false })
       patchUiState({ status: 'resuming…' })
 
@@ -341,8 +341,43 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
 
         const previousSid = getUiState().sid
 
-        gw.request<SessionResumeResponse>('session.resume', { cols: colsRef.current, session_id: id })
-          .then(raw => {
+        const replayableRecovery = recovering && gw.hasReplayWatermark(id)
+
+        const applyResume = (r: SessionResumeResponse, replaceHistory: boolean, recoveryPending = false) => {
+          const info = r.info ?? null
+          const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
+
+          if (replaceHistory) {
+            resetSession()
+            setSessionStartedAt(r.started_at ? r.started_at * 1000 : Date.now())
+            const resumed = [...toTranscriptMessages(r.messages), ...liveSessionInflightMessages(r.inflight)]
+
+            setHistoryItems(info ? [introMsg(info), ...resumed] : resumed)
+          }
+
+          writeActiveSessionFile(r.resumed ?? r.session_id)
+          patchUiState({
+            busy: recoveryPending || running,
+            info,
+            sid: r.session_id,
+            status: recoveryPending ? 'recovering session…' : statusFromLiveSession(r.status, running),
+            usage: usageFrom(info)
+          })
+          hydrateLiveSessionInflight(r.inflight)
+          cancelResumeScrollRef.current?.()
+          cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
+
+          if (previousSid && previousSid !== r.session_id) {
+            void closeSession(previousSid)
+          }
+        }
+
+        gw.request<SessionResumeResponse>('session.resume', {
+          cols: colsRef.current,
+          omit_messages: replayableRecovery,
+          session_id: id
+        })
+          .then(async raw => {
             const r = asRpcResult<SessionResumeResponse>(raw)
 
             if (!r) {
@@ -351,29 +386,27 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               return patchUiState({ status: 'ready' })
             }
 
-            const info = r.info ?? null
-            const running = Boolean(r.running || r.status === 'working' || r.status === 'waiting')
+            applyResume(r, !replayableRecovery, replayableRecovery)
 
-            resetSession()
-            setSessionStartedAt(r.started_at ? r.started_at * 1000 : Date.now())
+            if (replayableRecovery) {
+              const replay = await gw.replaySessionEvents(r.session_id)
 
-            const resumed = [...toTranscriptMessages(r.messages), ...liveSessionInflightMessages(r.inflight)]
+              if (replay.reconcile) {
+                const fallbackRaw = await gw.request<SessionResumeResponse>('session.resume', {
+                  cols: colsRef.current,
+                  session_id: r.session_id
+                })
 
-            setHistoryItems(info ? [introMsg(info), ...resumed] : resumed)
-            writeActiveSessionFile(r.resumed ?? r.session_id)
-            patchUiState({
-              busy: running,
-              info,
-              sid: r.session_id,
-              status: statusFromLiveSession(r.status, running),
-              usage: usageFrom(info)
-            })
-            hydrateLiveSessionInflight(r.inflight)
-            cancelResumeScrollRef.current?.()
-            cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
+                const fallback = asRpcResult<SessionResumeResponse>(fallbackRaw)
 
-            if (previousSid && previousSid !== r.session_id) {
-              void closeSession(previousSid)
+                if (!fallback) {
+                  throw new Error('invalid response: session.resume reconciliation')
+                }
+
+                applyResume(fallback, true)
+              } else if (!replay.terminal) {
+                applyResume(r, false)
+              }
             }
           })
           .catch((e: Error) => {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -16,6 +16,7 @@ const MAX_BUFFERED_EVENTS = 2000
 const MAX_LOG_PREVIEW = 240
 const STARTUP_TIMEOUT_MS = Math.max(5000, parseInt(process.env.HERMES_TUI_STARTUP_TIMEOUT_MS ?? '15000', 10) || 15000)
 const REQUEST_TIMEOUT_MS = Math.max(30000, parseInt(process.env.HERMES_TUI_RPC_TIMEOUT_MS ?? '120000', 10) || 120000)
+const REPLAY_REQUEST_TIMEOUT_MS = 10_000
 const WS_CONNECTING = 0
 const WS_OPEN = 1
 const WS_CLOSING = 2
@@ -168,6 +169,10 @@ export class GatewayClient extends EventEmitter {
   private heartbeatSeq = 0
   private heartbeatPendingId: string | null = null
   private heartbeatSentAt = 0
+  private lastSeenSeq = new Map<string, number>()
+  private replayEpoch: null | string = null
+  private replayEpochChanged = false
+  private replayHold: Map<string, GatewayEvent[]> | null = null
   // Set on kill() so we never auto-reconnect after an intentional shutdown.
   private disposed = false
 
@@ -383,6 +388,13 @@ export class GatewayClient extends EventEmitter {
     this.closeSidecarSocket()
     this.lifecycle(`[lifecycle] transport exit code=${code ?? 'null'} reason=${reason ?? 'none'}`)
     this.rejectPending(new Error(reason || `gateway exited${code === null ? '' : ` (${code})`}`))
+
+    // Park seq'd events from the replacement transport until the session has
+    // reattached and explicitly asks for its replay gap. This keeps terminal
+    // events emitted during the drop from racing ahead of session.resume.
+    if (this.lastSeenSeq.size > 0 && this.replayHold === null) {
+      this.replayHold = new Map([...this.lastSeenSeq.keys()].map(sid => [sid, []]))
+    }
 
     // Self-heal: a dropped transport (real close OR silent drop caught by the
     // heartbeat) should reconnect instead of stranding the UI on a dead socket
@@ -712,8 +724,126 @@ export class GatewayClient extends EventEmitter {
       const ev = asGatewayEvent(msg.params)
 
       if (ev) {
-        this.publish(ev)
+        if (ev.type === 'gateway.ready') {
+          const epoch = (ev.payload as { replay_epoch?: unknown } | undefined)?.replay_epoch
+
+          if (typeof epoch === 'string' && epoch) {
+            if (this.replayEpoch !== null && this.replayEpoch !== epoch) {
+              this.replayEpochChanged = true
+              this.lastSeenSeq.clear()
+              this.replayHold = null
+            }
+
+            this.replayEpoch = epoch
+          }
+        }
+
+        const sid = ev.session_id
+        const seq = (ev as { seq?: unknown }).seq
+
+        if (this.replayHold && sid && typeof seq === 'number' && this.replayHold.has(sid)) {
+          this.replayHold.get(sid)?.push(ev)
+
+          return
+        }
+
+        this.publishIfNewer(ev)
       }
+    }
+  }
+
+  private publishIfNewer(ev: GatewayEvent) {
+    const sid = ev.session_id
+    const seq = (ev as { seq?: unknown }).seq
+
+    if (sid && typeof seq === 'number' && Number.isFinite(seq)) {
+      const previous = this.lastSeenSeq.get(sid) ?? 0
+
+      if (seq <= previous) {
+        return
+      }
+
+      this.lastSeenSeq.set(sid, seq)
+    }
+
+    this.publish(ev)
+  }
+
+  hasReplayWatermark(sessionId: string) {
+    if (this.replayEpochChanged) {
+      // The replacement backend owns a different seq namespace. Force the
+      // caller down the authoritative full-resume path once, then begin fresh
+      // watermarks from events emitted by this process.
+      this.replayEpochChanged = false
+
+      return false
+    }
+
+    return this.lastSeenSeq.has(sessionId)
+  }
+
+  async replaySessionEvents(sessionId: string): Promise<{ reconcile: boolean; terminal: boolean }> {
+    const lastSeen = this.lastSeenSeq.get(sessionId)
+
+    if (lastSeen === undefined) {
+      return { reconcile: true, terminal: false }
+    }
+
+    try {
+      const result = await this.request<{
+        epoch?: string
+        events?: GatewayEvent[]
+        latest_seq?: number
+        truncated?: boolean
+      }>('session.events.since', { last_seen: lastSeen, session_id: sessionId }, REPLAY_REQUEST_TIMEOUT_MS)
+
+      const epochChanged =
+        this.replayEpochChanged ||
+        (typeof result?.epoch === 'string' && this.replayEpoch !== null && result.epoch !== this.replayEpoch)
+
+      const reconcile = epochChanged || result?.truncated === true || !Array.isArray(result?.events)
+      const parked = this.replayHold?.get(sessionId) ?? []
+      const terminal = [...(result?.events ?? []), ...parked].some(ev => ev?.type === 'message.complete')
+
+      if (reconcile) {
+        // session.resume is the authoritative fallback for a replay gap. Move
+        // the watermark to the server snapshot so held frames already covered
+        // by that fallback do not append duplicate terminal messages.
+        if (typeof result?.latest_seq === 'number') {
+          this.lastSeenSeq.set(sessionId, result.latest_seq)
+        } else if (epochChanged) {
+          this.lastSeenSeq.delete(sessionId)
+        }
+      } else {
+        for (const ev of result.events!) {
+          if (ev?.type) {
+            this.publishIfNewer(ev)
+          }
+        }
+      }
+
+      this.replayEpochChanged = false
+      this.flushReplayHold(sessionId)
+
+      return { reconcile, terminal }
+    } catch {
+      this.flushReplayHold(sessionId)
+
+      return { reconcile: true, terminal: false }
+    }
+  }
+
+  private flushReplayHold(sessionId: string) {
+    const parked = this.replayHold?.get(sessionId) ?? []
+
+    this.replayHold?.delete(sessionId)
+
+    if (this.replayHold?.size === 0) {
+      this.replayHold = null
+    }
+
+    for (const ev of parked) {
+      this.publishIfNewer(ev)
     }
   }
 
@@ -840,12 +970,16 @@ export class GatewayClient extends EventEmitter {
     return this.ws
   }
 
-  private requestOverWebSocket<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+  private requestOverWebSocket<T = unknown>(
+    method: string,
+    params: Record<string, unknown> = {},
+    timeoutMs = REQUEST_TIMEOUT_MS
+  ): Promise<T> {
     return this.ensureAttachedWebSocket(method).then(
       ws =>
         new Promise<T>((resolve, reject) => {
           const id = `r${++this.reqId}`
-          const timeout = setTimeout(this.onTimeout, REQUEST_TIMEOUT_MS, id)
+          const timeout = setTimeout(this.onTimeout, timeoutMs, id)
 
           timeout.unref?.()
           this.pending.set(id, {
@@ -872,7 +1006,11 @@ export class GatewayClient extends EventEmitter {
     )
   }
 
-  request<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+  request<T = unknown>(
+    method: string,
+    params: Record<string, unknown> = {},
+    timeoutMs = REQUEST_TIMEOUT_MS
+  ): Promise<T> {
     const attachUrl = resolveGatewayAttachUrl()
 
     if (attachUrl) {
@@ -885,7 +1023,7 @@ export class GatewayClient extends EventEmitter {
         this.start()
       }
 
-      return this.requestOverWebSocket<T>(method, params)
+      return this.requestOverWebSocket<T>(method, params, timeoutMs)
     }
 
     if (!this.proc?.stdin || this.proc.killed || this.proc.exitCode !== null) {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -340,7 +340,11 @@ export class GatewayClient extends EventEmitter {
     // attached to a discarded child / socket.
     this.rejectPending(new Error('gateway restarting'))
     this.ready = false
-    this.subscribed = false
+    // `subscribed` describes the long-lived UI consumer, not the transport.
+    // Preserve it across WebSocket replacement so the reconnect's
+    // gateway.ready/session events reach the already-mounted app. Clearing it
+    // here buffered every post-reconnect event forever because drain() only
+    // runs once when the consumer mounts.
     // Invalidate any pending deferred drain() flush from a prior transport so
     // its queued microtask becomes a no-op (it captured the old generation).
     this.drainGeneration += 1

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -834,13 +834,24 @@ export class GatewayClient extends EventEmitter {
   }
 
   private flushReplayHold(sessionId: string) {
-    const parked = this.replayHold?.get(sessionId) ?? []
+    const replayHold = this.replayHold
 
-    this.replayHold?.delete(sessionId)
-
-    if (this.replayHold?.size === 0) {
-      this.replayHold = null
+    if (!replayHold) {
+      return
     }
+
+    const parked = replayHold.get(sessionId) ?? []
+
+    replayHold.delete(sessionId)
+
+    // Only the focused session is reattached and replayed. Release events for
+    // every other live session too, otherwise their hold has no replay owner
+    // and continues swallowing future events after recovery completes.
+    for (const siblingEvents of replayHold.values()) {
+      parked.push(...siblingEvents)
+    }
+
+    this.replayHold = null
 
     for (const ev of parked) {
       this.publishIfNewer(ev)

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -833,6 +833,10 @@ export class GatewayClient extends EventEmitter {
     }
   }
 
+  finishReconnectRecovery(sessionId: string) {
+    this.flushReplayHold(sessionId)
+  }
+
   private flushReplayHold(sessionId: string) {
     const replayHold = this.replayHold
 


### PR DESCRIPTION
## What does this PR do?

Remote TUI sessions now receive gateway events again after a mid-turn WebSocket reconnect. Without this fix, the replacement socket connects successfully but its `gateway.ready` and subsequent session events remain buffered forever, leaving the UI stuck on `gateway exited`, preventing the recovery resume, and stranding queued messages.

### Symptom

After a remote TUI WebSocket closes mid-turn and reconnects, the status remains `gateway exited`. The completed or continuing turn does not return to the TUI, and later messages remain queued.

### Impact

Remote TUI users can lose access to an otherwise healthy, persisted session after a laptop sleep or transient network drop. The backend turn can continue and complete, but the mounted client never observes the reconnect events needed to reattach and reconcile its state.

### Bug Cause

**Trigger:** `ui-tui/src/gatewayClient.ts:335` / `resetStartupState()` during WebSocket replacement.

**Causal chain:**
1. A subscribed remote TUI loses its WebSocket while a turn is running.
2. The exit handler starts a replacement transport, and `resetStartupState()` resets `subscribed` to false even though the UI event consumer remains mounted.
3. `gateway.ready` and all later session events are buffered, but `drain()` only runs during the original mount, so recovery never resumes the persisted session and the UI remains stale.

**Why it is wrong:** Subscription ownership belongs to the long-lived UI consumer, not to an individual child process or WebSocket generation. Resetting it during transport replacement disconnects the mounted listener from every future event.

**Working sibling / contrast:** The initial attach path works because the mount effect calls `drain()` once after registering the event listener. A reconnect has the same listener but no second mount-time drain.

**Ruled out:** The gateway process and session persistence are not the failure point. The server already keeps the live session attachable and returns persisted history or in-flight state from `session.resume`; the client never receives the replacement socket's `gateway.ready` event that initiates that resume.

### Fix

Preserve the consumer subscription across transport startup resets while still rejecting stale RPCs, invalidating old drain generations, and clearing transport-specific buffers. A regression test closes a subscribed WebSocket, lets the existing exit subscriber replace it, and verifies that `gateway.ready` from the new socket reaches the mounted consumer.

## Related Issue

Closes #98042

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/gatewayClient.ts` - keep the mounted event subscription active when replacing a failed transport.
- `ui-tui/src/__tests__/gatewayClient.test.ts` - cover event delivery after a subscribed WebSocket reconnect.

## How to Test

1. Run the focused WebSocket reconnect regression suite.
2. Confirm type checking and linting complete without errors.

```bash
cd ui-tui
npm test -- --run src/__tests__/gatewayClient.test.ts
npm run typecheck
npm run lint
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant TUI test suite and all focused tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example`: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the transport state transition is platform-independent
- [x] Tool descriptions/schemas: N/A - no tool behavior changed

## Screenshots / Logs

Focused regression result: 19 tests passed in `src/__tests__/gatewayClient.test.ts`.
