### PR TITLE
fix(agent): use canonical EXCLUDED_SKILL_DIRS in skill scan and exclude _archive

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 
 from hermes_constants import display_hermes_home
 from agent.prompt_cache_boundary import register_stable_prefix
+from agent.skill_utils import EXCLUDED_SKILL_DIRS
 from agent.skill_preprocessing import (
     expand_inline_shell as _expand_inline_shell,
     load_skills_config as _load_skills_config,
@@ -464,7 +465,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                 else iter_skill_index_files(scan_dir, "SKILL.md")
             )
             for skill_md in _iter:
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
+                if any(part in EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -31,6 +31,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".github",
         ".hub",
         ".archive",
+        "_archive",
         ".venv",
         "venv",
         "node_modules",


### PR DESCRIPTION
Fixes #98044

**What & why**
- `scan_skill_commands()` hardcoded `{'.git','.github','.hub','.archive'}` while `skill_utils.EXCLUDED_SKILL_DIRS` has 14 entries. Skills under `venv/`, `node_modules/`, etc. were incorrectly scanned from one code path but not the other.
- Non-dot archive dirs (`_archive`) — a natural Finder-visible alternative to hidden `.archive` — were not excluded anywhere, so archived skills remained invocable.

**Fix**
- Import the authoritative set instead of inlining a subset
- Add `_archive` to the canonical exclusion set

Verified with headless repro: skills under `_archive`, `venv`, `node_modules`, etc. are now correctly skipped while normal skills remain discoverable.