### PR TITLE
test(gateway): skip real-UNIX-socket witness cases on native Windows

### DIFF
--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -14,6 +14,7 @@ import json
 import os
 import shutil
 import socket
+import sys
 import tempfile
 import threading
 import time
@@ -28,6 +29,19 @@ from gateway.shutdown_watchdog import (
     get_loop_tick_socket_path,
     loop_heartbeat_forever,
     write_loop_heartbeat,
+)
+
+# Native Windows exposes neither ``socket.AF_UNIX`` nor an asyncio UNIX
+# server, so the witness cases that create real socket nodes
+# (``_silent_socket_node``) or run the real producer
+# (``loop_heartbeat_forever``) cannot execute there. Only those cases are
+# skipped: the witness-absent contracts (mocked probes, file-only
+# heartbeats) are platform-independent and keep running on Windows, per
+# the Windows behavior pinned alongside the product-side guarantee.
+_NEEDS_UNIX_SOCKETS = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="requires real UNIX-domain sockets "
+    "(socket.AF_UNIX / asyncio.start_unix_server), unavailable on native Windows",
 )
 
 
@@ -482,6 +496,7 @@ class TestLoopTickWitness:
     witnesses agree the loop stopped scheduling.
     """
 
+    @_NEEDS_UNIX_SOCKETS
     def test_stalled_heartbeat_write_never_escalates_a_running_loop(
         self, tmp_path, monkeypatch
     ):
@@ -631,6 +646,7 @@ class TestLoopTickWitness:
             thread.join(timeout=5.0)
             assert not errors, errors
 
+    @_NEEDS_UNIX_SOCKETS
     def test_off_loop_completion_cannot_manufacture_fresh_liveness(self, tmp_path):
         """A write landing after the loop froze must not look alive.
 
@@ -650,6 +666,7 @@ class TestLoopTickWitness:
             == gateway_cli.GATEWAY_LOOP_UNKNOWN
         )
 
+    @_NEEDS_UNIX_SOCKETS
     def test_true_wedge_requires_sustained_witness_silence(self, tmp_path):
         """Stale file + armed socket silent across the whole window: WEDGED.
 
@@ -808,10 +825,16 @@ class TestLoopTickWitness:
             gateway_cli.probe_gateway_loop_liveness(pid, home=tmp_path)
             == gateway_cli.GATEWAY_LOOP_WEDGED
         )
-        # And a fresh legacy file stays safe even if a dead-listener node
-        # exists for the PID (leftover from a newer process): the silent
-        # socket denies ALIVE, and UNKNOWN never escalates — the drain path
-        # keeps the full budget either way.
+
+    @_NEEDS_UNIX_SOCKETS
+    def test_legacy_fresh_file_with_dead_node_is_unknown(self, tmp_path):
+        """A fresh legacy file stays safe under a dead-listener node.
+
+        A dead-listener node for the PID (leftover from a newer process):
+        the silent socket denies ALIVE, and UNKNOWN never escalates — the
+        drain path keeps the full budget either way.
+        """
+        pid = 4242
         _write_heartbeat(tmp_path, pid, age_s=5.0)
         _silent_socket_node(get_loop_tick_socket_path(tmp_path, pid))
         assert (
@@ -821,6 +844,7 @@ class TestLoopTickWitness:
             == gateway_cli.GATEWAY_LOOP_UNKNOWN
         )
 
+    @_NEEDS_UNIX_SOCKETS
     @pytest.mark.asyncio
     async def test_producer_rebinds_over_stale_socket_node(self, tmp_path):
         """A leftover node from a dead process must not disarm the witness.
@@ -862,6 +886,7 @@ class TestLoopTickWitness:
             except asyncio.CancelledError:
                 pass
 
+    @_NEEDS_UNIX_SOCKETS
     def test_transient_stall_below_wedge_budget_never_escalates(
         self, tmp_path, monkeypatch
     ):
@@ -914,6 +939,7 @@ class TestLoopTickWitness:
             state["thread"].join(timeout=5.0)
             assert not errors, errors
 
+    @_NEEDS_UNIX_SOCKETS
     def test_sustained_stop_above_wedge_budget_still_escalates(
         self, tmp_path
     ):


### PR DESCRIPTION
## What does this PR do?

All seven `TestLoopTickWitness` cases in `tests/hermes_cli/test_update_wedged_gateway.py` that need real UNIX-domain sockets fail on native Windows: native Windows Python exposes neither `socket.AF_UNIX` nor `asyncio.start_unix_server`, so three cases raise `AttributeError` in the `_silent_socket_node` helper and four cannot arm their heartbeat producer. This PR marks exactly those seven cases with a shared module-level `skipif(sys.platform == "win32", ...)`, following the existing repo convention (e.g. `tests/test_timezone.py`'s "UDS not available on Windows"), so a native Windows run reports `SKIPPED` instead of erroring.

Only the socket-primitive-dependent cases are skipped — the witness-absent contracts (`mocked probes`, file-only heartbeats: unarmed flag, armed-but-no-node, legacy payload, single-silent-probe, sustained-silence, witness-vanishing) are platform-independent and keep running on Windows, preserving the coverage the issue's closure criteria ask for. The product code itself already handles Windows safely (`gateway/shutdown_watchdog.py` disarms the witness when `asyncio.start_unix_server` is unavailable), so no product change is needed.

To keep the legacy single-witness-contract test's stale-file arm running on Windows, it is split in two: the file-only first half keeps the original name and runs everywhere; the dead-listener-node second half needs a real socket node and becomes its own skipped case.

## Related Issue

Fixes #98039

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/hermes_cli/test_update_wedged_gateway.py`
  - added `sys` import and a module-level `_NEEDS_UNIX_SOCKETS = pytest.mark.skipif(sys.platform == "win32", ...)` marker with a comment explaining which primitives are missing on native Windows and why only the socket-dependent cases are skipped
  - decorated the seven real-UNIX-socket cases: `test_stalled_heartbeat_write_never_escalates_a_running_loop`, `test_off_loop_completion_cannot_manufacture_fresh_liveness`, `test_true_wedge_requires_sustained_witness_silence`, `test_producer_rebinds_over_stale_socket_node`, `test_transient_stall_below_wedge_budget_never_escalates`, `test_sustained_stop_above_wedge_budget_still_escalates`, and the split-out `test_legacy_fresh_file_with_dead_node_is_unknown`
  - split `test_legacy_payload_keeps_single_witness_contract` into the file-only stale-file assertion (unchanged name, runs on all platforms) and the new skipped `test_legacy_fresh_file_with_dead_node_is_unknown` (its original second half, verbatim)

## How to Test

1. `python -m pytest tests/hermes_cli/test_update_wedged_gateway.py -q` on macOS/Linux — Observed result: **31 passed** (30 original cases plus the split-out legacy arm), all behavioral assertions unchanged on POSIX.
2. `python -m pytest tests/hermes_cli/ --collect-only -q` — Observed result: 31 tests collected for the changed file (30 original cases plus the split-out legacy arm); no collection errors. (The change adds only skip markers to this one test file — no product code — so it cannot affect other files' outcomes.)
3. Verified the skip set under a `sys.platform = "win32"` illusion (load the test module after the platform switch, then evaluate each method's `skipif` mark): exactly the seven cases listed above carry an active skip, and the six platform-independent cases keep running — matching the issue's "four AF_UNIX + three producer" failure census one-to-one. Real native-Windows evidence: the issue reporter ran the affected selection on this PR's exact head — complete modified file: **24 passed, 7 skipped** (`TestLoopTickWitness` class: 6 passed, 7 skipped) — versus **7 failed, 5 passed** on `main@4209d371aa`, matching the same four `AF_UNIX` + three producer census. (Correction of an earlier wording: the hosted Windows-only CI job selects via `-m windows_only` and does not execute this unmarked file; the native-run results above, not that CI job, are the real-platform evidence for Windows.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the changed file's full suite: `pytest tests/hermes_cli/test_update_wedged_gateway.py -q` → 31 passed (twice, on two fresh checkouts)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — the change is itself test-surface: the platform gate is the regression coverage
- [x] I've tested on my platform: macOS 15 (ARM64); Windows behavior verified via platform-illusion mark evaluation plus the issue reporter's native-Windows run on this exact head (24 passed, 7 skipped for the complete modified file; the hosted Windows-only CI job selects `-m windows_only` and does not run this unmarked file)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the marker's comment documents the Windows boundary in place — N/A otherwise
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this change *is* the cross-platform boundary for these tests
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
