### PR TITLE
fix(desktop): prevent embed card compositor ghosting across session switches

### DIFF
--- a/apps/desktop/src/components/assistant-ui/embeds/social-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/social-embed.tsx
@@ -113,6 +113,11 @@ export default function SocialEmbedRenderer({ descriptor }: { descriptor: EmbedD
         clearTimeout(timer)
       }
 
+      // Explicitly detach generated iframes before clearing innerHTML
+      // so Chromium's compositor layer drops backing stores immediately.
+      const iframes = container.querySelectorAll('iframe')
+      iframes.forEach(iframe => iframe.remove())
+
       container.innerHTML = ''
     }
   }, [descriptor, isDark])

--- a/apps/desktop/src/components/assistant-ui/embeds/url-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/url-embed.tsx
@@ -60,9 +60,10 @@ export function UrlEmbed({ descriptor }: { descriptor: EmbedDescriptor }) {
 
   // Ratio embeds cap WIDTH off the ratio so height tops out at the cap while
   // scaling. Non-ratio embeds own their own height (measured / fixed).
+  // Note: contentVisibility: 'auto' is deliberately omitted to prevent Chromium GPU
+  // compositor layer ghosting/quad retention across session switches on third-party iframes.
   const style: CSSProperties = {
     containIntrinsicSize: `auto ${intrinsicHeight(descriptor)}px`,
-    contentVisibility: 'auto',
     ...(aspect
       ? { width: `min(${descriptor.maxWidth ?? 640}px, 100%, calc(${EMBED_MAX_H} * ${aspect}))` }
       : { width: descriptor.maxWidth ? `min(${descriptor.maxWidth}px, 100%)` : '100%' })

--- a/apps/desktop/vitest.setup.ts
+++ b/apps/desktop/vitest.setup.ts
@@ -7,8 +7,13 @@ import { configure } from '@testing-library/react'
 // accessor shadows jsdom's Storage and every `localStorage.getItem(...)` in a
 // test throws "Cannot read properties of undefined". Install a real in-memory
 // Storage when the global resolves to nothing, before any test module reads it.
-if (typeof (globalThis as any).localStorage === 'undefined') {
+if (
+  typeof (globalThis as any).localStorage === 'undefined' ||
+  typeof (globalThis as any).localStorage?.getItem !== 'function' ||
+  typeof (globalThis as any).localStorage?.removeItem !== 'function'
+) {
   const store = new Map<string, string>()
+
   const storage: Storage = {
     get length() {
       return store.size
@@ -19,6 +24,7 @@ if (typeof (globalThis as any).localStorage === 'undefined') {
     removeItem: (k: string) => void store.delete(String(k)),
     clear: () => store.clear(),
   }
+
   for (const target of [globalThis, (globalThis as any).window].filter(Boolean)) {
     Object.defineProperty(target, 'localStorage', {
       value: storage,


### PR DESCRIPTION
## What does this PR do?

Fixes a visual ghosting / "component shadow" bug in the Electron desktop app where third-party iframe embeds (Twitter/X, Instagram, etc.) from one session linger on screen and flicker across subsequent session switches.

### Root Cause
1. `UrlEmbed` (`apps/desktop/src/components/assistant-ui/embeds/url-embed.tsx`) applied `contentVisibility: 'auto'` to embed containers. When child iframes and hardware-accelerated widgets reside inside an element with `content-visibility: auto`, Chromium's GPU compositor skips layout/paint when off-screen or during fast session swaps, but retains the cached layer quad in GPU memory.
2. In `SocialEmbedRenderer` (`apps/desktop/src/components/assistant-ui/embeds/social-embed.tsx`), unmounting relied solely on `container.innerHTML = ''`, which does not reliably force immediate synchronous compositor backing store release for async-injected iframes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/embeds/url-embed.tsx`: Removed `contentVisibility: 'auto'` from embed card wrapper to eliminate GPU layer retention on iframe containers.
- `apps/desktop/src/components/assistant-ui/embeds/social-embed.tsx`: Added explicit child `iframe.remove()` loop in `useEffect` cleanup hook prior to clearing `innerHTML`.
- `apps/desktop/vitest.setup.ts`: Strengthened Node 26 global `localStorage` detection to prevent undefined method errors (`getItem`/`removeItem`) in tests.

## How to Test

1. Open the Hermes Desktop app.
2. In Session A, receive a message containing a bare X (Twitter) or Instagram link so the embed card renders.
3. Switch to Session B (and cycle between sidebar sessions).
4. Verify the embed card cleanly unmounts and leaves no visual residue, layer ghost, or flickering shadow in other sessions.
5. Run unit test suite: `npm run typecheck && npm run test:ui` in `apps/desktop`.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've tested on macOS / Chromium Electron