### PR TITLE
fix(recovery): try min/max rowid aggregates before the domain fallback

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -493,6 +493,29 @@ def _salvage_rowid_bounds(
     if rows["low"] is None and rows["high"] is None and not result["errors"]:
         result["empty"] = True
         return result
+
+    # Issue #98050: an ordered edge probe walks the table b-tree, but the
+    # min/max aggregates can satisfy themselves from any covering index —
+    # an independent physical path through the file. When damage eats the
+    # table b-tree edge the aggregate answers with the true bounds in one
+    # query, instead of leaving the missing side on the 64-bit domain
+    # fallback that range bisection spends its whole budget subdividing.
+    if rows["low"] is None or rows["high"] is None:
+        try:
+            agg = source.execute(
+                f'SELECT min(rowid), max(rowid) FROM "{table}"'
+            ).fetchone()
+        except sqlite3.DatabaseError as exc:
+            result["errors"].append(f"min/max rowid aggregate: {exc}")
+            agg = None
+        if agg is not None:
+            if rows["low"] is None and agg[0] is not None:
+                rows["low"] = int(agg[0])
+                result.setdefault("aggregate_recovered", []).append("low")
+            if rows["high"] is None and agg[1] is not None:
+                rows["high"] = int(agg[1])
+                result.setdefault("aggregate_recovered", []).append("high")
+
     if rows["low"] is None and rows["high"] is None:
         result["unavailable"] = True
         return result

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -17,6 +17,7 @@ from hermes_cli import session_recovery
 from hermes_cli.session_recovery import (
     SessionRecoverySafetyError,
     SessionRecoverySourceError,
+    _salvage_rowid_bounds,
     inspect_session_database,
     recover_session_database,
 )
@@ -648,4 +649,114 @@ def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
         conn.close()
 
 
+def _damage_btree_root_header(path: Path, root_page: int) -> None:
+    """Flip the cell-count bytes of a b-tree page header.
 
+    Both ordered rowid-edge probes and any table-b-tree scan of pages below
+    the damaged header raise ``database disk image is malformed``, while a
+    covering index rooted on a different page keeps answering queries.
+    """
+    data = bytearray(path.read_bytes())
+    page_size = int.from_bytes(data[16:18], "big") or 65_536
+    offset = (root_page - 1) * page_size + (100 if root_page == 1 else 0)
+    assert data[offset] in {0x05, 0x0A, 0x0D}
+    data[offset + 3 : offset + 5] = b"\xff\xff"
+    path.write_bytes(bytes(data))
+
+
+def test_rowid_bounds_aggregate_recovers_edges_when_table_btree_probes_fail(
+    tmp_path: Path,
+) -> None:
+    """#98050: the min/max aggregates are an independent path to the bounds.
+
+    The ordered rowid-edge probes walk the table b-tree, but a
+    ``min(rowid), max(rowid)`` aggregate satisfies itself from any covering
+    index. When table-b-tree damage eats both ordered probes, the aggregate
+    must answer with the true bounds in one query instead of leaving the
+    missing edges on the 64-bit domain fallback that range bisection
+    exhausts its whole query budget subdividing.
+    """
+    source = tmp_path / "indexed.db"
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        conn.execute(
+            "CREATE TABLE gateway_routing ("
+            "scope TEXT NOT NULL, session_key TEXT NOT NULL, "
+            "entry_json TEXT NOT NULL, "
+            "PRIMARY KEY (scope, session_key))"
+        )
+        conn.executemany(
+            "INSERT INTO gateway_routing (scope, session_key, entry_json) "
+            "VALUES (?, ?, ?)",
+            [
+                (f"scope-{i % 5}", f"key-{i:05d}", "x" * 64)
+                for i in range(1, 41)
+            ],
+        )
+    finally:
+        conn.close()
+
+    conn = sqlite3.connect(str(source))
+    try:
+        root_page = conn.execute(
+            "SELECT rootpage FROM sqlite_master WHERE name = 'gateway_routing'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    _damage_btree_root_header(source, root_page)
+
+    conn = sqlite3.connect(str(source))
+    try:
+        # Premise check: both ordered probes fail on the damaged table
+        # b-tree while the covering-index aggregate still answers.
+        for direction in ("ASC", "DESC"):
+            with pytest.raises(sqlite3.DatabaseError):
+                conn.execute(
+                    'SELECT rowid FROM "gateway_routing" '
+                    f"ORDER BY rowid {direction} LIMIT 1"
+                ).fetchone()
+        assert conn.execute(
+            'SELECT min(rowid), max(rowid) FROM "gateway_routing"'
+        ).fetchone() == (1, 40)
+
+        bounds = _salvage_rowid_bounds(conn, "gateway_routing")
+    finally:
+        conn.close()
+
+    assert bounds["low"] == 1
+    assert bounds["high"] == 40
+    assert bounds["fallback_edges"] == []
+    assert bounds["aggregate_recovered"] == ["low", "high"]
+    assert len(bounds["errors"]) == 2
+
+
+def test_rowid_bounds_unavailable_when_aggregate_also_fails(
+    tmp_path: Path,
+) -> None:
+    """Without a covering index the aggregate scans the same damaged table
+    b-tree and fails too; both edges stay unknown and the table is reported
+    as unavailable instead of inventing bounds."""
+    source = tmp_path / "unindexed.db"
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        conn.execute("CREATE TABLE t (v TEXT)")
+        conn.executemany("INSERT INTO t (v) VALUES (?)", [("x",)] * 10)
+    finally:
+        conn.close()
+
+    _damage_btree_root_header(source, 2)
+
+    conn = sqlite3.connect(str(source))
+    try:
+        with pytest.raises(sqlite3.DatabaseError):
+            conn.execute('SELECT rowid FROM "t" ORDER BY rowid ASC LIMIT 1').fetchone()
+        with pytest.raises(sqlite3.DatabaseError):
+            conn.execute('SELECT min(rowid), max(rowid) FROM "t"').fetchone()
+
+        bounds = _salvage_rowid_bounds(conn, "t")
+    finally:
+        conn.close()
+
+    assert bounds.get("unavailable") is True
+    assert "low" not in bounds
+    assert "high" not in bounds

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -155,9 +155,12 @@ def test_exact_lookup_recovers_tail_row_next_to_damaged_high_edge(
 
     copied = report["copy"]["messages"]
     bounds = copied["rowid_bounds"]
-    # Premise check: the high edge probe really failed and fell back.
+    # Premise check: the high edge probe really failed; the covering-index
+    # aggregate (#98050) answers the true bound in one query, so the gallop
+    # fallback edges are no longer consulted on this shape.
     assert any("high rowid" in error for error in bounds["errors"]), bounds
-    assert "high" in bounds["fallback_edges"]
+    assert bounds.get("aggregate_recovered") == ["high"], bounds
+    assert bounds["fallback_edges"] == []
 
     conn = sqlite3.connect(str(output))
     try:


### PR DESCRIPTION
## What does this PR do?

Fixes Gap 1 of #98050: when `sessions recover --allow-partial` runs rowid-range salvage on a table whose table b-tree edge is damaged, the ordered rowid-edge probes fail and the missing edge falls back to the full 64-bit rowid domain. Range bisection then burns the entire 10,000-query budget subdividing a synthetic tail that cannot contain rows, and readable rows are recorded as skipped (the report's `gateway_routing` case: 4 real rows, `low = INT64_MIN`, `query_limit_reached: true`, table lost).

The fix tries `SELECT min(rowid), max(rowid)` once after an ordered probe fails. The ordered probes walk the table b-tree, but the aggregate can satisfy itself from any covering index — an independent physical path through the file, which is exactly why a damaged edge can kill one and not the other. When the aggregate answers, it returns the **true** bounds in one query, so:

- clean databases are untouched (the aggregate only runs after a probe fails, and only non-NULL values are adopted);
- edges recovered this way are real bounds, not guesses, so they stay out of `fallback_edges` and skip the gallop probing entirely;
- if the aggregate fails too (e.g. no covering index), behavior is unchanged (gallop / domain fallback).

## Related Issue

Fixes #98050 (Gap 1 — the rowid-boundary half; Gap 2, `--inspect-only` payload decodability, is not addressed here)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/session_recovery.py` — `_salvage_rowid_bounds`: after an ordered edge probe fails, try `SELECT min(rowid), max(rowid)` before the unavailable/domain-fallback paths; record recovered edges in `rowid_bounds.aggregate_recovered` and append an error entry if the aggregate itself raises.
- `tests/hermes_cli/test_session_recovery.py` — two regression tests: (1) physical root-header damage on a table with a covering index → both ordered probes raise while the aggregate answers `[1, 40]`, and the bounds use those true values with no `fallback_edges`; (2) no covering index → the aggregate fails too and the table stays `unavailable` instead of inventing bounds.
- `tests/hermes_cli/test_session_recovery_lost_and_found.py` — the #80205 high-edge test now asserts the aggregate path (the damaged high edge is answered by the covering-index aggregate, so `fallback_edges` is empty); all downstream row-recovery assertions are unchanged and still pass.

## How to Test

1. `pytest tests/hermes_cli/test_session_recovery.py tests/hermes_cli/test_session_recovery_lost_and_found.py -q` — Observed result: `13 passed` (on unmodified `upstream/main`: `11 passed`; the new file adds 2 tests, and 1 existing premise assertion moves from the gallop path to the aggregate path with the same recovery outcome).
2. `pytest tests/test_hermes_state.py -q` — Observed result: `243 passed, 2 skipped`.
3. Physical premise check (embedded in test 1): with the table b-tree root damaged and a `PRIMARY KEY (scope, session_key)` covering index intact, `SELECT rowid ... ORDER BY rowid ASC/DESC LIMIT 1` raises `database disk image is malformed` while `SELECT min(rowid), max(rowid)` returns the true `(1, 40)` — the covering-index plan is a genuinely independent path, matching the manual sqlite3 verification in the issue.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#80243 caps the high edge via the `sqlite_sequence` hint for AUTOINCREMENT tables; this PR covers tables without a sequence entry, which that PR's own notes call out as the residual gap)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full targeted suites: session_recovery ×13, hermes_state ×243)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (pure-stdlib sqlite3 logic, no platform-specific code)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Not applicable — behavior is observable via the recovery JSON report fields (`rowid_bounds.aggregate_recovered`, empty `fallback_edges`) asserted in the tests.
