### PR TITLE
test(cli): complete launchd simulation on Windows

### DIFF
--- a/tests/hermes_cli/test_update_launchd_unloaded_gateway.py
+++ b/tests/hermes_cli/test_update_launchd_unloaded_gateway.py
@@ -153,6 +153,8 @@ class TestServicePidSweepExclusion:
         monkeypatch.setattr(gateway_mod, "is_macos", lambda: True)
         monkeypatch.setattr(gateway_mod, "get_launchd_label", lambda: "ai.hermes.gateway")
         monkeypatch.setattr(gateway_mod, "_launchd_domain", lambda: "gui/501")
+        # Complete the simulated macOS boundary on hosts without POSIX getuid.
+        monkeypatch.setattr(gateway_mod.os, "getuid", lambda: 501, raising=False)
 
         def fake_run(argv, **kwargs):
             if argv[:2] == ["launchctl", "list"]:


### PR DESCRIPTION
## Summary

- complete the simulated macOS launchd fixture used by `TestServicePidSweepExclusion`
- provide the mocked `os.getuid()` value that the launchd domain probe expects
- keep the three PID-exclusion contracts running on Windows instead of skipping them

## Root cause

The tests already simulate macOS by stubbing `is_macos()`, the launchd label, and the launchd domain. The current `_get_service_pids()` path also reaches `os.getuid()`, but native Windows Python does not expose that POSIX API.

That left the simulated platform boundary incomplete: the tests failed before reaching the launchd PID-exclusion behaviour they are meant to verify.

The fixture now supplies the same UID (`501`) as its mocked `gui/501` launchd domain. `raising=False` allows the attribute to be installed on Windows while remaining harmless on macOS.

## Testing

Independent Windows validation on exact `head@0a086f55d7` confirmed:

- on current `main@4209d371aa`, all three `TestServicePidSweepExclusion` cases fail because native Windows does not provide `os.getuid()`
- on this PR head, the same three cases pass
- the complete modified test file passes: `11 passed`

The reviewer found no active overlapping implementation and confirmed that the patch remains within the closure criteria of #98038.

Closes #98038
