### PR TITLE
fix(computer-use): stop elevated Windows overlays from pinning the desktop

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3720,10 +3720,11 @@ DEFAULT_CONFIG = {
         "capture_after_mode": "som",
         # Disable the cursor overlay rendered by cua-driver. The overlay
         # shows where agent actions land but can peg a core when idle
-        # (macOS vImage redraw loop #47032; Linux/WSL2 idle spin #28152).
+        # (macOS vImage redraw loop #47032; Linux/WSL2 idle spin #28152;
+        # elevated Windows daemon orphan overlay #98052).
         # cua-driver ≥ 0.6.x supports --no-overlay; Hermes also calls
         # set_agent_cursor_enabled(false) after start_session when this is on.
-        #   None  = auto-detect (off on macOS + headless/WSL2 Linux; on elsewhere)
+        #   None  = auto-detect (off on macOS, Windows, and headless/WSL2/X11 Linux)
         #   True  = always disable the overlay
         #   False = always enable the overlay
         "no_overlay": None,

--- a/tests/computer_use/test_cua_no_overlay.py
+++ b/tests/computer_use/test_cua_no_overlay.py
@@ -4,7 +4,8 @@ cua-driver's cursor overlay rendering loop can consume CPU indefinitely when
 idle (#28152, #47032), and on Linux/X11 its fullscreen always-on-top overlay
 window can wedge the desktop when a session ends uncleanly. Hermes passes
 ``--no-overlay`` to suppress it when the ``computer_use.no_overlay`` config is
-enabled (or auto-detected on macOS, headless Linux / WSL2, and Linux X11).
+enabled (or auto-detected on macOS, Windows, headless Linux / WSL2, and Linux
+X11).
 
 These assert the behavior contract (auto-detect, explicit override, version
 probe), not specific config snapshots.
@@ -28,6 +29,19 @@ class TestNoOverlayFlag:
         with patch("hermes_cli.config.load_config",
                    return_value={"computer_use": {"no_overlay": True}}):
             assert cua_backend._cua_no_overlay() is True
+
+    @pytest.mark.windows_only
+    def test_windows_auto_detects_off(self):
+        """Windows defaults off so an elevated orphan cannot pin the desktop."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert cua_backend._cua_no_overlay() is True
+
+    @pytest.mark.windows_only
+    def test_windows_explicit_false_restores_cursor(self):
+        """Users may explicitly opt back into the cosmetic Windows cursor."""
+        with patch("hermes_cli.config.load_config",
+                   return_value={"computer_use": {"no_overlay": False}}):
+            assert cua_backend._cua_no_overlay() is False
 
 
     @pytest.mark.macos_only

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -236,18 +236,21 @@ def _cua_no_overlay() -> bool:
     Reads ``computer_use.no_overlay``. Default ``None`` (auto-detect):
     disable the overlay where idle CPU burn or an X11 desktop wedge is a
     known failure mode — macOS (cursor-overlay vImage redraw loop,
-    #28152/#47032), headless Linux / WSL2 / containers, and Linux X11
-    (fullscreen always-on-top overlay window that can get stuck over every
-    workspace after an unclean session end) — and keep it on Windows and
-    Linux Wayland. Explicit ``True`` / ``False`` overrides auto-detection.
+    #28152/#47032), Windows (an elevated scheduled-task daemon can leave an
+    overlay that a normal-integrity Hermes process cannot dismiss), headless
+    Linux / WSL2 / containers, and Linux X11 (fullscreen always-on-top overlay
+    window that can get stuck over every workspace after an unclean session
+    end) — and keep it on Linux Wayland. Explicit ``True`` / ``False``
+    overrides auto-detection.
     """
     val = _computer_use_cfg().get("no_overlay")
     if val is not None:
         return bool(val)
-    # Auto-detect: macOS overlay can peg a core indefinitely after a
-    # computer_use session (#47032). Prefer off until the driver teardown
-    # is solid; set computer_use.no_overlay: false to keep the cursor.
-    if sys.platform == "darwin":
+    # macOS can peg a core indefinitely (#47032). On Windows, an elevated
+    # autostart daemon can orphan a fullscreen overlay that the normal-
+    # integrity Hermes process cannot dismiss (#98052). Prefer off until
+    # driver-owned teardown is reliable; explicit false keeps the cursor.
+    if sys.platform in {"darwin", "win32"}:
         return True
     if sys.platform != "linux":
         return False

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -232,12 +232,13 @@ private lifecycle session inside the runtime; the public name does not.
 
 The overlay cursor is cosmetic — captures, clicks, and typing all work
 without it. Hermes disables it automatically where it is a known failure
-mode: macOS (idle CPU burn), headless Linux / WSL2 / containers, and
-**Linux X11 desktops** (the overlay is a fullscreen always-on-top window
-that can get stuck over every workspace after an unclean session end,
-wedging desktop input). Linux Wayland and Windows keep the overlay. Set
-`computer_use.no_overlay: false` in `config.yaml` to force the cursor on
-(or `true` to force it off) on any platform.
+mode: macOS (idle CPU burn), **Windows** (an elevated autostart daemon can
+leave a fullscreen overlay that a normal-integrity Hermes process cannot
+dismiss), headless Linux / WSL2 / containers, and **Linux X11 desktops**
+(the overlay can get stuck over every workspace after an unclean session
+end, wedging desktop input). Linux Wayland keeps the overlay. Set
+`computer_use.no_overlay: false` in `config.yaml` to force the cursor on (or
+`true` to force it off) on any platform.
 
 Tune the cursor with `cua-driver`'s CLI flags or the runtime
 `set_agent_cursor_style` MCP tool — see


### PR DESCRIPTION
## What does this PR do?

Windows users can be left with a fullscreen, always-on-top cursor overlay after Hermes exits when cua-driver was started by an elevated autostart task. A normal-integrity Hermes process cannot hide or terminate that elevated window, so this change disables the cosmetic overlay by default on Windows while preserving an explicit opt-in.

### Symptom

After a computer-use session and Hermes shutdown, `Cua.AgentCursorOverlay.default` can remain fullscreen and always on top. Relaunching Hermes does not clear it, and non-elevated `WM_CLOSE`, `ShowWindow`, and process termination attempts are rejected by the Windows integrity boundary.

### Impact

Affected Windows users can have the desktop obscured by a window with no close affordance until an elevated recovery action or reboot removes the elevated cua-driver process.

### Bug Cause

**Trigger:** `tools/computer_use/cua_backend.py:233` / `_cua_no_overlay()` returning `False` for the default Windows configuration.

**Causal chain:**
1. An elevated scheduled task starts the shared cua-driver runtime with cursor overlays enabled.
2. Hermes starts a computer-use session, then exits before the remote runtime reliably tears down that session's overlay.
3. The elevated fullscreen overlay survives, while the normal-integrity Hermes process is blocked by Windows UIPI from dismissing it.

**Why it is wrong:** The overlay is cosmetic, but the default enabled it on a platform where the client process cannot reliably recover an orphan owned by a higher-integrity runtime.

**Working sibling / contrast:** macOS and Linux X11 already default the overlay off for equivalent persistent-overlay failure modes while keeping computer-use input and capture functionality intact.

**Ruled out:** Killing or hiding the elevated daemon from Hermes is not a safe recovery mechanism. The captured non-elevated process and window operations fail with access denied, and adding an elevation path would expand privilege rather than remove the failure source.

### Fix

Treat Windows like the existing macOS and Linux X11 safe defaults: auto-detected policy now passes `--no-overlay` and disables the session cursor. Users who accept the lifecycle risk can still set `computer_use.no_overlay: false` to restore it. The config comments and computer-use documentation now describe the Windows behavior.

## Related Issue

Closes #98052

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py` - default the cosmetic cursor overlay off on Windows.
- `tests/computer_use/test_cua_no_overlay.py` - cover the Windows default and explicit opt-in on a native Windows test host.
- `hermes_cli/config_defaults.py` - document the auto-detected Windows policy.
- `website/docs/user-guide/features/computer-use.md` - explain the Windows safety default and opt-in.

## How to Test

1. Run the computer-use overlay policy and teardown tests on Windows:

```bash
scripts/run_tests.sh tests/computer_use/test_cua_atexit_teardown.py tests/computer_use/test_cua_no_overlay.py -q
```

2. Confirm the result reports 14 passed and 0 failed on Windows, including the native `windows_only` policy cases.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the policy behavior on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Config example update is N/A because no config key was added or changed
- [x] Architecture/workflow documentation update is N/A
- [x] I've considered cross-platform impact; explicit overrides and Linux/macOS behavior remain unchanged
- [x] Tool schema updates are N/A because the model-facing tool contract is unchanged

## Screenshots / Logs

The targeted Windows test run completed with 14 passed, 0 failed, and 6 host-gated Linux/macOS cases skipped.
