### PR TITLE
Keep inherited profile credentials owned by the global store

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -75,6 +75,20 @@ STATUS_EXHAUSTED = "exhausted"
 # login) rewrites the tokens.
 STATUS_DEAD = "dead"
 
+
+class CredentialOwnershipRefused(RuntimeError):
+    code = "INHERITED-CREDENTIAL-OWNER-REFUSAL"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
+class CredentialBrakeRequired(RuntimeError):
+    code = "CREDENTIAL-BRAKE-REQUIRED"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
 # OAuth error reasons that indicate the credential is permanently invalid
 # server-side and cannot be recovered by retry/refresh.  Sourced from
 # OpenAI Codex Responses API, Anthropic, xAI, and Google OAuth spec.
@@ -648,9 +662,18 @@ def _write_through_provider_state_to_global_root(
 
 
 class CredentialPool:
-    def __init__(self, provider: str, entries: List[PooledCredential]):
+    def __init__(
+        self,
+        provider: str,
+        entries: List[PooledCredential],
+        *,
+        persistence_path: Optional[Path] = None,
+        inherited_from_global: bool = False,
+    ):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
+        self._persistence_path = persistence_path
+        self._inherited_from_global = inherited_from_global
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
         # RLock: the mutation primitives below (_replace_entry/_persist)
@@ -782,6 +805,7 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                target_path=self._persistence_path,
             )
 
     def _is_terminal_auth_failure(
@@ -1305,6 +1329,11 @@ class CredentialPool:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
     def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
+        if os.environ.get("HERMES_CREDENTIAL_RECOVERY_SUPPRESSED") == "1":
+            # Read-only health canaries may present the existing access token,
+            # but they cannot refresh, rotate, login, or mutate credential
+            # custody. Surface the kernel brake as a machine-readable refusal.
+            raise CredentialBrakeRequired()
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
                 self._mark_exhausted(entry, None)
@@ -2355,6 +2384,12 @@ class CredentialPool:
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:
         with self._lock:
+            # A profile may read the global pool as a fallback, but an explicit
+            # remove in that profile must not delete a globally-owned grant.
+            # Return a distinct ownership refusal so CLI/API callers cannot
+            # confuse the global row with an absent profile-local credential.
+            if self._inherited_from_global:
+                raise CredentialOwnershipRefused()
             if index < 1 or index > len(self._entries):
                 return None
             removed = self._entries.pop(index - 1)
@@ -2399,6 +2434,14 @@ class CredentialPool:
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
         with self._lock:
+            if self._inherited_from_global:
+                # A deliberate profile add establishes a local pool and thereby
+                # shadows the global fallback. Do not copy inherited credential
+                # bytes into that new profile-local store.
+                self._entries = []
+                self._current_id = None
+                self._persistence_path = None
+                self._inherited_from_global = False
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
             self._persist()
@@ -3131,6 +3174,24 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
+    active_store = _load_auth_store()
+    active_pool = active_store.get("credential_pool")
+    active_entries = active_pool.get(provider) if isinstance(active_pool, dict) else None
+    has_active_entries = isinstance(active_entries, list) and bool(active_entries)
+    global_path = _global_auth_file_path()
+    global_entries = None
+    if global_path is not None and not has_active_entries:
+        global_store = auth_mod._load_global_auth_store()
+        global_pool = global_store.get("credential_pool")
+        if isinstance(global_pool, dict):
+            global_entries = global_pool.get(provider)
+    inherited_from_global = bool(
+        global_path is not None
+        and not has_active_entries
+        and isinstance(global_entries, list)
+        and global_entries
+    )
+    persistence_path = global_path if inherited_from_global else None
     raw_entries = read_credential_pool(provider)
     disk_ids = {
         entry.get("id")
@@ -3191,5 +3252,11 @@ def load_pool(provider: str) -> CredentialPool:
             provider,
             [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
             removed_ids=disk_ids - new_ids,
+            target_path=persistence_path,
         )
-    return CredentialPool(provider, entries)
+    return CredentialPool(
+        provider,
+        entries,
+        persistence_path=persistence_path,
+        inherited_from_global=inherited_from_global,
+    )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1611,8 +1611,10 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     ``hermes auth add <provider>`` inside the profile, profile entries
     fully shadow global for that provider on the next read.
 
-    Writes always go to the profile (``write_credential_pool`` is unchanged).
-    See issue #18594 follow-up.
+    Explicit profile writes go to the profile. Runtime persistence for an
+    inherited row passes the global owner path explicitly, so status/refresh
+    updates cannot materialize a profile-local shadow. See issue #18594
+    follow-up.
     """
     auth_store = _load_auth_store()
     pool = auth_store.get("credential_pool")
@@ -1717,6 +1719,7 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    target_path: Optional[Path] = None,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1735,10 +1738,21 @@ def write_credential_pool(
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
     merge does not resurrect them from the on-disk copy.
+
+    ``target_path`` is reserved for the profile-fallback runtime: inherited
+    rows persist status/refresh updates to the global store that owns them,
+    rather than materializing a profile-local shadow. Ordinary callers omit it
+    and retain the active-profile write contract.
     """
+    if os.getenv("HERMES_CREDENTIAL_PERSISTENCE_SUPPRESSED") == "1":
+        # Health probes/canaries are observational. They may exercise the
+        # currently loaded access token but can never mark, refresh, resurrect,
+        # add, or remove rows in either the profile or global owner store.
+        return target_path if target_path is not None else _auth_file_path()
+
     removed = {rid for rid in (removed_ids or ()) if rid}
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    with _auth_store_lock(target_path=target_path):
+        auth_store = _load_auth_store(target_path)
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
             pool = {}
@@ -1776,7 +1790,7 @@ def write_credential_pool(
                 continue
             merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
         pool[provider_id] = merged
-        return _save_auth_store(auth_store)
+        return _save_auth_store(auth_store, target_path)
 
 
 def suppress_credential_source(provider_id: str, source: str) -> None:

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -3,7 +3,8 @@
 When ``HERMES_HOME`` points to a named profile, ``read_credential_pool()``
 and ``get_provider_auth_state()`` fall back to the global-root
 ``auth.json`` per-provider when the profile has no entries for that
-provider.  Writes still target the profile only.
+provider. Explicit profile writes stay local; runtime status/refresh writes on
+an inherited row follow the global store that owns it.
 
 See the #18594 follow-up report: profile workers couldn't see providers
 authenticated only at the global root.
@@ -12,6 +13,8 @@ authenticated only at the global root.
 from __future__ import annotations
 
 import json
+import multiprocessing
+import os
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -50,6 +53,25 @@ def profile_env(tmp_path, monkeypatch):
 
 def _write(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2))
+
+
+def _concurrent_write_worker(auth_root: str, entry_id: str, start, results) -> None:
+    os.environ["HERMES_HOME"] = auth_root
+    try:
+        from hermes_cli.auth import write_credential_pool
+
+        start.wait(10)
+        write_credential_pool("openrouter", [{
+            "id": entry_id,
+            "label": entry_id,
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "fixture-" + entry_id,
+        }])
+        results.put(None)
+    except Exception as exc:  # pragma: no cover - reported in parent
+        results.put("%s:%s" % (type(exc).__name__, exc))
 
 
 # ---------------------------------------------------------------------------
@@ -200,6 +222,167 @@ def test_write_credential_pool_targets_profile_not_global(profile_env):
     assert [e["id"] for e in read_credential_pool("openrouter")] == ["prof-new"]
 
 
+def test_runtime_failure_on_global_fallback_never_materializes_profile_shadow(
+    profile_env,
+):
+    """Runtime status writes follow the store that owns the inherited grant.
+
+    A profile with no local Codex pool reads the global grant. Before this
+    regression fix, a 401 status update persisted that inherited entry into
+    the profile's auth.json. The resulting local row then shadowed every later
+    repair to the global pool.
+    """
+    from agent.credential_pool import STATUS_DEAD, load_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{
+            "id": "glob-codex",
+            "label": "global-codex",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "global-access",
+            "refresh_token": "global-refresh",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.id == "glob-codex"
+    pool.mark_exhausted_and_rotate(
+        status_code=401,
+        error_context={"reason": "token_invalidated"},
+    )
+
+    profile_store = json.loads(
+        (profile_env["profile"] / "auth.json").read_text()
+    )
+    assert profile_store.get("credential_pool", {}).get("openai-codex", []) == []
+
+    global_store = json.loads(
+        (profile_env["global"] / "auth.json").read_text()
+    )
+    persisted = global_store["credential_pool"]["openai-codex"][0]
+    assert persisted["id"] == "glob-codex"
+    assert persisted["last_status"] == STATUS_DEAD
+    assert persisted["last_error_reason"] == "token_invalidated"
+
+
+def test_profile_add_shadows_global_without_copying_inherited_secret(profile_env):
+    """An explicit profile add starts a local pool; it never copies globals."""
+    from agent.credential_pool import (
+        AUTH_TYPE_API_KEY,
+        PooledCredential,
+        SOURCE_MANUAL,
+        load_pool,
+    )
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [{
+            "id": "glob-openrouter",
+            "label": "global",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "global-secret",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+
+    pool = load_pool("openrouter")
+    pool.add_entry(PooledCredential(
+        provider="openrouter",
+        id="profile-openrouter",
+        label="profile",
+        auth_type=AUTH_TYPE_API_KEY,
+        priority=0,
+        source=SOURCE_MANUAL,
+        access_token="profile-secret",
+    ))
+
+    profile_store = json.loads(
+        (profile_env["profile"] / "auth.json").read_text()
+    )
+    rows = profile_store["credential_pool"]["openrouter"]
+    assert [row["id"] for row in rows] == ["profile-openrouter"]
+    assert "global-secret" not in (profile_env["profile"] / "auth.json").read_text()
+
+    global_store = json.loads(
+        (profile_env["global"] / "auth.json").read_text()
+    )
+    assert [
+        row["id"] for row in global_store["credential_pool"]["openrouter"]
+    ] == ["glob-openrouter"]
+
+
+def test_profile_remove_returns_distinct_global_owner_refusal(profile_env):
+    from agent.credential_pool import CredentialOwnershipRefused, load_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openrouter": [{
+            "id": "glob-openrouter",
+            "label": "global",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": "global-secret",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+
+    pool = load_pool("openrouter")
+    with pytest.raises(
+        CredentialOwnershipRefused,
+        match="INHERITED-CREDENTIAL-OWNER-REFUSAL",
+    ):
+        pool.remove_index(1)
+    assert json.loads(
+        (profile_env["profile"] / "auth.json").read_text()
+    ).get("credential_pool", {}).get("openrouter", []) == []
+
+
+def test_persistence_suppression_makes_canary_write_paths_read_only(
+    profile_env, monkeypatch
+):
+    from hermes_cli.auth import write_credential_pool
+
+    original = _make_auth_store(pool={
+        "openrouter": [_pool_entry(id="original", access_token="original-secret")],
+    })
+    _write(profile_env["profile"] / "auth.json", original)
+    before = (profile_env["profile"] / "auth.json").read_bytes()
+    monkeypatch.setenv("HERMES_CREDENTIAL_PERSISTENCE_SUPPRESSED", "1")
+    write_credential_pool(
+        "openrouter",
+        [_pool_entry(id="replacement", access_token="replacement-secret")],
+    )
+    assert (profile_env["profile"] / "auth.json").read_bytes() == before
+
+
+def test_recovery_suppression_raises_credential_brake(profile_env, monkeypatch):
+    from agent.credential_pool import CredentialBrakeRequired, load_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{
+            "id": "glob-codex",
+            "label": "global",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "expired-access",
+            "refresh_token": "must-not-use",
+            "expires_at_ms": 1,
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+    monkeypatch.setenv("HERMES_CREDENTIAL_RECOVERY_SUPPRESSED", "1")
+    pool = load_pool("openai-codex")
+    with pytest.raises(CredentialBrakeRequired, match="CREDENTIAL-BRAKE-REQUIRED"):
+        pool.try_refresh_matching(credential_id="glob-codex")
+
+
 
 
 def test_auth_lock_reentrancy_is_scoped_after_profile_context_switch(profile_env):
@@ -288,3 +471,52 @@ def test_write_pool_never_merges_cooldown_onto_reauthed_entry(classic_env):
     assert persisted["access_token"] == "sk-new"
     assert persisted.get("last_status") != "exhausted"
     assert persisted.get("last_error_code") is None
+
+
+def test_concurrent_owner_store_writers_are_serialized_and_merged(classic_env):
+    """Two processes cannot tear or last-writer-drop the owner auth store."""
+    _write(classic_env / "auth.json", _make_auth_store(pool={"openrouter": []}))
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_concurrent_write_worker,
+            args=(str(classic_env), entry_id, start, results),
+        )
+        for entry_id in ("writer-a", "writer-b")
+    ]
+    for process in processes:
+        process.start()
+    start.set()
+    for process in processes:
+        process.join(20)
+        assert process.exitcode == 0
+    assert [results.get(timeout=2), results.get(timeout=2)] == [None, None]
+    persisted = json.loads((classic_env / "auth.json").read_text())
+    assert {row["id"] for row in persisted["credential_pool"]["openrouter"]} == {
+        "writer-a",
+        "writer-b",
+    }
+
+
+def test_crash_before_atomic_replace_preserves_complete_owner_store(
+    classic_env, monkeypatch
+):
+    """A crash after tmpfile fsync but before rename leaves old JSON intact."""
+    import hermes_cli.auth as auth
+
+    original = _make_auth_store(pool={"openrouter": [_pool_entry(id="original")]})
+    _write(classic_env / "auth.json", original)
+    before = (classic_env / "auth.json").read_bytes()
+
+    def crash_before_replace(_source, _destination):
+        raise RuntimeError("fixture-crash-before-rename")
+
+    monkeypatch.setattr(auth, "atomic_replace", crash_before_replace)
+    with pytest.raises(RuntimeError, match="fixture-crash-before-rename"):
+        auth.write_credential_pool(
+            "openrouter", [_pool_entry(id="replacement")]
+        )
+    assert (classic_env / "auth.json").read_bytes() == before
+    assert list(classic_env.glob("auth.json.tmp.*")) == []


### PR DESCRIPTION
A named profile that inherits a global credential currently can persist runtime status/refresh changes into its profile auth store, materializing a local shadow. This change tracks the owning persistence path: inherited runtime writes go to the global owner, explicit profile add starts an empty local pool, and profile-scoped removal raises a distinct ownership refusal.

It also provides read-only canary suppression for persistence/recovery and exercises existing cross-process flock plus atomic fsync/replace behavior.

Proof: expanded auth/pool suites 139/139, including two-process merge, crash-before-rename, 401 global-owner persistence, no local shadow, and explicit local add isolation.