### PR TITLE
test(update): keep updater fixtures isolated from live gateways

### DIFF
--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -97,6 +97,10 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     monkeypatch.setattr(
         hermes_main, "_resume_windows_gateways_after_update", lambda *a, **k: None
     )
+    # This fixture validates fleet-restart bookkeeping, not updater
+    # module-generation refresh. Keep gateway mocks attached to the configured
+    # module object so the test cannot rediscover live gateway processes.
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
     monkeypatch.setattr(hermes_main, "_write_update_incomplete_marker", lambda: None)
     monkeypatch.setattr(hermes_main, "_clear_update_incomplete_marker", lambda: None)
     monkeypatch.setattr(

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -103,8 +103,13 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
     monkeypatch.setattr(hermes_main, "_write_update_incomplete_marker", lambda: None)
     monkeypatch.setattr(hermes_main, "_clear_update_incomplete_marker", lambda: None)
+    # These restart helpers are bare globals in hermes_cli.update_cmd, so
+    # patch that namespace rather than the hermes_cli.main re-export surface.
     monkeypatch.setattr(
-        hermes_main, "_finish_dashboard_update_cleanup", lambda *a, **k: None
+        update_cmd, "_finish_dashboard_update_cleanup", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        update_cmd, "_restart_macos_launchd_gateways", lambda *a, **k: None
     )
     monkeypatch.setattr(hermes_main, "_build_web_ui", lambda *a, **k: None)
     monkeypatch.setattr(
@@ -115,7 +120,7 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     import hermes_cli.gateway as hermes_gateway
 
     monkeypatch.setattr(
-        hermes_gateway, "find_gateway_pids", lambda all_profiles=False: []
+        hermes_gateway, "find_gateway_pids", lambda *a, **k: []
     )
     monkeypatch.setattr(hermes_gateway, "supports_systemd_services", lambda: False)
     monkeypatch.setattr(

--- a/tests/hermes_cli/test_update_head_moved_gate.py
+++ b/tests/hermes_cli/test_update_head_moved_gate.py
@@ -107,15 +107,23 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     # Short-circuit the long tail: dependency install + desktop build.
     monkeypatch.setattr(hermes_main, "_write_update_incomplete_marker", lambda: None)
     monkeypatch.setattr(hermes_main, "_clear_update_incomplete_marker", lambda: None)
-    # Gateway restart path (called after a successful update).
-    monkeypatch.setattr(hermes_main, "_finish_dashboard_update_cleanup", lambda *a: None)
+    # These restart helpers are bare globals in hermes_cli.update_cmd, so
+    # patch that namespace rather than the hermes_cli.main re-export surface.
+    monkeypatch.setattr(
+        "hermes_cli.update_cmd._finish_dashboard_update_cleanup",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_cmd._restart_macos_launchd_gateways",
+        lambda *a, **k: None,
+    )
     # Keep the (now surfaced — #78574) gateway auto-restart phase away from
     # this machine's real gateways: discovery returns nothing, systemd is
     # unsupported, so the phase is a clean no-op for both snapshots.
     import hermes_cli.gateway as hermes_gateway
 
     monkeypatch.setattr(
-        hermes_gateway, "find_gateway_pids", lambda all_profiles=False: []
+        hermes_gateway, "find_gateway_pids", lambda *a, **k: []
     )
     monkeypatch.setattr(
         hermes_gateway, "supports_systemd_services", lambda: False

--- a/tests/hermes_cli/test_update_head_moved_gate.py
+++ b/tests/hermes_cli/test_update_head_moved_gate.py
@@ -100,6 +100,10 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     monkeypatch.setattr(
         hermes_main, "_resume_windows_gateways_after_update", lambda *a, **k: None
     )
+    # This fixture validates the HEAD gate, not updater module-generation
+    # refresh. Disabling the purge keeps gateway mocks attached to the module
+    # object the test configured instead of rediscovering live gateways.
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
     # Short-circuit the long tail: dependency install + desktop build.
     monkeypatch.setattr(hermes_main, "_write_update_incomplete_marker", lambda: None)
     monkeypatch.setattr(hermes_main, "_clear_update_incomplete_marker", lambda: None)


### PR DESCRIPTION
## Summary

- keep the HEAD-movement and fleet-restart updater fixtures hermetic across the update flow
- prevent their mocked gateway discovery from being invalidated by the stale-module purge
- use production-compatible gateway scanner mocks and patch restart helpers on their actual `hermes_cli.update_cmd` bindings
- leave production module-purge and gateway behavior unchanged

## Root cause

Both fixtures patch `hermes_cli.gateway` so gateway discovery returns no live processes. During a successful update, the production path deliberately calls `_purge_stale_hermes_modules()` and later reimports `hermes_cli.gateway`.

That creates a new module object, while the fixture's monkeypatches remain attached to the discarded one. The tests can therefore fall through to the real gateway process scanner and attempt to interact with a developer's running Hermes gateway.

The stale-module purge is not part of either test's contract. Each shared fixture patches `hermes_main._purge_stale_hermes_modules` to a no-op, keeping the gateway mocks attached for the duration of the test.

The fixtures also need to match the production restart surface: `find_gateway_pids` can receive additional keyword arguments such as `exclude_pids`, while `_finish_dashboard_update_cleanup` and `_restart_macos_launchd_gateways` are invoked through bindings in `hermes_cli.update_cmd`.

## Changes

- `tests/hermes_cli/test_update_head_moved_gate.py`
  - preserve gateway mocks across the separately tested stale-module purge
  - accept the production PID-scanner call signature
  - stub the dashboard cleanup and macOS launchd restart helpers on `hermes_cli.update_cmd`
- `tests/hermes_cli/test_update_fleet_restart_pending.py`
  - apply the same isolation to the fleet-restart fixture

No production code is changed.

## Testing

Reviewer validation on exact current head `10f215cf29e67e823cd2394b7d8bebbf814db119` under Windows 11 Home build 26200, Python 3.11.7 and pytest 9.1.1:

- `tests/hermes_cli/test_update_head_moved_gate.py`
- `tests/hermes_cli/test_update_fleet_restart_pending.py`
- `tests/hermes_cli/test_update_stale_module_purge.py`
- result: `20 passed in 11.81s`

This confirms the two modified fixtures pass with the production-compatible PID mock and corrected `hermes_cli.update_cmd` bindings, while the dedicated stale-module-purge regression suite remains green.

## Overlap

#96435 partially overlaps the `test_update_head_moved_gate.py` isolation and is still open, but it does not cover `test_update_fleet_restart_pending.py`. This PR remains independently complete for #98037; if the overlapping change lands first, the duplicated HEAD-movement fixture change can be dropped during rebase.

Closes #98037
