### PR TITLE
fix(mcp): read SDK snake-case safety annotations

### DIFF
--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -231,6 +231,17 @@ class TestAnnotationCaptureAtDiscovery:
         assert not hints.get("delete_repo")
         assert not hints.get("no_annotations")
 
+    def test_sdk_tool_annotations_supported(self):
+        """The MCP SDK exposes aliased hints as snake_case attributes."""
+        from mcp.types import ToolAnnotations
+
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=ToolAnnotations(read_only_hint=True))
+        ) is True
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=ToolAnnotations(read_only_hint=False))
+        ) is False
+
     def test_dict_annotations_supported(self):
         """Cached/JSON annotations arrive as plain dicts."""
         assert mcp_tool._annotation_read_only_hint(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4629,18 +4629,22 @@ def _normalize_server_trust(value: Any) -> str:
 def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     """Return True only when the tool's annotations carry readOnlyHint=True.
 
-    Accepts both SDK annotation objects (attribute access) and plain dicts
-    (schema-cache JSON). Anything else — missing annotations, missing key,
-    non-bool truthy values — is False: unknown metadata means the tool must
-    be treated as write-capable.
+    Accepts plain dicts from the JSON schema cache and SDK annotation objects.
+    Current MCP Python SDK models expose the aliased wire field
+    ``readOnlyHint`` as the Python attribute ``read_only_hint``; older/fake
+    objects may expose the camelCase attribute directly. Anything else —
+    missing annotations, missing key, non-bool truthy values — is False:
+    unknown metadata means the tool must be treated as write-capable.
     """
     annotations = getattr(mcp_tool, "annotations", None)
     if annotations is None:
         return False
     if isinstance(annotations, dict):
-        hint = annotations.get("readOnlyHint")
+        hint = annotations.get("readOnlyHint", annotations.get("read_only_hint"))
     else:
-        hint = getattr(annotations, "readOnlyHint", None)
+        hint = getattr(annotations, "read_only_hint", None)
+        if hint is None:
+            hint = getattr(annotations, "readOnlyHint", None)
     return hint is True
 
 


### PR DESCRIPTION
## Summary
- recognize the MCP Python SDK's snake_case `ToolAnnotations.read_only_hint` attribute
- preserve camelCase and cached-dict compatibility
- add a regression test using the real SDK `ToolAnnotations` model

## Why
MCP annotations arrive on the wire as `readOnlyHint`, but the Python SDK exposes that field as `read_only_hint`. Hermes checked only the camelCase object attribute, so live MCP discovery classified every SDK tool as write-capable. On an `untrusted` server this caused read-only calls to require approval and wrote false hints into the lazy schema cache.

## Verification
- `uv run --extra dev pytest -q tests/tools/test_mcp_trust_gating.py tests/tools/test_mcp_schema_cache.py` — 23 passed
- `uv run --extra dev pytest -q tests/tools/test_mcp*.py` — 597 passed
- `uv run --extra dev ruff check tools/mcp_tool.py tests/tools/test_mcp_trust_gating.py` — passed
- reproduced against a live MCP server: `ToolAnnotations.model_dump(by_alias=True)` returned `readOnlyHint: true` while the Python attribute was `read_only_hint=True`
