### PR TITLE
fix(skills): share the authoritative exclusion set in the slash-command scan

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -440,6 +440,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import (
+            EXCLUDED_SKILL_DIRS,
             get_external_skills_dirs,
             get_project_skills_dirs,
             iter_project_skill_files,
@@ -464,7 +465,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                 else iter_skill_index_files(scan_dir, "SKILL.md")
             )
             for skill_md in _iter:
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
+                if any(part in EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -82,6 +82,23 @@ class TestScanSkillCommands:
         assert message is not None
         assert "Apply impeccable design craft." in message
 
+    def test_post_walk_guard_uses_authoritative_exclusion_set(self, tmp_path):
+        """The post-walk exclusion guard must share the authoritative set.
+
+        ``tools/skills_tool.py`` checks every produced ``SKILL.md`` path
+        against ``agent.skill_utils.EXCLUDED_SKILL_DIRS``. The slash-command
+        scan used a drifted inline subset of that set, so a skills root whose
+        own path crosses an excluded dir (e.g. a venv) registered slash
+        commands for skills the skills tool already refuses to list.
+        """
+        skills_root = tmp_path / "venv" / "skills"
+        _make_skill(skills_root, "probe-skill")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            result = scan_skill_commands()
+
+        assert "/probe-skill" not in result
+
     def test_get_skill_commands_rescans_when_platform_scope_changes(self, tmp_path):
         """Platform-specific disabled-skill caches must not leak across platforms.
 


### PR DESCRIPTION
## What does this PR do?

`scan_skill_commands()` re-checked every produced `SKILL.md` path against a hardcoded inline subset (`{'.git', '.github', '.hub', '.archive'}`) instead of the authoritative `EXCLUDED_SKILL_DIRS` from `agent/skill_utils.py` — the set `tools/skills_tool.py` already imports and applies to the same walk (point 1 of #98044). The inline copy was missing 10 entries (`venv`, `node_modules`, `site-packages`, `__pycache__`, `.tox`, `.nox`, and the tool caches), so the two consumers of the same concept could disagree: with a skills root whose own path crosses one of those dirs (e.g. `~/.venv/.hermes/skills/`), `skills_tool` refuses to list a skill while the slash-command scan still auto-registers its `/command`. This PR imports and reuses `EXCLUDED_SKILL_DIRS`, leaving a single source of truth for the exclusion set.

Note on the walker: `iter_skill_index_files()` already prunes `EXCLUDED_SKILL_DIRS` during the `os.walk`, so the drift was observable in the post-walk guard (which checks the full path parts, exactly like `tools/skills_tool.py:755`) — the regression test pins that guard to the authoritative set.

The issue's second point (non-dot archive dir names such as `skills/_archive/` not being excluded anywhere) is a naming-convention decision the reporter themselves left open ("treat additional common names as excluded **or** surface a warning"); this PR deliberately leaves that behavior unchanged for maintainers to decide.

## Related Issue

Fixes #98044

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_commands.py` — import `EXCLUDED_SKILL_DIRS` from `agent.skill_utils` in the existing lazy-import block and replace the drifted inline 4-entry set in the post-walk guard of `scan_skill_commands()` with it (net −1 line of logic).
- `tests/agent/test_skill_commands.py` — add `test_post_walk_guard_uses_authoritative_exclusion_set`: a skills root placed under a `venv/` path segment must not register slash commands (fails on `main`, passes with the fix).

## How to Test

1. `pytest tests/agent/test_skill_commands.py::TestScanSkillCommands::test_post_walk_guard_uses_authoritative_exclusion_set -q` — Observed result: `1 failed` on `main` (the `/probe-skill` command registers even though the path crosses a `venv` segment that `tools/skills_tool.py` excludes), `1 passed` with this PR.
2. `pytest tests/agent/test_skill_commands.py -q` — Observed result: `30 passed`.
3. Related consumers: `pytest tests/test_session_skill_previews.py tests/agent/test_skill_invocation_description.py tests/agent/test_prompt_cache_boundary.py tests/gateway/test_unavailable_skill_hint.py -q` — Observed result: `42 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (locally verified: `tests/agent/test_skill_commands.py` 30 passed + the four skill-consumer suites 42 passed; the local venv lacks optional `acp`/`aiohttp` extras whose test dirs fail collection identically on clean `main`, full suite delegated to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no new skill.
