### PR TITLE
feat(providers): add native WorkBuddy provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,6 +183,16 @@
 # TOKENPLAN_BASE_URL=https://api.lkeap.cloud.tencent.com/plan/anthropic
 
 # =============================================================================
+# LLM PROVIDER (WorkBuddy — Tencent consumer plan)
+# =============================================================================
+# OpenAI-compatible endpoint fronting the WorkBuddy subscription. Sign in via
+# your browser and export the resulting bearer token; see
+# https://github.com/owenisas/workbuddy-openai (unofficial) for one way to
+# obtain it. Endpoint is stream-only — Hermes handles that automatically.
+# WORKBUDDY_ACCESS_TOKEN=your_token_here
+# WORKBUDDY_BASE_URL=https://www.workbuddy.ai/v2
+
+# =============================================================================
 # TOOL API KEYS
 # =============================================================================
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -712,6 +712,9 @@ _PROVIDER_ALIASES = {
     "tencentmaas": "tencent-tokenhub",
     "tokenplan": "tencent-tokenplan",
     "tencent-lkeap": "tencent-tokenplan",
+    "workbuddy": "workbuddy",
+    "workbuddy-ai": "workbuddy",
+    "wb": "workbuddy",
 }
 
 
@@ -1084,6 +1087,10 @@ _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
     "ollama-cloud": "nemotron-3-nano:30b",
     "tencent-tokenhub": "hy4-preview",
     "tencent-tokenplan": "hy4-preview",
+    # WorkBuddy — cheapest tier slot. Without an entry here, auxiliary
+    # tasks (title generation, compression, vision) fall back to the
+    # session default provider instead of WorkBuddy.
+    "workbuddy": "fast-model",
     # NB: no "deepinfra" entry — its aux model lives on the ProviderProfile
     # (plugins/model-providers/deepinfra: default_aux_model), which
     # _get_aux_model_for_provider() reads first. Duplicating it here would be
@@ -9402,6 +9409,10 @@ def _provider_requires_stream(provider: str, base_url: Optional[str]) -> bool:
         return False
     # Tencent Copilot — "Non-stream chat request is currently not supported"
     if base_url_host_matches(_url, "copilot.tencent.com"):
+        return True
+    # WorkBuddy — same 11101 envelope as Tencent Copilot; the endpoint
+    # only accepts streamed chat completions.
+    if base_url_host_matches(_url, "workbuddy.ai"):
         return True
     try:
         from hermes_cli.config import load_config

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -583,6 +583,17 @@ DEFAULT_CONTEXT_LENGTHS = {
     "hy3-preview": 262144,
     # Tencent — Hy3 (GA successor to Hy3 Preview), same 256K window.
     "hy3": 262144,
+    # WorkBuddy tier slots — these are aliases resolved server-side to
+    # whatever model currently backs each slot, so the real window moves
+    # without a Hermes release. Values are the /v3/config advertised
+    # maxInputTokens as of 2026-08-29; they are conservative ceilings for
+    # token budgeting, not a guarantee. hy4-preview / hy3 above already
+    # cover the two named Tencent models WorkBuddy also exposes.
+    "default-model": 176000,
+    "fast-model": 200000,
+    "balanced-model": 256000,
+    "primary-model": 272000,
+    "deep-model": 176000,
     # OpenCode Zen — "Ox Alpha" stealth model (x-preview-f-free). 1M context
     # per OpenCode's launch announcement (2026-08-20); free, ZDR.
     "x-preview-f": 1_048_576,
@@ -766,6 +777,8 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.novita.ai": "novita",
     "tokenhub.tencentmaas.com": "tencent-tokenhub",
     "api.lkeap.cloud.tencent.com": "tencent-tokenplan",
+    "www.workbuddy.ai": "workbuddy",
+    "workbuddy.ai": "workbuddy",
     "ollama.com": "ollama-cloud",
 }
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -534,6 +534,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("TOKENPLAN_API_KEY",),
         base_url_env_var="TOKENPLAN_BASE_URL",
     ),
+    "workbuddy": ProviderConfig(
+        id="workbuddy",
+        name="WorkBuddy",
+        auth_type="api_key",
+        inference_base_url="https://www.workbuddy.ai/v2",
+        api_key_env_vars=("WORKBUDDY_ACCESS_TOKEN",),
+        base_url_env_var="WORKBUDDY_BASE_URL",
+    ),
     "ollama-cloud": ProviderConfig(
         id="ollama-cloud",
         name="Ollama Cloud",
@@ -2246,6 +2254,7 @@ def resolve_provider(
         "tencent": "tencent-tokenhub", "tokenhub": "tencent-tokenhub",
         "tencent-cloud": "tencent-tokenhub", "tencentmaas": "tencent-tokenhub",
         "tokenplan": "tencent-tokenplan", "tencent-lkeap": "tencent-tokenplan",
+        "workbuddy": "workbuddy", "workbuddy-ai": "workbuddy", "wb": "workbuddy",
         "aws": "bedrock", "aws-bedrock": "bedrock", "amazon-bedrock": "bedrock", "amazon": "bedrock",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4211,6 +4211,7 @@ def select_provider_and_model(args=None):
         "ollama-cloud",
         "tencent-tokenhub",
         "tencent-tokenplan",
+        "workbuddy",
         "lmstudio",
     } or _is_profile_api_key_provider(selected_provider):
         _model_flow_api_key_provider(config, selected_provider, current_model)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -487,6 +487,33 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "hy3",
         "hy3-preview",
     ],
+    # WorkBuddy — Tencent's consumer AI assistant (www.workbuddy.ai).
+    # Tier aliases resolve server-side to the current model behind each
+    # slot, so the concrete model behind "default-model" can change without
+    # a Hermes release. Named models are advertised by /v3/config and are
+    # stable within a session. Only agentic (tool-calling) entries are
+    # listed — see workbuddy-openai `models` for the live catalog.
+    "workbuddy": [
+        "default-model",
+        "fast-model",
+        "balanced-model",
+        "primary-model",
+        "deep-model",
+        "hy4-preview",
+        "hy3",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.3-codex",
+        "gemini-3.5-flash",
+        "glm-5.3",
+        "glm-5.2",
+        "kimi-k3",
+        "kimi-k2.6",
+        "minimax-m3",
+    ],
     "arcee": [
         "trinity-large-thinking",
         "trinity-large-preview",
@@ -1243,6 +1270,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models: pro, omni, flash)"),
     ProviderEntry("tencent-tokenhub", "Tencent TokenHub",       "Tencent TokenHub (Hy4 preview via tokenhub.tencentmaas.com)"),
     ProviderEntry("tencent-tokenplan", "Tencent TokenPlan",     "Tencent TokenPlan (Hy4 preview via api.lkeap.cloud.tencent.com, Anthropic Messages)"),
+    ProviderEntry("workbuddy",         "WorkBuddy",             "WorkBuddy (Tencent consumer plan — multi-model via www.workbuddy.ai; browser sign-in)"),
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
@@ -1475,6 +1503,9 @@ _PROVIDER_ALIASES = {
     "tencentmaas": "tencent-tokenhub",
     "tokenplan": "tencent-tokenplan",
     "tencent-lkeap": "tencent-tokenplan",
+    "workbuddy": "workbuddy",
+    "workbuddy-ai": "workbuddy",
+    "wb": "workbuddy",
     "aws": "bedrock",
     "aws-bedrock": "bedrock",
     "amazon-bedrock": "bedrock",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -201,6 +201,17 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.lkeap.cloud.tencent.com/plan/anthropic",
         base_url_env_var="TOKENPLAN_BASE_URL",
     ),
+    "workbuddy": HermesOverlay(
+        transport="openai_chat",
+        # Endpoint is stream-only: a non-streaming chat request returns
+        # HTTP 400 {"code": 11101, "msg": "Non-stream chat request ... not
+        # supported"}. Same failure class as Tencent Copilot — see
+        # auxiliary_client._provider_requires_stream(). Model catalog lives
+        # in _PROVIDER_MODELS (the /v2/models route is not exposed); users
+        # with a session can list live ids via workbuddy-openai.
+        base_url_override="https://www.workbuddy.ai/v2",
+        base_url_env_var="WORKBUDDY_BASE_URL",
+    ),
     "arcee": HermesOverlay(
         transport="openai_chat",
         base_url_override="https://api.arcee.ai/api/v1",
@@ -391,6 +402,11 @@ ALIASES: Dict[str, str] = {
     "tencentmaas": "tencent-tokenhub",
     "tokenplan": "tencent-tokenplan",
     "tencent-lkeap": "tencent-tokenplan",
+
+    # workbuddy
+    "workbuddy": "workbuddy",
+    "workbuddy-ai": "workbuddy",
+    "wb": "workbuddy",
 
     # bedrock
     "aws": "bedrock",

--- a/tests/hermes_cli/test_workbuddy_provider.py
+++ b/tests/hermes_cli/test_workbuddy_provider.py
@@ -1,0 +1,199 @@
+"""Tests for the WorkBuddy provider (www.workbuddy.ai/v2).
+
+WorkBuddy is Tencent's consumer AI assistant exposed over an
+OpenAI-compatible endpoint. Two properties make it more than "another
+base URL + API key", and both are asserted here:
+
+1. It is stream-only. A non-streaming chat request returns HTTP 400
+   ``{"code": 11101, "msg": "Non-stream chat request is currently not
+   supported"}`` — the same envelope as Tencent Copilot. Auxiliary tasks
+   (title generation, compression, vision) use the non-streaming path, so
+   without handling they fail on every call.
+2. It exposes tier aliases (``default-model``, ``fast-model``, ...) that
+   resolve server-side, plus named models advertised by ``/v3/config``.
+"""
+
+import pytest
+
+from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider
+from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_MODELS
+
+
+# Other provider env vars to clear during auto-detection tests.
+_OTHER_PROVIDER_KEYS = (
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY",
+    "GOOGLE_API_KEY", "GEMINI_API_KEY", "DASHSCOPE_API_KEY",
+    "XAI_API_KEY", "KIMI_API_KEY", "KIMI_CN_API_KEY",
+    "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY", "AI_GATEWAY_API_KEY",
+    "KILOCODE_API_KEY", "HF_TOKEN", "GLM_API_KEY", "ZAI_API_KEY",
+    "XIAOMI_API_KEY", "OPENROUTER_API_KEY", "COPILOT_GITHUB_TOKEN",
+    "GH_TOKEN", "GITHUB_TOKEN", "ARCEEAI_API_KEY",
+    "TOKENHUB_API_KEY", "TOKENPLAN_API_KEY",
+)
+
+
+# =============================================================================
+# Provider registry
+# =============================================================================
+
+
+class TestWorkBuddyProviderRegistry:
+    """Verify workbuddy is registered as a first-class provider."""
+
+    def test_registered(self):
+        assert "workbuddy" in PROVIDER_REGISTRY
+
+    def test_inference_base_url(self):
+        assert (
+            PROVIDER_REGISTRY["workbuddy"].inference_base_url
+            == "https://www.workbuddy.ai/v2"
+        )
+
+    def test_api_key_env_var(self):
+        assert PROVIDER_REGISTRY["workbuddy"].api_key_env_vars == (
+            "WORKBUDDY_ACCESS_TOKEN",
+        )
+
+    def test_base_url_env_var(self):
+        assert PROVIDER_REGISTRY["workbuddy"].base_url_env_var == "WORKBUDDY_BASE_URL"
+
+    def test_auth_type_is_api_key(self):
+        # The token is obtained out-of-band (browser OAuth), but every
+        # inference request authenticates with a plain Bearer token, so
+        # Hermes' standard api_key path applies.
+        assert PROVIDER_REGISTRY["workbuddy"].auth_type == "api_key"
+
+
+# =============================================================================
+# Aliases — these gate `provider:model` parsing and /model
+# =============================================================================
+
+
+@pytest.mark.parametrize("alias", ["workbuddy", "workbuddy-ai", "wb"])
+def test_alias_resolves(alias, monkeypatch):
+    """`--provider <alias>` and `provider:model` must reach workbuddy."""
+    for key in _OTHER_PROVIDER_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("WORKBUDDY_ACCESS_TOKEN", "wb-test-token")
+    assert resolve_provider(alias) == "workbuddy"
+
+
+@pytest.mark.parametrize("alias", ["workbuddy", "workbuddy-ai", "wb"])
+def test_normalize_provider_models_py(alias):
+    from hermes_cli.models import normalize_provider
+
+    assert normalize_provider(alias) == "workbuddy"
+
+
+@pytest.mark.parametrize("alias", ["workbuddy", "workbuddy-ai", "wb"])
+def test_normalize_provider_providers_py(alias):
+    from hermes_cli.providers import normalize_provider
+
+    assert normalize_provider(alias) == "workbuddy"
+
+
+# =============================================================================
+# Model catalog
+# =============================================================================
+
+
+class TestWorkBuddyModelCatalog:
+    def test_catalog_present(self):
+        assert "workbuddy" in _PROVIDER_MODELS
+
+    def test_tier_aliases_listed(self):
+        models = _PROVIDER_MODELS["workbuddy"]
+        for slot in (
+            "default-model",
+            "fast-model",
+            "balanced-model",
+            "primary-model",
+            "deep-model",
+        ):
+            assert slot in models
+
+    def test_no_empty_entries(self):
+        assert all(m and m.strip() for m in _PROVIDER_MODELS["workbuddy"])
+
+    def test_offered_in_model_picker(self):
+        slugs = {p.slug for p in CANONICAL_PROVIDERS}
+        assert "workbuddy" in slugs
+
+
+# =============================================================================
+# Stream-only handling — the bug this provider would otherwise hit
+# =============================================================================
+
+
+class TestWorkBuddyRequiresStream:
+    """Aux calls to WorkBuddy must be sent with stream=True.
+
+    Reproduces the real failure: without this, title generation returned
+    HTTP 400 code 11101 because the auxiliary path never sets ``stream``.
+    """
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://www.workbuddy.ai/v2",
+            "https://www.workbuddy.ai",
+            "https://api.workbuddy.ai/v2",
+        ],
+    )
+    def test_workbuddy_endpoints_require_stream(self, base_url):
+        from agent.auxiliary_client import _provider_requires_stream
+
+        assert _provider_requires_stream("workbuddy", base_url) is True
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.openai.com/v1",
+            "https://openrouter.ai/api/v1",
+            "https://api.anthropic.com",
+        ],
+    )
+    def test_other_endpoints_unaffected(self, base_url):
+        from agent.auxiliary_client import _provider_requires_stream
+
+        assert _provider_requires_stream("custom", base_url) is False
+
+    def test_no_base_url_is_not_stream_only(self):
+        from agent.auxiliary_client import _provider_requires_stream
+
+        assert _provider_requires_stream("workbuddy", None) is False
+        assert _provider_requires_stream("workbuddy", "") is False
+
+    def test_lookalike_host_does_not_match(self):
+        """Guard the substring-match bug class (see base_url_host_matches)."""
+        from agent.auxiliary_client import _provider_requires_stream
+
+        assert (
+            _provider_requires_stream("custom", "https://evil.com/workbuddy.ai/v1")
+            is False
+        )
+        assert _provider_requires_stream("custom", "https://workbuddy.ai.evil/v1") is False
+
+
+# =============================================================================
+# Auxiliary model routing
+# =============================================================================
+
+
+def test_aux_model_registered():
+    """Without this, aux tasks leak to the session default provider."""
+    from agent.auxiliary_client import _API_KEY_PROVIDER_AUX_MODELS
+
+    assert _API_KEY_PROVIDER_AUX_MODELS.get("workbuddy")
+
+
+def test_hostname_maps_to_workbuddy():
+    """model_metadata reverse-maps base URL host -> provider id.
+
+    Without this entry, a WorkBuddy endpoint reached via a custom base URL
+    is treated as an unknown endpoint and loses context-window resolution.
+    """
+    from agent.model_metadata import _URL_TO_PROVIDER
+
+    assert _URL_TO_PROVIDER.get("www.workbuddy.ai") == "workbuddy"
+    assert _URL_TO_PROVIDER.get("workbuddy.ai") == "workbuddy"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -41,6 +41,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
 | **Tencent TokenPlan** | `TOKENPLAN_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenplan`, aliases: `tokenplan`, `tencent-lkeap`; Anthropic Messages endpoint) |
+| **WorkBuddy** | `WORKBUDDY_ACCESS_TOKEN` in `~/.hermes/.env` (provider: `workbuddy`, aliases: `workbuddy-ai`, `wb`; stream-only endpoint) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **CommandCode** | `COMMANDCODE_API_KEY` in `~/.hermes/.env` (provider: `commandcode`, alias: `commandcode-chat`; Claude models via `commandcode-anthropic`, alias: `commandcode-claude`). Works with GOAT/Pro/Max/Provider plans (not the $1 Go plan — no API access). |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
@@ -295,6 +296,10 @@ hermes chat --provider tencent-tokenhub --model hy4-preview
 # Tencent TokenPlan (Hy4 preview via Anthropic Messages endpoint)
 hermes chat --provider tencent-tokenplan --model hy4-preview
 # Requires: TOKENPLAN_API_KEY in ~/.hermes/.env
+
+# WorkBuddy (Tencent consumer plan; stream-only endpoint)
+hermes chat --provider workbuddy --model default-model
+# Requires: WORKBUDDY_ACCESS_TOKEN in ~/.hermes/.env
 
 # Arcee AI (Trinity models)
 hermes chat --provider arcee --model trinity-large-thinking

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -61,6 +61,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `TOKENHUB_BASE_URL` | Override Tencent TokenHub base URL (default: `https://tokenhub.tencentmaas.com/v1`) |
 | `TOKENPLAN_API_KEY` | Tencent TokenPlan API key (LKEAP; Anthropic Messages endpoint) |
 | `TOKENPLAN_BASE_URL` | Override Tencent TokenPlan base URL (default: `https://api.lkeap.cloud.tencent.com/plan/anthropic`) |
+| `WORKBUDDY_ACCESS_TOKEN` | WorkBuddy bearer token (OpenAI-compatible endpoint at `https://www.workbuddy.ai/v2`) |
+| `WORKBUDDY_BASE_URL` | Override WorkBuddy base URL (default: `https://www.workbuddy.ai/v2`) |
 | `AZURE_FOUNDRY_API_KEY` | Microsoft Foundry / Azure OpenAI API key ([ai.azure.com](https://ai.azure.com/)). Not needed when `model.auth_mode: entra_id` |
 | `AZURE_FOUNDRY_BASE_URL` | Microsoft Foundry endpoint URL (e.g. `https://<resource>.openai.azure.com/openai/v1` for OpenAI-style, or `https://<resource>.services.ai.azure.com/anthropic` for Anthropic-style) |
 | `AZURE_ANTHROPIC_KEY` | Azure Anthropic API key for `provider: anthropic` + `base_url` pointing at a Microsoft Foundry Claude deployment (alternative to `ANTHROPIC_API_KEY` when both Anthropic and Azure Anthropic are configured) |


### PR DESCRIPTION
Adds WorkBuddy (`www.workbuddy.ai`) as a native provider, same shape as TokenHub / TokenPlan.

Refs #97294.

WorkBuddy is Tencent's consumer assistant. Chat is OpenAI-compatible at `https://www.workbuddy.ai/v2`. Auth is a Bearer token in `WORKBUDDY_ACCESS_TOKEN`. No new adapter.

A custom `base_url` is not enough, because of two real failures I hit live.

Non-stream chat returns HTTP 400 `{"code": 11101, "msg": "Non-stream chat request is currently not supported"}`. The conversation loop already streams, so `hermes chat --provider workbuddy` works. Aux tasks do not stream. Title generation, compression, and vision all fail:

```
⚠ Auxiliary title generation failed: HTTP 400: Error code: 400 - {'code': 11101, 'msg': 'Non-stream chat request is currently not supported'}
```

`_provider_requires_stream()` already treats Tencent Copilot this way (#60686). This PR adds `workbuddy.ai` to that host list so aux calls send `stream=True`.

Without an aux-model mapping, those same tasks also leak to the session default provider. Mapped to `fast-model`.

`/v2/models` 404s, so the catalog is static. Tier slots (`default-model`, `fast-model`, `balanced-model`, `primary-model`, `deep-model`) resolve server-side. Named models come from `/v3/config`.

```
hermes chat --provider workbuddy --model fast-model -q "Reply with exactly: WORKBUDDY_NATIVE_OK"
WORKBUDDY_NATIVE_OK

Session:  20260829_113601_6814ce
Title:    Verify workbuddy native response
```

The aux warning is gone. Session title came from WorkBuddy, not the default provider. Tool calling checked separately (`get_weather` → `{"city": "Paris"}`).

28 tests in `tests/hermes_cli/test_workbuddy_provider.py`. Aliases `workbuddy`, `workbuddy-ai`, `wb` all resolve.

Token comes from browser OAuth against Tencent. Out of scope here. Unofficial helper at `github.com/owenisas/workbuddy-openai`. This PR does not import it.

Tier-slot context lengths are `/v3/config` `maxInputTokens` as of 2026-08-29. They are ceilings. The slots can move.
