### PR TITLE
feat(tts): openai_compatible streaming provider for self-hosted servers

### DIFF
--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -155,6 +155,116 @@ def test_openai_streamer_prefers_configured_api_key(monkeypatch):
     assert captured["client"]["api_key"] == "cfg-key"
 
 
+# ── openai_compatible: self-hosted servers with no mandatory key ─────────
+
+
+def test_openai_compatible_available_requires_configured_base_url(monkeypatch):
+    monkeypatch.setattr(
+        ts, "_load_tts_config",
+        lambda: {"openai_compatible": {"base_url": "http://127.0.0.1:8902/v1"}},
+    )
+    assert ts.OpenAICompatibleStreamer.available() is True
+    monkeypatch.setattr(ts, "_load_tts_config", lambda: {"openai_compatible": {}})
+    assert ts.OpenAICompatibleStreamer.available() is False
+    monkeypatch.setattr(ts, "_load_tts_config", lambda: {})
+    assert ts.OpenAICompatibleStreamer.available() is False
+
+
+def test_openai_compatible_streams_pcm_without_any_api_key(monkeypatch):
+    """A keyless local server is the whole point — auth header must be absent."""
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=None):
+            yield b"\x01\x00\x02\x00"
+            yield b"\x03\x00"
+
+    class _Requests:
+        @staticmethod
+        def post(url, headers=None, json=None, timeout=None, stream=None):
+            captured.update(
+                url=url, headers=headers, json=json, timeout=timeout, stream=stream
+            )
+            return _Response()
+
+    monkeypatch.setitem(sys.modules, "requests", _Requests)
+    monkeypatch.setattr(
+        ts, "_load_tts_config",
+        lambda: {"openai_compatible": {"base_url": "http://127.0.0.1:8902/v1"}},
+    )
+
+    config = {
+        "provider": "openai_compatible",
+        "openai_compatible": {"base_url": "http://127.0.0.1:8902/v1"},
+    }
+    streamer = ts.resolve_streaming_provider(config)
+
+    assert streamer is not None
+    assert list(streamer.stream("Hola.")) == [b"\x01\x00\x02\x00", b"\x03\x00"]
+    assert captured["url"] == "http://127.0.0.1:8902/v1/audio/speech"
+    assert "Authorization" not in (captured["headers"] or {})
+    assert captured["json"]["response_format"] == "pcm"
+    assert captured["json"]["model"] == "tts-1"
+    assert captured["stream"] is True
+
+
+def test_openai_compatible_sends_bearer_when_key_configured(monkeypatch):
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=None):
+            yield b"\x01\x00"
+
+    class _Requests:
+        @staticmethod
+        def post(url, headers=None, json=None, timeout=None, stream=None):
+            captured.update(url=url, headers=headers, json=json)
+            return _Response()
+
+    monkeypatch.setitem(sys.modules, "requests", _Requests)
+    monkeypatch.setattr(
+        ts, "_load_tts_config",
+        lambda: {"openai_compatible": {
+            "base_url": "http://tts.example/v1",
+            "api_key": "local-secret",
+            "voice": "argentina",
+        }},
+    )
+
+    config = {
+        "provider": "openai_compatible",
+        "openai_compatible": {
+            "base_url": "http://tts.example/v1",
+            "api_key": "local-secret",
+            "voice": "argentina",
+        },
+    }
+    streamer = ts.resolve_streaming_provider(config)
+
+    assert streamer is not None
+    list(streamer.stream("Hola."))
+    assert captured["headers"] == {"Authorization": "Bearer local-secret"}
+    assert captured["json"]["voice"] == "argentina"
+
+
 # ── Dispatch: chunked streamer path ──────────────────────────────────────
 
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -293,6 +293,67 @@ class OpenAIStreamer(StreamingTTSProvider):
             yield from _capped(response.iter_bytes(), "OpenAI streaming TTS")
 
 
+@register("openai_compatible")
+class OpenAICompatibleStreamer(StreamingTTSProvider):
+    """Any OpenAI-compatible server with ``response_format=pcm`` (24 kHz).
+
+    Serves the self-hosted ecosystem — qwentts.cpp, LocalAI, kokoro-fastapi,
+    Speaches, cloned-openai proxies — where ``base_url`` identifies the
+    server and an API key is usually optional (sent as ``Bearer`` when set).
+    Unlike the ``openai`` streamer there is nothing to auto-detect: no
+    configured ``tts.openai_compatible.base_url`` means unavailable.
+    """
+
+    sample_rate = 24000
+
+    @staticmethod
+    def available() -> bool:
+        try:
+            section = (_load_tts_config().get("openai_compatible") or {})
+        except Exception:
+            return False
+        return bool(str(section.get("base_url") or "").strip())
+
+    def _base_url(self) -> str:
+        return str(
+            self.section.get("base_url")
+            or get_env_value("OPENAI_COMPATIBLE_TTS_BASE_URL")
+            or ""
+        ).strip().rstrip("/")
+
+    def stream(self, text: str) -> Iterator[bytes]:
+        import requests
+
+        base_url = self._base_url()
+        if not base_url:
+            raise RuntimeError(
+                "openai_compatible streaming TTS requires tts.openai_compatible.base_url"
+            )
+        api_key = str(self.section.get("api_key") or "").strip()
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        payload = {
+            "model": str(self.section.get("model") or "tts-1").strip(),
+            "input": text,
+            "response_format": "pcm",
+        }
+        voice = str(self.section.get("voice") or "").strip()
+        if voice:
+            payload["voice"] = voice
+
+        def _pcm_chunks() -> Iterator[bytes]:
+            with requests.post(
+                f"{base_url}/audio/speech",
+                headers=headers,
+                json=payload,
+                timeout=120,
+                stream=True,
+            ) as response:
+                response.raise_for_status()
+                yield from response.iter_content(chunk_size=4096)
+
+        yield from _capped(_pcm_chunks(), "openai_compatible streaming TTS")
+
+
 def _capped(chunks: Iterator[bytes], label: str) -> Iterator[bytes]:
     """Pass chunks through, aborting past the 16 MiB per-sentence cap.
 


### PR DESCRIPTION
## What

Adds an `openai_compatible` `StreamingTTSProvider` for any server exposing an OpenAI-compatible `POST /v1/audio/speech` with `response_format=pcm` — the self-hosted TTS ecosystem: **qwentts.cpp** (Qwen3-TTS), **LocalAI**, **kokoro-fastapi**, **Speaches**, OpenAI proxies, etc.

## Why

The existing `openai` streamer supports `base_url` but gates `available()` on an API key — so a local keyless server can never be selected as the streaming provider, even though its API is identical. Self-hosted voice is a real use case: I'm running qwentts.cpp (Qwen3-TTS 1.7B Q8) on a Vulkan iGPU with sub-second first-audio and wanted Hermes voice mode to speak through it.

## How

- `@register("openai_compatible")` `OpenAICompatibleStreamer`: `requests` streamed body through the existing `_capped` 16 MiB per-sentence guard, `int16` mono PCM at 24 kHz.
- `available()` requires only `tts.openai_compatible.base_url` in config (nothing to auto-detect). `api_key` optional — `Authorization: Bearer` sent only when set.
- `model` (default `tts-1`) / `voice` passthrough; trailing-slash normalization on `base_url`.
- Config: `tts.provider: openai_compatible` or `tts.streaming.provider: openai_compatible`.

## Testing

- Contract tests in `tests/tools/test_tts_streaming.py`: availability gate (base_url required), keyless streaming (asserts **no** auth header, pcm format, stream=True), Bearer + voice passthrough when configured. 32/32 pass.
- **E2E against a live server** (qwentts.cpp, Qwen3-TTS 1.7B Q8_0, Vulkan iGPU): resolver → `stream()` → 6.16s of valid 24kHz int16 PCM in 77 chunks, wall 1.67s, RTF 0.27.

## Doc

Follows the "Adding a new streaming provider" recipe in `docs/streaming-tts.md` (subclass + `@register` + tests). Happy to add the provider to that doc's capability matrix if you tell me which doc table you want updated.