### PR TITLE
test(runner): allow seven minutes per test file

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -80,20 +80,16 @@ _SKIP_PARTS = {"integration", "e2e", "docker"}
 # Per-file wall-clock cap. Override
 # via --file-timeout or HERMES_TEST_FILE_TIMEOUT.
 #
-# Set to 360s (6 min) deliberately generous: the per-test subprocess
-# isolation plugin spawns a fresh Python process per test, so a
-# large-collection file pays N × (interpreter startup + import) of
-# overhead before any test logic runs — and that overhead dilates under
-# load on shared CI runners, producing false "no tests ran" timeouts on
-# files that finish in ~100s on a quiet box. The Docker build matrix jobs
-# take 7-10 min anyway, so this headroom costs nothing on total CI wall
-# time while keeping a genuinely hung file bounded.
-_DEFAULT_FILE_TIMEOUT_SECONDS = 360.0
+# Set to 420s (7 min): native-Windows validation has observed a passing
+# test file taking as long as 359.8s. A 360s cap therefore left effectively
+# no scheduling or host-load margin; seven minutes adds about 60s of headroom
+# while keeping a genuinely hung file bounded.
+_DEFAULT_FILE_TIMEOUT_SECONDS = 420.0
 
 # One-shot retry of failing test FILES. A file that exits non-zero is re-run
 # once in a fresh subprocess; if the re-run passes, the file counts as passed
 # but is loudly reported as FLAKY so it gets fixed rather than hidden.
-# Deterministic failures fail both attempts — a real regression can never be
+# Deterministic failures fail every attempt — a real regression can never be
 # laundered into green by this (it would have to flake in our favor twice in
 # a row on the same runner, which is exactly the definition of a flake).
 # Set to 0 to disable (env: HERMES_TEST_FILE_RETRIES).
@@ -619,7 +615,7 @@ def _print_inline_failure(
         print(f"  ║ {line}", flush=True)
     print("  ║", flush=True)
     print(f"  ║  Repro: {repro}", flush=True)
-    print("  ╚╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍", flush=True)
+    print("  ╚╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍", flush=True)
     print(flush=True)
 
 
@@ -657,7 +653,6 @@ def _save_durations(
         data[key] = round(t, 3)
     path = repo_root / _DURATIONS_FILE
     path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
 
 def _compute_lpt_slices(
     files: List[Path],
@@ -997,6 +992,7 @@ def main() -> int:
             roots = [repo_root / p for p in args.paths_positional]
         else:
             roots = [repo_root / p for p in _split_pathspec(args.paths)]
+
         if args.include_integration:
             # Caller takes responsibility — typically used via explicit -k filter.
             global _SKIP_PARTS  # noqa: PLW0603 — config knob

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -80,7 +80,7 @@ _SKIP_PARTS = {"integration", "e2e", "docker"}
 # Per-file wall-clock cap. Override
 # via --file-timeout or HERMES_TEST_FILE_TIMEOUT.
 #
-# Set to 300s (5 min) deliberately generous: the per-test subprocess
+# Set to 360s (6 min) deliberately generous: the per-test subprocess
 # isolation plugin spawns a fresh Python process per test, so a
 # large-collection file pays N × (interpreter startup + import) of
 # overhead before any test logic runs — and that overhead dilates under
@@ -88,7 +88,7 @@ _SKIP_PARTS = {"integration", "e2e", "docker"}
 # files that finish in ~100s on a quiet box. The Docker build matrix jobs
 # take 7-10 min anyway, so this headroom costs nothing on total CI wall
 # time while keeping a genuinely hung file bounded.
-_DEFAULT_FILE_TIMEOUT_SECONDS = 300.0
+_DEFAULT_FILE_TIMEOUT_SECONDS = 360.0
 
 # One-shot retry of failing test FILES. A file that exits non-zero is re-run
 # once in a fresh subprocess; if the re-run passes, the file counts as passed
@@ -997,7 +997,6 @@ def main() -> int:
             roots = [repo_root / p for p in args.paths_positional]
         else:
             roots = [repo_root / p for p in _split_pathspec(args.paths)]
-
         if args.include_integration:
             # Caller takes responsibility — typically used via explicit -k filter.
             global _SKIP_PARTS  # noqa: PLW0603 — config knob

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -89,7 +89,7 @@ _DEFAULT_FILE_TIMEOUT_SECONDS = 420.0
 # One-shot retry of failing test FILES. A file that exits non-zero is re-run
 # once in a fresh subprocess; if the re-run passes, the file counts as passed
 # but is loudly reported as FLAKY so it gets fixed rather than hidden.
-# Deterministic failures fail every attempt — a real regression can never be
+# Deterministic failures fail both attempts — a real regression can never be
 # laundered into green by this (it would have to flake in our favor twice in
 # a row on the same runner, which is exactly the definition of a flake).
 # Set to 0 to disable (env: HERMES_TEST_FILE_RETRIES).
@@ -615,7 +615,7 @@ def _print_inline_failure(
         print(f"  ║ {line}", flush=True)
     print("  ║", flush=True)
     print(f"  ║  Repro: {repro}", flush=True)
-    print("  ╚╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍", flush=True)
+    print("  ╚╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍╍", flush=True)
     print(flush=True)
 
 
@@ -653,6 +653,7 @@ def _save_durations(
         data[key] = round(t, 3)
     path = repo_root / _DURATIONS_FILE
     path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
 
 def _compute_lpt_slices(
     files: List[Path],


### PR DESCRIPTION
## Summary

- raise the canonical per-file test timeout from 300s to 420s
- give `tests/hermes_cli/test_cmd_update.py` meaningful headroom on supported native Windows, where observed passing runtime has reached 359.8s
- keep the runner's hard process-tree timeout and all timeout overrides unchanged

## Root cause

The runner's 300-second default sits below the observed passing runtime of `tests/hermes_cli/test_cmd_update.py` on native Windows.

The issue reproduction showed the file completing successfully under direct pytest in 305.48s, while the canonical runner terminated it at 300s. Because the runner retries timed-out files once by default, that deterministic threshold miss consumes about ten minutes and then reports `NO TESTS RAN`.

Initial validation showed a 360s override passing in 307.5s. Additional validation on exact `head@558d140081` then produced two canonical runs at 343.0s and 359.8s. The latter leaves effectively no margin under a 360-second default.

## Change

Raise `_DEFAULT_FILE_TIMEOUT_SECONDS` from `300.0` to `420.0`.

Seven minutes gives about 60 seconds of headroom over the slowest observed passing Windows run while remaining bounded. A genuinely hung file is still terminated after seven minutes, and users/CI can continue to override the limit with `--file-timeout` or `HERMES_TEST_FILE_TIMEOUT`.

## Validation

Reviewer-reported Windows validation:

- on `head@558d140081`, Python 3.11.7 and pytest 9.1.1, the prior 360s candidate completed canonical runs in `343.0s` and `359.8s`; runner tests were `9 passed, 1 skipped`
- on exact current head `daaca30d98f39fd4f1fa76b1fe552b5c1b6c1c33`, Windows 11 Home build 26200, Python 3.11.7 and pytest 9.1.1:
  - runner tests: `12 passed, 1 skipped in 72.55s` on the clean rerun
  - canonical runner with no `--file-timeout` override and `--file-retries 0`: `39 passed in 336.5s`

The exact-head canonical run leaves 83.5s of measured headroom under the revised 420s bound and supports closing #98040.

Closes #98040
