### PR TITLE
fix(desktop): route to the branched session so its window renders

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1612,6 +1612,55 @@ describe('branchStoredSession desktop source tagging', () => {
     expect($sessionTiles.get().some(tile => tile.storedSessionId === 'branch-stored')).toBe(false)
   })
 
+  it('routes the main workspace to the branch session (branch window renders without a manual away-and-back)', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          message_count: 0,
+          messages: [],
+          resumed: 'branch-stored',
+          session_id: 'branch-runtime',
+          session_key: 'branch-stored'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
+    setSelectedStoredSessionId('stored-parent')
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    const navigate = vi.fn()
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        navigate={navigate}
+        onReady={branch => (branchStoredSession = branch)}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="stored-parent"
+      />
+    )
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    // resumeSession swaps the selection but never the URL. Without a navigate
+    // here the route stays on the PARENT while the selection is the CHILD, so
+    // isRouteSessionMismatch stays true: the transcript is suppressed and the
+    // routed loader never retires — the branched window stays blank until the
+    // user switches away and back. The URL must follow the selection.
+    expect(navigate).toHaveBeenCalledWith(sessionRoute('branch-stored'), { replace: true })
+  })
+
   it('keeps the current view when branching a different session from the sidebar (does not reintroduce #69750)', async () => {
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.create') {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2022,6 +2022,16 @@ export function useSessionActions({
         // (ensureSessionState/updateSessionState) instead of an extra resume RPC.
         if (parentStoredId !== null && selectedStoredSessionIdRef.current === parentStoredId) {
           await resumeSession(routedSessionId)
+          // resumeSession swaps the selection but never touches the URL — its
+          // `replaceRoute` parameter is accepted and ignored. The route still
+          // points at the PARENT, so isRouteSessionMismatch (route = parent,
+          // selection = child) stays true: ChatRuntimeBoundary keeps the
+          // transcript suppressed and the routed loader never retires, so the
+          // branched window shows an empty spinner until the user switches
+          // away and back (a sidebar click routes properly via openSession).
+          // Navigate here, same tick as the selection swap, so route and
+          // selection land atomically.
+          navigate(sessionRoute(routedSessionId), { replace: true })
         } else {
           openSessionTile(routedSessionId, 'center')
           patchSessionTile(routedSessionId, { runtimeId: branched.session_id })
@@ -2045,6 +2055,7 @@ export function useSessionActions({
       copy,
       creatingSessionRef,
       ensureSessionState,
+      navigate,
       requestGateway,
       resumeSession,
       selectedStoredSessionIdRef,


### PR DESCRIPTION
# fix(desktop): route to the branched session so its window renders

## Symptom

Clicking a bubble's branch action (the GitFork "branch in new chat" button, or any path that forks the open chat into a child session) creates the branch correctly, but the branched session's window shows a blank spinner until the user switches to some other session and switches back — only then does the content render.

## Root cause

`forkBranch` (`use-session-actions/index.ts`) takes over the main pane like this:

```ts
if (parentStoredId !== null && selectedStoredSessionIdRef.current === parentStoredId) {
  await resumeSession(routedSessionId)
}
```

`resumeSession` swaps the **selection** (`$selectedStoredSessionId` / `selectedStoredSessionIdRef`) but never touches the **URL** — its `replaceRoute` parameter is accepted and ignored, and the function body contains no `navigate` call at all.

So after a branch the route still points at the PARENT (`/:parent-id`) while the selection points at the CHILD. On every render:

- `isRouteSessionMismatch(routed=parent, selected=child)` → **true** (`chat/index.tsx`, `route-session-state.ts`)
- `ChatRuntimeBoundary` gets `suppressMessages = true` → the transcript is suppressed
- `routedSessionIsLoading` → the session loader never retires
- `use-route-resume` even sees `stuckOnRoutedSession` (route ≠ selection) and can re-resume the **parent**, yanking the view back

Switching away and back works because a sidebar click routes through `openSession`, which **does** call `navigate(sessionRoute(id))` — that's the only thing the branch path was missing.

## Fix

One line in the main-pane takeover path of `forkBranch`, plus the `navigate` dependency:

```ts
if (parentStoredId !== null && selectedStoredSessionIdRef.current === parentStoredId) {
  await resumeSession(routedSessionId)
  navigate(sessionRoute(routedSessionId), { replace: true })
}
```

Route and selection now land atomically, so the mismatch suppression never engages.

The background-branch path (branching a session that is NOT currently open) is intentionally untouched: it opens a **tile**, which carries no route, and navigating there would reintroduce the #69750 focus-stealing bug.

## Testing

- New regression test: `routes the main workspace to the branch session (branch window renders without a manual away-and-back)` — asserts `navigate` is called with `sessionRoute('branch-stored')` + `{ replace: true }` after a main-pane branch.
- `use-session-actions.test.tsx`: **85 passed** (was 84)
- Adjacent surface (`src/app/session/hooks/` + `src/app/chat/`): **144 files, 1557 tests passed**
- `tsc -p tsconfig.json --noEmit`: clean
- `eslint` on both touched files: clean
