### PR TITLE
fix(mcp): reuse stdio watcher coroutine

### DIFF
--- a/tests/tools/test_mcp_stdio_fastfail_reconnect.py
+++ b/tests/tools/test_mcp_stdio_fastfail_reconnect.py
@@ -110,8 +110,15 @@ def test_midcall_child_exit_signals_reconnect(monkeypatch, tmp_path):
         mcp_tool, "srv-midcall", _hanging_call, children_dead=lambda: False
     )
 
-    async def _watch_children():
-        return  # children die immediately → watcher resolves first
+    watch_calls = {"n": 0}
+
+    def _watch_children():
+        watch_calls["n"] += 1
+
+        async def _child_exit():
+            return  # children die immediately → watcher resolves first
+
+        return _child_exit()
 
     server._watch_stdio_children = _watch_children
     mcp_tool._ensure_mcp_loop()
@@ -122,5 +129,6 @@ def test_midcall_child_exit_signals_reconnect(monkeypatch, tmp_path):
         assert "error" in parsed, parsed
         assert "exited mid-call" in parsed["error"], parsed
         assert server._reconnect_event.set_calls == 1
+        assert watch_calls["n"] == 1, "watcher coroutine must be created exactly once"
     finally:
         _cleanup(mcp_tool, "srv-midcall")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6184,11 +6184,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         )
                     _call_coro = server.session.call_tool(tool_name, arguments=args)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
-                    _watch_ok = (
-                        _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
-                        and asyncio.iscoroutine(_call_coro)
-                    )
+                    _watch_coro = None
+                    if callable(_watch_children) and asyncio.iscoroutine(_call_coro):
+                        _watch_coro = _watch_children()
+                    _watch_ok = inspect.isawaitable(_watch_coro)
                     if not _watch_ok:
                         # Stubbed sessions (MagicMock in tests) return a
                         # non-awaitable, or there is no child-watcher to race
@@ -6205,7 +6204,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         # the call immediately instead of riding out the full
                         # tool timeout.
                         rpc_task = asyncio.ensure_future(_call_coro)
-                        watch_task = asyncio.ensure_future(_watch_children())
+                        watch_task = asyncio.ensure_future(_watch_coro)
                         try:
                             done, _pending = await asyncio.wait(
                                 {rpc_task, watch_task},


### PR DESCRIPTION
## Summary
- create the stdio child-watcher coroutine exactly once
- reuse that coroutine for awaitability validation and task scheduling
- prevent the discarded probe coroutine from emitting `RuntimeWarning: coroutine ... was never awaited`
- assert in the reconnect regression test that the watcher is constructed once

The MCP-prefixed pre-discovery validation changes were removed because they are already covered more broadly by #44044.

## Verification
- `uv run pytest -q tests/tools/test_mcp_stdio_fastfail_reconnect.py` (2 passed)
- `uv run pytest -q tests/tools/test_mcp*.py` (596 passed)
- `uv run ruff check tools/mcp_tool.py tests/tools/test_mcp_stdio_fastfail_reconnect.py`
- `git diff --check`
