### PR TITLE
fix(telegram): send explicit video dimensions

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -15,6 +15,8 @@ import logging
 import os
 import html as _html
 import re
+import shutil
+import subprocess
 import threading
 import time
 from contextvars import ContextVar
@@ -24,6 +26,69 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 logger = logging.getLogger(__name__)
 
 from agent.deadline import run_bounded_async
+from hermes_cli._subprocess_compat import windows_hide_flags
+
+
+def _probe_video_dimensions(video_path: str) -> Optional[tuple[int, int]]:
+    """Return coded video dimensions for Telegram's sendVideo metadata.
+
+    Telegram can infer an incorrect preview aspect ratio when width and height
+    are omitted. Keep probing best-effort so media delivery still works on
+    hosts without ffprobe or for files ffprobe cannot decode.
+    """
+    try:
+        ffprobe = shutil.which("ffprobe")
+        if not ffprobe:
+            return None
+        result = subprocess.run(
+            [
+                ffprobe,
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height:stream_side_data=rotation",
+                "-of",
+                "json",
+                video_path,
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdin=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+            creationflags=windows_hide_flags(),
+        )
+        if result.returncode != 0:
+            return None
+        streams = json.loads(result.stdout).get("streams") or []
+        if not streams:
+            return None
+        stream = streams[0]
+        width = int(stream.get("width") or 0)
+        height = int(stream.get("height") or 0)
+        if width <= 0 or height <= 0:
+            return None
+        for side_data in stream.get("side_data_list") or []:
+            rotation = side_data.get("rotation")
+            if rotation is None:
+                continue
+            if abs(int(round(float(rotation)))) % 180 == 90:
+                width, height = height, width
+            break
+        return width, height
+    except (
+        FileNotFoundError,
+        OSError,
+        subprocess.SubprocessError,
+        ValueError,
+        TypeError,
+        json.JSONDecodeError,
+    ):
+        return None
 
 
 def _redact_telegram_error_text(error: object) -> str:
@@ -8208,6 +8273,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
+            dimensions = await asyncio.to_thread(_probe_video_dimensions, video_path)
+            video_kwargs: Dict[str, Any] = {"supports_streaming": True}
+            if dimensions is not None:
+                video_kwargs.update(width=dimensions[0], height=dimensions[1])
             with open(video_path, "rb") as f:
                 msg = await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_video,
@@ -8217,6 +8286,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
                         "read_timeout": _MEDIA_SEND_READ_TIMEOUT,
+                        **video_kwargs,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },

--- a/tests/gateway/test_telegram_media_read_timeout.py
+++ b/tests/gateway/test_telegram_media_read_timeout.py
@@ -104,3 +104,83 @@ async def test_send_image_upload_fallback_uses_media_read_timeout(adapter, monke
     upload = calls[1]
     assert isinstance(upload["photo"], (bytes, bytearray))
     assert upload["read_timeout"] == tg._MEDIA_SEND_READ_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_send_video_passes_probed_dimensions_to_telegram(adapter, monkeypatch, tmp_path):
+    """Telegram must receive explicit geometry instead of guessing the preview ratio."""
+    video = tmp_path / "wide.mp4"
+    video.write_bytes(b"fake-video")
+    monkeypatch.setattr(tg, "_probe_video_dimensions", lambda path: (1280, 720), raising=False)
+
+    msg = MagicMock(message_id=3)
+    adapter._bot.send_video = AsyncMock(return_value=msg)
+
+    result = await adapter.send_video("123", str(video), caption="wide")
+
+    assert result.success
+    call = adapter._bot.send_video.await_args
+    assert call is not None
+    payload = call.kwargs
+    assert payload["width"] == 1280
+    assert payload["height"] == 720
+    assert payload["supports_streaming"] is True
+
+
+@pytest.mark.parametrize(
+    ("rotation", "expected"),
+    [
+        (0, (160, 90)),
+        (90, (90, 160)),
+        (-90, (90, 160)),
+        (270, (90, 160)),
+    ],
+)
+def test_probe_video_dimensions_applies_display_rotation(monkeypatch, rotation, expected):
+    """Display-matrix quarter turns swap coded width and height."""
+    probe = MagicMock(
+        returncode=0,
+        stdout=(
+            '{"streams":[{"width":160,"height":90,'
+            f'"side_data_list":[{{"side_data_type":"Display Matrix","rotation":{rotation}}}]}}]}}'
+        ),
+    )
+    monkeypatch.setattr(tg.shutil, "which", lambda name: "/usr/bin/ffprobe")
+    monkeypatch.setattr(tg.subprocess, "run", MagicMock(return_value=probe))
+
+    assert tg._probe_video_dimensions("rotated.mp4") == expected
+
+
+def test_probe_video_dimensions_returns_none_without_ffprobe(monkeypatch):
+    run = MagicMock()
+    monkeypatch.setattr(tg.shutil, "which", lambda name: None)
+    monkeypatch.setattr(tg.subprocess, "run", run)
+
+    assert tg._probe_video_dimensions("video.mp4") is None
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "probe",
+    [
+        MagicMock(returncode=1, stdout=""),
+        MagicMock(returncode=0, stdout="not-json"),
+        MagicMock(returncode=0, stdout='{"streams":[]}'),
+    ],
+)
+def test_probe_video_dimensions_returns_none_for_unusable_output(monkeypatch, probe):
+    monkeypatch.setattr(tg.shutil, "which", lambda name: "/usr/bin/ffprobe")
+    monkeypatch.setattr(tg.subprocess, "run", MagicMock(return_value=probe))
+
+    assert tg._probe_video_dimensions("video.mp4") is None
+
+
+def test_probe_video_dimensions_returns_none_on_timeout(monkeypatch):
+    monkeypatch.setattr(tg.shutil, "which", lambda name: "/usr/bin/ffprobe")
+    monkeypatch.setattr(
+        tg.subprocess,
+        "run",
+        MagicMock(side_effect=tg.subprocess.TimeoutExpired("ffprobe", 5)),
+    )
+
+    assert tg._probe_video_dimensions("video.mp4") is None


### PR DESCRIPTION
## Bug Description

Telegram can render an uploaded MP4 with the wrong preview aspect ratio when `sendVideo` is called without explicit dimensions. In a live reproduction, a 1280×720 H.264/AAC video was displayed close to 4:3 even though the file itself reported a 16:9 display aspect ratio.

No matching open or closed issue/PR was found for this symptom.

## Root Cause

`TelegramAdapter.send_video()` uploaded the file without `width`, `height`, or `supports_streaming`. Telegram therefore had to infer the video geometry during server-side processing, and that inference was incorrect for the reproduced file.

## Fix

- Best-effort probe the first video stream with `ffprobe` off the asyncio event loop.
- Apply MP4 display-matrix rotation so 90°/270° phone videos send swapped display dimensions.
- Pass the resulting display `width` and `height` explicitly to Telegram.
- Set `supports_streaming=True` for native video uploads.
- Preserve the previous behavior when `ffprobe` is unavailable or the file cannot be probed.
- Add regression coverage for Bot API payloads, display rotation, unavailable `ffprobe`, malformed output, and probe timeouts.

## How to Verify

1. Send a 1280×720 MP4 through a `MEDIA:` response on Telegram.
2. Confirm the message renders as a 16:9 native video preview and streams normally.
3. Confirm the adapter sends `width=1280`, `height=720`, and `supports_streaming=True`.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing Telegram gateway tests pass
- [x] Manual verification of the fix on Telegram

Commands run:

```bash
uv run --python 3.11 --with pytest --with pytest-asyncio pytest tests/gateway/test_telegram*.py tests/gateway/test_tts_media_routing.py -q -o 'addopts='
# 607 passed

uv run --python 3.11 --with ruff ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_media_read_timeout.py
# All checks passed
```

## Risk Assessment

Low — the change is limited to Telegram native video sends. Probing is best-effort, bounded by a five-second timeout, and runs in a worker thread. If probing fails, the adapter still uploads the video with the previous inference behavior while retaining `supports_streaming=True`.
