### PR TITLE
fix(desktop): re-probe the sandbox once when a launch-time ACL repair succeeds

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -555,10 +555,18 @@ if (PASSWORD_STORE.store) {
 // sandbox (any cause, including a manual --no-sandbox flag) — guards the
 // relaunch handlers. `windowsSandboxFallbackSticky` = the fallback machinery
 // engaged and the marker must stay `fallback` after a successful boot; a
-// manual flag alone is honored but never made sticky.
+// manual flag alone is honored but never made sticky. A successful launch-time
+// ACL repair re-probes the sandbox once (like a version change), and
+// `windowsSandboxFallbackAclProbed` keeps that one-shot consumed so a
+// still-broken host returns to sticky --no-sandbox instead of re-crashing on
+// every launch.
 let windowsSandboxFallbackActive = false
 let windowsSandboxFallbackSticky = false
 let windowsSandboxFallbackReason: SandboxFallbackReason = 'boot-loop'
+// True once the one-shot ACL-repair re-probe is in flight (or already failed)
+// for this fallback episode; the relaunch handlers carry it into the fallback
+// marker they write so a still-broken host does not re-probe every launch.
+let windowsSandboxFallbackAclProbed = false
 let windowsNoSandboxRelaunchAttempted = false
 
 if (IS_WINDOWS) {
@@ -569,10 +577,17 @@ if (IS_WINDOWS) {
   // engaged — icacls /T recurses the whole install tree, so healthy launches
   // skip it (the installer already granted the ACE at install time). Repair
   // targets the install dir only: granting AppContainer read on userData would
-  // expose Hermes sessions/config to every packaged app on the machine.
+  // expose Hermes sessions/config to every packaged app on the machine. A
+  // SUCCESSFUL repair is fed into the sandbox decision below: while the
+  // fallback is engaged it triggers the same one-shot re-probe as a version
+  // change, so a healed host returns to full sandboxing without waiting for
+  // the next app update.
+  let aclRepairSucceeded = false
+
   if (shouldAttemptAclRepair(priorMarker)) {
     const exeDir = path.dirname(process.execPath)
     const acl = grantAllApplicationPackagesAcl(exeDir, { execFileSync })
+    aclRepairSucceeded = acl.ok
 
     if (acl.ok) {
       console.log(`[hermes] granted ALL APPLICATION PACKAGES RX on ${exeDir} (#38216)`)
@@ -585,11 +600,13 @@ if (IS_WINDOWS) {
     argv: process.argv,
     env: process.env,
     marker: priorMarker,
-    appVersion: app.getVersion()
+    appVersion: app.getVersion(),
+    aclRepairSucceeded
   })
 
   windowsSandboxFallbackActive = sandboxDecision.enable
   windowsSandboxFallbackSticky = sandboxDecision.nextMarker.state === 'fallback'
+  windowsSandboxFallbackAclProbed = sandboxDecision.nextMarker.aclRepairProbed === true
 
   if (sandboxDecision.nextMarker.state === 'fallback' && sandboxDecision.nextMarker.reason) {
     windowsSandboxFallbackReason = sandboxDecision.nextMarker.reason
@@ -624,7 +641,13 @@ if (IS_WINDOWS) {
     windowsSandboxFallbackReason = 'gpu-breakpoint'
 
     try {
-      writeSandboxMarker(app.getPath('userData'), fallbackMarker('gpu-breakpoint', app.getVersion()))
+      const marker = fallbackMarker('gpu-breakpoint', app.getVersion())
+
+      if (windowsSandboxFallbackAclProbed) {
+        marker.aclRepairProbed = true
+      }
+
+      writeSandboxMarker(app.getPath('userData'), marker)
     } catch {
       void 0
     }
@@ -14003,7 +14026,8 @@ function createWindow() {
             markerAfterSuccessfulBoot({
               fallbackActive: windowsSandboxFallbackSticky,
               reason: windowsSandboxFallbackReason,
-              appVersion: app.getVersion()
+              appVersion: app.getVersion(),
+              aclRepairProbed: windowsSandboxFallbackAclProbed
             })
           )
         } catch (error) {
@@ -14086,7 +14110,13 @@ function createWindow() {
         windowsSandboxFallbackReason = 'renderer-crash-loop'
 
         try {
-          writeSandboxMarker(app.getPath('userData'), fallbackMarker('renderer-crash-loop', app.getVersion()))
+          const marker = fallbackMarker('renderer-crash-loop', app.getVersion())
+
+          if (windowsSandboxFallbackAclProbed) {
+            marker.aclRepairProbed = true
+          }
+
+          writeSandboxMarker(app.getPath('userData'), marker)
         } catch {
           void 0
         }

--- a/apps/desktop/electron/windows-sandbox-fallback.test.ts
+++ b/apps/desktop/electron/windows-sandbox-fallback.test.ts
@@ -145,6 +145,112 @@ test('an app update re-probes the sandbox once instead of degrading forever', ()
   assert.equal(legacy.reason, 'sticky-fallback')
 })
 
+test('a successful ACL repair while fallback is engaged re-probes the sandbox once', () => {
+  // Host healed between launches: the launch-time ACL repair succeeds while the
+  // sticky fallback marker is in place → same one-shot re-probe as a version
+  // change, so the sandboxed boot gets a chance before --no-sandbox.
+  const probed = decideWindowsSandboxLaunch({
+    platform: 'win32',
+    marker: { state: 'fallback', reason: 'gpu-breakpoint', version: '1.2.3' },
+    argv: [],
+    env: {},
+    appVersion: '1.2.3',
+    aclRepairSucceeded: true
+  })
+
+  assert.equal(probed.enable, false)
+  assert.equal(probed.reason, null)
+  assert.deepEqual(probed.nextMarker, { state: 'booting', reprobe: true, bootAborts: 0, aclRepairProbed: true })
+})
+
+test('an aborted ACL-repair re-probe returns straight to fallback, consumed', () => {
+  // The one-shot ACL-repair re-probe boot aborted → back to fallback without a
+  // second strike, exactly like the version-change re-probe failure path — and
+  // the fallback records that the one-shot was consumed.
+  const failedProbe = decideWindowsSandboxLaunch({
+    platform: 'win32',
+    marker: { state: 'booting', reprobe: true, bootAborts: 0, aclRepairProbed: true },
+    argv: [],
+    env: {},
+    appVersion: '1.2.3'
+  })
+
+  assert.equal(failedProbe.enable, true)
+  assert.equal(failedProbe.reason, 'reprobe-failed')
+  assert.deepEqual(failedProbe.nextMarker, {
+    state: 'fallback',
+    reason: 'boot-loop',
+    version: '1.2.3',
+    aclRepairProbed: true
+  })
+})
+
+test('a failed ACL repair keeps the sticky fallback exactly as today', () => {
+  const decision = decideWindowsSandboxLaunch({
+    platform: 'win32',
+    marker: { state: 'fallback', reason: 'gpu-breakpoint', version: '1.2.3' },
+    argv: [],
+    env: {},
+    appVersion: '1.2.3',
+    aclRepairSucceeded: false
+  })
+
+  assert.equal(decision.enable, true)
+  assert.equal(decision.reason, 'sticky-fallback')
+  assert.equal(decision.nextMarker.state, 'fallback')
+  assert.equal(decision.nextMarker.aclRepairProbed, undefined)
+})
+
+test('the ACL-repair re-probe is one-shot per fallback episode', () => {
+  // After the probe aborted, the fallback marker carries aclRepairProbed — a
+  // still-broken host must NOT re-probe (and re-crash) on every launch even
+  // though the ACL repair keeps succeeding.
+  const decision = decideWindowsSandboxLaunch({
+    platform: 'win32',
+    marker: { state: 'fallback', reason: 'boot-loop', version: '1.2.3', aclRepairProbed: true },
+    argv: [],
+    env: {},
+    appVersion: '1.2.3',
+    aclRepairSucceeded: true
+  })
+
+  assert.equal(decision.enable, true)
+  assert.equal(decision.reason, 'sticky-fallback')
+  assert.equal(decision.nextMarker.state, 'fallback')
+  assert.equal(decision.nextMarker.aclRepairProbed, true)
+})
+
+test('a version-change re-probe does not consume the ACL-repair one-shot', () => {
+  const decision = decideWindowsSandboxLaunch({
+    platform: 'win32',
+    marker: { state: 'fallback', reason: 'boot-loop', version: '1.2.3' },
+    argv: [],
+    env: {},
+    appVersion: '1.3.0',
+    aclRepairSucceeded: true
+  })
+
+  // Version change wins the ordering and probes without marking the ACL
+  // one-shot as consumed, so the two mechanisms stay independent.
+  assert.equal(decision.enable, false)
+  assert.deepEqual(decision.nextMarker, { state: 'booting', reprobe: true, bootAborts: 0 })
+  assert.equal(decision.nextMarker.aclRepairProbed, undefined)
+})
+
+test('ACL repair success never probes outside the fallback state', () => {
+  const cleanOk = decideWindowsSandboxLaunch({
+    platform: 'win32',
+    marker: { state: 'ok' },
+    argv: [],
+    env: {},
+    appVersion: '1.2.3',
+    aclRepairSucceeded: true
+  })
+
+  assert.equal(cleanOk.enable, false)
+  assert.deepEqual(cleanOk.nextMarker, { state: 'booting' })
+})
+
 test('manual --no-sandbox is honored but never made sticky', () => {
   const manual = decideWindowsSandboxLaunch({
     platform: 'win32',
@@ -177,6 +283,21 @@ test('marker transitions after a successful boot', () => {
     reason: 'gpu-breakpoint',
     version: '1.2.3'
   })
+
+  // A sticky fallback boot keeps the consumed ACL-repair one-shot so a later
+  // launch does not re-probe on a host the repair could not fix.
+  assert.deepEqual(
+    markerAfterSuccessfulBoot({
+      fallbackActive: true,
+      reason: 'gpu-breakpoint',
+      appVersion: '1.2.3',
+      aclRepairProbed: true
+    }),
+    { state: 'fallback', reason: 'gpu-breakpoint', version: '1.2.3', aclRepairProbed: true }
+  )
+
+  // A clean boot drops the flag — a future episode starts fresh.
+  assert.deepEqual(markerAfterSuccessfulBoot({ fallbackActive: false, aclRepairProbed: true }), { state: 'ok' })
 })
 
 test('shouldAttemptAclRepair only fires on evidence of trouble', () => {
@@ -203,12 +324,27 @@ test('sandbox marker round-trips through the userData file', () => {
       version: '1.2.3'
     })
 
+    // The consumed ACL-repair one-shot round-trips through the file too.
+    writeSandboxMarker(dir, { state: 'fallback', reason: 'boot-loop', version: '1.2.3', aclRepairProbed: true })
+    assert.deepEqual(readSandboxMarker(dir), {
+      state: 'fallback',
+      reason: 'boot-loop',
+      version: '1.2.3',
+      aclRepairProbed: true
+    })
+
     assert.equal(parseSandboxMarker({ state: 'fallback' })?.state, 'fallback')
     assert.equal(parseSandboxMarker({ state: 'nope' }), null)
     // Unknown reason strings and junk fields are dropped, not fatal.
     assert.deepEqual(parseSandboxMarker({ state: 'fallback', reason: 'weird', bootAborts: -3 }), {
       state: 'fallback'
     })
+    // aclRepairProbed is only honored as an explicit true.
+    assert.deepEqual(parseSandboxMarker({ state: 'booting', aclRepairProbed: true }), {
+      state: 'booting',
+      aclRepairProbed: true
+    })
+    assert.deepEqual(parseSandboxMarker({ state: 'booting', aclRepairProbed: 'yes' }), { state: 'booting' })
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }

--- a/apps/desktop/electron/windows-sandbox-fallback.ts
+++ b/apps/desktop/electron/windows-sandbox-fallback.ts
@@ -19,7 +19,11 @@
  * 3. The fallback is sticky per app version, not forever: after an update
  *    the sandbox is re-probed once (a new Electron or an installer-applied
  *    ACL grant may have fixed the host). If the re-probe boot aborts, the
- *    next launch goes straight back to `--no-sandbox`.
+ *    next launch goes straight back to `--no-sandbox`. A successful
+ *    launch-time ACL repair re-uses that same one-shot re-probe, so a host
+ *    healed between launches returns to full sandboxing without waiting for
+ *    the next app update — while a host the repair could not fix still gets
+ *    exactly one probe attempt, then sticky `--no-sandbox` again.
  *
  * Pure helpers stay injectable so tests never boot Electron or touch real ACLs.
  */
@@ -53,6 +57,11 @@ export interface SandboxMarker {
   /** This boot is a sandbox re-probe after an app update; an abort returns
    *  straight to fallback instead of restarting the two-strike count. */
   reprobe?: boolean
+  /** The one-shot ACL-repair re-probe for this fallback episode has been
+   *  consumed. Set on the re-probe booting marker, and carried into the
+   *  fallback marker if that probe aborts, so a still-broken host returns to
+   *  sticky --no-sandbox instead of re-probing (and re-crashing) every launch. */
+  aclRepairProbed?: boolean
 }
 
 export function sandboxMarkerPath(userDataDir: string): string {
@@ -114,6 +123,10 @@ export function parseSandboxMarker(raw: unknown): SandboxMarker | null {
 
   if (record.reprobe === true) {
     marker.reprobe = true
+  }
+
+  if (record.aclRepairProbed === true) {
+    marker.aclRepairProbed = true
   }
 
   return marker
@@ -179,6 +192,11 @@ export function decideWindowsSandboxLaunch(
     env?: NodeJS.ProcessEnv
     marker?: SandboxMarker | null
     appVersion?: string
+    /** True when the launch-time ACL repair (recovery ladder line 1) just
+     *  succeeded. While the fallback is engaged this triggers the same one-shot
+     *  sandbox re-probe as a version change: the host may have healed, so the
+     *  degraded --no-sandbox launch gets one chance to come back. */
+    aclRepairSucceeded?: boolean
   } = {}
 ): SandboxLaunchDecision {
   const appVersion = String(options.appVersion || '')
@@ -209,6 +227,20 @@ export function decideWindowsSandboxLaunch(
       }
     }
 
+    if (options.aclRepairSucceeded && !marker.aclRepairProbed) {
+      // The launch-time ACL repair just succeeded while the fallback is
+      // engaged — the host may be fixed, so re-probe the sandbox once exactly
+      // like a version change. One-shot per fallback episode: the probe marker
+      // records aclRepairProbed, so if the probe aborts the next launch goes
+      // straight back to sticky --no-sandbox instead of re-probing (and
+      // re-crashing) on every launch.
+      return {
+        enable: false,
+        reason: null,
+        nextMarker: { state: 'booting', reprobe: true, bootAborts: 0, aclRepairProbed: true }
+      }
+    }
+
     return {
       enable: true,
       reason: 'sticky-fallback',
@@ -221,11 +253,15 @@ export function decideWindowsSandboxLaunch(
 
     if (marker.reprobe) {
       // The one post-update sandboxed re-probe aborted → back to fallback.
-      return {
-        enable: true,
-        reason: 'reprobe-failed',
-        nextMarker: fallbackMarker('boot-loop', appVersion)
+      const nextMarker = fallbackMarker('boot-loop', appVersion)
+
+      if (marker.aclRepairProbed) {
+        // The aborted probe was the one-shot ACL-repair re-probe — keep it
+        // consumed so a still-broken host does not re-probe every launch.
+        nextMarker.aclRepairProbed = true
       }
+
+      return { enable: true, reason: 'reprobe-failed', nextMarker }
     }
 
     if (abortsObserved >= BOOT_ABORTS_BEFORE_FALLBACK) {
@@ -260,18 +296,28 @@ export function fallbackMarker(reason: SandboxFallbackReason, appVersion?: strin
 /**
  * After the main window reaches ready-to-show: keep the sticky fallback when
  * we launched with `--no-sandbox`, otherwise mark a clean boot so future
- * launches trust the sandbox again.
+ * launches trust the sandbox again. When a fallback episode has already
+ * consumed its one-shot ACL-repair re-probe, `aclRepairProbed` is carried
+ * through so a later launch does not re-probe (and re-crash) on a host the
+ * repair could not fix.
  */
 export function markerAfterSuccessfulBoot(options: {
   fallbackActive: boolean
   reason?: SandboxFallbackReason
   appVersion?: string
+  aclRepairProbed?: boolean
 }): SandboxMarker {
   if (!options.fallbackActive) {
     return { state: 'ok' }
   }
 
-  return fallbackMarker(options.reason ?? 'boot-loop', options.appVersion)
+  const marker = fallbackMarker(options.reason ?? 'boot-loop', options.appVersion)
+
+  if (options.aclRepairProbed) {
+    marker.aclRepairProbed = true
+  }
+
+  return marker
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a Windows sandbox fallback that degrades forever even after the underlying problem is repaired.

**Problem:** Hermes Desktop runs with `--no-sandbox` after repeated crash-loop boots. The only thing that ever re-probes full sandboxing is an **app version change**. But the fallback often engages because a launch-time ACL repair (granting `ALL APPLICATION PACKAGES RX` on the install dir, #38216) is **missing or failed** — and that repair happens on *every* launch. When the repair eventually succeeds (e.g. after the installer re-runs, or the user fixes permissions), the host is healthy again, yet Hermes stays pinned to `--no-sandbox` until the next app update.

**Fix:** feed the launch-time ACL-repair result into the sandbox decision. When the repair succeeds while the sticky fallback is engaged, trigger the **same one-shot re-probe** as a version change — a healed host returns to full sandboxing on the very next launch instead of waiting indefinitely.

The re-probe is **one-shot**: the fallback marker records `aclRepairProbed`, so a *still*-broken host returns straight to sticky `--no-sandbox` rather than re-crashing on every launch (same failure-tolerant behavior as the existing version-change re-probe).

## What changed

- `apps/desktop/electron/main.ts` — thread `aclRepairSucceeded` into the sandbox decision; propagate `aclRepairProbed` through the marker writes in all relaunch paths (gpu-breakpoint, renderer-crash-loop, successful-boot).
- `apps/desktop/electron/windows-sandbox-fallback.ts` — the decision state machine accepts the ACL-repair result and honors the one-shot `aclRepairProbed` marker flag.
- `apps/desktop/electron/windows-sandbox-fallback.test.ts` — 3 new unit tests covering the healed-host re-probe, the aborted re-probe returning to consumed fallback, and the failed-repair keeping today's behavior.

## Testing

`npx vitest run electron/windows-sandbox-fallback.test.ts` — **21 passed**.

## Scope

Windows-only, desktop-app only. Pure decision logic + state wiring; no change to healthy launch paths (ACL repair is skipped entirely when no fallback marker is present).
