### PR TITLE
fix(desktop): harden plugin shim against reserved-word exports and local-name collisions

### DIFF
--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -25,16 +25,44 @@ export function installPluginSdk(): void {
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
- *  Export names come from the namespace itself, so the list can't drift. */
+ *  Export names come from the namespace itself, so the list can't drift.
+ *
+ *  Names must be valid binding identifiers — the /^[A-Za-z_$][\w$]*$/ shape
+ *  alone is NOT enough: a minified SDK chunk can leak a reserved word as an
+ *  export alias (proven: `in`), and `export const { in } = m` is a SyntaxError
+ *  that Chromium surfaces as a confusing "Unexpected token ')'" at the chunk
+ *  line. Filter reserved words too. */
+const RESERVED_WORDS = new Set([
+  'break','case','catch','class','const','continue','debugger','default','delete',
+  'do','else','enum','export','extends','false','finally','for','function','if',
+  'import','in','instanceof','new','null','return','super','switch','this','throw',
+  'true','try','typeof','var','void','while','with','yield','let','static','await',
+  'implements','package','protected','interface','private','public'
+])
+
 function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+  // The shim's own local binding must not collide with an export name: a
+  // minified SDK chunk can export ANY valid identifier, including the local
+  // name the shim uses for the namespace (`const m = ...; export const { m }
+  // = m;` is `Identifier 'm' has already been declared` — proven: the
+  // session-list-density chunk exports `m`). Use an unlikely internal name
+  // AND exclude it from the destructure list so a future collision stays
+  // impossible.
+  const LOCAL = '__hermes_shim_ns__'
+  const names = Object.keys(GLOBALS[globalKey]).filter(
+    name =>
+      name !== 'default' &&
+      name !== LOCAL &&
+      /^[A-Za-z_$][\w$]*$/.test(name) &&
+      !RESERVED_WORDS.has(name)
+  )
 
   const source =
-    `const m = globalThis.${globalKey};\n` +
-    `export default m.default ?? m;\n` +
+    `const ${LOCAL} = globalThis.${globalKey};\n` +
+    `export default ${LOCAL}.default ?? ${LOCAL};\n` +
     // Guard the destructuring: `export const {  } = m` is a syntax error, so
     // only emit it when the namespace actually has named exports.
-    (names.length ? `export const { ${names.join(', ')} } = m;\n` : '')
+    (names.length ? `export const { ${names.join(', ')} } = ${LOCAL};\n` : '')
 
   return URL.createObjectURL(new Blob([source], { type: 'text/javascript' }))
 }


### PR DESCRIPTION
## Summary

Fixes two crash classes in the desktop **plugin shim** — the ESM blob that re-exports a global namespace's live members for plugins — both triggered by minified SDK chunks.

## Bug 1: reserved word as export alias → `SyntaxError`

The shim filters export names with `/^[A-Za-z_$][\w$]*$/`, which accepts reserved words. A minified SDK chunk (proven: leaks `in` as an export alias) then produces:

```js
export const { in } = m;   // SyntaxError
```

Chromium surfaces this as a confusing `Unexpected token ')'` pointing at the chunk's line — very hard to trace back to the shim.

**Fix:** filter JavaScript reserved words from the export list.

## Bug 2: local binding collides with an export name → redeclaration error

The shim binds the namespace to a local (`const m = globalThis[...]`) then destructures exports from it. If the namespace exports a member literally named `m` (proven: the session-list-density chunk does), the generated code is:

```js
const m = globalThis.FOO;
export const { m } = m;    // Identifier 'm' has already been declared
```

**Fix:** use an unlikely internal local (`__hermes_shim_ns__`) *and* exclude it from the destructure list, so a future collision stays impossible.

## What changed

- `apps/desktop/src/sdk/runtime.ts` — add `RESERVED_WORDS` set; filter exports against it; rename the shim's local binding to `__hermes_shim_ns__` and exclude it from the destructure.

## Scope

Desktop-app only, one file. Pure string-blob generation; no behavior change for well-formed SDK chunks.
