### PR TITLE
fix(telegram): recover exhausted request pool

### DIFF
--- a/contributors/emails/yu_zhengbo@foxmail.com
+++ b/contributors/emails/yu_zhengbo@foxmail.com
@@ -1,0 +1,2 @@
+AideYu
+# PR #98094 salvage of #68983

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2738,21 +2738,27 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         async with self._get_general_request_drain_lock():
             try:
-                await general_req.shutdown()
+                await _await_with_thread_deadline(
+                    general_req.shutdown(), timeout=_DRAIN_TIMEOUT
+                )
             except Exception:
                 logger.debug(
-                    "[%s] General request shutdown failed after pool timeout (non-fatal)",
+                    "[%s] General request shutdown failed/timed out after pool "
+                    "timeout (non-fatal)",
                     self.name, exc_info=True,
                 )
             try:
-                await general_req.initialize()
+                await _await_with_thread_deadline(
+                    general_req.initialize(), timeout=_DRAIN_TIMEOUT
+                )
                 logger.warning(
                     "[%s] General request pool drained after Telegram pool timeout",
                     self.name,
                 )
             except Exception:
                 logger.debug(
-                    "[%s] General request re-initialize failed after pool timeout (non-fatal)",
+                    "[%s] General request re-initialize failed/timed out after "
+                    "pool timeout (non-fatal)",
                     self.name, exc_info=True,
                 )
 
@@ -3037,6 +3043,18 @@ class TelegramAdapter(BasePlatformAdapter):
                     return
         except Exception:
             pass
+
+        if getattr(self, "_polling_teardown_started", False):
+            return
+        # start_polling() performs Bot API bootstrap calls through PTB's
+        # general request pool before it starts getUpdates. If that pool is
+        # exhausted by stale proxy sockets, draining only the polling request
+        # below cannot recover: every retry fails in bootstrap before polling
+        # begins. A confirmed pool timeout means the request was not sent, so
+        # it is safe to rebuild the general pool before retrying. Keep generic
+        # network-error recovery polling-only so in-flight sends are untouched.
+        if self._looks_like_pool_timeout(error):
+            await self._drain_general_connections_after_pool_timeout()
 
         if getattr(self, "_polling_teardown_started", False):
             return

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -149,13 +149,69 @@ async def test_initialize_still_runs_when_shutdown_fails():
     mock_app, mock_polling_req = _make_mock_app()
     mock_polling_req.shutdown = AsyncMock(side_effect=Exception("shutdown boom"))
     adapter._app = mock_app
+    general_req = mock_app.bot._request[1]
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
         await adapter._handle_polling_network_error(Exception("Bad Gateway"))
 
     # initialize MUST be called even though shutdown raised
     mock_polling_req.initialize.assert_called_once()
+    # Generic polling errors must leave concurrent Bot API sends untouched.
+    general_req.shutdown.assert_not_called()
+    general_req.initialize.assert_not_called()
     mock_app.updater.start_polling.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_drains_general_pool_after_pool_timeout():
+    """A confirmed bootstrap pool timeout must rebuild both request pools."""
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 1
+
+    mock_app, mock_polling_req = _make_mock_app()
+    general_req = AsyncMock()
+    general_req.shutdown = AsyncMock()
+    general_req.initialize = AsyncMock()
+    mock_app.bot._request = (mock_polling_req, general_req)
+    adapter._app = mock_app
+
+    error = Exception(
+        "Pool timeout: All connections in the connection pool are occupied. "
+        "Request was not sent to Telegram."
+    )
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(error)
+
+    general_req.shutdown.assert_awaited_once()
+    general_req.initialize.assert_awaited_once()
+    mock_polling_req.shutdown.assert_awaited_once()
+    mock_polling_req.initialize.assert_awaited_once()
+    mock_app.updater.start_polling.assert_awaited_once()
+    await _complete_current_polling_generation(adapter)
+
+
+@pytest.mark.asyncio
+async def test_general_pool_drain_is_bounded_when_close_hangs(monkeypatch):
+    """A wedged general-pool close must not freeze the reconnect ladder."""
+    adapter = _make_adapter()
+    mock_app, mock_polling_req = _make_mock_app()
+
+    async def _hang(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    general_req = AsyncMock()
+    general_req.shutdown = AsyncMock(side_effect=_hang)
+    general_req.initialize = AsyncMock(side_effect=_hang)
+    mock_app.bot._request = (mock_polling_req, general_req)
+    adapter._app = mock_app
+    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.05, raising=False)
+
+    await asyncio.wait_for(
+        adapter._drain_general_connections_after_pool_timeout(), timeout=1
+    )
+
+    general_req.shutdown.assert_awaited_once()
+    general_req.initialize.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Telegram polling recovery currently resets only PTB's dedicated `getUpdates` request pool. When the triggering error is a confirmed pool timeout, that is insufficient: `start_polling()` performs Bot API bootstrap calls through PTB's separate general request pool before polling begins, so an exhausted general pool causes every reconnect attempt to fail before it can reach `getUpdates`.

This change resets the general request pool only for classifier-confirmed pool timeouts, then continues through the existing polling-pool drain and restart path. Generic network errors remain polling-only so ordinary recovery does not interrupt concurrent sends. General-pool shutdown and initialization are bounded with the adapter's existing wall-clock deadline helper so a cancellation-resistant transport cannot freeze the reconnect ladder.

This salvages #68983 by @AideYu onto current `main`; the original commit authorship is preserved.

## Related Issue

Supersedes #68983, which no longer applies cleanly to current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Reset PTB's general Bot API request pool before polling recovery when the error is a confirmed pool timeout.
- Keep generic polling-network recovery scoped to the `getUpdates` pool.
- Bound general-pool shutdown and initialization with the current thread-deadline helper.
- Add behavioral coverage for pool-timeout recovery, generic-error isolation, and a hung general-pool drain.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_telegram_network_reconnect.py -q -j 4`.
2. Confirm a pool-timeout recovery resets both PTB request pools and reaches `start_polling()`.
3. Confirm a generic network error leaves the general request pool untouched, and a hung general-pool close cannot pin recovery indefinitely.

Local execution was not performed under the workstation test policy. Static verification completed: both changed Python files parse, `git diff --check` passes, and `scripts/check-windows-footguns.py --diff origin/main` passes. Focused execution is left to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. The regression is covered with mocked PTB request pools and lifecycle behavior.
