### PR TITLE
feat(tts): openai_compatible streaming provider for self-hosted servers

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -50,6 +50,7 @@ _BUILTIN_NAMES = frozenset({
     "edge",
     "elevenlabs",
     "openai",
+    "openai_compatible",
     "minimax",
     "xai",
     "mistral",

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -155,6 +155,116 @@ def test_openai_streamer_prefers_configured_api_key(monkeypatch):
     assert captured["client"]["api_key"] == "cfg-key"
 
 
+# ── openai_compatible: self-hosted servers with no mandatory key ─────────
+
+
+def test_openai_compatible_available_requires_configured_base_url(monkeypatch):
+    monkeypatch.setattr(
+        ts, "_load_tts_config",
+        lambda: {"openai_compatible": {"base_url": "http://127.0.0.1:8902/v1"}},
+    )
+    assert ts.OpenAICompatibleStreamer.available() is True
+    monkeypatch.setattr(ts, "_load_tts_config", lambda: {"openai_compatible": {}})
+    assert ts.OpenAICompatibleStreamer.available() is False
+    monkeypatch.setattr(ts, "_load_tts_config", lambda: {})
+    assert ts.OpenAICompatibleStreamer.available() is False
+
+
+def test_openai_compatible_streams_pcm_without_any_api_key(monkeypatch):
+    """A keyless local server is the whole point — auth header must be absent."""
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=None):
+            yield b"\x01\x00\x02\x00"
+            yield b"\x03\x00"
+
+    class _Requests:
+        @staticmethod
+        def post(url, headers=None, json=None, timeout=None, stream=None):
+            captured.update(
+                url=url, headers=headers, json=json, timeout=timeout, stream=stream
+            )
+            return _Response()
+
+    monkeypatch.setitem(sys.modules, "requests", _Requests)
+    monkeypatch.setattr(
+        ts, "_load_tts_config",
+        lambda: {"openai_compatible": {"base_url": "http://127.0.0.1:8902/v1"}},
+    )
+
+    config = {
+        "provider": "openai_compatible",
+        "openai_compatible": {"base_url": "http://127.0.0.1:8902/v1"},
+    }
+    streamer = ts.resolve_streaming_provider(config)
+
+    assert streamer is not None
+    assert list(streamer.stream("Hola.")) == [b"\x01\x00\x02\x00", b"\x03\x00"]
+    assert captured["url"] == "http://127.0.0.1:8902/v1/audio/speech"
+    assert "Authorization" not in (captured["headers"] or {})
+    assert captured["json"]["response_format"] == "pcm"
+    assert captured["json"]["model"] == "tts-1"
+    assert captured["stream"] is True
+
+
+def test_openai_compatible_sends_bearer_when_key_configured(monkeypatch):
+    captured = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=None):
+            yield b"\x01\x00"
+
+    class _Requests:
+        @staticmethod
+        def post(url, headers=None, json=None, timeout=None, stream=None):
+            captured.update(url=url, headers=headers, json=json)
+            return _Response()
+
+    monkeypatch.setitem(sys.modules, "requests", _Requests)
+    monkeypatch.setattr(
+        ts, "_load_tts_config",
+        lambda: {"openai_compatible": {
+            "base_url": "http://tts.example/v1",
+            "api_key": "local-secret",
+            "voice": "argentina",
+        }},
+    )
+
+    config = {
+        "provider": "openai_compatible",
+        "openai_compatible": {
+            "base_url": "http://tts.example/v1",
+            "api_key": "local-secret",
+            "voice": "argentina",
+        },
+    }
+    streamer = ts.resolve_streaming_provider(config)
+
+    assert streamer is not None
+    list(streamer.stream("Hola."))
+    assert captured["headers"] == {"Authorization": "Bearer local-secret"}
+    assert captured["json"]["voice"] == "argentina"
+
+
 # ── Dispatch: chunked streamer path ──────────────────────────────────────
 
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -293,6 +293,67 @@ class OpenAIStreamer(StreamingTTSProvider):
             yield from _capped(response.iter_bytes(), "OpenAI streaming TTS")
 
 
+@register("openai_compatible")
+class OpenAICompatibleStreamer(StreamingTTSProvider):
+    """Any OpenAI-compatible server with ``response_format=pcm`` (24 kHz).
+
+    Serves the self-hosted ecosystem — qwentts.cpp, LocalAI, kokoro-fastapi,
+    Speaches, cloned-openai proxies — where ``base_url`` identifies the
+    server and an API key is usually optional (sent as ``Bearer`` when set).
+    Unlike the ``openai`` streamer there is nothing to auto-detect: no
+    configured ``tts.openai_compatible.base_url`` means unavailable.
+    """
+
+    sample_rate = 24000
+
+    @staticmethod
+    def available() -> bool:
+        try:
+            section = (_load_tts_config().get("openai_compatible") or {})
+        except Exception:
+            return False
+        return bool(str(section.get("base_url") or "").strip())
+
+    def _base_url(self) -> str:
+        return str(
+            self.section.get("base_url")
+            or get_env_value("OPENAI_COMPATIBLE_TTS_BASE_URL")
+            or ""
+        ).strip().rstrip("/")
+
+    def stream(self, text: str) -> Iterator[bytes]:
+        import requests
+
+        base_url = self._base_url()
+        if not base_url:
+            raise RuntimeError(
+                "openai_compatible streaming TTS requires tts.openai_compatible.base_url"
+            )
+        api_key = str(self.section.get("api_key") or "").strip()
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        payload = {
+            "model": str(self.section.get("model") or "tts-1").strip(),
+            "input": text,
+            "response_format": "pcm",
+        }
+        voice = str(self.section.get("voice") or "").strip()
+        if voice:
+            payload["voice"] = voice
+
+        def _pcm_chunks() -> Iterator[bytes]:
+            with requests.post(
+                f"{base_url}/audio/speech",
+                headers=headers,
+                json=payload,
+                timeout=120,
+                stream=True,
+            ) as response:
+                response.raise_for_status()
+                yield from response.iter_content(chunk_size=4096)
+
+        yield from _capped(_pcm_chunks(), "openai_compatible streaming TTS")
+
+
 def _capped(chunks: Iterator[bytes], label: str) -> Iterator[bytes]:
     """Pass chunks through, aborting past the 16 MiB per-sentence cap.
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -311,8 +311,13 @@ class OpenAICompatibleStreamer(StreamingTTSProvider):
         try:
             section = (_load_tts_config().get("openai_compatible") or {})
         except Exception:
-            return False
-        return bool(str(section.get("base_url") or "").strip())
+            section = {}
+        # Same resolution _base_url() will use at stream time — an env-only
+        # setup must not advertise a provider that can never stream.
+        return bool(
+            str(section.get("base_url") or "").strip()
+            or str(get_env_value("OPENAI_COMPATIBLE_TTS_BASE_URL") or "").strip()
+        )
 
     def _base_url(self) -> str:
         return str(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -781,6 +781,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "edge",
     "elevenlabs",
     "openai",
+    "openai_compatible",
     "minimax",
     "xai",
     "mistral",
@@ -1935,6 +1936,60 @@ def _generate_openai_tts(
 # (filtered by the ``tts`` surface tag) — no hardcoded model ids in this
 # file, so retired models disappear from hermes the next time the
 # catalog is fetched without a patch.
+
+
+def _generate_openai_compatible_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio from any OpenAI-compatible ``/v1/audio/speech`` server.
+
+    Self-hosted companions of the ``openai`` provider — qwentts.cpp,
+    LocalAI, kokoro-fastapi, Speaches… — where ``base_url`` is the server
+    and an API key is usually optional. Uses ``requests`` directly (no SDK)
+    so keyless servers work, mirroring the ``openai_compatible`` streaming
+    provider in ``tools/tts_streaming.py``.
+    """
+    # ``tts.openai_compatible: null`` in YAML yields None — coalesce.
+    section = (tts_config.get("openai_compatible") if isinstance(tts_config, dict) else None) or {}
+    base_url = str(section.get("base_url") or "").strip().rstrip("/")
+    if not base_url:
+        raise ValueError(
+            "openai_compatible TTS requires tts.openai_compatible.base_url "
+            "(e.g. http://127.0.0.1:8080/v1) in config.yaml."
+        )
+    api_key = str(section.get("api_key") or "").strip()
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    payload: Dict[str, Any] = {
+        "model": str(section.get("model") or "tts-1").strip(),
+        "input": text,
+        # mp3 matches the OpenAI default — every compatible server speaks it,
+        # and Hermes' delivery pipeline already handles it.
+        "response_format": "mp3",
+    }
+    voice = str(section.get("voice") or "").strip()
+    if voice:
+        payload["voice"] = voice
+    speed_default = tts_config.get("speed", 1.0) if isinstance(tts_config, dict) else 1.0
+    speed = float(section.get("speed", speed_default))
+    if speed != 1.0:
+        payload["speed"] = speed
+
+    import requests
+
+    response = requests.post(
+        f"{base_url}/audio/speech",
+        headers=headers,
+        json=payload,
+        timeout=300,
+    )
+    response.raise_for_status()
+    content_type = response.headers.get("Content-Type", "")
+    if "audio" not in content_type and "octet-stream" not in content_type:
+        raise ValueError(
+            f"openai_compatible TTS: unexpected Content-Type {content_type!r} "
+            f"from {base_url} — is it an OpenAI-compatible speech endpoint?"
+        )
+    with open(output_path, "wb") as f:
+        f.write(response.content)
+    return output_path
 
 
 def _generate_deepinfra_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
@@ -3305,6 +3360,10 @@ def _text_to_speech_single(
                 }, ensure_ascii=False)
             logger.info("Generating speech with OpenAI TTS...")
             _generate_openai_tts(text, file_str, tts_config, instructions=instructions)
+
+        elif provider == "openai_compatible":
+            logger.info("Generating speech with OpenAI-compatible TTS...")
+            _generate_openai_compatible_tts(text, file_str, tts_config)
 
         elif provider == "deepinfra":
             try:


### PR DESCRIPTION
## What does this PR do?

Adds an `openai_compatible` **streaming** TTS provider so Hermes can talk through any self-hosted / OpenAI-compatible speech server that supports `response_format=pcm` (24 kHz mono int16) — qwentts.cpp, LocalAI, kokoro-fastapi, Speaches, cloned-OpenAI proxies, etc. This closes the streaming gap for the self-hosted ecosystem: until now, running a local TTS server meant falling back to the per-sentence sync path, while chunked streaming was reserved for ElevenLabs/OpenAI/Gemini/xAI.

Design notes:

- **`base_url` is the server identity; the API key is optional.** Local servers usually run keyless, so the `Authorization: Bearer` header is only sent when `tts.openai_compatible.api_key` is set — the keyless case is the whole point and is explicitly tested.
- **No silent detection**: `available()` is `True` only when `tts.openai_compatible.base_url` is configured (or `OPENAI_COMPATIBLE_TTS_BASE_URL`). An unconfigured install never sees the provider.
- **Same contract as the built-in streamers**: `@register("openai_compatible")` on a `StreamingTTSProvider` subclass — the dispatcher, `tts.streaming.provider` config knob, and resolver pick it up with no other changes; the 16 MiB per-sentence `_capped` upstream bound applies like every other chunked provider.
- Config (`base_url`, `model`, `voice`, `api_key`) routes through the same `tts.openai_compatible` section shape the sync path already uses; `voice` is omitted from the payload when unset (some servers reject empty voice).

## Related Issue

N/A (self-hosted TTS streaming — no tracking issue found; searched open PRs for duplicates first)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/tts_streaming.py`: new `OpenAICompatibleStreamer` (`@register("openai_compatible")`) — streamed `POST {base_url}/audio/speech` with `response_format=pcm`, optional Bearer auth, voice/model via config, routed through `_capped`.
- `tests/tools/test_tts_streaming.py`: 3 tests — `available()` gating on configured `base_url` (incl. missing-section cases), keyless streaming with the exact request contract asserted (URL, no `Authorization` header, `response_format=pcm`, `stream=True`), and Bearer/voice passthrough when a key is configured.

## How to Test

1. Run any OpenAI-compatible TTS server with PCM support, e.g. `kokoro-fastapi` or `qwentts.cpp`, on `http://127.0.0.1:8902/v1`.
2. In `config.yaml`:
   ```yaml
   tts:
     provider: openai_compatible
     openai_compatible:
       base_url: http://127.0.0.1:8902/v1
     streaming:
       provider: openai_compatible
   ```
3. `hermes chat` and speak — audio should start streaming on the first sentence rather than per-reply.

Automated: `scripts/run_tests.sh tests/tools/test_tts_streaming.py` (32 tests, all green).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(this file: 32/32; ruff clean)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8 (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(provider docstring documents the config section; matches how the existing five streamers are documented)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(uses the existing `tts.openai_compatible` section shape; only `streaming.provider` values gain one entry)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `requests` streaming, no platform-specific constructs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(no tool schema changes; the dispatcher resolves the new provider by name)*
