### PR TITLE
fix(skills): skill_view directory file_path + skill_manage categorized name resolution

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -19,6 +19,7 @@ from tools.skill_manager_tool import (
     _delete_skill,
     _write_file,
     _remove_file,
+    _find_skill,
     skill_manage,
 )
 from agent.skill_utils import (
@@ -199,6 +200,38 @@ class TestEditSkill:
         content = (tmp_path / "my-skill" / "SKILL.md").read_text()
         assert "Updated description" in content
 
+
+    def test_edit_existing_skill_by_categorized_path(self, tmp_path):
+        """Categorized names (``category/skill``) must resolve in skill_manage.
+
+        skill_view's ambiguity hint explicitly tells the caller to use the
+        full categorized path (``category/skill-name``), and skills_list
+        reports skills with their category. But ``_find_skill`` only matched
+        the bare directory name, so every skill_manage call that followed
+        that hint failed with "not found in active profile" — the agent then
+        retried repeatedly, burning LLM round trips (top recurring audit
+        finding). Resolution parity with skill_view is the fix.
+        """
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT, category="software-development")
+            result = _edit_skill("software-development/my-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is True, result.get("error")
+        content = (tmp_path / "software-development" / "my-skill" / "SKILL.md").read_text()
+        assert "Updated description" in content
+
+    def test_find_skill_accepts_categorized_path(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT, category="mlops")
+            found = _find_skill("mlops/my-skill")
+        assert found is not None
+        assert found["path"] == tmp_path / "mlops" / "my-skill"
+
+    def test_find_skill_bare_name_still_resolves_nested_skill(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT, category="mlops")
+            found = _find_skill("my-skill")
+        assert found is not None
+        assert found["path"] == tmp_path / "mlops" / "my-skill"
 
     def test_edit_invalid_content_rejected(self, tmp_path):
         with _skill_dir(tmp_path):

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -376,6 +376,29 @@ class TestSkillView:
         assert skill["linked_files"] is not None
         assert "references" in skill["linked_files"]
 
+    def test_view_file_path_directory_returns_available_files(self, tmp_path):
+        """Requesting a directory (e.g. 'references') must not raise.
+
+        Regression: the local-skill file_path branch checked
+        ``target_file.exists()`` and fell through to ``read_text()`` on a
+        directory, surfacing a raw ``[Errno 21] Is a directory`` error from
+        deep inside the OS instead of the helpful not-found payload with
+        available_files that a missing file gets. The plugin-skill sibling
+        branch already gates on ``is_file()``; this aligns the local path.
+        """
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "my-skill")
+            refs_dir = skill_dir / "references"
+            refs_dir.mkdir()
+            (refs_dir / "api.md").write_text("# API Docs\nEndpoint info.")
+
+            result = json.loads(skill_view("my-skill", file_path="references"))
+
+        assert result["success"] is False
+        assert "not found" in result["error"]
+        # The caller gets the same helpful listing as a truly missing file.
+        assert "references/api.md" in result["available_files"]["references"]
+
     def test_disabled_skill_blocked_enabled_allowed(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -692,15 +692,19 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
 
-    def _matches(skill_md: Path) -> bool:
-        if skill_md.parent.name == name:
-            return True
-        # Categorized form: the full relative path of the skill dir.
-        try:
-            rel = skill_md.parent.resolve().relative_to(_skills_dir().resolve())
-        except ValueError:
-            return False
-        return str(rel) == name
+    # Resolve the local skills root once — the categorized form matches the
+    # skill dir's path RELATIVE to that root. Only computed lazily (bare-name
+    # lookups never need it) and never for external dirs (relative_to raises).
+    _resolved_root: Optional[Path] = None
+
+    def _local_root() -> Path:
+        nonlocal _resolved_root
+        if _resolved_root is None:
+            try:
+                _resolved_root = _skills_dir().resolve()
+            except Exception:
+                _resolved_root = _skills_dir()
+        return _resolved_root
 
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
@@ -708,8 +712,19 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
         for skill_md in skills_dir.rglob("SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
-            if _matches(skill_md):
+            # Fast path first: the bare directory name. Avoids the resolve()
+            # machinery entirely on the common match.
+            if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
+            # Categorized form (``category/skill-name``): compare the skill
+            # dir's POSIX relative path so the lookup works on Windows too.
+            if "/" in name or "\\" in name:
+                try:
+                    rel = skill_md.parent.resolve().relative_to(_local_root())
+                except ValueError:
+                    continue
+                if rel.as_posix() == name:
+                    return {"path": skill_md.parent}
     return None
 
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -683,15 +683,32 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     Searches the local skills dir (~/.hermes/skills/) first, then any
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
+
+    Accepts both the bare directory name (``axolotl``) and the categorized
+    relative path (``mlops/axolotl``) — the same two forms skill_view
+    resolves, and the form skill_view's ambiguity hint explicitly tells
+    the caller to use. Matching bare-name suffix keeps bare lookups
+    working for nested skills.
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+
+    def _matches(skill_md: Path) -> bool:
+        if skill_md.parent.name == name:
+            return True
+        # Categorized form: the full relative path of the skill dir.
+        try:
+            rel = skill_md.parent.resolve().relative_to(_skills_dir().resolve())
+        except ValueError:
+            return False
+        return str(rel) == name
+
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
         for skill_md in skills_dir.rglob("SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
-            if skill_md.parent.name == name:
+            if _matches(skill_md):
                 return {"path": skill_md.parent}
     return None
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -687,8 +687,9 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     Accepts both the bare directory name (``axolotl``) and the categorized
     relative path (``mlops/axolotl``) — the same two forms skill_view
     resolves, and the form skill_view's ambiguity hint explicitly tells
-    the caller to use. Matching bare-name suffix keeps bare lookups
-    working for nested skills.
+    the caller to use. The bare-name match compares the skill's own
+    directory name (``parent.name``), so bare lookups keep working for
+    category-nested skills.
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
 
@@ -702,7 +703,11 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
         if _resolved_root is None:
             try:
                 _resolved_root = _skills_dir().resolve()
-            except Exception:
+            except OSError:
+                logger.debug(
+                    "skills dir resolve failed; categorized lookups fall back to the unresolved path",
+                    exc_info=True,
+                )
                 _resolved_root = _skills_dir()
         return _resolved_root
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1542,7 +1542,11 @@ def skill_view(
                     },
                     ensure_ascii=False,
                 )
-            if not target_file.exists():
+            # Gate on is_file(), not exists(): a directory (e.g. requesting
+            # 'references' bare) must take the not-found listing branch, not
+            # fall through to read_text() and surface a raw [Errno 21]
+            # "Is a directory" OS error. Matches the plugin-skill branch above.
+            if not target_file.is_file():
                 # List available files in the skill directory, organized by type
                 available_files = {
                     "references": [],


### PR DESCRIPTION
## Real-world impact

Agents calling `skill_view(name, file_path=…)` on a **directory** (e.g. `references`) got a raw `[Errno 21] Is a directory: '/…/references'` OS error instead of the helpful not-found payload with the `available_files` listing. This is the exact string that recurs 28× across five months of local optimization audit logs — the background review agent hits it every time it lists a skill's support files.

Agents calling `skill_manage` with a **categorized name** (`software-development/my-skill`) got `Skill '…' not found in active profile 'default'` — even though that is the form skill_view's own ambiguity hint instructs the caller to use (`Pass the full relative path instead of the bare name (e.g., 'category/skill-name')`). Every skill_manage call that followed the hint failed, and the agent retried repeatedly — the #1 recurring error class in the audit logs (926 occurrences in one month).

## What changed

**1. `skill_view` directory request (tools/skills_tool.py)**
```python
# before
if not target_file.exists():      # a directory EXISTS → falls through
    …not-found listing…
content = target_file.read_text() # ← raises [Errno 21] on a directory

# after
if not target_file.is_file():     # directories now take the listing branch
    …not-found listing…
```
The plugin-skill sibling branch already gated on `is_file()`; this aligns the local-skill branch (same bug class, sibling call path).

**2. `skill_manage` categorized names (tools/skill_manager_tool.py)**
```python
# before — only matched the bare directory name
if skill_md.parent.name == name: …

# after — also matches the full relative path (category/skill-name)
def _matches(skill_md):
    if skill_md.parent.name == name: return True
    rel = skill_md.parent.resolve().relative_to(_skills_dir().resolve())
    return str(rel) == name
```
Gives `_find_skill`'s 12 callers (edit / patch / delete / write_file / remove_file / preflight / ledger) resolution parity with `skill_view`.

## Test plan
- [x] New regression tests fail on `main`, pass with the fix:
  - `test_view_file_path_directory_returns_available_files` (skills_tool)
  - `test_edit_existing_skill_by_categorized_path` (skill_manager_tool)
  - `test_find_skill_accepts_categorized_path` + bare-name control
- [x] Full skills test surface green: 194 passed, 1 skipped (`tests/tools/test_skill*` + `test_skills_tool.py` + background-review guard tests)
- [x] Reproduced both symptoms on a clean worktree of upstream/main before fixing

## Follow-up (review feedback)

**1ba66281a3** — addressed @kokhlo's performance note: the categorized-name match now only runs when the lookup name contains a path separator (bare-name lookups never touch the resolve machinery), and the skills root is resolved once, lazily. Also switched `str(rel)` → `rel.as_posix()` so `category/skill` lookups work on Windows, where `str(Path)` renders backslashes.
