### PR TITLE
fix(tui): drop the OSC 8 layer when a link label already shows the URL

### DIFF
--- a/ui-tui/src/__tests__/markdownOsc8SingleLayer.test.ts
+++ b/ui-tui/src/__tests__/markdownOsc8SingleLayer.test.ts
@@ -1,0 +1,129 @@
+import { PassThrough } from 'stream'
+
+import { Box, renderSync } from '@hermes/ink'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Md } from '../components/markdown.js'
+import { __resetLinkTitleCache } from '../lib/externalLink.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+afterEach(() => {
+  __resetLinkTitleCache()
+  vi.unstubAllGlobals()
+})
+
+const ESC = String.fromCharCode(27)
+const BEL = String.fromCharCode(7)
+
+// No network in unit tests: unresolved titles fall back to the
+// hostPathLabel-derived label, which is exactly the shape whose OSC 8
+// wrapping stacks on the terminal's own URL autodetection (#98091).
+const stubUnresolvedTitles = () => {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+}
+
+// The renderer emits `ESC ] 8 ; id=<group> ; url BEL` (the id param groups
+// wrapped lines), so match the url with an optional id segment.
+const osc8For = (url: string) =>
+  new RegExp(`${ESC}\\]8;(?:id=[^;${BEL}]*;)?${url.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)}${BEL}`)
+
+const renderPlain = (text: string, width = 120) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(
+    React.createElement(Box, { width }, React.createElement(Md, { t: DEFAULT_THEME, text })),
+    {
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream
+    }
+  )
+
+  instance.unmount()
+
+  return output
+}
+
+describe('URL-shaped labels emit a single clickable layer (#98091)', () => {
+  it('does not wrap a bare URL whose label equals the target in OSC 8', () => {
+    stubUnresolvedTitles()
+
+    const output = renderPlain('see https://github.com for details')
+
+    // The fallback label (hostPathLabel) is `github.com`, which the
+    // terminal autodetects as a link by itself; an OSC 8 wrapper on top
+    // makes Cmd+Click in Warp open two tabs.
+    expect(output).toContain('github.com')
+    expect(output).not.toMatch(osc8For('https://github.com'))
+  })
+
+  it('does not wrap a markdown link whose label is just the URL', () => {
+    stubUnresolvedTitles()
+
+    // A numeric path has no readable slug, so the label falls back to the
+    // host/path itself — URL-shaped text that pickAuthoredLabel also drops
+    // from `[url](url)` forms.
+    const url = 'https://github.com/123'
+    const output = renderPlain(`[${url}](${url})`)
+
+    expect(output).toContain('github.com/123')
+    expect(output).not.toMatch(osc8For(url))
+  })
+
+  it('keeps OSC 8 when the label drops part of the target, so the href stays exact', async () => {
+    // `https://example.com/1?q=1` falls back to the host/path label
+    // `example.com/1` — the query string never survives into the text, so
+    // without the OSC 8 layer the click would silently drop `?q=1`.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('<html><head><title></title></head></html>', {
+          headers: { 'content-type': 'text/html' },
+          status: 200
+        })
+      )
+    )
+
+    const output = renderPlain('see https://example.com/1?q=1 now')
+
+    expect(output).toContain('example.com/1')
+    expect(output).toMatch(osc8For('https://example.com/1?q=1'))
+  })
+
+  it('keeps OSC 8 for authored labels and resolved titles', async () => {
+    const url = 'https://www.expedia.com/things-to-do/puerto-rico-el-yunque-rainforest-adventure'
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(`<html><head><title>Rainforest Adventure Tour</title></head></html>`, {
+          headers: { 'content-type': 'text/html' },
+          status: 200
+        })
+      )
+    )
+
+    const { fetchLinkTitle } = await import('../lib/externalLink.js')
+    await fetchLinkTitle(url)
+
+    const authored = renderPlain(`[Trip details](${url})`)
+    expect(authored).toContain('Trip details')
+    expect(authored).toMatch(osc8For(url))
+
+    const titled = renderPlain(`see ${url} now`)
+    expect(titled).toContain('Rainforest Adventure Tour')
+    expect(titled).toMatch(osc8For(url))
+  })
+})

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -175,13 +175,25 @@ function ResolvedLink({ authoredLabel, t, url }: ResolvedLinkProps) {
   const fetched = useLinkTitle(authoredLabel ? null : url)
   const display = authoredLabel || fetched || defaultLinkLabel(url)
 
-  return (
-    <Link url={url}>
-      <Text color={t.color.accent} underline>
-        {display}
-      </Text>
-    </Link>
+  const label = (
+    <Text color={t.color.accent} underline>
+      {display}
+    </Text>
   )
+
+  // Until a page title resolves, the fallback label for a bare URL is the
+  // host/path itself (`github.com`). Wrapping URL-shaped text in OSC 8 stacks
+  // our hyperlink on the terminal's own URL autodetection, so Cmd+Click in
+  // Warp fires both and opens two tabs (#98091) — the visible text already
+  // points at the same place, so plain text keeps a single clickable layer.
+  // Labels that differ from the target (authored labels, resolved titles,
+  // host/path text that drops a query string) keep the OSC 8 href so the
+  // exact URL survives the click.
+  if (normalizeExternalUrl(display) === url) {
+    return label
+  }
+
+  return <Link url={url}>{label}</Link>
 }
 
 const renderResolvedLink = (k: number, t: Theme, rawUrl: string, label?: string) => {


### PR DESCRIPTION
## What does this PR do?

Fixes a double-open on Cmd+Click for bare URLs printed by the Hermes TUI in terminals that autodetect URLs (reported in Warp, #98091).

When Hermes TUI prints a pure URL, `ResolvedLink` renders it with a fallback label derived from the host/path (e.g. `https://github.com` shows as `github.com` until a page title resolves), and wraps that label in an OSC 8 hyperlink whose href is the same URL. Warp registers the OSC 8 hyperlink *and* its own autodetected link for the URL-shaped visible text as two overlapping click targets, so Cmd+Click opens two identical tabs. (`echo "https://github.com"` in the same Warp session opens one tab, confirming the overlay is the difference.)

The fix: when the visible label already points at the target (`normalizeExternalUrl(display) === url`), emit plain text without the OSC 8 wrapper — the terminal's own URL detection then provides a single clickable layer. Labels that differ from the target keep the OSC 8 wrapper so the exact href survives the click: authored labels, resolved page titles, and host/path labels that drop a query string (`https://example.com/1?q=1` shows as `example.com/1`).

## Related Issue

Fixes #98091

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/components/markdown.tsx` — in `ResolvedLink`, skip the `<Link>` (OSC 8) wrapper when the display label is URL-shaped and equivalent to the link target; extract the label element so both branches share it
- `ui-tui/src/__tests__/markdownOsc8SingleLayer.test.ts` — new regression tests pinning the single-layer behavior for bare URLs and `[url](url)` markdown, and the preserved OSC 8 href for query-dropping labels, authored labels, and resolved titles

## How to Test

1. `cd ui-tui && npx vitest run src/__tests__/markdownOsc8SingleLayer.test.ts` — 4 tests should pass (verified: `Tests 4 passed (4)`)
2. `cd ui-tui && npx vitest run src/__tests__/markdown.test.ts src/__tests__/externalLink.test.ts src/__tests__/streamingMarkdown.test.ts` — should pass (verified: 65 passed)
3. Manual (needs Warp): before the fix, the rendered output for a bare URL contains `ESC]8;id=…;https://github.com BEL github.com ESC]8;; BEL`; after the fix the same output is plain `github.com` text with no OSC 8 wrapper, so Cmd+Click opens a single tab. Observed result: the repro harness confirmed the wrapper is gone and the `?q=1` case still emits `ESC]8;id=…;https://example.com/1?q=1 BEL`
4. `npx tsc --noEmit -p tsconfig.json` — clean (exit 0); `npx eslint` on both changed files — clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (TypeScript-only change in `ui-tui/`; ran `vitest run` instead: 1690 passed, and the 22 failures in 7 files reproduce identically on a clean `upstream/main` checkout, i.e. pre-existing environment-sensitive failures unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior-preserving rendering fix, code comment documents the constraint)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-ability-guide) — N/A (OSC 8 emission is platform-independent; terminals without URL autodetection simply lose nothing since the href was redundant with the visible text)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (repro harness, bare `https://github.com`):

```
see ESC]8;id=19nr2md;https://github.comBELgithub.comESC]8;;BEL for details
```

After: the same render emits plain `github.com` (single clickable layer via terminal autodetection), while `https://example.com/1?q=1` keeps `ESC]8;id=…;https://example.com/1?q=1BEL` so the query survives the click.
