### PR TITLE
fix(cron): refuse cross-vendor model/provider pairs at create/update time

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -7,6 +7,7 @@ from tools.cronjob_tools import (
     _scan_cron_prompt,
     check_cronjob_requirements,
     cronjob,
+    model_provider_vendor_mismatch,
 )
 
 
@@ -732,3 +733,109 @@ class TestGithubExemptionAbuse:
         assert _scan_cron_prompt(
             "generate a keypair and explain id_rsa vs id_ed25519"
         ) == ""
+
+
+# =========================================================================
+# Cross-vendor (model, provider) pair — create/update admission gate
+# A job pinned to model='gpt-5-codex' + provider='anthropic' is accepted,
+# persisted, and then fails EVERY fire with an opaque HTTP 400. Catching the
+# pair at create/update time turns a silent recurring cron failure into one
+# immediately actionable error.
+# =========================================================================
+class TestModelProviderVendorConsistency:
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+
+    # ---- the pure predicate ----
+    def test_mismatch_detected(self):
+        assert model_provider_vendor_mismatch("gpt-5-codex", "anthropic") == (
+            "openai",
+            "anthropic",
+        )
+
+    def test_matching_pair_is_not_a_mismatch(self):
+        assert model_provider_vendor_mismatch("gpt-5-codex", "openai") is None
+        assert model_provider_vendor_mismatch("claude-sonnet-4-5", "anthropic") is None
+
+    def test_unknown_side_fails_open(self):
+        # New/unclassifiable names must never be blocked.
+        assert model_provider_vendor_mismatch("some-local-model", "anthropic") is None
+        assert model_provider_vendor_mismatch("gpt-5-codex", "my-proxy") is None
+        assert model_provider_vendor_mismatch(None, None) is None
+
+    # ---- create path ----
+    def _create(self, **kw):
+        return json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Vendor Check",
+                deliver="local",
+                repeat=3,
+                **kw,
+            )
+        )
+
+    def test_create_rejected_on_cross_vendor_pair(self):
+        result = self._create(model="gpt-5-codex", provider="anthropic")
+        assert result["success"] is False
+        error = result.get("error") or result.get("message") or ""
+        assert "gpt-5-codex" in error and "openai" in error
+        assert "anthropic" in error
+        assert "retrying will not help" in error
+        # And nothing was persisted.
+        listing = json.loads(cronjob(action="list"))
+        assert listing["count"] == 0
+
+    def test_create_allowed_on_matching_pair(self):
+        assert self._create(model="gpt-5-codex", provider="openai")["success"] is True
+
+    def test_create_allowed_when_model_unrecognized(self):
+        assert self._create(model="mystery-7b", provider="anthropic")["success"] is True
+
+    def test_create_allowed_when_provider_unrecognized(self):
+        assert self._create(model="gpt-5-codex", provider="my-proxy")["success"] is True
+
+    # ---- update path (EFFECTIVE post-update pair) ----
+    def _create_pinned(self):
+        created = self._create(model="gpt-5-codex", provider="openai")
+        assert created["success"] is True
+        return created["job"]["job_id"]
+
+    def test_update_rejected_when_only_provider_changes(self):
+        job_id = self._create_pinned()
+        result = json.loads(
+            cronjob(action="update", job_id=job_id, provider="anthropic")
+        )
+        assert result["success"] is False
+        error = result.get("error") or result.get("message") or ""
+        assert "gpt-5-codex" in error and "anthropic" in error
+
+    def test_update_rejected_when_only_model_changes(self):
+        job_id = self._create_pinned()
+        result = json.loads(
+            cronjob(action="update", job_id=job_id, model="claude-sonnet-4-5")
+        )
+        assert result["success"] is False
+
+    def test_update_allowed_when_pair_stays_consistent(self):
+        job_id = self._create_pinned()
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=job_id,
+                model="claude-sonnet-4-5",
+                provider="anthropic",
+            )
+        )
+        assert result["success"] is True
+
+    def test_update_of_unrelated_field_still_allowed(self):
+        job_id = self._create_pinned()
+        result = json.loads(
+            cronjob(action="update", job_id=job_id, name="Renamed Check")
+        )
+        assert result["success"] is True

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -12,7 +12,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from hermes_constants import display_hermes_home
 
@@ -628,6 +628,89 @@ def _resolve_cron_context_deliver(deliver: Optional[str]) -> Optional[str]:
     seen: set = set()
     unique = [p for p in resolved if not (p in seen or seen.add(p))]
     return ",".join(unique) if unique else None
+
+
+# --- Vendor consistency of the (model, provider) pair --------------------
+# A job pinned to e.g. model="gpt-5-codex" + provider="anthropic" is accepted
+# today, persisted, and then fails EVERY fire with an HTTP 400 along the lines
+# of "the model field names a different vendor model than this endpoint
+# serves" -- a mis-paired pin, not a transient outage, so every retry and
+# every future tick fails the same way.
+#
+# The check is mechanical: infer each side's vendor from its name prefix and
+# refuse a provably cross-vendor pair at create/update time. The prefix maps
+# are deliberately conservative -- an unrecognized model or provider name
+# yields vendor None and is NOT flagged (fail-open on unknowns). This exists to
+# catch obvious mis-pairs, not to maintain a model catalog: a brand new model
+# name simply falls through and is allowed.
+_MODEL_VENDOR_PREFIXES: Tuple[Tuple[str, str], ...] = (
+    ("claude", "anthropic"),
+    ("gpt-", "openai"),
+    ("o1", "openai"),
+    ("o3", "openai"),
+    ("o4", "openai"),
+    ("gemini", "google"),
+    ("grok", "xai"),
+    ("kimi", "moonshot"),
+    ("deepseek", "deepseek"),
+    ("llama", "meta"),
+    ("qwen", "alibaba"),
+)
+_PROVIDER_VENDOR_PREFIXES: Tuple[Tuple[str, str], ...] = (
+    ("claude", "anthropic"),
+    ("anthropic", "anthropic"),
+    ("openai", "openai"),
+    ("codex", "openai"),
+    ("gemini", "google"),
+    ("google", "google"),
+    ("grok", "xai"),
+    ("xai", "xai"),
+    ("moonshot", "moonshot"),
+    ("kimi", "moonshot"),
+    ("deepseek", "deepseek"),
+)
+
+
+def _vendor_of(name: Any, prefixes: Tuple[Tuple[str, str], ...]) -> Optional[str]:
+    text = str(name or "").strip().lower()
+    for prefix, vendor in prefixes:
+        if text.startswith(prefix):
+            return vendor
+    return None
+
+
+def model_provider_vendor_mismatch(
+    model_name: Any, provider_name: Any
+) -> Optional[Tuple[str, str]]:
+    """Return ``(model_vendor, provider_vendor)`` when the pair is provably
+    cross-vendor, else None. Unknown names on either side -> None (fail-open).
+    """
+    model_vendor = _vendor_of(model_name, _MODEL_VENDOR_PREFIXES)
+    provider_vendor = _vendor_of(provider_name, _PROVIDER_VENDOR_PREFIXES)
+    if model_vendor and provider_vendor and model_vendor != provider_vendor:
+        return (model_vendor, provider_vendor)
+    return None
+
+
+def _validate_model_provider_vendors(
+    model: Optional[Any], provider: Optional[Any]
+) -> Optional[str]:
+    """Hard-block message for a provably cross-vendor (model, provider) pin.
+
+    Returns an error string if the pair can never run, else None (including
+    whenever either side's vendor cannot be inferred).
+    """
+    mismatch = model_provider_vendor_mismatch(model, provider)
+    if not mismatch:
+        return None
+    model_vendor, provider_vendor = mismatch
+    return (
+        f"model {str(model).strip()!r} ({model_vendor}) cannot run on provider "
+        f"{str(provider).strip()!r} ({provider_vendor}) — this pair fails every "
+        "run with HTTP 400 (the model field names a different vendor model than "
+        "this endpoint serves; retrying will not help). Pick a provider that "
+        "serves this model's vendor, or clear one side of the pin."
+    )
 
 
 def _validate_cron_base_url(
@@ -1537,6 +1620,17 @@ def cronjob(
             if base_url_error:
                 return tool_error(base_url_error, success=False)
 
+            # A cross-vendor model/provider pin is dead on arrival: every fire
+            # returns HTTP 400. Refuse it before create_job() persists anything,
+            # so the caller gets one actionable error instead of a silent
+            # recurring failure. Fail-open on names we cannot classify.
+            vendor_error = _validate_model_provider_vendors(
+                _normalize_optional_job_value(model),
+                _normalize_optional_job_value(provider),
+            )
+            if vendor_error:
+                return tool_error(vendor_error, success=False)
+
             # bot-chat deliver targets are machine-local: named profiles must
             # exist here, and a bad name should fail the CREATE, not the run.
             bot_chat_error = _validate_bot_chat_deliver(_normalize_deliver_param(deliver))
@@ -1833,6 +1927,15 @@ def cronjob(
             base_url_error = _validate_cron_base_url(eff_provider, eff_base_url)
             if base_url_error:
                 return tool_error(base_url_error, success=False)
+            # Same for the model/provider vendor pair, and for the same reason
+            # it must run on the EFFECTIVE pair: an update may supply only
+            # `model` or only `provider`, so repointing an openai-pinned job at
+            # an anthropic provider is only detectable after merging this
+            # update over the stored job.
+            eff_model = updates["model"] if "model" in updates else job.get("model")
+            vendor_error = _validate_model_provider_vendors(eff_model, eff_provider)
+            if vendor_error:
+                return tool_error(vendor_error, success=False)
             if script is not None:
                 # Pass empty string to clear an existing script
                 if script:


### PR DESCRIPTION
## Problem

A cron job can be pinned to a `model` and a `provider` from **different vendors** — e.g. `model='gpt-5-codex'` + `provider='anthropic'`. `cronjob(action='create')` accepts it, `create_job()` persists it, and then every single fire returns an opaque HTTP 400 ("the model field names a different vendor model than this endpoint serves").

This is not a transient outage. Every retry and every future tick fails identically, so the job is **dead on arrival** — and because the failure lives in per-run delivery errors rather than at the call site, it's typically only noticed after the job has already burned a string of scheduled runs. Catching the pair at create/update time turns a silent recurring cron failure into one immediately actionable error.

## Fix

Refuse a provably cross-vendor pair at admission time, next to the existing `_validate_cron_base_url` guard in `tools/cronjob_tools.py`:

- **`model_provider_vendor_mismatch(model, provider)`** — infers each side's vendor from a conservative name-prefix map (`_MODEL_VENDOR_PREFIXES` / `_PROVIDER_VENDOR_PREFIXES`) and returns `(model_vendor, provider_vendor)` only when both are known and differ.
- **Fail-open by design.** An unrecognized model or provider name yields vendor `None` and is **not** flagged. This rule exists to catch obvious mis-pairs, not to maintain a model catalog — a brand-new model name simply falls through and is allowed. That's the property that keeps this from becoming a maintenance burden as vendors ship names.
- **CREATE:** checked before `create_job_with_scheduler_registration()` persists anything, so a rejected pair leaves no job behind.
- **UPDATE:** checked against the **effective post-update pair**, reusing the same merged `eff_provider` the `base_url` re-validation already computes. An update may supply only `model` or only `provider`, so repointing an openai-pinned job at an anthropic provider is only detectable after merging the update over the stored job.

The error names both inferred vendors and states explicitly that retrying will not help:

```
model 'gpt-5-codex' (openai) cannot run on provider 'anthropic' (anthropic) — this pair
fails every run with HTTP 400 (the model field names a different vendor model than this
endpoint serves; retrying will not help). Pick a provider that serves this model's vendor,
or clear one side of the pin.
```

## Tests

New `TestModelProviderVendorConsistency` in `tests/tools/test_cronjob_tools.py`, following the file's existing `monkeypatch.setattr("cron.jobs.CRON_DIR", ...)` fixture convention:

- predicate: mismatch detected; matching pair not flagged; **fail-open** on unrecognized model, unrecognized provider, and `None`/`None`
- create rejected on a cross-vendor pair, error names both vendors, and `cronjob(action='list')` confirms **nothing was persisted**
- create allowed on a matching pair, and allowed when either side is unrecognized
- update rejected when **only the provider** changes, and when **only the model** changes
- update allowed when the pair stays consistent, and for unrelated fields (rename)

**Verification on this base:**
- `pytest tests/tools/test_cronjob_tools.py tests/cron` → **1106 passed, 10 skipped** on the branch.
- **RED-proved:** with the two hook call sites removed (helpers left in place), exactly the 3 rejection tests fail (`create_rejected_on_cross_vendor_pair`, `update_rejected_when_only_provider_changes`, `update_rejected_when_only_model_changes`); restoring them returns green. The tests fail for the reason they claim.

## Notes

- Ports a fix from our fork ([ANG-Ventures/hermes-agent#641](https://github.com/ANG-Ventures/hermes-agent/pull/641)), re-authored against this tree rather than cherry-picked. Adaptation: the fork's create path builds a preview-job dict for a shared admission-gate helper this tree doesn't have, so the checks are hooked directly into `cronjob()`'s create/update branches beside the existing `base_url` validation. The fork also handles a `{"model": ..., "provider": ...}` dict shape for `model`; here `model` is normalized to a plain string by `_normalize_optional_job_value`, so only the string shape is handled.
- No new config knobs, no new env vars, no new tools — two guard calls plus a pure predicate.
