### PR TITLE
fix(desktop): keep project previews visible on drill-in

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -161,6 +161,7 @@ import {
   ProjectBackRow,
   ProjectMenu,
   projectTreeCwd,
+  reconcileEnteredProjectSessions,
   sessionRecency as sessionTime,
   type SidebarProjectTree,
   type SidebarSessionGroup,
@@ -1006,14 +1007,22 @@ export function ChatSidebar({
     )
   }, [overviewEnteredProject, enteredProjectTree, orderRepos, isHiddenFromProjects])
 
+  const enteredProjectOverlaySessions = useMemo(
+    () => reconcileEnteredProjectSessions(agentSessions, overviewEnteredProject?.previewSessions),
+    [agentSessions, overviewEnteredProject?.previewSessions]
+  )
+
   // Overlay live `$sessions` onto the entered project so a just-created session
   // (which the backend snapshot hasn't folded in yet) counts as content and
-  // renders immediately — same optimistic layer as the overview previews. The
-  // backend now seeds each project folder as an (empty) repo, so the overlay
-  // always has a lane to place a new in-project session into.
+  // renders immediately. Also carry over the overview's current preview rows:
+  // its project tree and the separately hydrated drill-in can resolve at
+  // different times, but a row visible in the overview must not disappear on
+  // entry. The backend seeds each project folder as an (empty) repo, so the
+  // overlay always has a lane to place a missing in-project session into.
   const enteredProjectContent = useMemo(
-    () => (enteredProject ? overlayLiveLanes(enteredProject, agentSessions, removedSessionIds) : undefined),
-    [enteredProject, agentSessions, removedSessionIds]
+    () =>
+      enteredProject ? overlayLiveLanes(enteredProject, enteredProjectOverlaySessions, removedSessionIds) : undefined,
+    [enteredProject, enteredProjectOverlaySessions, removedSessionIds]
   )
 
   const scopedRepoPaths = useMemo(
@@ -1804,7 +1813,7 @@ export function ChatSidebar({
                     ) : undefined
                   ) : undefined
                 }
-                liveSessions={inProject ? agentSessions : undefined}
+                liveSessions={inProject ? enteredProjectOverlaySessions : undefined}
                 manualOrderIds={agentOrderManual ? agentOrderIds : sortOrderIds}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -15,6 +15,7 @@ export {
   liveSessionProjectId,
   overlayLiveLanes,
   overlayLivePreviews,
+  reconcileEnteredProjectSessions,
   sessionRecency,
   type SidebarProjectTree,
   type SidebarSessionGroup,

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -13,6 +13,7 @@ import {
   NO_PROJECT_ID,
   overlayLiveLanes,
   overlayLivePreviews,
+  reconcileEnteredProjectSessions,
   sessionProjectColor,
   type SidebarProjectTree,
   type SidebarSessionGroup,
@@ -613,6 +614,59 @@ describe('sessionProjectColor', () => {
 })
 
 describe('overlayLiveLanes', () => {
+  it('keeps an overview preview visible when the hydrated drill-in is stale', () => {
+    const staleHistory = makeCwdSession('/www/app', {
+      id: 'stale-history',
+      git_branch: 'main',
+      last_active: 10
+    })
+
+    const currentPreview = makeCwdSession('/www/app', {
+      id: 'current-preview',
+      git_branch: 'main',
+      last_active: 20
+    })
+
+    const project = projectNode({
+      id: '/www/app',
+      isAuto: true,
+      previewSessions: [currentPreview],
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 1,
+          groups: [
+            lane({
+              id: '/www/app::branch::main',
+              label: 'main',
+              isMain: true,
+              path: '/www/app',
+              sessions: [staleHistory]
+            })
+          ]
+        }
+      ]
+    })
+
+    const overlaySessions = reconcileEnteredProjectSessions([], project.previewSessions)
+    const overlaid = overlayLiveLanes(project, overlaySessions)
+
+    expect(overlaid.repos[0].groups[0].sessions.map(session => session.id)).toEqual([
+      'current-preview',
+      'stale-history'
+    ])
+  })
+
+  it('keeps the live row when it is also present in the overview preview', () => {
+    const live = makeCwdSession('/www/app', { id: 'same', title: 'live title' })
+    const preview = makeCwdSession('/www/app', { id: 'same', title: 'preview title' })
+    const reconciled = reconcileEnteredProjectSessions([live], [preview])
+
+    expect(reconciled).toEqual([live])
+  })
+
   it('injects a live session into the matching main lane instantly', () => {
     const project = projectNode({
       id: '/www/app',

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -741,6 +741,26 @@ export function overlayLiveLanes(
   return { ...project, repos, sessionCount: repos.reduce((n, repo) => n + repo.sessionCount, 0) }
 }
 
+/**
+ * Keep the project drill-in consistent with the overview while its separate
+ * full-tree request is stale or still loading. The live cache remains the
+ * freshest copy when both sources contain a row; overview previews only fill
+ * sessions that are missing from that cache.
+ */
+export function reconcileEnteredProjectSessions(
+  live: SessionInfo[],
+  previewSessions: SessionInfo[] | undefined
+): SessionInfo[] {
+  if (!previewSessions?.length) {
+    return live
+  }
+
+  const liveIds = new Set(live.map(session => session.id))
+  const missingPreviews = previewSessions.filter(session => !liveIds.has(session.id))
+
+  return missingPreviews.length ? [...live, ...missingPreviews] : live
+}
+
 interface PreviewOverlayOptions {
   removed?: ReadonlySet<string>
   /** The active sort key as an id order; recency when empty. */


### PR DESCRIPTION
## What does this PR do?

Keeps recent sessions visible when a user opens a project from the Desktop sidebar.

The overview and project drill-in are loaded independently. When the full drill-in tree was stale or still loading, a recent session could appear in the project preview and then disappear after the project was opened if that session was also outside the renderer's current global session window.

This change reconciles the overview's existing preview rows into the drill-in overlay. The global live-session cache still wins for duplicate IDs, while preview rows fill only sessions missing from that cache. The hydrated project tree remains the source for full history and lane structure.

## Related Issue

No linked GitHub issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Reconcile current project preview rows with the live session overlay used by project drill-in.
- Reuse the reconciled rows for the per-repository lane overlay.
- Add a behavioral regression for a current overview preview paired with stale hydrated history.
- Cover duplicate IDs so the live session row remains authoritative.

## How to Test

1. Open Desktop with project grouping enabled and a project whose overview preview includes a recent session outside the current global session window.
2. Open that project while its separately hydrated project tree contains only older history.
3. Confirm the recent preview session remains visible in the correct project lane and is not duplicated when the live cache also contains it.

Automated verification:

- `vitest run --project ui src/app/chat/sidebar/projects/workspace-groups.test.ts` (64 passed)
- Renderer TypeScript check: `tsc -p . --noEmit`
- ESLint on the four changed Desktop files
- Prettier check on the four changed Desktop files
- `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Python tests are N/A for this Desktop-only TypeScript change; the focused Vitest regression and renderer typecheck pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, focused automated Desktop checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure renderer reconciliation, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused regression result: 1 test file passed, 64 tests passed.
