### PR TITLE
feat(tts): add Groq Orpheus as a first-class TTS provider

### DIFF
--- a/agent/tts_provider.py
+++ b/agent/tts_provider.py
@@ -77,7 +77,8 @@ class TTSProvider(abc.ABC):
         Lowercase, no spaces. Examples: ``cartesia``, ``fishaudio``,
         ``deepgram``. Names that collide with a built-in TTS provider
         (``edge``, ``openai``, ``elevenlabs``, ``minimax``, ``gemini``,
-        ``mistral``, ``xai``, ``piper``, ``kittentts``, ``neutts``) are
+        ``mistral``, ``xai``, ``piper``, ``kittentts``, ``neutts``,
+        ``deepinfra``, ``groq``) are
         rejected at registration time.
         """
 

--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -58,6 +58,7 @@ _BUILTIN_NAMES = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "groq",
 })
 
 

--- a/docs/streaming-tts.md
+++ b/docs/streaming-tts.md
@@ -57,7 +57,7 @@ tts:
 | openai      | chunked HTTP (`with_streaming_response`, `pcm`) | yes | `tts.openai.api_key` → env → managed gateway |
 | gemini      | SSE (`streamGenerateContent?alt=sse`) | yes         | `GEMINI_API_KEY` / `GOOGLE_API_KEY` |
 | xai         | WebSocket (`wss://api.x.ai/v1/tts`)   | yes         | xAI OAuth or `XAI_API_KEY` |
-| edge, piper, kitten, neutts, mistral, minimax, deepinfra, … | — | no (per-sentence sync fallback) | as usual |
+| edge, piper, kitten, neutts, mistral, minimax, deepinfra, groq, … | — | no (per-sentence sync fallback) | as usual |
 
 All credential lookups go through `resolve_provider_secret()`
 (config > env/.env > credential pool) — never bare env reads. Streamed bodies

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1781,7 +1781,7 @@ DEFAULT_CONFIG = {
     # Gemini 32000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
         # Set explicitly to pin a backend:
-        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "groq" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "provider": "edge",
         "edge": {
             "voice": "en-US-AriaNeural",
@@ -1855,6 +1855,11 @@ DEFAULT_CONFIG = {
             "model": "",  # empty = first tts-tagged model from the live catalog
             "voice": "default",
             # "base_url": "",  # override DEEPINFRA_BASE_URL for TTS only
+        },
+        "groq": {
+            "model": "canopylabs/orpheus-v1-english",
+            "voice": "autumn",
+            # "base_url": "",  # override GROQ_BASE_URL for TTS only
         },
     },
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -411,6 +411,15 @@ TOOL_CATEGORIES = {
                 ],
                 "tts_provider": "deepinfra",
             },
+            {
+                "name": "Groq Orpheus TTS",
+                "badge": "paid",
+                "tag": "Canopy Labs Orpheus via GROQ_API_KEY (same key as Groq STT)",
+                "env_vars": [
+                    {"key": "GROQ_API_KEY", "prompt": "Groq API key", "url": "https://console.groq.com/keys"},
+                ],
+                "tts_provider": "groq",
+            },
         ],
     },
     "stt": {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1246,7 +1246,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"],
+        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper", "deepinfra", "groq"],
     },
     "stt.provider": {
         "type": "select",

--- a/tests/tools/test_tts_groq.py
+++ b/tests/tools/test_tts_groq.py
@@ -1,0 +1,250 @@
+"""Offline tests for the Groq Orpheus TTS provider.
+
+These tests never hit the network. An optional live smoke is skipped
+unless GROQ_API_KEY is already present in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.tts_tool import (
+    BUILTIN_TTS_PROVIDERS,
+    DEFAULT_GROQ_TTS_BASE_URL,
+    DEFAULT_GROQ_TTS_MODEL,
+    DEFAULT_GROQ_TTS_VOICE,
+    _bounded_provider_error,
+    _generate_groq_tts,
+    _groq_tts_response_format,
+)
+
+
+def test_groq_is_builtin_tts_provider():
+    assert "groq" in BUILTIN_TTS_PROVIDERS
+
+
+def test_requirements_follow_explicit_groq_provider(monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setattr(
+        tts_tool,
+        "_load_tts_config",
+        lambda: {"provider": "groq", "groq": {}},
+    )
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object)
+    monkeypatch.setenv("GROQ_API_KEY", "gsk_test")
+    assert tts_tool.check_tts_requirements() is True
+
+
+def test_requirements_fail_without_groq_key(monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setattr(
+        tts_tool,
+        "_load_tts_config",
+        lambda: {"provider": "groq", "groq": {}},
+    )
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object)
+    monkeypatch.setattr(tts_tool, "_resolve_provider_key", lambda *a, **k: "")
+    assert tts_tool.check_tts_requirements() is False
+
+
+def test_unselected_groq_credentials_do_not_expose_edge_tool(monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", MagicMock(side_effect=ImportError))
+    monkeypatch.setenv("GROQ_API_KEY", "unselected-key")
+    assert tts_tool.check_tts_requirements() is False
+
+
+def test_missing_key_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "tools.tts_tool._resolve_provider_key",
+        lambda *a, **k: "",
+    )
+    with pytest.raises(ValueError, match="GROQ_API_KEY"):
+        _generate_groq_tts("hi", str(tmp_path / "out.mp3"), {})
+
+
+def test_forwards_model_and_voice_exactly(monkeypatch, tmp_path):
+    captured = {}
+
+    class _Speech:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            response = MagicMock()
+            response.stream_to_file.side_effect = (
+                lambda path: open(path, "wb").write(b"ID3fake")
+            )
+            return response
+
+    class _Client:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+            self.audio = MagicMock()
+            self.audio.speech = _Speech()
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr("tools.tts_tool._resolve_provider_key", lambda *a, **k: "gsk_live")
+    monkeypatch.setattr("tools.tts_tool._import_openai_client", lambda: _Client)
+
+    out = tmp_path / "out.mp3"
+    cfg = {
+        "groq": {
+            "model": "canopylabs/orpheus-arabic-saudi",
+            "voice": "hannah",
+            "base_url": "https://example.test/openai/v1/",
+        }
+    }
+    assert _generate_groq_tts("hello", str(out), cfg) == str(out)
+    assert captured["model"] == "canopylabs/orpheus-arabic-saudi"
+    assert captured["voice"] == "hannah"
+    assert captured["input"] == "hello"
+    assert captured["response_format"] == "mp3"
+    assert captured["client"]["api_key"] == "gsk_live"
+    assert captured["client"]["base_url"] == "https://example.test/openai/v1"
+    assert captured.get("closed") is True
+    assert out.read_bytes() == b"ID3fake"
+
+
+def test_defaults_when_section_missing(monkeypatch, tmp_path):
+    captured = {}
+
+    class _Speech:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            response = MagicMock()
+            response.stream_to_file.side_effect = (
+                lambda path: open(path, "wb").write(b"RIFF")
+            )
+            return response
+
+    class _Client:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+            self.audio = MagicMock()
+            self.audio.speech = _Speech()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("tools.tts_tool._resolve_provider_key", lambda *a, **k: "gsk")
+    monkeypatch.setattr("tools.tts_tool._import_openai_client", lambda: _Client)
+    monkeypatch.delenv("GROQ_BASE_URL", raising=False)
+
+    out = tmp_path / "out.wav"
+    _generate_groq_tts("hi", str(out), {"groq": None})
+    assert captured["model"] == DEFAULT_GROQ_TTS_MODEL
+    assert captured["voice"] == DEFAULT_GROQ_TTS_VOICE
+    assert captured["response_format"] == "wav"
+    assert captured["client"]["base_url"] == DEFAULT_GROQ_TTS_BASE_URL
+
+
+def test_empty_body_fails_closed(monkeypatch, tmp_path):
+    class _Speech:
+        def create(self, **kwargs):
+            response = MagicMock()
+            response.stream_to_file = None
+            response.content = b""
+            return response
+
+    class _Client:
+        def __init__(self, **kwargs):
+            self.audio = MagicMock()
+            self.audio.speech = _Speech()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("tools.tts_tool._resolve_provider_key", lambda *a, **k: "gsk")
+    monkeypatch.setattr("tools.tts_tool._import_openai_client", lambda: _Client)
+    with pytest.raises(ValueError, match="empty audio body"):
+        _generate_groq_tts("hi", str(tmp_path / "out.mp3"), {})
+
+
+def test_provider_errors_are_redacted(monkeypatch, tmp_path):
+    class _Speech:
+        def create(self, **kwargs):
+            raise RuntimeError(
+                "POST https://api.groq.com/openai/v1/audio/speech failed "
+                "Authorization: Bearer gsk_SUPERSECRETTOKEN status 401"
+            )
+
+    class _Client:
+        def __init__(self, **kwargs):
+            self.audio = MagicMock()
+            self.audio.speech = _Speech()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("tools.tts_tool._resolve_provider_key", lambda *a, **k: "gsk")
+    monkeypatch.setattr("tools.tts_tool._import_openai_client", lambda: _Client)
+    with pytest.raises(ValueError) as excinfo:
+        _generate_groq_tts("hi", str(tmp_path / "out.mp3"), {})
+    msg = str(excinfo.value)
+    assert "gsk_SUPERSECRETTOKEN" not in msg
+    assert "https://api.groq.com" not in msg
+    assert "<redacted>" in msg
+    assert "<url>" in msg
+
+
+def test_timeout_is_bounded(monkeypatch, tmp_path):
+    class _Speech:
+        def create(self, **kwargs):
+            raise TimeoutError("timed out after 60s contacting https://api.groq.com/x")
+
+    class _Client:
+        def __init__(self, **kwargs):
+            self.audio = MagicMock()
+            self.audio.speech = _Speech()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("tools.tts_tool._resolve_provider_key", lambda *a, **k: "gsk")
+    monkeypatch.setattr("tools.tts_tool._import_openai_client", lambda: _Client)
+    with pytest.raises(ValueError, match="Groq TTS request failed"):
+        _generate_groq_tts("hi", str(tmp_path / "out.mp3"), {})
+
+
+def test_response_format_mapping():
+    assert _groq_tts_response_format("a.mp3") == "mp3"
+    assert _groq_tts_response_format("a.wav") == "wav"
+    assert _groq_tts_response_format("a.ogg") == "ogg"
+    assert _groq_tts_response_format("a.opus") == "ogg"
+    assert _groq_tts_response_format("a.flac") == "flac"
+    assert _groq_tts_response_format("a.bin") == "mp3"
+
+
+def test_bounded_error_truncates():
+    msg = _bounded_provider_error(RuntimeError("x" * 500), limit=40)
+    assert len(msg) <= 40
+
+
+def test_sabotage_builtin_name_must_stay():
+    """Removal of groq from the built-in set is a regression."""
+    from agent.tts_registry import _BUILTIN_NAMES
+
+    assert "groq" in _BUILTIN_NAMES
+    assert "groq" in BUILTIN_TTS_PROVIDERS
+
+
+@pytest.mark.skipif(
+    not os.environ.get("GROQ_API_KEY"),
+    reason="optional live smoke; skipped without existing GROQ_API_KEY",
+)
+def test_optional_live_smoke(tmp_path):
+    out = tmp_path / "live.mp3"
+    path = _generate_groq_tts(
+        "Hermes Groq TTS smoke.",
+        str(out),
+        {"groq": {"model": DEFAULT_GROQ_TTS_MODEL, "voice": DEFAULT_GROQ_TTS_VOICE}},
+    )
+    assert os.path.getsize(path) > 0

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -254,6 +254,11 @@ DEFAULT_GEMINI_AUDIO_TAGS = False
 GEMINI_AUDIO_TAG_REWRITE_TASK = "tts_audio_tags"
 # Base URL now resolved via hermes_cli.models.deepinfra_base_url (shared).
 DEFAULT_DEEPINFRA_TTS_VOICE = "default"
+DEFAULT_GROQ_TTS_MODEL = "canopylabs/orpheus-v1-english"
+DEFAULT_GROQ_TTS_VOICE = "autumn"
+DEFAULT_GROQ_TTS_BASE_URL = "https://api.groq.com/openai/v1"
+GROQ_TTS_RESPONSE_FORMATS = frozenset({"flac", "mp3", "mulaw", "ogg", "wav"})
+GROQ_TTS_REQUEST_TIMEOUT_SECONDS = 60.0
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -285,6 +290,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "groq": 10000,        # Groq Orpheus; no published hard cap — conservative
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -789,6 +795,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "groq",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -1982,6 +1989,108 @@ def _generate_deepinfra_tts(text: str, output_path: str, tts_config: Dict[str, A
         voice=di_config.get("voice", DEFAULT_DEEPINFRA_TTS_VOICE),
         speed=float(di_config.get("speed", tts_config.get("speed", 1.0))),
     )
+
+
+def _bounded_provider_error(exc: BaseException, *, limit: int = 240) -> str:
+    """Return a short diagnostic with URLs and token-shaped secrets stripped."""
+    raw = str(exc) or exc.__class__.__name__
+    raw = re.sub(r"https?://\S+", "<url>", raw)
+    raw = re.sub(r"(?i)(bearer\s+|gsk_|sk-)[A-Za-z0-9._\-]+", "<redacted>", raw)
+    raw = re.sub(r"\s+", " ", raw).strip()
+    if len(raw) > limit:
+        return raw[: limit - 1] + "…"
+    return raw or "provider error"
+
+
+def _groq_tts_response_format(output_path: str) -> str:
+    """Map an output path to a Groq-supported speech response_format."""
+    ext = Path(output_path).suffix.lower().lstrip(".")
+    if ext == "opus":
+        return "ogg"
+    if ext in GROQ_TTS_RESPONSE_FORMATS:
+        return ext
+    return "mp3"
+
+
+def _groq_tts_base_url(section: Dict[str, Any]) -> str:
+    configured = section.get("base_url") if isinstance(section, dict) else None
+    if isinstance(configured, str) and configured.strip():
+        return configured.strip().rstrip("/")
+    env_url = (get_env_value("GROQ_BASE_URL") or "").strip()
+    if env_url:
+        return env_url.rstrip("/")
+    return DEFAULT_GROQ_TTS_BASE_URL
+
+
+def _generate_groq_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Synthesize via Groq Orpheus (OpenAI-compatible /audio/speech).
+
+    Groq TTS is a cascaded speech shell (STT and TTS stay independently
+    selectable). It is not a native bidirectional speech session.
+    Credentials reuse ``GROQ_API_KEY``; model/voice are forwarded exactly
+    from ``tts.groq`` (defaults only when unset).
+    """
+    api_key = _resolve_provider_key("GROQ_API_KEY", "groq")
+    if not api_key:
+        raise ValueError(
+            "GROQ_API_KEY not set. Run `hermes setup` to configure, "
+            "or set the env var directly. Get a key at https://console.groq.com/keys"
+        )
+
+    groq_config = tts_config.get("groq") if isinstance(tts_config, dict) else None
+    if not isinstance(groq_config, dict):
+        groq_config = {}
+
+    model = groq_config.get("model")
+    if not isinstance(model, str) or not model.strip():
+        model = DEFAULT_GROQ_TTS_MODEL
+    else:
+        model = model.strip()
+
+    voice = groq_config.get("voice")
+    if not isinstance(voice, str) or not voice.strip():
+        voice = DEFAULT_GROQ_TTS_VOICE
+    else:
+        voice = voice.strip()
+
+    response_format = _groq_tts_response_format(output_path)
+    OpenAIClient = _import_openai_client()
+    client = OpenAIClient(
+        api_key=api_key,
+        base_url=_groq_tts_base_url(groq_config),
+        timeout=GROQ_TTS_REQUEST_TIMEOUT_SECONDS,
+    )
+    try:
+        try:
+            create_kwargs: Dict[str, Any] = {
+                "model": model,
+                "voice": voice,
+                "input": text,
+                "response_format": response_format,
+            }
+            response = client.audio.speech.create(**create_kwargs)
+            writer = getattr(response, "stream_to_file", None)
+            if callable(writer):
+                writer(output_path)
+            else:
+                body = getattr(response, "content", None)
+                if not body:
+                    raise ValueError("Groq TTS returned an empty audio body")
+                Path(output_path).write_bytes(body)
+        except ValueError:
+            raise
+        except Exception as exc:
+            raise ValueError(
+                f"Groq TTS request failed: {_bounded_provider_error(exc)}"
+            ) from None
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+
+    if not os.path.exists(output_path) or os.path.getsize(output_path) == 0:
+        raise ValueError("Groq TTS produced no audio")
+    return output_path
 
 
 # ===========================================================================
@@ -3250,7 +3359,7 @@ def _text_to_speech_single(
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini", "groq"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -3316,6 +3425,17 @@ def _text_to_speech_single(
                 }, ensure_ascii=False)
             logger.info("Generating speech with DeepInfra TTS...")
             _generate_deepinfra_tts(text, file_str, tts_config)
+
+        elif provider == "groq":
+            try:
+                _import_openai_client()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "Groq TTS uses the 'openai' SDK but it isn't installed."
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Groq Orpheus TTS...")
+            _generate_groq_tts(text, file_str, tts_config)
 
         elif provider == "minimax":
             logger.info("Generating speech with MiniMax TTS...")
@@ -3457,7 +3577,7 @@ def _text_to_speech_single(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
+        elif provider in {"elevenlabs", "openai", "mistral", "gemini", "groq"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)
@@ -3606,7 +3726,7 @@ def text_to_speech_tool(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             base_path = out_dir / f"tts_{timestamp}.{fmt}"
-        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini", "groq"}:
             base_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             base_path = out_dir / f"tts_{timestamp}.mp3"
@@ -3747,6 +3867,10 @@ def check_tts_requirements() -> bool:
         if importlib.util.find_spec("openai") is None:
             return False
         return bool(_resolve_provider_key("DEEPINFRA_API_KEY", "deepinfra"))
+    if provider == "groq":
+        if importlib.util.find_spec("openai") is None:
+            return False
+        return bool(_resolve_provider_key("GROQ_API_KEY", "groq"))
     if provider == "minimax":
         try:
             _resolve_minimax_tts_runtime(tts_config)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1800,7 +1800,7 @@ The same gate also enables **result-reference stubbing**: when a re-issued ident
 
 ```yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper" | "deepinfra"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper" | "deepinfra" | "groq"
   speed: 1.0                    # Global speed multiplier (fallback for all providers)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -1830,6 +1830,10 @@ tts:
     sample_rate: 24000
     bit_rate: 128000            # MP3 bitrate
     # base_url: "https://api.x.ai/v1"
+  groq:
+    model: "canopylabs/orpheus-v1-english"  # or canopylabs/orpheus-arabic-saudi
+    voice: "autumn"
+    # base_url: "https://api.groq.com/openai/v1"  # override GROQ_BASE_URL
   neutts:
     ref_audio: ''
     ref_text: ''
@@ -1838,6 +1842,8 @@ tts:
 ```
 
 This controls both the `text_to_speech` tool and spoken replies in voice mode (`/voice tts` in the CLI or messaging gateway).
+
+**Groq.** `tts.provider: groq` uses Canopy Labs Orpheus through Groq's OpenAI-compatible `/audio/speech` endpoint and reuses `GROQ_API_KEY` (the same secret as Groq Whisper STT). STT and TTS stay independently selectable. Groq Whisper transcription is a finalized file/URL job — it does not itself provide partial ASR or a native bidirectional speech session. Pairing Groq STT with Groq TTS is a fast cascaded shell, not duplex.
 
 **Speed fallback hierarchy:** provider-specific speed (e.g. `tts.edge.speed`) → global `tts.speed` → `1.0` default. Set the global `tts.speed` to apply a uniform speed across all providers, or override per-provider for fine-grained control.
 


### PR DESCRIPTION
## Summary

Adds Groq Orpheus as a first-class `tts.provider: groq` through the existing TTS abstraction (Groq OpenAI-compatible `/audio/speech`, Canopy Labs Orpheus). Reuses `GROQ_API_KEY`. This is cascaded TTS only, not native duplex, STT, Voice Duplex UI, or #95147.

Closes #98053

## Test evidence

Independent review of `feat/groq-orpheus-tts` @ `548df5dcc037e85d8ed47de57ddb75cce3661af7` (base `origin/main` `4209d371aa1bb8840ce8447555bdd863a1a96c38`):

```
pytest tests/tools/test_tts_groq.py
13 passed, 1 skipped (live smoke; skipped without live Groq credentials)
```

No STT/#95147/UI claims. Live smoke was not run in that independent session.

## AI assistance

This change was implemented and reviewed with AI assistance (Hermes agents). Humans remain responsible for merge.

## Notes

Exact reviewed bytes published unchanged and marked ready following author approval. Upstream `main` was re-fetched at publish time and matched the reviewed base (`4209d371aa1bb8840ce8447555bdd863a1a96c38`); no rebase.

