### PR TITLE
fix(gateway): fence orphan timers and reconnect interrupt races

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5439,7 +5439,7 @@ def test_resume_rebind_cancels_pending_ws_orphan_reap(monkeypatch):
 
 
 def test_claim_or_reuse_live_winner_cancels_pending_reap(monkeypatch):
-    """A resume that reuses the live winner cancels the winner's pending reap."""
+    """The winner's pending reap is cancelled only once guarded reuse is accepted."""
     cancelled = []
 
     class _Timer:
@@ -5472,6 +5472,17 @@ def test_claim_or_reuse_live_winner_cancels_pending_reap(monkeypatch):
         )
 
         assert live == ("winner-sid", winner)
+        assert "winner-sid" in server._pending_ws_reaps
+        assert cancelled == []
+        assert winner["transport"] is server._detached_ws_transport
+
+        transport = object()
+        monkeypatch.setattr(server, "current_transport", lambda: transport)
+        ctx = server._Resume(1, {"omit_messages": True}, "stored-claim")
+        response = server._resume_reuse_live(ctx, *live)
+
+        assert response["result"]["session_id"] == "winner-sid"
+        assert winner["transport"] is transport
         assert "winner-sid" not in server._pending_ws_reaps
         assert len(cancelled) == 1
     finally:

--- a/tests/tui_gateway/test_ws_orphan_races.py
+++ b/tests/tui_gateway/test_ws_orphan_races.py
@@ -1,0 +1,159 @@
+"""Orphan callbacks own only their detachment, never a later reconnect."""
+
+from contextlib import nullcontext
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.mark.parametrize("phase", ["before_callback", "before_continuation", "before_initial_timer", "cold_resume_claim"])
+def test_obsolete_orphan_cannot_replace_new_detachment(monkeypatch, phase):
+    timers = []
+
+    class Timer:
+        def __init__(self, delay, callback):
+            self.callback = callback
+            timers.append(self)
+
+        def start(self):
+            pass
+
+        def cancel(self):
+            pass  # A dispatched callback can still execute after cancel().
+
+    sid = "generation-race"
+    session = dict(transport=server._detached_ws_transport, running=True,
+                   agent=SimpleNamespace(get_activity_summary=lambda: {"seconds_since_activity": 0}))
+    monkeypatch.setattr(server, "_sessions", {sid: session})
+    monkeypatch.setattr(server, "_pending_ws_reaps", {})
+    monkeypatch.setattr(server.threading, "Timer", Timer)
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20)
+    monkeypatch.setattr(server, "_WS_ORPHAN_ACTIVITY_STALE_S", 600)
+    monkeypatch.setattr(server, "_session_has_active_delegations", lambda *a: False)
+    if phase == "before_initial_timer":
+        transport = object()
+        session["transport"] = transport
+        newest = None
+
+        class DisconnectLock:
+            def __enter__(self):
+                pass
+
+            def __exit__(self, *args):
+                # A new client reconnects and drops as the old disconnect
+                # releases its claim, before any out-of-lock scheduling.
+                nonlocal newest
+                server._cancel_ws_orphan_reap(sid)
+                server._schedule_ws_orphan_reap(sid)
+                newest = timers[-1]
+
+        monkeypatch.setattr(server, "_session_resume_lock", DisconnectLock())
+        assert server._close_sessions_for_transport(transport) == (0, 1)
+        assert server._pending_ws_reaps[sid] is newest
+        return
+    server._schedule_ws_orphan_reap(sid)
+    old = timers[-1]
+    if phase == "cold_resume_claim":
+        # A cold resume missed the live lookup before a concurrent resume won.
+        # Its claim discovers that winner while orphan interrupt I/O is in flight.
+        session["session_key"] = sid
+        monkeypatch.setattr(server, "_WS_ORPHAN_ACTIVITY_STALE_S", 0)
+        replies = []
+
+        def resume_during_interrupt(*a, **kw):
+            ctx = server._Resume(1, {}, sid)
+            replies.append(ctx.claim("unused", {}))
+
+        monkeypatch.setattr(server, "_interrupt_session_turn", resume_during_interrupt)
+        old.callback()
+        assert replies[0]["error"]["code"] == 4009
+        assert session["transport"] is server._detached_ws_transport
+        assert session["_client_gone_interrupt_requested"]
+        assert len(timers) == 2
+        assert server._pending_ws_reaps[sid] is timers[-1]
+        return
+
+    def redetach():
+        server._cancel_ws_orphan_reap(sid)
+        session["transport"] = server._detached_ws_transport
+        server._schedule_ws_orphan_reap(sid)
+        return timers[-1]
+
+    if phase == "before_callback":
+        newest = redetach()
+    else:
+        # Interrupt I/O runs outside the resume lock. A reconnect/redetach
+        # can win before the old callback registers its next poll.
+        monkeypatch.setattr(server, "_WS_ORPHAN_ACTIVITY_STALE_S", 0)
+        def interrupt(*a, **kw):
+            nonlocal newest
+            session.pop("_client_gone_interrupt_requested", None)
+            newest = redetach()
+        monkeypatch.setattr(server, "_interrupt_session_turn", interrupt)
+        newest = None
+    old.callback()
+    assert server._pending_ws_reaps[sid] is newest
+    assert timers == [old, newest]
+
+
+@pytest.mark.parametrize("path", ["unpersisted", "reuse", "eager", "activate", "prompt"])
+@pytest.mark.parametrize("claim", ["already_claimed", "wins_lock", "retired"])
+def test_reconnect_cannot_cross_orphan_interrupt_claim(monkeypatch, path, claim):
+    sid = "interrupt-race"
+    session = dict(transport=server._detached_ws_transport, running=True,
+                   history_lock=threading.Lock(), history=[], session_key="stored",
+                   agent=SimpleNamespace(model="test"), queued_prompt=None)
+    session["_client_gone_interrupt_requested"] = claim == "already_claimed"
+    monkeypatch.setattr(server, "_sessions", {sid: session})
+    monkeypatch.setattr(server, "_pending_ws_reaps", {sid: Mock()})
+    transport = object()
+    monkeypatch.setattr(server, "current_transport", lambda: transport)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test")
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a: None)
+    monkeypatch.setattr(server, "_legacy_group_fence_error", lambda *a: None)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a: False)
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda: {})
+    monkeypatch.setattr(server, "_handle_busy_submit", lambda *a, **kw: {"result": {"queued": True}})
+    monkeypatch.setattr(server, "_sess", lambda *a: (session, None))
+
+    class ResumeLock:
+        held = False
+
+        def __enter__(self):
+            assert not self.held, "resume path recursively acquired a non-reentrant lock"
+            self.held = True
+            if claim == "wins_lock":
+                session["_client_gone_interrupt_requested"] = True
+            elif claim == "retired":
+                server._sessions.pop(sid, None)
+
+        def __exit__(self, *args):
+            self.held = False
+
+    monkeypatch.setattr(server, "_session_resume_lock", ResumeLock())
+    ctx = SimpleNamespace(rid=1, owns_db=False, db=None, cols=80, omit_messages=True,
+                          defer_history=False, target="stored", profile=None,
+                          profile_home=None, profile_resume_cwd=None, found={},
+                          messages=lambda history: [], mint=lambda: ("unused", "tui", "."),
+                          restore=lambda: ([], [], []), display_prefix=lambda: [])
+    if path == "eager":
+        monkeypatch.setattr(server, "_profile_build_scope", lambda *a: nullcontext())
+        monkeypatch.setattr(server, "_make_agent_in_context", lambda *a, **kw: Mock())
+        monkeypatch.setattr(server, "_find_live_session_by_key", lambda *a: (sid, session))
+        response = server._resume_eager(ctx)
+    elif path == "unpersisted":
+        response = server._resume_live_unpersisted(ctx, sid, session)
+    elif path == "reuse":
+        response = server._resume_reuse_live(ctx, sid, session)
+    else:
+        name = {"activate": "session.activate", "prompt": "prompt.submit"}[path]
+        response = server.handle_request({"jsonrpc": "2.0", "id": 1, "method": name,
+                                          "params": {"session_id": sid, "text": "continue", "omit_messages": True}})
+    assert response.get("error", {}).get("code") == (4007 if claim == "retired" else 4009)
+    assert session["transport"] is server._detached_ws_transport
+    assert sid in server._pending_ws_reaps
+    assert session["queued_prompt"] is None

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -574,8 +574,14 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4121, "hosted room turns do not support isolated compute workers yet")
     # Re-bind to the current transport: streaming must stay on the active websocket even
     # if a disconnect/fallback moved the session to stdio.
-    if (t := current_transport()) is not None:
-        session["transport"] = t
+    with _session_resume_lock:
+        if _sessions.get(sid) is not session:
+            return _err(rid, 4007, "session no longer live; retry resume")
+        if session.get("_client_gone_interrupt_requested"):
+            return _err(rid, 4009, "session disconnect interrupt settling")
+        if (t := current_transport()) is not None:
+            session["transport"] = t
+            _cancel_ws_orphan_reap(sid)
     # Claim the turn against a possibly-running session (busy/queued reply, else fall
     # through once ``running`` is observed False).  The provider interrupt happens after
     # history_lock is released (a non-interruptible tool may hold it); if the old turn

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -523,16 +523,17 @@ def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
     sentinel-parked the record) or it fires against this client."""
     if ctx.owns_db:
         _release_db(ctx.db)
-    live["last_active"] = time.time()
-    if (transport := current_transport()) is not None:
-        # This resume reattaches the live record. A lazy session (no state.db row yet — every fresh Bot
-        # Chat) that was sentinel-parked by a WS drop MUST be rebound here, or it keeps the drop sentinel
-        # and the armed orphan-reap Timer fires against a client that is attached right now — the
-        # unpersisted sibling of the storm-killer paths (#91276).
-        with live.setdefault("history_lock", threading.Lock()):
-            live["transport"] = transport
-            live.setdefault("viewers", {})[transport] = time.time()
-    _cancel_ws_orphan_reap(live_sid)
+    with _session_resume_lock:
+        if _sessions.get(live_sid) is not live:
+            return _err(ctx.rid, 4007, "session no longer live; retry resume")
+        if live.get("_client_gone_interrupt_requested"):
+            return _err(ctx.rid, 4009, "session disconnect interrupt settling")
+        live["last_active"] = time.time()
+        if (transport := current_transport()) is not None:
+            with live.setdefault("history_lock", threading.Lock()):
+                live["transport"] = transport
+                live.setdefault("viewers", {})[transport] = time.time()
+        _cancel_ws_orphan_reap(live_sid)
     history = live.get("history") or []
     return _ok(ctx.rid, _attach_todo_state({
         "session_id": live_sid, "stored_session_id": str(live.get("session_key") or ""),
@@ -631,21 +632,26 @@ def _resume_reuse_live(ctx: _Resume, sid: str, session: dict) -> dict:
     """Reattach an already-live session under the resume lock (held across the client-gone check,
     transport rebind and reap cancel so grace expiry is atomic)."""
     with _session_resume_lock:
-        if _sessions.get(sid) is not session:
-            return _err(ctx.rid, 4007, "session no longer live; retry resume")
-        if session.get("_client_gone_interrupt_requested"):
-            return _err(ctx.rid, 4009, "session disconnect interrupt settling")
-        _cancel_ws_orphan_reap(sid)  # unconditionally: the fast path must never race the reap Timer
-        payload = _live_session_payload(sid, session, cols=ctx.cols, touch=True, omit_messages=ctx.omit_messages,
-                                        transport=current_transport() or _stdio_transport)
-        payload["resumed"] = ctx.target
-        if ctx.defer_history:
-            payload.update(messages=[], hydrating=bool(session.get("resume_hydrating")),
-                           message_count=int(session.get("resume_message_count") or payload["message_count"]))
-        # A lazy watch session never owns a run loop — overlay the child-run registry.
-        if session.get("agent") is None and _child_run_active(ctx.target):
-            payload.update(running=True, status="streaming")
-        return _ok(ctx.rid, payload)
+        return _resume_reuse_live_locked(ctx, sid, session)
+
+
+def _resume_reuse_live_locked(ctx: _Resume, sid: str, session: dict) -> dict:
+    """Reuse with _session_resume_lock already held (including the eager double-check)."""
+    if _sessions.get(sid) is not session:
+        return _err(ctx.rid, 4007, "session no longer live; retry resume")
+    if session.get("_client_gone_interrupt_requested"):
+        return _err(ctx.rid, 4009, "session disconnect interrupt settling")
+    _cancel_ws_orphan_reap(sid)  # unconditionally: the fast path must never race the reap Timer
+    payload = _live_session_payload(sid, session, cols=ctx.cols, touch=True, omit_messages=ctx.omit_messages,
+                                    transport=current_transport() or _stdio_transport)
+    payload["resumed"] = ctx.target
+    if ctx.defer_history:
+        payload.update(messages=[], hydrating=bool(session.get("resume_hydrating")),
+                       message_count=int(session.get("resume_message_count") or payload["message_count"]))
+    # A lazy watch session never owns a run loop — overlay the child-run registry.
+    if session.get("agent") is None and _child_run_active(ctx.target):
+        payload.update(running=True, status="streaming")
+    return _ok(ctx.rid, payload)
 
 
 def _resume_response(
@@ -751,7 +757,7 @@ def _resume_eager(ctx: _Resume) -> dict:
         if live is not None:
             with contextlib.suppress(Exception):
                 agent.close()
-            return _resume_reuse_live(ctx, *live)
+            return _resume_reuse_live_locked(ctx, *live)
         try:
             with _profile_build_scope(ctx.profile_home):
                 _init_session(sid, ctx.target, agent, history, cols=ctx.cols, cwd=ctx.profile_resume_cwd,
@@ -890,9 +896,15 @@ def _(rid, params: dict) -> dict:
 @_session_method("session.activate")
 def _(rid, params: dict, session: dict) -> dict:
     """Attach the frontend to a live TUI session without closing the previously focused one."""
-    return _ok(rid, _live_session_payload(
-        str(params.get("session_id") or ""), session, touch=True, transport=current_transport() or _stdio_transport,
-        omit_messages=is_truthy_value(params.get("omit_messages", False))))
+    sid = str(params.get("session_id") or "")
+    with _session_resume_lock:
+        if _sessions.get(sid) is not session:
+            return _err(rid, 4007, "session no longer live; retry resume")
+        if session.get("_client_gone_interrupt_requested"):
+            return _err(rid, 4009, "session disconnect interrupt settling")
+        return _ok(rid, _live_session_payload(
+            sid, session, touch=True, transport=current_transport() or _stdio_transport,
+            omit_messages=is_truthy_value(params.get("omit_messages", False))))
 
 
 @method("session.delete")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2444,8 +2444,8 @@ def _claim_or_reuse_live(sid: str, session_key: str, record: dict, lease) -> tup
         if live is not None:
             if lease is not None:
                 lease.release()
-            # The winner is being reattached: a pending ws-orphan reap must not fire against the reclaimed client.
-            _cancel_ws_orphan_reap(live[0])
+            # Guarded reuse cancels the reap only after accepting reattachment;
+            # a rejected resume must leave an in-flight orphan interrupt polling.
             return live
         with _sessions_lock:
             _sessions[sid] = record

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -463,7 +463,9 @@ def _ws_orphan_turn_activity_is_fresh(session: dict) -> bool:
         return False
 
 
-def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
+def _schedule_ws_orphan_reap(
+    sid: str, *, delay_s: float | None = None, _expected_timer: threading.Timer | None = None,
+) -> None:
     """After a grace window, reap session ``sid`` iff it's still orphaned. Called from the WS-disconnect path; a
     reconnect or ``session.resume`` cancels the reap by re-binding a live transport. Disabled when grace is 0."""
     if _WS_ORPHAN_REAP_GRACE_S <= 0:
@@ -473,13 +475,14 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
         # Serialize the re-check against session.resume (rebinds under _session_resume_lock). Claim teardown by popping
         # under both locks, then release the resume lock before slow finalization. Order: resume_lock -> sessions_lock.
         reschedule_delay = interrupt_session = session = None
-        with _session_resume_lock:
-            # Drop this Timer's registration so a concurrent _cancel_ws_orphan_reap can't cancel a dead Timer while a
-            # rescheduled one (registered below) is the owner.
-            with _sessions_lock:
-                _pending_ws_reaps.pop(sid, None)
+        with _session_resume_lock, _sessions_lock:
+            # Keep ownership through interrupt I/O and continuation registration. A cancelled
+            # callback may already be dispatched, but cannot act on a later detachment.
+            if _pending_ws_reaps.get(sid) is not timer:
+                return
             current = _sessions.get(sid)
             if current is None or not _ws_session_is_detached(current):
+                _pending_ws_reaps.pop(sid, None)
                 return
             if _session_has_active_delegations(sid, current):
                 reschedule_delay = _WS_ORPHAN_REAP_GRACE_S
@@ -506,6 +509,8 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
                         current["_client_gone_interrupt_requested"] = True
                         interrupt_session = current
                     reschedule_delay = _WS_ORPHAN_INTERRUPT_REAP_POLL_S
+            if reschedule_delay is None:
+                _pending_ws_reaps.pop(sid, None)
         if interrupt_session is not None:
             try:
                 isolated = _interrupt_session_turn(sid, interrupt_session, request_id=f"client-gone-{sid}")
@@ -513,18 +518,21 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
             except Exception:
                 logger.exception("client_gone interrupt failed sid=%s", sid)
                 with _sessions_lock:
-                    if _sessions.get(sid) is interrupt_session:
+                    if (_sessions.get(sid) is interrupt_session
+                            and _pending_ws_reaps.get(sid) is timer):
                         interrupt_session.pop("_client_gone_interrupt_requested", None)
         if reschedule_delay is not None:
-            _schedule_ws_orphan_reap(sid, delay_s=reschedule_delay)
+            _schedule_ws_orphan_reap(sid, delay_s=reschedule_delay, _expected_timer=timer)
             return
         if session is not None and session.get("_client_gone_interrupt_requested"):
             logger.info("client_gone sid=%s action=reap", sid)
         _teardown_popped_session(session, end_reason="ws_orphan_reap")
 
-    timer = threading.Timer(_WS_ORPHAN_REAP_GRACE_S if delay_s is None else max(0.0, delay_s), _reap)
-    timer.daemon = True
     with _sessions_lock:
+        if _expected_timer is not None and _pending_ws_reaps.get(sid) is not _expected_timer:
+            return
+        timer = threading.Timer(_WS_ORPHAN_REAP_GRACE_S if delay_s is None else max(0.0, delay_s), _reap)
+        timer.daemon = True
         prior = _pending_ws_reaps.pop(sid, None)
         _pending_ws_reaps[sid] = timer
     if prior is not None:
@@ -569,12 +577,14 @@ def _close_sessions_for_transport(transport, *, end_reason: str = "ws_disconnect
                     current["transport"] = _detached_ws_transport
                     current.pop("_client_gone_interrupt_requested", None)
                     should_schedule_reap = True
+                    # Register before releasing the detachment claim: an old disconnect
+                    # must not arm its first timer over a reconnect's newer detachment.
+                    with contextlib.suppress(Exception):
+                        _schedule_ws_orphan_reap(sid)
         if claimed_for_teardown is not None:
             reaped += _teardown_popped_session(claimed_for_teardown, end_reason=end_reason)
         elif should_schedule_reap:
             detached += 1
-            with contextlib.suppress(Exception):
-                _schedule_ws_orphan_reap(sid)
     return reaped, detached
 
 


### PR DESCRIPTION
## Summary

Re-scoped on current `main` (`1e69c12b64dba4090eddffeae27f5a147068d34b`) after #100504 merged the activity-based fix for healthy detached turns. This PR now contains only the remaining orphan-timer and reconnect/interrupt race fixes.

- Fence dispatched callbacks and their continuations by timer identity, so an obsolete detachment cannot remove or replace a newer detachment's timer.
- Register the first orphan timer while holding the detachment claim, closing the disconnect/reconnect/redetach scheduling window.
- Serialize lazy/unpersisted resume, activation, and prompt transport rebind with the orphan interrupt claim; reject a settling interrupt with the existing `4009` response and revalidate live-session identity.
- Avoid recursive acquisition of the non-reentrant resume lock in the eager-resume double-check.
- Cancel a concurrent cold-resume winner's timer only after guarded reuse accepts reattachment; a rejected reconnect must not strand interrupt-settlement polling.

## Policy and scope

The previous revision's fixed 12-hour running-turn allowance and `ws_orphan_running_grace_s` setting are **removed**. This revision does not change configuration or documentation defaults. It preserves #100504's policy: fresh activity protects detached running turns, stale/missing activity is eligible for interruption, and `ws_orphan_activity_stale_s: 0` retains interrupt-at-grace behavior. Existing delegation protection, bounded interrupt settlement/force-reap, explicit Stop, and sidecar `close_on_disconnect` behavior remain intact.

Follow-up to #100504; related to #98028. No merging or unrelated PR changes.

## Verification

All Python test runs used the canonical `scripts/run_tests.sh` runner with the development interpreter, clean environment, temporary Hermes home, and per-file subprocess isolation.

- New deterministic regression file: **19 passed** on this head. Applied to unchanged upstream: **15 failed, 4 passed**, reproducing the stale callback/continuation/initial-registration races and reconnect/eager-resume failures. Tests were written and observed failing before their fixes.
- Independent review identified a concurrent cold-resume cancellation regression. Added the `cold_resume_claim` regression and observed it fail, fixed the cancellation point, then repeated the independent review: **passed**, no security concerns or logic errors.
- Focused orphan/reconnect/claim coverage: **45 passed, 0 failed**.
- Broad affected suite below: **1,702 passed, 1 failed** across 115 files. The sole failure, `tests/test_tui_gateway_server.py::test_model_options_preserves_canonical_custom_row_after_agent_init`, also fails in a separate unchanged-upstream worktree (**1,683 passed, 1 failed**, 114 files). No new broad-suite failures. This is not a claim that the full repository suite passed.
- Ruff on all six changed files, Python bytecode compilation, `scripts/check_compat_pointers.py`, and `git diff --check`: **passed**.

```bash
scripts/run_tests.sh tests/tui_gateway/test_ws_orphan_races.py -q
scripts/run_tests.sh tests/tui_gateway/test_ws_orphan_races.py tests/test_tui_gateway_server.py \
  -k 'orphan or reconnect_cannot or claim_or_reuse_live' -q
scripts/run_tests.sh tests/tui_gateway/ tests/test_tui_gateway_server.py \
  tests/test_tui_gateway_server_crash_history.py tests/test_tui_gateway_ws.py \
  tests/test_tui_gateway_event_replay.py tests/test_tui_gateway_loop_noise.py \
  tests/test_tui_gateway_queue_on_busy.py tests/test_ws_keepalive_config.py \
  tests/test_pty_keepalive_ws.py -j 8 -q
```

Local verification is reported above; GitHub CI status is tracked by the checks on this PR.

