### PR TITLE
compression: skip a stalled primary summary route after fallback-recovered stalls (#95879)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -106,6 +106,38 @@ _PINNED_ROUTE_FIELDS: tuple[str, ...] = (
     "timeout",
 )
 
+# #95879: persisted keys for the route-specific primary-stall ledger. The
+# ledger is deliberately SEPARATE from the shared summary-failure cooldown
+# ladder (record_timeout_failure / _summary_failure_cooldown_until): that
+# ladder is route-agnostic, so recording a fallback-recovered stall there
+# would suppress ALL compression — including the fallback that just worked —
+# and re-break the #95433 ordering (fallback runs before on_timeout precisely
+# so the cooldown can't suppress the retry). Values ride the session's
+# model_config JSON (same merge discipline as proactive-prune rearm), so no
+# schema migration is needed and a restart cannot disarm mid-escalation.
+_PRIMARY_STALL_STREAK_KEY = "primary_stall_streak"
+_PRIMARY_STALL_SKIP_UNTIL_KEY = "primary_stall_skip_until"
+_PRIMARY_STALL_DEFAULT_SKIP_THRESHOLD = 2
+_PRIMARY_STALL_DEFAULT_SKIP_SECONDS = 600.0
+
+
+def _compression_config_value(key: str, default: Any):
+    """Read one ``compression.*`` config value, falling back to ``default``.
+
+    Mirrors ``resolve_context_compression_timeouts``'s read of the same
+    section: fresh read per call (the events are rare), never raises.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        raw = load_config()
+        cfg = raw.get("compression", {}) if isinstance(raw, dict) else {}
+        if isinstance(cfg, dict) and key in cfg and cfg[key] is not None:
+            return cfg[key]
+    except Exception:
+        pass
+    return default
+
 
 @contextlib.contextmanager
 def pin_summary_route(route: Optional[Dict[str, Any]]):
@@ -2303,6 +2335,8 @@ class ContextCompressor(ContextEngine):
         self._structural_no_op_backoff_until = 0.0
         self._prellm_skip_count = 0
         self._fallback_compression_streak = 0
+        self._primary_stall_streak = 0
+        self._primary_stall_skip_until = 0.0
         self._verify_compaction_cleared_threshold = False
         self._last_compression_made_progress = False
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
@@ -2607,6 +2641,8 @@ class ContextCompressor(ContextEngine):
         self._structural_no_op_backoff_until = 0.0
         self._prellm_skip_count = 0
         self._fallback_compression_streak = 0
+        self._primary_stall_streak = 0
+        self._primary_stall_skip_until = 0.0
         self._verify_compaction_cleared_threshold = False
         self._last_compression_made_progress = False
         self._summary_failure_cooldown_until = 0.0
@@ -2639,10 +2675,13 @@ class ContextCompressor(ContextEngine):
         self._anti_thrash_recovery_deadline = 0.0
         self._structural_no_op_backoff_until = 0.0
         self._proactive_prune_rearm_tokens = 0
+        self._primary_stall_streak = 0
+        self._primary_stall_skip_until = 0.0
         self.get_active_compression_failure_cooldown()
         self._load_fallback_compression_streak()
         self._load_ineffective_compression_count()
         self._load_proactive_prune_rearm_tokens()
+        self._load_primary_stall_state()
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
         """Bind session-scoped compression state for a new or resumed session."""
@@ -2652,6 +2691,8 @@ class ContextCompressor(ContextEngine):
         session_db = kwargs.get("session_db", getattr(self, "_session_db", None))
         previous_fallback_streak = self._fallback_compression_streak
         previous_ineffective_count = self._ineffective_compression_count
+        previous_primary_stall_streak = None
+        previous_primary_stall_skip_until = None
         if boundary_reason == "compression" and old_session_id:
             getter = getattr(session_db, "get_compression_fallback_streak", None)
             if callable(getter):
@@ -2683,6 +2724,33 @@ class ContextCompressor(ContextEngine):
                         "compression parent ineffective count lookup failed (non-sqlite): %s",
                         exc,
                     )
+            # #95879: the primary-stall ledger is a logical-conversation
+            # property too — a half-dead primary must not be silently healed
+            # by a session-id rotation. Read the parent row's ledger via the
+            # same model_config channel bind_session_state will use on the
+            # child.
+            parent_config_getter = getattr(
+                session_db, "get_session_model_config_value", None,
+            )
+            if callable(parent_config_getter):
+                try:
+                    previous_primary_stall_streak = parent_config_getter(
+                        old_session_id, _PRIMARY_STALL_STREAK_KEY, None,
+                    )
+                    previous_primary_stall_skip_until = parent_config_getter(
+                        old_session_id, _PRIMARY_STALL_SKIP_UNTIL_KEY, None,
+                    )
+                except (TypeError, ValueError, sqlite3.Error) as exc:
+                    logger.debug(
+                        "compression parent primary-stall ledger lookup failed: %s",
+                        exc,
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "compression parent primary-stall ledger lookup failed "
+                        "(non-sqlite): %s",
+                        exc,
+                    )
         self.bind_session_state(session_db, session_id)
         if boundary_reason == "compression":
             # Rotation creates a fresh child row before this callback. Preserve
@@ -2697,6 +2765,48 @@ class ContextCompressor(ContextEngine):
             if self._ineffective_compression_count != previous_ineffective_count:
                 self._ineffective_compression_count = previous_ineffective_count
                 self._persist_ineffective_compression_count()
+            # Same carry discipline for the primary-stall ledger (#95879):
+            # bind_session_state() loaded the FRESH child row (zeros), so
+            # restore + persist the parent's streak and skip-window now. A
+            # restart between rotation and the next stall/success would
+            # otherwise disarm the escalation mid-window.
+            if previous_primary_stall_streak is not None:
+                try:
+                    carried_streak = max(
+                        0,
+                        int(previous_primary_stall_streak)
+                        if isinstance(
+                            previous_primary_stall_streak, (int, float, str)
+                        )
+                        else 0,
+                    )
+                except (TypeError, ValueError):
+                    carried_streak = 0
+            else:
+                carried_streak = self._primary_stall_streak
+            if previous_primary_stall_skip_until is not None:
+                try:
+                    carried_epoch = float(previous_primary_stall_skip_until or 0.0)
+                except (TypeError, ValueError):
+                    carried_epoch = 0.0
+                if carried_epoch > 0.0:
+                    carried_remaining = carried_epoch - time.time()
+                    carried_skip_until = (
+                        time.monotonic() + carried_remaining
+                        if carried_remaining > 0.0
+                        else 0.0
+                    )
+                else:
+                    carried_skip_until = 0.0
+            else:
+                carried_skip_until = self._primary_stall_skip_until
+            if (
+                self._primary_stall_streak != carried_streak
+                or self._primary_stall_skip_until != carried_skip_until
+            ):
+                self._primary_stall_streak = carried_streak
+                self._primary_stall_skip_until = carried_skip_until
+                self._persist_primary_stall_state()
 
     def _load_fallback_compression_streak(self) -> None:
         session_db = getattr(self, "_session_db", None)
@@ -2764,6 +2874,208 @@ class ContextCompressor(ContextEngine):
             logger.debug("compression fallback streak persist failed: %s", exc)
         except Exception as exc:
             logger.debug("compression fallback streak persist failed (non-sqlite): %s", exc)
+
+    # ------------------------------------------------------------------
+    # Primary-stall ledger (#95879) — route-specific escalation
+    # ------------------------------------------------------------------
+    #
+    # The shared cooldown ladder (record_timeout_failure /
+    # _summary_failure_cooldown_until) is route-agnostic: recording a
+    # fallback-recovered stall there would suppress ALL compression —
+    # including the fallback that just worked — and re-break the #95433
+    # ordering (fallback runs before on_timeout so the cooldown can't
+    # suppress the retry). This separate, persisted ledger counts
+    # consecutive fallback-recovered primary stalls and, past a threshold,
+    # arms a bounded skip-primary window during which the host pre-pins the
+    # first fallback_chain entry as the FIRST attempt.
+
+    def _load_primary_stall_state(self) -> None:
+        """Restore the primary-stall ledger for a bound/resumed session.
+
+        Reads both keys from the session's model_config JSON (the same
+        merge-discipline channel as proactive-prune rearm), so a fresh
+        compressor on a resumed session inherits an armed skip window
+        instead of letting a restart silently heal a half-dead primary
+        (#95879).
+        """
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        getter = getattr(session_db, "get_session_model_config_value", None)
+        if not session_id or not callable(getter):
+            return
+        try:
+            stored_streak = getter(session_id, _PRIMARY_STALL_STREAK_KEY, 0)
+            self._primary_stall_streak = max(
+                0,
+                int(stored_streak)
+                if isinstance(stored_streak, (int, float, str))
+                else 0,
+            )
+            stored_epoch = getter(session_id, _PRIMARY_STALL_SKIP_UNTIL_KEY, 0.0)
+            if isinstance(stored_epoch, (int, float, str)):
+                try:
+                    epoch = float(stored_epoch or 0.0)
+                except (TypeError, ValueError):
+                    epoch = 0.0
+            else:
+                epoch = 0.0
+            if epoch > 0.0:
+                remaining = epoch - time.time()
+                # Persisted window stores wall-clock epoch; the in-memory
+                # mirror is monotonic, matching _summary_failure_cooldown_until.
+                self._primary_stall_skip_until = (
+                    time.monotonic() + remaining if remaining > 0.0 else 0.0
+                )
+            else:
+                self._primary_stall_skip_until = 0.0
+        except (TypeError, ValueError, sqlite3.Error) as exc:
+            logger.debug("compression primary-stall ledger lookup failed: %s", exc)
+        except Exception as exc:
+            logger.debug(
+                "compression primary-stall ledger lookup failed (non-sqlite): %s",
+                exc,
+            )
+
+    def _persist_primary_stall_state(self) -> None:
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        patcher = getattr(session_db, "patch_session_model_config", None)
+        if not session_id or not callable(patcher):
+            return
+        try:
+            skip_epoch = 0.0
+            if self._primary_stall_skip_until > 0.0:
+                skip_epoch = time.time() + max(
+                    0.0, self._primary_stall_skip_until - time.monotonic()
+                )
+            patcher(
+                session_id,
+                {
+                    _PRIMARY_STALL_STREAK_KEY: max(
+                        0, int(self._primary_stall_streak)
+                    ),
+                    _PRIMARY_STALL_SKIP_UNTIL_KEY: skip_epoch,
+                },
+            )
+        except sqlite3.Error as exc:
+            logger.debug("compression primary-stall ledger persist failed: %s", exc)
+        except Exception as exc:
+            logger.debug(
+                "compression primary-stall ledger persist failed (non-sqlite): %s",
+                exc,
+            )
+
+    def record_primary_route_stall_recovered(self) -> None:
+        """Record one fallback-recovered primary-route stall (#95879).
+
+        Called by the host (via ``run_compress_context_with_progress_timeout``
+        's ``on_primary_stall`` hook) when the stall path recovered on the
+        fallback chain. Route-specific counterpart to
+        :meth:`record_timeout_failure`: the SHARED ladder must NOT learn about
+        this — the fallback just worked, and suppressing it with the shared
+        cooldown would re-break #95433 ordering.
+
+        When the streak reaches ``compression.primary_stall_skip_threshold``
+        (default 2), a bounded skip-primary window
+        (``compression.primary_stall_skip_seconds``, default 600s) is armed so
+        the host pre-pins the first fallback_chain entry as the next attempt.
+        Once the window lapses the next compression re-probes the real primary;
+        a stall re-arms the window, a token-producing primary clears the ledger.
+        """
+        self._primary_stall_streak += 1
+        threshold = self._primary_stall_skip_threshold()
+        if self._primary_stall_streak >= threshold:
+            # Re-arm only when the previous window has lapsed (or never
+            # armed). While the window is ACTIVE the primary is skipped, so a
+            # stall cannot be recorded to extend it; after it lapses the
+            # re-probe stall re-arms a fresh full window — bounded cadence,
+            # not a permanent bypass.
+            if self._primary_stall_skip_until <= time.monotonic():
+                self._primary_stall_skip_until = (
+                    time.monotonic() + self._primary_stall_skip_window_seconds()
+                )
+        self._persist_primary_stall_state()
+        if not self.quiet_mode:
+            logger.warning(
+                "Primary summary route stalled and was recovered by the "
+                "fallback chain; primary_stall_streak=%d%s",
+                self._primary_stall_streak,
+                " — skipping the primary on the next compression attempts"
+                if self._primary_stall_streak >= threshold
+                else "",
+            )
+
+    def record_primary_route_success(self) -> None:
+        """Clear the primary-stall ledger after a real primary summary.
+
+        Called from ``_generate_summary`` only when the successful summary
+        call was NOT driven by a pinned fallback route (and no earlier call in
+        the same attempt consumed a pin — a main-model retry after a pinned
+        fallback error inherits the consumed echo and must not clear the
+        streak). An unpinned success is proof the primary (task) route
+        produced tokens again, so both the streak and any armed skip window
+        are reset — durably.
+        """
+        if (
+            self._primary_stall_streak == 0
+            and self._primary_stall_skip_until <= 0.0
+        ):
+            return
+        self._primary_stall_streak = 0
+        self._primary_stall_skip_until = 0.0
+        self._persist_primary_stall_state()
+        if not self.quiet_mode:
+            logger.info("Primary summary route healthy; primary-stall ledger cleared")
+
+    def _primary_stall_skip_threshold(self) -> int:
+        value = _compression_config_value(
+            "primary_stall_skip_threshold", _PRIMARY_STALL_DEFAULT_SKIP_THRESHOLD
+        )
+        try:
+            return max(1, int(value))
+        except (TypeError, ValueError):
+            return _PRIMARY_STALL_DEFAULT_SKIP_THRESHOLD
+
+    def _primary_stall_skip_window_seconds(self) -> float:
+        value = _compression_config_value(
+            "primary_stall_skip_seconds", _PRIMARY_STALL_DEFAULT_SKIP_SECONDS
+        )
+        try:
+            return max(1.0, float(value))
+        except (TypeError, ValueError):
+            return _PRIMARY_STALL_DEFAULT_SKIP_SECONDS
+
+    def _primary_stall_gate_tripped(self) -> bool:
+        """Evaluate the skip-primary gate on in-memory state only."""
+        if self._primary_stall_streak < self._primary_stall_skip_threshold():
+            return False
+        skip_until = self._primary_stall_skip_until
+        if skip_until > 0.0 and time.monotonic() < skip_until:
+            return True
+        return False
+
+    def should_skip_primary_route(self) -> bool:
+        """Whether the next compression should skip the primary summary route.
+
+        True only when the primary-stall streak reached
+        ``compression.primary_stall_skip_threshold`` AND the skip window armed
+        by the last fallback-recovered stall has not lapsed. Route-specific:
+        never consults the shared ``_summary_failure_cooldown_until`` ladder.
+
+        When True, the host pre-pins the first ``fallback_chain`` entry so it
+        becomes the FIRST attempt (``pin_summary_route``), instead of burning
+        the full idle window on a half-dead primary before the fallback saves
+        the compaction.
+        """
+        if not self._primary_stall_gate_tripped():
+            return False
+        # Durable ledger may have been cleared by another agent since
+        # bind_session_state() — a primary attempt that produced tokens on a
+        # sibling process zeroes the streak and window. Refresh and re-evaluate
+        # before letting a stale local skip outlive the durable state that
+        # justified it (same shape as _automatic_compression_blocked).
+        self._load_primary_stall_state()
+        return self._primary_stall_gate_tripped()
 
     def _load_ineffective_compression_count(self) -> None:
         """Load the durable anti-thrash strike count for the bound session.
@@ -3504,6 +3816,17 @@ class ContextCompressor(ContextEngine):
         # real-usage effectiveness counter, ordinary fitting responses must not
         # reset this breaker; only a healthy completed summary does.
         self._fallback_compression_streak: int = 0
+        # #95879: route-specific escalation state for a stalled primary
+        # summary route. ``_primary_stall_streak`` counts consecutive
+        # fallback-recovered stalls; when it reaches the skip threshold,
+        # ``_primary_stall_skip_until`` (monotonic) arms a bounded window
+        # during which the host pre-pins the first fallback_chain entry as the
+        # FIRST attempt instead of burning the full idle budget on the
+        # half-dead primary. A real (unpinned) primary summary resets both.
+        # Deliberately separate from the shared timeout ladder — see
+        # record_primary_route_stall_recovered.
+        self._primary_stall_streak: int = 0
+        self._primary_stall_skip_until: float = 0.0
         # Set after a completed compression boundary; consumed by the next
         # provider-reported prompt count in update_from_response().
         self._verify_compaction_cleared_threshold: bool = False
@@ -5318,6 +5641,16 @@ This compaction should PRIORITISE preserving all information related to the focu
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._clear_compression_failure_cooldown()
+            # #95879: reset the route-specific primary-stall ledger when the
+            # successful summary was NOT driven by a stall-fallback pin — and
+            # no earlier call in this attempt consumed one. The consumed echo
+            # (``_SUMMARY_ROUTE_CONSUMED``) is set only inside a pinned
+            # attempt, so a main-model retry after a pinned fallback error
+            # keeps the streak: the primary stalled and we are still on a
+            # fallback journey. An unpinned success is proof the primary
+            # (task) route produced tokens again.
+            if not _pinned_route and not _SUMMARY_ROUTE_CONSUMED.get():
+                self.record_primary_route_success()
             self._summary_model_fallen_back = False
             self._last_summary_error = None
             self._last_summary_auth_failure = False

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1189,6 +1189,7 @@ def run_compress_context_with_progress_timeout(
     telemetry_agent: Any = None,
     stall_fallback: bool = True,
     new_fence: Optional[Callable[[], CompressionCommitFence]] = None,
+    on_primary_stall: Optional[Callable[[], None]] = None,
 ) -> Tuple[list, str]:
     """Run ``worker(fence)`` under a sync progress-aware timeout.
 
@@ -1227,6 +1228,16 @@ def run_compress_context_with_progress_timeout(
     handling (exception-path only) never sees it (#78981). ``on_timeout``
     therefore fires only after that attempt has also failed, which keeps its
     cooldown bookkeeping from suppressing the retry it precedes.
+
+    ``on_primary_stall`` is the route-specific escalation hook for the
+    fallback-RECOVERED case (#95879): when the retry succeeds, this callback
+    fires (once) BEFORE the recovered result is returned, so the host can
+    record the stall in the dedicated primary-stall ledger
+    (``ContextCompressor.record_primary_route_stall_recovered``) — which the
+    shared cooldown ladder (``on_timeout``) deliberately must not learn about.
+    ``on_timeout`` is NOT called in that case; the ladder stays untouched and
+    the healthy fallback keeps running while the half-dead primary accrues
+    escalation state.
 
     ``new_fence`` mints that retry's fence. Hosts that publish the active
     fence for hard-interrupt admission pass a factory that publishes the new
@@ -1450,6 +1461,27 @@ def run_compress_context_with_progress_timeout(
                 new_fence=new_fence,
             )
             if recovered is not None:
+                # #95879: the fallback saved the compaction, but the PRIMARY
+                # stalled to get here. Escalate that in the route-specific
+                # ledger BEFORE returning (on_timeout — the shared cooldown
+                # ladder — must not learn about a recovery: the fallback just
+                # worked and suppressing it would re-break #95433 ordering).
+                if on_primary_stall is not None:
+                    try:
+                        on_primary_stall()
+                    except Exception:
+                        logger.debug(
+                            "compress_context primary-stall callback failed",
+                            exc_info=True,
+                        )
+                if telemetry_agent is not None:
+                    _emit_compression_attempt_telemetry(
+                        telemetry_agent,
+                        started_at=wait_started,
+                        commit_status="fallback_recovered",
+                        split_status="fallback_recovered",
+                        failure_class="primary_route_stall_recovered",
+                    )
                 return recovered
         if on_timeout is not None:
             try:
@@ -1578,6 +1610,14 @@ def _emit_compression_attempt_telemetry(
             payload["commit_ms"] = commit_ms
         if failure_class:
             payload["failure_class"] = failure_class
+        if failure_class == "primary_route_stall_recovered":
+            # #95879: surface the route-specific ledger count on the stall
+            # telemetry line so a half-dead primary is visible in the same
+            # stream as other compression failures without changing the shape
+            # of every other attempt's payload.
+            payload["primary_stall_streak"] = getattr(
+                agent.context_compressor, "_primary_stall_streak", 0
+            )
         payload.setdefault("chunking", False)
         payload.setdefault("chunk_count", 0)
         payload["fallback_used"] = bool(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -929,6 +929,19 @@ DEFAULT_CONFIG = {
                                       # warning channel while the host keeps
                                       # waiting in bounded increments for the
                                       # commit to finish.
+        "primary_stall_skip_threshold": 2,  # #95879: N consecutive fallback-recovered
+                                      # primary-route stalls before the next
+                                      # compression SKIPS the primary and uses the
+                                      # first fallback_chain entry as the FIRST
+                                      # attempt (route-specific escalation; the
+                                      # shared cooldown ladder is deliberately not
+                                      # touched so the healthy fallback keeps
+                                      # running).
+        "primary_stall_skip_seconds": 600,  # how long the skip-primary gate stays
+                                      # armed after it trips. After this window the
+                                      # next compression re-probes the real
+                                      # primary: a stall re-arms the window, a
+                                      # token-producing primary clears the ledger.
         "protect_first_n": 3,         # non-system head messages always preserved
                                       # verbatim, in ADDITION to the system prompt
                                       # (which is always implicitly protected). Set to

--- a/run_agent.py
+++ b/run_agent.py
@@ -8216,7 +8216,47 @@ class AIAgent:
                         self._active_compression_commit_fence = retry_fence
                     return retry_fence
 
-                result = run_compress_context_with_progress_timeout(
+                # #95879: route-specific escalation for a stalled primary
+                # summary route. When the primary-stall ledger tripped the
+                # skip-primary gate, make the FIRST fallback_chain entry the
+                # FIRST attempt (pre-pinned via the existing single-use pin
+                # mechanism) instead of burning the full idle window on a
+                # half-dead primary before the fallback saves the compaction.
+                # The gate is route-specific — it never touches the shared
+                # cooldown ladder, so a healthy fallback keeps running.
+                compressor = getattr(self, "context_compressor", None)
+                pre_pin_route = None
+                if compressor is not None:
+                    should_skip = getattr(
+                        compressor, "should_skip_primary_route", None
+                    )
+                    if callable(should_skip):
+                        try:
+                            if should_skip():
+                                pre_pin_route = resolve_compression_fallback_route()
+                        except Exception:
+                            logger.debug(
+                                "primary-route skip gate check failed",
+                                exc_info=True,
+                            )
+
+                def _on_primary_stall():
+                    # Fallback-recovered stall: record it in the dedicated
+                    # route-specific ledger (never the shared cooldown ladder).
+                    record = getattr(
+                        compressor, "record_primary_route_stall_recovered", None
+                    )
+                    if not callable(record):
+                        return
+                    try:
+                        record()
+                    except Exception:
+                        logger.debug(
+                            "failed to record primary-route stall",
+                            exc_info=True,
+                        )
+
+                _run_kwargs = dict(
                     worker=_snapshot_worker,
                     messages=messages,
                     system_prompt_fallback=_fallback_prompt,
@@ -8227,7 +8267,23 @@ class AIAgent:
                     fence=active_fence,
                     telemetry_agent=self,
                     new_fence=_publish_new_fence,
+                    on_primary_stall=_on_primary_stall,
                 )
+                if pre_pin_route is not None:
+                    # The pre-pinned attempt IS the fallback; do not burn a
+                    # second retry on the same chain entry if it stalls too
+                    # (the shared ladder then degrades, exactly as FM3).
+                    _run_kwargs["stall_fallback"] = False
+                    from agent.context_compressor import pin_summary_route
+
+                    with pin_summary_route(pre_pin_route):
+                        result = run_compress_context_with_progress_timeout(
+                            **_run_kwargs
+                        )
+                else:
+                    result = run_compress_context_with_progress_timeout(
+                        **_run_kwargs
+                    )
             # _DB_PERSISTED_MARKER lives at module level in
             # agent.context_compressor; conversation_compression only
             # imports it locally (cannot be imported from there). Imported

--- a/tests/agent/test_compression_primary_stall_escalation.py
+++ b/tests/agent/test_compression_primary_stall_escalation.py
@@ -1,0 +1,538 @@
+"""Primary summary-route stall escalation — #95879.
+
+A primary summary route that *stalls* (connection open, zero tokens) is
+aborted by the host's progress-aware timeout and retried once on the
+configured ``auxiliary.compression.fallback_chain`` (#78981/#95433). When that
+retry RECOVERS, the stall path historically returned the recovered result
+before ``on_timeout`` fired, so the route-agnostic cooldown ladder
+(``record_timeout_failure``) never learned the primary stalled — and a
+permanently half-dead primary was retried at FULL SPEED every compaction,
+burning one full idle window each time, forever.
+
+These tests pin the escalation contract:
+
+* the fallback-recovered path fires an ``on_primary_stall`` hook (the shared
+  ``on_timeout`` ladder deliberately does NOT learn about a recovery — the
+  fallback just worked, #95433 ordering),
+* the compressor keeps a SEPARATE, persisted ``_primary_stall_streak`` ledger
+  that accumulates those recoveries,
+* at ``compression.primary_stall_skip_threshold`` (default 2) a bounded
+  skip-primary window arms: the host pre-pins the first fallback_chain entry
+  as the FIRST attempt (no idle-window burn on the half-dead primary),
+* after the window lapses the primary is re-probed; a stall re-arms the
+  window, a token-producing primary clears the ledger,
+* healthy routes are bit-for-bit unchanged: no hook, no streak, no skip.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.context_compressor import (
+    ContextCompressor,
+    pin_summary_route,
+    take_pinned_summary_route,
+)
+from agent.conversation_compression import (
+    CompressionCommitFence,
+    resolve_compression_fallback_route,
+    run_compress_context_with_progress_timeout,
+)
+from hermes_state import SessionDB
+
+CHAIN_ENTRY = {
+    "provider": "custom",
+    "model": "backup-summarizer",
+    "base_url": "https://fallback.invalid/v1",
+    "api_key": "sk-fallback",
+    "timeout": 45,
+}
+
+
+def _patch_chain(chain):
+    """Pin auxiliary.compression config without touching the real config.yaml."""
+    return patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value={"fallback_chain": chain},
+    )
+
+
+class _StalledSummaryWorker:
+    """A compression worker whose first attempt streams nothing at all.
+
+    Mirrors the #78981 fixture: the provider holds the connection open, so the
+    worker never calls ``fence.touch_progress()`` and the host's idle budget
+    lapses. ``stall_attempts`` controls how many attempts hang; any later
+    attempt commits a real summary. ``stall_attempts=0`` commits immediately
+    (the healthy-route shape).
+    """
+
+    def __init__(self, compressed, *, stall_attempts=1):
+        self.compressed = compressed
+        self.stall_attempts = stall_attempts
+        self.routes = []
+        self.fences = []
+        self._lock = threading.Lock()
+        self.release = threading.Event()
+
+    @property
+    def attempts(self):
+        return len(self.routes)
+
+    def __call__(self, fence: CompressionCommitFence):
+        with self._lock:
+            self.routes.append(take_pinned_summary_route())
+            self.fences.append(fence)
+            attempt = len(self.routes)
+        if attempt <= self.stall_attempts:
+            # Connection open, zero tokens, zero fence progress.
+            self.release.wait(timeout=10)
+            return ([{"role": "assistant", "content": "late"}], "late-prompt")
+        if not fence.begin_commit():
+            return ([{"role": "assistant", "content": "cancelled"}], "cancelled")
+        try:
+            return (self.compressed, "summarized-prompt")
+        finally:
+            fence.finish_commit()
+
+
+def _run(
+    worker,
+    *,
+    chain,
+    timeouts,
+    messages=None,
+    idle=0.05,
+    ceiling=0.2,
+    on_stall=None,
+    telemetry_agent=None,
+):
+    with _patch_chain(chain):
+        return run_compress_context_with_progress_timeout(
+            worker=worker,
+            messages=messages
+            if messages is not None
+            else [{"role": "user", "content": "keep-me"}],
+            system_prompt_fallback="degraded-prompt",
+            idle_timeout_seconds=idle,
+            total_ceiling_seconds=ceiling,
+            on_timeout=lambda *args: timeouts.append(args),
+            on_primary_stall=on_stall,
+            telemetry_agent=telemetry_agent,
+        )
+
+
+def _compressor(db: SessionDB | None = None, session_id: str = "") -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        cc = ContextCompressor(model="test/model", quiet_mode=True)
+    if db is not None:
+        cc.bind_session_state(db, session_id)
+    return cc
+
+
+def _db(tmp_path: Path) -> SessionDB:
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _gate_tripped_compressor(
+    db: SessionDB | None = None, session_id: str = ""
+) -> ContextCompressor:
+    """A compressor whose primary-stall ledger has already tripped the gate."""
+    cc = _compressor(db, session_id)
+    cc._primary_stall_streak = 2
+    cc._primary_stall_skip_until = time.monotonic() + 600
+    return cc
+
+
+def _msgs():
+    return [
+        {"role": "user", "content": "u1 " + "x" * 200},
+        {"role": "assistant", "content": "a1 " + "y" * 200},
+        {"role": "user", "content": "u2 " + "z" * 200},
+    ]
+
+
+def _ok_response(content="SUMMARY BODY"):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _make_compressor(summary_model="aux-summarizer"):
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100000
+    ):
+        return ContextCompressor(
+            model="main-model",
+            quiet_mode=True,
+            summary_model_override=summary_model,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stall detection: the recovered path escalates (on_primary_stall fires)
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_recovered_stall_fires_escalation_hook():
+    original = [{"role": "user", "content": "keep-me"}]
+    compressed = [{"role": "user", "content": "summary of earlier turns"}]
+    worker = _StalledSummaryWorker(compressed)
+    timeouts = []
+    stalls = []
+
+    try:
+        msgs, prompt = _run(
+            worker,
+            chain=[CHAIN_ENTRY],
+            timeouts=timeouts,
+            messages=original,
+            on_stall=lambda: stalls.append("stall"),
+        )
+    finally:
+        worker.release.set()
+
+    assert worker.attempts == 2, "the aborted stall must be retried once"
+    assert msgs == compressed, "the fallback attempt's compression is published"
+    assert prompt == "summarized-prompt"
+    assert stalls == ["stall"], (
+        "the fallback-recovered stall must fire the route-specific hook"
+    )
+    assert not timeouts, (
+        "on_timeout (the shared cooldown ladder) must NOT fire on a recovery"
+    )
+
+
+def test_fallback_recovered_stall_increments_ledger_to_skip_gate(tmp_path):
+    """End-to-end: two fallback-recovered stalls trip the skip-primary gate."""
+    db = _db(tmp_path)
+    db.create_session("s1", source="cli")
+    compressor = _compressor(db, "s1")
+    timeouts = []
+
+    def _on_stall():
+        compressor.record_primary_route_stall_recovered()
+
+    for _ in range(2):
+        worker = _StalledSummaryWorker([{"role": "user", "content": "summary"}])
+        try:
+            _run(worker, chain=[CHAIN_ENTRY], timeouts=timeouts, on_stall=_on_stall)
+        finally:
+            worker.release.set()
+
+    assert compressor._primary_stall_streak == 2
+    assert compressor.should_skip_primary_route() is True, (
+        "two consecutive fallback-recovered stalls must arm the skip gate"
+    )
+    assert not timeouts, "no degradation was ever signalled"
+
+
+# ---------------------------------------------------------------------------
+# Escalation firing: the skip-primary gate routes the FIRST attempt to fallback
+# ---------------------------------------------------------------------------
+
+
+def test_skip_primary_gate_prepins_fallback_as_first_attempt():
+    """Host wiring simulation: gate tripped -> first attempt IS the fallback."""
+    compressed = [{"role": "user", "content": "summary via fallback"}]
+    worker = _StalledSummaryWorker(compressed, stall_attempts=0)
+    stalls = []
+    compressor = _gate_tripped_compressor()
+
+    with _patch_chain([CHAIN_ENTRY]):
+        assert compressor.should_skip_primary_route() is True
+        route = resolve_compression_fallback_route()
+    assert route is not None
+
+    try:
+        with _patch_chain([CHAIN_ENTRY]):
+            with pin_summary_route(route):
+                msgs, prompt = run_compress_context_with_progress_timeout(
+                    worker=worker,
+                    messages=[{"role": "user", "content": "keep-me"}],
+                    system_prompt_fallback="degraded-prompt",
+                    idle_timeout_seconds=0.05,
+                    total_ceiling_seconds=0.2,
+                    stall_fallback=False,
+                    on_primary_stall=lambda: stalls.append("stall"),
+                )
+    finally:
+        worker.release.set()
+
+    assert worker.attempts == 1, (
+        "the pre-pinned fallback is the only attempt — no idle burn, no retry"
+    )
+    pinned = worker.routes[0]
+    assert pinned is not None, "the first attempt must carry the fallback route"
+    assert pinned["provider"] == "custom"
+    assert pinned["model"] == "backup-summarizer"
+    assert msgs == compressed
+    assert stalls == [], "a healthy pre-pinned attempt is not a new stall"
+
+
+def test_skipped_primary_stall_degrades_without_second_retry():
+    """A stall on the pre-pinned fallback must not re-run the same route."""
+    original = [{"role": "user", "content": "keep-me"}]
+    worker = _StalledSummaryWorker(
+        [{"role": "user", "content": "unused"}], stall_attempts=1
+    )
+    timeouts = []
+    entry = dict(CHAIN_ENTRY, timeout=0.05)
+
+    try:
+        with _patch_chain([CHAIN_ENTRY]):
+            with pin_summary_route(entry):
+                msgs, prompt = run_compress_context_with_progress_timeout(
+                    worker=worker,
+                    messages=original,
+                    system_prompt_fallback="degraded-prompt",
+                    idle_timeout_seconds=0.05,
+                    total_ceiling_seconds=0.2,
+                    stall_fallback=False,
+                    on_timeout=lambda *args: timeouts.append(args),
+                )
+    finally:
+        worker.release.set()
+
+    assert worker.attempts == 1, "no chained retry on the same fallback route"
+    assert msgs is original
+    assert prompt == "degraded-prompt"
+    assert len(timeouts) == 1, "degrade via the shared ladder exactly once"
+
+
+# ---------------------------------------------------------------------------
+# Non-regression: healthy routes behave exactly as before
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_route_never_fires_escalation_hook():
+    compressed = [{"role": "user", "content": "summary"}]
+    worker = _StalledSummaryWorker(compressed, stall_attempts=0)
+    stalls = []
+
+    try:
+        msgs, prompt = _run(
+            worker, chain=[CHAIN_ENTRY], timeouts=[], on_stall=lambda: stalls.append("stall")
+        )
+    finally:
+        worker.release.set()
+
+    assert worker.attempts == 1, "a healthy route is not retried"
+    assert worker.routes[0] is None, "a healthy route is never pinned"
+    assert msgs == compressed
+    assert prompt == "summarized-prompt"
+    assert stalls == [], "no stall, no escalation hook"
+
+
+def test_healthy_route_keeps_ledger_untouched(tmp_path):
+    db = _db(tmp_path)
+    db.create_session("s1", source="cli")
+    compressor = _compressor(db, "s1")
+    worker = _StalledSummaryWorker(
+        [{"role": "user", "content": "summary"}], stall_attempts=0
+    )
+    try:
+        _run(worker, chain=[CHAIN_ENTRY], timeouts=[])
+    finally:
+        worker.release.set()
+    assert compressor._primary_stall_streak == 0
+    assert compressor.should_skip_primary_route() is False
+    stored = db.get_session_model_config_value("s1", "primary_stall_streak")
+    assert stored in (None, 0), (
+        "the durable ledger is untouched on a healthy route"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Telemetry: a half-dead primary is visible in the compression stream
+# ---------------------------------------------------------------------------
+
+
+def test_stall_recovery_emits_route_specific_telemetry(caplog):
+    compressor = _gate_tripped_compressor()
+    agent = SimpleNamespace(context_compressor=compressor)
+    worker = _StalledSummaryWorker([{"role": "user", "content": "summary"}])
+
+    with caplog.at_level(logging.INFO, logger="agent.conversation_compression"):
+        try:
+            _run(
+                worker,
+                chain=[CHAIN_ENTRY],
+                timeouts=[],
+                on_stall=lambda: None,
+                telemetry_agent=agent,
+            )
+        finally:
+            worker.release.set()
+
+    stall_lines = [
+        r.message
+        for r in caplog.records
+        if "compression attempt telemetry" in r.message
+        and "primary_route_stall_recovered" in r.message
+    ]
+    assert stall_lines, "the recovered stall must be visible in the telemetry stream"
+    assert any('"primary_stall_streak":2' in line for line in stall_lines), (
+        "the telemetry line must carry the route-specific ledger count"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Compressor ledger: gate, re-probe, reset
+# ---------------------------------------------------------------------------
+
+
+def test_streak_below_threshold_does_not_skip():
+    cc = _compressor()
+    cc.record_primary_route_stall_recovered()
+    assert cc._primary_stall_streak == 1
+    assert cc.should_skip_primary_route() is False
+
+
+def test_skip_window_expiry_reprobes_primary():
+    """After the window lapses the gate drops, re-probing the real primary."""
+    cc = _gate_tripped_compressor()
+    assert cc.should_skip_primary_route() is True
+
+    # Window lapses (simulated): the next compression probes the primary again.
+    cc._primary_stall_skip_until = time.monotonic() - 1.0
+    assert cc.should_skip_primary_route() is False, (
+        "an expired skip window must re-probe the primary"
+    )
+
+    # The probe stalls and the fallback recovers it: window re-arms, gate back.
+    cc.record_primary_route_stall_recovered()
+    assert cc._primary_stall_streak == 3
+    assert cc.should_skip_primary_route() is True, (
+        "a re-probe stall must re-arm a fresh skip window"
+    )
+
+
+def test_unpinned_summary_success_resets_ledger():
+    """A primary attempt that produces tokens clears the ledger."""
+    compressor = _gate_tripped_compressor()
+    calls = []
+
+    def _fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _ok_response()
+
+    with patch("agent.context_compressor.call_llm", side_effect=_fake_call_llm):
+        summary = compressor._generate_summary(_msgs())
+
+    assert summary and "SUMMARY BODY" in summary
+    assert "provider" not in calls[0], "an unpinned call is the real primary"
+    assert compressor._primary_stall_streak == 0
+    assert compressor._primary_stall_skip_until == 0.0
+    assert compressor.should_skip_primary_route() is False
+
+
+def test_pinned_summary_success_keeps_ledger():
+    """A pre-pinned fallback success is NOT proof the primary recovered."""
+    compressor = _gate_tripped_compressor()
+    calls = []
+
+    def _fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _ok_response()
+
+    with patch("agent.context_compressor.call_llm", side_effect=_fake_call_llm):
+        with pin_summary_route(dict(CHAIN_ENTRY)):
+            summary = compressor._generate_summary(_msgs())
+
+    assert summary
+    assert calls[0]["provider"] == "custom", "the pin reached the summary call"
+    assert compressor._primary_stall_streak == 2, (
+        "a fallback success must not clear the primary-stall ledger"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistence: restart must not disarm mid-escalation (#95879 constraint)
+# ---------------------------------------------------------------------------
+
+
+def test_primary_stall_ledger_roundtrips_and_rearms(tmp_path):
+    db = _db(tmp_path)
+    db.create_session("s1", source="cli")
+
+    first = _compressor(db, "s1")
+    first.record_primary_route_stall_recovered()
+    first.record_primary_route_stall_recovered()
+    assert first._primary_stall_streak == 2
+    assert db.get_session_model_config_value("s1", "primary_stall_streak") == 2
+    stored_until = db.get_session_model_config_value("s1", "primary_stall_skip_until")
+    assert isinstance(stored_until, (int, float)) and stored_until > time.time()
+
+    # Process restart: a fresh compressor inherits the tripped gate.
+    second = _compressor(db, "s1")
+    assert second._primary_stall_streak == 2
+    assert second.should_skip_primary_route() is True, (
+        "a fresh compressor on a resumed session must inherit the skip window"
+    )
+
+
+def test_primary_success_resets_ledger_durably(tmp_path):
+    db = _db(tmp_path)
+    db.create_session("s1", source="cli")
+
+    cc = _compressor(db, "s1")
+    cc.record_primary_route_stall_recovered()
+    cc.record_primary_route_stall_recovered()
+    assert cc.should_skip_primary_route() is True
+
+    cc.record_primary_route_success()
+    assert cc._primary_stall_streak == 0
+    assert db.get_session_model_config_value("s1", "primary_stall_streak") == 0
+
+    fresh = _compressor(db, "s1")
+    assert fresh.should_skip_primary_route() is False
+
+
+def test_rebind_to_other_session_does_not_leak_ledger(tmp_path):
+    db = _db(tmp_path)
+    db.create_session("hot", source="cli")
+    db.create_session("cold", source="cli")
+
+    cc = _compressor(db, "hot")
+    cc.record_primary_route_stall_recovered()
+    cc.record_primary_route_stall_recovered()
+    assert cc.should_skip_primary_route() is True
+
+    cc.bind_session_state(db, "cold")
+    assert cc._primary_stall_streak == 0
+    assert cc.should_skip_primary_route() is False
+
+
+def test_session_rotation_carries_primary_ledger(tmp_path):
+    """A compression rotation must not silently heal a half-dead primary."""
+    db = _db(tmp_path)
+    db.create_session("parent", source="cli")
+    db.create_session("child", source="cli")
+
+    cc = _compressor(db, "parent")
+    cc.record_primary_route_stall_recovered()
+    cc.record_primary_route_stall_recovered()
+    assert cc.should_skip_primary_route() is True
+
+    rotated = _compressor(db, "child")  # fresh child row: zeros
+    rotated.on_session_start(
+        "child",
+        boundary_reason="compression",
+        old_session_id="parent",
+        session_db=db,
+    )
+    assert rotated._primary_stall_streak == 2
+    assert rotated.should_skip_primary_route() is True
+
+    # The carried ledger was persisted onto the child row.
+    restarted = _compressor(db, "child")
+    assert restarted._primary_stall_streak == 2


### PR DESCRIPTION
## Summary

Fixes #95879. A permanently half-dead primary summarizer (connection open, zero tokens) was retried at full speed every compaction: the fallback-RECOVERED path in `run_compress_context_with_progress_timeout` returns before `on_timeout` fires, so the shared cooldown ladder never learned the primary stalled, and every compaction burned a full idle window (default 120s) on the dead primary forever.

## Mechanism

- `on_primary_stall` callback fired only on the fallback-recovered path (before `on_timeout`), so the shared route-agnostic ladder stays untouched (recording a recovery there would suppress the healthy fallback and re-break #95433).
- Route-specific persisted ledger on `ContextCompressor` (`_primary_stall_streak`, `_primary_stall_skip_until`) via session model_config keys: no schema migration, restart-safe.
- At `compression.primary_stall_skip_threshold` (default 2) fallback-recovered stalls, a bounded skip-primary window (`compression.primary_stall_skip_seconds`, default 600s) arms; the host pre-pins `fallback_chain[0]` as the FIRST attempt instead of probing the half-dead primary.
- Window lapse re-probes the primary; a stall re-arms a fresh window (bounded cadence); an unpinned (real primary) summary success clears the ledger durably.
- Telemetry: `failure_class=primary_route_stall_recovered` + `primary_stall_streak` make the stall visible in the compression telemetry stream.

## Tests

15 new tests in `tests/agent/test_compression_primary_stall_escalation.py` (hook fires on recovered stall / never on healthy route, ledger increment to gate, pre-pin makes fallback the first attempt, pre-pinned fallback stall degrades once, telemetry, below-threshold no skip, window expiry re-probe + re-arm, unpinned success resets, pinned success keeps streak, persistence round-trip, session-rotation carry, durable reset). Full regression suite passes (one pre-existing timing flake in `test_compression_review_76354` fails identically on base).

Reviewed and APPROVED in kanban review (t_4d407de1): no blocking comments; 6 non-blocking notes recorded.
