### PR TITLE
fix(doctor): skip browser-use warning when backend is off

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -364,6 +364,16 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
             continue
+        # browser-use is intentionally disabled when browser.backend is "off"
+        # (seat uses agent-browser browser_* tools instead). Suppress noise.
+        if name == "browser-use":
+            try:
+                from tools.browser_use_cli import BACKEND_DISABLED, get_browser_backend
+
+                if get_browser_backend() == BACKEND_DISABLED:
+                    continue
+            except Exception:
+                pass
         updated_unavailable.append(item)
     return updated_available, updated_unavailable
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -226,6 +226,50 @@ class TestDoctorToolAvailabilityOverrides:
         assert available == []
         assert unavailable == [kanban_entry]
 
+    def test_suppresses_browser_use_when_backend_is_off(self, monkeypatch):
+        """backend: off means agent-browser is the stack — not a missing dep."""
+        monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: False)
+        import tools.browser_use_cli as bu
+
+        monkeypatch.setattr(bu, "get_browser_backend", lambda: bu.BACKEND_DISABLED)
+        browser_use_entry = {
+            "name": "browser-use",
+            "env_vars": [],
+            "tools": ["browser_exec"],
+        }
+        discord_entry = {
+            "name": "discord",
+            "env_vars": ["DISCORD_BOT_TOKEN"],
+            "tools": ["discord_send"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            ["browser"],
+            [browser_use_entry, discord_entry],
+        )
+
+        assert available == ["browser"]
+        assert unavailable == [discord_entry]
+
+    def test_keeps_browser_use_unavailable_when_backend_is_not_off(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: False)
+        import tools.browser_use_cli as bu
+
+        monkeypatch.setattr(bu, "get_browser_backend", lambda: "browser-use")
+        browser_use_entry = {
+            "name": "browser-use",
+            "env_vars": [],
+            "tools": ["browser_exec"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [browser_use_entry],
+        )
+
+        assert available == []
+        assert unavailable == [browser_use_entry]
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

When `browser.backend` is explicitly `off`, Hermes uses the built-in agent-browser `browser_*` tools. `hermes doctor` still listed the unused `browser-use` toolset as `⚠ browser-use (system dependency not met)` because that toolset has no env vars and its check_fn returns false.

This treats an intentional opt-out as a missing dependency. Doctor already has the same pattern for kanban/honcho in `_apply_doctor_tool_availability_overrides`.

## Related Issue

No existing issue. Reproduced on a seat with `browser.backend: 'off'` and a working agent-browser install.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/doctor.py`: skip the `browser-use` unavailable row when `get_browser_backend() == BACKEND_DISABLED`
- `tests/hermes_cli/test_doctor.py`: suppress when backend is off; keep unavailable when backend is `browser-use`

## How to Test

1. Set `browser.backend: off` in `~/.hermes/config.yaml`
2. Run `hermes doctor`
3. Confirm Tool Availability has no `⚠ browser-use (system dependency not met)` while `browser` / `browser-cdp` stay healthy
4. `uv run --extra dev pytest tests/hermes_cli/test_doctor.py::TestDoctorToolAvailabilityOverrides -v`

Red-green: stashing the doctor.py change makes `test_suppresses_browser_use_when_backend_is_off` fail (browser-use remains in unavailable).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the targeted doctor override class, 4 passed; full suite not run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0 Darwin arm64 (M5 Max)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (uses existing `get_browser_backend()`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A