### PR TITLE
fix(kanban): count request_review/request_changes as terminal worker exits

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8407,7 +8407,9 @@ def run_conversation(
                     continue
 
                 # ── Kanban worker terminal-tool stop guard ─────────────
-                # Workers must end with kanban_complete / kanban_block.
+                # Workers must end their run with a terminal board tool
+                # (kanban_complete / kanban_block / kanban_request_review /
+                # kanban_request_changes — see agent/kanban_stop.py).
                 # Models sometimes narrate the next step ("Let me write the
                 # report") and stop with finish_reason=stop — a clean exit
                 # that the dispatcher records as protocol_violation. Nudge
@@ -8443,7 +8445,7 @@ def run_conversation(
                     )
                     agent._emit_status(
                         "⚠️ Kanban worker tried to exit without "
-                        "kanban_complete/kanban_block — nudging to finish"
+                        "a terminal kanban tool — nudging to finish"
                     )
                     # Same finalizer contract as verify-on-stop: clear
                     # final_response while continuing so a later budget

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -1,7 +1,10 @@
 """Turn-end guard for kanban workers.
 
-Kanban workers must end with ``kanban_complete`` or ``kanban_block``. Models
-(especially GLM / Qwen families) sometimes narrate the next step
+Kanban workers must end their run with a terminal board tool:
+``kanban_complete``, ``kanban_block``, ``kanban_request_review`` (ends the
+implementation run; the card moves to the review lane), or
+``kanban_request_changes`` (ends a review run; the card returns for rework).
+Models (especially GLM / Qwen families) sometimes narrate the next step
 ("Let me write the report now") and stop with ``finish_reason=stop`` and no
 tool calls. Hermes treats that as a clean exit → ``rc=0`` → dispatcher
 ``protocol_violation``.
@@ -17,7 +20,17 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+_TERMINAL_KANBAN_TOOLS = frozenset({
+    "kanban_complete",
+    "kanban_block",
+    # request_review / request_changes are documented run-enders in the
+    # worker system prompt (KANBAN_GUIDANCE §5) and in the board state
+    # machine: request_review leaves the card in review (the dispatcher's
+    # clean-exit check only flags tasks still ``running``), and
+    # request_changes closes the review run and re-queues rework (#98107).
+    "kanban_request_review",
+    "kanban_request_changes",
+})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 
@@ -90,12 +103,17 @@ def build_kanban_stop_nudge(
         "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
         "terminal state for the board.\n\n"
         f"Task `{tid}` is still `running`. Ending now without a board tool "
-        "causes a protocol violation (clean exit with no "
-        "`kanban_complete` / `kanban_block`).\n\n"
+        "causes a protocol violation (clean exit with no terminal kanban "
+        "call).\n\n"
         "Do this immediately in your next response — do not narrate intent:\n"
         "1. Finish any remaining deliverable (write the required file(s) now).\n"
         "2. Call `kanban_complete(summary=..., artifacts=[...])` if the work "
-        "is done, OR `kanban_block(reason=...)` if you are blocked.\n\n"
+        "is done; `kanban_request_review(summary=..., metadata=...)` if the "
+        "card needs review before it is final; `kanban_request_changes"
+        "(reason=...)` if you are the reviewer sending it back for rework; "
+        "OR `kanban_block(reason=...)` if you are blocked. If a lifecycle "
+        "call already succeeded, do not repeat it — pick the one legal "
+        "transition for the card's current column.\n\n"
         "Never end a turn with only a promise of future action. Repeated "
         "protocol violations will block this task and require manual intervention.]"
     )

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,84 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+def test_no_nudge_after_kanban_request_review(clear_kanban_env):
+    # #98107: a worker that ends its turn right after a successful
+    # kanban_request_review (card moves to the review lane) must not be
+    # nudged — the only tool the old nudge taught, kanban_complete, fails
+    # on an already-review card with "unknown id or already terminal".
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_4a177ae4")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Implementation finished; handing off for review.",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_request_review",
+                        "arguments": '{"summary": "implemented and verified"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "kanban_request_review",
+            "tool_call_id": "1",
+            "content": "review requested",
+        },
+    ]
+    assert session_called_kanban_terminal(messages) is True
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
+def test_no_nudge_after_kanban_request_changes(clear_kanban_env):
+    # Review workers run under HERMES_KANBAN_TASK too; request_changes is
+    # the documented ender for a review run (card returns for rework).
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {
+                        "name": "kanban_request_changes",
+                        "arguments": '{"reason": "missing test coverage"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "kanban_request_changes",
+            "tool_call_id": "1",
+            "content": "changes requested",
+        },
+    ]
+    assert session_called_kanban_terminal(messages) is True
+    assert build_kanban_stop_nudge(messages=messages) is None
+
+
+def test_nudge_lists_all_run_enders(clear_kanban_env):
+    # The nudge must teach every legal run-ender, not just
+    # kanban_complete/kanban_block, or a nudged worker on an already-review
+    # card burns turns on impossible kanban_complete calls (#98107).
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    nudge = build_kanban_stop_nudge(messages=[], attempts=0)
+    assert nudge is not None
+    for tool in (
+        "kanban_complete",
+        "kanban_block",
+        "kanban_request_review",
+        "kanban_request_changes",
+    ):
+        assert tool in nudge
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

The kanban worker stop guard only accepted `kanban_complete` / `kanban_block` as run-ending tools. But the worker system prompt (KANBAN_GUIDANCE §5) teaches `kanban_request_review(summary=..., metadata=...)` as the normal ender when a card needs review, and `kanban_request_changes(reason=...)` as the reviewer's ender for a review run. A worker that followed the prompt and ended its turn right after a successful `kanban_request_review` was nudged ("tried to exit without kanban_complete/kanban_block"), and the only tool the nudge taught — `kanban_complete` — fails on an already-review card with "unknown id or already terminal", so the worker burned turns on impossible calls.

Both transitions are documented run-enders in the board state machine, so the guard and the dispatcher already disagree about them today:

- `kanban_request_review` moves the card out of `running` into the review lane, so the dispatcher's clean-exit check (which only flags tasks still `running`) never treats it as a protocol violation — only the in-loop guard does.
- `kanban_request_changes` ("Finish an active review run and route the task back for rework") closes the review run; review workers spawn through the same `_default_spawn` path and run under `HERMES_KANBAN_TASK`, so the guard fires for them too.

The fix adds both tools to `_TERMINAL_KANBAN_TOOLS` in `agent/kanban_stop.py` (the single source the conversation-loop guard consults) and updates the synthetic nudge to teach every legal run-ender instead of only complete/block, with an explicit "if a lifecycle call already succeeded, do not repeat it — pick the one legal transition for the card's current column" line to break the impossible-`kanban_complete` loop from the issue report.

## Related Issue

Fixes #98107

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/kanban_stop.py` — added `kanban_request_review` and `kanban_request_changes` to `_TERMINAL_KANBAN_TOOLS` (with a comment explaining why both are run-enders); updated the module docstring; rewrote nudge step 2 to list all four legal run-enders and to warn against repeating an already-successful lifecycle call.
- `agent/conversation_loop.py` — guard comment block and the `_emit_status` message now say "a terminal kanban tool" instead of enumerating only complete/block (comment + status-string only, no logic change).
- `tests/agent/test_kanban_stop.py` — added `test_no_nudge_after_kanban_request_review` (the issue's exact scenario), `test_no_nudge_after_kanban_request_changes` (review-worker ender), and `test_nudge_lists_all_run_enders` (pins that the nudge teaches all four tools so the taught-tool set can't silently drift from the guard set again).

## How to Test

1. `pytest tests/agent/test_kanban_stop.py -q` — Observed result: `6 passed` (3 pre-existing + 3 new).
2. Adjacent kanban suites: `pytest tests/agent/test_kanban_stop.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_core_functionality.py -q` — Observed result: `31 passed, 1 skipped` (the skip is pre-existing).
3. Manual shape of the reported scenario, now covered by `test_no_nudge_after_kanban_request_review`: a message history containing a successful `kanban_request_review` tool call returns `None` from `build_kanban_stop_nudge`, so the worker's turn ends normally instead of being nudged toward an impossible `kanban_complete`; before the fix, the same history produced a nudge (`kanban_request_review` was not in the terminal set).
4. `ruff check` on the three changed files passes; `ruff format --check` is clean for the new code (pre-existing main-only reformat diffs in untouched regions of `conversation_loop.py` / `test_kanban_stop.py` were left alone deliberately).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the targeted kanban suites (`tests/agent/test_kanban_stop.py`, `tests/hermes_cli/test_kanban_block_kinds.py`, `tests/hermes_cli/test_kanban_core_functionality.py`: 31 passed, 1 skipped); this change touches only the guard's tool-name set, nudge string, and one status string, with no other call sites
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.4.0, arm64); change is platform-independent (pure Python policy set)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module docstring in `agent/kanban_stop.py` and the guard comment updated to state the full terminal contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no platform-specific code; new tests use monkeypatched env vars only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tool behavior unchanged; only the stop guard's acceptance set)
