### PR TITLE
fix(proxy): resolve Nous auth state through global fallback in profiles

### DIFF
--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -23,6 +23,7 @@ from hermes_cli.auth import (
     _save_auth_store,
     _validate_nous_inference_url_from_network,
     _write_shared_nous_state,
+    get_provider_auth_state,
     resolve_nous_runtime_credentials,
 )
 from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
@@ -162,12 +163,10 @@ class NousPortalAdapter(UpstreamAdapter):
     def _read_state(self) -> Optional[Dict[str, Any]]:
         try:
             with _auth_store_lock():
-                store = _load_auth_store()
+                state = get_provider_auth_state("nous")
         except Exception as exc:
             logger.warning("proxy: failed to load auth store: %s", exc)
             return None
-        providers = store.get("providers") or {}
-        state = providers.get("nous")
         if not isinstance(state, dict):
             return None
         return dict(state)  # copy so the refresh helper can mutate freely

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -45,6 +45,39 @@ def _write_auth_store(hermes_home: Path, nous_state: Dict[str, Any]) -> Path:
 
 
 
+def test_nous_adapter_falls_back_to_global_auth_store_in_profile(tmp_path, monkeypatch):
+    """In a profile with empty providers, NousPortalAdapter must resolve from global auth store."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    global_home = tmp_path / ".hermes"
+    global_home.mkdir()
+    _write_auth_store(global_home, {
+        "access_token": "global-access-token",
+        "refresh_token": "global-refresh-token",
+    })
+
+    profile_home = global_home / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    (profile_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    adapter = NousPortalAdapter()
+    assert adapter.is_authenticated() is True
+    with patch(
+        "hermes_cli.proxy.adapters.nous_portal.resolve_nous_runtime_credentials",
+        return_value={
+            "api_key": "jwt-token",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "expires_at": "2099-01-01T00:00:00Z",
+        },
+    ):
+        cred = adapter.get_credential()
+        assert cred.bearer == "jwt-token"
+
+
 def test_nous_adapter_concurrent_refresh_serialized(tmp_path, monkeypatch):
     """Two parallel get_credential() calls must serialize through the lock."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

Resolves Nous Portal authentication state through the canonical `get_provider_auth_state("nous")` resolver in `NousPortalAdapter._read_state()`.

In a profile-scoped Hermes environment (`HERMES_HOME` pointing to a named profile), `auth.json` in the profile directory may lack a local `providers.nous` entry when credentials were authenticated at the global scope (`~/.hermes/auth.json`). While `hermes auth status nous` resolves credentials via global fallback (the #18594 hierarchy), `NousPortalAdapter._read_state()` previously read only the profile store directly, wrongly reporting that Nous Portal was not logged in.

Switching `_read_state()` to `get_provider_auth_state("nous")` restores parity between CLI auth status and proxy start without affecting profile isolation or credential quarantine write-back.

## Related Issue

Fixes #98098

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/proxy/adapters/nous_portal.py`: In `_read_state()`, replace direct profile `_load_auth_store().get("providers", {}).get("nous")` with `get_provider_auth_state("nous")`.
- `tests/hermes_cli/test_proxy.py`: Add `test_nous_adapter_falls_back_to_global_auth_store_in_profile` ensuring `is_authenticated()` and `get_credential()` resolve credentials when defined in the global auth store but absent from the active profile.

## How to Test

Run the proxy and profile fallback test suites:

```bash
pytest tests/hermes_cli/test_proxy.py tests/hermes_cli/test_auth_profile_fallback.py -q
```

Result: 12 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
