### PR TITLE
fix: inject current time into per-turn runtime context

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2931,7 +2931,21 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
 
     summary_request = MAX_ITERATIONS_SUMMARY_REQUEST
-    append_message(messages, {"role": "user", "content": summary_request})
+    summary_request_message = append_message(
+        messages, {"role": "user", "content": summary_request}
+    )
+    # Persist the exact API-bound summary bytes beside the stable synthetic
+    # marker.  The next turn can therefore replay the same prefix instead of
+    # replacing this timestamp with clean marker content and invalidating the
+    # cache at the largest request of the turn.
+    try:
+        from hermes_time import prepend_current_time_context
+
+        summary_api_content = prepend_current_time_context(summary_request)
+        if summary_api_content != summary_request:
+            summary_request_message["api_content"] = summary_api_content
+    except Exception:
+        logger.debug("max-iterations time context unavailable", exc_info=True)
 
     try:
         # Build API messages, stripping internal-only fields

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1940,6 +1940,7 @@ def run_conversation(
     current_turn_user_idx = _ctx.current_turn_user_idx
     _should_review_memory = _ctx.should_review_memory
     _plugin_user_context = _ctx.plugin_user_context
+    _runtime_time_context = _ctx.runtime_time_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
     # Commentary deduplication spans all provider continuations and tool calls
@@ -2018,8 +2019,15 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        # codex_app_server owns its thread and receives only the current user
+        # input here. Add the volatile clock block to that API copy while the
+        # Hermes transcript keeps the clean user message. The subprocess
+        # retains the exact input it received for later turns.
+        _codex_user_message = compose_user_api_content(
+            user_message, "", _runtime_time_context
+        )
         return agent._run_codex_app_server_turn(
-            user_message=user_message,
+            user_message=_codex_user_message or user_message,
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -499,6 +499,9 @@ class TurnContext:
     should_review_memory: bool = False
     # Context contributed by ``pre_llm_call`` plugins (appended to user message).
     plugin_user_context: str = ""
+    # Volatile wall-clock context for this inference turn. Kept separate for
+    # runtimes such as codex_app_server that bypass the standard sidecar path.
+    runtime_time_context: str = ""
     # External-memory prefetch result, reused across loop iterations.
     ext_prefetch_cache: str = ""
     # Turn-start preflight already proved an immediate retry ineffective.
@@ -1399,6 +1402,27 @@ def build_turn_context(
                 else _gateway_notes
             )
 
+    # Per-turn current-time context (volatile). Composed into the API copy of
+    # the current turn's user message — never the cached system prompt — so
+    # every inference turn sees fresh wall-clock time while the cached prompt
+    # prefix stays byte-stable (see AGENTS.md "prompt caching is sacred").
+    # Runs for every entrypoint (CLI, gateway platforms, cron) because this is
+    # the single shared turn prologue. Fail-open: a formatting problem must
+    # never block a turn.
+    runtime_time_context = ""
+    try:
+        from hermes_time import format_current_time_context
+
+        runtime_time_context = format_current_time_context()
+        if runtime_time_context:
+            plugin_user_context = (
+                runtime_time_context + "\n\n" + plugin_user_context
+                if plugin_user_context
+                else runtime_time_context
+            )
+    except Exception:
+        logger.debug("per-turn time context unavailable", exc_info=True)
+
     # Per-turn file-mutation verifier state.
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
@@ -1562,6 +1586,7 @@ def build_turn_context(
         current_turn_user_idx=current_turn_user_idx,
         should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context,
+        runtime_time_context=runtime_time_context,
         ext_prefetch_cache=ext_prefetch_cache,
         preflight_compression_blocked=_preflight_compression_blocked,
     )

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -133,3 +133,75 @@ def now() -> datetime:
     return datetime.now().astimezone()
 
 
+def get_timezone_name() -> str:
+    """Return the configured IANA timezone name (e.g. ``Asia/Shanghai``).
+
+    Returns an empty string when no timezone is configured.
+    """
+    timezone = get_timezone()  # ensure the cache is resolved and validated
+    return (_cached_tz_name or "") if timezone is not None else ""
+
+
+def get_utc_offset_display(now_dt: Optional[datetime] = None) -> str:
+    """Return the UTC offset for the configured timezone (e.g. ``+08:00``).
+
+    ``now_dt`` defaults to ``now()``. With no configured timezone, the
+    server-local offset is used. Returns ``+00:00`` for UTC.
+    """
+    current = now_dt if now_dt is not None else now()
+    offset = current.utcoffset()
+    if offset is None:  # defensive: now() is always tz-aware
+        return "+00:00"
+    total_seconds = int(offset.total_seconds())
+    sign = "+" if total_seconds >= 0 else "-"
+    hours, remainder = divmod(abs(total_seconds), 3600)
+    minutes = remainder // 60
+    return f"{sign}{hours:02d}:{minutes:02d}"
+
+
+def format_current_time_context(now_dt: Optional[datetime] = None) -> str:
+    """Format a ``[Runtime Context]`` time block for per-turn injection.
+
+    Injected into the API copy of the current turn's user message (never the
+    cached system prompt), so the volatile timestamp re-renders every turn
+    while the cached prompt prefix stays byte-stable. Generates ``now()`` when
+    ``now_dt`` is omitted; tests pass a fixed value for determinism.
+
+    Example::
+
+        [Runtime Context]
+        Current datetime: 2026-08-29T13:25:42+08:00
+        Timezone: Asia/Shanghai
+        UTC offset: +08:00
+    """
+    current = now_dt if now_dt is not None else now()
+    lines = [
+        "[Runtime Context]",
+        f"Current datetime: {current.isoformat(timespec='seconds')}",
+    ]
+    tz_name = get_timezone_name()
+    if tz_name:
+        lines.append(f"Timezone: {tz_name}")
+    lines.append(f"UTC offset: {get_utc_offset_display(current)}")
+    return "\n".join(lines)
+
+
+def prepend_current_time_context(
+    text: str,
+    now_dt: Optional[datetime] = None,
+) -> str:
+    """Prepend the per-turn current-time block to *text*.
+
+    Shared by the turn prologue and the max-iterations summary path so both
+    API copies carry the same volatile time block, formatted from the same
+    instant. Fail-open: if time formatting fails for any reason, *text* is
+    returned unchanged so a formatting problem can never block a turn.
+    """
+    try:
+        block = format_current_time_context(now_dt=now_dt)
+        if block:
+            return block + "\n\n" + text
+    except Exception:
+        pass
+    return text
+

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -258,16 +258,19 @@ class TestPrologueStamping:
         assert msg["api_content"] == compose_user_api_content(
             "hello", ctx.ext_prefetch_cache, ctx.plugin_user_context
         )
-        assert msg["api_content"] == "hello\n\nPLUGIN-CTX"
+        assert msg["api_content"].startswith("hello\n\n[Runtime Context]")
+        assert msg["api_content"].endswith("\n\nPLUGIN-CTX")
         # The early persist saw the stamped sidecar (written in one insert).
-        assert agent.api_content_at_persist == "hello\n\nPLUGIN-CTX"
+        assert agent.api_content_at_persist == msg["api_content"]
 
     def test_no_stamp_without_injections(self):
         agent = _FakeAgent()
         with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
             ctx = _build(agent)
-        assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
-        assert agent.api_content_at_persist is None
+        msg = ctx.messages[ctx.current_turn_user_idx]
+        assert msg["content"] == "hello"
+        assert msg["api_content"].startswith("hello\n\n[Runtime Context]")
+        assert agent.api_content_at_persist == msg["api_content"]
 
     def test_no_stamp_for_codex_app_server(self):
         """codex_app_server turns bypass the api_messages build, so the
@@ -503,7 +506,8 @@ class TestWireInvariant:
         assert len(reqs) == 2
         sent_1 = _user_messages(reqs[0])[0]["content"]
         sent_2 = _user_messages(reqs[1])[0]["content"]
-        assert sent_1 == "hello please\n\nPLUGIN-CTX"
+        assert sent_1.startswith("hello please\n\n[Runtime Context]")
+        assert sent_1.endswith("\n\nPLUGIN-CTX")
         assert sent_2 == sent_1  # repeated builds: identical bytes
 
         # The sidecar never reaches the provider.
@@ -544,7 +548,10 @@ class TestWireInvariant:
 
         # And the new current-turn message got its own injection + sidecar.
         current = _user_messages(_chat_requests(handler)[0])[-1]
-        assert current["content"] == "second question\n\nPLUGIN-CTX"
+        assert current["content"].startswith(
+            "second question\n\n[Runtime Context]"
+        )
+        assert current["content"].endswith("\n\nPLUGIN-CTX")
 
 
 # ---------------------------------------------------------------------------
@@ -636,9 +643,10 @@ class TestPrologueMoaAndInPlaceBackfill:
 
         msg = ctx.messages[ctx.current_turn_user_idx]
         assert msg["content"] == "hello"
-        assert msg["api_content"] == "hello\n\nPLUGIN-CTX"
+        assert msg["api_content"].startswith("hello\n\n[Runtime Context]")
+        assert msg["api_content"].endswith("\n\nPLUGIN-CTX")
         agent._session_db.set_latest_user_api_content.assert_called_once_with(
-            "sess-1", "hello", "hello\n\nPLUGIN-CTX"
+            "sess-1", "hello", msg["api_content"]
         )
 
 

--- a/tests/agent/test_gateway_turn_sidecar.py
+++ b/tests/agent/test_gateway_turn_sidecar.py
@@ -155,7 +155,8 @@ class TestStringContentSidecarDelivery:
             ctx = _build(agent)
         msg = ctx.messages[ctx.current_turn_user_idx]
         assert msg["content"] == "hello"
-        assert msg["api_content"] == "hello\n\n" + RESET_NOTE
+        assert msg["api_content"].startswith("hello\n\n[Runtime Context]")
+        assert msg["api_content"].endswith("\n\n" + RESET_NOTE)
         # The composed bytes match what conversation_loop would send.
         assert msg["api_content"] == compose_user_api_content(
             "hello", ctx.ext_prefetch_cache, ctx.plugin_user_context
@@ -172,13 +173,18 @@ class TestStringContentSidecarDelivery:
         ):
             ctx = _build(agent)
         msg = ctx.messages[ctx.current_turn_user_idx]
-        assert msg["api_content"] == "hello\n\nPLUGIN-CTX\n\n" + VC_NOTE
+        assert msg["api_content"].startswith("hello\n\n[Runtime Context]")
+        assert msg["api_content"].endswith(
+            "\n\nPLUGIN-CTX\n\n" + VC_NOTE
+        )
 
-    def test_no_notes_means_no_stamp(self):
+    def test_no_notes_still_gets_runtime_context(self):
         agent = _FakeAgent()
         with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
             ctx = _build(agent)
-        assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
+        msg = ctx.messages[ctx.current_turn_user_idx]
+        assert msg["content"] == "hello"
+        assert msg["api_content"].startswith("hello\n\n[Runtime Context]")
 
 
 class TestMultimodalFallback:

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -78,7 +78,7 @@ class TestRunConversationCodexPath:
         # No background review fork during tests
         with patch.object(agent, "_spawn_background_review", return_value=None):
             result = agent.run_conversation("hello there")
-        assert result["final_response"] == "echo: hello there"
+        assert result["final_response"].startswith("echo: hello there\n\n[Runtime Context]")
         assert result["completed"] is True
         assert result["partial"] is False
         assert result["error"] is None
@@ -197,7 +197,9 @@ class TestRunConversationCodexPath:
         assert msgs[0]["content"] == "hello"
         # Last assistant message has the final text
         final = [m for m in msgs if m.get("role") == "assistant"
-                 and m.get("content") == "echo: hello"]
+                 and (m.get("content") or "").startswith(
+                     "echo: hello\n\n[Runtime Context]"
+                 )]
         assert final, f"expected final assistant message in {msgs}"
 
     def test_projected_messages_are_synced_to_external_memory(self, fake_session):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3228,7 +3228,21 @@ class TestRunConversation:
         ]
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
         assert all("request" in c and "messages" in c["request"]["body"] for c in pre_request_calls)
-        assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
+        # Contract: the user's text remains fully intact AND the volatile
+        # per-turn runtime context (current time) is appended to the API
+        # copy after it. A bare prefix check would let arbitrary trailing
+        # content pass; require the exact two-part shape.
+        _user_msgs = [
+            msg.get("content")
+            for msg in pre_request_calls[0]["request_messages"]
+            if msg.get("role") == "user"
+            and isinstance(msg.get("content"), str)
+        ]
+        assert any(
+            m.startswith("search something\n\n[Runtime Context]")
+            and "\nCurrent datetime: " in m
+            for m in _user_msgs
+        )
         assert all("usage" in c and "response" in c for c in post_request_calls)
         assert all("assistant_message" in c["response"] for c in post_request_calls)
 
@@ -4916,7 +4930,13 @@ class TestRunConversation:
         # output-cap retry would call the compressor but re-transmit the same
         # oversized request forever.
         second_messages = second_call.get("messages", [])
-        assert second_messages[-1].get("content") == "hello"
+        # The compressed history is re-sent; the single user message carries
+        # the full user text plus the volatile per-turn runtime context
+        # appended after it (exact shape, not a loose prefix).
+        _retry_content = second_messages[-1].get("content")
+        assert isinstance(_retry_content, str)
+        assert _retry_content.startswith("hello\n\n[Runtime Context]")
+        assert "\nCurrent datetime: " in _retry_content
         assert len(second_messages) == 2
         assert second_messages[0]["role"] == "system"
         # context_length was NOT mutated by an output-cap error.

--- a/tests/test_per_turn_time_context.py
+++ b/tests/test_per_turn_time_context.py
@@ -1,0 +1,397 @@
+"""Behavior contracts for cache-safe per-turn current-time context."""
+
+from __future__ import annotations
+
+import types
+from datetime import datetime, timedelta, timezone as dt_timezone
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import hermes_time
+from agent.chat_completion_helpers import handle_max_iterations
+from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
+from agent.turn_context import (
+    build_turn_context,
+    compose_user_api_content,
+    substitute_api_content,
+)
+from hermes_time import format_current_time_context
+
+
+def _reset_hermes_time_cache():
+    hermes_time._cached_tz = None
+    hermes_time._cached_tz_name = None
+    hermes_time._cache_resolved = False
+
+
+@pytest.fixture(autouse=True)
+def _clean_time_env(monkeypatch):
+    monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+    _reset_hermes_time_cache()
+    yield
+    _reset_hermes_time_cache()
+
+
+class TestFormatCurrentTimeContext:
+    def test_configured_timezone_and_offset(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TIMEZONE", "Asia/Shanghai")
+        fixed = datetime(2026, 8, 29, 13, 25, 42, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+        assert format_current_time_context(now_dt=fixed) == (
+            "[Runtime Context]\n"
+            "Current datetime: 2026-08-29T13:25:42+08:00\n"
+            "Timezone: Asia/Shanghai\n"
+            "UTC offset: +08:00"
+        )
+
+    @pytest.mark.parametrize(
+        ("month", "expected_offset"),
+        [(8, "-07:00"), (12, "-08:00")],
+    )
+    def test_timezone_offset_follows_dst(self, monkeypatch, month, expected_offset):
+        monkeypatch.setenv("HERMES_TIMEZONE", "America/Los_Angeles")
+        fixed = datetime(2026, month, 29, 6, 0, tzinfo=ZoneInfo("America/Los_Angeles"))
+
+        assert f"UTC offset: {expected_offset}" in format_current_time_context(fixed)
+
+    def test_default_time_is_timezone_aware(self):
+        datetime_line = next(
+            line
+            for line in format_current_time_context().splitlines()
+            if line.startswith("Current datetime:")
+        )
+        parsed = datetime.fromisoformat(datetime_line.split(": ", 1)[1])
+
+        assert parsed.tzinfo is not None
+        assert isinstance(parsed.utcoffset(), timedelta)
+
+    def test_invalid_timezone_falls_back_safely(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TIMEZONE", "Not/AZone")
+
+        context = format_current_time_context()
+        assert "Current datetime:" in context
+        assert "Timezone: Not/AZone" not in context
+
+    def test_prepend_helper_fails_open(self):
+        with patch.object(
+            hermes_time,
+            "format_current_time_context",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert hermes_time.prepend_current_time_context("summary") == "summary"
+
+
+class _FakeTodoStore:
+    def has_items(self):
+        return True
+
+
+class _FakeGuardrails:
+    def reset_for_turn(self):
+        pass
+
+
+class _FakeAgent:
+    def __init__(self, *, platform="cli", api_mode="chat_completions"):
+        self.session_id = "time-context-test"
+        self.model = "test/model"
+        self.provider = "openrouter"
+        self.base_url = "https://openrouter.ai/api/v1"
+        self.api_key = "test-key"
+        self.api_mode = api_mode
+        self.platform = platform
+        self.quiet_mode = True
+        self.max_iterations = 90
+        self.tools = []
+        self.valid_tool_names = set()
+        self._skip_mcp_refresh = True
+        self.compression_enabled = False
+        self.context_compressor = types.SimpleNamespace(
+            protect_first_n=2, protect_last_n=2
+        )
+        self._cached_system_prompt = "STABLE SYSTEM"
+        self._memory_store = None
+        self._memory_manager = None
+        self._memory_nudge_interval = 0
+        self._turns_since_memory = 0
+        self._user_turn_count = 0
+        self._todo_store = _FakeTodoStore()
+        self._tool_guardrails = _FakeGuardrails()
+        self._compression_warning = None
+        self._interrupt_requested = False
+        self._memory_write_origin = "assistant_tool"
+        self._stream_context_scrubber = None
+        self._stream_think_scrubber = None
+        self.persisted_content = None
+
+    def _ensure_db_session(self):
+        pass
+
+    def _restore_primary_runtime(self):
+        pass
+
+    def _cleanup_dead_connections(self):
+        return False
+
+    def _emit_status(self, _message):
+        pass
+
+    def _replay_compression_warning(self):
+        pass
+
+    def _hydrate_todo_store(self, *_args, **_kwargs):
+        pass
+
+    def _safe_print(self, *_args, **_kwargs):
+        pass
+
+    def _persist_session(self, messages, _history=None):
+        self.persisted_content = messages[-1]["content"]
+
+
+def _build(agent, user_message="hello"):
+    return build_turn_context(
+        agent=agent,
+        user_message=user_message,
+        system_message=None,
+        conversation_history=None,
+        task_id=None,
+        stream_callback=None,
+        persist_user_message=None,
+        restore_or_build_system_prompt=lambda *_a, **_k: None,
+        install_safe_stdio=lambda: None,
+        sanitize_surrogates=lambda value: value,
+        summarize_user_message_for_log=lambda value: str(value),
+        set_session_context=lambda _sid: None,
+        set_current_write_origin=lambda _origin: None,
+        ra=lambda: types.SimpleNamespace(_set_interrupt=lambda *_a, **_k: None),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime_main():
+    with (
+        patch("agent.auxiliary_client.set_runtime_main", lambda *_a, **_k: None),
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        yield
+
+
+class TestSharedTurnPrologue:
+    @pytest.mark.parametrize(
+        ("platform", "api_mode"),
+        [
+            ("cli", "chat_completions"),
+            ("discord", "chat_completions"),
+            ("cli", "codex_responses"),
+        ],
+    )
+    def test_every_surface_gets_time_in_user_api_copy(self, platform, api_mode):
+        agent = _FakeAgent(platform=platform, api_mode=api_mode)
+        fixed = datetime(2026, 8, 29, 10, 0, tzinfo=dt_timezone.utc)
+
+        with patch.object(hermes_time, "now", return_value=fixed):
+            ctx = _build(agent)
+
+        message = ctx.messages[ctx.current_turn_user_idx]
+        assert message["content"] == "hello"
+        assert message["api_content"].startswith("hello\n\n[Runtime Context]")
+        assert "2026-08-29T10:00:00+00:00" in message["api_content"]
+        assert agent.persisted_content == "hello"
+        assert ctx.active_system_prompt == "STABLE SYSTEM"
+
+    def test_time_regenerates_without_changing_cached_system_prompt(self):
+        first = datetime(2026, 8, 29, 10, 0, tzinfo=dt_timezone.utc)
+        second = datetime(2026, 8, 29, 10, 5, 30, tzinfo=dt_timezone.utc)
+
+        with patch.object(hermes_time, "now", side_effect=[first, second]):
+            first_ctx = _build(_FakeAgent())
+            second_ctx = _build(_FakeAgent())
+
+        first_message = first_ctx.messages[first_ctx.current_turn_user_idx]
+        second_message = second_ctx.messages[second_ctx.current_turn_user_idx]
+        assert first_ctx.active_system_prompt == second_ctx.active_system_prompt
+        assert first_message["api_content"] != second_message["api_content"]
+        assert "10:00:00" in first_message["api_content"]
+        assert "10:05:30" in second_message["api_content"]
+
+    def test_responses_adapter_receives_substituted_runtime_context(self):
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        ctx = _build(_FakeAgent(api_mode="codex_responses"))
+        api_message = ctx.messages[ctx.current_turn_user_idx].copy()
+        substitute_api_content(api_message)
+
+        response_input = _chat_messages_to_responses_input([api_message])
+        assert "[Runtime Context]" in str(response_input)
+        assert "api_content" not in str(response_input)
+
+    def test_multimodal_turn_is_not_mutated_without_byte_stable_sidecar(self):
+        original = [
+            {"type": "text", "text": "look"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.invalid/a.png"},
+            },
+        ]
+        ctx = _build(_FakeAgent(), user_message=original)
+        clean_content = ctx.messages[ctx.current_turn_user_idx]["content"]
+        assert clean_content == original
+        assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
+
+    def test_codex_app_server_input_copy_gets_runtime_context(self):
+        ctx = _build(_FakeAgent(api_mode="codex_app_server"))
+        api_input = compose_user_api_content(
+            ctx.user_message, "", ctx.runtime_time_context
+        )
+
+        assert api_input is not None
+        assert api_input.startswith("hello\n\n[Runtime Context]")
+        assert ctx.messages[ctx.current_turn_user_idx]["content"] == "hello"
+
+
+class TestMaxIterationsSummary:
+    def _agent(self):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._cached_system_prompt = "STABLE SYSTEM"
+        return agent
+
+    def test_chat_completions_gets_time_without_mutating_marker(self):
+        agent = self._agent()
+        captured = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return "RAW"
+
+        client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=_Completions())
+        )
+        transport = types.SimpleNamespace(
+            normalize_response=lambda _response: types.SimpleNamespace(
+                content="SUMMARY"
+            )
+        )
+        messages = [{"role": "user", "content": "question"}]
+
+        with (
+            patch.object(agent, "_ensure_primary_openai_client", return_value=client),
+            patch.object(agent, "_get_transport", return_value=transport),
+        ):
+            assert handle_max_iterations(agent, messages, 5) == "SUMMARY"
+
+        persisted_summary = next(
+            message
+            for message in messages
+            if message.get("role") == "user"
+            and message.get("content") == MAX_ITERATIONS_SUMMARY_REQUEST
+        )
+        assert persisted_summary["content"] == MAX_ITERATIONS_SUMMARY_REQUEST
+        assert persisted_summary["api_content"].endswith(MAX_ITERATIONS_SUMMARY_REQUEST)
+        wire_summary = captured["messages"][-1]["content"]
+        # Consecutive-user repair may merge the preceding question into the
+        # wire message, but the persisted sidecar must remain its exact suffix
+        # so replay produces the same repaired bytes.
+        assert wire_summary.endswith(persisted_summary["api_content"])
+        assert "[Runtime Context]" in wire_summary
+        assert wire_summary.endswith(MAX_ITERATIONS_SUMMARY_REQUEST)
+
+    def test_codex_responses_gets_fresh_time(self):
+        agent = self._agent()
+        agent.api_mode = "codex_responses"
+        captured = {}
+
+        def _build_api_kwargs(messages):
+            captured["messages"] = messages
+            return {"messages": messages, "tools": []}
+
+        agent._build_api_kwargs = _build_api_kwargs
+        agent._run_codex_stream = lambda _kwargs: "RAW"
+        transport = types.SimpleNamespace(
+            normalize_response=lambda _response: types.SimpleNamespace(
+                content="SUMMARY"
+            )
+        )
+        messages = [{"role": "user", "content": "question"}]
+
+        with patch.object(agent, "_get_transport", return_value=transport):
+            assert handle_max_iterations(agent, messages, 5) == "SUMMARY"
+
+        persisted_summary = next(
+            message
+            for message in messages
+            if message.get("role") == "user"
+            and message.get("content") == MAX_ITERATIONS_SUMMARY_REQUEST
+        )
+        assert persisted_summary["content"] == MAX_ITERATIONS_SUMMARY_REQUEST
+        assert persisted_summary["api_content"].endswith(MAX_ITERATIONS_SUMMARY_REQUEST)
+        wire_summary = captured["messages"][-1]["content"]
+        assert wire_summary.endswith(persisted_summary["api_content"])
+        assert "[Runtime Context]" in wire_summary
+        assert wire_summary.endswith(MAX_ITERATIONS_SUMMARY_REQUEST)
+
+    def test_historical_summary_marker_keeps_its_original_bytes(self):
+        agent = self._agent()
+        captured = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return "RAW"
+
+        client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=_Completions())
+        )
+        transport = types.SimpleNamespace(
+            normalize_response=lambda _response: types.SimpleNamespace(
+                content="SUMMARY"
+            )
+        )
+        messages = [
+            {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST},
+            {"role": "assistant", "content": "older summary"},
+            {"role": "user", "content": "continue"},
+        ]
+
+        with (
+            patch.object(agent, "_ensure_primary_openai_client", return_value=client),
+            patch.object(agent, "_get_transport", return_value=transport),
+            patch.object(
+                agent, "_sanitize_api_messages", side_effect=lambda value: value
+            ),
+            patch.object(
+                agent,
+                "_drop_thinking_only_and_merge_users",
+                side_effect=lambda value: value,
+            ),
+        ):
+            assert handle_max_iterations(agent, messages, 5) == "SUMMARY"
+
+        sent_users = [
+            message["content"]
+            for message in captured["messages"]
+            if message.get("role") == "user"
+        ]
+        assert sent_users.count(MAX_ITERATIONS_SUMMARY_REQUEST) == 1
+        assert (
+            sum(
+                "[Runtime Context]" in content
+                and content.endswith(MAX_ITERATIONS_SUMMARY_REQUEST)
+                for content in sent_users
+            )
+            == 1
+        )
+        new_summary = messages[-2]
+        assert new_summary["content"] == MAX_ITERATIONS_SUMMARY_REQUEST
+        assert new_summary["api_content"] == sent_users[-1]


### PR DESCRIPTION
## Summary

Hermes now receives fresh wall-clock time on every standard text inference turn through the current user-message runtime context. This reimplements and updates the cache-safe per-turn current-time injection approach proposed in #15872 against the current Hermes main architecture.

Credit to @quinnmacro for the original design direction and implementation in #15872.

## Problem

Session-start or date-only context becomes stale in long-running gateways, CLI sessions, cron workflows, and agent loops. That can make the model misinterpret relative expressions such as “today”, “now”, or “tomorrow”.

## Implementation

- Reuses the existing `hermes_time` timezone resolution and respects `HERMES_TIMEZONE`.
- Formats an aware current datetime, configured timezone name, and UTC offset.
- Adds the dynamic context to the API-bound copy of the current user message through the shared turn prologue.
- Covers Chat Completions, Responses, gateway/common turns, and the Codex app-server runtime.
- Gives the independent max-iterations summary path its own fresh runtime timestamp.
- Fails open if time formatting is unavailable.

## Prompt Cache

The cached system prompt is unchanged. Dynamic time is attached to the current user API copy, while Hermes’ existing `api_content` sidecar persists the exact bytes sent and replays them on later turns. This keeps the historical prompt prefix byte-stable.

Multimodal/list user content is intentionally left unchanged because the current sidecar is string-only; injecting a non-replayable list copy would violate the cache invariant.

## Transcript Safety

Canonical persistent conversation `content` remains the original clean user text. Runtime context is carried separately in the internal API replay sidecar, so it does not pollute the user-visible or memory-facing transcript.

## Testing

After rebasing onto current `main`:

- 153 related tests passed across the feature suite, API sidecar, gateway sidecar, shared turn context, provider parity, and Codex app-server integration.
- Ruff checks passed for all changed Python files.
- `ruff format --check` passed for the new feature test file.
- `git diff --check` passed.

A broader `tests/run_agent/test_run_agent.py` run produced 278 passes and one environment failure because the optional `anthropic` package was unavailable. The same failure reproduces on the upstream baseline, so it is not attributed to this change.

## Related Work

The earlier #15872 PR established the cache-safe per-turn injection direction. Its history no longer shares a merge base with current `main`, and Hermes now uses the shared turn prologue plus exact-wire `api_content` replay, current max-iterations handling, Responses paths, and Codex app-server runtime. This PR is therefore a refreshed implementation against current main rather than a silent duplicate or claim of original design.

Related to #15872.
Related to #17476.
Related to #10421.