### PR TITLE
fix(cli): preserve terminal escape sequences

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8596,6 +8596,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     provider=self.provider,
                     availability=snapshot["availability"],
                     skills_by_category=snapshot.get("skills_by_category"),
+                    deferred_print=self._console_print,
                 )
 
                 def _refresh_banner_snapshot() -> None:
@@ -8642,6 +8643,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     context_length=ctx_len,
                     provider=self.provider,
                     availability=availability,
+                    deferred_print=self._console_print,
                 )
                 try:
                     tmap = {

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -12,7 +12,7 @@ import time
 from pathlib import Path
 from urllib.parse import urlparse
 from hermes_constants import get_hermes_home
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 # rich and prompt_toolkit are imported lazily (inside the functions that use
 # them) rather than at module level.  Importing this module is on the TUI
@@ -747,7 +747,11 @@ def _format_update_notice(behind: int) -> str:
 _deferred_update_notice_started = False
 
 
-def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
+def _defer_update_notice(
+    console: "Console",
+    max_wait: float = 30.0,
+    print_fn: Optional[Callable[[str], None]] = None,
+) -> None:
     """Print the update warning once the prefetched check completes.
 
     Used when the banner rendered before the update prefetch finished so
@@ -757,6 +761,7 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
     if _deferred_update_notice_started:
         return
     _deferred_update_notice_started = True
+    emit = print_fn or console.print
 
     def _wait_and_print() -> None:
         try:
@@ -765,7 +770,7 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
             behind = _update_result
             if behind is None or behind == 0:
                 return
-            console.print(_format_update_notice(behind))
+            emit(_format_update_notice(behind))
         except Exception:
             pass  # never break the session over an update notice
 
@@ -965,7 +970,8 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                          context_length: int = None,
                          provider: str = None,
                          availability: Dict[str, Any] = None,
-                         skills_by_category: Dict[str, List[str]] = None):
+                         skills_by_category: Optional[Dict[str, List[str]]] = None,
+                         deferred_print: Optional[Callable[[str], None]] = None):
     """Build and print a welcome banner with caduceus on left and info on right.
 
     Args:
@@ -984,6 +990,8 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
             ``compute_toolset_availability`` (e.g. replayed from the banner
             snapshot). When provided together with ``get_toolset_for_tool``,
             this function performs no ``model_tools`` import at all.
+        deferred_print: Optional prompt-toolkit-safe callback for notices that
+            may be emitted after the interactive input application starts.
     """
     from rich.panel import Panel
     from rich.table import Table
@@ -1268,7 +1276,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
     try:
         behind = get_update_result(timeout=0.05)
         if behind is None and not _update_check_done.is_set():
-            _defer_update_notice(console)
+            _defer_update_notice(console, print_fn=deferred_print)
         elif behind is not None and behind != 0:
             right_lines.append(_format_update_notice(behind))
     except Exception:

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -273,6 +273,11 @@ def install_modify_other_keys_aliases() -> int:
         if existing is not None:
             ctrl_key_map[codepoint] = existing
 
+    # Ctrl+. has no legacy C0 representation or Hermes binding.  Enhanced
+    # keyboard protocols still report it, and leaving it unmapped makes
+    # prompt_toolkit insert the tail (``[46;5u``) as literal user input.
+    ctrl_key_map[ord('.')] = Keys.Ignore
+
     changed = 0
 
     # Kitty CSI-u encodes CapsLock/NumLock state as extra modifier bits

--- a/tests/cli/test_cli_context_warning.py
+++ b/tests/cli/test_cli_context_warning.py
@@ -119,6 +119,17 @@ class TestLowContextWarning:
         generic_hints = [c for c in calls if "config.yaml" in c]
         assert len(generic_hints) == 1
 
+    def test_wide_banner_defers_output_through_runtime_safe_console(self, cli_obj):
+        with patch("shutil.get_terminal_size", return_value=os.terminal_size((120, 40))), \
+             patch("cli.get_tool_definitions", return_value=[]), \
+             patch("hermes_cli.banner.load_banner_snapshot", return_value=None), \
+             patch("hermes_cli.banner.compute_toolset_availability", return_value={}), \
+             patch("hermes_cli.banner.save_banner_snapshot"), \
+             patch.object(cli_obj, "_show_tool_availability_warnings"), \
+             patch("cli.build_welcome_banner") as build_banner:
+            cli_obj.show_banner()
+
+        assert build_banner.call_args.kwargs["deferred_print"] == cli_obj._console_print
 
     def test_compact_banner_does_not_crash_on_narrow_terminal(self, cli_obj):
         """Compact mode should still have ctx_len defined for warning logic."""

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -208,6 +208,12 @@ def test_ctrl_space_under_modify_other_keys():
     assert _parse("\x1b[32;5u") == _parse("\x00")
 
 
+def test_ctrl_period_does_not_leak_literal_csi_u():
+    """Unbound Ctrl+. is consumed instead of inserting ``[46;5u``."""
+    assert _parse("\x1b[27;5;46~") == [Keys.Ignore]
+    assert _parse("\x1b[46;5u") == [Keys.Ignore]
+
+
 # ---------------------------------------------------------------------------
 # Alt+letter
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -192,6 +192,30 @@ class TestBannerUpdateCheckNonBlocking:
         assert printed, "deferred update notice never printed"
         assert "3 commits behind" in printed[0]
 
+    def test_deferred_notice_uses_supplied_output_adapter(self):
+        import hermes_cli.banner as banner
+
+        printed = []
+
+        class _UnsafeConsole:
+            def print(self, *_args, **_kwargs):
+                raise AssertionError("raw Rich console must not handle deferred output")
+
+        done = threading.Event()
+        with patch.object(banner, "_update_check_done", done), \
+             patch.object(banner, "_update_result", None), \
+             patch.object(banner, "_deferred_update_notice_started", False):
+            banner._defer_update_notice(
+                _UnsafeConsole(), max_wait=5.0, print_fn=printed.append
+            )
+            banner._update_result = 3
+            done.set()
+            deadline = time.time() + 5
+            while not printed and time.time() < deadline:
+                time.sleep(0.02)
+        assert printed, "deferred update notice never reached the output adapter"
+        assert "3 commits behind" in printed[0]
+
     def test_deferred_notice_silent_when_up_to_date(self):
         import hermes_cli.banner as banner
 


### PR DESCRIPTION
## Summary

- route delayed update notices through the prompt-toolkit-safe output adapter so ANSI ESC bytes are not rendered as literal `?`
- consume unsupported Ctrl+. extended-key sequences instead of leaking `[46;5u` into the prompt
- add focused regression coverage for deferred output wiring and both CSI-u/modifyOtherKeys encodings

## Verification

- `scripts/run_tests.sh tests/tools/test_startup_latency_regressions.py tests/cli/test_cli_context_warning.py tests/cli/test_modify_other_keys_aliases.py tests/hermes_cli/test_banner.py tests/hermes_cli/test_banner_skills_width.py tests/cli/test_cprint_bg_thread.py -q` — 253 passed
- `uv run --extra dev ruff check cli.py hermes_cli/banner.py hermes_cli/pt_input_extras.py tests/tools/test_startup_latency_regressions.py tests/cli/test_cli_context_warning.py tests/cli/test_modify_other_keys_aliases.py` — passed
- Herdr end-to-end PTY check: ANSI retained real ESC bytes; Ctrl+. changed from `RESULT '[46;5u'` to `RESULT ''`
- independent review: no security, logic, threading/race, or compatibility blockers

## Full-suite note

The full suite was attempted and remained red in unrelated optional-integration areas: 121 failures across 41 files plus 11 collection/import errors. None of the modified files were in the failure or collection-error lists; the focused canonical suites above are green.
