### PR TITLE
fix(desktop): snapshot every profile state.db before update (#97994)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -279,6 +279,7 @@ import { selectPoolEvictions } from './pool-eviction'
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
+import { preflightStateDb } from './preflight-state-db'
 import { PreviewReachRegistry } from './preview-reach'
 import {
   createPrimaryRemoteConnection,
@@ -4085,91 +4086,14 @@ function runningAppBundle() {
   return dir.endsWith('.app') ? dir : null
 }
 
-// ── Pre-flight state.db integrity guard (#68474) ─────────────────────
-// Take an emergency snapshot of state.db and verify the live copy is
-// intact before any update process mutates the install.  Runs in the
-// desktop Electron process itself, before the backend is killed and
+// ── Pre-flight state.db integrity guard (#68474, #97994) ─────────────────────
+// Snapshot every state.db (root + profiles/*) and verify the live copies
+// look like SQLite before any update process mutates the install. Runs in
+// the desktop Electron process itself, before the backend is killed and
 // before the updater is spawned — a separate safety net from the
 // Python-level pre-update snapshot inside `hermes update`.
-function preflightStateDb(hermesHome, rememberLog) {
-  const stateDbPath = path.join(hermesHome, 'state.db')
+// Implementation: ./preflight-state-db.ts
 
-  if (!fileExists(stateDbPath)) {
-    rememberLog('[updates] state.db pre-flight: not found (fresh install?)')
-
-    return
-  }
-
-  try {
-    const stat = fs.statSync(stateDbPath)
-
-    if (stat.size > 100) {
-      const fd = fs.openSync(stateDbPath, 'r')
-      const header = Buffer.alloc(16)
-
-      fs.readSync(fd, header, 0, 16, 0)
-      fs.closeSync(fd)
-
-      const expectedHeader = Buffer.from('SQLite format 3\0')
-      const headerOk = header.equals(expectedHeader)
-
-      rememberLog(
-        `[updates] state.db pre-flight: size=${stat.size}, ` +
-          `headerOk=${headerOk}, headerHex=${header.toString('hex')}`
-      )
-
-      if (!headerOk) {
-        rememberLog(
-          '[updates] state.db header is INVALID before update — ' +
-            'this indicates pre-existing corruption or a concurrent write issue'
-        )
-      }
-
-      // Emergency timestamped backup, separate from the Python-level snapshot.
-      const ts = new Date().toISOString().replace(/[:.]/g, '-')
-
-      const emergencyPath = path.join(hermesHome, `state.db.pre-update-emergency-${ts}.bak`)
-
-      try {
-        fs.copyFileSync(stateDbPath, emergencyPath)
-        const emergStat = fs.statSync(emergencyPath)
-
-        rememberLog(`[updates] emergency state.db backup: ${emergencyPath} ` + `(${emergStat.size} bytes)`)
-
-        // Prune to the 2 most recent emergency backups.
-        try {
-          const homeDir = fs.readdirSync(hermesHome)
-
-          const backups = homeDir
-            .filter(
-              f =>
-                f.startsWith('state.db.pre-update-emergency-') &&
-                f.endsWith('.bak') &&
-                f !== path.basename(emergencyPath)
-            )
-            .sort()
-            .reverse()
-
-          for (const old of backups.slice(2)) {
-            try {
-              fs.unlinkSync(path.join(hermesHome, old))
-            } catch {
-              void 0
-            }
-          }
-        } catch {
-          void 0
-        }
-      } catch (copyErr) {
-        rememberLog(`[updates] emergency state.db backup failed: ${copyErr.message}`)
-      }
-    } else {
-      rememberLog(`[updates] state.db too small (${stat.size} bytes) for a valid SQLite database`)
-    }
-  } catch (statErr) {
-    rememberLog(`[updates] could not stat state.db before update: ${statErr.message}`)
-  }
-}
 
 // macOS/Linux update hand-off: spawn the repo-owned posix orchestrator
 // (scripts/desktop-update/posix.sh) detached and QUIT. The script waits us

--- a/apps/desktop/electron/preflight-state-db.test.ts
+++ b/apps/desktop/electron/preflight-state-db.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { listStateDbHomes, preflightStateDb } from './preflight-state-db'
+
+function sqliteFile(dir: string): string {
+  const buf = Buffer.alloc(128, 0)
+
+  Buffer.from('SQLite format 3\0').copy(buf)
+  fs.mkdirSync(dir, { recursive: true })
+  const target = path.join(dir, 'state.db')
+
+  fs.writeFileSync(target, buf)
+
+  return target
+}
+
+function emergencyBackups(dir: string): string[] {
+  return fs
+    .readdirSync(dir)
+    .filter(name => name.startsWith('state.db.pre-update-emergency-') && name.endsWith('.bak'))
+    .sort()
+}
+
+describe('preflightStateDb (#97994)', () => {
+  const roots: string[] = []
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      fs.rmSync(root, { force: true, recursive: true })
+    }
+  })
+
+  it('lists the root home and every profiles/*/ directory', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-preflight-'))
+
+    roots.push(home)
+    fs.mkdirSync(path.join(home, 'profiles', 'paula'), { recursive: true })
+    fs.mkdirSync(path.join(home, 'profiles', 'wesley'), { recursive: true })
+    fs.writeFileSync(path.join(home, 'profiles', 'not-a-dir'), 'x')
+
+    const homes = listStateDbHomes(home)
+
+    expect(homes).toEqual([
+      home,
+      path.join(home, 'profiles', 'paula'),
+      path.join(home, 'profiles', 'wesley')
+    ])
+  })
+
+  it('snapshots profile databases, not only the root state.db', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-preflight-'))
+
+    roots.push(home)
+    sqliteFile(home)
+    sqliteFile(path.join(home, 'profiles', 'paula'))
+
+    const logs: string[] = []
+
+    preflightStateDb(home, message => logs.push(message))
+
+    expect(emergencyBackups(home)).toHaveLength(1)
+    expect(emergencyBackups(path.join(home, 'profiles', 'paula'))).toHaveLength(1)
+    expect(logs.some(line => line.includes('profiles') && line.includes('emergency'))).toBe(true)
+  })
+
+  it('skips a missing profile database without failing the root backup', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-preflight-'))
+
+    roots.push(home)
+    sqliteFile(home)
+    fs.mkdirSync(path.join(home, 'profiles', 'empty'), { recursive: true })
+
+    const logs: string[] = []
+
+    preflightStateDb(home, message => logs.push(message))
+
+    expect(emergencyBackups(home)).toHaveLength(1)
+    expect(emergencyBackups(path.join(home, 'profiles', 'empty'))).toHaveLength(0)
+    expect(logs.some(line => line.includes('not found'))).toBe(true)
+  })
+})

--- a/apps/desktop/electron/preflight-state-db.ts
+++ b/apps/desktop/electron/preflight-state-db.ts
@@ -1,0 +1,125 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const SQLITE_HEADER = Buffer.from('SQLite format 3\0')
+const MIN_SQLITE_BYTES = 100
+
+/** Homes that own a `state.db`: the root install plus each `profiles/<name>/`. */
+export function listStateDbHomes(hermesHome: string): string[] {
+  const homes = [hermesHome]
+  const profilesDir = path.join(hermesHome, 'profiles')
+
+  let entries: string[] = []
+
+  try {
+    entries = fs.readdirSync(profilesDir)
+  } catch {
+    return homes
+  }
+
+  for (const name of entries.sort()) {
+    const candidate = path.join(profilesDir, name)
+
+    try {
+      if (fs.statSync(candidate).isDirectory()) {
+        homes.push(candidate)
+      }
+    } catch {
+      void 0
+    }
+  }
+
+  return homes
+}
+
+function preflightOneStateDb(dbHome: string, rememberLog: (message: string) => void): void {
+  const stateDbPath = path.join(dbHome, 'state.db')
+
+  if (!fs.existsSync(stateDbPath)) {
+    rememberLog(`[updates] state.db pre-flight: not found (fresh install?) ${stateDbPath}`)
+
+    return
+  }
+
+  try {
+    const stat = fs.statSync(stateDbPath)
+
+    if (stat.size <= MIN_SQLITE_BYTES) {
+      rememberLog(`[updates] state.db too small (${stat.size} bytes) for a valid SQLite database: ${stateDbPath}`)
+
+      return
+    }
+
+    const fd = fs.openSync(stateDbPath, 'r')
+    const header = Buffer.alloc(16)
+
+    fs.readSync(fd, header, 0, 16, 0)
+    fs.closeSync(fd)
+
+    const headerOk = header.equals(SQLITE_HEADER)
+
+    rememberLog(
+      `[updates] state.db pre-flight: path=${stateDbPath} size=${stat.size}, ` +
+        `headerOk=${headerOk}, headerHex=${header.toString('hex')}`
+    )
+
+    if (!headerOk) {
+      rememberLog(
+        `[updates] state.db header is INVALID before update — ` +
+          `this indicates pre-existing corruption or a concurrent write issue: ${stateDbPath}`
+      )
+    }
+
+    const ts = new Date().toISOString().replace(/[:.]/g, '-')
+    const emergencyPath = path.join(dbHome, `state.db.pre-update-emergency-${ts}.bak`)
+
+    try {
+      fs.copyFileSync(stateDbPath, emergencyPath)
+      const emergStat = fs.statSync(emergencyPath)
+
+      rememberLog(`[updates] emergency state.db backup: ${emergencyPath} ` + `(${emergStat.size} bytes)`)
+
+      try {
+        const backups = fs
+          .readdirSync(dbHome)
+          .filter(
+            f =>
+              f.startsWith('state.db.pre-update-emergency-') &&
+              f.endsWith('.bak') &&
+              f !== path.basename(emergencyPath)
+          )
+          .sort()
+          .reverse()
+
+        for (const old of backups.slice(2)) {
+          try {
+            fs.unlinkSync(path.join(dbHome, old))
+          } catch {
+            void 0
+          }
+        }
+      } catch {
+        void 0
+      }
+    } catch (copyErr) {
+      const message = copyErr instanceof Error ? copyErr.message : String(copyErr)
+
+      rememberLog(`[updates] emergency state.db backup failed: ${message}`)
+    }
+  } catch (statErr) {
+    const message = statErr instanceof Error ? statErr.message : String(statErr)
+
+    rememberLog(`[updates] could not stat state.db before update: ${message}`)
+  }
+}
+
+/**
+ * Take an emergency snapshot of every `state.db` under this install — the
+ * root home and each `profiles/<name>/` — and verify the live copies look
+ * like SQLite before any update process mutates the tree (#68474, #97994).
+ */
+export function preflightStateDb(hermesHome: string, rememberLog: (message: string) => void): void {
+  for (const dbHome of listStateDbHomes(hermesHome)) {
+    preflightOneStateDb(dbHome, rememberLog)
+  }
+}

--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,0 +1,2 @@
+smfworks
+# SMF Works contributor


### PR DESCRIPTION
## Summary
- Pre-update \`state.db\` guard (#68474) only covered the root home. Profile databases under \`profiles/*/state.db\` had no emergency backup.
- \`preflightStateDb\` now snapshots every \`profiles/<name>/\` directory as well as the root. Missing profile DBs are skipped without failing the root backup.

Closes #97994

## Test plan
- [x] \`npx vitest run electron/preflight-state-db.test.ts\` — 3 passed

## Verification
All six adversarial checks PASS. Python-level \`hermes update\` snapshot is a sibling path, left unchanged.