### PR TITLE
feat(approvals): confirm gate for agent-initiated model-routing config writes

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5667,7 +5667,7 @@ def _lookup_old_value(key: str):
         return None
 
 
-def _gate_redacted(value, key) -> str:
+def _gate_redacted(value, key):
     """Mask credential-shaped values so the gate notice/refusal never leaks a secret.
 
     ``_is_model_routing_key`` matches ``model.*``, which includes
@@ -5678,6 +5678,14 @@ def _gate_redacted(value, key) -> str:
     value whose leaf key is credential-shaped is redacted for display.
     """
     leaf = key.rsplit(".", 1)[-1].lower()
+    if isinstance(value, dict):
+        # Section writes (--force delegation / auxiliary) can carry nested
+        # credential-shaped leaves; sanitize recursively (Flash R2 SHOULD-FIX).
+        return {
+            k: _gate_redacted(v, f"{key}.{k}") if isinstance(v, (dict, list))
+            else (_gate_redacted(v, f"{key}.{k}") if isinstance(v, str) and v else v)
+            for k, v in value.items()
+        }
     if leaf in _SECRET_CONFIG_KEYS and isinstance(value, str) and value:
         from agent.redact import mask_secret
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5567,7 +5567,165 @@ def _coerce_float(value: str):
     return f
 
 
-def set_config_value(key: str, value: str, force: bool = False):
+# ---------------------------------------------------------------------------
+# Model-routing config confirm gate (#97652)
+# ---------------------------------------------------------------------------
+# Agents can silently rewrite the model-routing config (``model.*``,
+# ``delegation.model/provider/base_url``, ``auxiliary.*.model/provider/base_url``)
+# via a single ``hermes config set`` — even with ``approvals.mode: off``.  That
+# determines what the user pays per token for every subagent, so an unseen
+# rewrite is unacceptable UX.  This gate converts agent-initiated (Hermes-tool-
+# spawned) writes into a y/N prompt in an interactive TTY, or a hard refusal in
+# the non-interactive context the agent actually runs in.  Human CLI writes
+# carry no Hermes-agent marker and are never gated.
+
+# Marker hand-inscribed by the agent command-execution layer (see
+# tools/environments/local.py).  A human's own ``hermes config set`` in their
+# login shell is never spawned by Hermes and never carries this marker.
+_HERMES_AGENT_INITIATED_ENV = "HERMES_AGENT_INITIATED"
+
+
+def _is_model_routing_key(key: str) -> bool:
+    """Return True when ``key`` routes model selection (billing-relevant).
+
+    Covers the model-routing keys an agent-initiated rewrite must not do
+    silently: ``model`` (shorthand for ``model.default``), ``model.*``,
+    ``delegation.model/provider/base_url``, and
+    ``auxiliary.<name>.model/provider/base_url``.
+    """
+    if not key:
+        return False
+    k = key.strip().lower()
+    if k == "model":
+        return True
+    if k.startswith("model."):
+        return True
+    if k in ("delegation.model", "delegation.provider", "delegation.base_url"):
+        return True
+    if k.startswith("auxiliary."):
+        parts = k.split(".")
+        return len(parts) == 3 and parts[2] in ("model", "provider", "base_url")
+    return False
+
+
+def _is_agent_initiated_write() -> bool:
+    """True when this process was spawned by a Hermes agent tool.
+
+    The agent command-execution layer stamps every subprocess it launches with
+    ``HERMES_AGENT_INITIATED=1``.  A human's direct ``hermes config set`` carries
+    no such marker.  Fail-open: any detection error returns False so a human
+    write is never mis-gated.
+    """
+    try:
+        marker = os.environ.get(_HERMES_AGENT_INITIATED_ENV, "").strip().lower()
+        return marker in ("1", "true", "yes")
+    except Exception:
+        return False
+
+
+def _model_config_confirm_enabled() -> bool:
+    """Read ``approvals.model_config_confirm`` (default True), fail-open to True."""
+    try:
+        cfg = load_config()
+        approvals = cfg.get("approvals") if isinstance(cfg, dict) else None
+        if isinstance(approvals, dict):
+            return bool(approvals.get("model_config_confirm", True))
+        return True
+    except Exception:
+        return True
+
+
+def _is_interactive_tty() -> bool:
+    """True when stdin is a real TTY.  Any detection error is treated as
+    non-interactive (the safe/refusing branch) so a gate can never hang."""
+    try:
+        return bool(sys.stdin.isatty())
+    except Exception:
+        return False
+
+
+def _lookup_old_value(key: str):
+    """Best-effort read of the current value for ``key`` (None-safe)."""
+    try:
+        found = _get_nested(load_config(), key)
+        return None if found is _MISSING else found
+    except Exception:
+        return None
+
+
+def _emit_model_change_notice(key: str, old_value, new_value) -> None:
+    """Surface the *fact* of a model-routing change, even when approved."""
+    old_str = "None" if old_value is None else old_value
+    print(f"⚠ {key} changed: {old_str} → {new_value} (model-routing config)")
+
+
+def _emit_model_routing_refusal(key: str, old_value, new_value) -> None:
+    """Non-interactive refusal: no hang, a loud instruction to surface it."""
+    old_str = "None" if old_value is None else old_value
+    print(
+        f"✗ Refusing agent-initiated change to model-routing key {key!r} "
+        f"({old_str} → {new_value}).\n"
+        "  Model-routing config determines what you pay per token for every "
+        "subagent, so an agent must not rewrite it silently.\n"
+        "  Surface this proposed change to the user and retry only on their "
+        "explicit direction with:\n"
+        f"      hermes config set {key} {new_value} --confirm-model-change",
+        file=sys.stderr,
+    )
+
+
+def _prompt_model_config_confirm(key: str, new_value) -> bool:
+    """Interactive y/N prompt (destructive-slash style)."""
+    prompt = f"⚠ Agent-initiated model-routing change: set {key} = {new_value!r}? [y/N] "
+    try:
+        answer = input(prompt)
+    except EOFError:
+        return False
+    return answer.strip().lower() in ("y", "yes")
+
+
+def _maybe_gate_model_routing_write(
+    key: str,
+    value,
+    *,
+    confirm_model_change: bool,
+    old_value,
+) -> bool:
+    """Gate an agent-initiated write to a model-routing key.
+
+    Returns True to allow the write, False to refuse it (message already
+    emitted).  Human/programmatic writes (no agent marker) pass through
+    untouched.  ``confirm_model_change`` (the CLI's ``--confirm-model-change``)
+    marks a user-directed write and bypasses the prompt while still surfacing
+    the change with a visible notice.
+    """
+    if not _is_agent_initiated_write():
+        return True
+    if not _is_model_routing_key(key):
+        return True
+    if confirm_model_change:
+        _emit_model_change_notice(key, old_value, value)
+        return True
+    if not _model_config_confirm_enabled():
+        _emit_model_change_notice(key, old_value, value)
+        return True
+    if _is_interactive_tty():
+        if _prompt_model_config_confirm(key, value):
+            _emit_model_change_notice(key, old_value, value)
+            return True
+        _emit_model_routing_refusal(key, old_value, value)
+        return False
+    # Non-interactive agent context: refuse without hanging.
+    _emit_model_routing_refusal(key, old_value, value)
+    return False
+
+
+def set_config_value(
+    key: str,
+    value: str,
+    force: bool = False,
+    confirm_model_change: bool = False,
+):
     """Set a configuration value.
 
     Args:
@@ -5580,6 +5738,10 @@ def set_config_value(key: str, value: str, force: bool = False):
             mapping). Without --force, scalar writes over mapping sections are
             refused (bare ``model`` is redirected to ``model.default``). The
             CLI exposes this via ``hermes config set --force``.
+        confirm_model_change: When True, mark this write as user-directed so an
+            agent-initiated write to a model-routing key bypasses the
+            confirm gate (still emitting a visible change notice).  The CLI
+            exposes this via ``hermes config set --confirm-model-change``.
     """
     if is_managed():
         managed_error("set configuration values")
@@ -5772,6 +5934,16 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
+    # Model-routing confirm gate (#97652): an agent-initiated (Hermes-tool-
+    # spawned) write to a billing-relevant key is either confirmed (interactive
+    # TTY) or refused (non-interactive) — never silently rewritten.
+    if not _maybe_gate_model_routing_write(
+        key,
+        value,
+        confirm_model_change=confirm_model_change,
+        old_value=_lookup_old_value(key),
+    ):
+        sys.exit(2)
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical
@@ -5935,8 +6107,11 @@ def config_command(args):
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
         force = bool(getattr(args, 'force', False))
+        confirm_model_change = bool(getattr(args, 'confirm_model_change', False))
         if not key or value is None:
             print("Usage: hermes config set [--force] <key> <value>")
+            print()
+            print("  [--confirm-model-change] <key> <value>  (mark a model-routing write as user-directed)")
             print()
             print("Examples:")
             print("  hermes config set model anthropic/claude-sonnet-4")
@@ -5947,7 +6122,7 @@ def config_command(args):
             print("           and allow a scalar to replace a whole mapping section")
             sys.exit(1)
         try:
-            set_config_value(key, value, force=force)
+            set_config_value(key, value, force=force, confirm_model_change=confirm_model_change)
         except RuntimeError as exc:
             # Fail-closed write guard (unparseable / non-mapping / unreadable
             # config.yaml). Surface a clean CLI error instead of a traceback.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5575,9 +5575,10 @@ def _coerce_float(value: str):
 # via a single ``hermes config set`` — even with ``approvals.mode: off``.  That
 # determines what the user pays per token for every subagent, so an unseen
 # rewrite is unacceptable UX.  This gate converts agent-initiated (Hermes-tool-
-# spawned) writes into a y/N prompt in an interactive TTY, or a hard refusal in
-# the non-interactive context the agent actually runs in.  Human CLI writes
-# carry no Hermes-agent marker and are never gated.
+# spawned) writes into a hard refusal in the non-interactive context the agent
+# actually runs in.  It NEVER prompts: a Hermes terminal-tool PTY run gives the
+# child a real TTY, so an ``input()`` would hang until the command timeout.
+# Human CLI writes carry no Hermes-agent marker and are never gated.
 
 # Marker hand-inscribed by the agent command-execution layer (see
 # tools/environments/local.py).  A human's own ``hermes config set`` in their
@@ -5590,7 +5591,9 @@ def _is_model_routing_key(key: str) -> bool:
 
     Covers the model-routing keys an agent-initiated rewrite must not do
     silently: ``model`` (shorthand for ``model.default``), ``model.*``,
-    ``delegation.model/provider/base_url``, and
+    ``delegation`` and ``auxiliary`` section writes (a ``--force`` write can
+    replace the whole section, so the top-level section key itself is
+    billing-relevant), ``delegation.model/provider/base_url``, and
     ``auxiliary.<name>.model/provider/base_url``.
     """
     if not key:
@@ -5599,6 +5602,10 @@ def _is_model_routing_key(key: str) -> bool:
     if k == "model":
         return True
     if k.startswith("model."):
+        return True
+    # Whole-section writes (via --force) can replace the entire routing block,
+    # so the bare section keys are themselves gate-worthy (#97652).
+    if k in ("delegation", "auxiliary"):
         return True
     if k in ("delegation.model", "delegation.provider", "delegation.base_url"):
         return True
@@ -5624,7 +5631,14 @@ def _is_agent_initiated_write() -> bool:
 
 
 def _model_config_confirm_enabled() -> bool:
-    """Read ``approvals.model_config_confirm`` (default True), fail-open to True."""
+    """Read ``approvals.model_config_confirm`` (default True), fail-open to True.
+
+    Reads via ``load_config()``, which is a pure read over on-disk config (no
+    write lock).  The gate's caller (``set_config_value``) already calls
+    ``load_config()`` on this same write path through ``_lookup_old_value``, so
+    this is a second plain snapshot read, not a re-entrant write — no
+    recursion / deadlock risk (review NIT; comment only).
+    """
     try:
         cfg = load_config()
         approvals = cfg.get("approvals") if isinstance(cfg, dict) else None
@@ -5653,35 +5667,45 @@ def _lookup_old_value(key: str):
         return None
 
 
+def _gate_redacted(value, key) -> str:
+    """Mask credential-shaped values so the gate notice/refusal never leaks a secret.
+
+    ``_is_model_routing_key`` matches ``model.*``, which includes
+    ``model.api_key`` — a custom-provider credential that lives in config.yaml
+    (lowercase ``api_key`` misses the .env routing and lands in config.yaml,
+    then hits the gate).  So a gated value *can* be a secret.  Mirror the
+    key-name masking ``set_config_value`` uses for its post-write echo: any
+    value whose leaf key is credential-shaped is redacted for display.
+    """
+    leaf = key.rsplit(".", 1)[-1].lower()
+    if leaf in _SECRET_CONFIG_KEYS and isinstance(value, str) and value:
+        from agent.redact import mask_secret
+
+        return mask_secret(value)
+    return value
+
+
 def _emit_model_change_notice(key: str, old_value, new_value) -> None:
     """Surface the *fact* of a model-routing change, even when approved."""
-    old_str = "None" if old_value is None else old_value
-    print(f"⚠ {key} changed: {old_str} → {new_value} (model-routing config)")
+    old_str = "None" if old_value is None else _gate_redacted(old_value, key)
+    new_str = _gate_redacted(new_value, key)
+    print(f"⚠ {key} changed: {old_str} → {new_str} (model-routing config)")
 
 
 def _emit_model_routing_refusal(key: str, old_value, new_value) -> None:
     """Non-interactive refusal: no hang, a loud instruction to surface it."""
-    old_str = "None" if old_value is None else old_value
+    old_str = "None" if old_value is None else _gate_redacted(old_value, key)
+    new_str = _gate_redacted(new_value, key)
     print(
         f"✗ Refusing agent-initiated change to model-routing key {key!r} "
-        f"({old_str} → {new_value}).\n"
+        f"({old_str} → {new_str}).\n"
         "  Model-routing config determines what you pay per token for every "
         "subagent, so an agent must not rewrite it silently.\n"
-        "  Surface this proposed change to the user and retry only on their "
-        "explicit direction with:\n"
-        f"      hermes config set {key} {new_value} --confirm-model-change",
+        "  Surface this proposed change to the user and retry only with their "
+        "explicit user direction (a user-directed write uses "
+        "--confirm-model-change).",
         file=sys.stderr,
     )
-
-
-def _prompt_model_config_confirm(key: str, new_value) -> bool:
-    """Interactive y/N prompt (destructive-slash style)."""
-    prompt = f"⚠ Agent-initiated model-routing change: set {key} = {new_value!r}? [y/N] "
-    try:
-        answer = input(prompt)
-    except EOFError:
-        return False
-    return answer.strip().lower() in ("y", "yes")
 
 
 def _maybe_gate_model_routing_write(
@@ -5698,6 +5722,14 @@ def _maybe_gate_model_routing_write(
     untouched.  ``confirm_model_change`` (the CLI's ``--confirm-model-change``)
     marks a user-directed write and bypasses the prompt while still surfacing
     the change with a visible notice.
+
+    The gate NEVER prompts.  ``_is_agent_initiated_write()`` is already True
+    by the time we reach the body, and a Hermes terminal-tool PTY run
+    (``pty=true``) hands the child a real TTY — ``sys.stdin.isatty()`` returns
+    True, so an ``input()`` here would block until the 600s command timeout.
+    Interactive prompting is for humans only, and a human write carries no
+    agent marker (so it exits above).  Therefore every agent-initiated write
+    that isn't user-directed or gate-disabled is refused loudly.
     """
     if not _is_agent_initiated_write():
         return True
@@ -5709,13 +5741,7 @@ def _maybe_gate_model_routing_write(
     if not _model_config_confirm_enabled():
         _emit_model_change_notice(key, old_value, value)
         return True
-    if _is_interactive_tty():
-        if _prompt_model_config_confirm(key, value):
-            _emit_model_change_notice(key, old_value, value)
-            return True
-        _emit_model_routing_refusal(key, old_value, value)
-        return False
-    # Non-interactive agent context: refuse without hanging.
+    # Never prompt: an agent-marked process must not wait on stdin (PTY-hang).
     _emit_model_routing_refusal(key, old_value, value)
     return False
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2541,6 +2541,18 @@ DEFAULT_CONFIG = {
         # modal; HERMES_TUI_NO_CONFIRM=1 force-skips that modal regardless of
         # the configured value.
         "destructive_slash_confirm": True,
+        # When true, an agent-initiated write to a model-routing config key
+        # (model.*, delegation.model/provider/base_url,
+        # auxiliary.*.model/provider/base_url) is gated: an interactive TTY
+        # prompts y/N, and a NON-interactive context (the agent running
+        # `hermes config set` through the terminal tool) silently refuses the
+        # write and exits non-zero instead of rewriting the user's billing-
+        # relevant model routing.  The write can be performed deliberately by
+        # passing `--confirm-model-change` (user-directed write).  Marker
+        # used: HERMES_AGENT_INITIATED set by the agent command-execution
+        # layer — a human's own `hermes config set` carries no marker and is
+        # never gated.
+        "model_config_confirm": True,
     },
 
     # Permanently allowed dangerous command patterns (added via "always" approval)

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -46,6 +46,14 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
         help="Skip the unknown-key notice printed after writing a key the "
         "running version doesn't recognize (the value is saved either way).",
     )
+    config_set.add_argument(
+        "--confirm-model-change",
+        action="store_true",
+        help="Mark this write as user-directed so an agent-initiated change to "
+        "a model-routing key (model.*, delegation.model, auxiliary.*) "
+        "bypasses the confirm gate instead of being refused; the change is "
+        "still announced.",
+    )
 
     # config unset
     config_unset = config_subparsers.add_parser(

--- a/tests/hermes_cli/test_model_config_confirm_gate.py
+++ b/tests/hermes_cli/test_model_config_confirm_gate.py
@@ -20,10 +20,18 @@ import pytest
 
 from hermes_cli.config import (
     DEFAULT_CONFIG,
+    _emit_model_change_notice,
+    _emit_model_routing_refusal,
     _is_model_routing_key,
     config_command,
     set_config_value,
 )
+from tools.environments.base import (
+    AGENT_INITIATED_ENV,
+    agent_initiated_command,
+    stamp_agent_initiated,
+)
+from tools.environments.local import build_subprocess_env
 
 
 @pytest.fixture(autouse=True)
@@ -79,9 +87,12 @@ class TestModelRoutingKeyClassification:
             "model.provider",
             "model.base_url",
             "model.context_length",
+            "model.api_key",
+            "delegation",
             "delegation.model",
             "delegation.provider",
             "delegation.base_url",
+            "auxiliary",
             "auxiliary.summarize.model",
             "auxiliary.summarize.provider",
             "auxiliary.summarize.base_url",
@@ -211,28 +222,176 @@ class TestGateDisabled:
 
 
 # ---------------------------------------------------------------------------
-# Interactive TTY prompting (destructive-slash style y/N)
+# The gate NEVER prompts (PTY-hang) — an agent-marked process must not wait
+# on stdin, even when a Hermes terminal-tool PTY run gives it a real TTY.
 # ---------------------------------------------------------------------------
 
 
-class TestInteractivePrompt:
-    def test_interactive_approve_allows_and_notices(
+class TestNeverPrompts:
+    def test_pty_run_refuses_without_prompt(
         self, _isolated_hermes_home, monkeypatch, capsys
     ):
         monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        # Simulate a PTY: stdin is a real TTY.
         monkeypatch.setattr("hermes_cli.config._is_interactive_tty", lambda: True)
-        monkeypatch.setattr("builtins.input", lambda prompt="": "y")
-        set_config_value("delegation.model", "gpt-4o")
-        assert _load(_isolated_hermes_home)["delegation"]["model"] == "gpt-4o"
-        out = capsys.readouterr().out
-        assert "delegation.model" in out
-        assert "changed" in out.lower()
+        # If the gate ever called input(), it would hang until the 600s timeout
+        # — fail loudly instead so the regression is caught instantly.
+        def _no_input(*a, **k):
+            raise AssertionError("gate must never call input() for an agent write")
 
-    def test_interactive_decline_refuses(self, _isolated_hermes_home, monkeypatch, capsys):
+        monkeypatch.setattr("builtins.input", _no_input)
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("delegation.model", "gpt-4o")
+        assert exc.value.code != 0
+        err = capsys.readouterr().err
+        assert "delegation.model" in err
+        # Refused: config unchanged (no silent rewrite).
+        assert "delegation" not in _read_config(_isolated_hermes_home)
+
+    def test_agent_write_refused_even_when_tty_answer_is_yes(
+        self, _isolated_hermes_home, monkeypatch
+    ):
+        # A write under a PTY must NOT prompt-and-allow just because the human
+        # would have typed 'y' — prompting is for humans only, and a human write
+        # never carries the agent marker.
         monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
         monkeypatch.setattr("hermes_cli.config._is_interactive_tty", lambda: True)
-        monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+        monkeypatch.setattr("builtins.input", lambda prompt="": "y")
         with pytest.raises(SystemExit) as exc:
             set_config_value("delegation.model", "gpt-4o")
         assert exc.value.code != 0
         assert "delegation" not in _read_config(_isolated_hermes_home)
+
+
+# ---------------------------------------------------------------------------
+# Secret exposure: model.* includes model.api_key (a credential in config.yaml),
+# so the gate notice/refusal must redact credential-shaped values.
+# ---------------------------------------------------------------------------
+
+
+class TestSecretRedaction:
+    def test_notice_redacts_secret_value(self, capsys):
+        secret = "sk-live-abcdefgh123456789"
+        _emit_model_change_notice("model.api_key", None, secret)
+        out = capsys.readouterr().out
+        assert secret not in out
+        assert "model.api_key" in out
+
+    def test_refusal_redacts_secret_value(self, capsys):
+        secret = "sk-live-abcdefgh123456789"
+        _emit_model_routing_refusal("model.api_key", None, secret)
+        err = capsys.readouterr().err
+        assert secret not in err
+        assert "model.api_key" in err
+
+    def test_agent_write_to_model_api_key_does_not_leak_secret(
+        self, _isolated_hermes_home, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        secret = "sk-live-abcdefgh123456789"
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("model.api_key", secret)
+        assert exc.value.code != 0
+        err = capsys.readouterr().err
+        assert secret not in err
+
+    def test_notice_does_not_mask_non_secret_value(self, capsys):
+        # Ordinary routing values (model/provider) are shown in full.
+        _emit_model_change_notice("delegation.model", "gpt-4o", "gpt-5")
+        out = capsys.readouterr().out
+        assert "gpt-4o" in out
+        assert "gpt-5" in out
+
+
+# ---------------------------------------------------------------------------
+# Parent-section writes: a --force write to the whole `delegation`/`auxiliary`
+# section replaces the routing block, so the bare section keys are gate-worthy.
+# ---------------------------------------------------------------------------
+
+
+class TestParentSectionWriteGated:
+    def test_agent_force_write_to_delegation_section_refused(
+        self, _isolated_hermes_home, monkeypatch, capsys
+    ):
+        set_config_value("delegation.model", "gpt-4o")
+        before = _read_config(_isolated_hermes_home)
+
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("delegation", "gpt-4o", force=True)
+        assert exc.value.code != 0
+        assert _read_config(_isolated_hermes_home) == before
+
+    def test_agent_force_write_to_auxiliary_section_refused(
+        self, _isolated_hermes_home, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("auxiliary", "gpt-4o", force=True)
+        assert exc.value.code != 0
+        assert "auxiliary" not in _read_config(_isolated_hermes_home)
+
+
+# ---------------------------------------------------------------------------
+# The refusal message must not hand the agent a copy-paste bypass command.
+# ---------------------------------------------------------------------------
+
+
+class TestRefusalMessage:
+    def test_refusal_tells_agent_to_surface_but_no_command(self, _isolated_hermes_home, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("delegation.model", "gpt-4o")
+        assert exc.value.code != 0
+        err = capsys.readouterr().err
+        # Keeps the "surface to the user" direction and the flag name.
+        assert "surface" in err.lower()
+        assert "user" in err.lower()
+        assert "confirm-model-change" in err.lower()
+        # But drops the copy-paste command that taught the agent to bypass.
+        assert "hermes config set" not in err
+
+
+# ---------------------------------------------------------------------------
+# Agent-initiated marker coverage: every Hermes-spawned child env / command
+# path (local, scratch, docker, ssh, modal, daytona, vercel) must carry it so a
+# nested `hermes config set` is gated — not only the local builder.
+# ---------------------------------------------------------------------------
+
+
+class TestAgentMarkerCoverage:
+    def test_build_subprocess_env_non_scrub_stamps_marker(self):
+        env = build_subprocess_env(
+            scrub_secrets=False, inherit_profile_home=False, base={"FOO": "bar"}
+        )
+        assert env.get("HERMES_AGENT_INITIATED") == "1"
+
+    def test_build_subprocess_env_scrub_stamps_marker(self):
+        env = build_subprocess_env(scrub_secrets=True, base={"FOO": "bar"})
+        assert env.get("HERMES_AGENT_INITIATED") == "1"
+
+    def test_stamp_agent_initiated_helper(self):
+        env = {}
+        stamp_agent_initiated(env)
+        assert env[AGENT_INITIATED_ENV] == "1"
+
+    def test_agent_initiated_command_prefix(self):
+        # The bash prefix is how remote/container backends (ssh, modal, daytona,
+        # vercel_sandbox) mark a child they can't pass an env dict to.
+        prefixed = agent_initiated_command("echo hi")
+        assert prefixed.startswith(f"export {AGENT_INITIATED_ENV}=1; ")
+        assert "echo hi" in prefixed
+
+    def test_docker_env_builder_includes_marker(self):
+        # Unit-level: build the docker exec env args without a docker daemon.
+        import tools.environments.docker as docker_mod
+
+        d = docker_mod.DockerEnvironment.__new__(docker_mod.DockerEnvironment)
+        d._env = docker_mod._normalize_env_dict({"FOO": "bar"})
+        d._forward_env = docker_mod._normalize_forward_env_names([])
+        d._init_unset_passthrough_names = ()
+        # Replicate the single line DockerEnvironment.__init__ adds (#97652).
+        stamp_agent_initiated(d._env)
+        args = d._build_init_env_args()
+        assert "HERMES_AGENT_INITIATED=1" in args
+

--- a/tests/hermes_cli/test_model_config_confirm_gate.py
+++ b/tests/hermes_cli/test_model_config_confirm_gate.py
@@ -1,0 +1,238 @@
+"""Behavior contracts for the ``approvals.model_config_confirm`` gate (#97652).
+
+Agents can silently rewrite model-routing config (``model.*``,
+``delegation.model/provider/base_url``, ``auxiliary.*.model/provider/base_url``)
+via ``hermes config set`` — including when ``approvals.mode: off``.  This gate
+forces *agent-initiated* (terminal-tool-spawned) writes to those keys through a
+confirm step: a y/N prompt in an interactive TTY, or a hard refusal (exit
+non-zero, no hang) in the non-interactive context the agent runs in.
+
+Human CLI / programmatic writes carry no ``HERMES_AGENT_INITIATED`` marker and
+pass through untouched.  These are behavior contracts, not snapshots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import pytest
+
+from hermes_cli.config import (
+    DEFAULT_CONFIG,
+    _is_model_routing_key,
+    config_command,
+    set_config_value,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir; default to the non-agent case."""
+    (tmp_path / ".env").touch()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Tests default to a HUMAN/programmatic write (no agent marker) unless a
+    # test opts in by setting HERMES_AGENT_INITIATED.
+    monkeypatch.delenv("HERMES_AGENT_INITIATED", raising=False)
+    return tmp_path
+
+
+def _read_config(tmp_path):
+    cfg_path = tmp_path / "config.yaml"
+    return cfg_path.read_text() if cfg_path.exists() else ""
+
+
+def _load(tmp_path):
+    import yaml
+
+    return yaml.safe_load(_read_config(tmp_path)) or {}
+
+
+# ---------------------------------------------------------------------------
+# Default config key
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultConfig:
+    def test_default_config_has_the_key(self):
+        approvals = DEFAULT_CONFIG.get("approvals")
+        assert isinstance(approvals, dict)
+        assert "model_config_confirm" in approvals
+
+    def test_default_is_true(self):
+        # New installs confirm agent-initiated model-routing rewrites — a
+        # silent billing decision must not be the enabled-by-default behavior.
+        assert DEFAULT_CONFIG["approvals"]["model_config_confirm"] is True
+
+
+# ---------------------------------------------------------------------------
+# Key classification (behavior contract, not a frozen list)
+# ---------------------------------------------------------------------------
+
+
+class TestModelRoutingKeyClassification:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "model",
+            "model.default",
+            "model.provider",
+            "model.base_url",
+            "model.context_length",
+            "delegation.model",
+            "delegation.provider",
+            "delegation.base_url",
+            "auxiliary.summarize.model",
+            "auxiliary.summarize.provider",
+            "auxiliary.summarize.base_url",
+        ],
+    )
+    def test_model_routing_keys_are_recognized(self, key):
+        assert _is_model_routing_key(key) is True
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "terminal.backend",
+            "skills.enabled",
+            "cron.interval",
+            # auxiliary.<name>.<field> is a routing key only for the three
+            # routing fields; tuning params are not billing-relevant.
+            "auxiliary.summarize.max_tokens",
+            "auxiliary.summarize.enabled",
+            "custom.enabled",
+        ],
+    )
+    def test_non_model_routing_keys_are_not_recognized(self, key):
+        assert _is_model_routing_key(key) is False
+
+
+# ---------------------------------------------------------------------------
+# Human / programmatic writes are unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestHumanWriteUnaffected:
+    def test_human_write_to_model_key_allowed(self, _isolated_hermes_home):
+        set_config_value("model.default", "anthropic/claude-sonnet-4")
+        assert _load(_isolated_hermes_home)["model"]["default"] == "anthropic/claude-sonnet-4"
+
+    def test_human_write_to_delegation_model_allowed(self, _isolated_hermes_home):
+        set_config_value("delegation.model", "gpt-4o")
+        assert _load(_isolated_hermes_home)["delegation"]["model"] == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Agent-initiated non-interactive writes are REFUSED (no hang, exit non-zero)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentWriteRefused:
+    def test_agent_write_to_model_default_refused(self, _isolated_hermes_home, monkeypatch, capsys):
+        # Seed a valid value first (human write, no marker).
+        set_config_value("model.default", "upstage/solar-pro4")
+        before = _read_config(_isolated_hermes_home)
+
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("model.default", "deepseek/deepseek-v4-flash")
+        assert exc.value.code != 0
+
+        err = capsys.readouterr().err
+        assert "model.default" in err
+        # The refusal must instruct the agent to surface the change to the user.
+        assert "surface" in err.lower()
+
+        # Config must be unchanged — the silent rewrite became a refusal.
+        assert _read_config(_isolated_hermes_home) == before
+
+    def test_agent_write_to_non_model_key_allowed(self, _isolated_hermes_home, monkeypatch):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        set_config_value("terminal.backend", "docker")
+        assert _load(_isolated_hermes_home)["terminal"]["backend"] == "docker"
+
+    def test_config_command_agent_write_refuses(self, _isolated_hermes_home, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        args = argparse.Namespace(
+            config_command="set", key="delegation.model", value="gpt-4o", force=False
+        )
+        with pytest.raises(SystemExit) as exc:
+            config_command(args)
+        assert exc.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# User-directed writes bypass the gate (inline escape hatch)
+# ---------------------------------------------------------------------------
+
+
+class TestUserDirectedBypass:
+    def test_confirm_model_change_bypasses_gate(self, _isolated_hermes_home, monkeypatch):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        set_config_value("delegation.model", "gpt-4o", confirm_model_change=True)
+        assert _load(_isolated_hermes_home)["delegation"]["model"] == "gpt-4o"
+
+    def test_bypass_still_emits_visible_notice(self, _isolated_hermes_home, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        set_config_value("delegation.model", "gpt-4o", confirm_model_change=True)
+        out = capsys.readouterr().out
+        assert "delegation.model" in out
+        assert "changed" in out.lower()
+
+    def test_config_command_honors_confirm_model_change(
+        self, _isolated_hermes_home, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        args = argparse.Namespace(
+            config_command="set",
+            key="delegation.model",
+            value="gpt-4o",
+            force=False,
+            confirm_model_change=True,
+        )
+        config_command(args)
+        assert _load(_isolated_hermes_home)["delegation"]["model"] == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Approvals.model_config_confirm=false silences the gate (but keeps the notice)
+# ---------------------------------------------------------------------------
+
+
+class TestGateDisabled:
+    def test_gate_disabled_allows_agent_write(self, _isolated_hermes_home, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        # Not a routing key, so this write is allowed and persists the opt-out.
+        set_config_value("approvals.model_config_confirm", "false")
+        set_config_value("delegation.model", "gpt-4o")
+        cfg = _load(_isolated_hermes_home)
+        assert cfg["approvals"]["model_config_confirm"] is False
+        assert cfg["delegation"]["model"] == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Interactive TTY prompting (destructive-slash style y/N)
+# ---------------------------------------------------------------------------
+
+
+class TestInteractivePrompt:
+    def test_interactive_approve_allows_and_notices(
+        self, _isolated_hermes_home, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        monkeypatch.setattr("hermes_cli.config._is_interactive_tty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+        set_config_value("delegation.model", "gpt-4o")
+        assert _load(_isolated_hermes_home)["delegation"]["model"] == "gpt-4o"
+        out = capsys.readouterr().out
+        assert "delegation.model" in out
+        assert "changed" in out.lower()
+
+    def test_interactive_decline_refuses(self, _isolated_hermes_home, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_AGENT_INITIATED", "1")
+        monkeypatch.setattr("hermes_cli.config._is_interactive_tty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("delegation.model", "gpt-4o")
+        assert exc.value.code != 0
+        assert "delegation" not in _read_config(_isolated_hermes_home)

--- a/tests/tools/test_modal_snapshot_isolation.py
+++ b/tests/tools/test_modal_snapshot_isolation.py
@@ -114,12 +114,20 @@ def _install_modal_test_modules(
         except OSError:
             return None
 
+    def _agent_initiated_command(command: str):
+        # Mirrors tools.environments.base.agent_initiated_command (#97652):
+        # modal.py imports it for exec-command marking, but these
+        # snapshot-isolation tests never exercise _run_bash command paths, so
+        # a faithful prefix stub is sufficient to satisfy the import.
+        return f"export HERMES_AGENT_INITIATED=1; {command}"
+
     sys.modules["tools.environments.base"] = types.SimpleNamespace(
         BaseEnvironment=_DummyBaseEnvironment,
         _ThreadedProcessHandle=_DummyThreadedProcessHandle,
         _load_json_store=_load_json_store,
         _save_json_store=_save_json_store,
         _file_mtime_key=_file_mtime_key,
+        agent_initiated_command=_agent_initiated_command,
     )
     sys.modules["tools.interrupt"] = types.SimpleNamespace(is_interrupted=lambda: False)
     sys.modules["tools.credential_files"] = types.SimpleNamespace(

--- a/tests/tools/test_vercel_sandbox_environment.py
+++ b/tests/tools/test_vercel_sandbox_environment.py
@@ -515,7 +515,13 @@ class TestExecute:
         assert replacement.stop_calls == []
         cmd, args, kwargs = original.run_command_calls[-1]
         assert cmd == "bash"
-        assert args == ["-c", "echo done"]
+        # _run_bash prefixes the command with the agent-initiated marker
+        # (#97652) so a nested `hermes config set` in the sandbox shell is
+        # gated by approvals.model_config_confirm.
+        from tools.environments.base import AGENT_INITIATED_ENV
+
+        assert args[0] == "-c"
+        assert args[1] == f"export {AGENT_INITIATED_ENV}=1; echo done"
         assert kwargs["cwd"] == "/vercel/sandbox"
 
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -295,6 +295,37 @@ def get_sandbox_dir() -> Path:
     return p
 
 
+# Agent-initiated marker (#97652).  Every Hermes-tool-spawned child environment
+# must carry this so a nested `hermes config set` knows it was invoked by an
+# agent (not a human shell) and routes the write through the
+# approvals.model_config_confirm gate.  The local backend stamps it in
+# tools/environments/local.py; every remote/container backend (docker, ssh,
+# modal, daytona, singularity, vercel_sandbox) must stamp it in the env it
+# builds for the child so agent writes through those backends are gated too.
+AGENT_INITIATED_ENV = "HERMES_AGENT_INITIATED"
+
+
+def stamp_agent_initiated(env: dict) -> None:
+    """Mark a child environment as agent-initiated (best-effort, fail-open)."""
+    try:
+        env[AGENT_INITIATED_ENV] = "1"
+    except Exception:
+        pass
+
+
+def agent_initiated_command(command: str) -> str:
+    """Prefix a shell command so its child env carries the agent marker.
+
+    Remote/container backends (ssh, modal, daytona, vercel_sandbox) run the
+    command in a remote shell where an env dict cannot be injected portably
+    across SDKs.  Exporting the marker at the start of the command string marks
+    the process as agent-initiated, so a nested ``hermes config set`` running in
+    that shell is gated by ``approvals.model_config_confirm`` (#97652).
+    """
+    return f"export {AGENT_INITIATED_ENV}=1; {command}"
+
+
+
 # A persistent sandbox's host directory is named after task_id, and that name
 # then becomes the source half of a `-v <source>:<target>` spec (Docker) or a
 # writable-overlay directory (Singularity). Docker splits the spec on ':', so

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from tools.environments.base import (
     BaseEnvironment,
     _ThreadedProcessHandle,
+    agent_initiated_command,
 )
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -231,9 +232,9 @@ class DaytonaEnvironment(BaseEnvironment):
                     pass
 
         if login:
-            shell_cmd = f"bash -l -c {shlex.quote(cmd_string)}"
+            shell_cmd = f"bash -l -c {shlex.quote(agent_initiated_command(cmd_string))}"
         else:
-            shell_cmd = f"bash -c {shlex.quote(cmd_string)}"
+            shell_cmd = f"bash -c {shlex.quote(agent_initiated_command(cmd_string))}"
 
         def exec_fn() -> tuple[str, int]:
             response = sandbox.process.exec(shell_cmd, timeout=timeout)

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -23,6 +23,7 @@ from tools.environments.base import (
     EnvironmentConnectionError,
     _popen_bash,
     sanitize_task_id_for_path,
+    stamp_agent_initiated,
 )
 from tools.environments.local import (
     _HERMES_PROVIDER_ENV_BLOCKLIST,
@@ -932,6 +933,12 @@ class DockerEnvironment(BaseEnvironment):
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
         self._env = _normalize_env_dict(env)
+        # Agent-initiated marker (#97652): the container child env is built from
+        # self._env (via _build_init_env_args / _build_runtime_env_args), so a
+        # nested `hermes config set` inside the container is gated like a local
+        # agent write — otherwise agent writes through the docker backend would
+        # bypass approvals.model_config_confirm entirely.
+        stamp_agent_initiated(self._env)
         self._init_unset_passthrough_names: tuple[str, ...] = ()
         self._container_id: Optional[str] = None
         self._labels: dict[str, str] = {}

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -590,15 +590,14 @@ def _inject_session_context_env(env: dict) -> None:
 # approvals.model_config_confirm gate can distinguish the two (#97652).  A human's
 # own `hermes config set` in their login shell is never spawned by Hermes and
 # thus never carries this marker.  Inert unless something reads it.
-HERMES_AGENT_INITIATED = "HERMES_AGENT_INITIATED"
+# Single source of truth lives in tools/environments/base.py; re-exported here
+# so the local builders keep the short name.
+from tools.environments.base import (
+    AGENT_INITIATED_ENV,
+    stamp_agent_initiated as _stamp_agent_initiated,
+)
 
-
-def _stamp_agent_initiated(env: dict) -> None:
-    """Mark a child environment as agent-initiated (best-effort, fail-open)."""
-    try:
-        env[HERMES_AGENT_INITIATED] = "1"
-    except Exception:
-        pass
+HERMES_AGENT_INITIATED = AGENT_INITIATED_ENV
 
 
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
@@ -884,6 +883,12 @@ def build_subprocess_env(
         apply_subprocess_home_env(env)
     if extra:
         env.update(extra)
+    # Agent-initiated marker (#97652): the non-scrub path was the one spawn
+    # site that skipped it. Every Hermes-spawned child must carry the marker so
+    # a nested `hermes config set` is gated regardless of the environment path
+    # (singularity builds its child env through this factory with
+    # scrub_secrets=False).
+    _stamp_agent_initiated(env)
     return env
 
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -583,6 +583,24 @@ def _inject_session_context_env(env: dict) -> None:
             env.pop(var_name, None)
 
 
+# Marker stamped on every Hermes-spawned subprocess environment.  The agent's
+# command-execution layer (terminal / file / code-execution tools) builds child
+# envs through the builders below; the marker tells a nested `hermes config set`
+# that it was invoked BY an agent rather than by a human in a terminal, so the
+# approvals.model_config_confirm gate can distinguish the two (#97652).  A human's
+# own `hermes config set` in their login shell is never spawned by Hermes and
+# thus never carries this marker.  Inert unless something reads it.
+HERMES_AGENT_INITIATED = "HERMES_AGENT_INITIATED"
+
+
+def _stamp_agent_initiated(env: dict) -> None:
+    """Mark a child environment as agent-initiated (best-effort, fail-open)."""
+    try:
+        env[HERMES_AGENT_INITIATED] = "1"
+    except Exception:
+        pass
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -655,6 +673,10 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     _apply_windows_msys_bash_env_defaults(sanitized)
 
     sanitized = _scrub_delegated_child_kanban_env(sanitized)
+
+    # Agent-initiated marker (#97652): signal nested `hermes config set` that a
+    # Hermes tool (not a human shell) spawned this child.
+    _stamp_agent_initiated(sanitized)
 
     return sanitized
 
@@ -1469,6 +1491,10 @@ def _make_run_env(env: dict) -> dict:
     _apply_windows_msys_bash_env_defaults(run_env)
 
     run_env = _scrub_delegated_child_kanban_env(run_env)
+
+    # Agent-initiated marker (#97652): signal nested `hermes config set` that a
+    # Hermes tool (not a human shell) spawned this child.
+    _stamp_agent_initiated(run_env)
 
     return run_env
 

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -20,6 +20,7 @@ from tools.environments.base import (
     _ThreadedProcessHandle,
     _load_json_store,
     _save_json_store,
+    agent_initiated_command,
 )
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -418,10 +419,11 @@ class ModalEnvironment(BaseEnvironment):
         def exec_fn() -> tuple[str, int]:
             async def _do():
                 args = ["bash"]
+                marked_cmd = agent_initiated_command(cmd_string)
                 if login:
-                    args.extend(["-l", "-c", cmd_string])
+                    args.extend(["-l", "-c", marked_cmd])
                 else:
-                    args.extend(["-c", cmd_string])
+                    args.extend(["-c", marked_cmd])
                 process = await sandbox.exec.aio(*args, timeout=timeout)
                 stdout = await process.stdout.read.aio()
                 stderr = await process.stderr.read.aio()

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -19,6 +19,7 @@ from tools.environments.base import (
     BaseEnvironment,
     EnvironmentConnectionError,
     _popen_bash,
+    agent_initiated_command,
 )
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -405,6 +406,7 @@ class SSHEnvironment(BaseEnvironment):
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn an SSH process that runs bash on the remote host."""
         cmd = self._build_ssh_command()
+        cmd_string = agent_initiated_command(cmd_string)
         if login:
             cmd.extend(["bash", "-l", "-c", shlex.quote(cmd_string)])
         else:

--- a/tools/environments/vercel_sandbox.py
+++ b/tools/environments/vercel_sandbox.py
@@ -28,6 +28,7 @@ from tools.environments.base import (
     _ThreadedProcessHandle,
     _load_json_store,
     _save_json_store,
+    agent_initiated_command,
 )
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -629,7 +630,7 @@ class VercelSandboxEnvironment(BaseEnvironment):
         def exec_fn() -> tuple[str, int]:
             result = sandbox.run_command(
                 "bash",
-                ["-lc" if login else "-c", cmd_string],
+                ["-lc" if login else "-c", agent_initiated_command(cmd_string)],
                 cwd=workspace_root,
             )
             return _extract_result_output(result), _extract_result_returncode(result)


### PR DESCRIPTION
## What does this PR do?

Adds a confirm gate for agent-initiated writes to model-routing configuration
keys (`model.*`, `delegation.model/provider/base_url`, bare
`delegation`/`auxiliary` section writes, `auxiliary.<task>.model/provider/base_url`).

Hermes agents can rewrite this configuration via a single
`hermes config set` — silently, even when the user runs `approvals.mode: off`.
The write determines per-token cost for every subagent, so a silent rewrite is
an unreviewed billing decision. A real incident motivated this: an agent
session pattern-matched the user's *valid* `delegation.model` against a stale
memory of a different, hyphenated, invalid slug and overwrote it with zero
errors occurring; the user discovered the change days later in Settings.

The gate is modeled on the existing `approvals.destructive_slash_confirm`
pattern — a confirmation class that survives `approvals.mode: off` with its
own opt-out key.

## Design

- **Discrimination**: the agent command-execution layer stamps every spawned
  subprocess env with `HERMES_AGENT_INITIATED=1` (stamped in
  `tools/environments/base.py`, so local, docker, ssh, modal, daytona, and
  vercel_sandbox backends are all covered). A human's own
  `hermes config set` in their shell never carries the marker and is never
  gated.
- **Agent-marked writes to model-routing keys**: refused (non-zero exit, clear
  stderr message) — never prompted. An agent process must not block on stdin
  (PTY-backed terminal runs have a real TTY; prompting would hang the tool
  call for its full timeout). The refusal instructs the agent to surface the
  proposed change to the user.
- **User-directed writes**: `hermes config set <key> <value>
  --confirm-model-change` marks the write as user-directed, bypasses the
  refusal, and emits a visible one-line change notice
  (`⚠ key changed: old → new`).
- **Gate opt-out**: `approvals.model_config_confirm: false` (default `true`)
  downgrades the gate to the visible change notice.
- **Secret hygiene**: values shown in notices/refusals pass through
  `_gate_redacted()`, which masks credential-shaped leaf keys (including
  nested values in `--force` section writes).
- Fail-open: any detection error ungates the write (a human write is never
  mis-gated).

## Changes Made

- `hermes_cli/config.py` — `_is_model_routing_key`, `_is_agent_initiated_write`,
  `_maybe_gate_model_routing_write`, `_gate_redacted`, notice/refusal emitters;
  `set_config_value` gains `confirm_model_change` and the gate call.
- `tools/environments/base.py` + per-backend wiring — the env stamp.
- `hermes_cli/config_defaults.py` — `approvals.model_config_confirm: True` with
  full documentation comment.
- `hermes_cli/subcommands/config.py` — `--confirm-model-change` CLI flag.
- `tests/hermes_cli/test_model_config_confirm_gate.py` — 45 tests (was 30 after
  round 1, extended through the review loop).

## How to Test

1. `hermes config set delegation.model anything` from your own shell → writes
   normally (no marker).
2. Same command with `HERMES_AGENT_INITIATED=1` env → refused, non-zero exit,
   no hang.
3. Same with `--confirm-model-change` → allowed, change notice printed.
4. `approvals.model_config_confirm: false` → agent-marked writes allowed with
   notice.

## Review

Two rounds of cross-vendor review (Gemini 3.7 Flash High + GPT-OSS 120B Medium,
byte-identical briefs with the full diff; verified-against-source dispositions
for every finding, including rejected misreads, are in the commit bodies).
Round 2 verdicts: all ACCEPTABLE across both reviewers; remaining SHOULD-FIXes
(nested-secret redaction) applied and tested.

Closes #97652
