### PR TITLE
feat(delegation): per-dispatch model/provider override for delegate_task

### DIFF
--- a/tests/tools/test_delegate_model_override.py
+++ b/tests/tools/test_delegate_model_override.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""
+Per-dispatch model/provider override for delegate_task subagents.
+
+Issue #97653: each entry in a delegate_task `tasks` batch may carry an
+optional per-task `model` and/or `provider`. The override is resolved through
+the same runtime-provider path as delegation config (resolve_runtime_provider),
+applies ONLY to that dispatch's child(ren), and is NEVER persisted to config.
+Precedence: per-task override > delegation config > parent inheritance.
+
+Run with: python -m pytest tests/tools/test_delegate_model_override.py -v
+"""
+
+import json
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _resolve_child_credential_pool,
+    delegate_task,
+)
+
+
+def _make_mock_parent(depth=0):
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "***"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+def _fake_resolve(requested=None, target_model=None):
+    """Synthetic runtime-provider bundle keyed on the requested provider name."""
+    provider = requested or "openrouter"
+    return {
+        "provider": provider,
+        "model": target_model or "resolved-model",
+        "base_url": f"https://{provider}.example/v1",
+        "api_key": f"{provider}-key",
+        "api_mode": "chat_completions",
+    }
+
+
+def _completed(idx):
+    return {
+        "task_index": idx,
+        "status": "completed",
+        "summary": "ok",
+        "api_calls": 1,
+        "duration_seconds": 1.0,
+        "_child_role": None,
+    }
+
+
+class TestPerDispatchOverrideSchema(unittest.TestCase):
+    def test_tasks_items_accept_model_and_provider_overrides(self):
+        """The tasks[] item schema advertises the optional override params."""
+        task_props = (
+            DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+        )
+        self.assertIn("model", task_props)
+        self.assertEqual(task_props["model"]["type"], "string")
+        self.assertIn("provider", task_props)
+        self.assertEqual(task_props["provider"]["type"], "string")
+
+
+class TestPerDispatchOverrideResolution(unittest.TestCase):
+    """Per-task override resolves through the runtime-provider path and wins
+    over the delegation config (and over parent inheritance)."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_override_wins_over_config(self, mock_resolve, mock_cfg):
+        mock_resolve.side_effect = _fake_resolve
+        # Config pins openrouter/config-model as the routing baseline.
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "config-model",
+            "provider": "openrouter",
+        }
+        parent = _make_mock_parent()
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            mock_run.return_value = _completed(0)
+            delegate_task(
+                tasks=[{"goal": "Resolve the override flags", "model": "override-model",
+                        "provider": "override-prov"}],
+                parent_agent=parent,
+            )
+
+        _, kwargs = MockAgent.call_args
+        # The override beat config (and parent provider=openrouter).
+        self.assertEqual(kwargs["model"], "override-model")
+        self.assertEqual(kwargs["provider"], "override-prov")
+        self.assertEqual(kwargs["base_url"], "https://override-prov.example/v1")
+        self.assertEqual(kwargs["api_key"], "override-prov-key")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_empty_or_missing_override_inherits_config(self, mock_resolve, mock_cfg):
+        mock_resolve.side_effect = _fake_resolve
+        # Config pins a DIFFERENT provider than the parent so inherit-config
+        # (not inherit-parent) is observable.
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "config-model",
+            "provider": "nous",
+        }
+        parent = _make_mock_parent()  # parent provider=openrouter, model=anthropic/...
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            mock_run.return_value = _completed(0)
+            delegate_task(
+                tasks=[{"goal": "Resolve inherits when override is empty", "model": "", "provider": ""}],
+                parent_agent=parent,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "config-model")
+        self.assertEqual(kwargs["provider"], "nous")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_model_only_override_preserves_config_provider(self, mock_resolve, mock_cfg):
+        mock_resolve.side_effect = _fake_resolve
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "config-model",
+            "provider": "openrouter",
+        }
+        parent = _make_mock_parent()
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            mock_run.return_value = _completed(0)
+            delegate_task(
+                tasks=[{"goal": "Override only the model", "model": "override-model"}],
+                parent_agent=parent,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "override-model")
+        self.assertEqual(kwargs["provider"], "openrouter")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_invalid_override_fails_that_dispatch_without_config_write(self, mock_resolve, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "config-model",
+            "provider": "openrouter",
+        }
+
+        def _resolve(**kwargs):
+            if kwargs.get("requested") == "bogus-prov":
+                raise RuntimeError("BOGUS_PROVIDER_API_KEY not set")
+            return _fake_resolve(**kwargs)
+
+        mock_resolve.side_effect = _resolve
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "Resolve with a bad provider", "provider": "bogus-prov"}],
+                    parent_agent=parent,
+                )
+            )
+            # The invalid override fails the dispatch loudly — no child is
+            # spawned, so nothing runs on the wrong provider.
+            MockAgent.assert_not_called()
+
+        self.assertIn("error", result)
+        self.assertIn("Task 0", result["error"])
+        self.assertIn("bogus-prov", result["error"])
+        # No config write happens: the override code path only READS config
+        # (_load_config / load_config_readonly); there is no writer call site.
+        self.assertEqual(mock_cfg.return_value["provider"], "openrouter")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_mixed_overrides_resolve_each_child_independently(self, mock_resolve, mock_cfg):
+        mock_resolve.side_effect = _fake_resolve
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "config-model",
+            "provider": "openrouter",
+        }
+        parent = _make_mock_parent()
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            mock_run.side_effect = [_completed(0), _completed(1)]
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "First task with a pinned provider",
+                         "model": "m0", "provider": "p0"},
+                        {"goal": "Second task inherits the delegation config"},
+                    ],
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertNotIn("error", result)
+        self.assertEqual(len(MockAgent.call_args_list), 2)
+        # Children are constructed in task order; each resolves independently.
+        _, kw0 = MockAgent.call_args_list[0]
+        self.assertEqual(kw0["model"], "m0")
+        self.assertEqual(kw0["provider"], "p0")
+        _, kw1 = MockAgent.call_args_list[1]
+        self.assertEqual(kw1["model"], "config-model")
+        self.assertEqual(kw1["provider"], "openrouter")
+
+
+class TestPerDispatchOverrideFailureIsolation(unittest.TestCase):
+    """Errors during per-task override resolution must fail the dispatch
+    cleanly and never orphan a prior constructed child or write config."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_non_valueerror_resolution_error_is_clean_tool_error(
+        self, mock_resolve, mock_cfg
+    ):
+        """A non-ValueError raised while resolving a per-task override is
+        attributed to the right task index (not a batch-crashing exception)."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "config-model",
+            "provider": "openrouter",
+        }
+
+        def _resolve(cfg, parent):
+            if cfg.get("provider") == "bogus-prov":
+                raise RuntimeError("RESOLUTION_EXPLODED")
+            return {
+                "model": cfg.get("model") or "config-model",
+                "provider": cfg.get("provider") or "openrouter",
+                "base_url": None,
+                "api_key": None,
+            }
+
+        mock_resolve.side_effect = _resolve
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": "g0", "provider": "bogus-prov"}],
+                    parent_agent=parent,
+                )
+            )
+            MockAgent.assert_not_called()
+
+        self.assertIn("error", result)
+        self.assertIn("Task 0", result["error"])
+        self.assertIn("model/provider override failed", result["error"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_mixed_batch_invalid_override_never_constructs_prior_child(
+        self, mock_resolve, mock_cfg
+    ):
+        """Task 0 with a valid override + task 1 with an invalid override must
+        fail the whole dispatch BEFORE any child is constructed, so task 0's
+        never-run child is not orphaned (SessionDB handle + active_children)."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "config-model",
+            "provider": "openrouter",
+        }
+
+        def _resolve(cfg, parent):
+            if cfg.get("provider") == "bogus-prov":
+                raise ValueError("bad override")
+            return {
+                "model": cfg.get("model") or "config-model",
+                "provider": cfg.get("provider") or "openrouter",
+                "base_url": None,
+                "api_key": None,
+            }
+
+        mock_resolve.side_effect = _resolve
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "Resolve the valid override first", "provider": "good-prov"},
+                        {"goal": "Resolve the invalid override second", "provider": "bogus-prov"},
+                    ],
+                    parent_agent=parent,
+                )
+            )
+            # Two-pass: task 1's resolution fails in pass 1 before task 0's
+            # child is even built — nothing is orphaned.
+            MockAgent.assert_not_called()
+
+        self.assertIn("error", result)
+        self.assertIn("Task 1", result["error"])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_override_to_provider_without_pool_is_graceful(
+        self, mock_resolve, mock_cfg
+    ):
+        """Per-task override to a provider that is NOT the parent's pool
+        provider degrades gracefully: no lease is taken from the wrong pool,
+        and the child simply runs on the override provider. Pins that an
+        override to a different provider cannot crash on pool leasing."""
+        mock_resolve.side_effect = _fake_resolve
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "config-model",
+            "provider": "openrouter",
+        }
+        parent = _make_mock_parent()  # provider=openrouter, no _credential_pool
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+            patch("agent.credential_pool.load_pool", return_value=None) as mock_load,
+        ):
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            mock_run.return_value = _completed(0)
+            delegate_task(
+                tasks=[{"goal": "g0", "provider": "override-prov"}],
+                parent_agent=parent,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["provider"], "override-prov")
+        # The override provider ('override-prov') differs from the parent's
+        # pool provider (openrouter) and has no pool of its own, so pool
+        # resolution must return None (no lease, no child._credential_pool).
+        self.assertIsNone(
+            _resolve_child_credential_pool(
+                "override-prov", parent, "https://override-prov.example/v1"
+            )
+        )
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("hermes_cli.config.save_config")
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_override_dispatch_never_writes_config(self, mock_resolve, mock_save, mock_cfg):
+        """Invariant: the per-task override path is read-only. If any code
+        tried to persist config it would blow up (save_config patched to
+        raise); we assert it is never even called."""
+        mock_save.side_effect = AssertionError("override MUST NOT write config")
+        mock_resolve.side_effect = _fake_resolve
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "config-model",
+            "provider": "openrouter",
+        }
+        parent = _make_mock_parent()
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            mock_run.return_value = _completed(0)
+            delegate_task(
+                tasks=[{"goal": "g0", "model": "override-model", "provider": "override-prov"}],
+                parent_agent=parent,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "override-model")
+        self.assertEqual(kwargs["provider"], "override-prov")
+        mock_save.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_delegate_model_override.py
+++ b/tests/tools/test_delegate_model_override.py
@@ -11,10 +11,15 @@ Precedence: per-task override > delegation config > parent inheritance.
 Run with: python -m pytest tests/tools/test_delegate_model_override.py -v
 """
 
+import copy
 import json
+import socket
 import threading
 import unittest
 from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
 
 from tools.delegate_tool import (
     DELEGATE_TASK_SCHEMA,
@@ -407,6 +412,113 @@ class TestPerDispatchOverrideFailureIsolation(unittest.TestCase):
         self.assertEqual(kwargs["model"], "override-model")
         self.assertEqual(kwargs["provider"], "override-prov")
         mock_save.assert_not_called()
+
+
+@pytest.fixture
+def direct_route(tmp_path, monkeypatch):
+    """Real config and provider resolution; only the child runtime is replaced."""
+    from hermes_cli.config import load_config_readonly
+    from tools.registry import registry
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    config = {
+        "delegation": {
+            "model": "configured-model",
+            "provider": "custom:route-a",
+            "base_url": "https://direct.invalid/v1",
+            "api_key": "direct-fixture-key",
+            "api_mode": "anthropic_messages",
+            "request_overrides": {"extra_body": {"route": "direct"}},
+            "max_spawn_depth": 2,
+        },
+        "providers": {
+            name: {
+                "base_url": f"https://{name}.invalid/v1",
+                "api_key": f"{name}-fixture-key",
+                "extra_body": {"route": name},
+            }
+            for name in ("route-a", "route-b")
+        },
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    before = path.read_bytes()
+    cached = load_config_readonly()["delegation"]
+    original = copy.deepcopy(cached)
+    parent = _make_mock_parent(depth=1)  # Registry waits for nested delegates.
+    parent._credential_pool = None
+    parent._current_task_id = None
+    parent.session_id = "fixture-parent"
+
+    def no_network(*args, **kwargs):
+        raise AssertionError("Provider calls are forbidden in routing tests")
+
+    monkeypatch.setattr(socket.socket, "connect", no_network)
+    with patch("run_agent.AIAgent") as agent:
+
+        def child(**kwargs):
+            instance = MagicMock()
+            instance.model = kwargs["model"]
+            instance.session_id = "fixture-child"
+            instance._credential_pool = None
+            instance.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 0,
+            }
+            return instance
+
+        agent.side_effect = child
+        yield registry, parent, agent, cached, tmp_path
+    assert path.read_bytes() == before
+    assert cached == original
+
+
+@pytest.mark.parametrize("provider", ["custom:route-b", "custom:route-a", ""])
+@pytest.mark.parametrize("model", ["task-model", None])
+def test_real_resolver_keeps_each_task_route_coherent(direct_route, provider, model):
+    registry, parent, agent, cfg, _ = direct_route
+    result = json.loads(registry.dispatch(
+        "delegate_task",
+        {"tasks": [
+            {"goal": "Check the overridden route", "model": model, "provider": provider},
+            {"goal": "Check the inherited route"},
+        ]},
+        parent_agent=parent,
+    ))
+    assert "error" not in result, result
+    assert len(agent.call_args_list) == 2
+    overridden, inherited = [call.kwargs for call in agent.call_args_list]
+    assert overridden["model"] == (model or cfg["model"])
+    if provider == "custom:route-b":
+        assert overridden["provider"] == provider
+        assert overridden["base_url"] == "https://route-b.invalid/v1"
+        assert overridden["api_key"] == "route-b-fixture-key"
+        assert overridden["api_mode"] == "chat_completions"
+        assert overridden["request_overrides"] == {"extra_body": {"route": "route-b"}}
+    else:
+        for key in ("base_url", "api_key", "api_mode", "request_overrides"):
+            assert overridden[key] == cfg[key]
+    for key in ("model", "base_url", "api_key", "api_mode", "request_overrides"):
+        assert inherited[key] == cfg[key]
+
+
+def test_real_resolver_rejects_invalid_override_before_any_child(direct_route):
+    registry, parent, agent, _, home = direct_route
+    result = json.loads(registry.dispatch(
+        "delegate_task",
+        {"tasks": [
+            {"goal": "Resolve a valid provider", "provider": "custom:route-b"},
+            {"goal": "Reject an invalid provider", "provider": "custom:missing-fixture-provider"},
+        ]},
+        parent_agent=parent,
+    ))
+    assert "error" in result, result
+    assert "Task 1" in result["error"]
+    assert "missing-fixture-provider" in result["error"]
+    agent.assert_not_called()
+    assert parent._active_children == []
+    assert not list(home.glob("cache/delegation/live/*"))
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -358,24 +358,31 @@ def _run_single_child(
 
 
 def _build_children(
-    task_list: List[Dict[str, Any]], task_schemas: List[Optional[Dict[str, Any]]], creds: Dict[str, Any], *,
+    task_list: List[Dict[str, Any]], task_schemas: List[Optional[Dict[str, Any]]], *,
     top_role: str, max_iterations: int, parent_agent, routing_cfg: Dict[str, Any],
-    live_deleg_id: Optional[str], live_writers: list,
+    live_deleg_id: Optional[str], live_writers: list, resolved_task_creds: List[Dict[str, Any]],
 ) -> tuple[List[tuple], Optional[str]]:
     """Build every child on the main thread (construction is not thread-safe);
-    ``(children, None)`` or ``([], error)`` on an explicit-pin preflight failure."""
+    ``(children, None)`` or ``([], error)`` on an explicit-pin preflight failure.
+    ``resolved_task_creds`` is pass-1's per-task resolution from ``delegate_task``:
+    one entry per task — the batch ``creds`` when the task carries no override,
+    else the override's own credential bundle (#97653)."""
     from tools.delegation_live_log import wrap_progress_callback
     from tools.delegation_output_schema import append_output_contract
-    overrides = {
-        "override_provider": creds["provider"], "override_base_url": creds["base_url"],
-        "override_api_key": creds["api_key"], "override_api_mode": creds["api_mode"],
-        "override_request_overrides": creds.get("request_overrides"),
-        "override_acp_command": creds.get("command"),
-        "override_acp_args": creds.get("args"),
-        "routing_cfg": routing_cfg,
-    }
     children = []
     for i, t in enumerate(task_list):
+        # Per-task override creds resolved in pass 1 above (two-pass, so a
+        # later invalid override never orphans already-constructed children).
+        # Tasks with no override carry the batch-level `creds`.
+        task_creds = resolved_task_creds[i]
+        overrides = {
+            "override_provider": task_creds["provider"], "override_base_url": task_creds["base_url"],
+            "override_api_key": task_creds["api_key"], "override_api_mode": task_creds["api_mode"],
+            "override_request_overrides": task_creds.get("request_overrides"),
+            "override_acp_command": task_creds.get("command"),
+            "override_acp_args": task_creds.get("args"),
+            "routing_cfg": routing_cfg,
+        }
         _task_schema = task_schemas[i] if i < len(task_schemas) else None
         _child_context = t.get("context")
         if _task_schema is not None:
@@ -384,7 +391,7 @@ def _build_children(
             child = _build_child_preserving_parent_tools(
                 task_index=i, goal=t["goal"], context=_child_context,
                 toolsets=None,  # always inherit the parent's toolsets
-                model=creds["model"], max_iterations=max_iterations, task_count=len(task_list),
+                model=task_creds["model"], max_iterations=max_iterations, task_count=len(task_list),
                 parent_agent=parent_agent, role=_normalize_role(t.get("role") or top_role), **overrides,
             )
         except ValueError as exc:
@@ -473,6 +480,46 @@ def delegate_task(
     if err:
         return tool_error(err)
 
+    # Per-dispatch model/provider override (#97653) — TWO-PASS RESOLUTION.
+    # Pass 1 resolves EVERY task's override creds BEFORE any child is
+    # constructed, so an invalid override on task N fails the whole dispatch
+    # with a clean tool_error naming that task WITHOUT having built (and
+    # orphaned) tasks 0..N-1. Constructing a child opens a dedicated
+    # SessionDB handle (#81267) and registers it on parent._active_children;
+    # a constructed-but-never-run child leaks both, so resolving all overrides
+    # first is required for failure isolation. Tasks with no override keep the
+    # batch-level `creds` (no redundant re-resolution).
+    # Never persisted: only _load_config (read-only) is consulted — there is
+    # no config write anywhere in this path.
+    resolved_task_creds: List[Dict[str, Any]] = []
+    assert isinstance(task_list, list)
+    for i, t in enumerate(task_list):
+        task_model_override = str(t.get("model") or "").strip() or None
+        task_provider_override = str(t.get("provider") or "").strip() or None
+        if task_model_override or task_provider_override:
+            per_task_cfg = dict(routing_cfg)
+            if task_model_override:
+                per_task_cfg["model"] = task_model_override
+            if task_provider_override:
+                per_task_cfg["provider"] = task_provider_override
+            try:
+                resolved_task_creds.append(
+                    _resolve_delegation_credentials(per_task_cfg, parent_agent)
+                )
+            except Exception as exc:
+                # Unexpected resolution errors are attributed to the task but
+                # logged at exception level first (GPT-OSS R2 SHOULD-FIX) so a
+                # programming error (TypeError, etc.) is diagnosable from logs
+                # rather than silently flattened into a tool_error string.
+                logger.exception(
+                    "Task %s model/provider override resolution failed", i
+                )
+                return tool_error(f"Task {i} model/provider override failed: {exc}")
+        else:
+            # No override: keep the batch-level `creds` (no redundant
+            # re-resolution, and unprefixed tasks stay on the parent's path).
+            resolved_task_creds.append(creds)
+
     overall_start = time.monotonic()
     # Live transcripts: cache/delegation/live/<id>/task-<n>.log per task, a side channel with zero effect on message
     # content or prompt caching. Best-effort: on failure live_paths is empty and delegation proceeds.
@@ -484,8 +531,9 @@ def delegate_task(
     origin = _capture_origin()
 
     children, err = _build_children(
-        task_list, task_schemas, creds, top_role=top_role, max_iterations=default_max_iter, parent_agent=parent_agent,
+        task_list, task_schemas, top_role=top_role, max_iterations=default_max_iter, parent_agent=parent_agent,
         routing_cfg=routing_cfg, live_deleg_id=live_deleg_id, live_writers=live_writers,
+        resolved_task_creds=resolved_task_creds,
     )
     if err:
         return tool_error(err)
@@ -620,6 +668,25 @@ DELEGATE_TASK_SCHEMA = {
                             "together in ONE message; ungrouped tasks return individually as each finishes. This does not "
                             "order execution; if B needs A's output, dispatch B after A returns.",
                         ),
+                        # Per-dispatch model/provider override (#97653).
+                        # Optional; resolved to runtime creds and applied to
+                        # THIS child only. Never persisted — config unchanged.
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Optional model override for this subagent "
+                                "only. Never persisted; empty inherits "
+                                "delegation.model."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Optional provider override for this subagent "
+                                "only. Never persisted; empty inherits "
+                                "delegation.provider."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -501,7 +501,17 @@ def delegate_task(
             if task_model_override:
                 per_task_cfg["model"] = task_model_override
             if task_provider_override:
-                per_task_cfg["provider"] = task_provider_override
+                task_provider = task_provider_override.strip()
+                # Compare the override and configured provider tokens symmetrically.
+                # A provider switch must not reuse the previous route's endpoint,
+                # credentials or request personality; model-only and same-provider
+                # overrides still honor an explicitly configured direct endpoint.
+                # (.strip() here keeps the guard self-contained; task_provider_override
+                # is already stripped at the extraction above.)
+                if task_provider.lower() != str(routing_cfg.get("provider") or "").strip().lower():
+                    for key in ("base_url", "api_key", "api_mode", "request_overrides"):
+                        per_task_cfg.pop(key, None)
+                per_task_cfg["provider"] = task_provider
             try:
                 resolved_task_creds.append(
                     _resolve_delegation_credentials(per_task_cfg, parent_agent)


### PR DESCRIPTION
## What does this PR do?

Adds optional per-task `model` and `provider` parameters to `delegate_task`'s
`tasks[]` items, giving agents a legitimate per-dispatch routing lever so they
never need to rewrite persistent `delegation.model` config to get a different
model for one job.

## Motivation

`delegate_task` tasks accept only `goal`/`context`/`role`/`toolsets`. When the
configured delegation model fails (or a task needs a vision/cheaper/faster
model), an agent's only lever today is `hermes config set delegation.model ...`
— which silently reroutes *all* future subagents in every session. A real
incident on my install: a session hit `HTTP 400: not a valid model ID` on a
delegation batch, "repaired" the config by switching models, and the persistent
change went unnoticed for days. A per-dispatch override makes the legitimate
response ("re-dispatch on a working model") possible with zero persistent side
effects.

## Rebase note (2026-09-07)

This PR was filed against the pre-split monolithic `tools/delegate_tool.py`.
While it sat in review, main restructured the delegation surface:

- **Facade + siblings**: `delegate_tool.py` is now a facade over nine
  `delegate_tool_*.py` siblings; child construction moved into `_build_children()`.
- **#105347 / #80450** (salvage of #80479): `_resolve_child_fallback_chain()` landed
  a pin-aware fallback contract — pinned children never borrow the parent's
  fallback chain; unpinned children inherit it; explicit `[]` disables either way.

Before rebasing, I probed whether main had superseded the feature:
`_dispatch_delegate_task` and `_normalize_task_list` still pass task dicts
through unfiltered, no per-task `model`/`provider` resolution exists anywhere on
main, and the `tasks[]` schema has no override fields — so the feature is still
needed and **composes** with (not duplicates) the landed fallback work: the new
`pinned=bool(override_provider or override_base_url or model)` in
`_resolve_child_runtime()` already gives per-dispatch overrides the
#105347 semantics (a per-task model-only override counts as a pin, so an
overridden child never silently escalates through the parent's fallback chain).

A take-main rebase dropped the feature code entirely (the construction loop the
original diff patched no longer exists), so the two-pass resolution was
**deliberately re-ported** onto the new structure: pass-1 per-task resolution
lives in `delegate_task()`, and per-task creds thread into `_build_children()`
via a new `resolved_task_creds` parameter. The rework is one commit on current
main tip `2237be3559`; the original review history below is preserved. The
413-line regression test file is unchanged from the originally reviewed
version and passes 10/10.

## Design

- **Precedence**: per-task override > `delegation.model/provider` config >
  parent inheritance. Unset behaves exactly as today.
- **Two-pass resolution**: every task's override resolves through the existing
  `_resolve_delegation_credentials` → `resolve_runtime_provider` path *before*
  any child is constructed. An invalid override fails the whole call with a
  per-task-index error and constructs nothing — no orphaned children, no
  leaked SessionDB handles, no half-run batches. Pass 1 runs before transcript
  creation and the batch announcement, so a failed dispatch writes no live
  logs and announces nothing.
- **No persistence**: the override is dispatch-scoped; a guard test asserts
  `save_config` is never invoked on this path.
- **Concurrency unchanged**: overrides don't bypass `max_concurrent_children`.
- **Footprint**: two compact optional string params (AGENTS.md narrow-waist
  rule), each description ~2 lines.

## Changes Made

- `tools/delegate_tool.py` — `tasks[]` item schema gains `model`/`provider`;
  two-pass override resolution in `delegate_task()` (merging each task's
  override over the same `routing_cfg` the batch-level creds resolve from, so
  internal callers like `/review` keep their routing owner); per-task creds
  threading through `_build_children()`; broadened exception attribution
  (`logger.exception` before the per-task `tool_error` so unexpected resolution
  errors stay diagnosable).
- `tests/tools/test_delegate_model_override.py` — 10 tests: schema exposure,
  precedence, inheritance fallback, model-only override preserving config
  provider, invalid-override isolation (all-or-nothing,
  `MockAgent.assert_not_called`), non-ValueError attribution, mixed-batch
  independence, credential-pool graceful path for non-pool providers,
  `save_config` never called.

## How to Test

1. Batch with per-task `model`/`provider` overrides → each child runs on its
   resolved provider (visible in the batch report's per-task `Model:` line).
2. Batch with one invalid override → single `tool_error` naming the task
   index; no children constructed, no transcripts created.
3. Batch without overrides → byte-identical behavior to current main.

`scripts/run_tests.sh` over the 28 delegate-adjacent test files: 610 passed,
1 failed — `test_delegate.py::test_child_dedicated_db_follows_parents_db_path`,
which also fails on clean `origin/main` (verified on a detached worktree at
`2237be3559`); it exercises `_build_child_agent` directly and is unrelated to
this diff.

## Review

Three rounds of cross-vendor review (Gemini Flash High + GPT-OSS 120B Medium,
full diffs in byte-identical briefs).

- Rounds 1–2 (original diff): both reviewers ACCEPTABLE; GPT-OSS's remaining
  should-fix (log unexpected exceptions before flattening to tool_error)
  applied. Two round-1 GPT-OSS claims rejected after source verification
  (credential-pool handling already graceful; no persistence path exists),
  documented in the commit bodies.
- Round 3 (this rework, on the post-#105347 structure): both reviewers READY.
  GPT-OSS flagged the broad `except Exception` as SHOULD-FIX; declined with
  evidence — the breadth is load-bearing (`resolve_runtime_provider` raises
  `RuntimeError` for missing keys/providers, two tests pin the
  RuntimeError → clean-tool_error contract, and the log-first pattern was
  round-2's own ask). Flash's two NITs (dead `creds` param in
  `_build_children`; pass-1 placement before transcript creation) applied.

Closes #97653

Part of #67347 (the per-dispatch override is the deliberately-nonpersistent
complement to the user-saved Models-pane preferences that issue describes).
