### PR TITLE
fix(delegation): honest subagent failure statuses + config-level model-rejection notice

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -676,6 +676,107 @@ class TestDelegateObservability(unittest.TestCase):
             self.assertEqual(result["results"][0]["status"], "failed")
 
 
+class TestDelegateFailedChildStatus(unittest.TestCase):
+    """Honest status / exit_reason for failed subagents (issue #97655).
+
+    A child that fails on its first API call (e.g. an HTTP 400 "not a valid
+    model ID") returns completed=False with failed=True + an error string as
+    its terminal final_response. It must be reported as status=failed with an
+    honest exit_reason — never status=completed + exit_reason=max_iterations
+    (which mislabels provider rejections as iteration-budget exhaustion and
+    would render the false "TRUNCATED" banner).
+    """
+
+    def _delegate_single(self, child_result):
+        """Dispatch a single task whose mock child returns `child_result`,
+        returning the parsed child result entry dict."""
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = child_result
+            MockAgent.return_value = mock_child
+            result = json.loads(
+                delegate_task(goal="Test child status", parent_agent=parent)
+            )
+            return result["results"][0]
+
+    def test_failed_flag_marks_status_failed(self):
+        """Regression (issue #97655): a provider-rejected child (HTTP 400 on its
+        first call) returns completed=False with failed=True + an error string.
+        It must be status=failed, exit_reason=error, and NOT truncated."""
+        entry = self._delegate_single(
+            {
+                "final_response": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+                "completed": False,
+                "interrupted": False,
+                "failed": True,
+                "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+                "api_calls": 1,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "error")
+        self.assertFalse(entry["truncated"])
+
+    def test_error_with_summary_still_failed(self):
+        """A child that returns BOTH an error field and a summary must still be
+        failed — the summary-presence heuristic must not override the
+        structured failure."""
+        entry = self._delegate_single(
+            {
+                "final_response": "partial work before crashing",
+                "completed": False,
+                "interrupted": False,
+                "failed": True,
+                "error": "provider boom",
+                "api_calls": 3,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "error")
+        self.assertFalse(entry["truncated"])
+
+    def test_genuine_truncation_stays_completed_max_iterations(self):
+        """REGRESSION GUARD: a child that genuinely exhausts its iteration
+        budget (completed=False, no failed flag, no error) but still returns a
+        summary must keep status=completed, exit_reason=max_iterations, and
+        truncated=True. This is the legitimate truncation path we must not
+        break while making failure labels honest."""
+        entry = self._delegate_single(
+            {
+                "final_response": "made partial progress before the budget ran out",
+                "completed": False,
+                "interrupted": False,
+                "api_calls": 10,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["exit_reason"], "max_iterations")
+        self.assertTrue(entry["truncated"])
+
+    def test_interrupted_unchanged(self):
+        """Interrupted children keep status=interrupted + exit_reason=interrupted
+        and are not marked truncated."""
+        entry = self._delegate_single(
+            {
+                "final_response": "some partial output",
+                "completed": False,
+                "interrupted": True,
+                "api_calls": 2,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "interrupted")
+        self.assertEqual(entry["exit_reason"], "interrupted")
+        self.assertFalse(entry["truncated"])
+
+
 class TestSubagentCostRollup(unittest.TestCase):
     """Port of Kilo-Org/kilocode#9448 — parent's session_estimated_cost_usd
     must include subagent spend, not just the parent's own API calls."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -741,6 +741,47 @@ class TestDelegateFailedChildStatus(unittest.TestCase):
         self.assertEqual(entry["exit_reason"], "error")
         self.assertFalse(entry["truncated"])
 
+    def test_error_without_failed_flag_marks_failed(self):
+        """A child result that carries a non-empty error string but OMITS the
+        ``failed`` key entirely (not ``failed=False`` — the key is absent, as in
+        legacy/partial result dicts) must still be status=failed + exit_reason=error.
+        The status branch checks ``result.get('failed') or result.get('error')``,
+        so the error field alone has to win — otherwise a dropped ``failed`` key
+        would silently mislabel a provider rejection as budget exhaustion."""
+        entry = self._delegate_single(
+            {
+                "final_response": "connection reset while streaming",
+                "completed": False,
+                "interrupted": False,
+                "error": "connection reset",
+                "api_calls": 2,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "error")
+        self.assertFalse(entry["truncated"])
+
+    def test_empty_error_with_summary_is_completed(self):
+        """REGRESSION PIN: an empty-string ``error`` field must NOT be treated as
+        a failure. ``result.get('error')`` returns ``''`` which is falsy, so the
+        failure branch correctly falls through to the summary-presence heuristic.
+        Empty error + a real summary => status=completed, exit_reason=completed
+        (or max_iterations if completed=False), never 'error'."""
+        entry = self._delegate_single(
+            {
+                "final_response": "work produced",
+                "completed": True,
+                "interrupted": False,
+                "error": "",
+                "api_calls": 2,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["exit_reason"], "completed")
+        self.assertFalse(entry["truncated"])
+
     def test_genuine_truncation_stays_completed_max_iterations(self):
         """REGRESSION GUARD: a child that genuinely exhausts its iteration
         budget (completed=False, no failed flag, no error) but still returns a

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2413,3 +2413,155 @@ class TestGetByPrefix:
         result = registry.poll("4dae56ca")
         assert result["session_id"] == "proc_4dae56ca81f6"
         assert result["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# Config-level model_not_found notice in delegation batch reports (#97654)
+# ---------------------------------------------------------------------------
+
+
+def _make_delegation_batch_evt(results):
+    """A batch async-delegation event carrying a per-task ``results`` list."""
+    return {
+        "type": "async_delegation",
+        "delegation_id": "deleg_97654",
+        "is_batch": True,
+        "results": results,
+        "goals": [r.get("goal") or "" for r in results],
+        "session_key": "agent:main:cli:dm:local",
+        "status": "completed",
+        "model": "upstage/solar-pro-4",
+    }
+
+
+def _patch_delegation_config(
+    monkeypatch, model="upstage/solar-pro-4", provider="openrouter", **over
+):
+    import tools.process_registry as _pr
+
+    cfg = {"model": model, "provider": provider}
+    cfg.update(over)
+    monkeypatch.setattr(_pr, "_delegation_config", lambda: cfg)
+    return cfg
+
+
+def _format_async(evt) -> str:
+    from tools.process_registry import format_process_notification
+
+    text = format_process_notification(evt)
+    assert text is not None, "format_process_notification returned None"
+    return text
+
+
+def test_model_not_found_notice_single_failure_once(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "exit_reason": "error",
+            "goal": "Create bridge module",
+            "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+            "summary": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+        }
+    ])
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert text is not None
+    assert text.count("SUBAGENT MODEL REJECTED") == 1
+    assert "upstage/solar-pro-4" in text
+    assert "openrouter" in text
+    assert "No fallback chain is configured" in text
+
+
+def test_model_not_found_notice_mixed_batch_named_model(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "exit_reason": "error",
+            "goal": "A",
+            "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+            "summary": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+        },
+        {
+            "task_index": 1,
+            "status": "completed",
+            "goal": "B",
+            "summary": "ok",
+            "api_calls": 3,
+        },
+    ])
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert text.count("SUBAGENT MODEL REJECTED") == 1
+    assert "upstage/solar-pro-4" in text
+
+
+def test_model_not_found_notice_absent_for_non_model_errors(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "goal": "A",
+            "error": "HTTP 429: rate limit exceeded",
+        },
+        {
+            "task_index": 1,
+            "status": "failed",
+            "goal": "B",
+            "error": "Connection timed out",
+        },
+    ])
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert "SUBAGENT MODEL REJECTED" not in text
+
+
+def test_model_not_found_notice_absent_when_configured_model_not_named(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "goal": "A",
+            "error": "HTTP 400: gpt-99 is not a valid model ID",
+        }
+    ])
+    # Configured model is upstage/solar-pro-4; the rejection names gpt-99.
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert "SUBAGENT MODEL REJECTED" not in text
+
+
+def test_model_not_found_notice_single_dispatch(monkeypatch):
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_single",
+        "session_key": "agent:main:cli:dm:local",
+        "goal": "task A",
+        "model": "upstage/solar-pro-4",
+        "status": "failed",
+        "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+        "summary": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+    }
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert text.count("SUBAGENT MODEL REJECTED") == 1
+    assert "upstage/solar-pro-4" in text
+
+
+def test_model_not_found_notice_absent_when_fallback_chain_configured(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "goal": "A",
+            "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+        }
+    ])
+    _patch_delegation_config(
+        monkeypatch,
+        fallback_providers=[{"provider": "openrouter", "model": "upstage/solar-pro4"}],
+    )
+    text = _format_async(evt)
+    assert text.count("SUBAGENT MODEL REJECTED") == 1
+    assert "No fallback chain is configured" not in text

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3049,6 +3049,14 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
+        elif result.get("failed") or result.get("error"):
+            # A structured failure (provider rejection / terminal exception)
+            # must WIN over the summary-presence heuristic below. The child's
+            # conversation loop returns the error text as final_response, so an
+            # error-shaped summary would otherwise be labeled "completed" here
+            # despite completed=False. The heuristic is only a fallback for
+            # legacy/mock results that omit the structured failure fields.
+            status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -3098,9 +3106,15 @@ def _run_single_child(
         # Determine exit reason
         if interrupted:
             exit_reason = "interrupted"
+        elif result.get("failed") or result.get("error"):
+            # Provider rejection / terminal failure. Do NOT report this as
+            # iteration-budget exhaustion — "max_iterations" is only truthful
+            # when the child actually hit its per-delegation iteration cap.
+            exit_reason = "error"
         elif completed:
             exit_reason = "completed"
         else:
+            # Genuine budget exhaustion: completed=False with no failure.
             exit_reason = "max_iterations"
 
         # Extract token counts (safe for mock objects)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2464,7 +2464,27 @@ def _run_single_child(
 ) -> Dict[str, Any]:
     """
     Run a pre-built child agent. Called from within a thread.
-    Returns a structured result dict.
+    Returns a structured result dict with a ``status`` and ``exit_reason``
+    that are derived honestly from the child's structured completion fields.
+
+    ``status`` ∈ {``"completed"``, ``"interrupted"``, ``"failed"``}:
+        * ``"completed"``  — the child reached a normal finish (may still have
+          hit its iteration budget; see ``exit_reason``).
+        * ``"interrupted"`` — the child was interrupted (``interrupted=True``).
+        * ``"failed"``    — a structured failure (``failed=True`` or a non-empty
+          ``error``) or a summary-less/invalid terminal state.
+
+    ``exit_reason`` ∈ {``"completed"``, ``"max_iterations"``, ``"interrupted"``,
+    ``"error"``}:
+        * ``"completed"``       — normal finish.
+        * ``"max_iterations"``  — genuine per-child iteration-budget exhaustion
+          (``completed=False`` with no failure fields).
+        * ``"interrupted"``     — interrupted by the parent.
+        * ``"error"``           — provider rejection / terminal failure; NOT
+          budget exhaustion (this is the case #97655 fixed).
+
+    ``truncated`` is derived as ``exit_reason == "max_iterations"`` only, so the
+    parent-visible truncation flag stays truthful for all of the above.
     """
     child_start = time.monotonic()
 
@@ -3122,6 +3142,10 @@ def _run_single_child(
         _output_tokens = getattr(child, "session_completion_tokens", 0)
         _model = getattr(child, "model", None)
 
+        # --- result entry contract (see _run_single_child docstring) ---
+        # status ∈ {completed, interrupted, failed}
+        # exit_reason ∈ {completed, max_iterations, interrupted, error}
+        # truncated is exactly (exit_reason == "max_iterations").
         entry: Dict[str, Any] = {
             "task_index": task_index,
             "status": status,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2960,6 +2960,93 @@ def _format_age(seconds: float) -> str:
     return f"{h}h" if m == 0 else f"{h}h{m}m"
 
 
+# Model-not-found phrases lifted from agent/error_classifier.py so the
+# delegation batch renderer can spot a config-level rejection without pulling
+# the classifier's failover machinery. Kept in sync by hand.
+_MODEL_NOT_FOUND_PATTERNS = (
+    "is not a valid model",
+    "invalid model",
+    "model not found",
+    "model_not_found",
+    "does not exist",
+    "no such model",
+    "unknown model",
+    "unsupported model",
+)
+
+
+def _delegation_config() -> dict:
+    """Load the active delegation config (model/provider/fallbacks), fail-open.
+
+    Mirrors ``tools.delegate_tool._load_config`` so the renderer sees the same
+    ``model`` / ``provider`` the dispatcher used, without importing the heavy
+    delegation module at import time. Returns ``{}`` on any error so callers
+    fail open to "no notice" rather than dropping the per-task blocks.
+    """
+    try:
+        from tools.delegate_tool import _load_config as _cfg
+
+        return _cfg() or {}
+    except Exception:
+        return {}
+
+
+def _delegation_model_not_found(results, config) -> bool:
+    """True when a result entry reflects a config-level model_not_found rejection.
+
+    Matches when at least one entry's error/summary text contains both a
+    model-not-found phrase AND the name of the currently-configured delegation
+    model — so a stale task failing on a *different* (removed) model is not
+    mis-attributed to the config-level root cause.
+    """
+    model = (config or {}).get("model")
+    if not model:
+        return False
+    model = str(model).lower()
+    for r in results or []:
+        text = " ".join(
+            str(part) for part in (r.get("error"), r.get("summary")) if part
+        ).lower()
+        if not text or model not in text:
+            continue
+        if any(p in text for p in _MODEL_NOT_FOUND_PATTERNS):
+            return True
+    return False
+
+
+def _delegation_model_not_found_notice(results) -> "list[str] | None":
+    """Build the config-level model_not_found notice lines, or None.
+
+    Returns ``None`` unless at least one result entry shows the configured
+    delegation model being rejected by its provider, in which case a short
+    actionable block is returned. Every failure path fails open to ``None`` so
+    a config hiccup never hides the per-task blocks. Emit once per batch.
+    """
+    config = _delegation_config()
+    if not _delegation_model_not_found(results, config):
+        return None
+    model = config.get("model") or "?"
+    provider = config.get("provider") or "configured provider"
+    lines = [
+        "⚠ SUBAGENT MODEL REJECTED: the configured Subagent Model "
+        f'"{model}" was rejected by provider "{provider}" '
+        "(HTTP 400: not a valid model ID).",
+        "Every task in this batch failed for this reason before doing any work.",
+        "Check Settings → Advanced → Subagent Model (or: "
+        "hermes config get delegation.model).",
+    ]
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        if not get_fallback_chain(config):
+            lines.append(
+                "No fallback chain is configured, so no failover was attempted."
+            )
+    except Exception:
+        pass
+    return lines
+
+
 def _format_async_delegation(evt: dict) -> str:
     """Format an async-delegation completion into a self-contained re-injection.
 
@@ -3018,6 +3105,10 @@ def _format_async_delegation(evt: dict) -> str:
             lines.append("--- ERROR ---")
             lines.append(f"The batch did not complete successfully: {error}")
             return "\n".join(lines)
+        _notice = _delegation_model_not_found_notice(results)
+        if _notice:
+            lines.append("")
+            lines.extend(_notice)
         for r in sorted(results, key=lambda x: x.get("task_index", 0)):
             idx = r.get("task_index", 0)
             r_status = r.get("status", "?")
@@ -3085,6 +3176,10 @@ def _format_async_delegation(evt: dict) -> str:
     if toolsets:
         lines.append(f"Toolsets: {', '.join(toolsets)}")
     lines.append(f"Role: {role}   Model: {model}")
+    _notice = _delegation_model_not_found_notice([evt])
+    if _notice:
+        lines.append("")
+        lines.extend(_notice)
     _trunc = " [TRUNCATED: hit max_iterations — work may be incomplete]" if truncated else ""
     lines.append(f"Status: {status}   API calls: {api_calls}   Duration: {duration}s{_trunc}")
     lines.append("--- RESULT ---")


### PR DESCRIPTION
## What does this PR do?

Two fixes to the delegation failure pipeline, closing issues #97655 and
#97654. Both were found the same way: a misconfigured (hyphenated)
`delegation.model` caused every subagent to die in <1s with
`HTTP 400: not a valid model ID` — and the parent-facing reports *hid* both
the failure and its cause.

## Fix 1 — honest statuses for failed children (#97655)

A child that died in 0.74s with `api_calls=1` was reported as
`status=completed`, `exit_reason=max_iterations`, "TRUNCATED: hit
max_iterations". All three labels false. Root cause (two mis-derivations in
`_run_single_child`):

1. Status keyed only on summary presence — the provider's error text *is* the
   child's `final_response`, so error → "completed". The structured
   `result['failed']`/`result['error']` fields (set by
   `agent/conversation_loop.py` on every failure path) were never consulted.
2. `exit_reason` defaulted to `max_iterations` whenever the child's
   `completed` was False — but every failure path also returns
   `completed=False`.

Fix: structured fields consulted first (`failed`/`error` → `status="failed"`,
`exit_reason="error"`); `max_iterations` now means *only* genuine budget
exhaustion; `interrupted` unchanged; genuine truncation (budget exhausted with
a real summary) still reports `completed` + `truncated` — pinned by a
regression test.

## Fix 2 — config-level rejection notice (#97654)

The batch renderer now detects "≥1 task failed with a model_not_found-class
error naming the configured delegation model" and prepends a single actionable
warning:

```
⚠ SUBAGENT MODEL REJECTED: the configured Subagent Model "<model>" was
  rejected by provider "<provider>" (not a valid model ID). ...
  Check Settings → Advanced → Subagent Model, or: hermes config get delegation.model
```

with a "no fallback chain configured, so no failover was attempted" line when
the parent's chain is empty (the default). Detection matches
`agent/error_classifier.py`'s `_MODEL_NOT_FOUND_PATTERNS` and requires the
configured model's name in the error text, so a stale task failing on a
*different* model isn't mis-attributed. Emitted once per batch, both
renderers (fan-out and single-dispatch).

## Changes Made

- `tools/delegate_tool.py` — `_run_single_child` status/exit_reason branch
  reorder + docstring enum (`status ∈ {completed, interrupted, failed}`,
  `exit_reason ∈ {completed, max_iterations, interrupted, error}`).
- `tools/process_registry.py` — config-level notice in both delegation
  renderers; renderer unchanged otherwise (it derives ✗/⚠ correctly from the
  now-honest fields).
- Tests: 8 new across `tests/tools/test_delegate.py` +
  `tests/tools/test_process_registry.py`, including edge cases (error without
  `failed` key; empty `error` string + summary → still completed; mixed
  batch; notice emitted exactly once; no notice for non-model errors).

## Review

Two rounds of cross-vendor review (Gemini 3.7 Flash High + GPT-OSS 120B
Medium). Round-2 verdicts: ACCEPTABLE from both reviewers on this delta
("ready to merge"); the full branch went through the same loop with every
round-1 finding either fixed or rejected-with-source-evidence (dispositions in
commit bodies). 301+ passed on the delegate/process_registry suites.

Closes #97655
Closes #97654
