### PR TITLE
feat(config): write-time model-slug validation in hermes config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5588,7 +5588,11 @@ def _model_routing_provider_key(key: str) -> Optional[str]:
     catalog the model id must come from.
     """
     segs = key.strip().lower().split(".")
-    if not segs or segs[-1] != "model":
+    if not segs:
+        return None
+    # Model-routing leaf keys are ``<...>.model`` plus the ``model`` /
+    # ``model.default`` dual (the mapping stores the id at ``model.default``).
+    if segs[-1] != "model" and segs != ["model", "default"]:
         return None
     if segs in (["model"], ["model", "default"]):
         return "model.provider"
@@ -5599,20 +5603,37 @@ def _model_routing_provider_key(key: str) -> Optional[str]:
     return None
 
 
+def _config_node(container: Any, path: str) -> Any:
+    """Walk *container* by dotted *path*, returning the node or ``None``."""
+    node = container
+    for seg in path.split("."):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(seg)
+    return node
+
+
 def _provider_for_config_path(provider_key: str) -> str:
-    """Read a provider config path from the merged config as a stripped string."""
+    """Read a provider config path from the merged config as a stripped string.
+
+    ``delegation.provider`` and ``auxiliary.<task>.provider`` may be *explicitly*
+    set to ``''`` to mean "inherit the parent provider" (delegation defaults to
+    ``''``; auxiliary tasks default to the ``auto`` sentinel).  An empty leaf
+    therefore falls back to the global ``model.provider`` so a delegation /
+    auxiliary model slug is validated against the provider that actually
+    resolves it.  ``model.provider`` is the root of the chain and has nothing
+    to fall back to.
+    """
     try:
         cfg = load_config()
     except Exception:
         return ""
-    node: Any = cfg
-    for seg in provider_key.split("."):
-        if not isinstance(node, dict):
-            return ""
-        node = node.get(seg)
-    if isinstance(node, str):
-        return node.strip()
-    return ""
+    node = _config_node(cfg, provider_key)
+    value = node.strip() if isinstance(node, str) else ""
+    if not value and provider_key != "model.provider":
+        parent = _config_node(cfg, "model.provider")
+        value = parent.strip() if isinstance(parent, str) else ""
+    return value
 
 
 def _provider_skips_catalog_validation(provider: str) -> bool:
@@ -5645,24 +5666,29 @@ def _provider_skips_catalog_validation(provider: str) -> bool:
     return False
 
 
-def _slug_in_catalog(value: str, catalog: List[str]) -> bool:
+def _slug_in_catalog(value: str, catalog: List[str], provider: str = "") -> bool:
     """Exact (case-insensitive) membership of *value* in *catalog*.
 
     OpenRouter per-request routing variants (``model:nitro`` / ``:floor`` /
     ``:exacto`` / ``:online``) are valid on any base id though not separate
-    catalog SKUs, so their base id is also checked.
+    catalog SKUs, so for OpenRouter their base id is also checked.  Those
+    suffixes are OpenRouter-specific, so they only widen membership when the
+    provider is OpenRouter — a ``:variant`` slug for any other provider keeps
+    the exact-match result.
     """
     ids = {str(m).strip().lower() for m in catalog}
     v = value.strip().lower()
     if v in ids:
         return True
-    try:
-        from hermes_cli.models import _openrouter_variant_base
-        base = _openrouter_variant_base(value)
-        if base and base.strip().lower() in ids:
-            return True
-    except Exception:
-        pass
+    if provider:
+        try:
+            from hermes_cli.models import normalize_provider, _openrouter_variant_base
+            if normalize_provider(provider) == "openrouter":
+                base = _openrouter_variant_base(value)
+                if base and base.strip().lower() in ids:
+                    return True
+        except Exception:
+            pass
     return False
 
 
@@ -5683,9 +5709,53 @@ def _print_model_slug_warning(value: str, provider: str, catalog: List[str]) -> 
               file=sys.stderr)
 
 
-def _stdin_is_tty() -> bool:
+def _is_interactive() -> bool:
+    """True only when BOTH stdin and stdout are TTYs (a real terminal session).
+
+    ``input()`` needs a readable console AND its prompt must reach the user.
+    When stdout is redirected (agent pipes, subprocess capture, CI) the y/N
+    prompt would be silently swallowed, so the interactive confirm path is
+    disabled and the read stays non-interactive (warn-only, fail-open).
+    """
     try:
-        return bool(sys.stdin.isatty())
+        return bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except Exception:
+        return False
+
+
+def _model_key_for_provider_path(provider_key: str) -> Optional[str]:
+    """Return the sibling ``<...>.model`` config path for a model-routing
+    provider key, or None when *provider_key* is not a model-routing provider
+    key.  This is the inverse of ``_model_routing_provider_key``: setting a
+    provider re-validates the sibling model value written earlier."""
+    segs = provider_key.strip().lower().split(".")
+    if segs == ["model", "provider"]:
+        return "model.default"
+    if segs == ["delegation", "provider"]:
+        return "delegation.model"
+    if len(segs) == 3 and segs[0] == "auxiliary" and segs[2] == "provider":
+        return "auxiliary.%s.model" % segs[1]
+    return None
+
+
+def _warn_if_slug_not_in_catalog(value: str, provider: str) -> bool:
+    """Print the ``not in provider catalog`` warning for *value* against
+    *provider's* catalog.  Returns True when the slug is genuinely absent
+    (warning printed).  Fails open — never raises — and silently proceeds for
+    unknown/custom/empty providers, empty/cold catalogs, and lookup errors.
+    Used for the write-time warning as well as the provider-set follow-up.
+    """
+    try:
+        if _provider_skips_catalog_validation(provider):
+            return False
+        from hermes_cli.models import cached_provider_model_ids
+        catalog = cached_provider_model_ids(provider)
+        if not catalog:
+            return False  # cold / unresolvable catalog → fail open
+        if _slug_in_catalog(value, catalog, provider):
+            return False
+        _print_model_slug_warning(value, provider, catalog)
+        return True
     except Exception:
         return False
 
@@ -5712,18 +5782,11 @@ def _validate_model_slug_for_write(key: str, value: Any, *, force: bool) -> bool
         if not raw_value:
             return False  # empty/cleared value has nothing to validate
         provider = _provider_for_config_path(provider_key)
-        if _provider_skips_catalog_validation(provider):
-            return False
-        from hermes_cli.models import cached_provider_model_ids
-        catalog = cached_provider_model_ids(provider)
-        if not catalog:
-            return False  # cold / unresolvable catalog → fail open
-        if _slug_in_catalog(raw_value, catalog):
-            return False
-        _print_model_slug_warning(raw_value, provider, catalog)
+        if not _warn_if_slug_not_in_catalog(raw_value, provider):
+            return False  # known slug, or provider/catalog skip → proceed
         if force:
             return False
-        if not _stdin_is_tty():
+        if not _is_interactive():
             return False  # scripts / agents: warn only, proceed
         reply = input("  Set anyway? [y/N] ")
         return reply.strip().lower() not in {"y", "yes"}
@@ -5950,6 +6013,17 @@ def set_config_value(key: str, value: str, force: bool = False):
             file=sys.stderr,
         )
         sys.exit(1)
+    # Provider-set follow-up (#97656): setting a model-routing provider key
+    # (model.provider / delegation.provider / auxiliary.<task>.provider) when a
+    # sibling model value already exists. The model may have been written while
+    # the provider was still empty (validation correctly skipped it), so now
+    # that the provider is known re-check the sibling against its catalog.
+    # Warn-only and fail-open — never blocks the provider write.
+    _sibling_model_key = _model_key_for_provider_path(key)
+    if _sibling_model_key:
+        _sibling_model_val = _config_node(user_config, _sibling_model_key)
+        if isinstance(_sibling_model_val, str) and _sibling_model_val.strip():
+            _warn_if_slug_not_in_catalog(_sibling_model_val.strip(), coerced_value)
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5567,6 +5567,171 @@ def _coerce_float(value: str):
     return f
 
 
+# ── Write-time model-slug validation (#97656) ───────────────────────────────
+# ``hermes config set`` used to accept ANY string for a model-routing leaf key
+# (model.default, delegation.model, auxiliary.<task>.model) with no check that
+# the value exists in the target provider's catalog. A mistyped slug
+# (e.g. ``upstage/solar-pro-4`` vs the real ``upstage/solar-pro4``) wrote
+# silently and only surfaced as per-task HTTP 400s days later. This is a
+# write-time WARNING + confirmation, never a hard block: custom endpoints,
+# pre-announced models, and scripted writes all keep working. The companion
+# hard gate for agent-initiated writes is tracked separately (#97652).
+
+
+def _model_routing_provider_key(key: str) -> Optional[str]:
+    """Return the sibling ``<...>.provider`` config path for a model-routing
+    leaf key, or None when *key* is not a model-routing leaf key at all.
+
+    Model-routing leaf keys are ``model.default`` (plus the bare ``model``
+    singular shorthand), ``delegation.model``, and ``auxiliary.<task>.model``.
+    The returned path is the sibling ``provider`` key whose value selects the
+    catalog the model id must come from.
+    """
+    segs = key.strip().lower().split(".")
+    if not segs or segs[-1] != "model":
+        return None
+    if segs in (["model"], ["model", "default"]):
+        return "model.provider"
+    if segs == ["delegation", "model"]:
+        return "delegation.provider"
+    if len(segs) == 3 and segs[0] == "auxiliary":
+        return "auxiliary.%s.provider" % segs[1]
+    return None
+
+
+def _provider_for_config_path(provider_key: str) -> str:
+    """Read a provider config path from the merged config as a stripped string."""
+    try:
+        cfg = load_config()
+    except Exception:
+        return ""
+    node: Any = cfg
+    for seg in provider_key.split("."):
+        if not isinstance(node, dict):
+            return ""
+        node = node.get(seg)
+    if isinstance(node, str):
+        return node.strip()
+    return ""
+
+
+def _provider_skips_catalog_validation(provider: str) -> bool:
+    """Return True when *provider* must not be checked against a catalog.
+
+    Empty, sentinel (``auto``/``custom``/``moa``/``none``), and user-defined
+    custom providers are skipped: a custom endpoint may legitimately serve
+    models absent from any catalog, and ``auto``/empty resolve dynamically
+    (the opposite of a fixed catalog-membership check).
+    """
+    raw = (provider or "").strip()
+    if not raw:
+        return True
+    lower = raw.lower()
+    if lower in {"auto", "custom", "moa", "none", "local"} or lower.startswith("custom:"):
+        return True
+    try:
+        from hermes_cli.models import normalize_provider
+        normalized = normalize_provider(raw)
+    except Exception:
+        normalized = lower
+    if normalized in {"auto", "custom", "moa", "none", "local"}:
+        return True
+    try:
+        from hermes_cli.runtime_provider import has_named_custom_provider
+        if has_named_custom_provider(raw):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _slug_in_catalog(value: str, catalog: List[str]) -> bool:
+    """Exact (case-insensitive) membership of *value* in *catalog*.
+
+    OpenRouter per-request routing variants (``model:nitro`` / ``:floor`` /
+    ``:exacto`` / ``:online``) are valid on any base id though not separate
+    catalog SKUs, so their base id is also checked.
+    """
+    ids = {str(m).strip().lower() for m in catalog}
+    v = value.strip().lower()
+    if v in ids:
+        return True
+    try:
+        from hermes_cli.models import _openrouter_variant_base
+        base = _openrouter_variant_base(value)
+        if base and base.strip().lower() in ids:
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _print_model_slug_warning(value: str, provider: str, catalog: List[str]) -> None:
+    """Print the ``not in catalog`` warning plus up to three close matches."""
+    matches: list[str] = []
+    try:
+        from difflib import get_close_matches
+        matches = get_close_matches(value, [str(m) for m in catalog], n=3, cutoff=0.6)
+    except Exception:
+        matches = []
+    # Warnings belong on stderr — non-TTY scripts/agents see them without the
+    # message being misread as part of the printed success line.
+    print(color(f"⚠ \"{value}\" is not in provider \"{provider}\"'s catalog.", Colors.YELLOW),
+          file=sys.stderr)
+    if matches:
+        print(color(f"  Did you mean: {', '.join(matches)}", Colors.YELLOW),
+              file=sys.stderr)
+
+
+def _stdin_is_tty() -> bool:
+    try:
+        return bool(sys.stdin.isatty())
+    except Exception:
+        return False
+
+
+def _validate_model_slug_for_write(key: str, value: Any, *, force: bool) -> bool:
+    """Warn (and optionally confirm) when a model-routing slug is absent from
+    the target provider's cached catalog.  Returns True when the write should
+    be ABORTED.  Never raises: any error path (unknown/custom provider, empty
+    catalog, network failure, unreadable config) silently proceeds so
+    ``config set`` stays available.
+
+    Behavior:
+      * known slug                 → no warning, proceed.
+      * unknown slug, interactive  → warning + y/N confirm; N aborts.
+      * unknown slug, non-TTY      → warning to stderr, proceed (fail-open).
+      * ``--force``                → warnings print, prompt skipped.
+      * custom/empty provider      → skipped (no validation).
+    """
+    try:
+        provider_key = _model_routing_provider_key(key)
+        if provider_key is None:
+            return False  # not a model-routing leaf key
+        raw_value = str(value).strip() if value is not None else ""
+        if not raw_value:
+            return False  # empty/cleared value has nothing to validate
+        provider = _provider_for_config_path(provider_key)
+        if _provider_skips_catalog_validation(provider):
+            return False
+        from hermes_cli.models import cached_provider_model_ids
+        catalog = cached_provider_model_ids(provider)
+        if not catalog:
+            return False  # cold / unresolvable catalog → fail open
+        if _slug_in_catalog(raw_value, catalog):
+            return False
+        _print_model_slug_warning(raw_value, provider, catalog)
+        if force:
+            return False
+        if not _stdin_is_tty():
+            return False  # scripts / agents: warn only, proceed
+        reply = input("  Set anyway? [y/N] ")
+        return reply.strip().lower() not in {"y", "yes"}
+    except Exception:
+        # Fail open: validation must never make ``config set`` unavailable.
+        return False
+
+
 def set_config_value(key: str, value: str, force: bool = False):
     """Set a configuration value.
 
@@ -5772,6 +5937,19 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
+    # Write-time model-slug validation (#97656): warn (and, on an interactive
+    # TTY, confirm) when a model-routing value isn't in the provider's cached
+    # catalog. Fails open — never blocks the write — so custom endpoints and
+    # scripted writes keep working. Returns True when the user declined.
+    if _validate_model_slug_for_write(key, value, force=force):
+        _provider_key = _model_routing_provider_key(key) or ""
+        _provider_for_abort = _provider_for_config_path(_provider_key)
+        print(
+            f"✗ Aborted: '{key}' was not set (model not in provider "
+            f"\"{_provider_for_abort}\"'s catalog).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical

--- a/tests/hermes_cli/test_config_model_slug_validation.py
+++ b/tests/hermes_cli/test_config_model_slug_validation.py
@@ -113,7 +113,7 @@ class TestUnknownSlugInteractive:
         self, _isolated_hermes_home, capsys, monkeypatch
     ):
         _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
-        monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: True))
+        monkeypatch.setattr("hermes_cli.config._is_interactive", lambda: True)
         with patch(
             "hermes_cli.models.cached_provider_model_ids",
             return_value=_OPENROUTER_CATALOG,
@@ -132,7 +132,7 @@ class TestUnknownSlugInteractive:
         self, _isolated_hermes_home, capsys, monkeypatch
     ):
         _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
-        monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: True))
+        monkeypatch.setattr("hermes_cli.config._is_interactive", lambda: True)
         with patch(
             "hermes_cli.models.cached_provider_model_ids",
             return_value=_OPENROUTER_CATALOG,
@@ -152,7 +152,7 @@ class TestUnknownSlugNonTty:
         self, _isolated_hermes_home, capsys, monkeypatch
     ):
         _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
-        monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: False))
+        monkeypatch.setattr("hermes_cli.config._is_interactive", lambda: False)
         with patch(
             "hermes_cli.models.cached_provider_model_ids",
             return_value=_OPENROUTER_CATALOG,
@@ -165,7 +165,7 @@ class TestUnknownSlugNonTty:
         self, _isolated_hermes_home, capsys, monkeypatch
     ):
         _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
-        monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: True))
+        monkeypatch.setattr("hermes_cli.config._is_interactive", lambda: True)
         with patch(
             "hermes_cli.models.cached_provider_model_ids",
             return_value=_OPENROUTER_CATALOG,
@@ -198,7 +198,9 @@ class TestCustomProvider:
         assert "my-custom-model" in _read_config(_isolated_hermes_home)
 
     def test_empty_provider_skips_validation(self, _isolated_hermes_home, capsys):
-        # delegation.provider defaults to '' (inherit parent) — skip silently.
+        # Both delegation.provider AND model.provider are '' (nothing to
+        # inherit) — the parent fallback finds an empty provider, so validation
+        # is skipped silently. No catalog may be consulted.
         with patch(
             "hermes_cli.models.cached_provider_model_ids",
             side_effect=AssertionError("catalog consulted for empty provider"),
@@ -230,3 +232,169 @@ class TestValidationFailsOpen:
             set_config_value("delegation.model", "totally-fake-model-xyz")
         assert "not in provider" not in _all_output(capsys)
         assert "totally-fake-model-xyz" in _read_config(_isolated_hermes_home)
+
+
+# ---------------------------------------------------------------------------
+# model.default is a genuine model-routing leaf (validated via model.provider)
+# ---------------------------------------------------------------------------
+
+class TestModelDefault:
+    def test_model_default_is_actually_validated(self, _isolated_hermes_home, capsys):
+        # Regression: previously `_model_routing_provider_key('model.default')`
+        # returned None (the leaf guard only matched `<...>.model`), so this
+        # key was NEVER validated. It must consult model.provider's catalog.
+        _seed_provider("model.provider", "openrouter", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("model.default", "totally-fake-model-xyz")
+        assert "not in provider" in capsys.readouterr().err
+        assert "totally-fake-model-xyz" in _read_config(_isolated_hermes_home)
+
+    def test_model_default_known_slug_validated_no_warning(
+        self, _isolated_hermes_home, capsys
+    ):
+        # A KNOWN slug must not only avoid the warning but must go THROUGH the
+        # catalog check (it consulted model.provider) rather than short-circuit.
+        _seed_provider("model.provider", "openrouter", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("model.default", "google/gemini-3-flash")
+        assert "not in provider" not in _all_output(capsys)
+        assert "google/gemini-3-flash" in _read_config(_isolated_hermes_home)
+
+
+# ---------------------------------------------------------------------------
+# Empty delegation/auxiliary provider inherits the parent model.provider
+# ---------------------------------------------------------------------------
+
+class TestProviderInheritance:
+    def test_delegation_model_inherits_parent_provider(
+        self, _isolated_hermes_home, capsys
+    ):
+        # delegation.provider is '' (inherit parent); model.provider is set.
+        # The model must be validated against the PARENT (model.provider).
+        _seed_provider("model.provider", "openrouter", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("delegation.model", "totally-not-a-model")
+        assert "not in provider" in capsys.readouterr().err
+        assert "totally-not-a-model" in _read_config(_isolated_hermes_home)
+
+    def test_auxiliary_model_inherits_parent_provider(
+        self, _isolated_hermes_home, capsys
+    ):
+        # auxiliary.vision.provider explicitly '' (inherit parent); the model
+        # must be validated against that inheritable parent (model.provider).
+        _seed_provider("model.provider", "openrouter", _isolated_hermes_home)
+        _seed_provider("auxiliary.vision.provider", "", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("auxiliary.vision.model", "totally-not-a-model")
+        assert "not in provider" in capsys.readouterr().err
+        assert "totally-not-a-model" in _read_config(_isolated_hermes_home)
+
+    def test_inherited_provider_matches_catalog_no_warning(
+        self, _isolated_hermes_home, capsys
+    ):
+        _seed_provider("model.provider", "openrouter", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("delegation.model", "upstage/solar-pro4")
+        assert "not in provider" not in _all_output(capsys)
+        assert "upstage/solar-pro4" in _read_config(_isolated_hermes_home)
+
+
+# ---------------------------------------------------------------------------
+# Setting a provider re-validates an already-written sibling model (#97656 gap)
+# ---------------------------------------------------------------------------
+
+class TestProviderSetFollowup:
+    def test_set_provider_revalidates_sibling_model(
+        self, _isolated_hermes_home, capsys
+    ):
+        # Model written first while provider was empty (validation legitimately
+        # skipped) — then provider is set. The sibling must be re-checked and
+        # warn (never block) against the now-known provider.
+        set_config_value("delegation.model", "totally-fake-model-xyz")
+        assert "not in provider" not in _all_output(capsys)  # skipped by empty provider
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("delegation.provider", "openrouter")
+        assert "not in provider" in capsys.readouterr().err
+        # Provider write still succeeds (fail-open, warn-only).
+        assert "openrouter" in _read_config(_isolated_hermes_home)
+
+    def test_model_provider_set_revalidates_model_default(
+        self, _isolated_hermes_home, capsys
+    ):
+        set_config_value("model.default", "totally-fake-model-xyz")
+        assert "not in provider" not in _all_output(capsys)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("model.provider", "openrouter")
+        assert "not in provider" in capsys.readouterr().err
+        assert "openrouter" in _read_config(_isolated_hermes_home)
+
+
+# ---------------------------------------------------------------------------
+# Interactive detection requires BOTH stdin and stdout to be TTYs
+# ---------------------------------------------------------------------------
+
+class TestIsInteractive:
+    def test_requires_both_stdin_and_stdout_tty(self, monkeypatch):
+        from hermes_cli.config import _is_interactive
+
+        monkeypatch.setattr("hermes_cli.config.sys.stdin", SimpleNamespace(isatty=lambda: True))
+        # stdout redirected (agent pipe / capture) → not interactive.
+        monkeypatch.setattr("hermes_cli.config.sys.stdout", SimpleNamespace(isatty=lambda: False))
+        assert _is_interactive() is False
+        # both TTYs → interactive.
+        monkeypatch.setattr("hermes_cli.config.sys.stdout", SimpleNamespace(isatty=lambda: True))
+        assert _is_interactive() is True
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter ':variant' broadening only applies to the OpenRouter provider
+# ---------------------------------------------------------------------------
+
+class TestVariantStripping:
+    def test_openrouter_variant_matches_base_in_catalog(
+        self, _isolated_hermes_home, capsys
+    ):
+        _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("delegation.model", "upstage/solar-pro4:nitro")
+        # ':nitro' is an OpenRouter base-id variant → no warning.
+        assert "not in provider" not in _all_output(capsys)
+        assert "upstage/solar-pro4:nitro" in _read_config(_isolated_hermes_home)
+
+    def test_variant_not_broadened_for_other_provider(
+        self, _isolated_hermes_home, capsys
+    ):
+        # A ':variant' slug for a NON-OpenRouter provider keeps the exact-match
+        # result — the base-id broadening is OpenRouter-specific.
+        _seed_provider("delegation.provider", "anthropic", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=["upstage/solar-pro4", "anthropic/claude-sonnet-4"],
+        ):
+            set_config_value("delegation.model", "upstage/solar-pro4:nitro")
+        assert "not in provider" in capsys.readouterr().err
+        assert "upstage/solar-pro4:nitro" in _read_config(_isolated_hermes_home)

--- a/tests/hermes_cli/test_config_model_slug_validation.py
+++ b/tests/hermes_cli/test_config_model_slug_validation.py
@@ -1,0 +1,232 @@
+"""Tests for write-time model-slug validation (#97656).
+
+``set_config_value`` now consults the target provider's cached catalog (the same
+machinery the model picker uses) when a model-routing leaf key
+(``model.default``, ``delegation.model``, ``auxiliary.<task>.model``) is
+written. These tests assert the *behavior contract* — warn / confirm / fail-open
+— rather than freezing catalog contents, and every network touch is mocked.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import set_config_value
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path):
+    """Point HERMES_HOME at a temp dir so tests never touch real config."""
+    env_file = tmp_path / ".env"
+    env_file.touch()
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        yield tmp_path
+
+
+def _read_config(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    return config_path.read_text() if config_path.exists() else ""
+
+
+def _seed_provider(provider_key, provider_value, *_ignored):
+    """Seed a runtime provider via the real set path (writes config.yaml)."""
+    set_config_value(provider_key, provider_value)
+
+
+_OPENROUTER_CATALOG = [
+    "upstage/solar-pro4",
+    "google/gemini-3-flash",
+    "anthropic/claude-sonnet-4",
+]
+
+
+def _echoing_input(answer: str):
+    """A builtins.input stand-in that echoes the prompt to stdout, like the
+    real ``input()`` does, then returns the canned answer."""
+    def _input(prompt=""):
+        sys.stdout.write(str(prompt))
+        sys.stdout.flush()
+        return answer
+    return _input
+
+
+def _all_output(capsys):
+    """Combined stdout+stderr for 'must not warn' assertions."""
+    captured = capsys.readouterr()
+    return captured.out + captured.err
+
+
+# ---------------------------------------------------------------------------
+# Known slug → no warning, write proceeds
+# ---------------------------------------------------------------------------
+
+class TestKnownSlug:
+    def test_delegation_model_known_slug_no_warning(self, _isolated_hermes_home, capsys):
+        _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("delegation.model", "upstage/solar-pro4")
+        assert "not in provider" not in _all_output(capsys)
+        assert "upstage/solar-pro4" in _read_config(_isolated_hermes_home)
+
+    def test_model_default_known_slug_no_warning(self, _isolated_hermes_home, capsys):
+        _seed_provider("model.provider", "openrouter", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("model.default", "google/gemini-3-flash")
+        assert "not in provider" not in _all_output(capsys)
+        assert "google/gemini-3-flash" in _read_config(_isolated_hermes_home)
+
+    def test_auxiliary_known_slug_no_warning(self, _isolated_hermes_home, capsys):
+        _seed_provider("auxiliary.vision.provider", "openrouter", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("auxiliary.vision.model", "anthropic/claude-sonnet-4")
+        assert "not in provider" not in _all_output(capsys)
+        assert "anthropic/claude-sonnet-4" in _read_config(_isolated_hermes_home)
+
+    def test_non_model_key_never_validates(self, _isolated_hermes_home, capsys):
+        # A non-model-routing key must never consult the catalog.
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            side_effect=AssertionError("catalog consulted for non-model key"),
+        ):
+            set_config_value("delegation.provider", "openrouter")
+        assert "not in provider" not in _all_output(capsys)
+
+
+# ---------------------------------------------------------------------------
+# Unknown slug + interactive TTY → warning + abort on N
+# ---------------------------------------------------------------------------
+
+class TestUnknownSlugInteractive:
+    def test_unknown_slug_tty_abort_on_n(
+        self, _isolated_hermes_home, capsys, monkeypatch
+    ):
+        _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
+        monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: True))
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            with patch("builtins.input", _echoing_input("N")):
+                with pytest.raises(SystemExit) as exc:
+                    set_config_value("delegation.model", "totally-fake-model-xyz")
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "not in provider" in captured.err  # warning → stderr
+        assert "Set anyway? [y/N]" in captured.out  # prompt → stdout
+        # Value must NOT be persisted.
+        assert "totally-fake-model-xyz" not in _read_config(_isolated_hermes_home)
+
+    def test_unknown_slug_tty_confirm_yes_writes(
+        self, _isolated_hermes_home, capsys, monkeypatch
+    ):
+        _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
+        monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: True))
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            with patch("builtins.input", _echoing_input("y")):
+                set_config_value("delegation.model", "totally-fake-model-xyz")
+        assert "not in provider" in capsys.readouterr().err
+        assert "totally-fake-model-xyz" in _read_config(_isolated_hermes_home)
+
+
+# ---------------------------------------------------------------------------
+# Unknown slug non-TTY → warning + write proceeds (fail-open)
+# ---------------------------------------------------------------------------
+
+class TestUnknownSlugNonTty:
+    def test_unknown_slug_nontty_warns_and_proceeds(
+        self, _isolated_hermes_home, capsys, monkeypatch
+    ):
+        _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
+        monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: False))
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            set_config_value("delegation.model", "totally-fake-model-xyz")
+        assert "not in provider" in capsys.readouterr().err
+        assert "totally-fake-model-xyz" in _read_config(_isolated_hermes_home)
+
+    def test_unknown_slug_force_skips_prompt_but_warns(
+        self, _isolated_hermes_home, capsys, monkeypatch
+    ):
+        _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
+        monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: True))
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            return_value=_OPENROUTER_CATALOG,
+        ):
+            # --force must skip the prompt but still print the warning.
+            with patch(
+                "builtins.input",
+                side_effect=AssertionError("prompt shown despite --force"),
+            ):
+                set_config_value("delegation.model", "totally-fake-model-xyz", force=True)
+        captured = capsys.readouterr()
+        assert "not in provider" in captured.err
+        assert "Set anyway?" not in captured.out
+        assert "totally-fake-model-xyz" in _read_config(_isolated_hermes_home)
+
+
+# ---------------------------------------------------------------------------
+# Custom provider → no validation
+# ---------------------------------------------------------------------------
+
+class TestCustomProvider:
+    def test_custom_provider_skips_validation(self, _isolated_hermes_home, capsys):
+        _seed_provider("delegation.provider", "custom", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            side_effect=AssertionError("catalog consulted for custom provider"),
+        ):
+            set_config_value("delegation.model", "my-custom-model")
+        assert "not in provider" not in _all_output(capsys)
+        assert "my-custom-model" in _read_config(_isolated_hermes_home)
+
+    def test_empty_provider_skips_validation(self, _isolated_hermes_home, capsys):
+        # delegation.provider defaults to '' (inherit parent) — skip silently.
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            side_effect=AssertionError("catalog consulted for empty provider"),
+        ):
+            set_config_value("delegation.model", "inherited-model")
+        assert "not in provider" not in _all_output(capsys)
+        assert "inherited-model" in _read_config(_isolated_hermes_home)
+
+
+# ---------------------------------------------------------------------------
+# Validation exception → write succeeds (fail-open)
+# ---------------------------------------------------------------------------
+
+class TestValidationFailsOpen:
+    def test_network_error_fails_open(self, _isolated_hermes_home, capsys):
+        _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
+        with patch(
+            "hermes_cli.models.cached_provider_model_ids",
+            side_effect=RuntimeError("catalog fetch failed"),
+        ):
+            # Must not raise and must still write — validation never blocks set.
+            set_config_value("delegation.model", "totally-fake-model-xyz")
+        assert "not in provider" not in _all_output(capsys)
+        assert "totally-fake-model-xyz" in _read_config(_isolated_hermes_home)
+
+    def test_empty_catalog_fails_open(self, _isolated_hermes_home, capsys):
+        _seed_provider("delegation.provider", "openrouter", _isolated_hermes_home)
+        with patch("hermes_cli.models.cached_provider_model_ids", return_value=[]):
+            set_config_value("delegation.model", "totally-fake-model-xyz")
+        assert "not in provider" not in _all_output(capsys)
+        assert "totally-fake-model-xyz" in _read_config(_isolated_hermes_home)


### PR DESCRIPTION
## What does this PR do?

Adds write-time validation to `hermes config set` for model-routing keys
(`model.default`, bare `model` shorthand, `delegation.model`,
`auxiliary.<task>.model`): the slug is checked against the *same cached
provider catalog the model picker uses* and a warning + confirmation fires
when it isn't present.

## Motivation

Today any string is accepted silently. A real incident: a one-hyphen typo
(`upstage/solar-pro-4` vs the valid `upstage/solar-pro4`) was written with a
success message and caused a week of instantly-failing delegations whose cause
was buried in batch reports. The UI half of this gap is covered by guided
pickers (#67523/#67557/#76480); this covers CLI, scripted, and agent-written
config, which the pickers don't reach.

## Behavior

| Case | Result |
|---|---|
| Known slug | no warning, proceeds |
| Unknown slug, interactive TTY | warning (stderr) + closest matches (difflib, ≤3) + `Set anyway? [y/N]`; N aborts (exit 1) |
| Unknown slug, non-TTY | warning to stderr, proceeds (scripts/agents keep working) |
| `--force` | warning printed, prompt skipped |
| Provider empty/`auto`/`custom`/unknown, or any validation exception | fail open — write proceeds untouched |

Details:

- Provider pairing per key: `model.default`→`model.provider`,
  `delegation.model`→`delegation.provider`,
  `auxiliary.<task>.model`→`auxiliary.<task>.provider` — with fallback to the
  parent `model.provider` when the leaf's own provider is empty (inherit).
- Catalog reuse: `cached_provider_model_ids()` — the picker's existing
  disk-cached catalog; no new network layer, and a cold cache triggers the
  picker's existing probe.
- OpenRouter `:nitro`-style routing suffixes match on their base id (gated to
  openrouter only).
- Interactive detection requires both stdin and stdout TTYs.
- Setting a *provider* key re-checks its already-configured sibling model, so
  the provider-then-model ordering gap (model written first, unvalidated
  because provider was unknown) closes on the very next provider write.

## Changes Made

- `hermes_cli/config.py` — `_model_routing_provider_key` (with the
  `model.default` leaf-guard fix), `_provider_for_config_path` (+ parent
  fallback), `_slug_in_catalog`, `_validate_model_slug_for_write`, provider-set
  sibling re-check; gate called before `_set_nested` so an abort writes
  nothing.
- `tests/hermes_cli/test_config_model_slug_validation.py` — 19 tests, network
  isolated (catalog mocked).

## How to Test

1. `hermes config set delegation.model totally-fake-model-xyz` in a terminal →
   warning + prompt; N aborts.
2. Same piped/non-TTY → warning only, write proceeds.
3. `hermes config set model.default gpt-5.5 --provider-openai` equivalent
   writes → no warning for real catalog slugs.
4. Any network/cache failure → write proceeds as before (fail open).

## Review

Two rounds of cross-vendor review (Gemini 3.7 Flash High + GPT-OSS 120B
Medium, full diffs, byte-identical briefs). Round-2 verdicts: ACCEPTABLE from
both reviewers ("ready to merge"). Notable round-1 dispositions verified
against source: the `model.default`-never-validated bug (Flash BLOCKER — real,
refined: the original parse-failure claim was wrong but the leaf guard was),
provider-inheritance fallback (real, fixed), GPT-OSS's "config load masking"
BLOCKER rejected as contradicting the issue's own fail-open contract.
Commit bodies carry the full per-finding ledger. 139 passed post-rebase on
target suites.

Closes #97656
