### PR TITLE
fix(desktop): ignore truncated macOS ps parent markers

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -221,13 +221,30 @@ def _process_start_marker(pid: int) -> str:
     raise OSError(f"ps could not inspect PID {pid}: {result.stderr.strip()}")
 
 
+def _normalize_parent_start_marker(marker: str) -> str:
+    """Collapse ps(1) column padding so Node trim and Python strip compare equal."""
+    prefix, separator, value = marker.partition(":")
+    if not separator:
+        return marker
+    return f"{prefix}:{' '.join(value.split())}"
+
+
 def _valid_parent_start_marker(marker: str) -> bool:
     prefix, separator, value = marker.partition(":")
     if not separator or not value or value != value.strip():
         return False
     if prefix in ("linux", "win", "winms"):
         return value.isdigit()
-    return prefix == "ps"
+    if prefix != "ps":
+        return False
+    # macOS/BSD ``ps -o lstart=`` looks like ``Sat Aug 29 15:04:31 2026``.
+    # A truncated token (``ps:Sat``) is what you get if the marker is split on
+    # spaces in the environment; treating that as a real identity makes a live
+    # Desktop look dead and the backend exits 0 right after HERMES_BACKEND_READY.
+    tokens = value.split()
+    has_year = any(token.isdigit() and len(token) == 4 for token in tokens)
+    has_time = any(":" in token for token in tokens)
+    return len(tokens) >= 4 and has_year and has_time
 
 
 def _parent_start_markers_match(actual: str, expected: str) -> bool:
@@ -239,6 +256,8 @@ def _parent_start_markers_match(actual: str, expected: str) -> bool:
     exact FILETIME and normalizes it only when the expected marker is ``winms``.
     """
     if actual == expected:
+        return True
+    if _normalize_parent_start_marker(actual) == _normalize_parent_start_marker(expected):
         return True
     if not actual.startswith("win:") or not expected.startswith("winms:"):
         return False
@@ -19413,8 +19432,8 @@ def _start_parent_death_watchdog() -> None:
     tracking.
     """
     raw_pid = os.environ.get("HERMES_PARENT_PID")
-    start_marker = os.environ.get("HERMES_PARENT_START_MARKER")
-    nonce = os.environ.get("HERMES_PARENT_NONCE")
+    start_marker = os.environ.get("HERMES_PARENT_START_MARKER") or None
+    nonce = os.environ.get("HERMES_PARENT_NONCE") or None
 
     try:
         desktop_pid = int(raw_pid or "")
@@ -19442,6 +19461,14 @@ def _start_parent_death_watchdog() -> None:
     def _loop() -> None:
         while not _is_serve_orphaned(desktop_pid, start_marker):
             time.sleep(poll)
+        try:
+            print(
+                "parent-death watchdog: owner is gone; exiting 0 "
+                f"(pid={desktop_pid} marker={start_marker!r})",
+                flush=True,
+            )
+        except Exception:
+            pass
         os._exit(0)
 
     threading.Thread(target=_loop, daemon=True, name="serve-parent-watchdog").start()

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -57,3 +57,25 @@ def test_parent_watchdog_preserves_legacy_exact_windows_marker():
         )
         is False
     )
+
+
+def test_macos_ps_marker_requires_full_lstart_not_a_truncated_weekday():
+    from hermes_cli.web_server import _parent_start_markers_match
+
+    assert _valid_parent_start_marker("ps:Sat Aug 29 15:04:31 2026") is True
+    assert _valid_parent_start_marker("ps:Sat") is False
+    assert (
+        _parent_start_markers_match(
+            "ps:Sat Aug 29 15:04:31 2026",
+            "ps:Sat Aug 29 15:04:31 2026    ",
+        )
+        is True
+    )
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "ps:Sat Aug 29 15:04:31 2026",
+            process_start_marker=lambda _pid: "ps:Sat Aug 29 15:04:31 2026    ",
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary
On macOS, Desktop-spawned `hermes serve` can print `HERMES_BACKEND_READY` and then `os._exit(0)` because the parent-death watchdog treats a truncated or padded `ps:` start marker as a dead owner.

Reproduced locally: `HERMES_PARENT_START_MARKER=ps:Sat` (or a padded `ps:Sat Aug 29 15:04:31 2026    ` mismatch) exits 0 immediately after ready. A full matching `ps:` lstart stays up.

This made Hermes Desktop show `Hermes couldn't start` / `The background gateway didn't come up` even though Electron was still alive.

## Change
- Require a full `ps -o lstart=` value (year + time), so `ps:Sat` is invalid and the watchdog no-ops instead of killing the backend.
- Normalize `ps:` whitespace before compare.
- Treat empty inherited marker/nonce env as absent.
- Log before the watchdog `os._exit(0)`.

## Test
`python -m pytest tests/hermes_cli/test_serve_parent_watchdog.py -o addopts= -q` (6 passed)

No Electron rebuild is required. Packaged Desktop already spawns the git-install Python backend.