### PR TITLE
fix(agent): refresh xai-oauth on its 403 token-expiry signal, not 401 only

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1114,14 +1114,19 @@ def is_xai_stale_oauth_error(
     )
 
 
+_DEVICE_CODE_SOURCES = frozenset({"device_code", "manual:device_code"})
+
+
+def oauth_pool_entry_is_device_code(entry) -> bool:
+    return str(getattr(entry, "source", "") or "") in _DEVICE_CODE_SOURCES
+
+
 def oauth_active_key_is_foreign_pool_entry(agent, active_key: str) -> bool:
     """True when ``active_key`` belongs to a pooled credential.
 
     Used by the singleton OAuth refresh guard: if the live key is a real
     pool entry, force-refreshing/adopting the device_code singleton would
-    silently swap accounts. If the live key matches *no* entry, it is a
-    stale in-memory copy (the pool/store already rotated) and adopting
-    the singleton is the recovery, not an account swap.
+    silently swap accounts.
     """
     if not active_key:
         return False
@@ -1138,6 +1143,34 @@ def oauth_active_key_is_foreign_pool_entry(agent, active_key: str) -> bool:
         if runtime and runtime == needle:
             return True
     return False
+
+
+def resolve_stale_oauth_pool_entry(agent, pool):
+    """Pool entry that owns a stale-token failure, or None if we must not guess.
+
+    ``_credential_pool_entry_id`` survives access-token rotation, so it is
+    preferred even when ``runtime_api_key`` no longer matches. Without an
+    id, only a sole device_code entry is unambiguous — a sole MANUAL
+    other-account entry is not the failed request's identity.
+    """
+    if pool is None:
+        return None
+    try:
+        entries_fn = getattr(pool, "entries", None)
+        entries = list(entries_fn() or []) if callable(entries_fn) else []
+    except Exception:
+        return None
+    by_id = {}
+    for entry in entries:
+        eid = getattr(entry, "id", None)
+        if isinstance(eid, str) and eid:
+            by_id[eid] = entry
+    cred_id = getattr(agent, "_credential_pool_entry_id", None)
+    if isinstance(cred_id, str) and cred_id and cred_id in by_id:
+        return by_id[cred_id]
+    if len(entries) == 1 and oauth_pool_entry_is_device_code(entries[0]):
+        return entries[0]
+    return None
 
 
 def recover_with_credential_pool(
@@ -1428,26 +1461,32 @@ def recover_with_credential_pool(
             and (agent.provider or "") == "xai-oauth"
             and is_xai_stale_oauth_error(error_context, status_code)
         ):
-            # The failed request still carries the expired access token.
-            # After another process remints, that key matches no pool
-            # entry (``runtime_api_key`` is the new token), so
-            # try_refresh_matching(hint=expired) returns None and a
-            # single-entry pool then refuses to rotate — the 8:34 PM
-            # ``identity matched no xai-oauth entry`` hole. Refresh the
-            # only credential instead of giving up.
-            entries = []
-            try:
-                entries_fn = getattr(pool, "entries", None)
-                if callable(entries_fn):
-                    entries = list(entries_fn() or [])
-            except Exception:
-                entries = []
-            if len(entries) == 1:
-                _ra().logger.info(
-                    "xai-oauth stale 403: failed credential identity matched "
-                    "no pool entry; refreshing the only xai-oauth credential"
-                )
-                refreshed = pool.try_refresh_matching()
+            # Expired live token matches no runtime_api_key after remint.
+            # Identify the failed *account* (stable id, else sole
+            # device_code entry) and adopt its current token. Do not
+            # guess a lone MANUAL other-account entry, and do not
+            # force-refresh when the pool already holds a newer token.
+            entry = resolve_stale_oauth_pool_entry(agent, pool)
+            if entry is not None:
+                runtime = str(getattr(entry, "runtime_api_key", "") or "").strip()
+                active = str(getattr(agent, "api_key", "") or "").strip()
+                if runtime and runtime != active:
+                    _ra().logger.info(
+                        "xai-oauth stale 403: live key matched no pool entry; "
+                        "adopting reminted pool entry %s without a second refresh",
+                        getattr(entry, "id", "?"),
+                    )
+                    agent._swap_credential(entry)
+                    return True, has_retried_429
+                if not _credential_id:
+                    _ra().logger.info(
+                        "xai-oauth stale 403: failed credential identity "
+                        "matched no pool runtime key; refreshing pool entry %s",
+                        getattr(entry, "id", "?"),
+                    )
+                    refreshed = pool.try_refresh_matching(
+                        credential_id=getattr(entry, "id", None)
+                    )
         if refreshed is not None:
             # ``try_refresh_matching()`` re-mints a fresh OAuth token and reports
             # success even when the upstream keeps rejecting it — a single-entry

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1455,38 +1455,36 @@ def recover_with_credential_pool(
         refresh_kwargs = {"api_key_hint": _api_key_hint}
         if _credential_id:
             refresh_kwargs["credential_id"] = _credential_id
-        refreshed = pool.try_refresh_matching(**refresh_kwargs)
         if (
-            refreshed is None
-            and (agent.provider or "") == "xai-oauth"
+            (agent.provider or "") == "xai-oauth"
             and is_xai_stale_oauth_error(error_context, status_code)
         ):
-            # Expired live token matches no runtime_api_key after remint.
-            # Identify the failed *account* (stable id, else sole
-            # device_code entry) and adopt its current token. Do not
-            # guess a lone MANUAL other-account entry, and do not
-            # force-refresh when the pool already holds a newer token.
+            # Adopt a reminted token *before* try_refresh_matching so a
+            # bound _credential_pool_entry_id cannot force-POST the new
+            # single-use refresh token. Identify the failed account
+            # (stable id, else sole device_code); never guess a lone
+            # MANUAL other-account entry.
             entry = resolve_stale_oauth_pool_entry(agent, pool)
             if entry is not None:
                 runtime = str(getattr(entry, "runtime_api_key", "") or "").strip()
                 active = str(getattr(agent, "api_key", "") or "").strip()
                 if runtime and runtime != active:
-                    _ra().logger.info(
-                        "xai-oauth stale 403: live key matched no pool entry; "
-                        "adopting reminted pool entry %s without a second refresh",
-                        getattr(entry, "id", "?"),
-                    )
-                    agent._swap_credential(entry)
-                    return True, has_retried_429
-                if not _credential_id:
-                    _ra().logger.info(
-                        "xai-oauth stale 403: failed credential identity "
-                        "matched no pool runtime key; refreshing pool entry %s",
-                        getattr(entry, "id", "?"),
-                    )
-                    refreshed = pool.try_refresh_matching(
-                        credential_id=getattr(entry, "id", None)
-                    )
+                    from hermes_cli.auth import _codex_access_token_is_expiring
+
+                    if not _codex_access_token_is_expiring(runtime, 60):
+                        _ra().logger.info(
+                            "xai-oauth stale 403: live key matched no pool "
+                            "entry; adopting reminted pool entry %s without "
+                            "a second refresh",
+                            getattr(entry, "id", "?"),
+                        )
+                        agent._swap_credential(entry)
+                        return True, has_retried_429
+                if not refresh_kwargs.get("credential_id"):
+                    eid = getattr(entry, "id", None)
+                    if isinstance(eid, str) and eid:
+                        refresh_kwargs["credential_id"] = eid
+        refreshed = pool.try_refresh_matching(**refresh_kwargs)
         if refreshed is not None:
             # ``try_refresh_matching()`` re-mints a fresh OAuth token and reports
             # success even when the upstream keeps rejecting it — a single-entry

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1088,6 +1088,32 @@ def sync_credential_pool_entry_id(agent) -> None:
         agent._credential_pool_entry_id = None
 
 
+def is_xai_stale_oauth_error(
+    error_context: Optional[Dict[str, Any]], status_code: Optional[int]
+) -> bool:
+    """True for xAI's authoritative "stale token, not entitlement" 403.
+
+    xAI answers an *expired* OAuth access token with HTTP 403 -- not 401 --
+    carrying either a ``[WKE=unauthenticated:...]`` suffix or the phrase
+    ``OAuth2 access token could not be validated``.  Both mean the token is
+    merely stale and a refresh recovers it, which is exactly what separates
+    them from the entitlement 403s that refreshing can never fix (#29344).
+
+    Shared by the credential-pool recovery path and the singleton
+    ``codex_responses`` refresh path so the two cannot drift apart.
+    """
+    if status_code != 403 or not isinstance(error_context, dict):
+        return False
+    haystack = " ".join(
+        str(error_context.get(k) or "").lower()
+        for k in ("message", "reason", "code", "error")
+    )
+    return (
+        "[wke=unauthenticated:" in haystack
+        or "oauth2 access token could not be validated" in haystack
+    )
+
+
 def recover_with_credential_pool(
     agent,
     *,
@@ -1352,11 +1378,7 @@ def recover_with_credential_pool(
         ):
             is_entitlement = True
         if not is_entitlement and status_code == 403 and (agent.provider or "") == "xai-oauth":
-            _is_xai_auth_failure = (
-                "[wke=unauthenticated:" in _auth_haystack
-                or "oauth2 access token could not be validated" in _auth_haystack
-            )
-            if not _is_xai_auth_failure:
+            if not is_xai_stale_oauth_error(error_context, status_code):
                 is_entitlement = True
         if is_entitlement:
             _ra().logger.info(

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1114,6 +1114,32 @@ def is_xai_stale_oauth_error(
     )
 
 
+def oauth_active_key_is_foreign_pool_entry(agent, active_key: str) -> bool:
+    """True when ``active_key`` belongs to a pooled credential.
+
+    Used by the singleton OAuth refresh guard: if the live key is a real
+    pool entry, force-refreshing/adopting the device_code singleton would
+    silently swap accounts. If the live key matches *no* entry, it is a
+    stale in-memory copy (the pool/store already rotated) and adopting
+    the singleton is the recovery, not an account swap.
+    """
+    if not active_key:
+        return False
+    pool = getattr(agent, "_credential_pool", None)
+    if pool is None:
+        return False
+    try:
+        entries = pool.entries()
+    except Exception:
+        return False
+    needle = str(active_key).strip()
+    for entry in entries or ():
+        runtime = str(getattr(entry, "runtime_api_key", "") or "").strip()
+        if runtime and runtime == needle:
+            return True
+    return False
+
+
 def recover_with_credential_pool(
     agent,
     *,
@@ -1397,6 +1423,31 @@ def recover_with_credential_pool(
         if _credential_id:
             refresh_kwargs["credential_id"] = _credential_id
         refreshed = pool.try_refresh_matching(**refresh_kwargs)
+        if (
+            refreshed is None
+            and (agent.provider or "") == "xai-oauth"
+            and is_xai_stale_oauth_error(error_context, status_code)
+        ):
+            # The failed request still carries the expired access token.
+            # After another process remints, that key matches no pool
+            # entry (``runtime_api_key`` is the new token), so
+            # try_refresh_matching(hint=expired) returns None and a
+            # single-entry pool then refuses to rotate — the 8:34 PM
+            # ``identity matched no xai-oauth entry`` hole. Refresh the
+            # only credential instead of giving up.
+            entries = []
+            try:
+                entries_fn = getattr(pool, "entries", None)
+                if callable(entries_fn):
+                    entries = list(entries_fn() or [])
+            except Exception:
+                entries = []
+            if len(entries) == 1:
+                _ra().logger.info(
+                    "xai-oauth stale 403: failed credential identity matched "
+                    "no pool entry; refreshing the only xai-oauth credential"
+                )
+                refreshed = pool.try_refresh_matching()
         if refreshed is not None:
             # ``try_refresh_matching()`` re-mints a fresh OAuth token and reports
             # success even when the upstream keeps rejecting it — a single-entry

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4949,16 +4949,31 @@ def run_conversation(
                         )
                         continue
 
+                # xAI expires OAuth access tokens with a 403, not a 401 (the
+                # #29344 body signatures).  Gating this branch on 401 alone
+                # meant the singleton refresh never fired for xai-oauth: a
+                # long-running gateway kept re-presenting a token that died
+                # ~6h earlier until the process was restarted, so `hermes
+                # update` appeared to "fix Grok" for exactly one token
+                # lifetime at a time.  The pool path already makes this
+                # distinction; reuse its predicate rather than a second copy.
+                from agent.agent_runtime_helpers import is_xai_stale_oauth_error
+
+                _xai_stale_oauth = (
+                    agent.provider == "xai-oauth"
+                    and is_xai_stale_oauth_error(error_context, status_code)
+                )
                 if (
                     agent.api_mode == "codex_responses"
                     and agent.provider in {"openai-codex", "xai-oauth"}
-                    and status_code == 401
+                    and (status_code == 401 or _xai_stale_oauth)
                     and not _retry.codex_auth_retry_attempted
                 ):
                     _retry.codex_auth_retry_attempted = True
                     if agent._try_refresh_codex_client_credentials(force=True):
                         _label = "xAI OAuth" if agent.provider == "xai-oauth" else "Codex"
-                        agent._buffer_vprint(f"🔐 {_label} auth refreshed after 401. Retrying request...")
+                        _seen = status_code if status_code is not None else 401
+                        agent._buffer_vprint(f"🔐 {_label} auth refreshed after {_seen}. Retrying request...")
                         continue
                 if (
                     agent.api_mode == "chat_completions"

--- a/run_agent.py
+++ b/run_agent.py
@@ -5824,17 +5824,44 @@ class AIAgent:
 
         singleton_key = str(singleton_now.get("api_key") or "").strip()
         active_key = str(self.api_key or "").strip()
+        adopt_existing_singleton = False
         if singleton_key and active_key and singleton_key != active_key:
-            logger.debug(
-                "%s singleton tokens differ from the active api_key; "
-                "skipping singleton force-refresh to avoid silent account swap. "
-                "Reactive credential rotation should go through the pool.",
-                self.provider,
-            )
-            return False
+            from agent.agent_runtime_helpers import oauth_active_key_is_foreign_pool_entry
+
+            if oauth_active_key_is_foreign_pool_entry(self, active_key):
+                logger.debug(
+                    "%s singleton tokens differ from the active api_key; "
+                    "skipping singleton force-refresh to avoid silent account swap. "
+                    "Reactive credential rotation should go through the pool.",
+                    self.provider,
+                )
+                return False
+            if getattr(self, "_credential_pool", None) is not None:
+                # Live key matches no pool entry: stale in-memory copy of
+                # the singleton (store/pool already reminted). Adopting
+                # that token recovers without spending a second single-use
+                # refresh token. No pool + mismatched keys still skips —
+                # that is the explicit ``api_key=`` / other-account case.
+                logger.info(
+                    "%s active api_key matched no pool entry; adopting "
+                    "current singleton access token without force-refresh",
+                    self.provider,
+                )
+                adopt_existing_singleton = True
+            else:
+                logger.debug(
+                    "%s singleton tokens differ from the active api_key; "
+                    "skipping singleton force-refresh to avoid silent account swap. "
+                    "Reactive credential rotation should go through the pool.",
+                    self.provider,
+                )
+                return False
 
         try:
-            if self.provider == "openai-codex":
+            if adopt_existing_singleton:
+                old_key = active_key
+                creds = singleton_now
+            elif self.provider == "openai-codex":
                 from hermes_cli.auth import resolve_codex_runtime_credentials
 
                 old_key = str(self.api_key or "").strip()

--- a/run_agent.py
+++ b/run_agent.py
@@ -5826,7 +5826,12 @@ class AIAgent:
         active_key = str(self.api_key or "").strip()
         adopt_existing_singleton = False
         if singleton_key and active_key and singleton_key != active_key:
-            from agent.agent_runtime_helpers import oauth_active_key_is_foreign_pool_entry
+            from agent.agent_runtime_helpers import (
+                oauth_active_key_is_foreign_pool_entry,
+                oauth_pool_entry_is_device_code,
+                resolve_stale_oauth_pool_entry,
+            )
+            from hermes_cli.auth import _codex_access_token_is_expiring
 
             if oauth_active_key_is_foreign_pool_entry(self, active_key):
                 logger.debug(
@@ -5836,19 +5841,24 @@ class AIAgent:
                     self.provider,
                 )
                 return False
-            if getattr(self, "_credential_pool", None) is not None:
-                # Live key matches no pool entry: stale in-memory copy of
-                # the singleton (store/pool already reminted). Adopting
-                # that token recovers without spending a second single-use
-                # refresh token. No pool + mismatched keys still skips —
-                # that is the explicit ``api_key=`` / other-account case.
-                logger.info(
-                    "%s active api_key matched no pool entry; adopting "
-                    "current singleton access token without force-refresh",
-                    self.provider,
-                )
-                adopt_existing_singleton = True
-            else:
+            pool = getattr(self, "_credential_pool", None)
+            entry = resolve_stale_oauth_pool_entry(self, pool)
+            if (
+                pool is not None
+                and entry is not None
+                and oauth_pool_entry_is_device_code(entry)
+            ):
+                # Same device_code account; store already reminted. Adopt
+                # only when that token is not itself expired — otherwise
+                # fall through to force_refresh.
+                if not _codex_access_token_is_expiring(singleton_key, 60):
+                    logger.info(
+                        "%s adopting current singleton access token "
+                        "without force-refresh",
+                        self.provider,
+                    )
+                    adopt_existing_singleton = True
+            elif pool is None or entry is None or not oauth_pool_entry_is_device_code(entry):
                 logger.debug(
                     "%s singleton tokens differ from the active api_key; "
                     "skipping singleton force-refresh to avoid silent account swap. "

--- a/tests/agent/test_xai_stale_oauth_403_refresh.py
+++ b/tests/agent/test_xai_stale_oauth_403_refresh.py
@@ -126,19 +126,39 @@ def test_oauth_active_key_is_foreign_pool_entry():
     assert oauth_active_key_is_foreign_pool_entry(agent, "") is False
 
 
-def test_recover_refreshes_sole_xai_entry_when_expired_key_matches_nothing():
-    """8:34 hole: expired live key matches no pool entry, sole credential.
+def test_resolve_stale_oauth_pool_entry_does_not_guess_manual():
+    from types import SimpleNamespace
 
-    try_refresh_matching(hint=expired) returns None; a single-entry pool
-    then refuses to rotate. Recovery must retry without the hint.
-    """
+    from agent.agent_runtime_helpers import resolve_stale_oauth_pool_entry
+
+    manual = SimpleNamespace(id="manual-1", source="manual", runtime_api_key="other")
+    device = SimpleNamespace(id="dc-1", source="device_code", runtime_api_key="tok")
+
+    class _Pool:
+        def __init__(self, entries):
+            self._entries = entries
+
+        def entries(self):
+            return self._entries
+
+    assert resolve_stale_oauth_pool_entry(
+        SimpleNamespace(_credential_pool_entry_id=None), _Pool([manual])
+    ) is None
+    assert resolve_stale_oauth_pool_entry(
+        SimpleNamespace(_credential_pool_entry_id="manual-1"), _Pool([manual])
+    ) is manual
+    assert resolve_stale_oauth_pool_entry(
+        SimpleNamespace(_credential_pool_entry_id=None), _Pool([device])
+    ) is device
+
+
+def _xai_agent(*, api_key="expired-in-memory-token"):
     from unittest.mock import MagicMock
 
-    from agent.error_classifier import FailoverReason
     from run_agent import AIAgent
 
     agent = AIAgent(
-        api_key="expired-in-memory-token",
+        api_key=api_key,
         base_url="https://api.x.ai/v1",
         model="grok-4.6",
         quiet_mode=True,
@@ -150,24 +170,36 @@ def test_recover_refreshes_sole_xai_entry_when_expired_key_matches_nothing():
     agent._interrupt_requested = False
     agent._credential_pool_entry_id = None
     agent._swap_credential = MagicMock()
+    return agent
 
+
+def test_recover_adopts_reminted_device_code_entry_without_second_refresh():
+    """8:34 hole: expired live key, sole device_code entry already reminted."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from agent.error_classifier import FailoverReason
+
+    agent = _xai_agent()
     calls = []
-    refreshed = MagicMock(id="only-entry")
+    only = SimpleNamespace(
+        id="only-entry",
+        source="device_code",
+        runtime_api_key="fresh-store-token",
+    )
 
     class _FakePool:
         provider = "xai-oauth"
 
         def try_refresh_matching(self, api_key_hint=None, credential_id=None):
             calls.append({"api_key_hint": api_key_hint, "credential_id": credential_id})
-            if api_key_hint is None and credential_id is None:
-                return refreshed
             return None
 
         def mark_exhausted_and_rotate(self, **_kwargs):
-            raise AssertionError("must not rotate when the sole entry can refresh")
+            raise AssertionError("must not rotate when the reminted entry can be adopted")
 
         def entries(self):
-            return [MagicMock(id="only-entry", runtime_api_key="fresh-store-token")]
+            return [only]
 
         def has_available(self):
             return True
@@ -184,7 +216,99 @@ def test_recover_refreshes_sole_xai_entry_when_expired_key_matches_nothing():
     )
 
     assert recovered is True
-    assert calls[0]["api_key_hint"] == "expired-in-memory-token"
-    assert calls[-1] == {"api_key_hint": None, "credential_id": None}
-    agent._swap_credential.assert_called_once_with(refreshed)
+    assert calls == [
+        {"api_key_hint": "expired-in-memory-token", "credential_id": None}
+    ]
+    agent._swap_credential.assert_called_once_with(only)
+
+
+def test_recover_does_not_guess_sole_manual_other_account():
+    from types import SimpleNamespace
+
+    from agent.error_classifier import FailoverReason
+
+    agent = _xai_agent()
+    calls = []
+    manual = SimpleNamespace(
+        id="manual-other",
+        source="manual",
+        runtime_api_key="other-account-token",
+    )
+
+    class _FakePool:
+        provider = "xai-oauth"
+
+        def try_refresh_matching(self, api_key_hint=None, credential_id=None):
+            calls.append({"api_key_hint": api_key_hint, "credential_id": credential_id})
+            return None
+
+        def mark_exhausted_and_rotate(self, **_kwargs):
+            return None
+
+        def entries(self):
+            return [manual]
+
+        def has_available(self):
+            return True
+
+        def current(self):
+            return None
+
+    agent._credential_pool = _FakePool()
+    recovered, _ = agent._recover_with_credential_pool(
+        status_code=403,
+        has_retried_429=False,
+        classified_reason=FailoverReason.auth,
+        error_context={"message": REAL_EXPIRED_BODY},
+    )
+
+    assert recovered is False
+    assert all(c["credential_id"] is None for c in calls)
+    agent._swap_credential.assert_not_called()
+
+
+def test_recover_adopts_reminted_entry_by_credential_id():
+    from types import SimpleNamespace
+
+    from agent.error_classifier import FailoverReason
+
+    agent = _xai_agent()
+    agent._credential_pool_entry_id = "manual-1"
+    reminted = SimpleNamespace(
+        id="manual-1",
+        source="manual",
+        runtime_api_key="fresh-manual-token",
+    )
+    calls = []
+
+    class _FakePool:
+        provider = "xai-oauth"
+
+        def try_refresh_matching(self, api_key_hint=None, credential_id=None):
+            calls.append({"api_key_hint": api_key_hint, "credential_id": credential_id})
+            return None
+
+        def mark_exhausted_and_rotate(self, **_kwargs):
+            raise AssertionError("must adopt the reminted id, not rotate")
+
+        def entries(self):
+            return [reminted]
+
+        def has_available(self):
+            return True
+
+        def current(self):
+            return None
+
+    agent._credential_pool = _FakePool()
+    recovered, _ = agent._recover_with_credential_pool(
+        status_code=403,
+        has_retried_429=False,
+        classified_reason=FailoverReason.auth,
+        error_context={"message": REAL_EXPIRED_BODY},
+    )
+
+    assert recovered is True
+    agent._swap_credential.assert_called_once_with(reminted)
+    assert all(c.get("credential_id") != "manual-1" or c["api_key_hint"] for c in calls)
 

--- a/tests/agent/test_xai_stale_oauth_403_refresh.py
+++ b/tests/agent/test_xai_stale_oauth_403_refresh.py
@@ -1,0 +1,109 @@
+"""Regression tests: xAI signals an expired OAuth token with 403, not 401.
+
+xAI answers an access token that has simply aged out with HTTP 403 and a
+body carrying either ``[WKE=unauthenticated:...]`` or ``OAuth2 access token
+could not be validated`` -- never a 401.  #29344 taught the credential-pool
+recovery path to tell those bodies apart from the entitlement 403s that a
+refresh can never fix, but the singleton ``codex_responses`` refresh branch
+in ``run_conversation`` kept gating on ``status_code == 401`` alone.
+
+Consequence in the field: a long-running gateway on ``xai-oauth`` held a
+token that died ~6h earlier and had no path back.  Neither recovery arm
+fired -- the pool arm returns early whenever the agent carries no
+credential pool, and the singleton arm could not see a 403 -- so Grok
+stayed dead until the process was restarted.  ``hermes update`` restarts
+the stack and re-mints, which is why updating appeared to "fix Grok" for
+exactly one token lifetime at a time.
+
+These lock in the shared predicate and the widened gate.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from agent.agent_runtime_helpers import is_xai_stale_oauth_error
+
+
+# The exact body observed in production gateway logs.
+REAL_EXPIRED_BODY = (
+    'HTTP 403: {"code":"unauthenticated:bad-credentials",'
+    '"error":"The OAuth2 access token could not be validated."}'
+)
+
+ENTITLEMENT_BODY = (
+    "You have either run out of available resources or do not have an "
+    "active Grok subscription"
+)
+
+
+@pytest.mark.parametrize(
+    "error_context,status_code,expected",
+    [
+        # -- recoverable: the token is merely stale -------------------------
+        ({"message": REAL_EXPIRED_BODY}, 403, True),
+        ({"message": "boom [WKE=unauthenticated:bad-credentials]"}, 403, True),
+        ({"error": "The OAuth2 access token could not be validated."}, 403, True),
+        # xAI has shipped both casings; the match must be case-insensitive
+        ({"message": "OAUTH2 ACCESS TOKEN COULD NOT BE VALIDATED"}, 403, True),
+        # -- NOT recoverable: refreshing cannot fix these -------------------
+        ({"message": ENTITLEMENT_BODY}, 403, False),
+        (
+            {
+                "message": "oauth authentication is currently not allowed "
+                "for this organization"
+            },
+            403,
+            False,
+        ),
+        # -- wrong status: the predicate is 403-only ------------------------
+        ({"message": REAL_EXPIRED_BODY}, 401, False),
+        ({"message": REAL_EXPIRED_BODY}, 429, False),
+        ({"message": REAL_EXPIRED_BODY}, None, False),
+        # -- degenerate input never raises ----------------------------------
+        (None, 403, False),
+        ({}, 403, False),
+        ("not-a-dict", 403, False),
+        ({"message": None, "code": None}, 403, False),
+    ],
+)
+def test_stale_oauth_predicate(error_context, status_code, expected):
+    assert is_xai_stale_oauth_error(error_context, status_code) is expected
+
+
+def test_singleton_refresh_gate_accepts_the_403():
+    """The codex_responses refresh branch must not be 401-only anymore.
+
+    Asserted against source text because exercising the branch for real
+    means standing up the whole streaming conversation loop; the gate is a
+    four-line boolean whose regression mode is silent.
+    """
+    src = Path(__file__).resolve().parents[2] / "agent" / "conversation_loop.py"
+    body = src.read_text(encoding="utf-8")
+
+    gate = re.search(
+        r"if \(\s*\n\s*agent\.api_mode == .codex_responses.\s*\n"
+        r"\s*and agent\.provider in \{.openai-codex., .xai-oauth.\}\s*\n"
+        r"\s*and ([^\n]+)\n",
+        body,
+    )
+    assert gate, "codex_responses auth-refresh gate not found"
+    condition = gate.group(1)
+    assert "401" in condition, "401 handling must be preserved"
+    assert "_xai_stale_oauth" in condition, (
+        "the gate still ignores xAI's 403 expiry signal -- a stale "
+        "xai-oauth token has no recovery path"
+    )
+
+
+def test_pool_path_reuses_the_shared_predicate():
+    """The pool arm must call the helper, not keep a second copy of it."""
+    src = Path(__file__).resolve().parents[2] / "agent" / "agent_runtime_helpers.py"
+    body = src.read_text(encoding="utf-8")
+
+    recover = body[body.index("def recover_with_credential_pool(") :]
+    assert "is_xai_stale_oauth_error(error_context, status_code)" in recover
+    assert "_is_xai_auth_failure" not in recover, (
+        "inline duplicate of the predicate is back; the two arms will drift"
+    )

--- a/tests/agent/test_xai_stale_oauth_403_refresh.py
+++ b/tests/agent/test_xai_stale_oauth_403_refresh.py
@@ -150,6 +150,12 @@ def test_resolve_stale_oauth_pool_entry_does_not_guess_manual():
     assert resolve_stale_oauth_pool_entry(
         SimpleNamespace(_credential_pool_entry_id=None), _Pool([device])
     ) is device
+    imported = SimpleNamespace(
+        id="dc-imported", source="manual:device_code", runtime_api_key="tok"
+    )
+    assert resolve_stale_oauth_pool_entry(
+        SimpleNamespace(_credential_pool_entry_id=None), _Pool([imported])
+    ) is imported
 
 
 def _xai_agent(*, api_key="expired-in-memory-token"):
@@ -216,9 +222,7 @@ def test_recover_adopts_reminted_device_code_entry_without_second_refresh():
     )
 
     assert recovered is True
-    assert calls == [
-        {"api_key_hint": "expired-in-memory-token", "credential_id": None}
-    ]
+    assert calls == []
     agent._swap_credential.assert_called_once_with(only)
 
 
@@ -310,5 +314,55 @@ def test_recover_adopts_reminted_entry_by_credential_id():
 
     assert recovered is True
     agent._swap_credential.assert_called_once_with(reminted)
-    assert all(c.get("credential_id") != "manual-1" or c["api_key_hint"] for c in calls)
+    assert calls == []
+
+
+def test_recover_refreshes_device_code_entry_when_runtime_still_matches():
+    from types import SimpleNamespace
+
+    from agent.error_classifier import FailoverReason
+
+    agent = _xai_agent(api_key="same-expired-token")
+    calls = []
+    refreshed = SimpleNamespace(id="dc-1")
+    only = SimpleNamespace(
+        id="dc-1",
+        source="device_code",
+        runtime_api_key="same-expired-token",
+    )
+
+    class _FakePool:
+        provider = "xai-oauth"
+
+        def try_refresh_matching(self, api_key_hint=None, credential_id=None):
+            calls.append({"api_key_hint": api_key_hint, "credential_id": credential_id})
+            if credential_id == "dc-1":
+                return refreshed
+            return None
+
+        def mark_exhausted_and_rotate(self, **_kwargs):
+            raise AssertionError("must refresh the device_code entry by id")
+
+        def entries(self):
+            return [only]
+
+        def has_available(self):
+            return True
+
+        def current(self):
+            return None
+
+    agent._credential_pool = _FakePool()
+    recovered, _ = agent._recover_with_credential_pool(
+        status_code=403,
+        has_retried_429=False,
+        classified_reason=FailoverReason.auth,
+        error_context={"message": REAL_EXPIRED_BODY},
+    )
+
+    assert recovered is True
+    assert calls == [
+        {"api_key_hint": "same-expired-token", "credential_id": "dc-1"}
+    ]
+    agent._swap_credential.assert_called_once_with(refreshed)
 

--- a/tests/agent/test_xai_stale_oauth_403_refresh.py
+++ b/tests/agent/test_xai_stale_oauth_403_refresh.py
@@ -107,3 +107,84 @@ def test_pool_path_reuses_the_shared_predicate():
     assert "_is_xai_auth_failure" not in recover, (
         "inline duplicate of the predicate is back; the two arms will drift"
     )
+
+
+def test_oauth_active_key_is_foreign_pool_entry():
+    from types import SimpleNamespace
+
+    from agent.agent_runtime_helpers import oauth_active_key_is_foreign_pool_entry
+
+    assert oauth_active_key_is_foreign_pool_entry(SimpleNamespace(_credential_pool=None), "k") is False
+
+    class _Pool:
+        def entries(self):
+            return [SimpleNamespace(runtime_api_key="pooled-key")]
+
+    agent = SimpleNamespace(_credential_pool=_Pool())
+    assert oauth_active_key_is_foreign_pool_entry(agent, "pooled-key") is True
+    assert oauth_active_key_is_foreign_pool_entry(agent, "stale-in-memory") is False
+    assert oauth_active_key_is_foreign_pool_entry(agent, "") is False
+
+
+def test_recover_refreshes_sole_xai_entry_when_expired_key_matches_nothing():
+    """8:34 hole: expired live key matches no pool entry, sole credential.
+
+    try_refresh_matching(hint=expired) returns None; a single-entry pool
+    then refuses to rotate. Recovery must retry without the hint.
+    """
+    from unittest.mock import MagicMock
+
+    from agent.error_classifier import FailoverReason
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="expired-in-memory-token",
+        base_url="https://api.x.ai/v1",
+        model="grok-4.6",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "codex_responses"
+    agent.provider = "xai-oauth"
+    agent._interrupt_requested = False
+    agent._credential_pool_entry_id = None
+    agent._swap_credential = MagicMock()
+
+    calls = []
+    refreshed = MagicMock(id="only-entry")
+
+    class _FakePool:
+        provider = "xai-oauth"
+
+        def try_refresh_matching(self, api_key_hint=None, credential_id=None):
+            calls.append({"api_key_hint": api_key_hint, "credential_id": credential_id})
+            if api_key_hint is None and credential_id is None:
+                return refreshed
+            return None
+
+        def mark_exhausted_and_rotate(self, **_kwargs):
+            raise AssertionError("must not rotate when the sole entry can refresh")
+
+        def entries(self):
+            return [MagicMock(id="only-entry", runtime_api_key="fresh-store-token")]
+
+        def has_available(self):
+            return True
+
+        def current(self):
+            return None
+
+    agent._credential_pool = _FakePool()
+    recovered, _ = agent._recover_with_credential_pool(
+        status_code=403,
+        has_retried_429=False,
+        classified_reason=FailoverReason.auth,
+        error_context={"message": REAL_EXPIRED_BODY},
+    )
+
+    assert recovered is True
+    assert calls[0]["api_key_hint"] == "expired-in-memory-token"
+    assert calls[-1] == {"api_key_hint": None, "credential_id": None}
+    agent._swap_credential.assert_called_once_with(refreshed)
+

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1435,7 +1435,11 @@ def test_try_refresh_codex_client_credentials_adopts_store_token_when_pool_ident
     """
     agent = _build_xai_oauth_agent(monkeypatch)
     refresh_calls = {"count": 0}
-    store_token = "store-already-reminted"
+    store_token = (
+        "eyJhbGciOiJub25lIn0."
+        "eyJleHAiOjk5OTk5OTk5OTl9."
+        "sig"
+    )
 
     class _Pool:
         def entries(self):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1439,7 +1439,13 @@ def test_try_refresh_codex_client_credentials_adopts_store_token_when_pool_ident
 
     class _Pool:
         def entries(self):
-            return [SimpleNamespace(id="only", runtime_api_key=store_token)]
+            return [
+                SimpleNamespace(
+                    id="only",
+                    source="device_code",
+                    runtime_api_key=store_token,
+                )
+            ]
 
     agent._credential_pool = _Pool()
 
@@ -1522,6 +1528,112 @@ def test_try_refresh_codex_client_credentials_still_skips_foreign_pool_entry(mon
     assert ok is False
     assert refresh_calls["count"] == 0
     assert agent.api_key == pre
+
+
+def test_try_refresh_skips_when_sole_pool_entry_is_manual_other_account(monkeypatch):
+    """Identity miss on a reminted MANUAL entry must not adopt device_code."""
+    agent = _build_xai_oauth_agent(monkeypatch)
+    refresh_calls = {"count": 0}
+
+    class _Pool:
+        def entries(self):
+            return [
+                SimpleNamespace(
+                    id="manual",
+                    source="manual",
+                    runtime_api_key="reminted-manual-token",
+                )
+            ]
+
+    agent._credential_pool = _Pool()
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            refresh_calls["count"] += 1
+        return {
+            "api_key": "singleton-account-token",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        _fake_resolve,
+    )
+    pre = agent.api_key
+    ok = agent._try_refresh_codex_client_credentials(force=True)
+    assert ok is False
+    assert refresh_calls["count"] == 0
+    assert agent.api_key == pre
+
+
+def test_try_refresh_force_refreshes_when_store_token_is_expired_jwt(monkeypatch):
+    """Adopting an expired store token would burn the singleton retry."""
+    import base64
+    import json
+    import time
+
+    def _jwt(exp):
+        def _part(payload):
+            raw = json.dumps(payload, separators=(",", ":")).encode()
+            return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+        return f"{_part({'alg': 'none'})}.{_part({'exp': exp})}.sig"
+
+    agent = _build_xai_oauth_agent(monkeypatch)
+    expired_store = _jwt(int(time.time()) - 3600)
+    fresh = "fresh-after-force-refresh"
+    refresh_calls = {"count": 0}
+
+    class _Pool:
+        def entries(self):
+            return [
+                SimpleNamespace(
+                    id="dc",
+                    source="device_code",
+                    runtime_api_key=expired_store,
+                )
+            ]
+
+    agent._credential_pool = _Pool()
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            refresh_calls["count"] += 1
+            return {"api_key": fresh, "base_url": "https://api.x.ai/v1"}
+        return {"api_key": expired_store, "base_url": "https://api.x.ai/v1"}
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        _fake_resolve,
+    )
+
+    class _ExistingClient:
+        def close(self):
+            pass
+
+    class _RebuiltClient:
+        pass
+
+    rebuilt = {"kwargs": None}
+
+    def _fake_openai(**kwargs):
+        rebuilt["kwargs"] = kwargs
+        return _RebuiltClient()
+
+    monkeypatch.setattr(run_agent, "OpenAI", _fake_openai)
+    existing = _ExistingClient()
+    agent.client = existing
+    monkeypatch.setattr(
+        agent,
+        "_retire_shared_openai_client",
+        lambda client, *, reason: None,
+    )
+
+    ok = agent._try_refresh_codex_client_credentials(force=True)
+    assert ok is True
+    assert refresh_calls["count"] == 1
+    assert agent.api_key == fresh
+    assert rebuilt["kwargs"]["api_key"] == fresh
 
 
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1425,6 +1425,107 @@ def test_try_refresh_codex_client_credentials_skips_xai_oauth_when_singleton_dif
     assert agent.api_key == pre_refresh_key
 
 
+def test_try_refresh_codex_client_credentials_adopts_store_token_when_pool_identity_misses(monkeypatch):
+    """Stale in-memory key + pool whose runtime key is the store token.
+
+    This is the 8:34 production hole: the live client still has the expired
+    access token, auth.json/pool already hold a different one, and the
+    account-swap guard used to skip because the strings differ. Adopting
+    the store token must succeed without spending a second refresh token.
+    """
+    agent = _build_xai_oauth_agent(monkeypatch)
+    refresh_calls = {"count": 0}
+    store_token = "store-already-reminted"
+
+    class _Pool:
+        def entries(self):
+            return [SimpleNamespace(id="only", runtime_api_key=store_token)]
+
+    agent._credential_pool = _Pool()
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            refresh_calls["count"] += 1
+            return {
+                "api_key": "should-not-force-refresh",
+                "base_url": "https://api.x.ai/v1",
+            }
+        return {
+            "api_key": store_token,
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        _fake_resolve,
+    )
+
+    class _ExistingClient:
+        def close(self):
+            pass
+
+    class _RebuiltClient:
+        pass
+
+    rebuilt = {"kwargs": None}
+
+    def _fake_openai(**kwargs):
+        rebuilt["kwargs"] = kwargs
+        return _RebuiltClient()
+
+    monkeypatch.setattr(run_agent, "OpenAI", _fake_openai)
+    existing = _ExistingClient()
+    agent.client = existing
+    retired = {"client": None}
+    monkeypatch.setattr(
+        agent,
+        "_retire_shared_openai_client",
+        lambda client, *, reason: retired.__setitem__("client", client),
+    )
+
+    ok = agent._try_refresh_codex_client_credentials(force=True)
+
+    assert ok is True
+    assert refresh_calls["count"] == 0, "must adopt the store token, not remint"
+    assert agent.api_key == store_token
+    assert rebuilt["kwargs"]["api_key"] == store_token
+    assert retired["client"] is existing
+
+
+def test_try_refresh_codex_client_credentials_still_skips_foreign_pool_entry(monkeypatch):
+    """A live key that belongs to a pooled (non-singleton) credential must
+    not adopt the device_code singleton — that is the original account-swap
+    guard, now keyed off pool membership instead of string inequality."""
+    agent = _build_xai_oauth_agent(monkeypatch)
+    refresh_calls = {"count": 0}
+
+    class _Pool:
+        def entries(self):
+            return [SimpleNamespace(id="manual", runtime_api_key=agent.api_key)]
+
+    agent._credential_pool = _Pool()
+
+    def _fake_resolve(force_refresh=False, refresh_if_expiring=True, **_):
+        if force_refresh:
+            refresh_calls["count"] += 1
+        return {
+            "api_key": "singleton-account-token",
+            "base_url": "https://api.x.ai/v1",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        _fake_resolve,
+    )
+    pre = agent.api_key
+    ok = agent._try_refresh_codex_client_credentials(force=True)
+    assert ok is False
+    assert refresh_calls["count"] == 0
+    assert agent.api_key == pre
+
+
+
+
 
 
 


### PR DESCRIPTION
## Problem

xAI expires an OAuth access token with **HTTP 403** — carrying either `[WKE=unauthenticated:…]` or `OAuth2 access token could not be validated` — and never sends a 401.

The singleton `codex_responses` refresh branch in `run_conversation` gates on `status_code == 401`:

```python
if (
    agent.api_mode == "codex_responses"
    and agent.provider in {"openai-codex", "xai-oauth"}
    and status_code == 401          # xAI never sends this
    and not _retry.codex_auth_retry_attempted
):
```

so that arm cannot fire for `xai-oauth` at all.

The credential-pool arm already draws this distinction (#29344 deliberately exempts those two bodies from the entitlement override), but `recover_with_credential_pool()` returns early whenever `agent._credential_pool is None`.

With both arms out, a long-running gateway on `xai-oauth` keeps re-presenting a token that died ~6h earlier with no path back. Grok stops answering until the process is restarted — and since `hermes update` restarts the stack and re-mints, updating appears to "fix Grok" for exactly one token lifetime at a time.

## Evidence

From a gateway host running `grok-4.6` on `xai-oauth`:

```
agent.conversation_loop: API call failed (attempt 1/3)
  error_type=PermissionDeniedError provider=xai-oauth
  base_url=https://api.x.ai/v1 model=grok-4.6
  summary=HTTP 403: {"code":"unauthenticated:bad-credentials",
                     "error":"The OAuth2 access token could not be validated."}
```

Recurring across four consecutive days. At the time of capture the access token (6h lifetime) sat **16h past `exp`** with `last_refresh` 22h stale, and there were **zero** credential-pool log lines in that window — consistent with the silent `pool is None` early return.

The refresh token was healthy throughout: a single forced `resolve_xai_oauth_runtime_credentials(force_refresh=True)` minted a fresh 6h token immediately and chat recovered. The credential was never dead — nothing was pulling the trigger.

## Fix

Lift the #29344 predicate into `is_xai_stale_oauth_error()` and call it from both arms so they cannot drift, then widen the singleton gate to `401 or <stale xai 403>`.

Entitlement 403s still classify as entitlement, so the refresh loop cannot spin on an unsubscribed account — that guard is what the shared predicate exists to protect.

## Tests

`tests/agent/test_xai_stale_oauth_403_refresh.py` — 15 cases: the production body verbatim, the `WKE` variant, casing, entitlement and org-policy 403s that must **not** refresh, non-403 statuses, and degenerate input. Plus two structural tests pinning the widened gate and the single-owner predicate.

All three structural tests fail against unpatched `main`. Existing suites stay green:

```
tests/run_agent/test_codex_xai_oauth_recovery.py
tests/agent/test_credential_pool_routing.py
tests/agent/test_custom_pool_mismatch_guard.py
tests/agent/test_billing_unverified_carrythrough.py
tests/hermes_cli/test_auth_xai_oauth_provider.py
                                        72 passed
```

## Note

This only restores the *reactive* path. The pool arm being skipped when `_credential_pool is None` is a separate question — worth a look, but out of scope here.
