### PR TITLE
fix(desktop): no-sudo Linux namespace sandbox for chrome-sandbox 0755

### DIFF
--- a/contributors/emails/a.dltorreruiz@gmail.com
+++ b/contributors/emails/a.dltorreruiz@gmail.com
@@ -1,0 +1,2 @@
+4dlt
+# PR #98135 attribution repair

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8184,6 +8184,29 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
     return True
 
 
+def _desktop_linux_needs_disable_setuid_sandbox(packaged_executable: Path) -> bool:
+    """Return True when Chromium should skip the present-but-non-setuid helper.
+
+    A user-owned ``chrome-sandbox`` still makes Chromium abort with
+    ``setuid_sandbox_host`` even when the namespace sandbox works. Passing
+    ``--disable-setuid-sandbox`` keeps the userns sandbox and avoids sudo.
+    Call only after ``_desktop_linux_sandbox_fixup`` succeeded without making
+    the helper root-owned 4755 (the userns path). Does not re-probe userns.
+    """
+    if sys.platform != "linux":
+        return False
+    sandbox = packaged_executable.parent / "chrome-sandbox"
+    try:
+        sandbox_lstat = sandbox.lstat()
+    except OSError:
+        return False
+    if not stat.S_ISREG(sandbox_lstat.st_mode):
+        return False
+    if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+        return False
+    return True
+
+
 _LINUX_PASSWORD_STORES = frozenset({"gnome-libsecret", "kwallet", "kwallet5", "kwallet6", "basic"})
 
 
@@ -8578,6 +8601,8 @@ def cmd_gui(args: argparse.Namespace):
             launch_command.append("--no-sandbox")
         else:
             sys.exit(1)
+    elif _desktop_linux_needs_disable_setuid_sandbox(packaged_executable):
+        launch_command.append("--disable-setuid-sandbox")
 
     launch_command.extend(config_electron_flags)
     print(f"→ Launching packaged Hermes Desktop: {' '.join(launch_command)}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8098,6 +8098,37 @@ def _desktop_linux_needs_no_sandbox() -> bool:
         return False
 
 
+def _desktop_linux_userns_sandbox_available() -> bool:
+    """Return True when Chromium's unprivileged user-namespace sandbox works.
+
+    When an unprivileged process can create a user namespace, Chromium uses the
+    namespace sandbox and never consults the setuid ``chrome-sandbox`` helper,
+    so requiring the helper to be root-owned 4755 (and prompting for sudo) is
+    unnecessary. Probe the real capability with ``unshare`` instead of reading
+    distro-specific sysctls: the probe fails closed on hosts where user
+    namespaces are disabled or AppArmor-restricted, which then follow the
+    existing setuid-helper path.
+    """
+    if sys.platform != "linux":
+        return False
+    unshare = shutil.which("unshare")
+    if not unshare:
+        return False
+    try:
+        return (
+            subprocess.run(
+                [unshare, "--user", "--map-root-user", "true"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                check=False,
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
 def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> bool:
     """Return True when ``chrome-sandbox`` exists as a regular file."""
     if sys.platform != "linux":
@@ -8134,6 +8165,10 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
         return False
 
     if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+        return True
+
+    if _desktop_linux_userns_sandbox_available():
+        print("✓ Using Chromium's user-namespace sandbox (setuid helper not needed).")
         return True
 
     sudo = shutil.which("sudo")

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -316,6 +316,10 @@ linux_gate() {
   sb="$unpacked/chrome-sandbox"
   if [ ! -e "$sb" ]; then GATE=relaunch; return; fi
   if [ -u "$sb" ] && [ "$(stat -c %u "$sb" 2>/dev/null)" = "0" ]; then GATE=relaunch; return; fi
+  # Namespace sandbox usable => Electron never consults the setuid helper,
+  # so a non-root chrome-sandbox does not block relaunch (mirrors the
+  # _desktop_linux_userns_sandbox_available() probe in hermes_cli/main.py).
+  if unshare --user --map-root-user true 2>/dev/null; then GATE=relaunch; return; fi
 
   case "${ELECTRON_DISABLE_SANDBOX:-}" in 1|true|TRUE|True) GATE=relaunch; return ;; esac
   [ "$SANDBOX_FALLBACK" -eq 1 ] && { GATE=relaunch; return; }

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -130,7 +130,11 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert install_env is not None and "PATH" in install_env
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
-    assert mock_run.call_args_list[1].args[0] == [str(packaged_exe)]
+    launched = mock_run.call_args_list[1].args[0]
+    if sys.platform.startswith("linux"):
+        assert launched == [str(packaged_exe), "--disable-setuid-sandbox"]
+    else:
+        assert launched == [str(packaged_exe)]
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
@@ -968,7 +972,11 @@ def test_gui_launches_even_when_desktop_entry_install_fails(tmp_path, monkeypatc
         cli_main.cmd_gui(_ns())
 
     assert exc.value.code == 0
-    assert mock_run.call_args.args[0] == [str(packaged_exe)]
+    launched = mock_run.call_args.args[0]
+    if sys.platform.startswith("linux"):
+        assert launched == [str(packaged_exe), "--disable-setuid-sandbox"]
+    else:
+        assert launched == [str(packaged_exe)]
 
 
 @pytest.mark.macos_only

--- a/tests/hermes_cli/test_linux_sandbox_fixup.py
+++ b/tests/hermes_cli/test_linux_sandbox_fixup.py
@@ -1,0 +1,116 @@
+"""Tests for the Linux desktop sandbox-helper fixup and the userns probe.
+
+``_desktop_linux_sandbox_fixup`` historically demanded a root-owned 4755
+``chrome-sandbox`` on every Linux host and shelled out to ``sudo`` to get it
+— which fails silently when the desktop entry launches ``hermes desktop``
+without a TTY (#88032, #51327), and blocked the updater's relaunch gate
+(#58593). On hosts where unprivileged user namespaces work, Chromium uses
+its namespace sandbox and never consults the setuid helper, so the fixup now
+probes for that capability first and skips the sudo path entirely.
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+import sys
+from unittest.mock import patch
+
+from hermes_cli import main as cli_main
+
+
+class TestDesktopLinuxUsernsSandboxAvailable:
+    def test_false_on_non_linux(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_false_when_unshare_is_missing(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value=None):
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_true_when_probe_succeeds(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            assert cli_main._desktop_linux_userns_sandbox_available() is True
+        probe = run.call_args.args[0]
+        assert probe[0] == "/usr/bin/unshare"
+        assert "--user" in probe
+
+    def test_false_when_probe_fails(self, monkeypatch):
+        """EPERM from the kernel (userns disabled or AppArmor-restricted)."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value.returncode = 1
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_false_when_probe_raises(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(
+                 cli_main.subprocess,
+                 "run",
+                 side_effect=subprocess.TimeoutExpired(cmd="unshare", timeout=5),
+             ):
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+
+class TestDesktopLinuxSandboxFixup:
+    def _fake_packaged_app(self, tmp_path):
+        """Unpacked-app layout with a non-root, non-setuid chrome-sandbox."""
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        sandbox = unpacked / "chrome-sandbox"
+        sandbox.write_text("", encoding="utf-8")
+        sandbox.chmod(0o755)
+        return exe
+
+    def test_userns_host_skips_sudo_and_succeeds(self, monkeypatch, tmp_path):
+        """A user-owned helper must not trigger sudo when userns works.
+
+        This is the .desktop-launch regression: no TTY means sudo cannot
+        prompt, so reaching the sudo path at all kills the launch.
+        """
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+             ), \
+             patch.object(cli_main.subprocess, "run") as run:
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+        run.assert_not_called()
+
+    def test_restricted_host_without_sudo_still_fails(self, monkeypatch, tmp_path):
+        """The pre-existing strict path is preserved when userns is unusable."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=False
+             ), \
+             patch.object(cli_main.shutil, "which", return_value=None):
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is False
+
+    def test_root_owned_setuid_helper_short_circuits(self, monkeypatch, tmp_path):
+        """A correctly configured helper wins before the userns probe runs."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        real_lstat = (exe.parent / "chrome-sandbox").lstat()
+
+        class _RootSetuidStat:
+            st_mode = stat.S_IFREG | 0o4755
+            st_uid = 0
+
+            def __getattr__(self, name):
+                return getattr(real_lstat, name)
+
+        with patch.object(cli_main.Path, "lstat", return_value=_RootSetuidStat()), \
+             patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available"
+             ) as probe:
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+        probe.assert_not_called()

--- a/tests/hermes_cli/test_linux_sandbox_fixup.py
+++ b/tests/hermes_cli/test_linux_sandbox_fixup.py
@@ -114,3 +114,50 @@ class TestDesktopLinuxSandboxFixup:
              ) as probe:
             assert cli_main._desktop_linux_sandbox_fixup(exe) is True
         probe.assert_not_called()
+
+
+class TestDesktopLinuxNeedsDisableSetuidSandbox:
+    def _fake_packaged_app(self, tmp_path):
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        sandbox = unpacked / "chrome-sandbox"
+        sandbox.write_text("", encoding="utf-8")
+        sandbox.chmod(0o755)
+        return exe
+
+    def test_true_for_user_owned_helper_when_userns_works(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+            cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+        ):
+            assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is True
+
+    def test_false_for_root_owned_setuid_helper(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        real_lstat = (exe.parent / "chrome-sandbox").lstat()
+
+        class _RootSetuidStat:
+            st_mode = stat.S_IFREG | 0o4755
+            st_uid = 0
+
+            def __getattr__(self, name):
+                return getattr(real_lstat, name)
+
+        with patch.object(cli_main.Path, "lstat", return_value=_RootSetuidStat()), \
+             patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+             ) as probe:
+            assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is False
+        probe.assert_not_called()
+
+    def test_false_when_helper_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is False


### PR DESCRIPTION
## What & why

Linux `hermes desktop` still requires a root-owned 4755 `chrome-sandbox` and shells out to `sudo`. From a `Terminal=false` `.desktop` / no-TTY CLI launch, sudo cannot prompt, so the launcher `sys.exit(1)`s even when unprivileged user namespaces work (canonical **#51327**).

Existing open PRs (#89349, #90108, #95235, #96687, #97404, #51334, …) cover pieces of this. None on current `main` both (1) skip sudo after a fail-closed `unshare --user --map-root-user` probe **and** (2) pass `--disable-setuid-sandbox` so a *present-but-non-setuid* helper does not abort Chromium. This PR does both. It never adds `--no-sandbox` on the userns path.

## How

- Recovered/rebased 4dlt’s userns probe (`_desktop_linux_userns_sandbox_available`) so `_desktop_linux_sandbox_fixup` returns success before sudo when the probe passes; `linux_gate()` in `scripts/desktop-update/posix.sh` matches.
- After a successful non-4755 fixup, append `--disable-setuid-sandbox` (keeps the namespace sandbox).
- Restricted hosts (probe fails) keep the existing sudo → `--no-sandbox` fallback.

## Test

- `pytest tests/hermes_cli/test_linux_sandbox_fixup.py tests/hermes_cli/test_gui_command.py -q` → 52 passed, 9 skipped
- Live host (CachyOS, `unprivileged_userns_clone=1`, helper `kvn:kvn 0755`): userns probe True; fixup True with no sudo; disable-setuid True.

Fixes #51327

Ready for independent maintainer review following author approval. No merge authority.
