### PR TITLE
fix(terminal): guard interpreter-backed self-repo mutation effects

### DIFF
--- a/tests/tools/test_mutation_effect_guard.py
+++ b/tests/tools/test_mutation_effect_guard.py
@@ -1,0 +1,406 @@
+"""Adversarial acceptance for interpreter-backed live-checkout mutations."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.mutation_effect_guard import MutationEffect, MutationEffectGuard
+
+
+@pytest.fixture
+def repos(tmp_path: Path) -> tuple[Path, Path]:
+    live = tmp_path / "hermes-agent"
+    other = tmp_path / "other-project"
+    for root in (live, other):
+        root.mkdir()
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+    return live.resolve(), other.resolve()
+
+
+def _script(tmp_path: Path, name: str, source: str) -> Path:
+    path = tmp_path / name
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def test_blocks_exact_write_file_then_interpreter_incident(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, _ = repos
+    script = _script(
+        tmp_path,
+        "upgrade.py",
+        (
+            "import subprocess\n"
+            "subprocess.run("
+            "['git', 'reset', '--hard', 'origin/main'], "
+            f"cwd={str(live)!r}, check=True)\n"
+            "subprocess.run("
+            "['python', '-m', 'pip', 'install', '-e', '.'], "
+            "check=True)\n"
+        ),
+    )
+
+    effect = MutationEffectGuard(live).detect(f'python "{script}"', tmp_path)
+
+    assert effect is not None
+    assert effect.operation == "git reset"
+    assert "subprocess.run" in effect.origin
+    assert str(live) in effect.message
+
+
+def test_blocks_script_outside_repo_when_subprocess_cwd_targets_live_checkout(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, _ = repos
+    script = _script(
+        tmp_path,
+        "outside.py",
+        (
+            "from subprocess import check_call as run\n"
+            f"run(['git', 'checkout', 'main'], cwd={str(live)!r})\n"
+        ),
+    )
+
+    effect = MutationEffectGuard(live).detect(f'python "{script}"', tmp_path)
+
+    assert effect is not None
+    assert effect.operation == "git checkout"
+    assert "subprocess.check_call" in effect.origin
+
+
+def test_blocks_static_aliases_variables_and_path_composition(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, _ = repos
+    script = _script(
+        tmp_path,
+        "variables.py",
+        (
+            "import subprocess as sp\n"
+            "from pathlib import Path\n"
+            f"root = Path({str(live)!r})\n"
+            "command = ['git', '-C', str(root), 'reset', '--hard']\n"
+            "sp.Popen(command)\n"
+        ),
+    )
+
+    effect = MutationEffectGuard(live).detect(f'py -3.12 "{script}"', tmp_path)
+
+    assert effect is not None
+    assert effect.operation == "git reset"
+    assert "subprocess.Popen" in effect.origin
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python -c \"import os; os.system('git reset --hard')\"",
+        (
+            "bash -c \"python -c 'import subprocess; "
+            "subprocess.run([\\\"git\\\", \\\"checkout\\\", \\\"main\\\"])'\""
+        ),
+    ],
+)
+def test_blocks_inline_and_nested_interpreter_payloads(
+    repos: tuple[Path, Path],
+    command: str,
+) -> None:
+    live, _ = repos
+
+    effect = MutationEffectGuard(live).detect(command, live)
+
+    assert effect is not None
+    assert "Python -c" in effect.origin
+
+
+def test_blocks_nested_python_script_spawn(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, _ = repos
+    inner = _script(
+        tmp_path,
+        "inner.py",
+        "import os\nos.system('git reset --hard')\n",
+    )
+    outer = _script(
+        tmp_path,
+        "outer.py",
+        (
+            "import subprocess\n"
+            f"subprocess.check_call(['python', {str(inner)!r}])\n"
+        ),
+    )
+
+    effect = MutationEffectGuard(live).detect(f'python "{outer}"', live)
+
+    assert effect is not None
+    assert str(inner) in effect.origin
+    assert effect.operation == "git reset"
+
+
+def test_unscannable_oversized_script_fails_closed(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, _ = repos
+    script = _script(tmp_path, "large.py", "print('safe')\n" * 20)
+
+    effect = MutationEffectGuard(live, max_script_bytes=32).detect(
+        f'python "{script}"',
+        live,
+    )
+
+    assert effect is not None
+    assert effect.operation == "oversized interpreter input"
+    assert "cannot prove" in effect.message
+
+
+@pytest.mark.parametrize(
+    ("name", "source"),
+    [
+        ("safe.py", "print('safe')\n"),
+        ("syntax_error.py", "def broken(:\n"),
+    ],
+)
+def test_safe_or_non_executable_source_is_left_to_terminal_owner(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+    name: str,
+    source: str,
+) -> None:
+    live, _ = repos
+    script = _script(tmp_path, name, source)
+
+    assert MutationEffectGuard(live).detect(f'python "{script}"', live) is None
+
+
+def test_missing_script_is_left_to_terminal_owner(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, _ = repos
+
+    assert MutationEffectGuard(live).detect(
+        f"python {tmp_path / 'missing.py'}",
+        live,
+    ) is None
+
+
+def test_mutation_in_unrelated_repo_remains_allowed(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, other = repos
+    script = _script(
+        tmp_path,
+        "other.py",
+        (
+            "import subprocess\n"
+            f"subprocess.run(['git', 'reset', '--hard'], cwd={str(other)!r})\n"
+        ),
+    )
+
+    assert MutationEffectGuard(live).detect(f'python "{script}"', live) is None
+
+
+def test_uv_run_python_is_inspected(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, _ = repos
+    script = _script(
+        tmp_path,
+        "uv_child.py",
+        "import subprocess\nsubprocess.run(['git', 'reset', '--hard'])\n",
+    )
+
+    effect = MutationEffectGuard(live).detect(
+        f'uv run --python 3.12 python "{script}"',
+        live,
+    )
+
+    assert effect is not None
+    assert effect.operation == "git reset"
+
+
+def test_called_main_function_is_scanned_but_dormant_helper_is_not(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, _ = repos
+    dormant = _script(
+        tmp_path,
+        "dormant.py",
+        (
+            "import subprocess\n"
+            "def dangerous():\n"
+            "    subprocess.run(['git', 'reset', '--hard'])\n"
+            "print('safe')\n"
+        ),
+    )
+    called = _script(
+        tmp_path,
+        "called.py",
+        (
+            "import subprocess\n"
+            "def main():\n"
+            "    subprocess.run(['git', 'reset', '--hard'])\n"
+            "if __name__ == '__main__':\n"
+            "    main()\n"
+        ),
+    )
+
+    assert MutationEffectGuard(live).detect(f"python {dormant}", live) is None
+    effect = MutationEffectGuard(live).detect(f"python {called}", live)
+
+    assert effect is not None
+    assert effect.operation == "git reset"
+
+
+def test_static_exec_and_subprocess_alias_are_scanned(
+    repos: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    live, _ = repos
+    aliased = _script(
+        tmp_path,
+        "aliased.py",
+        (
+            "import subprocess\n"
+            "runner = subprocess.run\n"
+            "runner(['git', 'checkout', 'main'])\n"
+        ),
+    )
+
+    alias_effect = MutationEffectGuard(live).detect(f"python {aliased}", live)
+    exec_effect = MutationEffectGuard(live).detect(
+        (
+            "python -c \"exec(\\\"import os; "
+            "os.system('git reset --hard')\\\")\""
+        ),
+        live,
+    )
+
+    assert alias_effect is not None
+    assert alias_effect.operation == "git checkout"
+    assert exec_effect is not None
+    assert exec_effect.operation == "git reset"
+
+
+def test_wrapper_blocks_only_interpreter_owned_effect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools import terminal_mutation_guard as wrapper
+
+    nested = MutationEffect(
+        operation="git reset",
+        message="blocked",
+        origin="terminal command via script.py via subprocess.run",
+    )
+    monkeypatch.setattr(wrapper, "_terminal_effect", lambda *args, **kwargs: nested)
+    monkeypatch.setattr(
+        wrapper._terminal_owner,
+        "_handle_terminal",
+        lambda *args, **kwargs: "delegated",
+    )
+
+    payload = json.loads(
+        wrapper._handle_terminal_with_effect_guard({"command": "python x.py"})
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["exit_code"] == 1
+    assert "indirection" in payload["error"]
+
+
+def test_wrapper_preserves_existing_direct_command_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools import terminal_mutation_guard as wrapper
+
+    direct = MutationEffect(
+        operation="git reset",
+        message="blocked",
+        origin="terminal command",
+    )
+    monkeypatch.setattr(wrapper, "_terminal_effect", lambda *args, **kwargs: direct)
+    monkeypatch.setattr(
+        wrapper._terminal_owner,
+        "_handle_terminal",
+        lambda *args, **kwargs: "delegated",
+    )
+
+    assert wrapper._handle_terminal_with_effect_guard(
+        {"command": "git reset --hard"},
+    ) == "delegated"
+
+
+def test_terminal_effect_uses_the_terminal_owner_cwd_pipeline(
+    repos: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools import approval
+    from tools import terminal_mutation_guard as wrapper
+
+    live, other = repos
+    script = live / "upgrade.py"
+    script.write_text(
+        "import subprocess\n"
+        "subprocess.run(['git', 'reset', '--hard'], check=True)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        wrapper._terminal_owner,
+        "_get_env_config",
+        lambda: {"env_type": "local", "cwd": str(other)},
+    )
+    monkeypatch.setattr(
+        wrapper._terminal_owner,
+        "resolve_task_overrides",
+        lambda task_id: {"cwd": str(live)} if task_id == "session-a" else {},
+    )
+    monkeypatch.setattr(wrapper._terminal_owner, "get_session_cwd", lambda key: None)
+    monkeypatch.setattr(approval, "get_current_session_key", lambda default="": "")
+
+    effect = wrapper._terminal_effect(
+        {"command": "python upgrade.py"},
+        {"task_id": "session-a"},
+        source_root=live,
+        active=True,
+    )
+
+    assert effect is not None
+    assert effect.operation == "git reset"
+
+
+def test_terminal_effect_skips_nonlocal_execution_owner(
+    repos: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools import terminal_mutation_guard as wrapper
+
+    live, _ = repos
+    monkeypatch.setattr(
+        wrapper._terminal_owner,
+        "_get_env_config",
+        lambda: {"env_type": "ssh", "cwd": str(live)},
+    )
+
+    assert (
+        wrapper._terminal_effect(
+            {"command": "python upgrade.py"},
+            {},
+            source_root=live,
+            active=True,
+        )
+        is None
+    )

--- a/tools/mutation_effect_guard.py
+++ b/tools/mutation_effect_guard.py
@@ -1,0 +1,484 @@
+"""Effect-aware self-repo mutation analysis for interpreter-backed terminal calls.
+
+The existing Windows guard correctly blocks a literal ``git reset``/``checkout``
+against the checkout backing the running Hermes process.  This module closes the
+next execution shape without widening the terminal backend itself: inspect local
+interpreter inputs before the canonical terminal handler runs, recover statically
+visible child-process commands, and feed those effects through the existing
+self-repo guard.
+
+This remains a bounded pre-execution heuristic, not a sandbox.  It intentionally
+does not execute user code or guess dynamic values.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from tools.approval import (
+    _bash_exec_payload,
+    _deobfuscate_shell_word_for_detection,
+    _iter_shell_command_starts,
+    _read_shell_word,
+)
+from tools.self_repo_guard import detect_self_repo_git_mutation
+
+
+_MAX_SCRIPT_BYTES = 512 * 1024
+_MAX_EFFECT_DEPTH = 4
+_MAX_SHELL_WORDS = 128
+_PYTHON_EXE_RE = re.compile(
+    r"^(?:pythonw?|pypy)(?:\d+(?:\.\d+)*)?$",
+    re.IGNORECASE,
+)
+_ASSIGNMENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=(.*)", re.DOTALL)
+
+_SUDO_OPTIONS_WITH_ARG = frozenset({
+    "-C", "--chdir", "-c", "--close-from", "-g", "--group", "-h", "--host",
+    "-p", "--prompt", "-R", "--chroot", "-T", "--command-timeout", "-u", "--user",
+})
+_ENV_OPTIONS_WITH_ARG = frozenset({
+    "-a", "--argv0", "-C", "--chdir", "-S", "--split-string", "-u", "--unset",
+})
+_WRAPPER_OPTIONS_WITH_ARG = {
+    "exec": frozenset({"-a"}),
+    "time": frozenset({"-f", "--format", "-o", "--output"}),
+}
+_SIMPLE_WRAPPERS = frozenset({"builtin", "exec", "nohup", "setsid", "time"})
+_SHELL_EXECUTABLES = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
+
+
+@dataclass(frozen=True)
+class MutationEffect:
+    """One statically recovered operation that would rewrite the live checkout."""
+
+    operation: str
+    message: str
+    origin: str
+    script_path: Path | None = None
+
+
+def _resolve_path(value: str | os.PathLike[str], base: Path) -> Path:
+    path = Path(os.path.expanduser(os.fspath(value)))
+    if not path.is_absolute():
+        path = base / path
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return path
+
+
+def _executable_name(value: str) -> str:
+    return Path(value.replace("\\", "/")).name.removesuffix(".exe").lower()
+
+
+def _shell_word_value(raw_word: str) -> str:
+    """Decode one shell word without corrupting quoted interpreter payload data."""
+
+    try:
+        values = shlex.split(raw_word, posix=True)
+    except ValueError:
+        values = []
+    if len(values) == 1:
+        return values[0]
+    # The existing detector deliberately recognizes a narrow class of
+    # command-word obfuscations (for example literal command substitutions).
+    # Keep that behavior only when ordinary shell decoding cannot produce one
+    # semantic word; using it unconditionally destroys quotes *inside* data
+    # arguments such as Python ``-c`` source.
+    return _deobfuscate_shell_word_for_detection(raw_word)
+
+
+def _shell_words_at(command: str, start: int) -> list[str]:
+    words: list[str] = []
+    cursor = start
+    for _ in range(_MAX_SHELL_WORDS):
+        word_start, word_end, raw_word = _read_shell_word(command, cursor)
+        if word_start == word_end:
+            break
+        if words and "\n" in command[cursor:word_start]:
+            break
+        words.append(_shell_word_value(raw_word))
+        cursor = word_end
+    return words
+
+
+def _consume_options(
+    words: list[str],
+    start: int,
+    options_with_arg: frozenset[str],
+) -> int:
+    index = start
+    while index < len(words):
+        option = words[index]
+        if option == "--":
+            return index + 1
+        if not option.startswith("-") or option == "-":
+            break
+        option_name = option.split("=", 1)[0]
+        if "=" not in option and option_name in options_with_arg:
+            index += 2
+        else:
+            index += 1
+    return index
+
+
+def _command_parts(words: list[str]) -> tuple[str | None, list[str]]:
+    index = 0
+    while index < len(words):
+        if _ASSIGNMENT_RE.fullmatch(words[index]):
+            index += 1
+            continue
+        executable = _executable_name(words[index])
+        if executable == "sudo":
+            index = _consume_options(words, index + 1, _SUDO_OPTIONS_WITH_ARG)
+            continue
+        if executable == "env":
+            index = _consume_options(words, index + 1, _ENV_OPTIONS_WITH_ARG)
+            continue
+        if executable == "command":
+            if index + 1 < len(words) and words[index + 1] in {"-v", "-V"}:
+                return None, []
+            index = _consume_options(words, index + 1, frozenset())
+            continue
+        if executable in _SIMPLE_WRAPPERS:
+            index = _consume_options(
+                words,
+                index + 1,
+                _WRAPPER_OPTIONS_WITH_ARG.get(executable, frozenset()),
+            )
+            continue
+        return words[index], words[index + 1 :]
+    return None, []
+
+
+def _shell_script_arg(args: list[str]) -> str | None:
+    has_c, payload = _bash_exec_payload(args)
+    if has_c:
+        return payload
+    for index, arg in enumerate(args):
+        if arg == "--":
+            break
+        if arg.startswith("-") and "c" in arg[1:]:
+            return args[index + 1] if index + 1 < len(args) else None
+        if not arg.startswith("-"):
+            break
+    return None
+
+
+def _python_source_arg(args: list[str]) -> tuple[str, str | None]:
+    """Return ``(\"code\"|\"path\"|\"none\", value)`` for Python/py launcher argv."""
+
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--":
+            return (
+                ("path", args[index + 1])
+                if index + 1 < len(args)
+                else ("none", None)
+            )
+        if arg == "-":
+            return "none", None
+        if arg == "-c":
+            return (
+                ("code", args[index + 1])
+                if index + 1 < len(args)
+                else ("none", None)
+            )
+        if arg == "-m":
+            return "none", None
+        if arg in {"-W", "-X"}:
+            index += 2
+            continue
+        if arg.startswith(("-W", "-X")) and len(arg) > 2:
+            index += 1
+            continue
+        # Windows py launcher selectors: -3, -3.12, -V:Company/Tag.
+        if re.fullmatch(r"-\d+(?:\.\d+)?(?:-\d+)?", arg) or arg.startswith("-V:"):
+            index += 1
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        return "path", arg
+    return "none", None
+
+
+def _unwrap_runner(executable: str, args: list[str]) -> tuple[str, list[str]]:
+    """Unwrap common environment runners that preserve a nested command argv."""
+
+    name = _executable_name(executable)
+    if name == "uv" and args[:1] == ["run"]:
+        index = 1
+        options_with_arg = {
+            "--directory",
+            "--project",
+            "--python",
+            "--with",
+            "--with-editable",
+        }
+        while index < len(args):
+            arg = args[index]
+            if arg == "--":
+                index += 1
+                break
+            option = arg.split("=", 1)[0]
+            if not arg.startswith("-"):
+                break
+            index += 2 if "=" not in arg and option in options_with_arg else 1
+        if index < len(args):
+            return args[index], args[index + 1 :]
+    if name in {"poetry", "pipenv"} and args[:1] == ["run"] and len(args) > 1:
+        return args[1], args[2:]
+    return executable, args
+
+
+class MutationEffectGuard:
+    """Recover terminal-visible interpreter effects and reuse the live-repo guard."""
+
+    def __init__(
+        self,
+        source_root: Path,
+        *,
+        max_script_bytes: int = _MAX_SCRIPT_BYTES,
+        max_depth: int = _MAX_EFFECT_DEPTH,
+        command_detector: Callable[
+            [str, str | None, Path | None],
+            tuple[bool, str | None],
+        ] = detect_self_repo_git_mutation,
+    ) -> None:
+        self.source_root = _resolve_path(source_root, Path("/"))
+        self.max_script_bytes = max(1, int(max_script_bytes))
+        self.max_depth = max(1, int(max_depth))
+        self._command_detector = command_detector
+
+    def detect(
+        self,
+        command: str,
+        cwd: str | os.PathLike[str] | None,
+    ) -> MutationEffect | None:
+        """Return the first live-checkout mutation effect, otherwise ``None``."""
+
+        if not isinstance(command, str) or not command.strip():
+            return None
+        base = _resolve_path(cwd or os.getcwd(), Path("/"))
+        return self._detect_command(command, base, depth=0, origin="terminal command")
+
+    def _detect_command(
+        self,
+        command: str,
+        cwd: Path,
+        *,
+        depth: int,
+        origin: str,
+    ) -> MutationEffect | None:
+        if depth > self.max_depth:
+            return MutationEffect(
+                operation=f"interpreter effect depth >{self.max_depth}",
+                message=(
+                    "Blocked: interpreter indirection exceeded the self-repo mutation "
+                    "analysis depth while Hermes is running. Run the operation from a "
+                    "separate checkout, or stop Hermes and execute it externally."
+                ),
+                origin=origin,
+            )
+
+        hit, message = self._command_detector(command, str(cwd), self.source_root)
+        if hit:
+            operation = self._operation_from_message(message)
+            return MutationEffect(
+                operation=operation,
+                message=message or self._fallback_message(operation),
+                origin=origin,
+            )
+
+        current_cwd = cwd
+        for start in sorted(set(_iter_shell_command_starts(command))):
+            words = _shell_words_at(command, start)
+            executable, args = _command_parts(words)
+            if executable is None:
+                continue
+
+            name = _executable_name(executable)
+            if name in {"cd", "pushd"}:
+                target = next((arg for arg in args if not arg.startswith("-")), None)
+                if target:
+                    candidate = _resolve_path(target, current_cwd)
+                    if candidate.is_dir():
+                        current_cwd = candidate
+                continue
+
+            executable, args = _unwrap_runner(executable, args)
+            name = _executable_name(executable)
+
+            if _PYTHON_EXE_RE.fullmatch(name) or name == "py":
+                effect = self._inspect_python_invocation(
+                    args,
+                    current_cwd,
+                    depth=depth + 1,
+                    origin=origin,
+                )
+                if effect:
+                    return effect
+                continue
+
+            if name in _SHELL_EXECUTABLES:
+                payload = _shell_script_arg(args)
+                if payload:
+                    effect = self._detect_command(
+                        payload,
+                        current_cwd,
+                        depth=depth + 1,
+                        origin=f"{origin} via {name} -c",
+                    )
+                    if effect:
+                        return effect
+                continue
+
+            if name in {"cmd", "cmd.exe"}:
+                for flag in ("/c", "/k"):
+                    if flag in [arg.lower() for arg in args]:
+                        index = [arg.lower() for arg in args].index(flag)
+                        payload = " ".join(args[index + 1 :])
+                        if payload:
+                            effect = self._detect_command(
+                                payload,
+                                current_cwd,
+                                depth=depth + 1,
+                                origin=f"{origin} via cmd {flag}",
+                            )
+                            if effect:
+                                return effect
+                        break
+                continue
+
+            if name in {"powershell", "pwsh"}:
+                lowered = [arg.lower() for arg in args]
+                for flag in ("-command", "-c"):
+                    if flag in lowered:
+                        index = lowered.index(flag)
+                        payload = " ".join(args[index + 1 :])
+                        if payload:
+                            effect = self._detect_command(
+                                payload,
+                                current_cwd,
+                                depth=depth + 1,
+                                origin=f"{origin} via {name} {flag}",
+                            )
+                            if effect:
+                                return effect
+                        break
+
+        return None
+
+    def _inspect_python_invocation(
+        self,
+        args: list[str],
+        cwd: Path,
+        *,
+        depth: int,
+        origin: str,
+    ) -> MutationEffect | None:
+        source_kind, value = _python_source_arg(args)
+        if source_kind == "none" or value is None:
+            return None
+        if source_kind == "code":
+            return self._inspect_python_source(
+                value,
+                cwd,
+                script_path=None,
+                depth=depth,
+                origin=f"{origin} via Python -c",
+            )
+
+        script_path = _resolve_path(value, cwd)
+        try:
+            stat_result = script_path.stat()
+        except OSError:
+            # A missing/unreadable script cannot be executed successfully. Let
+            # the terminal owner report its ordinary execution error.
+            return None
+        if not script_path.is_file():
+            return MutationEffect(
+                operation="unscannable interpreter input",
+                message=self._unscannable_message(script_path, "is not a regular file"),
+                origin=origin,
+                script_path=script_path,
+            )
+        if stat_result.st_size > self.max_script_bytes:
+            return MutationEffect(
+                operation="oversized interpreter input",
+                message=self._unscannable_message(
+                    script_path,
+                    f"exceeds the {self.max_script_bytes}-byte analysis limit",
+                ),
+                origin=origin,
+                script_path=script_path,
+            )
+        try:
+            source = script_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            return MutationEffect(
+                operation="unscannable interpreter input",
+                message=self._unscannable_message(
+                    script_path,
+                    "could not be read as UTF-8",
+                ),
+                origin=origin,
+                script_path=script_path,
+            )
+        return self._inspect_python_source(
+            source,
+            cwd,
+            script_path=script_path,
+            depth=depth,
+            origin=f"{origin} via {script_path}",
+        )
+
+    def _inspect_python_source(
+        self,
+        source: str,
+        cwd: Path,
+        *,
+        script_path: Path | None,
+        depth: int,
+        origin: str,
+    ) -> MutationEffect | None:
+        from tools.python_mutation_effects import scan_python_effect
+
+        return scan_python_effect(
+            source,
+            cwd=cwd,
+            script_path=script_path,
+            depth=depth,
+            origin=origin,
+            detect_command=self._detect_command,
+        )
+
+    @staticmethod
+    def _operation_from_message(message: str | None) -> str:
+        if not message:
+            return "self-repo mutation"
+        match = re.search(r"Blocked: `([^`]+)`", message)
+        return match.group(1) if match else "self-repo mutation"
+
+    def _fallback_message(self, operation: str) -> str:
+        return (
+            f"Blocked: `{operation}` would rewrite Hermes's live source checkout "
+            f"({self.source_root}). Interpreter or script indirection does not change "
+            "that boundary. Use a separate checkout, or stop Hermes and run the "
+            "operation externally."
+        )
+
+    def _unscannable_message(self, path: Path, detail: str) -> str:
+        return (
+            f"Blocked: interpreter input {path} {detail}, so Hermes cannot prove it "
+            f"will leave the live source checkout ({self.source_root}) unchanged. "
+            "Run it from a separate checkout, or stop Hermes and execute it externally."
+        )

--- a/tools/python_mutation_effects.py
+++ b/tools/python_mutation_effects.py
@@ -1,0 +1,452 @@
+"""Static Python child-process effect recovery for MutationEffectGuard."""
+
+from __future__ import annotations
+
+import ast
+import os
+import shlex
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from tools.mutation_effect_guard import MutationEffect, _resolve_path
+
+
+_SUBPROCESS_ARGV_CALLS = frozenset({
+    "subprocess.call",
+    "subprocess.check_call",
+    "subprocess.check_output",
+    "subprocess.Popen",
+    "subprocess.run",
+    "asyncio.create_subprocess_exec",
+})
+_SUBPROCESS_SHELL_CALLS = frozenset({
+    "os.popen",
+    "os.system",
+    "asyncio.create_subprocess_shell",
+})
+_PATH_CONSTRUCTORS = frozenset({"Path", "pathlib.Path"})
+_STATIC_CALLABLES = (
+    _SUBPROCESS_ARGV_CALLS
+    | _SUBPROCESS_SHELL_CALLS
+    | _PATH_CONSTRUCTORS
+    | frozenset({
+        "eval",
+        "exec",
+        "os.fspath",
+        "runpy.run_path",
+        "str",
+    })
+)
+_UNKNOWN = object()
+
+
+def scan_python_effect(
+    source: str,
+    *,
+    cwd: Path,
+    script_path: Path | None,
+    depth: int,
+    origin: str,
+    detect_command: Callable[..., MutationEffect | None],
+) -> MutationEffect | None:
+    """Parse Python source without executing it and return its first mutation."""
+
+    try:
+        tree = ast.parse(source, filename=str(script_path or "<python -c>"))
+    except (SyntaxError, ValueError):
+        # Python will reject the source before any side effect occurs.
+        return None
+    scanner = _PythonEffectScanner(
+        detect_command=detect_command,
+        cwd=cwd,
+        script_path=script_path,
+        depth=depth,
+        origin=origin,
+    )
+    scanner.visit(tree)
+    return scanner.effect
+
+
+class _PythonEffectScanner(ast.NodeVisitor):
+    """Conservative, side-effect-free evaluator for process-spawning Python AST."""
+
+    def __init__(
+        self,
+        *,
+        detect_command: Callable[..., MutationEffect | None],
+        cwd: Path,
+        script_path: Path | None,
+        depth: int,
+        origin: str,
+    ) -> None:
+        self.detect_command = detect_command
+        self.cwd = cwd
+        self.script_path = script_path
+        self.depth = depth
+        self.origin = origin
+        self.effect: MutationEffect | None = None
+        self.bindings: dict[str, Any] = {"__name__": "__main__"}
+        self.imports: dict[str, str] = {
+            "Path": "pathlib.Path",
+        }
+        self.functions: dict[
+            str,
+            ast.FunctionDef | ast.AsyncFunctionDef,
+        ] = {}
+        self.active_functions: set[str] = set()
+        if script_path is not None:
+            self.bindings["__file__"] = script_path
+
+    def visit(self, node: ast.AST) -> Any:
+        if self.effect is not None:
+            return None
+        return super().visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.functions[node.name] = node
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.functions[node.name] = node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        # Class bodies can execute arbitrary code, but descending into methods
+        # would confuse definitions with effects. Inspect only decorators and
+        # base expressions, which Python evaluates while creating the class.
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        # A lambda body is dormant until invocation. Static local-function
+        # expansion below deliberately supports named defs only.
+        return None
+
+    def visit_If(self, node: ast.If) -> None:
+        truth = self._truth_value(node.test)
+        if truth is True:
+            statements = node.body
+        elif truth is False:
+            statements = node.orelse
+        else:
+            self.visit(node.test)
+            statements = [*node.body, *node.orelse]
+        for statement in statements:
+            self.visit(statement)
+            if self.effect is not None:
+                break
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.imports[alias.asname or alias.name.split(".", 1)[0]] = alias.name
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module:
+            for alias in node.names:
+                if alias.name != "*":
+                    self.imports[alias.asname or alias.name] = (
+                        f"{node.module}.{alias.name}"
+                    )
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        value = self._resolve(node.value)
+        for target in node.targets:
+            self._bind_target(target, value)
+        self.generic_visit(node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        value = self._resolve(node.value) if node.value is not None else _UNKNOWN
+        self._bind_target(node.target, value)
+        if node.value is not None:
+            self.generic_visit(node.value)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        value = self._resolve(node.value)
+        self._bind_target(node.target, value)
+        self.generic_visit(node.value)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Name) and node.func.id in self.functions:
+            self._visit_local_function(node.func.id, node)
+            return
+
+        qualified = self._qualified_name(node.func)
+        if qualified in {"os.chdir", "os.fchdir"}:
+            target = self._resolve_call_arg(node, 0, "path")
+            path = self._as_path(target, self.cwd)
+            if path is not None:
+                self.cwd = path
+        elif qualified in _SUBPROCESS_ARGV_CALLS:
+            if qualified == "asyncio.create_subprocess_exec":
+                command = [self._resolve(arg) for arg in node.args]
+            else:
+                command = self._resolve_call_arg(node, 0, "args")
+            call_cwd = self._call_cwd(node)
+            command_text = self._command_text(command)
+            if command_text:
+                self.effect = self.detect_command(
+                    command_text,
+                    call_cwd,
+                    depth=self.depth + 1,
+                    origin=f"{self.origin} via {qualified}",
+                )
+        elif qualified in _SUBPROCESS_SHELL_CALLS:
+            command = self._resolve_call_arg(node, 0, "command")
+            if command is _UNKNOWN:
+                command = self._resolve_call_arg(node, 0, "cmd")
+            if isinstance(command, str):
+                self.effect = self.detect_command(
+                    command,
+                    self._call_cwd(node),
+                    depth=self.depth + 1,
+                    origin=f"{self.origin} via {qualified}",
+                )
+        elif qualified in {"exec", "eval"}:
+            source = self._resolve_call_arg(node, 0, "source")
+            if isinstance(source, str):
+                command = shlex.join([sys.executable, "-c", source])
+                self.effect = self.detect_command(
+                    command,
+                    self.cwd,
+                    depth=self.depth + 1,
+                    origin=f"{self.origin} via {qualified}",
+                )
+        elif qualified == "runpy.run_path":
+            path = self._as_path(
+                self._resolve_call_arg(node, 0, "path_name"),
+                self.cwd,
+            )
+            if path is not None:
+                command = shlex.join([sys.executable, os.fspath(path)])
+                self.effect = self.detect_command(
+                    command,
+                    self.cwd,
+                    depth=self.depth + 1,
+                    origin=f"{self.origin} via runpy.run_path",
+                )
+        if self.effect is None:
+            self.generic_visit(node)
+
+    def _visit_local_function(self, name: str, call: ast.Call) -> None:
+        function = self.functions[name]
+        if name in self.active_functions:
+            return
+
+        saved_bindings = dict(self.bindings)
+        saved_imports = dict(self.imports)
+        saved_functions = dict(self.functions)
+        parameters = [
+            *function.args.posonlyargs,
+            *function.args.args,
+        ]
+        positional = [self._resolve(value) for value in call.args]
+        keyword_values = {
+            item.arg: self._resolve(item.value)
+            for item in call.keywords
+            if item.arg is not None
+        }
+        defaults_offset = len(parameters) - len(function.args.defaults)
+        for index, parameter in enumerate(parameters):
+            if index < len(positional):
+                value = positional[index]
+            elif parameter.arg in keyword_values:
+                value = keyword_values[parameter.arg]
+            elif index >= defaults_offset:
+                value = self._resolve(
+                    function.args.defaults[index - defaults_offset]
+                )
+            else:
+                value = _UNKNOWN
+            self.bindings[parameter.arg] = value
+
+        self.active_functions.add(name)
+        try:
+            for statement in function.body:
+                self.visit(statement)
+                if self.effect is not None:
+                    break
+        finally:
+            self.active_functions.discard(name)
+            self.bindings = saved_bindings
+            self.imports = saved_imports
+            self.functions = saved_functions
+
+    def _truth_value(self, node: ast.AST) -> bool | None:
+        value = self._resolve(node)
+        if isinstance(value, bool):
+            return value
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+            nested = self._truth_value(node.operand)
+            return None if nested is None else not nested
+        if (
+            isinstance(node, ast.Compare)
+            and len(node.ops) == 1
+            and len(node.comparators) == 1
+        ):
+            left = self._resolve(node.left)
+            right = self._resolve(node.comparators[0])
+            if left is not _UNKNOWN and right is not _UNKNOWN:
+                if isinstance(node.ops[0], (ast.Eq, ast.Is)):
+                    return left == right
+                if isinstance(node.ops[0], (ast.NotEq, ast.IsNot)):
+                    return left != right
+        return None
+
+    def _bind_target(self, target: ast.AST, value: Any) -> None:
+        if isinstance(target, ast.Name):
+            self.bindings[target.id] = value
+            return
+        if isinstance(target, (ast.Tuple, ast.List)) and isinstance(
+            value,
+            (list, tuple),
+        ):
+            for item, item_value in zip(target.elts, value):
+                self._bind_target(item, item_value)
+
+    def _qualified_name(self, node: ast.AST) -> str | None:
+        if isinstance(node, ast.Name):
+            imported = self.imports.get(node.id)
+            if imported is not None:
+                return imported
+            bound = self.bindings.get(node.id)
+            if isinstance(bound, str) and bound in _STATIC_CALLABLES:
+                return bound
+            return node.id
+        if isinstance(node, ast.Attribute):
+            prefix = self._qualified_name(node.value)
+            return f"{prefix}.{node.attr}" if prefix else None
+        return None
+
+    def _resolve_call_arg(self, node: ast.Call, index: int, keyword: str) -> Any:
+        if index < len(node.args):
+            return self._resolve(node.args[index])
+        for item in node.keywords:
+            if item.arg == keyword:
+                return self._resolve(item.value)
+        return _UNKNOWN
+
+    def _call_cwd(self, node: ast.Call) -> Path:
+        for item in node.keywords:
+            if item.arg == "cwd":
+                path = self._as_path(self._resolve(item.value), self.cwd)
+                if path is not None:
+                    return path
+        return self.cwd
+
+    @staticmethod
+    def _command_text(value: Any) -> str | None:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple)) and value and all(
+            isinstance(item, (str, os.PathLike)) for item in value
+        ):
+            return shlex.join(os.fspath(item) for item in value)
+        return None
+
+    @staticmethod
+    def _as_path(value: Any, base: Path) -> Path | None:
+        if isinstance(value, (str, os.PathLike)):
+            return _resolve_path(value, base)
+        return None
+
+    def _resolve(self, node: ast.AST | None) -> Any:
+        if node is None:
+            return _UNKNOWN
+        if isinstance(node, ast.Constant):
+            return node.value
+        if isinstance(node, ast.Name):
+            return self.bindings.get(node.id, _UNKNOWN)
+        if isinstance(node, (ast.List, ast.Tuple)):
+            values = [self._resolve(item) for item in node.elts]
+            return values if isinstance(node, ast.List) else tuple(values)
+        if isinstance(node, ast.JoinedStr):
+            parts: list[str] = []
+            for value in node.values:
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    parts.append(value.value)
+                    continue
+                if isinstance(value, ast.FormattedValue):
+                    resolved = self._resolve(value.value)
+                    if resolved is _UNKNOWN:
+                        return _UNKNOWN
+                    parts.append(
+                        os.fspath(resolved)
+                        if isinstance(resolved, os.PathLike)
+                        else str(resolved)
+                    )
+                    continue
+                return _UNKNOWN
+            return "".join(parts)
+        if isinstance(node, ast.BinOp):
+            left = self._resolve(node.left)
+            right = self._resolve(node.right)
+            if isinstance(node.op, ast.Add):
+                if isinstance(left, str) and isinstance(right, str):
+                    return left + right
+                if isinstance(left, list) and isinstance(right, list):
+                    return left + right
+                if isinstance(left, tuple) and isinstance(right, tuple):
+                    return left + right
+            if (
+                isinstance(node.op, ast.Div)
+                and isinstance(left, (str, os.PathLike))
+                and isinstance(right, (str, os.PathLike))
+            ):
+                return Path(left) / Path(right)
+            return _UNKNOWN
+        if isinstance(node, ast.Attribute):
+            value = self._resolve(node.value)
+            if node.attr == "parent" and isinstance(value, Path):
+                return value.parent
+            qualified = self._qualified_name(node)
+            if qualified == "sys.executable":
+                return sys.executable
+            return qualified if qualified else _UNKNOWN
+        if isinstance(node, ast.Call):
+            qualified = self._qualified_name(node.func)
+            if qualified in _PATH_CONSTRUCTORS:
+                parts = [self._resolve(arg) for arg in node.args]
+                if parts and all(
+                    isinstance(item, (str, os.PathLike)) for item in parts
+                ):
+                    return Path(parts[0]).joinpath(
+                        *(os.fspath(item) for item in parts[1:])
+                    )
+                return _UNKNOWN
+            if qualified in {"str", "os.fspath"} and node.args:
+                value = self._resolve(node.args[0])
+                if isinstance(value, (str, os.PathLike)):
+                    return os.fspath(value)
+                return _UNKNOWN
+            if qualified in {"os.getcwd", "pathlib.Path.cwd", "Path.cwd"}:
+                return self.cwd
+            if qualified == "os.path.join":
+                parts = [self._resolve(arg) for arg in node.args]
+                if parts and all(
+                    isinstance(item, (str, os.PathLike)) for item in parts
+                ):
+                    return os.path.join(*(os.fspath(item) for item in parts))
+                return _UNKNOWN
+            if qualified == "os.path.dirname" and node.args:
+                value = self._resolve(node.args[0])
+                if isinstance(value, (str, os.PathLike)):
+                    return os.path.dirname(os.fspath(value))
+                return _UNKNOWN
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "split":
+                value = self._resolve(node.func.value)
+                if isinstance(value, str) and not node.args and not node.keywords:
+                    return value.split()
+                return _UNKNOWN
+            if isinstance(node.func, ast.Attribute) and node.func.attr in {
+                "absolute", "resolve",
+            }:
+                value = self._resolve(node.func.value)
+                path = self._as_path(value, self.cwd)
+                return path.resolve() if path is not None else _UNKNOWN
+            return _UNKNOWN
+        return _UNKNOWN

--- a/tools/terminal_mutation_guard.py
+++ b/tools/terminal_mutation_guard.py
@@ -1,0 +1,106 @@
+"""Canonical terminal registration wrapper for interpreter-backed mutation effects."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from tools import terminal_tool as _terminal_owner
+from tools.mutation_effect_guard import MutationEffect, MutationEffectGuard
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+
+def _terminal_effect(
+    args: dict[str, Any],
+    kwargs: dict[str, Any],
+    *,
+    source_root: Path | None = None,
+    active: bool | None = None,
+) -> MutationEffect | None:
+    """Resolve and inspect the exact local terminal context before delegation."""
+
+    command = args.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return None
+
+    from tools.self_repo_guard import get_running_source_root, guard_active
+
+    if active is None:
+        active = guard_active()
+    if not active:
+        return None
+
+    config = _terminal_owner._get_env_config()
+    if config.get("env_type") != "local":
+        return None
+
+    root = source_root if source_root is not None else get_running_source_root()
+    if root is None:
+        return None
+
+    from tools.approval import get_current_session_key
+
+    task_id = kwargs.get("task_id") or ""
+    overrides = _terminal_owner.resolve_task_overrides(task_id)
+    default_cwd = (
+        overrides.get("cwd")
+        or _terminal_owner.get_session_cwd(task_id)
+        or config.get("cwd")
+    )
+    session_key = get_current_session_key(default="") or task_id
+    guard_cwd = _terminal_owner._resolve_command_cwd(
+        workdir=args.get("workdir"),
+        default_cwd=default_cwd,
+        session_key=session_key,
+    )
+    return MutationEffectGuard(Path(root)).detect(command, guard_cwd)
+
+
+def _blocked_result(effect: MutationEffect) -> str:
+    message = effect.message
+    if effect.origin != "terminal command":
+        message = (
+            f"{message} Interpreter or script indirection does not change this "
+            "boundary; the recovered operation was not executed."
+        )
+    return json.dumps(
+        {
+            "output": "",
+            "exit_code": 1,
+            "error": message,
+            "status": "blocked",
+        },
+        ensure_ascii=False,
+    )
+
+
+def _handle_terminal_with_effect_guard(args: dict[str, Any], **kwargs: Any) -> str:
+    effect = _terminal_effect(args, kwargs)
+    # Preserve the existing direct-command owner and its exact terminal timing.
+    # This wrapper owns only effects hidden behind an interpreter boundary.
+    if effect is not None and effect.origin != "terminal command":
+        logger.warning(
+            "Blocked interpreter-backed self-repo mutation: %s (%s)",
+            effect.operation,
+            effect.origin,
+        )
+        return _blocked_result(effect)
+    return _terminal_owner._handle_terminal(args, **kwargs)
+
+
+# This module is discovered as a built-in tool registration. Importing the
+# terminal owner above materializes its schema/handler first; this registration
+# then replaces only the handler while retaining the canonical contract.
+registry.register(
+    name="terminal",
+    toolset="terminal",
+    schema=_terminal_owner.TERMINAL_SCHEMA,
+    handler=_handle_terminal_with_effect_guard,
+    check_fn=_terminal_owner.check_terminal_requirements,
+    emoji="💻",
+    max_result_size_chars=100_000,
+)


### PR DESCRIPTION
## What does this PR do?

Closes the real `write_file` → Python interpreter bypass reported in #98078 without widening `tools/terminal_tool.py` or treating inert file contents as executed effects.

The new bounded guard resolves the terminal owner's actual local cwd, reads only an interpreter input that is about to execute, statically recovers visible child-process effects, and feeds each recovered command through the existing live-checkout mutation detector. The canonical terminal owner still handles literal commands, all execution backends, approvals, sessions, PTY/background behavior, and result formatting; this PR owns only operations hidden behind interpreter indirection.

The first hosted run also exposed a parser defect in the new guard itself: shell command-word deobfuscation was being applied to Python `-c` payload data, stripping nested quotes and making three executable mutation witnesses syntactically inert to the AST scanner. The submitted release object fixes that boundary by decoding ordinary shell argv with `shlex` and retaining the existing narrow deobfuscator only as a fallback when one semantic shell word cannot be recovered.

## Related Issue

Fixes #98078.

Interlock: #81664 owns fail-closed Git alias expansion inside the existing direct-command detector. This PR does not duplicate or overwrite that work; every recovered child command is delegated to that detector, so #81664 composes underneath this effect layer when landed.

Adjacent but distinct: #65592 covers generated-code execution policy, and #83787 covers file-tool execution-root writes. Neither owns the terminal interpreter chain reported here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `tools/mutation_effect_guard.py` — bounded command/interpreter orchestration; unwraps common runners, preserves shell cwd and quoted interpreter payload data, inspects Python files/`-c` payloads, and fails closed on oversized or unreadable executable inputs.
- `tools/python_mutation_effects.py` — side-effect-free AST recovery for `subprocess`, `os.system`/`popen`, aliases, named function calls, `__name__` gates, static `exec`/`eval`, `runpy`, path composition, and nested interpreter launches.
- `tools/terminal_mutation_guard.py` — canonical registry wrapper that preserves the existing terminal schema and delegates every safe/direct/non-local command unchanged.
- `tests/tools/test_mutation_effect_guard.py` — adversarial witness for the exact incident plus nested interpreters, aliases, cwd targeting, `uv run`, fail-closed limits, dormant helpers, unrelated repositories, and execution-owner continuity.

Original incident provenance is preserved in the submitted commit:

```text
Reported-by: LShang001 <67504607+LShang001@users.noreply.github.com>
```

## How to Test

1. Run the focused effect and existing direct-guard suites:

   ```bash
   python -m pytest -q \
     tests/tools/test_mutation_effect_guard.py \
     tests/tools/test_self_repo_guard.py
   ```

2. Run lint and source-integrity checks:

   ```bash
   python -m ruff check \
     tools/mutation_effect_guard.py \
     tools/python_mutation_effects.py \
     tools/terminal_mutation_guard.py \
     tests/tools/test_mutation_effect_guard.py
   git diff --check
   ```

3. On Windows with Hermes running from a git checkout, write a Python script that calls `subprocess.run(['git', 'reset', '--hard', 'origin/main'], cwd=<live checkout>)`, then execute it through `terminal`. The terminal result must be `status=blocked`, no subprocess may run, and the checkout HEAD/worktree must remain unchanged.

4. Execute a safe Python script, a script mutating a different repository, and the same command under a non-local terminal backend. All must continue through the pre-existing terminal owner.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows Conventional Commits and includes DCO sign-off
- [x] I searched for existing PRs and reconciled the live overlap with #81664
- [x] My PR contains **only** changes related to this fix
- [x] Hosted `pytest tests/ -q` / exact-head CI passes on the submitted release object
- [x] I've added tests for the reported bypass and adversarial sibling shapes
- [x] Deterministic construction harness: 18 focused scenarios passed

### Documentation & Housekeeping

- [x] Documentation/config changes are N/A; no public setting or schema changed
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; the canonical terminal architecture is preserved
- [x] Cross-platform impact considered: activation remains Windows-only through the existing `guard_active()` owner; SSH/container/Modal/Daytona/Singularity backends are explicitly excluded
- [x] Tool description/schema changes are N/A; registration reuses `TERMINAL_SCHEMA`
- [x] Every modified file is below 2,000 lines; no existing godfile was enlarged
- [x] FILE-LIST is exactly four bounded files and remains disjoint from the post-parent main interval

## Verification

| Object | Exact value |
|---|---|
| Construction parent | `c0875ba503ff1d03978831efb159443764fc4db4` |
| Current upstream main cross-check | `60a4442826ee063bf39aa26ebac2af0f347cfce0` |
| Head | `e508e560e0f23dfdbb046307d5ec809b604e255f` |
| Product tree | `0a2bfa88aad20a25d12235ebce32dd46d653886b` |
| Submitted train | exactly 1 surviving commit / 4 files |
| Superseded red object | `639f711e447ce9754fcad0452d6abff4f7eda607` removed from the surviving train |
| First hosted failure | CI `33273553715`: 3 focused failures caused by quote destruction in interpreter payload parsing |
| Exact-head CI | `33286451182` — success |
| Exact-head Docker | `33286450797` — success |
| Exact-head Nix | `33286450823` — success |
| Main drift after construction parent | 1 commit, zero overlap with the four submitted paths |
| Merge state | open, non-draft, mergeable |

## Adversarial acceptance matrix

| Shape | Required outcome |
|---|---|
| Exact reported `write_file` + `python upgrade.py` + `subprocess.run(git reset)` | block before execution |
| Script outside live repo with subprocess `cwd=<live repo>` | block |
| `from subprocess import check_call as run` / assigned callable alias | block |
| `main()` behind `if __name__ == '__main__'` | block |
| Dormant uncalled helper containing mutation text | allow |
| `python -c`, shell-wrapped Python, static `exec`, nested Python script | block |
| `uv run --python … python script.py` | block |
| Missing or syntactically invalid script | delegate ordinary terminal error |
| Oversized/non-UTF-8/nonregular executable input | fail closed |
| Same mutation against another repository | allow |
| SSH/container/other non-local execution owner | delegate unchanged |
| Literal direct `git reset` | remain owned by existing terminal/self-repo guard |

## For New Skills

N/A.

## Screenshots / Logs

The release object is exact-head green across CI, Docker, and Nix; no historical or adjacent commit is used as acceptance evidence.