### PR TITLE
fix(mcp): let Railway OAuth login reach authorization

### DIFF
--- a/tests/tools/test_mcp_oauth_authorization_url.py
+++ b/tests/tools/test_mcp_oauth_authorization_url.py
@@ -1,0 +1,120 @@
+"""Authorization URL compatibility tests for MCP OAuth providers."""
+
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from mcp.shared.auth import (
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthMetadata,
+)
+from pydantic import AnyUrl
+
+from tools.mcp_oauth import HermesTokenStorage
+from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS
+
+
+class _AuthorizationURLCaptured(Exception):
+    pass
+
+
+async def _capture_authorization_url(tmp_path, authorization_endpoint: str) -> str:
+    captured: list[str] = []
+
+    async def redirect_handler(url: str) -> None:
+        captured.append(url)
+        raise _AuthorizationURLCaptured
+
+    async def callback_handler():  # pragma: no cover - redirect stops first
+        raise AssertionError("callback must not run")
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="railway",
+        server_url="https://mcp.railway.com",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=HermesTokenStorage("railway", hermes_home=tmp_path),
+        redirect_handler=redirect_handler,
+        callback_handler=callback_handler,
+    )
+    provider.context.client_info = OAuthClientInformationFull(
+        client_id="test-client",
+        redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method="none",
+    )
+    provider.context.oauth_metadata = OAuthMetadata.model_validate(
+        {
+            "issuer": "https://backboard.railway.com",
+            "authorization_endpoint": authorization_endpoint,
+            "token_endpoint": "https://backboard.railway.com/oauth/token",
+            "response_types_supported": ["code"],
+        }
+    )
+    provider.context.protocol_version = "2025-06-18"
+
+    with pytest.raises(_AuthorizationURLCaptured):
+        await provider._perform_authorization_code_grant()
+
+    return captured[0]
+
+
+@pytest.mark.asyncio
+async def test_authorization_url_joins_existing_query_and_deduplicates_resource(
+    tmp_path,
+):
+    url = await _capture_authorization_url(
+        tmp_path,
+        "https://backboard.railway.com/oauth/auth?"
+        "resource=https%3A%2F%2Fmcp.railway.com",
+    )
+
+    parsed = urlsplit(url)
+    params = parse_qs(parsed.query)
+    assert params["response_type"] == ["code"]
+    assert params["resource"] == ["https://mcp.railway.com"]
+    assert parsed.fragment == ""
+
+
+@pytest.mark.asyncio
+async def test_authorization_url_preserves_existing_encoding_and_fragment(tmp_path):
+    url = await _capture_authorization_url(
+        tmp_path,
+        "https://backboard.railway.com/oauth/auth?"
+        "audience=hello%20world&opaque=a%2Bb#consent",
+    )
+
+    parsed = urlsplit(url)
+    assert parsed.query.startswith("audience=hello%20world&opaque=a%2Bb&")
+    assert parse_qs(parsed.query)["response_type"] == ["code"]
+    assert parsed.fragment == "consent"
+
+
+@pytest.mark.asyncio
+async def test_authorization_url_preserves_distinct_resource_parameters(tmp_path):
+    url = await _capture_authorization_url(
+        tmp_path,
+        "https://backboard.railway.com/oauth/auth?"
+        "resource=https%3A%2F%2Fapi.railway.com",
+    )
+
+    assert parse_qs(urlsplit(url).query)["resource"] == [
+        "https://api.railway.com",
+        "https://mcp.railway.com",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_authorization_url_without_existing_query_is_unchanged(tmp_path):
+    url = await _capture_authorization_url(
+        tmp_path,
+        "https://backboard.railway.com/oauth/auth",
+    )
+
+    parsed = urlsplit(url)
+    params = parse_qs(parsed.query)
+    assert params["response_type"] == ["code"]
+    assert params["resource"] == ["https://mcp.railway.com"]

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -59,7 +59,7 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 from hermes_constants import secure_parent_dir
 
 logger = logging.getLogger(__name__)
@@ -1161,6 +1161,74 @@ def _paste_callback_reader(result: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _join_authorization_endpoint_query(
+    authorization_endpoint: str,
+    authorization_url: str,
+) -> str:
+    """Join SDK-generated OAuth parameters onto a discovered endpoint.
+
+    MCP SDK 2.0 appends ``?`` unconditionally. Preserve the endpoint's raw
+    query and fragment while moving generated parameters into the query. An
+    identical RFC 8707 ``resource`` already supplied by the endpoint wins;
+    distinct resource values remain repeated as the RFC permits.
+    """
+    generated_prefix = f"{authorization_endpoint}?"
+    if not authorization_url.startswith(generated_prefix):
+        return authorization_url
+
+    generated_query = authorization_url[len(generated_prefix):]
+    endpoint = urlsplit(authorization_endpoint)
+    existing_resources = {
+        value
+        for key, value in parse_qsl(endpoint.query, keep_blank_values=True)
+        if key == "resource"
+    }
+    generated_params = [
+        (key, value)
+        for key, value in parse_qsl(generated_query, keep_blank_values=True)
+        if key != "resource" or value not in existing_resources
+    ]
+    encoded_generated = urlencode(generated_params)
+    merged_query = endpoint.query
+    if merged_query and encoded_generated:
+        merged_query += "&"
+    merged_query += encoded_generated
+    return urlunsplit(
+        (endpoint.scheme, endpoint.netloc, endpoint.path, merged_query, endpoint.fragment)
+    )
+
+
+async def _perform_authorization_code_grant_with_compatible_query(
+    provider: Any,
+    parent_method: Any,
+):
+    """Run the SDK grant while repairing its authorization URL."""
+    original_redirect_handler = provider.context.redirect_handler
+    metadata = provider.context.oauth_metadata
+    authorization_endpoint = (
+        str(metadata.authorization_endpoint)
+        if metadata is not None and metadata.authorization_endpoint
+        else None
+    )
+    if original_redirect_handler is None or authorization_endpoint is None:
+        return await parent_method()
+
+    async def redirect_handler(authorization_url: str) -> None:
+        await original_redirect_handler(
+            _join_authorization_endpoint_query(
+                authorization_endpoint,
+                authorization_url,
+            )
+        )
+
+    provider.context.redirect_handler = redirect_handler
+    try:
+        return await parent_method()
+    finally:
+        if provider.context.redirect_handler is redirect_handler:
+            provider.context.redirect_handler = original_redirect_handler
+
+
 HermesOAuthClientProvider: Any = None
 
 
@@ -1189,6 +1257,12 @@ def _get_hermes_oauth_provider_class() -> type | None:
         def __init__(self, *args: Any, token_user_agent: "str | None" = None, **kwargs: Any):
             super().__init__(*args, **kwargs)
             self._hermes_token_user_agent = token_user_agent
+
+        async def _perform_authorization_code_grant(self):
+            return await _perform_authorization_code_grant_with_compatible_query(
+                self,
+                super()._perform_authorization_code_grant,
+            )
 
         def _stamp_token_user_agent(self, request):
             ua = getattr(self, "_hermes_token_user_agent", None)

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -113,6 +113,9 @@ def _make_hermes_provider_class() -> Optional[type]:
         from mcp.client.auth.oauth2 import OAuthClientProvider
     except ImportError:  # pragma: no cover — SDK required in CI
         return None
+    from tools.mcp_oauth import (
+        _perform_authorization_code_grant_with_compatible_query,
+    )
 
     class HermesMCPOAuthProvider(OAuthClientProvider):
         """OAuthClientProvider with pre-flow disk-mtime reload.
@@ -158,6 +161,12 @@ def _make_hermes_provider_class() -> Optional[type]:
             # oauth.user_agent — stamped onto token-endpoint requests only;
             # some authorization servers/WAFs reject httpx's default (#75576).
             self._hermes_token_user_agent = token_user_agent
+
+        async def _perform_authorization_code_grant(self):
+            return await _perform_authorization_code_grant_with_compatible_query(
+                self,
+                super()._perform_authorization_code_grant,
+            )
 
         def _stamp_token_user_agent(self, request):
             ua = getattr(self, "_hermes_token_user_agent", None)


### PR DESCRIPTION
## What does this PR do?

Railway MCP login now reaches the authorization page when discovery returns an authorization endpoint that already contains query parameters. Hermes preserves the endpoint query and fragment, appends the MCP SDK's OAuth parameters with the correct separator, and avoids repeating an identical RFC 8707 resource value.

### Symptom

`hermes mcp login railway` prints an authorization URL with a second `?`. Railway parses `response_type=code` as part of the existing `resource` value and rejects login with `missing required parameter 'response_type'`.

### Impact

OAuth login cannot complete for catalog MCP servers whose discovered authorization endpoint already contains a query string, including Railway.

### Bug Cause

**Trigger:** `mcp.client.auth.oauth2.OAuthClientProvider._perform_authorization_code_grant` when `authorization_endpoint` already has a query component.

**Causal chain:**
1. OAuth discovery returns an authorization endpoint containing `resource=...`.
2. MCP SDK 2.0.0 unconditionally concatenates `?` plus its generated authorization parameters.
3. The resulting second `?` leaves `response_type` inside the first resource value, so the authorization server cannot find the required parameter.

**Why it is wrong:** RFC 3986 permits only one query delimiter. Client parameters must be joined to an existing query with `&` and must appear before any fragment.

**Working sibling / contrast:** Endpoints without a query string already work because the SDK's unconditional `?` is valid there.

**Ruled out:** OAuth discovery and callback handling are not the failure source. The captured production-provider URL shows the generated parameters are correct but placed behind the wrong delimiter.

### Fix

A shared compatibility wrapper now repairs the SDK-generated URL in both Hermes OAuth provider paths. It preserves the endpoint's raw query encoding and fragment, removes only an identical generated `resource` value, and retains distinct RFC 8707 resource parameters.

## Related Issue

Fixes #98117

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_oauth.py` - merge generated OAuth parameters into discovered authorization endpoint queries safely.
- `tools/mcp_oauth_manager.py` - apply the shared compatibility wrapper to the production managed provider.
- `tests/tools/test_mcp_oauth_authorization_url.py` - cover existing queries, fragments, encoding, duplicate and distinct resource values, and query-free endpoints.

## How to Test

1. Run the focused MCP OAuth regression and integration tests:

```bash
scripts/run_tests.sh tests/tools/test_mcp_oauth_authorization_url.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth_integration.py -q
```

2. Confirm all 82 tests pass with one existing skip.
3. Run Ruff on the changed Python files and `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - the regression test captures and validates the production provider's authorization URL directly.
