### PR TITLE
fix(mcp): prevent OAuth state rotation during interactive login

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -306,6 +306,17 @@ def _probe_single_server(
             connect_timeout = max(1.0, float(raw_timeout))
         except (TypeError, ValueError):
             connect_timeout = 30.0
+    else:
+        try:
+            connect_timeout = max(1.0, float(connect_timeout))
+        except (TypeError, ValueError):
+            connect_timeout = 30.0
+
+    # Propagate effective connect_timeout into config passed to _connect_server
+    # so that underlying HTTP/SSE/stdio transports honor the full probe timeout
+    # instead of disconnecting early (fixes #98118).
+    config = dict(config)
+    config["connect_timeout"] = connect_timeout
 
     _ensure_mcp_loop()
     tools_found: List[Tuple[str, str]] = []

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -528,6 +528,36 @@ class TestProbeEnvResolution:
         assert tools == [("do_thing", "a tool")]
         assert seen["config"]["headers"]["Authorization"] == "Bearer jwt-token-xyz"
 
+    def test_probe_propagates_connect_timeout_to_config(self, monkeypatch):
+        """_probe_single_server must propagate explicit connect_timeout into the config passed to _connect_server."""
+        import hermes_cli.mcp_config as mc
+
+        seen = {}
+
+        class _FakeTool:
+            name = "do_thing"
+            description = "a tool"
+
+        class _FakeServer:
+            _tools = [_FakeTool()]
+
+            async def shutdown(self):
+                return None
+
+        async def _fake_connect(name, config):
+            seen["config"] = config
+            return _FakeServer()
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", _fake_connect)
+
+        mc._probe_single_server(
+            "srv",
+            {"url": "http://localhost:5678/mcp", "auth": "oauth"},
+            connect_timeout=315.0,
+        )
+
+        assert seen["config"].get("connect_timeout") == 315.0
+
 
 class TestProbeCapabilityGating:
     """The ``details`` probe must not fire prompts/list or resources/list at

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -1112,3 +1112,47 @@ def test_humanize_non_registration_403_passthrough():
         )
         is None
     )
+
+
+def test_interactive_oauth_initial_failure_does_not_retry_loop(monkeypatch):
+    """Under force_interactive_oauth(), initial connection failure must fail fast
+    without burning reconnect retries that rotate PKCE state."""
+    from tools.mcp_tool import MCPServerTask
+    from tools.mcp_oauth import force_interactive_oauth
+
+    attempts = 0
+
+    async def _failing_http(self, config):
+        nonlocal attempts
+        attempts += 1
+        raise TimeoutError("HTTP read timeout")
+
+    monkeypatch.setattr(MCPServerTask, "_run_http", _failing_http)
+
+    task = MCPServerTask("oauth-srv")
+    task._auth_type = "oauth"
+
+    with force_interactive_oauth():
+        with pytest.raises(TimeoutError):
+            asyncio.run(task.start({"url": "https://mcp.example.com", "auth": "oauth"}))
+
+    assert attempts == 1
+
+
+def test_authorization_code_result_compatibility():
+    """_authorization_code_result must return a 2-tuple under mcp < 2.0 or AuthorizationCodeResult under mcp >= 2.0."""
+    from tools.mcp_oauth import _authorization_code_result
+
+    res = _authorization_code_result("test_code", "test_state", "test_iss")
+    if isinstance(res, tuple):
+        # Under mcp < 2.0, must unpack cleanly as 2-tuple
+        code, state = res
+        assert code == "test_code"
+        assert state == "test_state"
+    else:
+        assert res.code == "test_code"
+        assert res.state == "test_state"
+        assert res.iss == "test_iss"
+
+
+

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -365,6 +365,12 @@ def force_interactive_oauth():
         _oauth_interactive_forced.reset(token)
 
 
+def _is_interactive_forced() -> bool:
+    """Return True if interactive OAuth was explicitly forced (e.g. mcp login / dashboard)."""
+    return bool(_oauth_interactive_forced.get())
+
+
+
 @contextmanager
 def suppress_interactive_oauth():
     """Disable stdin-based OAuth prompts for the current execution context.
@@ -728,6 +734,27 @@ class HermesTokenStorage:
 # ---------------------------------------------------------------------------
 
 
+class _LegacyAuthCodeResult(tuple):
+    """Compatibility wrapper that acts as (code, state) tuple while supporting .code, .state, .iss."""
+
+    def __new__(cls, code: str, state: "str | None" = None, iss: "str | None" = None):
+        instance = super().__new__(cls, (code, state))
+        instance._iss = iss
+        return instance
+
+    @property
+    def code(self) -> str:
+        return self[0]
+
+    @property
+    def state(self) -> "str | None":
+        return self[1]
+
+    @property
+    def iss(self) -> "str | None":
+        return getattr(self, "_iss", None)
+
+
 def _authorization_code_result(code: str, state: "str | None", iss: "str | None" = None):
     """Package redirect parameters in the shape the installed SDK expects.
 
@@ -740,8 +767,9 @@ def _authorization_code_result(code: str, state: "str | None", iss: "str | None"
     try:
         from mcp.shared.auth import AuthorizationCodeResult
     except ImportError:  # mcp < 2.0
-        return code, state
+        return _LegacyAuthCodeResult(code, state, iss)
     return AuthorizationCodeResult(code=code, state=state, iss=iss)
+
 
 
 def _make_callback_handler() -> tuple[type, dict]:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4157,6 +4157,25 @@ class MCPServerTask:
                 # ``_ever_connected`` itself is set once and never cleared.
                 # (Ported from Kilo Code's MCP resilience fix.)
                 if not self._ever_connected:
+                    try:
+                        from tools.mcp_oauth import _is_interactive_forced
+
+                        is_interactive_forced = _is_interactive_forced()
+                    except Exception:
+                        is_interactive_forced = False
+
+                    if is_interactive_forced:
+                        # Interactive OAuth single-flight gate:
+                        # When running under force_interactive_oauth() (e.g. `hermes mcp login`
+                        # or interactive CLI probe), any initial connection failure must fail fast
+                        # immediately. Retrying in a background loop would re-enter _run_http,
+                        # rotate the PKCE state, print duplicate authorization prompts while the
+                        # user is mid-authorization, and cause 'State parameter mismatch' or
+                        # port collisions (#98118, #73997).
+                        self._error = exc
+                        self._ready.set()
+                        return
+
                     if failure_class == "permanent":
                         # Deterministic failure (bad command, non-MCP URL,
                         # 401/403): every retry hits the same wall. Park


### PR DESCRIPTION
## What does this PR do?

1. **Propagates effective \connect_timeout\ to connection config:** Ensures \_probe_single_server\ forwards the resolved \connect_timeout\ (>= 315.0s during \hermes mcp login\ and re-auth) into the \config\ dictionary passed to \_connect_server\, so underlying HTTP (\streamable_http_client\) and SSE (\sse_client\) transports do not disconnect early at 60s while the user is authenticating in a browser.
2. **Single-flight fail-fast during interactive OAuth:** Updates \MCPServerTask.run\ to check \_is_interactive_forced()\ on initial connection errors and fail fast immediately rather than entering an automatic background reconnection loop that burns retries, rotates PKCE \state\, and mints new authorization URLs while the paste prompt is open.
3. **Cross-SDK result compatibility:** Provides \_LegacyAuthCodeResult\ named tuple fallback for environments where \AuthorizationCodeResult\ is not present in \mcp.shared.auth\.

Fixes #98118

## Why is this change needed?

When running \hermes mcp login <server>\ over SSH or headless environments, the user is instructed to open the authorization URL in a local browser and paste the callback URL into the terminal prompt. If the user takes longer than 60 seconds (the default HTTP transport connect timeout), the underlying HTTP client times out.

Previously, \MCPServerTask.run\ treated this timeout as a transient connection failure and entered an automatic 5-attempt retry loop. Each retry re-ran \_run_http\, minting a new PKCE verifier, challenge, and new \state=B\ while printing duplicate authorization prompts. When the user pasted the callback with \state=A\ from the initial prompt, Hermes rejected it with \State parameter mismatch: A != B\.

## How to Test

- Run affected test suites:
  \\\ash
  scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/tools/test_mcp_oauth.py -q
  \\\
- Verified regression tests:
  - \TestProbeEnvResolution.test_probe_propagates_connect_timeout_to_config\: verifies that \connect_timeout\ passed to \_probe_single_server\ is injected into \config\ passed to \_connect_server\.
  - \	est_interactive_oauth_initial_failure_does_not_retry_loop\: verifies that under \orce_interactive_oauth()\, connection failures fail fast in 1 attempt without looping.