### PR TITLE
feat(credentials): configure dead manual pruning

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import random
 import threading
@@ -99,6 +100,38 @@ _TERMINAL_AUTH_REASONS = frozenset({
 # the cleanup.  They remain in the pool marked DEAD until an explicit re-auth
 # write-side sync (``_save_codex_tokens`` etc.) clears the status.
 DEAD_MANUAL_PRUNE_TTL_SECONDS = 24 * 60 * 60  # 24 hours
+MAX_DEAD_MANUAL_PRUNE_TTL_HOURS = 24 * 365
+
+
+def get_dead_manual_prune_settings() -> tuple[bool, float]:
+    """Return the profile-scoped enabled flag and TTL for DEAD manual pruning.
+
+    Malformed settings retain the historical 24-hour cleanup behavior rather
+    than preventing cleanup or causing credential selection to fail.
+    """
+    enabled = True
+    ttl_seconds = float(DEAD_MANUAL_PRUNE_TTL_SECONDS)
+    config = _load_config_safe()
+    if not isinstance(config, dict):
+        return enabled, ttl_seconds
+    pool_config = config.get("credential_pool")
+    if not isinstance(pool_config, dict):
+        return enabled, ttl_seconds
+
+    raw_enabled = pool_config.get("prune_dead_manual_entries")
+    if isinstance(raw_enabled, bool):
+        enabled = raw_enabled
+
+    raw_ttl_hours = pool_config.get("dead_manual_prune_ttl_hours")
+    if raw_ttl_hours is not None and not isinstance(raw_ttl_hours, bool):
+        try:
+            ttl_hours = float(raw_ttl_hours)
+        except (TypeError, ValueError):
+            ttl_hours = -1.0
+        if math.isfinite(ttl_hours) and 0 <= ttl_hours <= MAX_DEAD_MANUAL_PRUNE_TTL_HOURS:
+            ttl_seconds = ttl_hours * 3600.0
+
+    return enabled, ttl_seconds
 
 AUTH_TYPE_OAUTH = "oauth"
 AUTH_TYPE_API_KEY = "api_key"
@@ -1899,6 +1932,7 @@ class CredentialPool:
         now = time.time()
         cleared_any = False
         entries_to_prune: List[str] = []
+        dead_manual_prune_settings: Optional[tuple[bool, float]] = None
         available: List[PooledCredential] = []
         # Entries that need an OAuth refresh via a single-use token provider
         # (openai-codex, xai-oauth).  These require a cross-process file lock
@@ -1969,8 +2003,11 @@ class CredentialPool:
                 # would just be undone by ``_seed_from_singletons`` on the
                 # next load anyway.
                 if _is_manual_source(entry.source):
+                    if dead_manual_prune_settings is None:
+                        dead_manual_prune_settings = get_dead_manual_prune_settings()
+                    prune_enabled, prune_ttl_seconds = dead_manual_prune_settings
                     dead_at = entry.last_status_at or 0
-                    if dead_at and now - dead_at > DEAD_MANUAL_PRUNE_TTL_SECONDS:
+                    if prune_enabled and dead_at and now - dead_at > prune_ttl_seconds:
                         _label = entry.label or entry.id[:8]
                         logger.warning(
                             "credential pool: pruning DEAD manual entry %s "

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -9,6 +9,12 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    # Manual entries marked DEAD are pruned after this profile-scoped retention
+    # window. Disable pruning to retain tombstones until explicit action.
+    "credential_pool": {
+        "prune_dead_manual_entries": True,
+        "dead_manual_prune_ttl_hours": 24,
+    },
     "toolsets": ["hermes-cli"],
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -6,6 +6,7 @@ import base64
 import json
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -498,6 +499,91 @@ def test_generic_401_without_terminal_reason_still_uses_exhausted(tmp_path, monk
     persisted = auth_payload["credential_pool"]["openai-codex"][0]
     assert persisted["last_status"] == STATUS_EXHAUSTED
     assert persisted["last_error_code"] == 401
+
+
+def test_dead_manual_prune_policy_is_profile_scoped(tmp_path, monkeypatch):
+    """Each profile applies its own configured DEAD-manual retention policy."""
+    from agent.credential_pool import load_pool
+
+    def write_profile(name: str, *, prune: bool, ttl_hours: int) -> Path:
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "credential_pool:\n"
+            f"  prune_dead_manual_entries: {str(prune).lower()}\n"
+            f"  dead_manual_prune_ttl_hours: {ttl_hours}\n",
+            encoding="utf-8",
+        )
+        (home / "auth.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "credential_pool": {
+                        "openai-codex": [
+                            {
+                                "id": "dead-manual",
+                                "label": "dead-entry",
+                                "auth_type": "oauth",
+                                "source": "manual:device_code",
+                                "access_token": "test-access-token",
+                                "refresh_token": "test-refresh-token",
+                                "last_status": "dead",
+                                "last_status_at": time.time() - (25 * 3600),
+                            },
+                            {
+                                "id": "healthy-manual",
+                                "label": "healthy-entry",
+                                "auth_type": "oauth",
+                                "source": "manual:device_code",
+                                "access_token": "test-access-token-2",
+                                "refresh_token": "test-refresh-token-2",
+                            },
+                        ]
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return home
+
+    retain_home = write_profile("retain", prune=False, ttl_hours=1)
+    prune_home = write_profile("prune", prune=True, ttl_hours=1)
+
+    monkeypatch.setenv("HERMES_HOME", str(retain_home))
+    assert load_pool("openai-codex").select().id == "healthy-manual"
+    retained = json.loads((retain_home / "auth.json").read_text())
+    assert {entry["id"] for entry in retained["credential_pool"]["openai-codex"]} == {
+        "dead-manual",
+        "healthy-manual",
+    }
+
+    monkeypatch.setenv("HERMES_HOME", str(prune_home))
+    assert load_pool("openai-codex").select().id == "healthy-manual"
+    pruned = json.loads((prune_home / "auth.json").read_text())
+    assert [entry["id"] for entry in pruned["credential_pool"]["openai-codex"]] == [
+        "healthy-manual"
+    ]
+
+
+def test_dead_manual_prune_settings_reject_nonfinite_ttl(monkeypatch):
+    """Invalid retention values fall back safely instead of disabling cleanup."""
+    from agent import credential_pool as pool_mod
+
+    monkeypatch.setattr(
+        pool_mod,
+        "_load_config_safe",
+        lambda: {
+            "credential_pool": {
+                "prune_dead_manual_entries": True,
+                "dead_manual_prune_ttl_hours": "nan",
+            }
+        },
+    )
+
+    assert pool_mod.get_dead_manual_prune_settings() == (
+        True,
+        float(pool_mod.DEAD_MANUAL_PRUNE_TTL_SECONDS),
+    )
 
 
 def test_dead_manual_entry_pruned_after_24h(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1690,6 +1690,14 @@ def test_default_config_kanban_block_not_dropped_by_duplicate_key():
     assert "auto_decompose" in kanban
 
 
+def test_default_config_exposes_dead_manual_prune_retention_policy():
+    """Fresh profile configs document the legacy-safe tombstone retention."""
+    assert DEFAULT_CONFIG["credential_pool"] == {
+        "prune_dead_manual_entries": True,
+        "dead_manual_prune_ttl_hours": 24,
+    }
+
+
 def test_default_config_has_no_duplicate_top_level_keys():
     """Guard against any duplicate key silently shadowing a default."""
     import ast

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -149,6 +149,20 @@ Provider-supplied `reset_at` timestamps override these default cooldowns.
 
 The `has_retried_429` flag resets on every successful API call, so a single transient 429 doesn't trigger rotation.
 
+### Dead manual credential cleanup
+
+Manual credentials marked `dead` remain excluded from rotation. By default Hermes removes a dead manual entry after 24 hours during a later pool availability check. The policy is profile-scoped and can be changed in that profile's `config.yaml`:
+
+```yaml
+credential_pool:
+  # false keeps dead manual entries until explicit re-authentication or removal
+  prune_dead_manual_entries: false
+  # Accepted range: 0 through 8,760 hours when pruning is enabled
+  dead_manual_prune_ttl_hours: 72
+```
+
+Invalid retention values fall back to the 24-hour default. Singleton-seeded credentials are never auto-pruned because their backing auth source would recreate them on the next pool load.
+
 ## Custom Endpoint Pools
 
 Custom OpenAI-compatible endpoints (Together.ai, RunPod, local servers) get their own pools, keyed by the endpoint name from the `providers:` dict in config.yaml (or the legacy `custom_providers` list, which is auto-migrated).


### PR DESCRIPTION
## Summary

- Restores the work from closed PR #67647 as a clean replacement against current `main`.
- Adds profile-scoped configuration for retention of dead manual credential tombstones.
- Preserves historical defaults: pruning enabled with a 24-hour TTL; invalid TTL values safely fall back to that policy.
- Keeps automatic pruning limited to manual credentials; seeded/singleton credentials remain protected.

## Verification

- `scripts/run_tests.sh tests/agent/test_credential_pool.py tests/hermes_cli/test_config.py -q`
  - 172 passed, 0 failed, 4 Windows-only skips
- `ruff check` passed for all changed Python and test files.
- `git diff --check origin/main...HEAD` passed.
- Independent read-only publication review: PASS.

## Attribution / prior PR

This replaces closed PR #67647 after its old PR record became detached during an authorship repair. The replacement contains only current-main-compatible, generic changes. All commits are authored and committed by `DeadlySilent`.
