### PR TITLE
fix(mcp): don't report a post-auth session failure as "Authentication failed"

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -417,6 +417,24 @@ def _oauth_tokens_present(name: str) -> bool:
         return True
 
 
+def _token_path_hint(name: str) -> str:
+    """Best-effort human-readable path to the cached OAuth token for ``name``.
+
+    Used in error messages so the user can see for themselves that auth
+    succeeded. Falls back to the conventional location if the storage class
+    can't be interrogated — this is display text, never a control decision.
+    """
+    try:
+        from tools.mcp_oauth import HermesTokenStorage
+
+        path = getattr(HermesTokenStorage(name), "token_path", None)
+        if path:
+            return str(path)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.debug("Could not resolve token path for '%s': %s", name, exc)
+    return f"~/.hermes/mcp-tokens/{name}.json"
+
+
 def _unwrap_exception_group(exc: BaseException) -> Exception:
     """Extract the root-cause exception from anyio TaskGroup wrappers.
 
@@ -903,6 +921,30 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
             )
         except Exception:
             humanized = None
+        # Distinguish "OAuth never completed" from "OAuth succeeded, then the
+        # MCP session failed". Every exception here used to be reported as
+        # "Authentication failed", which sent users re-running the browser
+        # flow over and over against a server that had already issued a
+        # perfectly good token. Observed with GitLab: the OAuth round-trip
+        # completed and cached a valid token, then POST /api/v4/mcp returned
+        # an application-level 404 (MCP disabled for the namespace), which the
+        # MCP SDK surfaces as the generic "Session terminated". The token on
+        # disk is the evidence that auth is not the failing stage.
+        if _oauth_tokens_present(name):
+            _error(f"Connected, but the MCP session failed: {humanized or exc}")
+            print()
+            _info(
+                "Authorization SUCCEEDED — a token is cached at "
+                f"{_token_path_hint(name)}. Re-running `hermes mcp login "
+                f"{name}` will not help; the failure is after auth."
+            )
+            _info(
+                "Common causes: the server requires a plan/feature/permission "
+                "your account lacks, the endpoint is disabled for your "
+                "org/namespace, or the URL is wrong. Check the vendor's MCP "
+                "docs for prerequisites, then `hermes mcp test " + name + "`."
+            )
+            return False
         _error(f"Authentication failed: {humanized or exc}")
         return False
 

--- a/tests/hermes_cli/test_mcp_login_post_auth_failure.py
+++ b/tests/hermes_cli/test_mcp_login_post_auth_failure.py
@@ -1,0 +1,109 @@
+"""Regression: `hermes mcp login` must not call a post-auth failure "auth failed".
+
+``_reauth_oauth_server`` wrapped the whole probe in one ``except`` that
+reported every exception as ``Authentication failed:``. That is wrong whenever
+the OAuth round-trip actually SUCCEEDED and the failure came later, in the MCP
+session itself.
+
+Observed live with GitLab: the browser flow completed and cached a valid
+``scope: mcp`` token with a refresh token, then ``POST /api/v4/mcp`` returned
+an application-level 404 (the MCP endpoint is gated behind GitLab Duo settings
+that only exist on group namespaces). The MCP SDK surfaces that as the generic
+``Session terminated``. Hermes printed "Authentication failed: Session
+terminated", so the user re-ran the browser flow repeatedly against a server
+that had already issued them a perfectly good token.
+
+The discriminator is already on disk: if a token is cached, auth is not the
+failing stage.
+"""
+
+import pytest
+
+import hermes_cli.mcp_config as mcp_config
+
+
+SERVER = {"url": "https://gitlab.com/api/v4/mcp", "auth": "oauth"}
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture _error/_info/_warning/_success output instead of printing."""
+    lines = {"error": [], "info": [], "warning": [], "success": []}
+    for level in lines:
+        monkeypatch.setattr(
+            mcp_config,
+            f"_{level}",
+            lambda msg, _l=level: lines[_l].append(str(msg)),
+        )
+    monkeypatch.setattr(mcp_config, "print", lambda *a, **k: None, raising=False)
+
+    # Neutralize the OAuth-state wipe and the interactive-OAuth context manager.
+    class _NullCtx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    import tools.mcp_oauth as mcp_oauth
+
+    monkeypatch.setattr(mcp_oauth, "force_interactive_oauth", lambda: _NullCtx())
+    return lines
+
+
+def _fail_probe(*args, **kwargs):
+    raise RuntimeError("Session terminated")
+
+
+def test_post_auth_failure_is_not_reported_as_auth_failure(captured, monkeypatch):
+    """Token on disk + probe raises => report a SESSION failure, not auth."""
+    monkeypatch.setattr(mcp_config, "_probe_single_server", _fail_probe)
+    monkeypatch.setattr(mcp_config, "_oauth_tokens_present", lambda name: True)
+
+    ok = mcp_config._reauth_oauth_server("gitlab", SERVER)
+
+    assert ok is False
+    joined = " ".join(captured["error"])
+    assert "Authentication failed" not in joined, (
+        "a post-auth session failure must not be labelled an auth failure"
+    )
+    assert "Session terminated" in joined, "the real error must still be shown"
+    # And the user must be told re-running login is pointless.
+    guidance = " ".join(captured["info"])
+    assert "SUCCEEDED" in guidance
+    assert "will not help" in guidance
+
+
+def test_genuine_auth_failure_still_reported_as_auth_failure(captured, monkeypatch):
+    """No token on disk + probe raises => the original message is correct."""
+    monkeypatch.setattr(mcp_config, "_probe_single_server", _fail_probe)
+    monkeypatch.setattr(mcp_config, "_oauth_tokens_present", lambda name: False)
+
+    ok = mcp_config._reauth_oauth_server("someserver", SERVER)
+
+    assert ok is False
+    joined = " ".join(captured["error"])
+    assert "Authentication failed" in joined
+    # No misleading "auth succeeded" guidance on a real auth failure.
+    assert "SUCCEEDED" not in " ".join(captured["info"])
+
+
+def test_token_path_hint_never_raises():
+    """Display helper must degrade to a sane string, never propagate."""
+    hint = mcp_config._token_path_hint("nonexistent-server-xyz")
+    assert isinstance(hint, str) and hint
+    assert "nonexistent-server-xyz" in hint
+
+
+def test_success_path_unchanged(captured, monkeypatch):
+    """A clean probe with a cached token still reports authenticated."""
+    monkeypatch.setattr(
+        mcp_config, "_probe_single_server", lambda *a, **k: [("t1", "desc")]
+    )
+    monkeypatch.setattr(mcp_config, "_oauth_tokens_present", lambda name: True)
+
+    ok = mcp_config._reauth_oauth_server("gitlab", SERVER)
+
+    assert ok is True
+    assert "Authenticated" in " ".join(captured["success"])
+    assert not captured["error"]


### PR DESCRIPTION
## Summary

`_reauth_oauth_server` wraps the whole probe in a single `except` that prefixes
**every** exception with `Authentication failed:` (`mcp_config.py:897`). That is
wrong whenever the OAuth round trip actually succeeded and the failure came
later, in the MCP session.

The result is a message that names the one stage that *did* work, so the user
re-runs the browser flow against a server that has already issued them a valid
token.

### Real-world reproduction (GitLab)

`hermes mcp login gitlab` completed the browser flow and cached a valid token:

```json
// ~/.hermes/mcp-tokens/gitlab.json
{ "access_token": "<64 chars>", "scope": "mcp", "refresh_token": "<64 chars>" }
```

Then `POST /api/v4/mcp` with that token returned:

```
HTTP 404  {"message":"404 Not Found"}
ratelimit-name: throttle_authenticated_api      <-- token WAS accepted
```

GitLab gates its MCP endpoint behind GitLab Duo settings that only exist on
**group** namespaces, so a personal namespace gets a 404 after a fully
successful authorization. The MCP SDK surfaces this as the generic
`Session terminated` (`streamable_http.py:519`), and Hermes printed:

```
x Authentication failed: Session terminated
```

Two full browser round trips were spent before the token on disk was noticed.

## Fix

The discriminator already existed three lines above — `_oauth_tokens_present`,
added for exactly this class of confusion. Consult it in the error path.

**Before**

```
x Authentication failed: Session terminated
```

**After**

```
x Connected, but the MCP session failed: Session terminated

  Authorization SUCCEEDED — a token is cached at ~/.hermes/mcp-tokens/gitlab.json.
  Re-running `hermes mcp login gitlab` will not help; the failure is after auth.
  Common causes: the server requires a plan/feature/permission your account
  lacks, the endpoint is disabled for your org/namespace, or the URL is wrong.
  Check the vendor's MCP docs for prerequisites, then `hermes mcp test gitlab`.
```

A genuine auth failure (no cached token) keeps the original message unchanged.

`_token_path_hint` is display-only and falls back to the conventional path; it
never influences a control decision.

## Test plan

Four tests in `tests/hermes_cli/test_mcp_login_post_auth_failure.py`:

- token present + probe raises → **not** labelled an auth failure, real error
  still shown, guidance says re-running login won't help
- no token + probe raises → original "Authentication failed" preserved, and no
  misleading "auth succeeded" guidance
- `_token_path_hint` degrades to a string, never raises
- the success path is unchanged

Verified RED/GREEN: the first test fails against the unpatched code with
exactly the string from the field report:

```
AssertionError: a post-auth session failure must not be labelled an auth failure
assert 'Authentication failed' not in 'Authentication failed: Session terminated'
```

Regression run against a clean `origin/main` worktree:

```
tests/hermes_cli/ -k "mcp or config"
  baseline (clean HEAD):  35 failed, 862 passed
  with this change:       35 failed, 870 passed
```

Identical failures, same test names — all pre-existing cross-test pollution
(they pass individually). Zero regressions.
