### PR TITLE
fix(update): reject recycled gateway state PIDs

### DIFF
--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -247,7 +247,7 @@ def collect_runtime_inventory() -> UpdatePlan:
     # --- per-profile gateways (PID files + runtime status stamps) ----------
     seen_pids: set[int] = set()
     try:
-        from gateway.status import _pid_exists, read_runtime_status
+        from gateway.status import get_runtime_status_running_pid, read_runtime_status
 
         for profile, home in profile_homes:
             # Prefer the gateway-owned control socket (#92091): identity
@@ -297,13 +297,10 @@ def collect_runtime_inventory() -> UpdatePlan:
             pid: Optional[int] = None
             code_sha = code_version = None
             if record:
-                try:
-                    pid = int(record.get("pid"))
-                except (TypeError, ValueError):
-                    pid = None
+                pid = get_runtime_status_running_pid(record, expected_home=home)
                 code_sha = record.get("code_sha")
                 code_version = record.get("code_version")
-            if pid is None or not _pid_exists(pid):
+            if pid is None:
                 continue
             seen_pids.add(pid)
             supervisor = _detect_supervisor_for_pid(

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -343,7 +343,7 @@ def collect_fleet_versions(
         expected_sha = None
 
     try:
-        from gateway.status import read_runtime_status, runtime_status_pid_is_live
+        from gateway.status import get_runtime_status_running_pid, read_runtime_status
         from hermes_cli.profiles import (
             _get_default_hermes_home,
             _get_profiles_root,
@@ -405,7 +405,8 @@ def collect_fleet_versions(
                 pid = int(pid)
             except (TypeError, ValueError):
                 continue
-            if not runtime_status_pid_is_live(record):
+            live_pid = get_runtime_status_running_pid(record, expected_home=home)
+            if live_pid is None:
                 # Dead PID (or a live PID recycled by an unrelated process
                 # during the update's own churn — #93258): a DOWN row only
                 # when this exact pid was alive at update start AND the
@@ -437,6 +438,7 @@ def collect_fleet_versions(
                         }
                     )
                 continue
+            pid = live_pid
             code_sha = record.get("code_sha")
             if not code_sha or not expected_sha:
                 state = "unknown"

--- a/tests/hermes_cli/test_fleet_matrix_down_state.py
+++ b/tests/hermes_cli/test_fleet_matrix_down_state.py
@@ -27,6 +27,9 @@ def _setup(monkeypatch, tmp_path, record: dict):
         "hermes_cli.profiles._get_profiles_root", lambda: tmp_path / "no-profiles"
     )
     monkeypatch.setattr("gateway.control_socket.identify_gateway", lambda h, **k: None)
+    monkeypatch.setattr(
+        "gateway.status._read_process_cmdline", lambda pid: "hermes gateway run"
+    )
     (home / "gateway_state.json").write_text(json.dumps(record), encoding="utf-8")
     return home
 

--- a/tests/hermes_cli/test_update_inventory.py
+++ b/tests/hermes_cli/test_update_inventory.py
@@ -9,7 +9,13 @@ import hermes_cli.update_inventory as ui
 
 
 def _write_state(home: Path, pid: int, sha: str | None = None, version: str | None = None):
-    record = {"pid": pid}
+    record = {
+        "pid": pid,
+        "kind": "hermes-gateway",
+        "argv": ["hermes", "gateway", "run"],
+        "gateway_state": "running",
+        "start_time": None,
+    }
     if sha:
         record["code_sha"] = sha
     if version:
@@ -31,6 +37,12 @@ def fleet(monkeypatch, tmp_path):
     monkeypatch.setattr("hermes_cli.profiles._get_profiles_root", lambda: default_home / "profiles")
     monkeypatch.setattr("hermes_cli.profiles._PROFILE_ID_RE", re.compile(r"^[a-z0-9][a-z0-9_-]*$"), raising=False)
     monkeypatch.setattr("gateway.status._pid_exists", lambda pid: pid in (100, 200))
+    monkeypatch.setattr(
+        "gateway.status._read_process_cmdline",
+        lambda pid: (
+            "hermes gateway run" if pid == 100 else "hermes --profile work gateway run"
+        ),
+    )
     monkeypatch.setattr("hermes_cli.gateway._get_service_pids", lambda all_profiles=False: {100})
     monkeypatch.setattr("hermes_cli.gateway.supports_systemd_services", lambda: True)
     monkeypatch.setattr("hermes_cli.gateway.find_profile_gateway_processes", lambda exclude_pids=None: [])
@@ -79,6 +91,28 @@ class TestCollectInventory:
     def test_dead_pids_excluded(self, fleet, monkeypatch):
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
         plan = ui.collect_runtime_inventory()
+        assert plan.runtimes == []
+
+    def test_recycled_pid_owned_by_non_gateway_is_excluded(self, fleet, monkeypatch):
+        """A stale state PID reused by Safari must not become a fleet runtime."""
+        monkeypatch.setattr(
+            "gateway.status._read_process_cmdline",
+            lambda pid: "/Applications/Safari.app/Contents/MacOS/Safari",
+        )
+
+        plan = ui.collect_runtime_inventory()
+
+        assert plan.runtimes == []
+
+    def test_named_profile_requires_matching_gateway_identity(self, fleet, monkeypatch):
+        """A live gateway for one profile cannot satisfy another profile's state."""
+        monkeypatch.setattr(
+            "gateway.status._read_process_cmdline",
+            lambda pid: "hermes --profile other gateway run",
+        )
+
+        plan = ui.collect_runtime_inventory()
+
         assert plan.runtimes == []
 
     def test_pid_file_fallback_covers_unstamped_profiles(self, fleet, monkeypatch):

--- a/tests/hermes_cli/test_update_receipt.py
+++ b/tests/hermes_cli/test_update_receipt.py
@@ -264,6 +264,13 @@ class TestFleetClassification:
         """Run collect_fleet_versions against one fake default profile."""
         home = tmp_path / "fleet_home"
         home.mkdir()
+        record = {
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "gateway_state": "running",
+            "start_time": None,
+            **record,
+        }
         (home / "gateway_state.json").write_text(
             json.dumps(record), encoding="utf-8"
         )
@@ -280,6 +287,9 @@ class TestFleetClassification:
             lambda: tmp_path / "nonexistent_profiles_root",
         )
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            "gateway.status._read_process_cmdline", lambda pid: "hermes gateway run"
+        )
         return ur.collect_fleet_versions()
 
     def test_current_gateway(self, monkeypatch, tmp_path):
@@ -322,6 +332,69 @@ class TestFleetClassification:
             lambda: tmp_path / "nope",
         )
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        assert ur.collect_fleet_versions() == []
+
+    def test_recycled_pid_owned_by_non_gateway_is_excluded(self, monkeypatch, tmp_path):
+        home = tmp_path / "fleet_home_recycled"
+        home.mkdir()
+        (home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": 4242,
+                    "kind": "hermes-gateway",
+                    "argv": ["hermes", "gateway", "run"],
+                    "gateway_state": "running",
+                    "start_time": None,
+                    "code_sha": "a" * 40,
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles._get_default_hermes_home", lambda: home
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles._get_profiles_root", lambda: tmp_path / "nope"
+        )
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            "gateway.status._read_process_cmdline",
+            lambda pid: "/Applications/Safari.app/Contents/MacOS/Safari",
+        )
+
+        assert ur.collect_fleet_versions() == []
+
+    def test_named_profile_pid_reused_by_other_gateway_is_excluded(
+        self, monkeypatch, tmp_path
+    ):
+        default_home = tmp_path / "fleet_root"
+        work_home = default_home / "profiles" / "work"
+        work_home.mkdir(parents=True)
+        (work_home / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "pid": 4242,
+                    "kind": "hermes-gateway",
+                    "argv": ["hermes", "--profile", "work", "gateway", "run"],
+                    "gateway_state": "running",
+                    "start_time": None,
+                    "code_sha": "a" * 40,
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles._get_profiles_root", lambda: default_home / "profiles"
+        )
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            "gateway.status._read_process_cmdline",
+            lambda pid: "hermes --profile other gateway run",
+        )
+
         assert ur.collect_fleet_versions() == []
 
     def test_matrix_returns_true_only_on_stale(self, capsys):


### PR DESCRIPTION
## Summary

- prevent `hermes update` from counting a stale `gateway_state.json` PID as a live gateway after the PID has been reused by an unrelated process
- apply the same runtime identity validation to both the pre-update inventory and post-update fleet verification paths
- add coverage for unrelated-process PID reuse and cross-profile gateway PID reuse

## Root cause

The `gateway_state.json` fallback in `collect_runtime_inventory()` only checked whether the recorded PID existed. `collect_fleet_versions()` used `runtime_status_pid_is_live()`, which verifies PID/start-time identity but not that a readable live command line is actually a Hermes gateway for the expected profile.

A long-dead profile record on macOS contained PID 1231. That PID had since been reused by `SafariWidgetExtension`, so `hermes update` printed:

```
Fleet: 1 running service(s) across profiles: work
```

No Hermes gateway was running.

## Fix

Reuse the existing `get_runtime_status_running_pid(record, expected_home=home)` validator in both update paths. It checks:

- the recorded PID exists and is not a zombie
- the recorded process start time still matches when available
- a readable live command line is a Hermes gateway runtime
- the gateway command belongs to the expected profile

The control-socket path remains authoritative and unchanged. Platforms where the command line cannot be read retain the validator's existing conservative metadata fallback.

## Test plan

```
venv/bin/python3 -m pytest -o 'addopts=' -q \
  tests/hermes_cli/test_update_inventory.py \
  tests/hermes_cli/test_update_receipt.py \
  tests/hermes_cli/test_fleet_matrix_down_state.py \
  tests/hermes_cli/test_gateway_runtime_health.py
# 48 passed

venv/bin/python3 -m ruff check \
  hermes_cli/update_inventory.py \
  hermes_cli/update_receipt.py \
  tests/hermes_cli/test_fleet_matrix_down_state.py \
  tests/hermes_cli/test_update_inventory.py \
  tests/hermes_cli/test_update_receipt.py
# All checks passed

git diff --check
```

Live verification against the original stale state file now returns:

```
inventory_runtimes= []
fleet_versions= []
```

The broad `tests/hermes_cli/test_update*.py` run has pre-existing failures on this macOS checkout: an untouched `origin/main` worktree produced 627 passed, 3 skipped, 19 failed; this branch produced 628 passed, 3 skipped, 20 failed, with the one additional loop-heartbeat timing failure passing when rerun alone.

## Disclosure

This patch was prepared with Hermes Agent assistance and independently reviewed before submission.
