### PR TITLE
feat(telegram): add scoped group response routing

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1213,7 +1213,8 @@ platform_toolsets:
 #     guest_mode: false
 #     # allowed_chats: ["-1001234567890"]
 #     # require_mention_chats applies require_mention-style gating only in selected chats.
-#     # strict_mention_chats accepts only explicit @bot mentions in selected chats.
+#     # strict_mention_chats accepts only explicit @bot mentions in selected chats,
+#     # overriding free_response_chats and free_response_users for those chats.
 #     # require_mention_chats: ["-1001234567890"]
 #     # strict_mention_chats: ["-1001234567890"]
 #     # free_response_users lets these Telegram user IDs bypass require_mention in groups.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1212,6 +1212,14 @@ platform_toolsets:
 #     # Default false; ordinary messages, replies, and regex wake words stay blocked.
 #     guest_mode: false
 #     # allowed_chats: ["-1001234567890"]
+#     # require_mention_chats applies require_mention-style gating only in selected chats.
+#     # strict_mention_chats accepts only explicit @bot mentions in selected chats.
+#     # require_mention_chats: ["-1001234567890"]
+#     # strict_mention_chats: ["-1001234567890"]
+#     # free_response_users lets these Telegram user IDs bypass require_mention in groups.
+#     # strict_mention_users must explicitly @mention this bot; replies/wake words do not count.
+#     # free_response_users: ["222222222"]
+#     # strict_mention_users: ["111111111"]
 #     extra:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9682,6 +9682,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if guest_mention:
             return True
+        if chat_id_str in self._telegram_strict_mention_chats():
+            return self._message_mentions_bot(message)
         sender_id = self._telegram_sender_id(message)
         if sender_id in self._telegram_free_response_users():
             return True
@@ -9691,8 +9693,6 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         if self._telegram_is_free_response_topic(message):
             return True
-        if chat_id_str in self._telegram_strict_mention_chats():
-            return self._message_mentions_bot(message)
         if chat_id_str not in self._telegram_require_mention_chats() and not self._telegram_require_mention():
             return True
         if self._is_reply_to_bot(message):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8727,6 +8727,40 @@ class TelegramAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
+    def _telegram_require_mention_chats(self) -> set[str]:
+        """Return chats where the normal mention trigger is required."""
+        raw = self.config.extra.get("require_mention_chats")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw or "").split(",") if part.strip()}
+
+    def _telegram_strict_mention_chats(self) -> set[str]:
+        """Return chats where only an explicit @bot mention may trigger a response."""
+        raw = self.config.extra.get("strict_mention_chats")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw or "").split(",") if part.strip()}
+
+    def _telegram_free_response_users(self) -> set[str]:
+        """Return user IDs that may respond in groups without a mention."""
+        raw = self.config.extra.get("free_response_users")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw or "").split(",") if part.strip()}
+
+    def _telegram_strict_mention_users(self) -> set[str]:
+        """Return user IDs that require an explicit @bot mention in groups."""
+        raw = self.config.extra.get("strict_mention_users")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw or "").split(",") if part.strip()}
+
+    @staticmethod
+    def _telegram_sender_id(message: Any) -> str:
+        sender = getattr(message, "from_user", None) or getattr(message, "sender_chat", None)
+        value = getattr(sender, "id", None)
+        return str(value) if value is not None else ""
+
     def _telegram_free_response_topics(self) -> set[str]:
         """Return topic-level free-response allowlist entries as ``<chat_id>:<thread_id>``.
 
@@ -9268,7 +9302,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         if self._telegram_is_free_response_topic(message):
             return False
-        if not self._telegram_require_mention():
+        if chat_id_str not in self._telegram_require_mention_chats() and not self._telegram_require_mention():
             return False
         if self._is_reply_to_bot(message):
             return False
@@ -9648,11 +9682,18 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if guest_mention:
             return True
+        sender_id = self._telegram_sender_id(message)
+        if sender_id in self._telegram_free_response_users():
+            return True
+        if sender_id in self._telegram_strict_mention_users():
+            return self._message_mentions_bot(message)
         if chat_id_str in self._telegram_free_response_chats():
             return True
         if self._telegram_is_free_response_topic(message):
             return True
-        if not self._telegram_require_mention():
+        if chat_id_str in self._telegram_strict_mention_chats():
+            return self._message_mentions_bot(message)
+        if chat_id_str not in self._telegram_require_mention_chats() and not self._telegram_require_mention():
             return True
         if self._is_reply_to_bot(message):
             return True
@@ -11043,7 +11084,16 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         # extras seed intentionally omitted (shared-key loop bridges group_allowed_chats).
         if not _skip_env_bridge and not os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS"):
             os.environ["TELEGRAM_GROUP_ALLOWED_CHATS"] = str(group_allowed_chats)
-    for _key in ("guest_mode", "disable_link_previews", "observe_unmentioned_group_messages", "free_response_topics"):
+    for _key in (
+        "guest_mode",
+        "disable_link_previews",
+        "observe_unmentioned_group_messages",
+        "free_response_topics",
+        "require_mention_chats",
+        "strict_mention_chats",
+        "free_response_users",
+        "strict_mention_users",
+    ):
         if _key in telegram_cfg:
             extras.setdefault(_key, telegram_cfg[_key])
     # Pass through telegram-specific extra keys (e.g. base_url proxy override),

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -382,6 +382,43 @@ def test_strict_mention_chats_reject_reply_and_pattern_fallbacks():
     ) is True
 
 
+def test_strict_mention_chat_overrides_free_response_chat():
+    adapter = _make_adapter(
+        require_mention=False,
+        strict_mention_chats=["-200"],
+        free_response_chats=["-200"],
+    )
+
+    assert adapter._should_process_message(_group_message("ordinary message", chat_id=-200)) is False
+
+    text = "@hermes_bot direct request"
+    assert adapter._should_process_message(
+        _group_message(text, chat_id=-200, entities=[_mention_entity(text)])
+    ) is True
+
+
+def test_strict_mention_chat_overrides_free_response_user():
+    adapter = _make_adapter(
+        require_mention=False,
+        strict_mention_chats=["-200"],
+        free_response_users=["222"],
+    )
+
+    assert adapter._should_process_message(
+        _group_message("ordinary message", chat_id=-200, from_user_id=222)
+    ) is False
+
+    text = "@hermes_bot direct request"
+    assert adapter._should_process_message(
+        _group_message(
+            text,
+            chat_id=-200,
+            from_user_id=222,
+            entities=[_mention_entity(text)],
+        )
+    ) is True
+
+
 def test_unmentioned_group_messages_can_be_observed_for_require_mention_chat():
     async def _run():
         adapter = _make_adapter(

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -12,6 +12,10 @@ def _make_adapter(
     require_mention=None,
     free_response_chats=None,
     free_response_topics=None,
+    require_mention_chats=None,
+    strict_mention_chats=None,
+    free_response_users=None,
+    strict_mention_users=None,
     mention_patterns=None,
     exclusive_bot_mentions=None,
     ignored_threads=None,
@@ -33,6 +37,14 @@ def _make_adapter(
         extra["free_response_chats"] = free_response_chats
     if free_response_topics is not None:
         extra["free_response_topics"] = free_response_topics
+    if require_mention_chats is not None:
+        extra["require_mention_chats"] = require_mention_chats
+    if strict_mention_chats is not None:
+        extra["strict_mention_chats"] = strict_mention_chats
+    if free_response_users is not None:
+        extra["free_response_users"] = free_response_users
+    if strict_mention_users is not None:
+        extra["strict_mention_users"] = strict_mention_users
     if mention_patterns is not None:
         extra["mention_patterns"] = mention_patterns
     if exclusive_bot_mentions is not None:
@@ -334,6 +346,108 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter_no_mention._should_process_message(_group_message("/status"), is_command=True) is True
 
 
+def test_free_response_users_bypass_group_mention_requirement():
+    adapter = _make_adapter(require_mention=True, free_response_users=["222"])
+
+    assert adapter._should_process_message(_group_message("message from regular user", from_user_id=111)) is False
+    assert adapter._should_process_message(_group_message("message from free response user", from_user_id=222)) is True
+
+
+def test_require_mention_chats_apply_mention_gate_to_one_chat():
+    adapter = _make_adapter(require_mention=False, require_mention_chats=["-200"])
+
+    assert adapter._should_process_message(_group_message("ordinary message in open chat", chat_id=-100)) is True
+    assert adapter._should_process_message(_group_message("ordinary message in mention-gated chat", chat_id=-200)) is False
+
+    text = "@hermes_bot direct request"
+    assert adapter._should_process_message(
+        _group_message(text, chat_id=-200, entities=[_mention_entity(text)])
+    ) is True
+
+
+def test_strict_mention_chats_reject_reply_and_pattern_fallbacks():
+    adapter = _make_adapter(
+        require_mention=False,
+        strict_mention_chats=["-200"],
+        mention_patterns=[r"\bbot\b"],
+    )
+
+    assert adapter._should_process_message(_group_message("ordinary message in open chat", chat_id=-100)) is True
+    assert adapter._should_process_message(_group_message("loose bot wake word", chat_id=-200)) is False
+    assert adapter._should_process_message(_group_message("reply in strict chat", chat_id=-200, reply_to_bot=True)) is False
+
+    text = "@hermes_bot direct request"
+    assert adapter._should_process_message(
+        _group_message(text, chat_id=-200, entities=[_mention_entity(text)])
+    ) is True
+
+
+def test_unmentioned_group_messages_can_be_observed_for_require_mention_chat():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=False,
+            require_mention_chats=["-100"],
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        update = SimpleNamespace(
+            update_id=1002,
+            message=_group_message("side chatter"),
+            effective_message=None,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        adapter._message_handler.assert_not_awaited()
+        assert len(store.messages) == 1
+        assert store.messages[0][1]["content"] == "[Alice Example|111]\nside chatter"
+
+    asyncio.run(_run())
+
+
+def test_strict_mention_users_do_not_wake_on_reply_or_pattern():
+    adapter = _make_adapter(
+        require_mention=True,
+        strict_mention_users=["222"],
+        mention_patterns=[r"\bbot\b"],
+    )
+
+    assert adapter._should_process_message(_group_message("loose bot wake word", from_user_id=222)) is False
+    assert adapter._should_process_message(
+        _group_message("reply in an operator conversation", from_user_id=222, reply_to_bot=True)
+    ) is False
+
+    text = "@hermes_bot please handle this"
+    assert adapter._should_process_message(
+        _group_message(text, from_user_id=222, entities=[_mention_entity(text)])
+    ) is True
+
+
+def test_free_response_and_strict_mention_users_allow_two_profile_group_routing():
+    """Profile 2 can answer user 2 while user 1 talks normally in the same group."""
+    profile_2_bot = _make_adapter(
+        require_mention=True,
+        free_response_users=["222"],
+        strict_mention_users=["111"],
+        bot_username="profile2_bot",
+    )
+
+    assert profile_2_bot._should_process_message(
+        _group_message("user 1 talking to user 2", from_user_id=111)
+    ) is False
+    assert profile_2_bot._should_process_message(
+        _group_message("user 2 asks profile 2 normally", from_user_id=222)
+    ) is True
+
+    text = "@profile2_bot user 1 explicitly asks profile 2"
+    assert profile_2_bot._should_process_message(
+        _group_message(text, from_user_id=111, entities=[_mention_entity(text, "@profile2_bot")])
+    ) is True
+
+
 def test_explicit_multi_bot_mentions_route_only_to_named_bots():
     text = "@research_bot @ops_bot hi"
     entities = _mention_entities(text, ["@research_bot", "@ops_bot"])
@@ -535,6 +649,14 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
         "    - \"^\\\\s*chompy\\\\b\"\n"
         "  free_response_chats:\n"
         "    - \"-123\"\n"
+        "  require_mention_chats:\n"
+        "    - \"-200\"\n"
+        "  strict_mention_chats:\n"
+        "    - \"-300\"\n"
+        "  free_response_users:\n"
+        "    - \"222\"\n"
+        "  strict_mention_users:\n"
+        "    - \"111\"\n"
         "  allowed_chats:\n"
         "    - \"-100\"\n"
         "  group_allowed_chats:\n"
@@ -587,6 +709,10 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     # TELEGRAM_FREE_RESPONSE_CHATS is not a key that appears in developer .env
     # files, so asserting it via os.environ stays deterministic.
     assert __import__("os").environ["TELEGRAM_FREE_RESPONSE_CHATS"] == "-123"
+    assert tg_cfg.extra.get("require_mention_chats") == ["-200"]
+    assert tg_cfg.extra.get("strict_mention_chats") == ["-300"]
+    assert tg_cfg.extra.get("free_response_users") == ["222"]
+    assert tg_cfg.extra.get("strict_mention_users") == ["111"]
 
 
 def test_top_level_require_mention_bridges_to_telegram(monkeypatch, tmp_path):

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -534,12 +534,16 @@ Hermes Agent works in Telegram group chats with a few considerations:
 - **Privacy mode** determines what messages the bot can see (see [Step 3](#step-3-privacy-mode-critical-for-groups))
 - `TELEGRAM_ALLOWED_USERS` still applies — only authorized users can trigger the bot, even in groups
 - You can keep the bot from responding to ordinary group chatter with `telegram.require_mention: true`
+- Use `telegram.require_mention_chats` to apply mention gating to specific chat IDs without changing the default for every Telegram group this profile can see.
+- Use `telegram.strict_mention_chats` when a specific chat must require explicit `@botusername` mentions; replies to the bot and `mention_patterns` do not wake the bot in those chats.
 - With `telegram.require_mention: true`, group messages are accepted when they are:
   - replies to one of the bot's messages
   - `@botusername` mentions
   - `/command@botusername` (Telegram's bot-menu command form that includes the bot name)
   - matches for one of your configured regex wake words in `telegram.mention_patterns`
 - In groups with multiple Hermes bots, `telegram.exclusive_bot_mentions` keeps routing deterministic. When a message explicitly mentions one or more Telegram bot usernames, only the mentioned bot profiles process it; other Hermes bots ignore it before reply and wake-word fallbacks run. This is enabled by default.
+- Use `telegram.free_response_users` to let specific Telegram user IDs bypass `telegram.require_mention` while everyone else still needs a trigger.
+- Use `telegram.strict_mention_users` for operator/user IDs that must explicitly `@botusername` this bot; replies to the bot and `mention_patterns` do not wake the bot for those users.
 - Renaming the bot's `@username` in BotFather is picked up automatically — Hermes follows the new handle for mention routing without a gateway restart. Collectible (Fragment) usernames that don't end in `bot` are supported too.
 - Use `telegram.ignored_threads` to keep Hermes silent in specific Telegram forum topics, even when the group would otherwise allow free responses or mention-triggered replies
 - If `telegram.require_mention` is left unset or false, Hermes keeps the previous open-group behavior and responds to normal group messages it can see
@@ -560,6 +564,22 @@ telegram:
 With this setup, a group message like `@research_bot @ops_bot summarize this` is processed by `research_bot` and `ops_bot` only. Other Hermes bots in the group stay silent, even if the message is a reply to one of their earlier messages or would otherwise match a shared wake word.
 
 Set `exclusive_bot_mentions: false` only for legacy groups where explicit mentions should not override reply and wake-word triggers.
+
+For a two-profile group where profile 1 should be able to talk normally without waking profile 2, while user 2 can talk to profile 2 naturally, configure profile 2 like this:
+
+```yaml
+telegram:
+  require_mention: true
+  exclusive_bot_mentions: true
+  # Alternative: keep require_mention false globally and use
+  # require_mention_chats / strict_mention_chats for only selected chat IDs.
+  free_response_users:
+    - "222222222"   # user 2 can use profile 2 conversationally
+  strict_mention_users:
+    - "111111111"   # user 1 must explicitly @mention profile 2
+```
+
+Run profile 1 as a separate Telegram bot/profile with its own token. If profile 1 should also stay quiet in that group, keep `require_mention: true` on profile 1 as well.
 
 To operate several profiles, run the gateway command once per profile. For example:
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -535,7 +535,7 @@ Hermes Agent works in Telegram group chats with a few considerations:
 - `TELEGRAM_ALLOWED_USERS` still applies — only authorized users can trigger the bot, even in groups
 - You can keep the bot from responding to ordinary group chatter with `telegram.require_mention: true`
 - Use `telegram.require_mention_chats` to apply mention gating to specific chat IDs without changing the default for every Telegram group this profile can see.
-- Use `telegram.strict_mention_chats` when a specific chat must require explicit `@botusername` mentions; replies to the bot and `mention_patterns` do not wake the bot in those chats.
+- Use `telegram.strict_mention_chats` when a specific chat must require explicit `@botusername` mentions; replies to the bot and `mention_patterns` do not wake the bot in those chats. This setting takes precedence over `telegram.free_response_chats` and `telegram.free_response_users`, so every message in a strict chat still needs a direct bot mention. `telegram.strict_mention_users` continues to require direct mentions for its configured users outside strict chats.
 - With `telegram.require_mention: true`, group messages are accepted when they are:
   - replies to one of the bot's messages
   - `@botusername` mentions


### PR DESCRIPTION
## Summary

- Restores the work from closed PR #50463 as a clean replacement against current `main`.
- Adds generic chat- and user-scoped Telegram mention/free-response routing controls.
- Strict chat controls take precedence over any overlapping free-response user/chat configuration; those chats accept only a direct `@botusername` mention.
- Retains the current plugin architecture and adds scoped mention-gated observation coverage.

## Verification

- `scripts/run_tests.sh tests/gateway/test_telegram_group_gating.py -q`
  - 31 passed, 0 failed
- Ruff and in-memory syntax checks passed for the adapter and targeted test.
- `git diff --check origin/main...HEAD` passed.
- Two independent read-only publication reviews were performed; the first caught a strict-chat precedence flaw, which was corrected and then re-reviewed as PASS.

## Attribution / prior PR

This replaces closed PR #50463 after its old PR record became detached during an authorship repair. The replacement contains only generic, current-main-compatible changes. All commits are authored and committed by `DeadlySilent`.
