### PR TITLE
fix(proxy): honor Nous auth profile fallback

### DIFF
--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, FrozenSet, Optional
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_NOUS_INFERENCE_URL,
+    get_provider_auth_state,
     _load_auth_store,
     _auth_store_lock,
     _is_terminal_nous_refresh_error,
@@ -161,13 +162,10 @@ class NousPortalAdapter(UpstreamAdapter):
 
     def _read_state(self) -> Optional[Dict[str, Any]]:
         try:
-            with _auth_store_lock():
-                store = _load_auth_store()
+            state = get_provider_auth_state("nous")
         except Exception as exc:
-            logger.warning("proxy: failed to load auth store: %s", exc)
+            logger.warning("proxy: failed to resolve Nous auth state: %s", exc)
             return None
-        providers = store.get("providers") or {}
-        state = providers.get("nous")
         if not isinstance(state, dict):
             return None
         return dict(state)  # copy so the refresh helper can mutate freely

--- a/tests/hermes_cli/test_proxy_nous_profile_fallback.py
+++ b/tests/hermes_cli/test_proxy_nous_profile_fallback.py
@@ -1,0 +1,67 @@
+"""Regression tests for Nous proxy auth resolution across named profiles."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+
+
+def _write_auth(path: Path, providers: dict) -> None:
+    path.write_text(json.dumps({"version": 1, "providers": providers}))
+
+
+def test_nous_proxy_falls_back_to_global_auth_for_named_profile(tmp_path, monkeypatch):
+    """Proxy readiness must agree with the canonical auth resolver."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    global_root = tmp_path / ".hermes"
+    profile_home = global_root / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    _write_auth(
+        global_root / "auth.json",
+        {
+            "nous": {
+                "access_token": "global-access",
+                "refresh_token": "global-refresh",
+            }
+        },
+    )
+    _write_auth(profile_home / "auth.json", {})
+
+    adapter = NousPortalAdapter()
+
+    assert adapter.is_authenticated()
+    assert adapter._read_state()["access_token"] == "global-access"
+
+
+def test_nous_proxy_keeps_profile_auth_precedence(tmp_path, monkeypatch):
+    """A profile-local Nous state must still shadow the global fallback."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    global_root = tmp_path / ".hermes"
+    profile_home = global_root / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    _write_auth(
+        global_root / "auth.json",
+        {
+            "nous": {
+                "access_token": "global-access",
+                "refresh_token": "global-refresh",
+            }
+        },
+    )
+    _write_auth(
+        profile_home / "auth.json",
+        {
+            "nous": {
+                "access_token": "profile-access",
+                "refresh_token": "profile-refresh",
+            }
+        },
+    )
+
+    assert NousPortalAdapter()._read_state()["access_token"] == "profile-access"


### PR DESCRIPTION
## Summary

- make the Nous proxy resolve authentication through Hermes' canonical provider-state resolver
- preserve profile-local auth precedence while allowing the existing global fallback for named profiles
- add focused regression coverage for both fallback and precedence

## Root cause

`NousPortalAdapter._read_state()` read `providers.nous` directly from the active profile's `auth.json`.

That bypassed the canonical `get_provider_auth_state("nous")` path, which already implements the intended rule: profile state wins when present, otherwise a named profile falls back to the global Hermes auth store.

As a result, `hermes auth status nous` could report the user as authenticated while `hermes proxy start --provider nous` reported that Nous Portal was not logged in.

## Fix

Use `get_provider_auth_state("nous")` for the proxy's read path. Refresh and persistence behavior is unchanged.

## Testing

- added regression coverage for global fallback from a named profile
- added coverage that profile-local Nous state still shadows the global state
- tests not run locally in this environment

Closes #98098
