### PR TITLE
feat(plugins): expose tool progress callbacks to handlers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3588,6 +3588,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
+                progress_callback=getattr(agent, "tool_progress_callback", None),
             )
             if skip_tool_execution_middleware:
                 dispatch_kwargs["skip_tool_execution_middleware"] = True

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2534,6 +2534,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_request_middleware_trace=list(middleware_trace),
                             enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                             disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                            progress_callback=getattr(agent, "tool_progress_callback", None),
                         )
 
                 (
@@ -2616,6 +2617,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_request_middleware_trace=list(middleware_trace),
                             enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                             disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                            progress_callback=getattr(agent, "tool_progress_callback", None),
                         )
 
                 (

--- a/model_tools.py
+++ b/model_tools.py
@@ -1253,6 +1253,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    progress_callback: Optional[Any] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1392,6 +1393,7 @@ def handle_function_call(
                 tool_request_middleware_trace=list(_tool_middleware_trace),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
+                progress_callback=progress_callback,
             )
 
     _tool_original_args = dict(function_args)
@@ -1548,6 +1550,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         enabled_tools=sandbox_enabled,
+                        progress_callback=progress_callback,
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
@@ -1556,6 +1559,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         user_task=user_task,
+                        progress_callback=progress_callback,
                     )
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)

--- a/tests/run_agent/test_plugin_progress_callback.py
+++ b/tests/run_agent/test_plugin_progress_callback.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.agent_runtime_helpers import invoke_tool
+
+
+def test_agent_progress_callback_reaches_registry_dispatch():
+    callback = object()
+    captured = {}
+
+    def fake_handle_function_call(name, args, task_id, **kwargs):
+        captured.update(kwargs)
+        return '{"ok":true}'
+
+    agent = SimpleNamespace(
+        session_id="session-1",
+        valid_tool_names={"web_search"},
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+        tool_progress_callback=callback,
+        _memory_manager=None,
+        _current_turn_id="turn-1",
+        _current_api_request_id="request-1",
+    )
+    fake_run_agent = SimpleNamespace(handle_function_call=fake_handle_function_call)
+
+    with patch("agent.agent_runtime_helpers._ra", return_value=fake_run_agent):
+        result = invoke_tool(
+            agent,
+            "web_search",
+            {"q": "test"},
+            "task-1",
+            pre_tool_block_checked=True,
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+
+    assert result == '{"ok":true}'
+    assert captured["progress_callback"] is callback

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -381,6 +381,36 @@ def test_execute_tool_calls_sequential_flushes_each_tool_result_before_next_disp
     ]
 
 
+@pytest.mark.parametrize("quiet_mode", [True, False])
+def test_sequential_dispatch_forwards_plugin_progress_callback(quiet_mode):
+    """Gateway progress must reach registry-backed plugin handlers."""
+    agent = _make_agent()
+    setattr(agent, "quiet_mode", quiet_mode)
+    callback = object()
+    setattr(agent, "tool_progress_callback", callback)
+    tool_call = _mock_tool_call(name="web_search", call_id="progress-call")
+    assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    captured: dict = {}
+
+    def _fake_dispatch(_name, _args, _task_id, **kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    agent._flush_messages_to_session_db = MagicMock()
+    with (
+        patch("run_agent.handle_function_call", side_effect=_fake_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_sequential(
+            assistant_message, [], "task-progress"
+        )
+
+    assert captured.get("progress_callback") is callback
+
+
 def test_sequential_keyboard_interrupt_emits_results_for_all_calls():
     """A KeyboardInterrupt mid-batch must not leave dangling tool_calls.
 

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -30,6 +30,46 @@ class TestHandleFunctionCall:
         assert "error" in result
         assert "totally_fake_tool_xyz" in result["error"]
 
+    def test_progress_callback_is_forwarded_to_registry_handler(self):
+        callback = object()
+        with patch("model_tools.registry.dispatch", return_value='{"ok":true}') as dispatch:
+            result = handle_function_call(
+                "web_search",
+                {"query": "test"},
+                task_id="task-1",
+                progress_callback=callback,
+            )
+
+        assert result == '{"ok":true}'
+        assert dispatch.call_args.kwargs["progress_callback"] is callback
+
+    def test_deferred_tool_call_forwards_progress_callback(self):
+        callback = object()
+        tool_def = {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        with (
+            patch("model_tools.get_tool_definitions", return_value=[tool_def]),
+            patch("tools.tool_search.resolve_underlying_call", return_value=("web_search", {"q": "test"}, None)),
+            patch("tools.tool_search.scoped_deferrable_names", return_value={"web_search"}),
+            patch("tools.tool_search.validate_deferred_call_args", return_value=None),
+            patch("model_tools.registry.dispatch", return_value='{"ok":true}') as dispatch,
+        ):
+            result = handle_function_call(
+                "tool_call",
+                {"name": "web_search", "arguments": {"q": "test"}},
+                task_id="task-bridge",
+                progress_callback=callback,
+            )
+
+        assert result == '{"ok":true}'
+        assert dispatch.call_args.kwargs["progress_callback"] is callback
+
 
 
     def test_post_tool_call_receives_non_negative_integer_duration_ms(self):


### PR DESCRIPTION
## Summary

- expose the existing per-turn `tool_progress_callback` to registry-backed custom/plugin tool handlers
- preserve callback identity through direct, deferred `tool_call`, concurrent, and both sequential executor paths
- keep the API backward compatible with an optional `None` default and no model-visible schema or transcript changes

## Motivation

Custom long-running tools can currently return only a final result even though the gateway already owns a turn-scoped progress renderer. The registry handler receives task/session context but not the existing presentation callback, so standalone plugins cannot publish safe local progress into the same editable gateway bubble.

This adds only the missing callback plumbing; it does not introduce a new tool, model call, message role, or persistence path.

## Verification

- `48 passed` — model dispatcher, invoke path, and sequential executor tests
- `15 passed` — gateway callback/render seam tests
- `73 passed` — registry and deferred tool-search bridge tests
- `136 passed` total across the focused groups
- `python -m py_compile` on all changed source/tests
- `git diff --check`
- independent review: PASS
- live Telegram E2E with an external role-task plugin showed multiple sanitized child activities updating during a 36-second custom tool invocation

## Safety

- callback defaults to `None`
- no model-visible tool schema changes
- no progress events are added to the model transcript
- no extra model/API calls are made for progress
- existing registry exception handling and middleware semantics are preserved
