### PR TITLE
fix(desktop): tear down backend on SIGTERM/SIGINT

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -17648,3 +17648,24 @@ app.on('window-all-closed', () => {
     app.quit()
   }
 })
+
+// SIGTERM/SIGINT (session logout, `kill`, a supervising process stopping us)
+// bypass the normal window-close -> before-quit -> backendShutdown path
+// entirely, since Node's default disposition for those signals is to die
+// immediately. Without an explicit handler here the backend child (and any
+// pooled backends) get reparented to init and keep running after the
+// desktop process is gone. Handle both so a signal-based stop always tears
+// the backend down before the process exits.
+let isExitingFromSignal = false
+
+function handleTerminationSignal() {
+  if (isExitingFromSignal) {
+    return
+  }
+
+  isExitingFromSignal = true
+  void exitAfterBackendShutdown(0)
+}
+
+process.on('SIGTERM', handleTerminationSignal)
+process.on('SIGINT', handleTerminationSignal)


### PR DESCRIPTION
## What this does

Adds `SIGTERM`/`SIGINT` handlers to the Electron main process so a signal-based stop tears the backend down before exit.

Only a graceful window-close reached the `before-quit` → `backendShutdown` path. A signal-based stop — session logout, `kill`, a supervising process — bypassed it entirely, because Node's default disposition for `SIGTERM`/`SIGINT` is immediate termination. The backend child and any pooled backends were then reparented to `init` and kept running after the desktop process was gone.

```js
let isExitingFromSignal = false

function handleTerminationSignal() {
  if (isExitingFromSignal) {
    return
  }

  isExitingFromSignal = true
  void exitAfterBackendShutdown(0)
}

process.on('SIGTERM', handleTerminationSignal)
process.on('SIGINT', handleTerminationSignal)
```

The `isExitingFromSignal` guard makes a repeated signal a no-op rather than re-entering teardown.

## Scope change since the original submission

This PR originally also carried a `.desktop` `Exec=` venv fix. **That half has been dropped** — 6fe933e7 (*"fix(cli): launch-context-independent Linux desktop-entry Exec"*, salvaged from #94874) landed upstream with a strictly more general fix: it keeps the lexical `sys.executable` when a `pyvenv.cfg` sits at or above it in the tree, and falls back to the dereferenced path otherwise. That supersedes what this PR did, so on rebase I took upstream's version of `hermes_cli/linux_desktop_entry.py` unchanged.

What remains is only the signal-teardown change, which is still unique — there are currently no `process.on(` signal handlers in `apps/desktop/electron/main.ts` on `main`.

## Verification

Rebased onto current `main` (1 ahead, 0 behind).

- `npm run typecheck` → `tsc -p tsconfig.electron.json --noEmit` passes clean
- `eslint electron/main.ts` passes clean

## Notes

`exitAfterBackendShutdown` is invoked fire-and-forget (`void`), as raised in the earlier automated review on this PR. If `backendShutdown` can hang, the signal handler will not force an exit. Happy to add a bounded timeout / `SIGKILL` escalation here if maintainers prefer that belt-and-braces.
