### PR TITLE
fix(desktop): preserve backend-skin theme across app restarts

### DIFF
--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -50,7 +50,17 @@ const resolveMode = (mode: ThemeMode, systemDark = matchesQuery('(prefers-color-
   mode === 'system' ? (systemDark ? 'dark' : 'light') : mode
 
 const normalizeSkin = (name: string | null): string =>
-  name && resolveTheme(name) && !RETIRED_SKINS.has(name) ? name : DEFAULT_SKIN_NAME
+  // LOCAL PATCH (darkside-boot-paint): do NOT drop names that don't resolve in
+  // the registry yet. Backend skins (custom YAML skins from the CLI side, e.g.
+  // `darkside`) only register into $backendThemes when the gateway connects —
+  // which is AFTER the boot paint and after normalizeSkin first runs at
+  // module scope. Rewriting them to DEFAULT_SKIN_NAME here erased the stored
+  // preference on every relaunch, so a backend-skin choice never survived a
+  // restart. deriveTheme() already falls back to the nous seed for unresolvable
+  // names, so an unknown name paints safely until the backend registers it;
+  // `activeTheme`'s memo re-derives when $backendThemes changes. Only truly
+  // retired names are normalized away.
+  !name || RETIRED_SKINS.has(name) ? DEFAULT_SKIN_NAME : name
 
 /**
  * A stored mode, or `system` when there isn't one.


### PR DESCRIPTION
## Bug Description

A skin activated from the backend (e.g. a custom YAML skin like `darkside` in `$HERMES_HOME/skins/`, activated via `hermes config set display.skin darkside` or `/skin`) is forgotten by the desktop app on every relaunch — the app repaints with the built-in default (`nous`) and the user has to re-pick it each session. Setting it in `config.yaml` has no lasting effect for the same reason.

## Root Cause

Two correct-looking safety mechanisms interact to erase the preference:

1. **Boot-time normalization runs before the backend connects.** The boot paint and `normalizeSkin()` execute at module scope, before the gateway connects. At that moment the theme registry (`resolveTheme`) contains only built-in desktop themes and user-installed themes — backend skins are not registered into `$backendThemes` until `gateway.ready`/`skin.changed` arrives (`themes/backend-sync.ts`).
2. `normalizeSkin` resolved the stored name against that incomplete registry and silently rewrote any unresolvable name to `DEFAULT_SKIN_NAME` (`nous`), **erasing the stored preference** in localStorage.
3. The gateway's connect-time seed deliberately does **not** re-apply (`ingestBackendSkin` with `apply: false`, per its own docstring: "a fresh connect never stomps the user's persisted desktop theme"). Since the persisted theme was already erased in step 2, nothing ever corrects it.

Net effect: a backend-skin choice can never survive a restart, while built-in desktop themes persist fine.

## Fix

`normalizeSkin` now keeps any non-empty, non-retired name instead of dropping names that don't resolve *yet*:

```ts
const normalizeSkin = (name: string | null): string =>
  !name || RETIRED_SKINS.has(name) ? DEFAULT_SKIN_NAME : name
```

Safety:
- `deriveTheme()` already falls back to the `nous` seed for unresolvable names, so an unknown name paints a complete, valid palette (no broken/garbled paint) until the backend registers the real skin.
- `activeTheme`'s memo depends on `backendThemes`, so the real palette repaints as soon as `ingestBackendSkin` registers it — no snap-back, no missed paint.
- `previewTheme` only previews names that resolve, and is unaffected.
- The `RETIRED_SKINS` guard is preserved, so genuinely removed skins still normalize away.

## How to Verify

1. Create a custom skin: `hermes config set display.skin darkside` (or any custom `~/.hermes/skins/*.yaml`).
2. Open the desktop app, confirm the skin appears in Appearance.
3. Quit and relaunch the desktop app.
4. Before: app repaints with `nous`; the Appearance grid shows the default selected. After this fix: the backend skin is still selected and painted.

## Test Plan

- [x] Manual verification on macOS (arm64): rebuilt the app, confirmed the patched `normalizeSkin` logic in the packaged bundle, picked a backend skin, restarted, theme persisted
- [ ] Existing `context.test.tsx` suite passes (CI)
- [ ] Consider adding a regression case: stored name that doesn't resolve in the registry is preserved, not rewritten

## Risk Assessment

Low — the change only stops discarding not-yet-resolvable names. Worst case for a garbage stored name is painting the `nous` fallback (same visual outcome as before) until it's either registered by the backend or manually changed; previously it was silently rewritten to the same default.