### PR TITLE
fix(desktop): avoid waking Bots for avatar hydration

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/routing-passive-assets.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/routing-passive-assets.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RosterRow } from './types'
+
+const { hostMock } = vi.hoisted(() => ({
+  hostMock: {
+    activeConnectionId: vi.fn(() => 'local'),
+    request: vi.fn(),
+    requestProfile: vi.fn(),
+    state: { connectionId: { get: vi.fn(() => 'local') } }
+  }
+}))
+
+vi.mock('@hermes/plugin-sdk', () => ({ host: hostMock }))
+
+const { requestForBot } = await import('./routing')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hostMock.activeConnectionId.mockReturnValue('local')
+  hostMock.state.connectionId.get.mockReturnValue('local')
+})
+
+describe('passive Bot asset routing', () => {
+  it('reads an avatar through the already-active source without activating the Bot profile', async () => {
+    hostMock.request.mockResolvedValue({ found: true, data: 'data:image/png;base64,avatar' })
+
+    const bot = {
+      connectionId: 'local',
+      connectionKind: 'local',
+      name: 'designer',
+      route: {
+        connectionId: 'local',
+        mode: 'local',
+        profile: 'designer',
+        targetProfile: 'designer-backend'
+      },
+      sourceScoped: true,
+      targetProfile: 'designer-backend'
+    } as RosterRow
+
+    await expect(
+      requestForBot(bot, 'profiles.get_asset', { name: 'designer', asset: 'avatar' })
+    ).resolves.toMatchObject({ found: true })
+
+    expect(hostMock.request).toHaveBeenCalledWith('profiles.get_asset', {
+      name: 'designer-backend',
+      asset: 'avatar'
+    })
+    expect(hostMock.requestProfile).not.toHaveBeenCalled()
+  })
+
+  it('defers an inactive source instead of dialing its dormant Bot profile', async () => {
+    hostMock.state.connectionId.get.mockReturnValue('source-a')
+    hostMock.activeConnectionId.mockReturnValue('source-a')
+
+    const bot = {
+      connectionId: 'source-b',
+      connectionKind: 'remote',
+      name: 'researcher',
+      remoteSource: true,
+      route: {
+        connectionId: 'source-b',
+        mode: 'remote',
+        profile: 'researcher',
+        targetProfile: 'backend-researcher'
+      },
+      sourceScoped: true,
+      targetProfile: 'backend-researcher'
+    } as RosterRow
+
+    await expect(
+      requestForBot(bot, 'profiles.get_asset', { name: 'researcher', asset: 'avatar' })
+    ).rejects.toThrow(/deferred until source source-b is active/)
+
+    expect(hostMock.request).not.toHaveBeenCalled()
+    expect(hostMock.requestProfile).not.toHaveBeenCalled()
+  })
+
+  it('keeps non-asset Bot RPCs on strict per-profile routing', async () => {
+    hostMock.requestProfile.mockResolvedValue({ ok: true })
+
+    const bot = {
+      connectionId: 'local',
+      connectionKind: 'local',
+      name: 'designer',
+      route: {
+        connectionId: 'local',
+        mode: 'local',
+        profile: 'designer',
+        targetProfile: 'designer-backend'
+      },
+      sourceScoped: true,
+      targetProfile: 'designer-backend'
+    } as RosterRow
+
+    await requestForBot(bot, 'profiles.configure', { name: 'designer', soul: '# hi' })
+
+    expect(hostMock.requestProfile).toHaveBeenCalledWith(bot.route, 'profiles.configure', {
+      name: 'designer-backend',
+      soul: '# hi'
+    })
+    expect(hostMock.request).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/routing.ts
+++ b/apps/desktop/src/plugins/hermes-bots/routing.ts
@@ -195,8 +195,12 @@ export function botBackendProfileScope(route: null | ProfileRoute | undefined, f
   }
 }
 
-/** Gateway RPC on the bot's OWN source. Source-scoped rows always use the
- * explicit descriptor, including a registered local source. */
+const PASSIVE_PROFILE_ASSET_METHODS = new Set(['profiles.get_asset', 'profiles.set_asset'])
+
+/** Gateway RPC on the bot's OWN source. Source-scoped rows normally use the
+ * explicit profile descriptor. Passive avatar reads/writes are the exception:
+ * any already-open gateway on the owning source can access the target profile's
+ * asset path, so never materialize a dormant Bot backend just to paint UI. */
 export async function requestForBot<T = unknown>(
   bot: Partial<RosterRow> | null | undefined,
   method: string,
@@ -205,12 +209,34 @@ export async function requestForBot<T = unknown>(
   const route = botConnectionRoute(bot)
 
   if (route) {
+    const scopedParams = scopedBotParams(route, method, params)
+
+    if (PASSIVE_PROFILE_ASSET_METHODS.has(method)) {
+      const activeConnectionId = String(
+        host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local'
+      ).trim()
+
+      // Avatar sync is best-effort presentation work. If its owning source is
+      // not the source already connected to this renderer, defer the asset
+      // refresh rather than opening the Bot's profile backend. The next roster
+      // refresh after that source becomes active will retry automatically.
+      if (activeConnectionId !== route.connectionId) {
+        throw new Error(`Passive ${method} deferred until source ${route.connectionId} is active`)
+      }
+
+      try {
+        return await host.request(method, scopedParams)
+      } catch (error) {
+        throw asRpcError(error, `Gateway request ${method} failed`)
+      }
+    }
+
     if (typeof host.requestProfile !== 'function') {
       throw new Error(`Cannot route ${method} for ${route.connectionId}::${route.profile}`)
     }
 
     try {
-      return await host.requestProfile(route, method, scopedBotParams(route, method, params))
+      return await host.requestProfile(route, method, scopedParams)
     } catch (error) {
       // React 19 formats query errors with `(error.name || '').trim()`. IPC /
       // JSON-RPC rejections are often plain objects whose `name` is a number,


### PR DESCRIPTION
## Summary

- keep passive Bot avatar reads and backfills on an already-active source gateway
- never open a dormant target-profile backend just to hydrate roster artwork
- preserve target-profile alias rewriting for asset paths
- leave all non-asset Bot RPCs on the existing strict per-profile route

## Root cause

`pullServerAvatars()` and the avatar backfill path both call `requestForBot()` for source-scoped roster rows.

`requestForBot()` normally routes through `host.requestProfile()`. That is correct for actual Bot work, but it also means a read-only `profiles.get_asset` can materialize the target profile backend. On a large local roster, passive avatar hydration therefore wakes every dormant specialist.

Profile asset handlers do not require the target runtime. They accept the target profile name and read/write that profile's asset path directly.

The router now treats `profiles.get_asset` and `profiles.set_asset` as passive asset operations. When the owning source is already active, they use that source's existing gateway with the target profile preserved in the RPC parameters. When the source is inactive, the best-effort avatar refresh is deferred instead of dialing a profile backend; the existing roster refresh path retries later.

All other Bot methods keep the existing `requestProfile` behavior.

## Testing

Focused regression coverage verifies:

- an active source avatar read uses `host.request` and never `requestProfile`
- an inactive source is deferred without dialing anything
- normal profile RPCs still use strict per-profile routing

Tests not run locally in this environment.

Closes #98123
