### PR TITLE
feat(desktop): add no-payload watchdog for stuck thinking spinner

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -35,6 +35,14 @@ import type { ClientSessionState } from '../../../types'
 import { useGatewayEventHandler } from './gateway-event'
 import { completionErrorText, delegateTaskPayloads, MAX_STREAM_FLUSH_GAP_MS, STREAM_DELTA_FLUSH_MS } from './utils'
 
+// When a turn goes live (message.start) but the backend dies before producing
+// ANY assistant payload, no message.complete ever arrives and the gateway may
+// stop heartbeating entirely. The existing 15s pre-start grace gate only covers
+// turns that never went live; once turnLive=true, a dead backend leaves the
+// spinner pinned until the 5-min session watchdog fires. This constant bounds
+// that wait: if a live turn has produced nothing for this long, force-settle.
+export const NO_PAYLOAD_WATCHDOG_MS = 60_000
+
 interface MessageStreamOptions {
   activeGatewayProfile?: string
   activeSessionIdRef: MutableRefObject<string | null>
@@ -873,6 +881,53 @@ export function useMessageStream({
     updateSessionState,
     upsertToolCall
   })
+
+  // No-payload watchdog: a turn that went live (message.start) but whose
+  // backend died before producing any assistant text leaves turnLive=busy=true
+  // forever — no message.complete arrives, and a dead gateway stops heartbeating,
+  // so the existing session.info running=false settle never fires. The 5-min
+  // session watchdog is the only existing backstop; this bounds the wait to
+  // NO_PAYLOAD_WATCHDOG_MS. Scans the per-runtime state map on a cheap
+  // interval and force-settles any live turn that has produced nothing.
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      const now = Date.now()
+      const states = sessionStateByRuntimeIdRef.current
+
+      for (const [sid, state] of states.entries()) {
+        if (
+          !state.turnLive ||
+          state.sawAssistantPayload ||
+          !state.busy ||
+          !state.awaitingResponse ||
+          typeof state.turnStartedAt !== 'number'
+        ) {
+          continue
+        }
+
+        if (now - state.turnStartedAt > NO_PAYLOAD_WATCHDOG_MS) {
+          updateSessionState(sid, s => {
+            // Re-check under the updater — state may have advanced since scan.
+            if (!s.turnLive || s.sawAssistantPayload || !s.busy) {
+              return s
+            }
+            return {
+              ...s,
+              awaitingResponse: false,
+              busy: false,
+              pendingBranchGroup: null,
+              streamId: null,
+              turnStartedAt: null,
+              turnLive: false
+            }
+          })
+          scheduleSessionsRefresh()
+        }
+      }
+    }, 5_000)
+
+    return () => window.clearInterval(intervalId)
+  }, [scheduleSessionsRefresh, sessionStateByRuntimeIdRef, updateSessionState])
 
   return {
     appendAssistantDelta,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -860,6 +860,117 @@ export function useMessageStream({
     [updateSessionState]
   )
 
+  // No-payload watchdog: a turn that went live (message.start) but whose
+  // backend died before producing any assistant text leaves turnLive=busy=true
+  // forever — no message.complete arrives, and a dead gateway stops
+  // heartbeating, so the existing session.info running=false settle never
+  // fires. The 5-min session watchdog is the only existing backstop; this
+  // bounds the wait to NO_PAYLOAD_WATCHDOG_MS.
+  //
+  // Lazy-armed, not a global interval: a permanent window timer would break
+  // consumers that count outstanding timers (vi.getTimerCount) and cost a
+  // tick per window forever. The single bounded timer exists only while some
+  // session sits in the stuck shape, and it re-checks every guard at fire time
+  // (plus under the settle updater), so a payload that arrives late or a turn
+  // settled by any other path between arm and fire is left untouched.
+  const watchdogTimerRef = useRef<null | number>(null)
+  const armNoPayloadWatchdogRef = useRef<() => void>(() => undefined)
+
+  useEffect(() => {
+    const fire = () => {
+      watchdogTimerRef.current = null
+      const now = Date.now()
+      let stillStuck = false
+
+      for (const [sid, state] of sessionStateByRuntimeIdRef.current.entries()) {
+        if (
+          state.turnLive &&
+          !state.sawAssistantPayload &&
+          state.busy &&
+          state.awaitingResponse &&
+          typeof state.turnStartedAt === 'number'
+        ) {
+          if (now - state.turnStartedAt > NO_PAYLOAD_WATCHDOG_MS) {
+            updateSessionState(sid, s => {
+              // Re-check under the updater — state may have advanced since
+              // the scan above (a late payload, a settle, a Stop).
+              if (!s.turnLive || s.sawAssistantPayload || !s.busy || !s.awaitingResponse) {
+                return s
+              }
+
+              return {
+                ...s,
+                awaitingResponse: false,
+                busy: false,
+                pendingBranchGroup: null,
+                streamId: null,
+                turnStartedAt: null,
+                turnLive: false
+              }
+            })
+            scheduleSessionsRefresh()
+          } else {
+            stillStuck = true
+          }
+        }
+      }
+
+      // A candidate is still inside the grace window — rearm once, bounded.
+      if (stillStuck) {
+        armNoPayloadWatchdogRef.current()
+      }
+    }
+
+    const arm = () => {
+      if (watchdogTimerRef.current !== null) {
+        return
+      }
+
+      watchdogTimerRef.current = window.setTimeout(fire, NO_PAYLOAD_WATCHDOG_MS)
+    }
+
+    armNoPayloadWatchdogRef.current = arm
+
+    return () => {
+      armNoPayloadWatchdogRef.current = () => undefined
+
+      if (watchdogTimerRef.current !== null) {
+        window.clearTimeout(watchdogTimerRef.current)
+        watchdogTimerRef.current = null
+      }
+    }
+  }, [scheduleSessionsRefresh, sessionStateByRuntimeIdRef, updateSessionState])
+
+  // Arming rides updateSessionState — the one chokepoint every stuck-shape
+  // write flows through. message.start / the session.info running=true edge /
+  // the optimistic submit arm all produce the shape (turnLive, no payload,
+  // busy, awaiting a response, clock seeded); every settle path produces a
+  // state that fails the predicate, so the timer never re-arms itself after
+  // its own settle. The watchdog's own settle write intentionally bypasses
+  // the wrapper (raw updateSessionState inside the effect above).
+  const watchfulUpdateSessionState = useCallback(
+    (
+      sessionId: string,
+      updater: (state: ClientSessionState) => ClientSessionState,
+      storedSessionId?: string | null
+    ): ClientSessionState => {
+      const next = updateSessionState(sessionId, updater, storedSessionId)
+
+      if (
+        next.turnLive &&
+        !next.sawAssistantPayload &&
+        next.busy &&
+        next.awaitingResponse &&
+        typeof next.turnStartedAt === 'number'
+      ) {
+        armNoPayloadWatchdogRef.current()
+      }
+
+      return next
+    },
+    [updateSessionState]
+  )
+
   const handleGatewayEvent = useGatewayEventHandler({
     activeGatewayProfile,
     appendAssistantDelta,
@@ -878,56 +989,9 @@ export function useMessageStream({
     scheduleSessionsRefresh,
     sessionInterrupted,
     sessionStateByRuntimeIdRef,
-    updateSessionState,
+    updateSessionState: watchfulUpdateSessionState,
     upsertToolCall
   })
-
-  // No-payload watchdog: a turn that went live (message.start) but whose
-  // backend died before producing any assistant text leaves turnLive=busy=true
-  // forever — no message.complete arrives, and a dead gateway stops heartbeating,
-  // so the existing session.info running=false settle never fires. The 5-min
-  // session watchdog is the only existing backstop; this bounds the wait to
-  // NO_PAYLOAD_WATCHDOG_MS. Scans the per-runtime state map on a cheap
-  // interval and force-settles any live turn that has produced nothing.
-  useEffect(() => {
-    const intervalId = window.setInterval(() => {
-      const now = Date.now()
-      const states = sessionStateByRuntimeIdRef.current
-
-      for (const [sid, state] of states.entries()) {
-        if (
-          !state.turnLive ||
-          state.sawAssistantPayload ||
-          !state.busy ||
-          !state.awaitingResponse ||
-          typeof state.turnStartedAt !== 'number'
-        ) {
-          continue
-        }
-
-        if (now - state.turnStartedAt > NO_PAYLOAD_WATCHDOG_MS) {
-          updateSessionState(sid, s => {
-            // Re-check under the updater — state may have advanced since scan.
-            if (!s.turnLive || s.sawAssistantPayload || !s.busy) {
-              return s
-            }
-            return {
-              ...s,
-              awaitingResponse: false,
-              busy: false,
-              pendingBranchGroup: null,
-              streamId: null,
-              turnStartedAt: null,
-              turnLive: false
-            }
-          })
-          scheduleSessionsRefresh()
-        }
-      }
-    }, 5_000)
-
-    return () => window.clearInterval(intervalId)
-  }, [scheduleSessionsRefresh, sessionStateByRuntimeIdRef, updateSessionState])
 
   return {
     appendAssistantDelta,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/no-payload-watchdog.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/no-payload-watchdog.test.tsx
@@ -3,10 +3,15 @@
 // arrives, and a dead gateway stops heartbeating, so the existing session.info
 // running=false settle never fires. The 5-min session watchdog is the only
 // existing backstop; the no-payload watchdog bounds that wait to 60s.
+//
+// The watchdog is lazy-armed: a bounded timer exists only while a session sits
+// in the stuck shape (turnLive, no payload, busy, awaitingResponse, clock
+// seeded), armed from the updateSessionState chokepoint. No global interval —
+// that would break consumers that count outstanding timers.
 import { act, cleanup } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
 
 import { type MessageStreamHarness, renderMessageStream } from './test-harness'
 import { NO_PAYLOAD_WATCHDOG_MS } from './index'
@@ -30,24 +35,20 @@ describe('no-payload watchdog settles a live turn that produced nothing', () => 
     vi.restoreAllMocks()
   })
 
-  it('force-settles a live turn with no payload after the watchdog fires', async () => {
+  it('force-settles a live turn with no payload once the watchdog deadline passes', async () => {
     await mountHarness()
 
-    // Seed state: turn went live, backend died before any assistant payload.
-    const seeded = createClientSessionState()
-    stream.states.set(SID, {
-      ...seeded,
-      turnLive: true,
-      busy: true,
-      awaitingResponse: true,
-      sawAssistantPayload: false,
-      turnStartedAt: Date.now() - NO_PAYLOAD_WATCHDOG_MS - 1
-    })
+    // message.start goes live and arms the watchdog (busy, no payload yet).
+    emit({ session_id: SID, type: 'message.start', payload: {} })
 
-    // Advance past the 5s watchdog interval.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000)
-    })
+    // The backend dies: no deltas, no message.complete, no heartbeats.
+    // The fire→settle can rearm once (fire lands a tick after the deadline),
+    // so advance well past it in bounded steps until settled.
+    for (let i = 0; i < 5 && stream.state(SID).busy; i += 1) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(NO_PAYLOAD_WATCHDOG_MS / 2)
+      })
+    }
 
     const state = stream.state(SID)
     expect(state.busy).toBe(false)
@@ -55,23 +56,33 @@ describe('no-payload watchdog settles a live turn that produced nothing', () => 
     expect(state.turnLive).toBe(false)
     expect(state.turnStartedAt).toBeNull()
     expect(state.streamId).toBeNull()
+    // The empty placeholder bubble is not stranded pending forever.
+    expect(state.messages.every(message => !message.pending)).toBe(true)
   })
 
-  it('does NOT settle a live turn that has produced payload', async () => {
+  it('does NOT settle a live turn whose payload arrived', async () => {
     await mountHarness()
 
-    const seeded = createClientSessionState()
-    stream.states.set(SID, {
-      ...seeded,
-      turnLive: true,
-      busy: true,
-      awaitingResponse: true,
-      sawAssistantPayload: true, // payload arrived — watchdog must not fire
-      turnStartedAt: Date.now() - NO_PAYLOAD_WATCHDOG_MS - 1
-    })
+    emit({ session_id: SID, type: 'message.start', payload: {} })
+    emit({ payload: { text: 'partial answer' }, session_id: SID, type: 'message.delta' })
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000)
+      await vi.advanceTimersByTimeAsync(NO_PAYLOAD_WATCHDOG_MS + 1_000)
+    })
+
+    // Payload arrived — the turn is legitimately still working; the watchdog
+    // must leave it alone (message.complete / session.info will settle it).
+    const state = stream.state(SID)
+    expect(state.busy).toBe(true)
+  })
+
+  it('does NOT settle a healthy turn mid-flight before the deadline', async () => {
+    await mountHarness()
+
+    emit({ session_id: SID, type: 'message.start', payload: {} })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(NO_PAYLOAD_WATCHDOG_MS - 5_000)
     })
 
     const state = stream.state(SID)
@@ -79,25 +90,20 @@ describe('no-payload watchdog settles a live turn that produced nothing', () => 
     expect(state.turnLive).toBe(true)
   })
 
-  it('does NOT settle a live turn before the watchdog deadline', async () => {
+  it('releases the watchdog timer once a turn settles normally', async () => {
     await mountHarness()
 
-    const seeded = createClientSessionState()
-    stream.states.set(SID, {
-      ...seeded,
-      turnLive: true,
-      busy: true,
-      awaitingResponse: true,
-      sawAssistantPayload: false,
-      turnStartedAt: Date.now() - 10_000 // only 10s ago, watchdog is 60s
-    })
-
+    emit({ session_id: SID, type: 'message.start', payload: {} })
+    emit({ payload: { text: 'done' }, session_id: SID, type: 'message.complete' })
+    // Advance well past where a stale watchdog would fire.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000)
+      await vi.advanceTimersByTimeAsync(NO_PAYLOAD_WATCHDOG_MS + 1_000)
     })
 
     const state = stream.state(SID)
-    expect(state.busy).toBe(true)
-    expect(state.turnLive).toBe(true)
+    expect(state.busy).toBe(false)
+    expect(state.messages.every(message => !message.pending)).toBe(true)
   })
 })
+
+const emit = (event: RpcEvent) => act(() => stream.handleEvent(event))

--- a/apps/desktop/src/app/session/hooks/use-message-stream/no-payload-watchdog.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/no-payload-watchdog.test.tsx
@@ -1,0 +1,103 @@
+// A turn that went live (message.start) but whose backend died before producing
+// ANY assistant payload leaves turnLive=busy=true forever — no message.complete
+// arrives, and a dead gateway stops heartbeating, so the existing session.info
+// running=false settle never fires. The 5-min session watchdog is the only
+// existing backstop; the no-payload watchdog bounds that wait to 60s.
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+import { NO_PAYLOAD_WATCHDOG_MS } from './index'
+
+const SID = 'no-payload-watchdog-session'
+
+let stream: MessageStreamHarness
+
+async function mountHarness() {
+  vi.useFakeTimers()
+  stream = renderMessageStream(SID)
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('no-payload watchdog settles a live turn that produced nothing', () => {
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('force-settles a live turn with no payload after the watchdog fires', async () => {
+    await mountHarness()
+
+    // Seed state: turn went live, backend died before any assistant payload.
+    const seeded = createClientSessionState()
+    stream.states.set(SID, {
+      ...seeded,
+      turnLive: true,
+      busy: true,
+      awaitingResponse: true,
+      sawAssistantPayload: false,
+      turnStartedAt: Date.now() - NO_PAYLOAD_WATCHDOG_MS - 1
+    })
+
+    // Advance past the 5s watchdog interval.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    const state = stream.state(SID)
+    expect(state.busy).toBe(false)
+    expect(state.awaitingResponse).toBe(false)
+    expect(state.turnLive).toBe(false)
+    expect(state.turnStartedAt).toBeNull()
+    expect(state.streamId).toBeNull()
+  })
+
+  it('does NOT settle a live turn that has produced payload', async () => {
+    await mountHarness()
+
+    const seeded = createClientSessionState()
+    stream.states.set(SID, {
+      ...seeded,
+      turnLive: true,
+      busy: true,
+      awaitingResponse: true,
+      sawAssistantPayload: true, // payload arrived — watchdog must not fire
+      turnStartedAt: Date.now() - NO_PAYLOAD_WATCHDOG_MS - 1
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    const state = stream.state(SID)
+    expect(state.busy).toBe(true)
+    expect(state.turnLive).toBe(true)
+  })
+
+  it('does NOT settle a live turn before the watchdog deadline', async () => {
+    await mountHarness()
+
+    const seeded = createClientSessionState()
+    stream.states.set(SID, {
+      ...seeded,
+      turnLive: true,
+      busy: true,
+      awaitingResponse: true,
+      sawAssistantPayload: false,
+      turnStartedAt: Date.now() - 10_000 // only 10s ago, watchdog is 60s
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    const state = stream.state(SID)
+    expect(state.busy).toBe(true)
+    expect(state.turnLive).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

When a turn goes live (`message.start`) but the backend dies before producing ANY assistant payload, `message.complete` never arrives. The gateway stops heartbeating, so the existing `session.info` running=false settle path never fires. The 5-minute session watchdog (`SESSION_WATCHDOG_TIMEOUT_MS`) was the only backstop — leaving users staring at a thinking spinner for 3-5 minutes.

Affected models: DeepSeek, GLM Flash, and any model that hits `max_iterations` where the summary call hangs or fails silently.

Sessions from bug reports:
- `20260827_154335_e3ed79`
- `20260731_183224_ce6b1a`

## Root Cause

In `use-message-stream/index.ts`, the `completeAssistantMessage` callback only fires on `message.complete` events. When the backend dies mid-turn with no assistant text, that event never arrives. The existing pre-start grace gate (`PRE_TURN_LIVE_SETTLE_GRACE_MS = 15s`) only covers turns that never went live. Once `turnLive=true` and `sawAssistantPayload=false`, nothing settles the turn until the 5-min watchdog.

## Fix

Added a client-side **no-payload watchdog** in `useMessageStream`:

- Scans the per-runtime state map every 5 seconds
- Force-settles any session where:
  - `turnLive=true` (backend confirmed the turn started)
  - `sawAssistantPayload=false` (no assistant text ever arrived)
  - `busy=true` / `awaitingResponse=true`
  - `turnStartedAt` is older than `NO_PAYLOAD_WATCHDOG_MS` (60 seconds)
- Under the updater, re-checks all guards to avoid racing with a late payload
- Triggers `scheduleSessionsRefresh()` so the sidebar clears the working dot

## Files Changed

- `apps/desktop/src/app/session/hooks/use-message-stream/index.ts` — added `NO_PAYLOAD_WATCHDOG_MS` constant + the watchdog `useEffect`
- `apps/desktop/src/app/session/hooks/use-message-stream/no-payload-watchdog.test.tsx` — three test cases (fires after 60s, skips if payload arrived, skips before deadline)

## Testing

Three new test cases:
1. Force-settles a live turn with no payload after the watchdog fires
2. Does NOT settle a live turn that has produced payload
3. Does NOT settle a live turn before the watchdog deadline

Co-authored-by: realkdc <realkdc@users.noreply.github.com>