### PR TITLE
fix(gateway): suppress the duplicated provider-error status copy

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -878,7 +878,14 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         ):
             return None
     if _looks_like_gateway_provider_error(text):
-        return _gateway_provider_error_reply(text)
+        # A provider error also reaches the chat as the failed turn's final
+        # response, which _sanitize_gateway_final_response rewrites to the
+        # same user-safe text — delivering the rewrite here too means two
+        # identical persistent messages (#72131). Failed runs are exempted
+        # from progress-bubble cleanup, so even adapters that implement
+        # send_or_update_status keep the status copy. Suppress the transient
+        # copy; the final response still reports the failure.
+        return None
     return text
 
 

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -255,20 +255,29 @@ def test_chat_gateways_drop_interrupt_sentinel(platform):
     assert _sanitize_gateway_final_response("local", sentinel) == sentinel
 
 
-def test_telegram_status_sanitizes_raw_provider_security_errors():
-    """Provider policy/security bodies should be replaced before chat delivery."""
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_suppress_provider_error_status(platform):
+    """Provider-error statuses must not double up with the final response.
+
+    The failed turn's final response is rewritten to the same user-safe text
+    by `_sanitize_gateway_final_response`, so a status copy here would land as
+    a second identical persistent message (#72131). Suppression also keeps the
+    raw body (request ids, policy text) out of chat — nothing is delivered on
+    this path at all.
+    """
     raw = (
         "❌ API failed after 3 retries — HTTP 400: request blocked because "
         "Operation contains cybersecurity risk. request_id=req_123"
     )
 
-    sanitized = _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", raw)
+    assert _prepare_gateway_status_message(platform, "lifecycle", raw) is None
 
-    assert sanitized is not None
-    assert "provider rejected" in sanitized.lower()
-    assert "cybersecurity risk" not in sanitized.lower()
-    assert "HTTP 400" not in sanitized
-    assert "req_123" not in sanitized
+
+def test_local_status_keeps_raw_provider_errors():
+    """Local/CLI surfaces keep the raw diagnostic stream on the status path."""
+    raw = "API call failed after 3 retries: HTTP 429 Too Many Requests"
+
+    assert _prepare_gateway_status_message("local", "warn", raw) == raw
 
 
 def test_telegram_final_response_sanitizes_raw_provider_errors():


### PR DESCRIPTION
## What does this PR do?

Fixes the double delivery of provider errors to chat surfaces (#72131). A provider failure was surfaced through two gateway channels that produce byte-identical text:

1. the mid-run status callback — `_prepare_gateway_status_message` rewrote the raw provider error via `_gateway_provider_error_reply` and sent it;
2. the failed turn's final response — `_sanitize_gateway_final_response` rewrote it to the same user-safe text and sent it again.

For adapters without `send_or_update_status`, `_send_or_update_status_coro` falls back to a plain `send()`, so the transient status becomes a second persistent message. And per ValeryP's analysis on the issue, even Telegram is affected on failed turns: progress-bubble cleanup is opt-in per platform (`display.platforms.<platform>.cleanup_progress`) and its registration is guarded by `and not response.get("failed")` ("Failed runs skip cleanup so the bubbles remain as breadcrumbs") — a provider failure is a failed turn, so the surviving bubble is a verbatim copy of the final answer.

The fix suppresses the transient status copy instead of delivering the rewrite: a provider-error-shaped status returns `None` from `_prepare_gateway_status_message`. This closes both surfaces with a single stateless change — no turn-scoped dedup state (the scoping problem that sank #72144). The final response still reports the failure with the same sanitized text, so the user still sees exactly one user-safe message per failed turn, and no raw provider body is delivered on either path.

## Related Issue

Fixes #72131

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_prepare_gateway_status_message`: provider-error-shaped text now returns `None` (suppressed) instead of being rewritten and delivered; the rewrite previously duplicated the final response's text as a persistent message.
- `tests/gateway/test_telegram_noise_filter.py` — replaced `test_telegram_status_sanitizes_raw_provider_security_errors` (asserted the rewrite was delivered on the status path) with `test_chat_gateways_suppress_provider_error_status` parametrized over chat platforms, asserting suppression; added `test_local_status_keeps_raw_provider_errors` pinning that local/CLI raw-text surfaces keep the raw diagnostic stream.

## How to Test

1. `python3 -m pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_local_model_connection_reply.py tests/gateway/test_compression_progress_notices.py -q` — Observed result: 183 passed.
2. `python3 -m pytest tests/gateway/ tests/agent/test_turn_context_overflow_warning.py -q` — Observed result: only the pre-existing `tests/gateway/relay/test_relay_going_idle.py` timing flakes fail; they fail identically on a clean `upstream/main` checkout (4 failed there), unrelated to this diff.
3. Behavioral check of the duplication itself: `python3 -c "from gateway.run import _prepare_gateway_status_message, _sanitize_gateway_final_response; from gateway.config import Platform; raw='API call failed after 3 retries: HTTP 429'; print(_prepare_gateway_status_message(Platform.TELEGRAM, 'lifecycle', raw)); print(_sanitize_gateway_final_response(Platform.TELEGRAM, raw))"` — Observed result: `None` (no status copy) followed by the single sanitized final reply, i.e. exactly one message per failed turn instead of two.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#72144 is closed; #81554 is an unrelated durability/egress feature)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (gateway + related suites; only pre-existing main flakes fail, see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the suppression contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.
