### PR TITLE
fix(desktop): keep profile scope when reusing primary remote backend

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11150,7 +11150,8 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       return {
         ...primaryDescriptor,
         profile: profileKey,
-        connectionId: id
+        connectionId: id,
+        sharedRemote: true
       }
     }
   }

--- a/apps/desktop/electron/registry-primary-profile-scope.test.ts
+++ b/apps/desktop/electron/registry-primary-profile-scope.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { pathForRegistryBackendRequest } from './connection-config'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+describe('primary-remote descriptor reuse keeps profile scope', () => {
+  it('scopes a shared-remote request with ?profile=<profile>', () => {
+    expect(pathForRegistryBackendRequest('/api/skills', 'acme', { sharedRemote: true })).toBe(
+      '/api/skills?profile=acme'
+    )
+  })
+
+  it('does not add a profile query when the backend is not shared-remote', () => {
+    // An isolated backend owns one profile; the router must not invent a scope.
+    expect(pathForRegistryBackendRequest('/api/skills', 'acme', { sharedRemote: false, remoteProfile: null })).toBe(
+      '/api/skills'
+    )
+  })
+
+  it('marks the reused primary-remote descriptor sharedRemote so the router scopes it', () => {
+    const branchStart = mainSource.indexOf('if (id === registry.primary && source.kind !== \'local\'')
+    expect(branchStart).toBeGreaterThan(-1)
+    const branch = mainSource.slice(branchStart, branchStart + 800)
+
+    // The reuse branch must decorate the ambient primary descriptor with
+    // sharedRemote: true, matching the explicit shared-remote connection path.
+    expect(branch).toContain('const primaryDescriptor = await ensureBackend(profile)')
+    expect(branch).toContain('registrySourceOwnsPrimaryBackend(registry, id, primaryDescriptor)')
+    expect(branch).toContain('sharedRemote: true')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes a profile-scoping defect in the Desktop client. When the registry primary is a shared remote/cloud gateway, `ensureRegistryBackend()` reuses the ambient primary descriptor but drops `sharedRemote: true`. The request router only appends `?profile=<profile>` for `sharedRemote` backends, so Capabilities/Skills requests were sent unscoped and the gateway served the default profile while a named profile was selected.

## Related Issue

Fixes #98168

## Type of Change

- [x] \u{1F41B} Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts`: add `sharedRemote: true` to the reused primary-remote descriptor in `ensureRegistryBackend()`.
- `apps/desktop/electron/registry-primary-profile-scope.test.ts`: regression test asserting the scoped URL and the flag on the reuse branch.

## How to Test

1. Configure the registry primary as a shared remote/cloud gateway.
2. Select a non-default profile in Capabilities \u2192 Skills.
3. Confirm the list shows the selected profile's skills (request carries `?profile=<profile>`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10 Desktop (remote shared gateway)

### Documentation & Housekeeping

- [x] Documentation: N/A
- [x] Config keys: N/A
- [x] Architecture/workflows: N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas: N/A