### PR TITLE
fix(cache): honor host-declared session key and conversation epoch for prompt cache affinity

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -597,6 +597,7 @@ def init_agent(
     chat_type: str = None,
     thread_id: str = None,
     gateway_session_key: str = None,
+    gateway_conversation_epoch: int = 1,
     skip_context_files: bool = False,
     load_soul_identity: bool = False,
     skip_memory: bool = False,
@@ -684,6 +685,7 @@ def init_agent(
     agent._chat_type = chat_type
     agent._thread_id = thread_id
     agent._gateway_session_key = gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
+    agent._gateway_conversation_epoch = gateway_conversation_epoch
     # Pluggable print function — CLI replaces this with _cprint so that
     # raw ANSI status lines are routed through prompt_toolkit's renderer
     # instead of going directly to stdout where patch_stdout's StdoutProxy

--- a/agent/portal_tags.py
+++ b/agent/portal_tags.py
@@ -54,6 +54,30 @@ from typing import List, Optional
 _conversation_id: ContextVar[Optional[str]] = ContextVar(
     "nous_portal_conversation_id", default=None
 )
+_affinity_scope: ContextVar[Optional[str]] = ContextVar(
+    "hermes_affinity_scope", default=None
+)
+
+
+def set_affinity_scope(scope: Optional[str]):
+    """Publish the declared routing/affinity scope for this turn.
+
+    Returns the ContextVar token; pair with :func:`reset_affinity_scope`.
+    """
+    return _affinity_scope.set(scope or None)
+
+
+def reset_affinity_scope(token) -> None:
+    """Restore the previous affinity scope (pair with ``set_affinity_scope``)."""
+    try:
+        _affinity_scope.reset(token)
+    except Exception:
+        _affinity_scope.set(None)
+
+
+def get_affinity_scope() -> Optional[str]:
+    """Return the declared routing/affinity scope, or ``None`` when unset."""
+    return _affinity_scope.get()
 
 
 def set_conversation_context(conversation_id: Optional[str]):

--- a/agent/prompt_cache_scope.py
+++ b/agent/prompt_cache_scope.py
@@ -28,6 +28,37 @@ intentionally different — do not "deduplicate" them.
   timestamp is stripped later by ``_cache_scope_from_session_id`` exactly as
   before.
 
+A host that mints one physical ``session_id`` per RESPONSE (Hermes Studio's
+group chat, and ``POST /v1/responses`` with client-managed history, which
+mints ``str(uuid4())`` per request) re-keys every conversation-affinity hint
+Hermes sends — ``prompt_cache_key`` on both OpenAI-wire transports, plus the
+OpenRouter/Nous sticky ``session_id`` and xAI's ``x-grok-conv-id`` through
+``portal_tags`` (issue #96811). Those rows carry no lineage, so the walk
+above correctly returns the physical id and the scope moves every reply.
+
+Hermes must not infer the logical conversation from the id's SYNTAX (that
+rule collides independent client-supplied ids and merges Studio members
+truncated past its 96-character boundary — the #79017 failure class). The
+host has to declare it, and one carrier already means exactly that:
+``gateway_session_key`` — the "stable per-chat key" (``agent:main:telegram:
+dm:123``) built by ``gateway.session.build_session_key`` from the
+``X-Hermes-Session-Key`` header, which branching deliberately does NOT key
+off. Together with ``gateway_conversation_epoch`` (incremented on ``/new`` /
+``reset_session()``), ``declared_conversation_scope()`` consumes it, and it
+wins over the lineage walk because it is stable across per-response ids while
+rotating on ``/new``. Two boundaries it must not cross:
+
+- explicit fork children (``/branch``, delegate subagents, tool children)
+  share their parent's chat key but are separate conversations — the row's
+  fork markers keep them on their own scope (#79161);
+- background-review forks run on a clone of the live runtime, so they are
+  excluded by ``_persist_disabled`` for the same reason.
+
+The declared key is hashed into ``gwk_<sha256[:24]>`` before it becomes a
+scope: unlike a session id it embeds platform/chat/user identifiers, and
+this value leaves the process verbatim as OpenRouter's sticky ``session_id``
+and xAI's ``x-grok-conv-id``.
+
 The resolution is memoized per (agent, session_id): the lineage walk runs
 once per transcript segment — NOT per API call — and re-runs only when
 rotation actually changes ``agent.session_id`` (per the no-DB-on-the-hot-path
@@ -35,12 +66,15 @@ constraint recorded on #79017). Default installs compact in place and never
 rotate, so they hit the memo forever and behave byte-identically to before.
 """
 
+import hashlib
 import logging
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 _MEMO_ATTR = "_prompt_cache_scope_memo"
+# Namespace for a scope resolved from a host-declared conversation key.
+_DECLARED_SCOPE_PREFIX = "gwk_"
 
 
 def _lineage_root(session_id: str, session_db: Any) -> Optional[str]:
@@ -64,18 +98,72 @@ def _lineage_root(session_id: str, session_db: Any) -> Optional[str]:
     return None
 
 
+def declared_conversation_scope(agent: Any) -> Optional[str]:
+    """Return the host-declared logical conversation scope, or None.
+
+    Resolved from ``agent._gateway_session_key`` (the ``X-Hermes-Session-Key``
+    /``build_session_key`` per-chat key) and ``agent._gateway_conversation_epoch``,
+    hashed into ``gwk_<sha256[:24]>`` so no platform/chat/user identifier reaches
+    a provider on the wire and the value stays inside every caller's length/charset budget.
+
+    None — meaning "fall back to the physical-id scope" — when no key was
+    declared, when this agent is a background-review fork (``_persist_disabled``:
+    it clones the live runtime, including the key), when the session row is an
+    explicit fork child (``/branch``, delegate, tool), and on any DB error
+    during that check.
+    """
+    key = str(getattr(agent, "_gateway_session_key", "") or "").strip()
+    if not key:
+        return None
+    if getattr(agent, "_persist_disabled", False):
+        return None
+    sid = str(getattr(agent, "session_id", None) or "")
+    db = getattr(agent, "_session_db", None)
+    if db is not None and sid:
+        try:
+            is_fork = getattr(db, "is_explicit_fork_child", None)
+            if callable(is_fork) and is_fork(sid):
+                return None
+            if not callable(is_fork) and hasattr(db, "get_session"):
+                sess = db.get_session(sid)
+                if sess and hasattr(db, "_is_explicit_fork_child_row") and db._is_explicit_fork_child_row(sess):
+                    return None
+        except Exception:
+            logger.debug(
+                "prompt-cache declared scope fork check failed", exc_info=True
+            )
+            return None
+    epoch = getattr(agent, "_gateway_conversation_epoch", 1) or 1
+    carrier = f"{key}:{epoch}" if epoch != 1 else key
+    digest = hashlib.sha256(carrier.encode("utf-8")).hexdigest()[:24]
+    return f"{_DECLARED_SCOPE_PREFIX}{digest}"
+
+
+def declared_conversation_scope_safe(agent: Any) -> Optional[str]:
+    """Never-raising variant of :func:`declared_conversation_scope`."""
+    try:
+        return declared_conversation_scope(agent)
+    except Exception:
+        logger.debug("declared conversation scope resolution failed", exc_info=True)
+        return None
+
+
 def resolve_prompt_cache_scope(agent: Any) -> str:
     """Resolve the rotation-stable cache-scope id for *agent*'s conversation.
 
-    Returns the compression-lineage ROOT of ``agent.session_id`` (the
-    physical id itself when the session has no compression ancestry, no DB
-    is attached, or the walk fails). The result is memoized on the agent
-    keyed by the current session id, so the DB walk happens once per
-    transcript segment rather than once per API call.
+    Returns the declared conversation scope when one is available, otherwise
+    the compression-lineage ROOT of ``agent.session_id`` (the physical id itself
+    when the session has no compression ancestry, no DB is attached, or the walk
+    fails). The result is memoized on the agent keyed by the current session id,
+    so the DB walk happens once per transcript segment rather than once per API call.
     """
     sid = str(getattr(agent, "session_id", None) or "")
     if not sid:
         return ""
+    declared = declared_conversation_scope(agent)
+    if declared is not None:
+        return declared
+
     db = getattr(agent, "_session_db", None)
     # Memo key includes DB presence: an agent that starts DB-less and gains a
     # handle later (run_agent._get_session_db_for_recall lazily attaches one)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5886,6 +5886,7 @@ class TurnRunner:
                 chat_type=ctx.source.chat_type,
                 thread_id=ctx.source.thread_id,
                 gateway_session_key=ctx.session_key,
+                gateway_conversation_epoch=getattr(ctx, "conversation_epoch", 1) or 1,
                 session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
                 # Reload from disk — do not reuse the startup snapshot (#60955).
                 fallback_model=self._runner._refresh_fallback_model(),
@@ -5906,6 +5907,8 @@ class TurnRunner:
                     )
                     self._runner._enforce_agent_cache_cap()
             logger.debug("Created new agent for session %s (sig=%s)", ctx.session_key, _sig)
+
+        agent._gateway_conversation_epoch = getattr(ctx, "conversation_epoch", 1) or 1
 
         # Per-message state — callbacks and reasoning config change every
         # turn and must not be baked into the cached agent constructor.
@@ -29450,6 +29453,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         long_tool_hint_fired = [False]
         _LONG_TOOL_THRESHOLD_S = 30.0
 
+        _session_epoch = 1
+        if session_key and getattr(self, "session_store", None) is not None:
+            _get_epoch = getattr(self.session_store, "get_conversation_epoch", None)
+            if callable(_get_epoch):
+                _session_epoch = _get_epoch(session_key)
+            else:
+                _entry = getattr(self.session_store, "_entries", {}).get(session_key)
+                if _entry is not None:
+                    _session_epoch = getattr(_entry, "conversation_epoch", 1) or 1
+
         turn_ctx = TurnContext(
             source=source,
             _run_still_current=_run_still_current,
@@ -29487,6 +29500,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             channel_prompt=channel_prompt,
             session_id=session_id,
             session_key=session_key,
+            conversation_epoch=_session_epoch,
             run_generation=run_generation,
             _interrupt_depth=_interrupt_depth,
             event_message_id=event_message_id,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -831,6 +831,11 @@ class SessionEntry:
     # context-note prepend — both wrong for an explicit manual reset.
     # See issue #6508.
     is_fresh_reset: bool = False
+
+    # Conversation generation / epoch for prompt cache affinity scoping.
+    # Incremented on reset_session() (/new) so declared conversation scopes
+    # rotate on /new while staying stable across per-response sessions.
+    conversation_epoch: int = 1
     
     # Set by the background expiry watcher after it finalizes an expired
     # session (invoking on_session_finalize hooks and evicting the cached
@@ -905,6 +910,7 @@ class SessionEntry:
                 else None
             ),
             "is_fresh_reset": self.is_fresh_reset,
+            "conversation_epoch": self.conversation_epoch,
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
             "reset_had_activity": self.reset_had_activity,
@@ -998,6 +1004,7 @@ class SessionEntry:
             active_turn_token=active_turn_token,
             active_turn_started_at=active_turn_started_at,
             is_fresh_reset=data.get("is_fresh_reset", False),
+            conversation_epoch=int(data.get("conversation_epoch", 1) or 1),
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
             reset_had_activity=data.get("reset_had_activity", False),
@@ -2502,6 +2509,15 @@ class SessionStore:
             return False
         return bool(row is not None and row.get("end_reason") is not None)
 
+    def get_conversation_epoch(self, session_key: str) -> int:
+        """Return the conversation generation for *session_key* (defaults to 1)."""
+        if not session_key:
+            return 1
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            return (getattr(entry, "conversation_epoch", 1) or 1) if entry is not None else 1
+
     def _should_reset(self, entry: SessionEntry, source: SessionSource) -> Optional[str]:
         """
         Check if a session should be reset based on policy.
@@ -2804,6 +2820,7 @@ class SessionStore:
         auto_reset_reason = None
         reset_had_activity = False
         prev_session_id: Optional[str] = None
+        auto_reset_epoch: Optional[int] = None
 
         with self._lock:
             self._ensure_loaded_locked()
@@ -2842,6 +2859,7 @@ class SessionStore:
                         reset_had_activity = entry.last_prompt_tokens > 0
                         db_end_session_id = entry.session_id
                         prev_session_id = entry.session_id
+                        auto_reset_epoch = (getattr(entry, "conversation_epoch", 1) or 1) + 1
                     entry = None
                     _needs_recover = True
                 elif entry.session_id != _stale_session_id:
@@ -2860,6 +2878,7 @@ class SessionStore:
                         reset_had_activity = entry.last_prompt_tokens > 0
                         db_end_session_id = entry.session_id
                         prev_session_id = entry.session_id
+                        auto_reset_epoch = (getattr(entry, "conversation_epoch", 1) or 1) + 1
                         self._entries.pop(session_key, None)
                         entry = None
                         _needs_recover = True
@@ -2889,6 +2908,7 @@ class SessionStore:
                     reset_had_activity = recovered.reset_had_activity
                     db_end_session_id = recovered.session_id
                     prev_session_id = recovered.session_id
+                    auto_reset_epoch = (getattr(recovered, "conversation_epoch", 1) or 1) + 1
                 else:
                     try:
                         self._db.reopen_session(recovered.session_id)
@@ -2923,6 +2943,7 @@ class SessionStore:
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
                 prev_session_id=prev_session_id,
+                conversation_epoch=auto_reset_epoch if was_auto_reset and auto_reset_epoch is not None else 1,
             )
             with self._lock:
                 current = self._entries.get(session_key)
@@ -3444,6 +3465,7 @@ class SessionStore:
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
                 is_fresh_reset=True,
+                conversation_epoch=getattr(old_entry, "conversation_epoch", 1) + 1,
             )
 
             self._entries[session_key] = new_entry

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -83,6 +83,7 @@ class TurnContext:
     channel_prompt: Optional[str] = None
     session_id: Optional[str] = None
     session_key: Optional[str] = None
+    conversation_epoch: int = 1
     run_generation: Optional[int] = None
     process_task_id: str = ""
     process_baseline: frozenset[str] = field(default_factory=frozenset)

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -2,7 +2,11 @@
 
 from typing import Any
 
-from agent.portal_tags import get_conversation_context, nous_portal_tags
+from agent.portal_tags import (
+    get_affinity_scope,
+    get_conversation_context,
+    nous_portal_tags,
+)
 from agent.transports.codex import _cache_scope_from_session_id
 from providers import register_provider
 from providers.base import ProviderProfile
@@ -57,7 +61,9 @@ class NousProfile(ProviderProfile):
         # session id; the ambient root additionally keeps the key stable for
         # installs that opt back into rotating compaction, and across
         # delegate-subagent trees.
-        sticky_key = _cache_scope_from_session_id(get_conversation_context() or session_id)
+        sticky_key = get_affinity_scope() or _cache_scope_from_session_id(
+            get_conversation_context() or session_id
+        )
         if sticky_key:
             body["session_id"] = sticky_key
         provider_preferences = context.get("provider_preferences")

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from agent.portal_tags import get_conversation_context
+from agent.portal_tags import get_affinity_scope, get_conversation_context
 from agent.transports.codex import _cache_scope_from_session_id
 from providers import register_provider
 from providers.base import ProviderProfile
@@ -133,7 +133,9 @@ class OpenRouterProfile(ProviderProfile):
         # (f2f4df064d). The ambient value is the session-lineage ROOT, so it
         # also stays stable for installs that opt out of the default
         # ``compression.in_place: true`` and across delegate-subagent trees.
-        sticky_key = _cache_scope_from_session_id(get_conversation_context() or session_id)
+        sticky_key = get_affinity_scope() or _cache_scope_from_session_id(
+            get_conversation_context() or session_id
+        )
         if sticky_key:
             body["session_id"] = sticky_key
         prefs = context.get("provider_preferences")
@@ -222,7 +224,9 @@ class OpenRouterProfile(ProviderProfile):
         # backend server via this header, and aux calls pass no session_id, so
         # reading the ambient conversation keeps compression/vision/MoA traffic
         # on the same Grok backend as the conversation it belongs to.
-        grok_conv_id = _cache_scope_from_session_id(get_conversation_context() or session_id)
+        grok_conv_id = get_affinity_scope() or _cache_scope_from_session_id(
+            get_conversation_context() or session_id
+        )
         if grok_conv_id and model and model.startswith(("x-ai/grok-", "xai/grok-")):
             extra_headers["x-grok-conv-id"] = grok_conv_id
         if extra_headers:

--- a/run_agent.py
+++ b/run_agent.py
@@ -507,6 +507,7 @@ class AIAgent:
         chat_type: str = None,
         thread_id: str = None,
         gateway_session_key: str = None,
+        gateway_conversation_epoch: int = 1,
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
         skip_memory: bool = False,
@@ -598,6 +599,7 @@ class AIAgent:
             chat_type=chat_type,
             thread_id=thread_id,
             gateway_session_key=gateway_session_key,
+            gateway_conversation_epoch=gateway_conversation_epoch,
             skip_context_files=skip_context_files,
             load_soul_identity=load_soul_identity,
             skip_memory=skip_memory,
@@ -8624,9 +8626,12 @@ class AIAgent:
         from agent import relay_runtime
         from agent.conversation_loop import run_conversation
         from agent.portal_tags import (
+            reset_affinity_scope,
             reset_conversation_context,
+            set_affinity_scope,
             set_conversation_context,
         )
+        from agent.prompt_cache_scope import declared_conversation_scope_safe
         from hermes_cli.observability.relay_shared_metrics import (
             finish_task_run,
             start_task_run,
@@ -8648,6 +8653,9 @@ class AIAgent:
             if task_context["platform"] == "subagent"
             else ""
         )
+        token = None
+        acct_token = None
+        affinity_token = None
         relay_lease = None
         relay_turn = None
         durable_turn_lease = None
@@ -8948,6 +8956,8 @@ class AIAgent:
             # (which copy this Context into their thread) — inherits the
             # ``conversation=<root>`` tag with zero per-call-site plumbing.
             token = set_conversation_context(self._conversation_root_id())
+            declared_scope = declared_conversation_scope_safe(self)
+            affinity_token = set_affinity_scope(declared_scope)
             # Publish the session accounting handles the same way so auxiliary
             # calls record their token usage into session_model_usage (task
             # dimension) — the fix for aux spend being invisible in analytics
@@ -9071,6 +9081,8 @@ class AIAgent:
                         self._relay_pending_turn_id = None
                     if acct_token is not None:
                         reset_accounting_context(acct_token)
+                    if affinity_token is not None:
+                        reset_affinity_scope(affinity_token)
                     if token is not None:
                         reset_conversation_context(token)
 

--- a/tests/agent/test_declared_conversation_scope.py
+++ b/tests/agent/test_declared_conversation_scope.py
@@ -1,0 +1,546 @@
+"""Tests for host-declared conversation affinity scope resolution (issue #96811).
+
+Hosts that mint one physical session_id per RESPONSE (e.g. Hermes Studio's
+group chat, /v1/responses stateless requests) re-key every conversation-affinity
+hint Hermes sends (prompt_cache_key, OpenRouter/Nous sticky session_id,
+x-grok-conv-id) on every reply unless a logical conversation scope is declared.
+
+These tests assert that:
+1. When a host declares a gateway session key (and optional epoch), consecutive
+   per-response sessions map to the SAME stable `gwk_<sha256[:24]>` affinity scope.
+2. When `/new` (reset_session) happens or the conversation epoch advances, the
+   affinity scope ROTATES to a fresh value (preserving #79017/#86733 isolation).
+3. Explicit fork children (/branch, delegates, reset children, tool-tagged children, background review)
+   and DB errors degrade to their own isolated physical scope.
+4. Wire-level kwargs (prompt_cache_key, sticky session_id, x-grok-conv-id) stay
+   stable across turns within an epoch and rotate across epochs.
+"""
+
+import hashlib
+from typing import Any, Optional
+import pytest
+
+from agent.portal_tags import (
+    get_affinity_scope,
+    reset_affinity_scope,
+    reset_conversation_context,
+    set_affinity_scope,
+    set_conversation_context,
+)
+from agent.prompt_cache_scope import (
+    declared_conversation_scope,
+    declared_conversation_scope_safe,
+    resolve_prompt_cache_scope,
+)
+from gateway.session import SessionEntry, SessionStore
+from hermes_state import SessionDB
+from providers import get_provider_profile
+
+
+RUN_1 = "gc_run_room42_default_Worker_5f2c1ab9d4e34f7a8b0c6d1e2f3a4b5c"
+RUN_2 = "gc_run_room42_default_Worker_9a7e3b1c05d24e6fb83a1c7d9e0f2a4b"
+CHAT_KEY = "agent:main:telegram:dm:12345"
+
+
+class DummyAgent:
+    def __init__(
+        self,
+        session_id: str,
+        session_db: Any = None,
+        gateway_session_key: Optional[str] = None,
+        gateway_conversation_epoch: int = 1,
+    ):
+        self.session_id = session_id
+        self._session_db = session_db
+        self._gateway_session_key = gateway_session_key
+        self._gateway_conversation_epoch = gateway_conversation_epoch
+        self._persist_disabled = False
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = tmp_path / "test_state.db"
+    return SessionDB(db_path)
+
+
+class TestDeclaredConversationScopeResolution:
+    def test_per_response_sessions_share_declared_scope(self, db):
+        """Consecutive per-response nonces resolve to identical gwk_ scope."""
+        db.create_session(RUN_1, source="api_server")
+        db.create_session(RUN_2, source="api_server")
+
+        agent_1 = DummyAgent(RUN_1, db, CHAT_KEY, gateway_conversation_epoch=1)
+        agent_2 = DummyAgent(RUN_2, db, CHAT_KEY, gateway_conversation_epoch=1)
+
+        scope_1 = resolve_prompt_cache_scope(agent_1)
+        scope_2 = resolve_prompt_cache_scope(agent_2)
+
+        assert scope_1.startswith("gwk_")
+        assert scope_1 == scope_2
+
+    def test_scope_rotates_on_epoch_advance_or_new(self, db):
+        """When /new rotates the conversation epoch, the affinity scope rotates."""
+        db.create_session(RUN_1, source="api_server")
+        db.create_session(RUN_2, source="api_server")
+
+        agent_epoch1 = DummyAgent(RUN_1, db, CHAT_KEY, gateway_conversation_epoch=1)
+        agent_epoch2 = DummyAgent(RUN_2, db, CHAT_KEY, gateway_conversation_epoch=2)
+
+        scope_epoch1 = resolve_prompt_cache_scope(agent_epoch1)
+        scope_epoch2 = resolve_prompt_cache_scope(agent_epoch2)
+
+        assert scope_epoch1.startswith("gwk_")
+        assert scope_epoch2.startswith("gwk_")
+        assert scope_epoch1 != scope_epoch2
+
+    def test_branch_child_ignores_declaration(self, db):
+        """Explicit /branch children keep their isolated physical scope."""
+        db.create_session("parent-sess", source="telegram")
+        db.create_session(
+            "branch-child",
+            source="telegram",
+            parent_session_id="parent-sess",
+            model_config={"_branched_from": "parent-sess"},
+        )
+
+        agent = DummyAgent("branch-child", db, CHAT_KEY)
+        assert declared_conversation_scope(agent) is None
+        assert resolve_prompt_cache_scope(agent) == "branch-child"
+
+    def test_delegate_child_ignores_declaration(self, db):
+        """Delegate subagents keep their isolated physical scope."""
+        db.create_session("parent-sess", source="telegram")
+        db.create_session(
+            "delegate-child",
+            source="telegram",
+            parent_session_id="parent-sess",
+            model_config={"_delegate_from": "parent-sess"},
+        )
+
+        agent = DummyAgent("delegate-child", db, CHAT_KEY)
+        assert declared_conversation_scope(agent) is None
+        assert resolve_prompt_cache_scope(agent) == "delegate-child"
+
+    def test_tool_child_ignores_declaration(self, db):
+        """Tool-spawned subagents keep their isolated physical scope."""
+        db.create_session("parent-sess", source="telegram")
+        db.create_session(
+            "tool-child",
+            source="tool",
+            parent_session_id="parent-sess",
+        )
+
+        agent = DummyAgent("tool-child", db, CHAT_KEY)
+        assert declared_conversation_scope(agent) is None
+        assert resolve_prompt_cache_scope(agent) == "tool-child"
+
+    def test_real_session_store_reset_and_per_response_flow(self, tmp_path):
+        """Full flow: SessionStore.reset_session advances epoch; opening session and subsequent per-response turns share new epoch scope."""
+        from gateway.config import GatewayConfig
+        from gateway.session import Platform, SessionSource
+
+        db_path = tmp_path / "gateway_state.db"
+        db = SessionDB(db_path)
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+        store._db = db
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+
+        # 1. First conversation epoch 1
+        entry_epoch1 = store.get_or_create_session(source)
+        agent_epoch1_turn1 = DummyAgent(
+            entry_epoch1.session_id, db, entry_epoch1.session_key,
+            gateway_conversation_epoch=entry_epoch1.conversation_epoch
+        )
+        agent_epoch1_turn2 = DummyAgent(
+            "gc_run_epoch1_turn2", db, entry_epoch1.session_key,
+            gateway_conversation_epoch=entry_epoch1.conversation_epoch
+        )
+
+        scope_epoch1_t1 = resolve_prompt_cache_scope(agent_epoch1_turn1)
+        scope_epoch1_t2 = resolve_prompt_cache_scope(agent_epoch1_turn2)
+
+        assert scope_epoch1_t1.startswith("gwk_")
+        assert scope_epoch1_t1 == scope_epoch1_t2
+
+        # 2. User types /new -> reset_session advances conversation_epoch to 2
+        entry_epoch2 = store.reset_session(entry_epoch1.session_key)
+        assert entry_epoch2.conversation_epoch == 2
+        assert entry_epoch2.session_id != entry_epoch1.session_id
+
+        agent_epoch2_opening = DummyAgent(
+            entry_epoch2.session_id, db, entry_epoch2.session_key,
+            gateway_conversation_epoch=entry_epoch2.conversation_epoch
+        )
+        agent_epoch2_turn2 = DummyAgent(
+            "gc_run_epoch2_turn2", db, entry_epoch2.session_key,
+            gateway_conversation_epoch=entry_epoch2.conversation_epoch
+        )
+        agent_epoch2_turn3 = DummyAgent(
+            "gc_run_epoch2_turn3", db, entry_epoch2.session_key,
+            gateway_conversation_epoch=entry_epoch2.conversation_epoch
+        )
+
+        scope_epoch2_opening = resolve_prompt_cache_scope(agent_epoch2_opening)
+        scope_epoch2_t2 = resolve_prompt_cache_scope(agent_epoch2_turn2)
+        scope_epoch2_t3 = resolve_prompt_cache_scope(agent_epoch2_turn3)
+
+        assert scope_epoch2_opening.startswith("gwk_")
+        # All turns in epoch 2 share the exact same affinity scope
+        assert scope_epoch2_opening == scope_epoch2_t2 == scope_epoch2_t3
+        # But epoch 2 scope is completely rotated and isolated from epoch 1 scope
+        assert scope_epoch1_t1 != scope_epoch2_opening
+
+    def test_background_review_fork_ignores_declaration(self, db):
+        """Background-review forks (_persist_disabled) keep their isolated physical scope."""
+        db.create_session("live-sess", source="telegram")
+        agent = DummyAgent("review-fork", db, CHAT_KEY)
+        agent._persist_disabled = True
+
+        assert declared_conversation_scope(agent) is None
+        assert resolve_prompt_cache_scope(agent) == "review-fork"
+
+    def test_blank_declarations_are_ignored(self, db):
+        """Empty or whitespace declarations fall back to physical scope."""
+        db.create_session(RUN_1, source="api_server")
+        for blank in (None, "", "   "):
+            agent = DummyAgent(RUN_1, db, blank)
+            assert declared_conversation_scope(agent) is None
+            assert resolve_prompt_cache_scope(agent) == RUN_1
+
+    def test_safe_variant_never_raises(self):
+        """declared_conversation_scope_safe never raises on hostile properties."""
+        class ExplodingAgent:
+            @property
+            def _gateway_session_key(self):
+                raise RuntimeError("hostile property")
+
+        assert declared_conversation_scope_safe(ExplodingAgent()) is None
+        agent = DummyAgent("sess", None, CHAT_KEY)
+        assert declared_conversation_scope_safe(agent).startswith("gwk_")
+
+
+class TestPromptCacheKeyStability:
+    """Wire-layer validation for OpenAI, Codex, OpenRouter, Nous, Grok."""
+
+    INSTRUCTIONS = "You are Reviewer in room7."
+    TOOLS = [{"type": "function", "name": "terminal"}]
+
+    def test_responses_transport_key_matches_across_responses(self, db):
+        from agent.transports.codex import ResponsesApiTransport
+
+        db.create_session(RUN_1, source="api_server")
+        db.create_session(RUN_2, source="api_server")
+        transport = ResponsesApiTransport()
+        base = dict(
+            model="gpt-5.5",
+            messages=[
+                {"role": "system", "content": self.INSTRUCTIONS},
+                {"role": "user", "content": "hi"},
+            ],
+            tools=[],
+        )
+
+        agent_1 = DummyAgent(RUN_1, db, CHAT_KEY, gateway_conversation_epoch=1)
+        agent_2 = DummyAgent(RUN_2, db, CHAT_KEY, gateway_conversation_epoch=1)
+
+        key_1 = transport.build_kwargs(
+            **base,
+            session_id=RUN_1,
+            cache_scope_id=resolve_prompt_cache_scope(agent_1),
+        )["prompt_cache_key"]
+        key_2 = transport.build_kwargs(
+            **base,
+            session_id=RUN_2,
+            cache_scope_id=resolve_prompt_cache_scope(agent_2),
+        )["prompt_cache_key"]
+
+        assert key_1 == key_2
+
+    def test_chat_completions_key_matches_across_responses(self, db):
+        from agent.transports.chat_completions import _add_prompt_cache_key
+
+        db.create_session(RUN_1, source="api_server")
+        db.create_session(RUN_2, source="api_server")
+        messages = [{"role": "system", "content": self.INSTRUCTIONS}]
+
+        agent_1 = DummyAgent(RUN_1, db, CHAT_KEY, gateway_conversation_epoch=1)
+        agent_2 = DummyAgent(RUN_2, db, CHAT_KEY, gateway_conversation_epoch=1)
+
+        kwargs_1: dict = {}
+        _add_prompt_cache_key(
+            kwargs_1,
+            messages=messages,
+            tools=None,
+            supports_prompt_cache_key=True,
+            session_id=RUN_1,
+            cache_scope_id=resolve_prompt_cache_scope(agent_1),
+        )
+        kwargs_2: dict = {}
+        _add_prompt_cache_key(
+            kwargs_2,
+            messages=messages,
+            tools=None,
+            supports_prompt_cache_key=True,
+            session_id=RUN_2,
+            cache_scope_id=resolve_prompt_cache_scope(agent_2),
+        )
+
+        assert kwargs_1["prompt_cache_key"] == kwargs_2["prompt_cache_key"]
+
+
+class TestProviderStickyKeys:
+    """OpenRouter and Nous sticky keys, plus x-grok-conv-id header."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_context(self):
+        affinity = set_affinity_scope(None)
+        conversation = set_conversation_context(None)
+        try:
+            yield
+        finally:
+            reset_conversation_context(conversation)
+            reset_affinity_scope(affinity)
+
+    def test_declared_affinity_scope_sets_openrouter_sticky_key(self):
+        profile = get_provider_profile("openrouter")
+        scope = "gwk_1234567890abcdef123456"
+        token = set_affinity_scope(scope)
+        try:
+            body_1 = profile.build_extra_body(session_id=RUN_1)
+            body_2 = profile.build_extra_body(session_id=RUN_2)
+        finally:
+            reset_affinity_scope(token)
+
+        assert body_1["session_id"] == scope
+        assert body_2["session_id"] == scope
+
+    def test_declared_affinity_scope_sets_nous_sticky_key(self):
+        profile = get_provider_profile("nous")
+        scope = "gwk_1234567890abcdef123456"
+        token = set_affinity_scope(scope)
+        try:
+            body_1 = profile.build_extra_body(session_id=RUN_1)
+            body_2 = profile.build_extra_body(session_id=RUN_2)
+        finally:
+            reset_affinity_scope(token)
+
+        assert body_1["session_id"] == scope
+        assert body_2["session_id"] == scope
+
+    def test_declared_affinity_scope_sets_x_grok_conv_id_header(self):
+        profile = get_provider_profile("openrouter")
+        scope = "gwk_1234567890abcdef123456"
+        token = set_affinity_scope(scope)
+        try:
+            _, top_1 = profile.build_api_kwargs_extras(
+                model="x-ai/grok-4", session_id=RUN_1
+            )
+            _, top_2 = profile.build_api_kwargs_extras(
+                model="x-ai/grok-4", session_id=RUN_2
+            )
+        finally:
+            reset_affinity_scope(token)
+
+        assert top_1["extra_headers"]["x-grok-conv-id"] == scope
+        assert top_2["extra_headers"]["x-grok-conv-id"] == scope
+
+    def test_nested_child_turn_shadows_parent_affinity_scope(self):
+        """A nested child/fork turn explicitly shadows the parent ContextVar to None."""
+        parent_scope = "gwk_parent1234567890123456"
+        token_parent = set_affinity_scope(parent_scope)
+        try:
+            assert get_affinity_scope() == parent_scope
+
+            # Child/fork agent turn runs (declared_scope is None)
+            child_declared_scope = None
+            token_child = set_affinity_scope(child_declared_scope)
+            try:
+                # Inside child turn, affinity scope is shadowed to None
+                assert get_affinity_scope() is None
+                profile = get_provider_profile("openrouter")
+                body = profile.build_extra_body(session_id="child-sess-42")
+                # Fallback to physical session_id works because get_affinity_scope() is None
+                assert body.get("session_id") == "child-sess-42"
+            finally:
+                reset_affinity_scope(token_child)
+
+            # When child finishes, parent context is fully restored
+            assert get_affinity_scope() == parent_scope
+        finally:
+            reset_affinity_scope(token_parent)
+
+        assert get_affinity_scope() is None
+
+    def test_agent_run_turn_shadows_parent_affinity_scope_live(self, tmp_path):
+        """Live AIAgent.run_turn shadows parent affinity scope to None during child turns."""
+        from unittest.mock import patch
+        from run_agent import AIAgent
+
+        db_path = tmp_path / "live_turn_test.db"
+        db = SessionDB(db_path)
+        db.create_session("parent-sess", source="telegram")
+        db.create_session(
+            "child-fork",
+            source="telegram",
+            parent_session_id="parent-sess",
+            model_config={"_branched_from": "parent-sess"},
+        )
+
+        with patch("run_agent.get_tool_definitions", return_value=[]), \
+             patch("run_agent.check_toolset_requirements", return_value={}), \
+             patch("run_agent.OpenAI"):
+
+            parent_agent = AIAgent(
+                session_id="parent-sess",
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+                gateway_session_key=CHAT_KEY,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            parent_agent._session_db = db
+
+            child_agent = AIAgent(
+                session_id="child-fork",
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                provider="openrouter",
+                gateway_session_key=CHAT_KEY,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            child_agent._session_db = db
+
+            child_observed_scope = "UNSET"
+            parent_inside_turn_scope = "UNSET"
+
+            def fake_child_run_conv(*args, **kwargs):
+                nonlocal child_observed_scope
+                child_observed_scope = get_affinity_scope()
+                return "child-done"
+
+            def fake_parent_run_conv(*args, **kwargs):
+                nonlocal parent_inside_turn_scope
+                parent_inside_turn_scope = get_affinity_scope()
+                # Nested child turn runs inside parent turn
+                with patch("agent.conversation_loop.run_conversation", side_effect=fake_child_run_conv):
+                    child_agent.run_conversation("child prompt")
+                # Parent scope should still be intact after child returns
+                assert get_affinity_scope() == parent_inside_turn_scope
+                return "parent-done"
+
+            assert get_affinity_scope() is None
+            with patch("agent.conversation_loop.run_conversation", side_effect=fake_parent_run_conv):
+                parent_agent.run_conversation("parent prompt")
+
+            assert parent_inside_turn_scope.startswith("gwk_")
+            assert child_observed_scope is None
+            assert get_affinity_scope() is None
+
+
+class TestGatewaySessionStoreResetEpoch:
+    """SessionStore advances conversation_epoch on reset_session (/new)."""
+
+    def test_session_store_reset_advances_epoch(self, tmp_path):
+        from gateway.config import GatewayConfig
+        from gateway.session import Platform, SessionSource
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+        entry_1 = store.get_or_create_session(source)
+        assert entry_1.conversation_epoch == 1
+
+        entry_2 = store.reset_session(entry_1.session_key)
+        assert entry_2 is not None
+        assert entry_2.session_id != entry_1.session_id
+        assert entry_2.conversation_epoch == 2
+
+    def test_turn_context_and_agent_epoch_propagation(self):
+        from gateway.turn_context import TurnContext
+
+        ctx = TurnContext(
+            session_id="sess-1",
+            session_key="agent:main:telegram:dm:12345",
+            conversation_epoch=3,
+        )
+        assert ctx.conversation_epoch == 3
+
+    def test_auto_reset_advances_epoch_and_gwk_scope(self, tmp_path):
+        from unittest.mock import patch
+        from gateway.config import GatewayConfig
+        from gateway.session import Platform, SessionSource
+        from agent.prompt_cache_scope import declared_conversation_scope
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat-auto-1", chat_type="dm")
+        entry_1 = store.get_or_create_session(source)
+        assert entry_1.conversation_epoch == 1
+        assert store.get_conversation_epoch(entry_1.session_key) == 1
+
+        agent_1 = DummyAgent(session_id=entry_1.session_id, gateway_session_key=entry_1.session_key, gateway_conversation_epoch=1)
+        scope_1 = declared_conversation_scope(agent_1)
+
+        # Trigger auto-reset by forcing _should_reset to return "idle"
+        with patch.object(store, "_should_reset", return_value="idle"):
+            entry_2 = store.get_or_create_session(source)
+
+        assert entry_2.session_id != entry_1.session_id
+        assert entry_2.was_auto_reset is True
+        assert entry_2.auto_reset_reason == "idle"
+        assert entry_2.conversation_epoch == 2
+        assert store.get_conversation_epoch(entry_2.session_key) == 2
+
+        agent_2 = DummyAgent(session_id=entry_2.session_id, gateway_session_key=entry_2.session_key, gateway_conversation_epoch=2)
+        scope_2 = declared_conversation_scope(agent_2)
+
+        assert scope_1.startswith("gwk_")
+        assert scope_2.startswith("gwk_")
+        assert scope_1 != scope_2
+
+    def test_mixed_new_and_auto_reset_never_rolls_back_epoch_aba(self, tmp_path):
+        from unittest.mock import patch
+        from gateway.config import GatewayConfig
+        from gateway.session import Platform, SessionSource
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat-aba-1", chat_type="dm")
+        
+        # Epoch 1: initial session
+        entry_1 = store.get_or_create_session(source)
+        assert entry_1.conversation_epoch == 1
+
+        # Epoch 2: explicit /new
+        entry_2 = store.reset_session(entry_1.session_key)
+        assert entry_2.conversation_epoch == 2
+
+        # Epoch 3: policy auto-reset (must be 3, NEVER rolling back to 1)
+        with patch.object(store, "_should_reset", return_value="daily"):
+            entry_3 = store.get_or_create_session(source)
+
+        assert entry_3.was_auto_reset is True
+        assert entry_3.conversation_epoch == 3
+        assert store.get_conversation_epoch(entry_3.session_key) == 3
+
+    def test_persistence_and_reload_preserves_epoch_before_reset(self, tmp_path):
+        from gateway.config import GatewayConfig
+        from gateway.session import Platform, SessionSource
+
+        config = GatewayConfig()
+        store_1 = SessionStore(sessions_dir=tmp_path, config=config)
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="chat-persist-1", chat_type="dm")
+        
+        entry_1 = store_1.get_or_create_session(source)
+        entry_2 = store_1.reset_session(entry_1.session_key)
+        assert entry_2.conversation_epoch == 2
+
+        # Instantiate fresh SessionStore from the same directory to simulate service restart
+        store_2 = SessionStore(sessions_dir=tmp_path, config=config)
+        assert store_2.get_conversation_epoch(entry_2.session_key) == 2
+
+        # Subsequent reset on reloaded store advances to epoch 3
+        entry_3 = store_2.reset_session(entry_2.session_key)
+        assert entry_3.conversation_epoch == 3
+


### PR DESCRIPTION
## Summary

Unifies and finalizes host-declared conversation affinity caching across all supported transports (OpenAI, Codex, OpenRouter, Nous, Grok), resolving the per-response session churn described in #96811 while building on the foundational work from #97158 and #97709:

1. **Host-Declared Affinity Scope**: Consumes \gateway_session_key\ (\X-Hermes-Session-Key\ / \uild_session_key\) and mixes \conversation_epoch\ to compute deterministic, collision-safe \gwk_<sha256(key:epoch)[:24]>\ affinity hashes.
2. **Monotonic Epoch Advancement**:
   - Explicit \/new\ (\SessionStore.reset_session()\) increments \conversation_epoch = old_epoch + 1\.
   - Policy auto-resets (\idle\, \daily\, and stale recovery in \get_or_create_session()\) monotonically advance \conversation_epoch = old_epoch + 1\, strictly preventing ABA roll-backs to epoch 1.
3. **SessionStore Abstraction Seam**: Added public \SessionStore.get_conversation_epoch(session_key: str) -> int\ helper consumed cleanly by \gateway/run.py\ without breaching store lock boundaries.
4. **Explicit Fork & Background Exclusions**: Explicit fork children (\/branch\, delegates, tool-spawned sessions) and background review forks (\_persist_disabled\) isolate to their own physical session scopes per #79161 invariants.
5. **ContextVar Propagation & Nested Turn Shadowing**: Manages \_affinity_scope\ via task-local ContextVar with safe \	ry/finally\ lifecycle handling in \un_agent.py\, including explicit \None\-shadowing on nested child turns.

## Attribution & Lineage

This PR serves as the superseding candidate incorporating:
- Source implementation from @JoaoMarcos44 (#97158)
- Turn-lease cleanup repair from @kshitijk4poor (#97709)
- Generational epoch engine, policy auto-reset advancement, ContextVar nested shadowing, and test suite by @StanleyStetson

## Validation

- **21 unit and integration tests** in \	ests/agent/test_declared_conversation_scope.py\ (including \/new\ rotation, policy auto-resets, ABA prevention, persistence reloads, nested turn shadowing, and wire transports).
- **56 tests** across related suites (\	est_prompt_cache_scope.py\, \	est_48031_model_switch_after_auto_reset.py\) passing 100% green.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🔒 Security fix
- [ ] 📚 Documentation update
- [ ] 🎨 Refactoring (no functional changes)
- [x] 🧪 Tests