### PR TITLE
fix(gateway): stop creating the unused Telegram System topic on /topic activation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23785,47 +23785,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "allows_users_to_create_topics": _field("allows_users_to_create_topics"),
         }
 
-    async def _ensure_telegram_system_topic(self, source: SessionSource) -> None:
-        """Create/pin the managed System topic after /topic activation when possible."""
-        adapter = self._adapter_for_source(source)
-        if adapter is None or not source.chat_id:
-            return
-
-        thread_id = None
-        create_topic = getattr(adapter, "_create_dm_topic", None)
-        if callable(create_topic):
-            try:
-                thread_id = await create_topic(int(source.chat_id), "System")
-            except Exception:
-                logger.debug("Failed to create Telegram System topic", exc_info=True)
-        if not thread_id:
-            return
-
-        message_id = None
-        try:
-            send_result = await adapter.send(
-                source.chat_id,
-                "System topic for Hermes commands and status.",
-                metadata={"thread_id": str(thread_id)},
-            )
-            message_id = getattr(send_result, "message_id", None)
-        except Exception:
-            logger.debug("Failed to send Telegram System topic intro", exc_info=True)
-        if not message_id:
-            return
-
-        bot = getattr(adapter, "_bot", None)
-        if bot is None or not hasattr(bot, "pin_chat_message"):
-            return
-        try:
-            await bot.pin_chat_message(
-                chat_id=int(source.chat_id),
-                message_id=int(message_id),
-                disable_notification=True,
-            )
-        except Exception:
-            logger.debug("Failed to pin Telegram System topic intro", exc_info=True)
-
     async def _send_telegram_topic_setup_image(self, source: SessionSource) -> None:
         """Send the bundled BotFather Threads Settings screenshot when available."""
         adapter = self._adapter_for_source(source)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4880,9 +4880,6 @@ class GatewaySlashCommandsMixin:
             logger.exception("Failed to enable Telegram topic mode")
             return t("gateway.topic.enable_failed", error=exc)
 
-        if not source.thread_id:
-            await self._ensure_telegram_system_topic(source)
-
         if source.thread_id:
             try:
                 binding = await self._session_db.get_telegram_topic_binding(

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -830,3 +830,36 @@ def test_get_telegram_topic_binding_by_session_returns_binding(tmp_path):
 # Test for session-split thread_id recovery (issue #27166)
 # ---------------------------------------------------------------------------
 
+
+# ---------------------------------------------------------------------------
+# Regression: /topic activation must not create the "System" forum topic
+# (issue #98066)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_topic_activation_does_not_create_system_topic(tmp_path, monkeypatch):
+    """/topic activation must not mint a "System" forum topic.
+
+    The root DM is the documented system lobby (/topic help), and the
+    "System" topic's thread id was never persisted — no code path ever
+    read from it, so it only ever produced an unexplained pinned topic
+    that silently survived deletion (#98066).
+    """
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    runner = _make_runner(session_db=session_db)
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("root /topic activation must not enter the agent loop")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/topic"))
+
+    assert "Telegram multi-session topics are enabled" in result
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter._create_dm_topic.assert_not_called()
+


### PR DESCRIPTION
## What does this PR do?

`/topic` activation mints a Telegram forum topic named "System", posts one intro message into it, and pins it. Nothing ever uses that topic again — this PR removes the leftover creation path.

Three facts pin it down as a leftover (per #98066):

1. **Nothing ever writes to it.** The string `"System"` appears exactly once in the whole codebase — the `create_topic` call itself. Watch-pattern notifications route to the thread of the originating event; nothing targets a fixed lane.
2. **Its `thread_id` is never persisted.** The `telegram_dm_topic_mode` table has `intro_message_id` / `pinned_message_id` columns that exist in `CREATE TABLE` only — no code writes them. The gateway cannot find the topic it created, cannot tell whether it still exists, and cannot notice when a user deletes it.
3. **The documented system lane is a different place.** `/topic help` says "The root DM becomes a system lobby — send /topic, /status, /help, /usage there." The root DM is the lobby; the "System" topic is a second, competing lane the help text never mentions.

Git history shows why: `25065283b3` ("fix: improve telegram topic mode setup", 2026-05-02) added the System topic; one day later `d35efb9898` introduced the `/topic help` text that assigns the system-lane role to the root DM instead, leaving the creation code in place. The behavior-pin test for it was later deleted in `6b81590c55` (low-value test prune), so the behavior has been uncovered since.

Removing the creation call is the right fix rather than persisting the topic: the documented design (root DM as lobby) already covers the system-lane role, and keeping a second lane alive would require new persistence and routing that nothing asks for.

## Related Issue

Fixes #98066

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py` — removed the `if not source.thread_id: await self._ensure_telegram_system_topic(source)` call after `enable_telegram_topic_mode` succeeds
- `gateway/run.py` — removed the now-unreferenced `_ensure_telegram_system_topic` helper (create + intro send + pin, all debug-swallow failures)
- `tests/gateway/test_telegram_topic_mode.py` — added `test_topic_activation_does_not_create_system_topic` pinning that `/topic` activation never calls `_create_dm_topic`

## How to Test

1. `python -m pytest tests/gateway/test_telegram_topic_mode.py -q` — Observed result: 20 passed (was 19 before this change; the new regression test passes with the creation path removed).
2. Red-check: re-adding the `_ensure_telegram_system_topic` call makes the new test fail (`AttributeError` / `_create_dm_topic` called), confirming it actually pins the removal.
3. `python -m pytest tests/gateway/test_slash_access_dispatch.py tests/gateway/test_telegram_forum_commands.py tests/gateway/test_dm_topics.py tests/gateway/test_base_topic_sessions.py -q` — Observed result: 26 passed (adjacent slash-command and topic surfaces unaffected).
4. `grep -rn "_ensure_telegram_system_topic" --include="*.py" .` — Observed result: no references remain.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — documentation update (no user-facing docs mention the System topic; `/topic help` already documents the root-DM lobby)
- [x] N/A — `cli-config.yaml.example` (no config keys changed)
- [x] N/A — `CONTRIBUTING.md` / `AGENTS.md` (no architecture or workflow change)
- [x] N/A — cross-platform impact (server-side gateway logic; no OS-specific behavior touched)
- [x] N/A — tool descriptions/schemas (no tool behavior changed)

## Screenshots / Logs

```text
$ python -m pytest tests/gateway/test_telegram_topic_mode.py -q
20 passed, 1 warning in 2.70s

$ python -m pytest tests/gateway/test_telegram_topic_mode.py::test_topic_activation_does_not_create_system_topic -q   # with the call temporarily re-added
1 failed  (AttributeError: _ensure_telegram_system_topic ... / _create_dm_topic called)
```