### PR TITLE
fix(model_metadata): skip Ollama /api/show on OpenAI-compat custom endpoints

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -812,6 +812,72 @@ def _is_known_provider_base_url(base_url: str) -> bool:
     return _infer_provider_from_url(base_url) is not None
 
 
+def _looks_like_ollama_base_url(base_url: str) -> bool:
+    """True when ``base_url`` is an Ollama host, not a generic OpenAI-compat relay.
+
+    Matches the custom-provider heuristic (default port 11434, ``ollama.com``,
+    or ``ollama`` as a hostname label). Arbitrary localhost is *not* Ollama —
+    llama.cpp, vLLM, LM Studio, and OpenAI-compat reverse proxies share it.
+    """
+    raw = (base_url or "").strip()
+    if not raw:
+        return False
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    try:
+        if parsed.port == 11434:
+            return True
+    except ValueError:
+        return False
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        return False
+    if host == "ollama.com" or host.endswith(".ollama.com"):
+        return True
+    return "ollama" in host.split(".")
+
+
+def _should_probe_ollama_native(base_url: str = "", provider: str = "") -> bool:
+    """Whether to fingerprint the endpoint as a local inference server.
+
+    Ollama (and LM Studio / llama.cpp / vLLM) expose native routes such as
+    ``POST /api/show`` and ``GET /api/tags``. OpenAI-compatible custom
+    gateways do not. Those probes are synchronous HTTP and commonly run on
+    the messaging gateway's asyncio thread during first-turn context
+    resolution — a slow or hanging ``/api/show`` stalls Slack/Discord ACKs.
+
+    Probe when the configured or inferred provider is Ollama, or the URL
+    looks like Ollama (port 11434 / ``ollama`` host), or the endpoint is
+    local *and* is not a named ``custom:*`` provider.
+
+    Skip when:
+    - provider is a named custom OpenAI-compat relay (``custom:acme``),
+      including loopback reverse proxies in front of one
+    - the host is a known non-Ollama provider
+    - the host is a remote unknown URL (HTTPS custom gateway)
+
+    Bare ``provider=custom`` on localhost still probes — that is the
+    documented local-Ollama / vLLM path. Same class of gate as
+    ``agent.image_routing._should_probe_ollama_vision`` (#89863).
+    """
+    provider_l = (provider or "").strip().lower()
+    if provider_l.startswith("ollama"):
+        return True
+    if _looks_like_ollama_base_url(base_url):
+        return True
+    inferred = _infer_provider_from_url(base_url) if base_url else None
+    if inferred and "ollama" in inferred:
+        return True
+    if inferred:
+        return False
+    # Named custom providers are OpenAI-compat relays even on loopback.
+    # Bare "custom" remains the local-runtime profile and still probes.
+    if provider_l.startswith("custom:"):
+        return False
+    if base_url and is_local_endpoint(base_url):
+        return True
+    return False
+
+
 def _endpoint_scoped_context_length(model: str, base_url: str) -> Optional[int]:
     """Return context metadata confirmed for one provider endpoint.
 
@@ -1346,11 +1412,16 @@ def fetch_endpoint_model_metadata(
     base_url: str,
     api_key: str = "",
     force_refresh: bool = False,
+    provider: str = "",
 ) -> Dict[str, Dict[str, Any]]:
     """Fetch model metadata from an OpenAI-compatible ``/models`` endpoint.
 
     This is used for explicit custom endpoints where hardcoded global model-name
     defaults are unreliable. Results are cached in memory per base URL.
+
+    ``provider`` is optional. When set, it gates the local-server-type
+    waterfall (LM Studio ``/api/v1/models`` before OpenAI ``/models``) so a
+    named ``custom:*`` relay on loopback is not fingerprinted as Ollama.
     """
     normalized = _normalize_base_url(base_url)
     if not normalized or _is_openrouter_base_url(normalized):
@@ -1380,7 +1451,9 @@ def fetch_endpoint_model_metadata(
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     last_error: Optional[Exception] = None
 
-    if is_local_endpoint(normalized):
+    if is_local_endpoint(normalized) and _should_probe_ollama_native(
+        normalized, provider
+    ):
         try:
             if detect_local_server_type(normalized, api_key=api_key) == "lm-studio":
                 server_url = _lmstudio_server_root(normalized)
@@ -1527,9 +1600,12 @@ def _resolve_endpoint_context_length(
     model: str,
     base_url: str,
     api_key: str = "",
+    provider: str = "",
 ) -> Optional[int]:
     """Resolve context length from an endpoint's live ``/models`` metadata."""
-    endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
+    endpoint_metadata = fetch_endpoint_model_metadata(
+        base_url, api_key=api_key, provider=provider,
+    )
     matched = endpoint_metadata.get(model)
     if not matched:
         if len(endpoint_metadata) == 1:
@@ -2083,10 +2159,11 @@ def query_ollama_supports_vision(model: str, base_url: str, api_key: str = "") -
 def _query_ollama_api_show(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query an Ollama server's native ``/api/show`` for context length.
 
-    Provider-agnostic: works against ANY Ollama-compatible server regardless
-    of hostname — local Ollama, Ollama Cloud (``ollama.com``), custom Ollama
-    hosting behind a reverse proxy, etc.  For non-Ollama servers the POST
-    returns 404/405 quickly; the function handles errors gracefully.
+    Provider-agnostic against Ollama-compatible servers — local Ollama,
+    Ollama Cloud (``ollama.com``), custom Ollama hosting behind a reverse
+    proxy. Callers must gate with ``_should_probe_ollama_native``: a
+    non-Ollama OpenAI-compat gateway may hang or 401 rather than 404
+    quickly, and this POST is synchronous.
 
     Results are cached in ``_LOCAL_CTX_PROBE_CACHE`` (same 30s TTL,
     positive-only — see ``_query_local_context_length``) so back-to-back
@@ -2956,7 +3033,7 @@ def get_model_context_length(
           portal-derived values are persisted to disk.
        c. Codex OAuth /models probe
        d. GMI /models endpoint
-       e. Ollama native /api/show probe (any base_url, provider-agnostic)
+       e. Ollama native /api/show probe (Ollama URLs / local runtimes only)
        f. models.dev registry lookup (with :cloud/-cloud suffix fallback)
     6. OpenRouter live API metadata (Kimi-family 32k guard)
     7. Local server query (before hardcoded defaults for local endpoints)
@@ -3224,7 +3301,9 @@ def get_model_context_length(
     # returns 128k) instead of the model's full context (400k).  models.dev
     # has the correct per-provider values and is checked at step 5+.
     if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
-        context_length = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
+        context_length = _resolve_endpoint_context_length(
+            model, base_url, api_key=api_key, provider=provider,
+        )
         if context_length is not None:
             return context_length
         if not _is_known_provider_base_url(base_url):
@@ -3233,21 +3312,29 @@ def get_model_context_length(
             # prefers num_ctx from Modelfile, while _query_ollama_api_show
             # returns the GGUF training max first which can be larger and
             # would create a false-safe window for compression (#63122).
-            # Non-local endpoints preserve the existing GGUF-first behavior.
-            if is_local_endpoint(base_url):
-                local_ctx = _query_local_context_length(model, base_url, api_key=api_key)
-                if local_ctx and local_ctx > 0:
+            # Remote OpenAI-compat gateways and named custom:* relays are
+            # not Ollama — POSTing /api/show at them is a synchronous stall
+            # (often on the messaging asyncio thread). Skip unless the URL
+            # actually looks like Ollama.
+            if _should_probe_ollama_native(base_url, provider):
+                if is_local_endpoint(base_url):
+                    local_ctx = _query_local_context_length(model, base_url, api_key=api_key)
+                    if local_ctx and local_ctx > 0:
+                        if not _skip_persistent_context_cache(base_url, provider):
+                            _maybe_cache_local_context_length(model, base_url, local_ctx)
+                        return local_ctx
+                # 2b. Ollama native /api/show — GGUF-first for hosted Ollama.
+                ctx = _query_ollama_api_show(model, base_url, api_key=api_key)
+                if ctx is not None:
                     if not _skip_persistent_context_cache(base_url, provider):
-                        _maybe_cache_local_context_length(model, base_url, local_ctx)
-                    return local_ctx
-            # 2b. Ollama native /api/show — non-local endpoints preserve
-            # the existing generic /api/show GGUF-first behavior.
-            # Non-Ollama servers return 404/405 quickly.
-            ctx = _query_ollama_api_show(model, base_url, api_key=api_key)
-            if ctx is not None:
-                if not _skip_persistent_context_cache(base_url, provider):
-                    save_context_length(model, base_url, ctx)
-                return ctx
+                        save_context_length(model, base_url, ctx)
+                    return ctx
+            else:
+                logger.debug(
+                    "Skipping Ollama /api/show probe for %s (provider=%s); "
+                    "set model.context_length if the window is unknown",
+                    base_url, provider or "(none)",
+                )
             # 3. Probe-down fallback after endpoint-specific detection failed
             logger.info(
                 "Could not detect context length for model %r at %s — "
@@ -3349,29 +3436,19 @@ def get_model_context_length(
         ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if ctx is not None:
             return ctx
-    # 5e. Ollama native /api/show probe — runs for providers whose base_url
-    # is NOT a known non-Ollama provider.  Ollama-compatible servers expose
-    # this endpoint regardless of hostname (local Ollama, Ollama Cloud,
-    # custom Ollama hosting).  The OpenAI-compat /v1/models endpoint
-    # correctly omits context_length per the OpenAI schema, but /api/show
-    # returns the authoritative GGUF model_info.context_length.
-    # Known hosted providers (OpenRouter, Anthropic, OpenAI, …) are skipped:
-    # they are definitively not Ollama, the POST always 404s, and the result
-    # is never cached for them — so every fresh process used to pay a
-    # ~300ms blocking HTTP round-trip on the first-turn critical path
-    # (measured against openrouter.ai; worse on slow DNS).
-    if base_url:
-        _inferred_for_probe = _infer_provider_from_url(base_url)
-        _skip_ollama_probe = (
-            _inferred_for_probe is not None
-            and "ollama" not in _inferred_for_probe
-        )
-        if not _skip_ollama_probe:
-            ctx = _query_ollama_api_show(model, base_url, api_key=api_key)
-            if ctx is not None:
-                if not _skip_persistent_context_cache(base_url, provider):
-                    save_context_length(model, base_url, ctx)
-                return ctx
+    # 5e. Ollama native /api/show probe — only for endpoints that actually
+    # look like Ollama (provider, ollama.com, port 11434, or a local
+    # runtime that is not a named custom:* relay). OpenAI-compat custom
+    # gateways omit context_length on /v1/models by spec; probing /api/show
+    # at them is a blocking miss, not a GGUF lookup.
+    if base_url and _should_probe_ollama_native(
+        base_url, provider or effective_provider
+    ):
+        ctx = _query_ollama_api_show(model, base_url, api_key=api_key)
+        if ctx is not None:
+            if not _skip_persistent_context_cache(base_url, provider):
+                save_context_length(model, base_url, ctx)
+            return ctx
     # 5f. OpenRouter live /models metadata — authoritative for OpenRouter-routed
     # models. OpenRouter's catalog carries per-model context_length (e.g.
     # anthropic/claude-fable-5 -> 1M) and refreshes as new slugs ship, so it

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -836,28 +836,60 @@ def _looks_like_ollama_base_url(base_url: str) -> bool:
     return "ollama" in host.split(".")
 
 
+def _looks_like_lmstudio_base_url(base_url: str) -> bool:
+    """True when ``base_url`` is LM Studio's default listener (port 1234)."""
+    raw = (base_url or "").strip()
+    if not raw:
+        return False
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    try:
+        return parsed.port == 1234
+    except ValueError:
+        return False
+
+
+def _should_fingerprint_local_server(base_url: str = "", provider: str = "") -> bool:
+    """Whether ``fetch_endpoint_model_metadata`` may run ``detect_local_server_type``.
+
+    LM Studio's native ``/api/v1/models`` is a separate path from Ollama
+    ``/api/show``. Fingerprint local LM Studio (port 1234 / provider) and
+    Ollama; do not fingerprint LiteLLM or other OpenAI-compat proxies on
+    loopback (#26489).
+    """
+    if _should_probe_ollama_native(base_url, provider):
+        return True
+    provider_l = (provider or "").strip().lower().replace("_", "-")
+    if provider_l in {"lmstudio", "lm-studio"}:
+        return True
+    return _looks_like_lmstudio_base_url(base_url)
+
+
 def _should_probe_ollama_native(base_url: str = "", provider: str = "") -> bool:
-    """Whether to fingerprint the endpoint as a local inference server.
+    """Whether to fingerprint the endpoint as an Ollama-native server.
 
-    Ollama (and LM Studio / llama.cpp / vLLM) expose native routes such as
-    ``POST /api/show`` and ``GET /api/tags``. OpenAI-compatible custom
-    gateways do not. Those probes are synchronous HTTP and commonly run on
-    the messaging gateway's asyncio thread during first-turn context
-    resolution — a slow or hanging ``/api/show`` stalls Slack/Discord ACKs.
+    Ollama exposes ``POST /api/show`` and ``GET /api/tags``. OpenAI-compatible
+    relays (LiteLLM, vLLM, corporate proxies, named ``custom:*`` gateways)
+    do not. Those probes are synchronous HTTP and commonly run on the
+    messaging gateway's asyncio thread during first-turn context
+    resolution — a slow or hanging ``/api/show`` stalls Slack/Discord ACKs
+    (#26489, #27331).
 
-    Probe when the configured or inferred provider is Ollama, or the URL
-    looks like Ollama (port 11434 / ``ollama`` host), or the endpoint is
-    local *and* is not a named ``custom:*`` provider.
+    Probe only on a *positive Ollama signal*:
+    - ``provider`` is ``ollama`` / ``ollama-cloud`` / similar
+    - URL is port 11434, ``ollama.com``, or has ``ollama`` as a host label
+
+    Do **not** use ``detect_local_server_type`` as this predicate — that
+    detector *is* the local waterfall. Loopback is not enough: LiteLLM and
+    other OpenAI-compat proxies listen on localhost too (#26489).
 
     Skip when:
-    - provider is a named custom OpenAI-compat relay (``custom:acme``),
-      including loopback reverse proxies in front of one
+    - provider is a named custom OpenAI-compat relay (``custom:acme``)
     - the host is a known non-Ollama provider
-    - the host is a remote unknown URL (HTTPS custom gateway)
+    - the host is a remote unknown URL
+    - the host is local but has no Ollama signal (LiteLLM, vLLM, reverse proxy)
 
-    Bare ``provider=custom`` on localhost still probes — that is the
-    documented local-Ollama / vLLM path. Same class of gate as
-    ``agent.image_routing._should_probe_ollama_vision`` (#89863).
+    Same class of gate as ``agent.image_routing._should_probe_ollama_vision``
+    (#89863).
     """
     provider_l = (provider or "").strip().lower()
     if provider_l.startswith("ollama"):
@@ -866,14 +898,6 @@ def _should_probe_ollama_native(base_url: str = "", provider: str = "") -> bool:
         return True
     inferred = _infer_provider_from_url(base_url) if base_url else None
     if inferred and "ollama" in inferred:
-        return True
-    if inferred:
-        return False
-    # Named custom providers are OpenAI-compat relays even on loopback.
-    # Bare "custom" remains the local-runtime profile and still probes.
-    if provider_l.startswith("custom:"):
-        return False
-    if base_url and is_local_endpoint(base_url):
         return True
     return False
 
@@ -1451,7 +1475,7 @@ def fetch_endpoint_model_metadata(
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     last_error: Optional[Exception] = None
 
-    if is_local_endpoint(normalized) and _should_probe_ollama_native(
+    if is_local_endpoint(normalized) and _should_fingerprint_local_server(
         normalized, provider
     ):
         try:
@@ -3312,10 +3336,13 @@ def get_model_context_length(
             # prefers num_ctx from Modelfile, while _query_ollama_api_show
             # returns the GGUF training max first which can be larger and
             # would create a false-safe window for compression (#63122).
-            # Remote OpenAI-compat gateways and named custom:* relays are
-            # not Ollama — POSTing /api/show at them is a synchronous stall
-            # (often on the messaging asyncio thread). Skip unless the URL
-            # actually looks like Ollama.
+            # Remote OpenAI-compat gateways, named custom:* relays, and local
+            # OpenAI-compat proxies (LiteLLM, vLLM) are not Ollama — POSTing
+            # /api/show at them is a synchronous stall (often on the
+            # messaging asyncio thread). Probe only on a positive Ollama
+            # signal (port 11434 / ollama.com / provider=ollama). Do not
+            # call detect_local_server_type to decide — that waterfall is
+            # the hang (#26489, #27331).
             if _should_probe_ollama_native(base_url, provider):
                 if is_local_endpoint(base_url):
                     local_ctx = _query_local_context_length(model, base_url, api_key=api_key)

--- a/tests/agent/test_skip_ollama_probe_custom_endpoint.py
+++ b/tests/agent/test_skip_ollama_probe_custom_endpoint.py
@@ -1,0 +1,218 @@
+"""Ollama /api/show must not run against OpenAI-compat custom gateways.
+
+Context-length resolution used to POST /api/show (and, on loopback, run the
+local server-type waterfall) whenever GET /v1/models omitted context_length.
+That is correct for Ollama. It is a synchronous stall for a remote or
+named-custom OpenAI-compat relay — including a loopback reverse proxy in
+front of one — and it can run on the messaging gateway's asyncio thread.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.model_metadata import (
+    DEFAULT_FALLBACK_CONTEXT,
+    _looks_like_ollama_base_url,
+    _should_probe_ollama_native,
+    fetch_endpoint_model_metadata,
+    get_model_context_length,
+)
+
+
+@pytest.mark.parametrize(
+    "base_url,expected",
+    [
+        ("http://127.0.0.1:11434", True),
+        ("http://127.0.0.1:11434/v1", True),
+        ("http://localhost:11434/v1", True),
+        ("https://ollama.com", True),
+        ("https://api.ollama.com/v1", True),
+        ("http://127.0.0.1:9000/v1", False),
+        ("https://llm-gateway.example.com/v1", False),
+        ("http://host:99999/v1", False),
+        ("", False),
+    ],
+)
+def test_looks_like_ollama_base_url(base_url, expected):
+    assert _looks_like_ollama_base_url(base_url) is expected
+
+
+@pytest.mark.parametrize(
+    "base_url,provider,expected",
+    [
+        ("https://llm-gateway.example.com/v1", "custom:internal", False),
+        ("https://llm-gateway.example.com/v1", "custom", False),
+        ("https://llm-gateway.example.com/v1", "", False),
+        ("http://127.0.0.1:9000/v1", "custom:internal", False),
+        ("http://127.0.0.1:9000/v1", "custom", True),
+        ("http://127.0.0.1:9000/v1", "", True),
+        ("http://127.0.0.1:11434/v1", "custom:internal", True),
+        ("http://127.0.0.1:11434", "ollama", True),
+        ("https://ollama.com", "", True),
+        ("https://api.openai.com/v1", "", False),
+        ("https://openrouter.ai/api/v1", "custom:internal", False),
+    ],
+)
+def test_should_probe_ollama_native(base_url, provider, expected):
+    assert _should_probe_ollama_native(base_url, provider) is expected
+
+
+class TestSkipOllamaProbeOnCustomOpenAICompat:
+    def test_remote_named_custom_does_not_post_api_show(self):
+        with (
+            patch("agent.model_metadata.get_cached_context_length", return_value=None),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.model_metadata._resolve_endpoint_context_length",
+                return_value=None,
+            ),
+            patch("agent.model_metadata._query_ollama_api_show") as show,
+            patch("agent.model_metadata._query_local_context_length") as local,
+            patch("agent.model_metadata.save_context_length"),
+        ):
+            result = get_model_context_length(
+                "totally-unknown-model",
+                base_url="https://llm-gateway.example.com/v1",
+                provider="custom:internal",
+            )
+        assert result == DEFAULT_FALLBACK_CONTEXT
+        show.assert_not_called()
+        local.assert_not_called()
+
+    def test_remote_unlabeled_custom_url_does_not_post_api_show(self):
+        with (
+            patch("agent.model_metadata.get_cached_context_length", return_value=None),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.model_metadata._resolve_endpoint_context_length",
+                return_value=None,
+            ),
+            patch("agent.model_metadata._query_ollama_api_show") as show,
+            patch("agent.model_metadata._query_local_context_length") as local,
+            patch("agent.model_metadata.save_context_length"),
+        ):
+            result = get_model_context_length(
+                "totally-unknown-model",
+                base_url="https://llm-gateway.example.com/v1",
+            )
+        assert result == DEFAULT_FALLBACK_CONTEXT
+        show.assert_not_called()
+        local.assert_not_called()
+
+    def test_named_custom_on_loopback_does_not_fingerprint_as_ollama(self):
+        with (
+            patch("agent.model_metadata.get_cached_context_length", return_value=None),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.model_metadata._resolve_endpoint_context_length",
+                return_value=None,
+            ),
+            patch("agent.model_metadata._query_ollama_api_show") as show,
+            patch("agent.model_metadata._query_local_context_length") as local,
+            patch("agent.model_metadata.save_context_length"),
+        ):
+            result = get_model_context_length(
+                "totally-unknown-model",
+                base_url="http://127.0.0.1:9000/v1",
+                provider="custom:internal",
+            )
+        assert result == DEFAULT_FALLBACK_CONTEXT
+        show.assert_not_called()
+        local.assert_not_called()
+
+    def test_local_ollama_port_still_probes_even_with_named_custom(self):
+        with (
+            patch("agent.model_metadata.get_cached_context_length", return_value=None),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.model_metadata._resolve_endpoint_context_length",
+                return_value=None,
+            ),
+            patch("agent.model_metadata._query_ollama_api_show", return_value=None) as show,
+            patch(
+                "agent.model_metadata._query_local_context_length",
+                return_value=32768,
+            ) as local,
+            patch("agent.model_metadata.save_context_length"),
+            patch("agent.model_metadata._maybe_cache_local_context_length"),
+        ):
+            result = get_model_context_length(
+                "llama3",
+                base_url="http://127.0.0.1:11434",
+                provider="custom:internal",
+            )
+        assert result == 32768
+        local.assert_called_once()
+        show.assert_not_called()
+
+    def test_bare_custom_on_loopback_still_probes_local_runtime(self):
+        with (
+            patch("agent.model_metadata.get_cached_context_length", return_value=None),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.model_metadata._resolve_endpoint_context_length",
+                return_value=None,
+            ),
+            patch("agent.model_metadata._query_ollama_api_show", return_value=None),
+            patch(
+                "agent.model_metadata._query_local_context_length",
+                return_value=8192,
+            ) as local,
+            patch("agent.model_metadata.save_context_length"),
+            patch("agent.model_metadata._maybe_cache_local_context_length"),
+        ):
+            result = get_model_context_length(
+                "local-model",
+                base_url="http://127.0.0.1:9000/v1",
+                provider="custom",
+            )
+        assert result == 8192
+        local.assert_called_once()
+
+    def test_explicit_config_context_length_still_short_circuits(self):
+        with (
+            patch("agent.model_metadata._query_ollama_api_show") as show,
+            patch("agent.model_metadata._query_local_context_length") as local,
+            patch("agent.model_metadata._resolve_endpoint_context_length") as resolve,
+        ):
+            result = get_model_context_length(
+                "any-model",
+                base_url="https://llm-gateway.example.com/v1",
+                provider="custom:internal",
+                config_context_length=1_000_000,
+            )
+        assert result == 1_000_000
+        show.assert_not_called()
+        local.assert_not_called()
+        resolve.assert_not_called()
+
+
+class TestFetchEndpointSkipsLocalWaterfall:
+    def setup_method(self):
+        import agent.model_metadata as mm
+
+        mm._endpoint_model_metadata_cache.clear()
+        mm._endpoint_model_metadata_cache_time.clear()
+
+    def test_named_custom_loopback_skips_server_type_waterfall(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "data": [{"id": "some-model", "object": "model"}]
+        }
+
+        with (
+            patch("agent.model_metadata.detect_local_server_type") as detect,
+            patch("agent.model_metadata.requests.get", return_value=response) as get,
+        ):
+            result = fetch_endpoint_model_metadata(
+                "http://127.0.0.1:9000/v1",
+                provider="custom:internal",
+                force_refresh=True,
+            )
+
+        detect.assert_not_called()
+        assert get.called
+        assert "some-model" in result
+        assert "context_length" not in result["some-model"]

--- a/tests/agent/test_skip_ollama_probe_custom_endpoint.py
+++ b/tests/agent/test_skip_ollama_probe_custom_endpoint.py
@@ -12,12 +12,24 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.model_metadata import (
+    DEFAULT_CONTEXT_LENGTHS,
     DEFAULT_FALLBACK_CONTEXT,
     _looks_like_ollama_base_url,
     _should_probe_ollama_native,
     fetch_endpoint_model_metadata,
     get_model_context_length,
 )
+
+
+def _hardcoded_catalog_context(model: str) -> int | None:
+    """Same longest-key-first match get_model_context_length uses at step 3b."""
+    model_lower = model.lower()
+    for key, length in sorted(
+        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda kv: len(kv[0]), reverse=True
+    ):
+        if key in model_lower:
+            return length
+    return None
 
 
 @pytest.mark.parametrize(
@@ -45,8 +57,9 @@ def test_looks_like_ollama_base_url(base_url, expected):
         ("https://llm-gateway.example.com/v1", "custom", False),
         ("https://llm-gateway.example.com/v1", "", False),
         ("http://127.0.0.1:9000/v1", "custom:internal", False),
-        ("http://127.0.0.1:9000/v1", "custom", True),
-        ("http://127.0.0.1:9000/v1", "", True),
+        ("http://127.0.0.1:9000/v1", "custom", False),
+        ("http://127.0.0.1:9000/v1", "", False),
+        ("http://localhost:4000/v1", "custom", False),
         ("http://127.0.0.1:11434/v1", "custom:internal", True),
         ("http://127.0.0.1:11434", "ollama", True),
         ("https://ollama.com", "", True),
@@ -146,7 +159,13 @@ class TestSkipOllamaProbeOnCustomOpenAICompat:
         local.assert_called_once()
         show.assert_not_called()
 
-    def test_bare_custom_on_loopback_still_probes_local_runtime(self):
+    def test_local_openai_compat_proxy_does_not_probe(self):
+        """LiteLLM / vLLM on loopback with provider=custom (#26489).
+
+        #27331 skipped probes only after a nonempty catalog, and used
+        detect_local_server_type as the predicate — that waterfall is the
+        hang. Classify by URL instead: localhost:4000 is not Ollama.
+        """
         with (
             patch("agent.model_metadata.get_cached_context_length", return_value=None),
             patch("agent.model_metadata.fetch_model_metadata", return_value={}),
@@ -154,21 +173,70 @@ class TestSkipOllamaProbeOnCustomOpenAICompat:
                 "agent.model_metadata._resolve_endpoint_context_length",
                 return_value=None,
             ),
-            patch("agent.model_metadata._query_ollama_api_show", return_value=None),
-            patch(
-                "agent.model_metadata._query_local_context_length",
-                return_value=8192,
-            ) as local,
+            patch("agent.model_metadata._query_ollama_api_show") as show,
+            patch("agent.model_metadata._query_local_context_length") as local,
+            patch("agent.model_metadata.detect_local_server_type") as detect,
             patch("agent.model_metadata.save_context_length"),
-            patch("agent.model_metadata._maybe_cache_local_context_length"),
         ):
             result = get_model_context_length(
-                "local-model",
-                base_url="http://127.0.0.1:9000/v1",
+                "qwen3-14b",
+                base_url="http://localhost:4000/v1",
                 provider="custom",
             )
-        assert result == 8192
-        local.assert_called_once()
+        assert result == _hardcoded_catalog_context("qwen3-14b")
+        show.assert_not_called()
+        local.assert_not_called()
+        detect.assert_not_called()
+
+    def test_empty_local_catalog_still_skips_probes(self):
+        """Empty /v1/models must not fall through to /api/show on a local
+        OpenAI-compat proxy. #27331 preserved that fall-through; it is the
+        hang when the catalog is slow or empty.
+        """
+        with (
+            patch("agent.model_metadata.get_cached_context_length", return_value=None),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.model_metadata._resolve_endpoint_context_length",
+                return_value=None,
+            ),
+            patch("agent.model_metadata._query_ollama_api_show") as show,
+            patch("agent.model_metadata._query_local_context_length") as local,
+            patch("agent.model_metadata.save_context_length"),
+        ):
+            result = get_model_context_length(
+                "totally-unknown-model",
+                base_url="http://localhost:4000/v1",
+                provider="custom",
+            )
+        assert result == DEFAULT_FALLBACK_CONTEXT
+        show.assert_not_called()
+        local.assert_not_called()
+
+    def test_remote_known_model_keeps_hardcoded_catalog(self):
+        """Teknium on #27331: skipping probes must not skip DEFAULT_CONTEXT_LENGTHS."""
+        with (
+            patch("agent.model_metadata.get_cached_context_length", return_value=None),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.model_metadata._resolve_endpoint_context_length",
+                return_value=None,
+            ),
+            patch("agent.model_metadata._query_ollama_api_show") as show,
+            patch("agent.model_metadata._query_local_context_length") as local,
+            patch("agent.model_metadata.detect_local_server_type") as detect,
+            patch("agent.model_metadata.save_context_length"),
+        ):
+            result = get_model_context_length(
+                "claude-opus-4-8",
+                base_url="https://my-proxy.example.com/v1",
+                provider="custom",
+            )
+        assert result == _hardcoded_catalog_context("claude-opus-4-8")
+        assert result != DEFAULT_FALLBACK_CONTEXT
+        show.assert_not_called()
+        local.assert_not_called()
+        detect.assert_not_called()
 
     def test_explicit_config_context_length_still_short_circuits(self):
         with (
@@ -216,3 +284,25 @@ class TestFetchEndpointSkipsLocalWaterfall:
         assert get.called
         assert "some-model" in result
         assert "context_length" not in result["some-model"]
+
+    def test_litellm_loopback_skips_server_type_waterfall(self):
+        """#26489: provider=custom on localhost:4000 must not fingerprint."""
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "data": [{"id": "qwen3-14b", "object": "model"}]
+        }
+
+        with (
+            patch("agent.model_metadata.detect_local_server_type") as detect,
+            patch("agent.model_metadata.requests.get", return_value=response) as get,
+        ):
+            result = fetch_endpoint_model_metadata(
+                "http://localhost:4000/v1",
+                provider="custom",
+                force_refresh=True,
+            )
+
+        detect.assert_not_called()
+        assert get.called
+        assert "qwen3-14b" in result


### PR DESCRIPTION
## What does this PR do?

When `GET /v1/models` does not advertise a context window (the OpenAI schema omits `context_length`), Hermes currently treats the endpoint as Ollama and issues a synchronous `POST /api/show` — and, if `base_url` is loopback, the full local server-type waterfall (`/api/tags`, `/v1/props`, `/version`, …).

That is correct for Ollama. It is wrong for an OpenAI-compatible custom gateway or local proxy (LiteLLM, vLLM, named `custom:*` relays):

- those servers do not speak `/api/show`
- a slow or hanging probe is blocking HTTP on the first turn
- messaging adapters can run this on the asyncio thread, which stalls Slack/Discord ACKs

Workaround today: set `model.context_length` in `config.yaml` (step-0 short-circuit) and/or have the server advertise `context_length` (or a sibling key Hermes already reads) on `GET /v1/models`.

This PR skips the Ollama fingerprint unless the endpoint actually looks like Ollama. It does **not** call `detect_local_server_type` to decide whether to skip — that detector *is* the hang.

## Related Issue

Addresses #26489
Supersedes #27331 (same family; that PR used the local server-type waterfall as the skip predicate)

Same class as #89863 (`image_routing` already refuses to fingerprint remote OpenAI-compat endpoints).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `_should_probe_ollama_native()` in `agent/model_metadata.py` — probe only for a positive Ollama signal (port 11434 / `ollama.com` / `provider=ollama`)
- Skip `POST /api/show` and `_query_local_context_length` for named `custom:*` providers, remote unknown HTTPS gateways, and local OpenAI-compat proxies (LiteLLM on `:4000`, etc.)
- `_should_fingerprint_local_server()` — `fetch_endpoint_model_metadata` may still detect LM Studio on port 1234; it does not fingerprint LiteLLM
- Fall through to `DEFAULT_CONTEXT_LENGTHS` (do not regress known model names to 256K)
- Tests in `tests/agent/test_skip_ollama_probe_custom_endpoint.py`

Local Ollama (`localhost:11434`, `provider=ollama`, `https://ollama.com`) is unchanged.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_skip_ollama_probe_custom_endpoint.py tests/agent/test_model_metadata.py tests/agent/test_model_metadata_local_ctx.py`
2. Custom OpenAI-compat `base_url` with no `context_length` on `/v1/models` and no `model.context_length` in config: first turn should not `POST /api/show` at that host; resolution falls through to the hardcoded catalog or the 256K default.
3. `provider: custom` + `http://localhost:4000/v1` (LiteLLM): no `/api/show`, no `/api/tags` waterfall.
4. `provider: ollama` or `http://127.0.0.1:11434`: `/api/show` still runs.
5. `model.context_length` still short-circuits before any probe.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the focused test files via `scripts/run_tests.sh` (214 green across the probe suites)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (darwin 25)

### Documentation & Housekeeping

- [x] Docstrings updated on the probe helpers — N/A for user-facing docs
- [x] `cli-config.yaml.example` — N/A (`model.context_length` already exists)
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform: URL/provider heuristics only, no POSIX-only APIs
- [x] Tool schemas — N/A