### PR TITLE
fix(tools): keep expected check_fn misses out of error logs

### DIFF
--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -1,6 +1,7 @@
 """Tests for terminal/file tool availability in local dev environments."""
 
 import importlib
+import logging
 
 import pytest
 
@@ -94,6 +95,66 @@ class TestCheckFnTransientFailureSuppression:
         # Within grace window of the success → flake suppressed, stays True.
         assert reg._check_fn_cached(flaky) is True
         assert calls["n"] == 2  # the probe actually ran (not just cached)
+
+    def test_initial_false_is_info_not_warning(self, caplog):
+        """An optional tool absent from startup is expected, not an outage."""
+        import tools.registry as reg
+
+        def unavailable():
+            return False
+
+        with caplog.at_level(logging.INFO, logger=reg.__name__):
+            assert reg._check_fn_cached(unavailable) is False
+
+        matching = [
+            record for record in caplog.records
+            if "dependent tools will be unavailable this turn" in record.getMessage()
+        ]
+        assert len(matching) == 1
+        assert matching[0].levelno == logging.INFO
+
+    def test_initial_exception_remains_warning(self, caplog):
+        """A broken availability probe is an anomaly and stays visible."""
+        import tools.registry as reg
+
+        def broken():
+            raise RuntimeError("probe broke")
+
+        with caplog.at_level(logging.INFO, logger=reg.__name__):
+            assert reg._check_fn_cached(broken) is False
+
+        matching = [
+            record for record in caplog.records
+            if "dependent tools will be unavailable this turn" in record.getMessage()
+        ]
+        assert len(matching) == 1
+        assert matching[0].levelno == logging.WARNING
+
+    def test_failure_after_prior_success_remains_warning(self, monkeypatch, caplog):
+        """A real outage after the grace window must remain actionable."""
+        import tools.registry as reg
+
+        state = {"ok": True}
+
+        def probe():
+            return state["ok"]
+
+        t = {"now": 1000.0}
+        monkeypatch.setattr(reg.time, "monotonic", lambda: t["now"])
+        assert reg._check_fn_cached(probe) is True
+
+        state["ok"] = False
+        t["now"] += reg._CHECK_FN_FAILURE_GRACE_SECONDS + 1
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=reg.__name__):
+            assert reg._check_fn_cached(probe) is False
+
+        matching = [
+            record for record in caplog.records
+            if "dependent tools will be unavailable this turn" in record.getMessage()
+        ]
+        assert len(matching) == 1
+        assert matching[0].levelno == logging.WARNING
 
     def test_persistent_failure_after_grace_is_honored(self, monkeypatch):
         import tools.registry as reg

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -293,9 +293,10 @@ def _prune_check_fn_caches(now: float) -> None:
     for key, (timestamp, _) in list(_check_fn_cache.items()):
         if now - timestamp >= _CHECK_FN_TTL_SECONDS:
             _check_fn_cache.pop(key, None)
-    for key, timestamp in list(_check_fn_last_good.items()):
-        if now - timestamp >= _CHECK_FN_FAILURE_GRACE_SECONDS:
-            _check_fn_last_good.pop(key, None)
+    # Keep last-good timestamps beyond the 60s functional grace window. They
+    # no longer keep a tool available once grace expires; they only distinguish
+    # "never available here" (INFO) from "was available, now down" (WARNING).
+    # Growth remains bounded by _CHECK_FN_CACHE_MAX below.
     while len(_check_fn_cache) >= _CHECK_FN_CACHE_MAX:
         _check_fn_cache.pop(next(iter(_check_fn_cache)))
     while len(_check_fn_last_good) >= _CHECK_FN_CACHE_MAX:
@@ -408,7 +409,13 @@ def _check_fn_cached(fn: Callable) -> bool:
 
         # No recent success (or grace expired) — honor the failure. Log it so
         # silent tool loss in quiet mode (subagents) is diagnosable.
-        logger.warning(
+        # A clean False with no prior success is the normal feature-gate path
+        # (headless browser absent, Kanban mode disabled, optional SDK missing).
+        # Keep it diagnosable in agent.log without polluting errors.log. A probe
+        # exception or a check that previously succeeded remains a warning.
+        log_level = logging.WARNING if raised or last_good is not None else logging.INFO
+        logger.log(
+            log_level,
             "check_fn %s %s; dependent tools will be unavailable this turn",
             getattr(fn, "__qualname__", fn),
             "raised" if raised else "returned False",


### PR DESCRIPTION
## Summary

- log an initial clean `check_fn=False` at INFO instead of WARNING
- keep exceptions and failures after a prior success at WARNING
- retain bounded last-good timestamps for diagnostics without extending tool availability

## Measured impact

`errors.log` contains 621 normal feature-gate warnings over seven days, including 90 today. A headless session emits roughly 15 warnings for browser, computer-use, Kanban-mode, and other optional checks that correctly return False.

## Behavior contract

| Check result | History | Level |
|---|---|---|
| False | never succeeded | INFO |
| exception | any | WARNING |
| False | previously succeeded, grace expired | WARNING |

The 60-second failure grace is unchanged. After grace, the tool is unavailable exactly as before.

### Real module before/after

```text
origin/main: initial False ×15  → INFO 0,  WARNING 15
PR branch:   initial False ×15  → INFO 15, WARNING 0
origin/main: exception ×1       → WARNING 1
PR branch:   exception ×1       → WARNING 1
origin/main: post-success fail  → WARNING 1
PR branch:   post-success fail  → WARNING 1
```

## Test plan

- [x] RED observed: initial False test failed at WARNING
- [x] RED observed: post-success failure test failed at INFO
- [x] 3 logging-contract tests pass
- [x] `pytest tests/tools/test_registry.py tests/tools/test_terminal_tool_requirements.py` — 54 passed
- [x] `ruff check tools/registry.py tests/tools/test_terminal_tool_requirements.py`
- [x] `git diff --check`
