### PR TITLE
feat(gateway): refresh runtime footer metadata

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import math
+from decimal import Decimal, InvalidOperation
+from urllib.parse import urlparse
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
@@ -748,8 +750,8 @@ def redeem_codex_reset_credit(
     )
 
 
-def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
-    token = (resolve_anthropic_token() or "").strip()
+def _fetch_anthropic_account_usage(api_key: Optional[str] = None) -> Optional[AccountUsageSnapshot]:
+    token = (str(api_key or "").strip() or (resolve_anthropic_token() or "").strip())
     if not token:
         return None
     if not _is_oauth_token(token):
@@ -881,6 +883,96 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+
+def _money_symbol(currency: str) -> str:
+    normalized = currency.strip().upper()
+    if normalized == "CNY":
+        return "¥"
+    if normalized == "USD":
+        return "$"
+    return f"{normalized} " if normalized else ""
+
+def _decimal_or_none(value: Any) -> Optional[Decimal]:
+    try:
+        parsed = Decimal(str(value).strip())
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    return parsed if parsed.is_finite() else None
+
+def _format_money(value: Decimal, currency: str) -> str:
+    return f"{_money_symbol(currency)}{value:.2f}"
+
+def _is_deepseek_base_url(base_url: Optional[str]) -> bool:
+    try:
+        host = urlparse(str(base_url or "")).hostname or ""
+    except Exception:
+        return False
+    host = host.lower().strip(".")
+    return host == "deepseek.com" or host.endswith(".deepseek.com")
+
+def _resolve_deepseek_balance_url(base_url: Optional[str]) -> str:
+    parsed = urlparse(str(base_url or "").strip() or "https://api.deepseek.com")
+    scheme = parsed.scheme or "https"
+    netloc = parsed.netloc or parsed.path or "api.deepseek.com"
+    return f"{scheme}://{netloc.rstrip('/')}/user/balance"
+
+def _fetch_deepseek_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
+    if api_key:
+        runtime = {
+            "base_url": (base_url or "https://api.deepseek.com").strip(),
+            "api_key": str(api_key).strip(),
+        }
+    else:
+        runtime = resolve_runtime_provider(
+            requested="deepseek",
+            explicit_base_url=base_url,
+            explicit_api_key=api_key,
+        )
+    token = str(runtime.get("api_key", "") or "").strip()
+    if not token:
+        return None
+    resolved_base_url = str(runtime.get("base_url", "") or base_url or "https://api.deepseek.com")
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    with httpx.Client(timeout=10.0) as client:
+        response = client.get(_resolve_deepseek_balance_url(resolved_base_url), headers=headers)
+        response.raise_for_status()
+    payload = response.json() or {}
+    details: list[str] = []
+    for info in payload.get("balance_infos") or []:
+        if not isinstance(info, dict):
+            continue
+        currency = str(info.get("currency") or "").strip().upper()
+        total = _decimal_or_none(info.get("total_balance"))
+        if total is None:
+            continue
+        parts = [f"Balance: {_format_money(total, currency)}"]
+        if currency:
+            parts[0] += f" {currency}"
+        subparts: list[str] = []
+        granted = _decimal_or_none(info.get("granted_balance"))
+        topped_up = _decimal_or_none(info.get("topped_up_balance"))
+        if granted is not None and granted > 0:
+            subparts.append(f"granted {_format_money(granted, currency)}")
+        if topped_up is not None and topped_up > 0:
+            subparts.append(f"topped up {_format_money(topped_up, currency)}")
+        if subparts:
+            parts.append(f"({', '.join(subparts)})")
+        details.append(" ".join(parts))
+    unavailable_reason = None
+    if payload.get("is_available") is False and not details:
+        unavailable_reason = "DeepSeek API balance is insufficient."
+    return AccountUsageSnapshot(
+        provider="deepseek",
+        source="balance_api",
+        fetched_at=_utc_now(),
+        title="Account balance",
+        details=tuple(details),
+        unavailable_reason=unavailable_reason,
+    )
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
@@ -888,15 +980,17 @@ def fetch_account_usage(
     api_key: Optional[str] = None,
 ) -> Optional[AccountUsageSnapshot]:
     normalized = str(provider or "").strip().lower()
-    if normalized in {"", "auto", "custom"}:
+    if normalized in {"", "auto", "custom"} and not _is_deepseek_base_url(base_url):
         return None
     try:
         if normalized == "openai-codex":
             return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
         if normalized == "anthropic":
-            return _fetch_anthropic_account_usage()
+            return _fetch_anthropic_account_usage(api_key=api_key)
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "deepseek" or _is_deepseek_base_url(base_url):
+            return _fetch_deepseek_account_usage(base_url, api_key)
     except Exception:
         return None
     return None

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -451,6 +451,21 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return _codex_backend_urls(base_url)[0]
 
 
+def _codex_window_label(window: dict[str, Any], fallback: str) -> str:
+    """Label a Codex quota window from its declared duration when available."""
+    raw_seconds = window.get("limit_window_seconds")
+    if isinstance(raw_seconds, (int, float)) and not isinstance(raw_seconds, bool):
+        seconds = int(raw_seconds)
+        if seconds > 0:
+            if seconds % 86400 == 0:
+                return f"{seconds // 86400}d"
+            if seconds % 3600 == 0:
+                return f"{seconds // 3600}h"
+            if seconds % 60 == 0:
+                return f"{seconds // 60}m"
+    return fallback
+
+
 def _resolve_codex_usage_credentials(
     base_url: Optional[str],
     api_key: Optional[str],
@@ -527,14 +542,14 @@ def _fetch_codex_account_usage(
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    for key, fallback_label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:
             continue
         windows.append(
             AccountUsageWindow(
-                label=label,
+                label=_codex_window_label(window, fallback_label),
                 used_percent=float(used),
                 reset_at=_parse_dt(window.get("reset_at")),
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2831,6 +2831,29 @@ def _footer_account_usage_cache_key(
     )
 
 
+
+
+def _footer_reasoning_effort_from_agent(agent) -> str | None:
+    """Return the active reasoning effort label for footer display.
+
+    Prefer the live agent runtime config (includes /reasoning overrides and
+    per-model clamps already applied on the agent). Fall back to nothing when
+    the agent is missing or has no reasoning config — the footer field is then
+    silently omitted.
+    """
+    if agent is None:
+        return None
+    rc = getattr(agent, "reasoning_config", None)
+    if not isinstance(rc, dict):
+        return None
+    if rc.get("enabled") is False:
+        return "none"
+    effort = rc.get("effort")
+    if effort is None:
+        return None
+    label = str(effort).strip().lower()
+    return label or None
+
 def _fetch_footer_account_usage_cached(
     provider: str | None,
     *,
@@ -6895,6 +6918,7 @@ class TurnRunner:
                 "provider": getattr(agent, "provider", None) if agent else None,
                 "base_url": getattr(agent, "base_url", None) if agent else None,
                 "api_key": getattr(agent, "api_key", None) if agent else None,
+                "reasoning_effort": _footer_reasoning_effort_from_agent(agent),
                 "context_length": _context_length,
             }
 
@@ -6979,6 +7003,7 @@ class TurnRunner:
             "provider": getattr(agent, "provider", None) if agent else None,
             "base_url": getattr(agent, "base_url", None) if agent else None,
             "api_key": getattr(agent, "api_key", None) if agent else None,
+            "reasoning_effort": _footer_reasoning_effort_from_agent(agent),
             "context_length": _context_length,
             "session_id": effective_session_id,
             "response_previewed": result.get("response_previewed", False),
@@ -21576,6 +21601,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     provider=_footer_provider,
                     account_label=_footer_account_label,
                     account_usage=_footer_account_usage,
+                    reasoning_effort=agent_result.get("reasoning_effort"),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2808,10 +2808,16 @@ from gateway.whatsapp_identity import (
 )
 
 
-# Short-lived runtime-footer quota cache: keyed by provider/base_url/credential
-# fingerprint so credential-pool rotation never reuses another account's snapshot.
-_FOOTER_ACCOUNT_USAGE_CACHE: dict[tuple[str, str, str], tuple[float, object]] = {}
+# Short-lived runtime-footer quota cache. The final-message path never waits for
+# provider usage APIs: cold/stale entries schedule a profile-scoped daemon
+# refresh and immediately return the last known snapshot (or None on first use).
+_FOOTER_ACCOUNT_USAGE_CACHE: dict[
+    tuple[str, str, str, str], tuple[float, object]
+] = {}
+_FOOTER_ACCOUNT_USAGE_REFRESHING: set[tuple[str, str, str, str]] = set()
+_FOOTER_ACCOUNT_USAGE_LOCK = threading.Lock()
 _FOOTER_ACCOUNT_USAGE_TTL_SECONDS = 90.0
+_FOOTER_ACCOUNT_USAGE_CACHE_MAX_ENTRIES = 64
 
 
 def _footer_account_usage_cache_key(
@@ -2819,28 +2825,83 @@ def _footer_account_usage_cache_key(
     *,
     base_url: str | None = None,
     api_key: str | None = None,
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     import hashlib
 
     token = str(api_key or "").strip()
     digest = hashlib.sha256(token.encode()).hexdigest()[:16] if token else ""
     return (
+        str(get_hermes_home()),
         str(provider or "").strip().lower(),
         str(base_url or "").strip().rstrip("/").lower(),
         digest,
     )
 
 
+def _refresh_footer_account_usage(
+    key: tuple[str, str, str, str],
+    provider: str | None,
+    base_url: str | None,
+    api_key: str | None,
+) -> None:
+    snapshot = None
+    try:
+        snapshot = fetch_account_usage(
+            provider,
+            base_url=base_url,
+            api_key=api_key,
+        )
+    except Exception:
+        snapshot = None
+    finally:
+        with _FOOTER_ACCOUNT_USAGE_LOCK:
+            previous = _FOOTER_ACCOUNT_USAGE_CACHE.get(key)
+            # True stale-while-revalidate: a transient miss must not blank a
+            # previously valid quota footer. Bump the timestamp to avoid an
+            # immediate retry storm against a failing usage endpoint.
+            if snapshot is None and previous is not None:
+                snapshot = previous[1]
+            if (
+                key not in _FOOTER_ACCOUNT_USAGE_CACHE
+                and len(_FOOTER_ACCOUNT_USAGE_CACHE)
+                >= _FOOTER_ACCOUNT_USAGE_CACHE_MAX_ENTRIES
+            ):
+                oldest = min(
+                    _FOOTER_ACCOUNT_USAGE_CACHE,
+                    key=lambda cached_key: _FOOTER_ACCOUNT_USAGE_CACHE[cached_key][0],
+                )
+                _FOOTER_ACCOUNT_USAGE_CACHE.pop(oldest, None)
+            _FOOTER_ACCOUNT_USAGE_CACHE[key] = (time.monotonic(), snapshot)
+            _FOOTER_ACCOUNT_USAGE_REFRESHING.discard(key)
+
+
+def _start_footer_account_usage_refresh(
+    key: tuple[str, str, str, str],
+    provider: str | None,
+    base_url: str | None,
+    api_key: str | None,
+) -> None:
+    try:
+        ctx = copy_context()
+        threading.Thread(
+            target=ctx.run,
+            args=(
+                _refresh_footer_account_usage,
+                key,
+                provider,
+                base_url,
+                api_key,
+            ),
+            name=f"runtime-footer-usage-{key[1] or 'unknown'}",
+            daemon=True,
+        ).start()
+    except Exception:
+        with _FOOTER_ACCOUNT_USAGE_LOCK:
+            _FOOTER_ACCOUNT_USAGE_REFRESHING.discard(key)
 
 
 def _footer_reasoning_effort_from_agent(agent) -> str | None:
-    """Return the active reasoning effort label for footer display.
-
-    Prefer the live agent runtime config (includes /reasoning overrides and
-    per-model clamps already applied on the agent). Fall back to nothing when
-    the agent is missing or has no reasoning config — the footer field is then
-    silently omitted.
-    """
+    """Return the active reasoning effort label for footer display."""
     if agent is None:
         return None
     rc = getattr(agent, "reasoning_config", None)
@@ -2854,27 +2915,41 @@ def _footer_reasoning_effort_from_agent(agent) -> str | None:
     label = str(effort).strip().lower()
     return label or None
 
+
 def _fetch_footer_account_usage_cached(
     provider: str | None,
     *,
     base_url: str | None = None,
     api_key: str | None = None,
 ):
-    """Fetch account usage for footer rendering with a short per-credential cache."""
-    import time
-
-    key = _footer_account_usage_cache_key(provider, base_url=base_url, api_key=api_key)
+    """Return cached usage and schedule refresh without blocking the caller."""
+    normalized = str(provider or "").strip().lower()
+    if normalized in {"", "auto"}:
+        return None
+    key = _footer_account_usage_cache_key(
+        provider,
+        base_url=base_url,
+        api_key=api_key,
+    )
     now = time.monotonic()
-    cached = _FOOTER_ACCOUNT_USAGE_CACHE.get(key)
-    if cached is not None:
-        expires_at, snapshot = cached
-        if now < expires_at:
-            return snapshot
-    try:
-        snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
-    except Exception:
-        snapshot = None
-    _FOOTER_ACCOUNT_USAGE_CACHE[key] = (now + _FOOTER_ACCOUNT_USAGE_TTL_SECONDS, snapshot)
+    should_refresh = False
+    with _FOOTER_ACCOUNT_USAGE_LOCK:
+        cached = _FOOTER_ACCOUNT_USAGE_CACHE.get(key)
+        snapshot = cached[1] if cached is not None else None
+        fresh = bool(
+            cached
+            and now - cached[0] < _FOOTER_ACCOUNT_USAGE_TTL_SECONDS
+        )
+        if not fresh and key not in _FOOTER_ACCOUNT_USAGE_REFRESHING:
+            _FOOTER_ACCOUNT_USAGE_REFRESHING.add(key)
+            should_refresh = True
+    if should_refresh:
+        _start_footer_account_usage_refresh(
+            key,
+            provider,
+            base_url,
+            api_key,
+        )
     return snapshot
 
 logger = logging.getLogger(__name__)
@@ -5712,6 +5787,27 @@ class TurnRunner:
         _skip_context = _plat_gw_cfg.get("skip_context_files")
         skip_context_files = bool(_skip_context) if _skip_context is not None else False
 
+        # Resolve footer config while the routed profile scope is active. This
+        # avoids reading the default profile after _run_agent() returns in a
+        # multiplexed gateway.
+        _footer_cfg: dict[str, Any] = {}
+        _want_footer_usage = False
+        try:
+            from gateway.runtime_footer import resolve_footer_config
+
+            _footer_cfg = resolve_footer_config(ctx.user_config, platform_key)
+            _footer_fields = {
+                str(field).strip().lower()
+                for field in (_footer_cfg.get("fields") or ())
+            }
+            _want_footer_usage = bool(
+                _footer_cfg.get("enabled")
+                and _footer_fields.intersection({"quota", "account"})
+            )
+        except Exception:
+            _footer_cfg = {}
+            _want_footer_usage = False
+
         # Check agent cache — reuse the AIAgent from the previous message
         # in this session to preserve the frozen system prompt and tool
         # schemas for prompt cache hits.
@@ -6780,6 +6876,15 @@ class TurnRunner:
             _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
         _resolved_model = getattr(_agent, "model", None) if _agent else None
+        _resolved_provider = getattr(_agent, "provider", None) if _agent else None
+        _resolved_base_url = getattr(_agent, "base_url", None) if _agent else None
+        _resolved_footer_usage = None
+        if _want_footer_usage and _agent:
+            _resolved_footer_usage = _fetch_footer_account_usage_cached(
+                _resolved_provider,
+                base_url=_resolved_base_url,
+                api_key=getattr(_agent, "api_key", None),
+            )
 
         # Sync session_id immediately after run_conversation(). Compression
         # can rotate before a follow-up model call fails; the failure return
@@ -6915,9 +7020,10 @@ class TurnRunner:
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
-                "provider": getattr(agent, "provider", None) if agent else None,
-                "base_url": getattr(agent, "base_url", None) if agent else None,
-                "api_key": getattr(agent, "api_key", None) if agent else None,
+                "provider": _resolved_provider,
+                "base_url": _resolved_base_url,
+                "account_usage": _resolved_footer_usage,
+                "runtime_footer_config": _footer_cfg,
                 "reasoning_effort": _footer_reasoning_effort_from_agent(agent),
                 "context_length": _context_length,
             }
@@ -7000,9 +7106,10 @@ class TurnRunner:
             "input_tokens": _input_toks,
             "output_tokens": _output_toks,
             "model": _resolved_model,
-            "provider": getattr(agent, "provider", None) if agent else None,
-            "base_url": getattr(agent, "base_url", None) if agent else None,
-            "api_key": getattr(agent, "api_key", None) if agent else None,
+            "provider": _resolved_provider,
+            "base_url": _resolved_base_url,
+            "account_usage": _resolved_footer_usage,
+            "runtime_footer_config": _footer_cfg,
             "reasoning_effort": _footer_reasoning_effort_from_agent(agent),
             "context_length": _context_length,
             "session_id": effective_session_id,
@@ -21561,47 +21668,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl, resolve_footer_config as _rfc
-                _footer_user_config = _load_gateway_config()
-                _footer_platform_key = _platform_config_key(source.platform)
-                _footer_cfg = _rfc(_footer_user_config, _footer_platform_key)
-                _footer_fields = {
-                    str(field).strip().lower()
-                    for field in (_footer_cfg.get("fields") or [])
-                }
-                _footer_provider = agent_result.get("provider")
-                _footer_base_url = agent_result.get("base_url")
-                _footer_api_key = agent_result.get("api_key")
-                _footer_account_usage = None
+                from gateway.runtime_footer import build_footer_line as _bfl
+
+                _footer_account_usage = agent_result.get("account_usage")
                 _footer_account_label = None
-                if "quota" in _footer_fields or "account" in _footer_fields:
-                    try:
-                        _footer_account_usage = await asyncio.to_thread(
-                            _fetch_footer_account_usage_cached,
-                            _footer_provider,
-                            base_url=_footer_base_url,
-                            api_key=_footer_api_key,
-                        )
-                    except Exception as _footer_usage_err:
-                        logger.debug("runtime_footer usage lookup failed: %s", _footer_usage_err)
-                        _footer_account_usage = None
-                    if _footer_account_usage is not None:
-                        _footer_account_label = (
-                            getattr(_footer_account_usage, "account_label", None)
-                            or getattr(_footer_account_usage, "plan", None)
-                        )
+                if _footer_account_usage is not None:
+                    _footer_account_label = (
+                        getattr(_footer_account_usage, "account_label", None)
+                        or getattr(_footer_account_usage, "plan", None)
+                    )
                 _footer_line = _bfl(
-                    user_config=_footer_user_config,
-                    platform_key=_footer_platform_key,
+                    user_config=_load_gateway_config(),
+                    platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                     turn_seconds=_turn_seconds,
-                    provider=_footer_provider,
+                    provider=agent_result.get("provider"),
                     account_label=_footer_account_label,
                     account_usage=_footer_account_usage,
                     reasoning_effort=agent_result.get("reasoning_effort"),
+                    resolved_config=agent_result.get("runtime_footer_config"),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2825,13 +2825,14 @@ def _footer_account_usage_cache_key(
     *,
     base_url: str | None = None,
     api_key: str | None = None,
+    hermes_home: str | Path | None = None,
 ) -> tuple[str, str, str, str]:
     import hashlib
 
     token = str(api_key or "").strip()
     digest = hashlib.sha256(token.encode()).hexdigest()[:16] if token else ""
     return (
-        str(get_hermes_home()),
+        str(hermes_home if hermes_home is not None else get_hermes_home()),
         str(provider or "").strip().lower(),
         str(base_url or "").strip().rstrip("/").lower(),
         digest,
@@ -2921,6 +2922,7 @@ def _fetch_footer_account_usage_cached(
     *,
     base_url: str | None = None,
     api_key: str | None = None,
+    hermes_home: str | Path | None = None,
 ):
     """Return cached usage and schedule refresh without blocking the caller."""
     normalized = str(provider or "").strip().lower()
@@ -2930,6 +2932,7 @@ def _fetch_footer_account_usage_cached(
         provider,
         base_url=base_url,
         api_key=api_key,
+        hermes_home=hermes_home,
     )
     now = time.monotonic()
     should_refresh = False
@@ -6733,8 +6736,11 @@ class TurnRunner:
 
         _approval_session_key = ctx.session_key or ""
         _approval_session_token = set_current_session_key(_approval_session_key)
+        _footer_profile_home = None
         register_gateway_notify(_approval_session_key, _approval_notify_sync)
         try:
+            if _want_footer_usage:
+                _footer_profile_home = get_hermes_home()
             # If _prepare_inbound_message_text buffered image paths for native
             # attachment, wrap the user turn as an OpenAI-style multimodal
             # content list. Consume-and-clear so subsequent turns on the same
@@ -6884,12 +6890,13 @@ class TurnRunner:
                 _resolved_provider,
                 base_url=_resolved_base_url,
                 api_key=getattr(_agent, "api_key", None),
+                hermes_home=_footer_profile_home,
             )
 
         # Sync session_id immediately after run_conversation(). Compression
         # can rotate before a follow-up model call fails; the failure return
         # below must still point the gateway at the compressed child.
-        agent = ctx.agent_holder[0]
+        agent = _agent
         _session_was_split = False
         # In-place compaction (compression.in_place / #38763) compacts the
         # transcript WITHOUT rotating the id, so the id-change diff below

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -48,6 +48,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
 
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
+from agent.account_usage import fetch_account_usage
 from agent.conversation_compression import (
     COMPACTION_DONE_STATUS,
     COMPACTION_STATUS,
@@ -2806,6 +2807,52 @@ from gateway.whatsapp_identity import (
     normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
 )
 
+
+# Short-lived runtime-footer quota cache: keyed by provider/base_url/credential
+# fingerprint so credential-pool rotation never reuses another account's snapshot.
+_FOOTER_ACCOUNT_USAGE_CACHE: dict[tuple[str, str, str], tuple[float, object]] = {}
+_FOOTER_ACCOUNT_USAGE_TTL_SECONDS = 90.0
+
+
+def _footer_account_usage_cache_key(
+    provider: str | None,
+    *,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> tuple[str, str, str]:
+    import hashlib
+
+    token = str(api_key or "").strip()
+    digest = hashlib.sha256(token.encode()).hexdigest()[:16] if token else ""
+    return (
+        str(provider or "").strip().lower(),
+        str(base_url or "").strip().rstrip("/").lower(),
+        digest,
+    )
+
+
+def _fetch_footer_account_usage_cached(
+    provider: str | None,
+    *,
+    base_url: str | None = None,
+    api_key: str | None = None,
+):
+    """Fetch account usage for footer rendering with a short per-credential cache."""
+    import time
+
+    key = _footer_account_usage_cache_key(provider, base_url=base_url, api_key=api_key)
+    now = time.monotonic()
+    cached = _FOOTER_ACCOUNT_USAGE_CACHE.get(key)
+    if cached is not None:
+        expires_at, snapshot = cached
+        if now < expires_at:
+            return snapshot
+    try:
+        snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+    except Exception:
+        snapshot = None
+    _FOOTER_ACCOUNT_USAGE_CACHE[key] = (now + _FOOTER_ACCOUNT_USAGE_TTL_SECONDS, snapshot)
+    return snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -6845,6 +6892,9 @@ class TurnRunner:
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": getattr(agent, "provider", None) if agent else None,
+                "base_url": getattr(agent, "base_url", None) if agent else None,
+                "api_key": getattr(agent, "api_key", None) if agent else None,
                 "context_length": _context_length,
             }
 
@@ -6926,6 +6976,9 @@ class TurnRunner:
             "input_tokens": _input_toks,
             "output_tokens": _output_toks,
             "model": _resolved_model,
+            "provider": getattr(agent, "provider", None) if agent else None,
+            "base_url": getattr(agent, "base_url", None) if agent else None,
+            "api_key": getattr(agent, "api_key", None) if agent else None,
             "context_length": _context_length,
             "session_id": effective_session_id,
             "response_previewed": result.get("response_previewed", False),
@@ -21483,15 +21536,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
+                from gateway.runtime_footer import build_footer_line as _bfl, resolve_footer_config as _rfc
+                _footer_user_config = _load_gateway_config()
+                _footer_platform_key = _platform_config_key(source.platform)
+                _footer_cfg = _rfc(_footer_user_config, _footer_platform_key)
+                _footer_fields = {
+                    str(field).strip().lower()
+                    for field in (_footer_cfg.get("fields") or [])
+                }
+                _footer_provider = agent_result.get("provider")
+                _footer_base_url = agent_result.get("base_url")
+                _footer_api_key = agent_result.get("api_key")
+                _footer_account_usage = None
+                _footer_account_label = None
+                if "quota" in _footer_fields or "account" in _footer_fields:
+                    try:
+                        _footer_account_usage = await asyncio.to_thread(
+                            _fetch_footer_account_usage_cached,
+                            _footer_provider,
+                            base_url=_footer_base_url,
+                            api_key=_footer_api_key,
+                        )
+                    except Exception as _footer_usage_err:
+                        logger.debug("runtime_footer usage lookup failed: %s", _footer_usage_err)
+                        _footer_account_usage = None
+                    if _footer_account_usage is not None:
+                        _footer_account_label = (
+                            getattr(_footer_account_usage, "account_label", None)
+                            or getattr(_footer_account_usage, "plan", None)
+                        )
                 _footer_line = _bfl(
-                    user_config=_load_gateway_config(),
-                    platform_key=_platform_config_key(source.platform),
+                    user_config=_footer_user_config,
+                    platform_key=_footer_platform_key,
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                     turn_seconds=_turn_seconds,
+                    provider=_footer_provider,
+                    account_label=_footer_account_label,
+                    account_usage=_footer_account_usage,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -357,6 +357,7 @@ def build_footer_line(
     account_label: Optional[str] = None,
     account_usage: Any = None,
     reasoning_effort: Optional[str] = None,
+    resolved_config: Optional[dict[str, Any]] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -368,7 +369,11 @@ def build_footer_line(
     the caller with ``time.monotonic()``.  Callers that don't measure it leave
     it ``None`` and the ``latency`` field is skipped.
     """
-    cfg = resolve_footer_config(user_config, platform_key)
+    cfg = (
+        resolved_config
+        if isinstance(resolved_config, dict)
+        else resolve_footer_config(user_config, platform_key)
+    )
     if not cfg.get("enabled"):
         return ""
     return format_runtime_footer(

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -10,6 +10,7 @@ Config (``~/.hermes/config.yaml``)::
       runtime_footer:
         enabled: true                         # off by default
         fields: [model, context_pct, cwd]     # order shown; drop any to hide
+        # also: provider, account, context, quota, reasoning
         underline: false                      # optional separator before footer
 
 Available fields:
@@ -64,6 +65,34 @@ def _model_short(model: Optional[str]) -> str:
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+# Compact labels for agent.reasoning_effort / runtime reasoning_config.
+# Keep these short so the footer stays one line on mobile clients.
+_REASONING_ABBREV = {
+    "none": "off",
+    "minimal": "min",
+    "low": "low",
+    "medium": "med",
+    "high": "high",
+    "xhigh": "xhi",
+    "max": "max",
+    "ultra": "ult",
+}
+
+
+def _reasoning_short(effort: Optional[str]) -> str:
+    """Return a compact reasoning-effort label, or "" when unknown/empty."""
+    raw = str(effort or "").strip().lower()
+    if not raw:
+        return ""
+    if raw in {"false", "disabled", "off"}:
+        return _REASONING_ABBREV["none"]
+    if raw in _REASONING_ABBREV:
+        return _REASONING_ABBREV[raw]
+    # Unknown but non-empty values still surface compactly so a new level
+    # is visible before we teach the map about it.
+    return raw[:6]
 
 
 def resolve_footer_config(
@@ -264,6 +293,7 @@ def format_runtime_footer(
     provider: Optional[str] = None,
     account_label: Optional[str] = None,
     account_usage: Any = None,
+    reasoning_effort: Optional[str] = None,
     underline: bool = False,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -277,6 +307,10 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field in {"reasoning", "reasoning_effort", "effort"}:
+            label = _reasoning_short(reasoning_effort)
+            if label:
+                parts.append(label)
         elif field == "provider":
             if provider:
                 parts.append(str(provider))
@@ -322,6 +356,7 @@ def build_footer_line(
     provider: Optional[str] = None,
     account_label: Optional[str] = None,
     account_usage: Any = None,
+    reasoning_effort: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -346,5 +381,6 @@ def build_footer_line(
         provider=provider,
         account_label=account_label,
         account_usage=account_usage,
+        reasoning_effort=reasoning_effort,
         underline=bool(cfg.get("underline")),
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,15 +1,16 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
-appends it to the FINAL message of an agent turn when enabled.  Off by default
-to keep replies minimal.
+Renders a compact footer showing runtime state (model, context %, cwd,
+and optional provider/account/quota metadata) and appends it to the FINAL
+message of an agent turn when enabled.  Off by default to keep replies minimal.
 
 Config (``~/.hermes/config.yaml``)::
 
     display:
       runtime_footer:
-        enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        enabled: true                         # off by default
+        fields: [model, context_pct, cwd]     # order shown; drop any to hide
+        underline: false                      # optional separator before footer
 
 Available fields:
     model        — bare model id, vendor prefix dropped (``gpt-5.4``)
@@ -34,7 +35,10 @@ piecemeal, the footer is sent as a separate trailing message via
 
 from __future__ import annotations
 
+import math
 import os
+import re
+from datetime import datetime, timezone
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
@@ -73,13 +77,15 @@ def resolve_footer_config(
         2. ``display.runtime_footer``
         3. ``display.platforms.<platform_key>.runtime_footer``
     """
-    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS)}
+    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS), "underline": False}
     cfg = (user_config or {}).get("display") or {}
 
     global_cfg = cfg.get("runtime_footer")
     if isinstance(global_cfg, dict):
         if "enabled" in global_cfg:
             resolved["enabled"] = bool(global_cfg.get("enabled"))
+        if "underline" in global_cfg:
+            resolved["underline"] = bool(global_cfg.get("underline"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
 
@@ -91,6 +97,8 @@ def resolve_footer_config(
             if isinstance(plat_footer, dict):
                 if "enabled" in plat_footer:
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
+                if "underline" in plat_footer:
+                    resolved["underline"] = bool(plat_footer.get("underline"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
 
@@ -108,6 +116,143 @@ def _format_latency(seconds: float) -> str:
     return f"{m}m{sec:02d}s"
 
 
+def _compact_number(value: int | float) -> str:
+    try:
+        n = float(value)
+    except Exception:
+        return str(value)
+    if abs(n) >= 1_000_000:
+        text = f"{n / 1_000_000:.1f}M"
+    elif abs(n) >= 1_000:
+        text = f"{n / 1_000:.1f}K"
+    else:
+        text = str(int(n))
+    return text.replace(".0K", "K").replace(".0M", "M")
+
+
+def _compact_reset(dt: Any) -> str:
+    if not dt:
+        return ""
+    if isinstance(dt, str):
+        try:
+            dt = datetime.fromisoformat(dt.strip().replace("Z", "+00:00"))
+        except Exception:
+            return ""
+    if not isinstance(dt, datetime):
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    seconds = int((dt - datetime.now(timezone.utc)).total_seconds())
+    if seconds <= 0:
+        return "now"
+    hours, rem = divmod(seconds, 3600)
+    minutes = rem // 60
+    if hours >= 24:
+        days, rem_hours = divmod(math.ceil(seconds / 3600), 24)
+        return f"{days}d{rem_hours}h"
+    if hours > 0:
+        return f"{hours}h{minutes}m"
+    return f"{minutes}m"
+
+
+def _quota_label(window: Any, provider: Optional[str] = None, model: Optional[str] = None) -> str:
+    """Return a compact quota-window label for footer display.
+
+    The detailed `/usage` command keeps provider wording.  The footer is space
+    constrained, so normalize the common OAuth/Codex rolling windows to the
+    short labels users expect while leaving unknown provider windows intact.
+    """
+    raw = str(getattr(window, "label", "") or "quota").strip() or "quota"
+    label = raw.lower().replace("_", "-")
+    provider_text = str(provider or getattr(window, "provider", "") or "").lower()
+    model_text = str(model or "").lower()
+
+    if "opus" in label:
+        return "opus7d"
+    if "sonnet" in label:
+        return "sonnet7d"
+    if (
+        "five" in label
+        or "5" in label
+        or "current session" in label
+        or label == "session"
+        or "primary" in label
+    ):
+        return "5h"
+    if (
+        "seven" in label
+        or "7" in label
+        or "current week" in label
+        or label == "weekly"
+        or "secondary" in label
+    ):
+        return "7d"
+    if "week" in label:
+        if "opus" in model_text:
+            return "opus7d"
+        if "sonnet" in model_text:
+            return "sonnet7d"
+        return "7d"
+    if "codex" in provider_text and label in {"session", "primary window"}:
+        return "5h"
+    if "codex" in provider_text and label in {"weekly", "secondary window"}:
+        return "7d"
+    return raw
+
+
+def _compact_quota_detail(detail: Any) -> str:
+    text = str(detail or "").strip()
+    if not text:
+        return ""
+    # Keep footer quota compact. Detailed breakdowns remain available via the
+    # usage renderer; the footer only needs the immediately useful balance.
+    if not re.match(r"^(credits\s+)?balance\s*:", text, flags=re.IGNORECASE):
+        return ""
+    text = re.sub(r"\s*\([^)]*\)\s*$", "", text).strip()
+    text = re.sub(r"^(credits\s+)?balance\s*:", "balance", text, flags=re.IGNORECASE).strip()
+    return text
+
+
+def _format_quota(account_usage: Any, *, provider: Optional[str] = None, model: Optional[str] = None) -> list[str]:
+    if not account_usage:
+        return []
+    provider = provider or getattr(account_usage, "provider", None)
+    parts: list[str] = []
+    for window in getattr(account_usage, "windows", ()) or ():
+        used = getattr(window, "used_percent", None)
+        if used is None:
+            continue
+        try:
+            remaining = max(0, round(100 - float(used)))
+        except Exception:
+            continue
+        label = _quota_label(window, provider=provider, model=model)
+        text = f"{label} {remaining}%"
+        reset = _compact_reset(getattr(window, "reset_at", None))
+        if reset:
+            text += f" {reset}"
+        parts.append(text)
+    for detail in getattr(account_usage, "details", ()) or ():
+        compact = _compact_quota_detail(detail)
+        if compact:
+            parts.append(compact)
+    return parts
+
+
+def _account_short(account_label: Optional[str], provider: Optional[str]) -> str:
+    raw = str(account_label or "").strip()
+    if not raw:
+        return ""
+    prov = str(provider or "").strip()
+    if prov:
+        for prefix in (prov, prov.replace("-", "_"), prov.replace("_", "-")):
+            for sep in ("-", "_"):
+                marker = prefix + sep
+                if raw.lower().startswith(marker.lower()):
+                    return raw[len(marker):]
+    return raw
+
+
 def format_runtime_footer(
     *,
     model: Optional[str],
@@ -116,6 +261,10 @@ def format_runtime_footer(
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    provider: Optional[str] = None,
+    account_label: Optional[str] = None,
+    account_usage: Any = None,
+    underline: bool = False,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -128,6 +277,16 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "provider":
+            if provider:
+                parts.append(str(provider))
+        elif field == "account":
+            acct = account_label or getattr(account_usage, "account_label", None) or getattr(account_usage, "plan", None)
+            if acct:
+                parts.append(_account_short(str(acct), provider))
+        elif field == "context":
+            if context_length and context_length > 0 and context_tokens >= 0:
+                parts.append(f"ctx {_compact_number(context_tokens)}/{_compact_number(context_length)}")
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -137,6 +296,8 @@ def format_runtime_footer(
             # timing (call sites that don't measure) or the value is negative.
             if turn_seconds is not None and turn_seconds >= 0:
                 parts.append(_format_latency(turn_seconds))
+        elif field == "quota":
+            parts.extend(_format_quota(account_usage, provider=provider, model=model))
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
@@ -145,7 +306,8 @@ def format_runtime_footer(
 
     if not parts:
         return ""
-    return _SEP.join(parts)
+    line = _SEP.join(parts)
+    return f"──────────────\n{line}" if underline else line
 
 
 def build_footer_line(
@@ -157,6 +319,9 @@ def build_footer_line(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
+    provider: Optional[str] = None,
+    account_label: Optional[str] = None,
+    account_usage: Any = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -178,4 +343,8 @@ def build_footer_line(
         cwd=cwd,
         turn_seconds=turn_seconds,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        provider=provider,
+        account_label=account_label,
+        account_usage=account_usage,
+        underline=bool(cfg.get("underline")),
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -193,39 +193,44 @@ def _quota_label(window: Any, provider: Optional[str] = None, model: Optional[st
     """
     raw = str(getattr(window, "label", "") or "quota").strip() or "quota"
     label = raw.lower().replace("_", "-")
-    provider_text = str(provider or getattr(window, "provider", "") or "").lower()
     model_text = str(model or "").lower()
 
     if "opus" in label:
         return "opus7d"
     if "sonnet" in label:
         return "sonnet7d"
-    if (
-        "five" in label
-        or "5" in label
-        or "current session" in label
-        or label == "session"
-        or "primary" in label
-    ):
+    if label in {
+        "5h",
+        "5-hour",
+        "5 hour",
+        "five-hour",
+        "five hour",
+        "current session",
+        "session",
+        "primary",
+        "primary-window",
+        "primary window",
+    }:
         return "5h"
-    if (
-        "seven" in label
-        or "7" in label
-        or "current week" in label
-        or label == "weekly"
-        or "secondary" in label
-    ):
+    if label in {
+        "7d",
+        "7-day",
+        "7 day",
+        "seven-day",
+        "seven day",
+        "current week",
+        "week",
+        "weekly",
+        "secondary",
+        "secondary-window",
+        "secondary window",
+    }:
         return "7d"
     if "week" in label:
         if "opus" in model_text:
             return "opus7d"
         if "sonnet" in model_text:
             return "sonnet7d"
-        return "7d"
-    if "codex" in provider_text and label in {"session", "primary window"}:
-        return "5h"
-    if "codex" in provider_text and label in {"weekly", "secondary window"}:
-        return "7d"
     return raw
 
 

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -9,8 +9,8 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                         # off by default
-        fields: [model, context_pct, cwd]     # order shown; drop any to hide
-        # also: provider, account, context, quota, reasoning
+        fields: [model, reasoning, context_pct, cwd]  # order shown; drop any to hide
+        # also: provider, account, context, quota
         underline: false                      # optional separator before footer
 
 Available fields:
@@ -42,7 +42,7 @@ import re
 from datetime import datetime, timezone
 from typing import Any, Iterable, Optional
 
-_DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_DEFAULT_FIELDS: tuple[str, ...] = ("model", "reasoning", "context_pct", "cwd")
 _SEP = " · "
 
 

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -178,10 +178,10 @@ def _compact_reset(dt: Any) -> str:
     minutes = rem // 60
     if hours >= 24:
         days, rem_hours = divmod(math.ceil(seconds / 3600), 24)
-        return f"{days}d{rem_hours}h"
+        return f"{days}d" + (f"{rem_hours}h" if rem_hours else "")
     if hours > 0:
-        return f"{hours}h{minutes}m"
-    return f"{minutes}m"
+        return f"{hours}h" + (f"{minutes}m" if minutes else "")
+    return f"{minutes}m" if minutes else "<1m"
 
 
 def _quota_label(window: Any, provider: Optional[str] = None, model: Optional[str] = None) -> str:

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -9,8 +9,8 @@ Config (``~/.hermes/config.yaml``)::
     display:
       runtime_footer:
         enabled: true                         # off by default
-        fields: [model, reasoning, context_pct, cwd]  # order shown; drop any to hide
-        # also: provider, account, context, quota
+        fields: [model, context_pct, cwd]     # order shown; drop any to hide
+        # also: provider, account, context, quota, reasoning
         underline: false                      # optional separator before footer
 
 Available fields:
@@ -42,7 +42,7 @@ import re
 from datetime import datetime, timezone
 from typing import Any, Iterable, Optional
 
-_DEFAULT_FIELDS: tuple[str, ...] = ("model", "reasoning", "context_pct", "cwd")
+_DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
 
 

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -40,10 +40,12 @@ def codex_usage_payload():
             "primary_window": {
                 "used_percent": 21,
                 "reset_at": 1779846359,
+                "limit_window_seconds": 18000,
             },
             "secondary_window": {
                 "used_percent": 4,
                 "reset_at": 1780230796,
+                "limit_window_seconds": 604800,
             },
         },
         "credits": {"has_credits": False},
@@ -72,7 +74,7 @@ def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_
     assert snapshot is not None
     assert snapshot.provider == "openai-codex"
     assert snapshot.plan == "Plus"
-    assert [w.label for w in snapshot.windows] == ["Session", "Weekly"]
+    assert [w.label for w in snapshot.windows] == ["5h", "7d"]
     assert snapshot.windows[0].used_percent == 21
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
     assert calls[0]["headers"]["Authorization"] == "Bearer live-agent-token"
@@ -109,8 +111,8 @@ def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usa
     snapshot = account_usage.fetch_account_usage("openai-codex")
 
     assert snapshot is not None
-    assert snapshot.windows[0].label == "Session"
-    assert snapshot.windows[1].label == "Weekly"
+    assert snapshot.windows[0].label == "5h"
+    assert snapshot.windows[1].label == "7d"
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
     assert calls[0]["headers"]["Authorization"] == "Bearer pooled-token"
     # Pool creds have no account_id concept — the ChatGPT-Account-Id header must

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -423,6 +423,20 @@ def test_build_footer_passes_extended_runtime_metadata():
     assert out == "──────────────\nopenai-codex · team-main · gpt-5.5 · ctx 18.2K/400K · 5h 80% · 7d 70%"
 
 
+def test_build_footer_prefers_profile_scoped_resolved_config():
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": False}}},
+        platform_key="telegram",
+        resolved_config={"enabled": True, "fields": ["model"], "underline": False},
+        model="openai/gpt-5.5",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+    )
+
+    assert out == "gpt-5.5"
+
+
 def test_build_footer_per_platform_off_suppresses():
     user = {
         "display": {

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -4,8 +4,10 @@ appended to final gateway replies."""
 from __future__ import annotations
 
 import os
+from datetime import datetime, timedelta, timezone
 
 import pytest
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 
 from gateway.runtime_footer import (
     _home_relative_cwd,
@@ -42,6 +44,16 @@ def test_home_relative_cwd_collapses_home(tmp_path, monkeypatch):
     assert result == "~/projects/hermes"
 
 
+def test_home_relative_cwd_leaves_abs_path_alone(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "other"))
+    result = _home_relative_cwd(str(tmp_path / "outside" / "dir"))
+    assert result == str(tmp_path / "outside" / "dir")
+
+
+def test_home_relative_cwd_empty_returns_empty():
+    assert _home_relative_cwd("") == ""
+
+
 # ---------------------------------------------------------------------------
 # format_runtime_footer
 # ---------------------------------------------------------------------------
@@ -74,9 +86,183 @@ def test_format_footer_skips_missing_context_length():
     assert "/tmp/wd" in out
 
 
+def test_format_footer_context_pct_clamped_to_100():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=500_000,  # way over
+        context_length=100_000,
+        cwd="",
+        fields=("context_pct",),
+    )
+    assert out == "100%"
+
+
+def test_format_footer_context_pct_never_negative():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=-50,
+        context_length=100,
+        cwd="",
+        fields=("context_pct",),
+    )
+    # Negative input => no field emitted (we require context_tokens >= 0)
+    assert out == ""
+
+
+def test_format_footer_empty_fields_returns_empty():
+    out = format_runtime_footer(
+        model="m", context_tokens=0, context_length=100,
+        cwd="/x", fields=(),
+    )
+    assert out == ""
+
+
+def test_format_footer_drops_cwd_when_empty(monkeypatch):
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=50, context_length=100,
+        cwd="",
+        fields=("model", "context_pct", "cwd"),
+    )
+    # cwd silently dropped; model + pct remain
+    assert out == "gpt-5.4 · 50%"
+
+
+def test_format_footer_custom_field_order():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=50, context_length=100,
+        cwd="/opt/project",
+        fields=("context_pct", "model"),  # swapped + no cwd
+    )
+    assert out == "50% · gpt-5.4"
+
+
+
+def test_format_footer_extended_fields_with_quota_and_underline():
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        plan="Team",
+        windows=(
+            AccountUsageWindow(label="Session", used_percent=20, reset_at=None),
+            AccountUsageWindow(label="Weekly", used_percent=30, reset_at=None),
+        ),
+    )
+    out = format_runtime_footer(
+        model="openai/gpt-5.5",
+        provider="openai-codex",
+        account_label="openai-codex-team-main",
+        context_tokens=21_800,
+        context_length=200_000,
+        account_usage=snapshot,
+        cwd="",
+        fields=("provider", "account", "model", "context", "quota"),
+        underline=True,
+    )
+    assert out == "──────────────\nopenai-codex · team-main · gpt-5.5 · ctx 21.8K/200K · 5h 80% · 7d 70%"
+
+
+def test_format_footer_compacts_reset_times_for_quota():
+    snapshot = AccountUsageSnapshot(
+        provider="anthropic",
+        source="oauth_usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(
+                label="Current session",
+                used_percent=32.2,
+                reset_at=datetime.now(timezone.utc) + timedelta(hours=2, minutes=10),
+            ),
+        ),
+    )
+    out = format_runtime_footer(
+        model="anthropic/claude-sonnet-4-6",
+        context_tokens=21_800,
+        context_length=200_000,
+        account_usage=snapshot,
+        cwd="",
+        fields=("quota",),
+    )
+    assert out.startswith("5h 68% 2h")
+
+
+
+def test_format_footer_uses_provider_specific_compact_quota_labels():
+    snapshot = AccountUsageSnapshot(
+        provider="anthropic",
+        source="oauth_usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(label="Current week", used_percent=40, reset_at=None),
+            AccountUsageWindow(label="Opus week", used_percent=50, reset_at=None),
+            AccountUsageWindow(label="Sonnet week", used_percent=60, reset_at=None),
+        ),
+    )
+    out = format_runtime_footer(
+        model="anthropic/claude-opus-4-5",
+        provider="anthropic",
+        context_tokens=0,
+        context_length=200_000,
+        account_usage=snapshot,
+        fields=("quota",),
+    )
+    assert out == "7d 60% · opus7d 50% · sonnet7d 40%"
+
+
+def test_format_footer_includes_balance_details_for_quota():
+    snapshot = AccountUsageSnapshot(
+        provider="deepseek",
+        source="balance_api",
+        fetched_at=datetime.now(timezone.utc),
+        details=("Balance: ¥110.00 CNY (granted ¥10.00, topped up ¥100.00)",),
+    )
+
+    out = format_runtime_footer(
+        model="deepseek/deepseek-chat",
+        provider="deepseek",
+        context_tokens=0,
+        context_length=200_000,
+        account_usage=snapshot,
+        fields=("quota",),
+    )
+
+    assert out == "balance ¥110.00 CNY"
+
+
+def test_format_footer_unknown_field_silently_ignored():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=50, context_length=100,
+        cwd="/x",
+        fields=("model", "bogus", "context_pct"),
+    )
+    assert out == "gpt-5.4 · 50%"
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------
+
+def test_resolve_defaults_off_empty_config():
+    cfg = resolve_footer_config({}, "telegram")
+    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"], "underline": False}
+
+
+def test_resolve_global_enable():
+    user = {"display": {"runtime_footer": {"enabled": True}}}
+    cfg = resolve_footer_config(user, "telegram")
+    assert cfg["enabled"] is True
+    assert cfg["fields"] == ["model", "context_pct", "cwd"]
+
+
+
+def test_resolve_supports_underline_flag():
+    user = {"display": {"runtime_footer": {"enabled": True, "underline": True}}}
+    cfg = resolve_footer_config(user, "feishu")
+    assert cfg["underline"] is True
 
 
 def test_resolve_platform_override_wins():
@@ -111,9 +297,74 @@ def test_resolve_platform_can_add_fields_only():
     assert dc["fields"] == ["context_pct"]
 
 
+def test_resolve_ignores_malformed_config():
+    # Non-dict runtime_footer shouldn't crash
+    user = {"display": {"runtime_footer": "on"}}
+    cfg = resolve_footer_config(user, "telegram")
+    assert cfg["enabled"] is False
+
+
 # ---------------------------------------------------------------------------
 # build_footer_line — top-level entry point used by gateway/run.py
 # ---------------------------------------------------------------------------
+
+def test_build_footer_empty_when_disabled():
+    out = build_footer_line(
+        user_config={},
+        platform_key="telegram",
+        model="openai/gpt-5.4",
+        context_tokens=10, context_length=100,
+        cwd="/tmp",
+    )
+    assert out == ""
+
+
+def test_build_footer_returns_rendered_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": True}}},
+        platform_key="telegram",
+        model="openai/gpt-5.4",
+        context_tokens=25, context_length=100,
+        cwd=str(tmp_path / "proj"),
+    )
+    (tmp_path / "proj").mkdir(exist_ok=True)
+    assert "gpt-5.4" in out
+    assert "25%" in out
+
+
+
+def test_build_footer_passes_extended_runtime_metadata():
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        plan="Team",
+        windows=(
+            AccountUsageWindow(label="Session", used_percent=20, reset_at=None),
+            AccountUsageWindow(label="Weekly", used_percent=30, reset_at=None),
+        ),
+    )
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "underline": True,
+                    "fields": ["provider", "account", "model", "context", "quota"],
+                }
+            }
+        },
+        platform_key="feishu",
+        model="openai/gpt-5.5",
+        provider="openai-codex",
+        account_label="team-main",
+        context_tokens=18_200,
+        context_length=400_000,
+        account_usage=snapshot,
+        cwd="",
+    )
+    assert out == "──────────────\nopenai-codex · team-main · gpt-5.5 · ctx 18.2K/400K · 5h 80% · 7d 70%"
 
 
 def test_build_footer_per_platform_off_suppresses():
@@ -317,3 +568,17 @@ def test_default_build_footer_line_ignores_turn_seconds(monkeypatch):
     with_timing = build_footer_line(**common, turn_seconds=125.0)
     assert baseline == "gpt-5.4 · 5% · /var/data"
     assert with_timing == baseline
+
+
+def test_build_footer_no_data_returns_empty_even_when_enabled():
+    # Enabled, but context_length is None AND cwd empty AND model empty ⇒ no fields
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {"enabled": True}}},
+        platform_key="telegram",
+        model="",
+        context_tokens=0, context_length=None,
+        cwd="",
+    )
+    # With no TERMINAL_CWD env either
+    if not os.environ.get("TERMINAL_CWD"):
+        assert out == ""

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -158,11 +158,12 @@ def test_format_footer_extended_fields_with_quota_and_underline():
         context_tokens=21_800,
         context_length=200_000,
         account_usage=snapshot,
+        reasoning_effort="ultra",
         cwd="",
-        fields=("provider", "account", "model", "context", "quota"),
+        fields=("provider", "account", "model", "reasoning", "context", "quota"),
         underline=True,
     )
-    assert out == "──────────────\nopenai-codex · team-main · gpt-5.5 · ctx 21.8K/200K · 5h 80% · 7d 70%"
+    assert out == "──────────────\nopenai-codex · team-main · gpt-5.5 · ult · ctx 21.8K/200K · 5h 80% · 7d 70%"
 
 
 def test_format_footer_compacts_reset_times_for_quota():
@@ -305,6 +306,61 @@ def test_resolve_ignores_malformed_config():
 
 
 # ---------------------------------------------------------------------------
+
+
+def test_format_footer_reasoning_abbreviations():
+    cases = {
+        "none": "off",
+        "minimal": "min",
+        "low": "low",
+        "medium": "med",
+        "high": "high",
+        "xhigh": "xhi",
+        "max": "max",
+        "ultra": "ult",
+        "false": "off",
+        "DISABLED": "off",
+    }
+    for effort, expected in cases.items():
+        out = format_runtime_footer(
+            model="m",
+            context_tokens=0,
+            context_length=100,
+            reasoning_effort=effort,
+            fields=("reasoning",),
+        )
+        assert out == expected, (effort, out)
+
+
+def test_format_footer_reasoning_omitted_when_missing():
+    out = format_runtime_footer(
+        model="openai/gpt-5.5",
+        context_tokens=10,
+        context_length=100,
+        fields=("model", "reasoning"),
+    )
+    assert out == "gpt-5.5"
+
+
+def test_build_footer_passes_reasoning_effort():
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["model", "reasoning"],
+                }
+            }
+        },
+        platform_key=None,
+        model="openai/gpt-5.5",
+        context_tokens=0,
+        context_length=None,
+        reasoning_effort="xhigh",
+    )
+    assert out == "gpt-5.5 · xhi"
+
+
 # build_footer_line — top-level entry point used by gateway/run.py
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -249,18 +249,14 @@ def test_format_footer_unknown_field_silently_ignored():
 
 def test_resolve_defaults_off_empty_config():
     cfg = resolve_footer_config({}, "telegram")
-    assert cfg == {
-        "enabled": False,
-        "fields": ["model", "reasoning", "context_pct", "cwd"],
-        "underline": False,
-    }
+    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"], "underline": False}
 
 
 def test_resolve_global_enable():
     user = {"display": {"runtime_footer": {"enabled": True}}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is True
-    assert cfg["fields"] == ["model", "reasoning", "context_pct", "cwd"]
+    assert cfg["fields"] == ["model", "context_pct", "cwd"]
 
 
 
@@ -296,7 +292,7 @@ def test_resolve_platform_can_add_fields_only():
     }
     tg = resolve_footer_config(user, "telegram")
     assert tg["enabled"] is True
-    assert tg["fields"] == ["model", "reasoning", "context_pct", "cwd"]
+    assert tg["fields"] == ["model", "context_pct", "cwd"]
     dc = resolve_footer_config(user, "discord")
     assert dc["enabled"] is True
     assert dc["fields"] == ["context_pct"]
@@ -572,28 +568,29 @@ def test_build_footer_line_threads_turn_seconds(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Default behavior: reasoning is visible when available; latency stays opt-in.
+# Byte-stability: `latency` is opt-in, so the DEFAULT footer is unchanged.
 #
 # Upstream doctrine: a system prompt / rendered surface must be byte-stable for
-# the life of a conversation. These tests pin the intended default field set
-# and prove that unavailable optional data is still skipped without artifacts.
+# the life of a conversation.  Adding a field to _DEFAULT_FIELDS would silently
+# change the footer text of every user who already enabled it.  These tests pin
+# the default set and the exact default-config output strings.
 # ---------------------------------------------------------------------------
 
-_EXPECTED_DEFAULT_FIELDS = ["model", "reasoning", "context_pct", "cwd"]
+_LEGACY_DEFAULT_FIELDS = ["model", "context_pct", "cwd"]
 
 
 def test_latency_not_in_default_fields():
     from gateway.runtime_footer import _DEFAULT_FIELDS
 
     assert "latency" not in _DEFAULT_FIELDS
-    assert list(_DEFAULT_FIELDS) == _EXPECTED_DEFAULT_FIELDS
+    assert list(_DEFAULT_FIELDS) == _LEGACY_DEFAULT_FIELDS
 
 
 def test_resolve_footer_config_default_fields_exclude_latency():
-    assert resolve_footer_config({}, "telegram")["fields"] == _EXPECTED_DEFAULT_FIELDS
+    assert resolve_footer_config({}, "telegram")["fields"] == _LEGACY_DEFAULT_FIELDS
     assert resolve_footer_config(
         {"display": {"runtime_footer": {"enabled": True}}}, "discord"
-    )["fields"] == _EXPECTED_DEFAULT_FIELDS
+    )["fields"] == _LEGACY_DEFAULT_FIELDS
 
 
 @pytest.mark.parametrize(

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -10,6 +10,7 @@ import pytest
 from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 
 from gateway.runtime_footer import (
+    _compact_reset,
     _home_relative_cwd,
     _model_short,
     build_footer_line,
@@ -188,6 +189,24 @@ def test_format_footer_compacts_reset_times_for_quota():
         fields=("quota",),
     )
     assert out.startswith("5h 68% 2h")
+
+
+def test_compact_reset_omits_zero_day_and_minute_components(monkeypatch):
+    import gateway.runtime_footer as runtime_footer
+
+    fixed_now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is not None else fixed_now.replace(tzinfo=None)
+
+    monkeypatch.setattr(runtime_footer, "datetime", FixedDateTime)
+    fixed_target = FixedDateTime(2026, 1, 1, tzinfo=timezone.utc)
+
+    assert _compact_reset(fixed_target + timedelta(days=1)) == "1d"
+    assert _compact_reset(fixed_target + timedelta(hours=1)) == "1h"
+    assert _compact_reset(fixed_target + timedelta(seconds=30)) == "<1m"
 
 
 

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -249,14 +249,18 @@ def test_format_footer_unknown_field_silently_ignored():
 
 def test_resolve_defaults_off_empty_config():
     cfg = resolve_footer_config({}, "telegram")
-    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"], "underline": False}
+    assert cfg == {
+        "enabled": False,
+        "fields": ["model", "reasoning", "context_pct", "cwd"],
+        "underline": False,
+    }
 
 
 def test_resolve_global_enable():
     user = {"display": {"runtime_footer": {"enabled": True}}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is True
-    assert cfg["fields"] == ["model", "context_pct", "cwd"]
+    assert cfg["fields"] == ["model", "reasoning", "context_pct", "cwd"]
 
 
 
@@ -292,7 +296,7 @@ def test_resolve_platform_can_add_fields_only():
     }
     tg = resolve_footer_config(user, "telegram")
     assert tg["enabled"] is True
-    assert tg["fields"] == ["model", "context_pct", "cwd"]
+    assert tg["fields"] == ["model", "reasoning", "context_pct", "cwd"]
     dc = resolve_footer_config(user, "discord")
     assert dc["enabled"] is True
     assert dc["fields"] == ["context_pct"]
@@ -568,29 +572,28 @@ def test_build_footer_line_threads_turn_seconds(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Byte-stability: `latency` is opt-in, so the DEFAULT footer is unchanged.
+# Default behavior: reasoning is visible when available; latency stays opt-in.
 #
 # Upstream doctrine: a system prompt / rendered surface must be byte-stable for
-# the life of a conversation.  Adding a field to _DEFAULT_FIELDS would silently
-# change the footer text of every user who already enabled it.  These tests pin
-# the default set and the exact default-config output strings.
+# the life of a conversation. These tests pin the intended default field set
+# and prove that unavailable optional data is still skipped without artifacts.
 # ---------------------------------------------------------------------------
 
-_LEGACY_DEFAULT_FIELDS = ["model", "context_pct", "cwd"]
+_EXPECTED_DEFAULT_FIELDS = ["model", "reasoning", "context_pct", "cwd"]
 
 
 def test_latency_not_in_default_fields():
     from gateway.runtime_footer import _DEFAULT_FIELDS
 
     assert "latency" not in _DEFAULT_FIELDS
-    assert list(_DEFAULT_FIELDS) == _LEGACY_DEFAULT_FIELDS
+    assert list(_DEFAULT_FIELDS) == _EXPECTED_DEFAULT_FIELDS
 
 
 def test_resolve_footer_config_default_fields_exclude_latency():
-    assert resolve_footer_config({}, "telegram")["fields"] == _LEGACY_DEFAULT_FIELDS
+    assert resolve_footer_config({}, "telegram")["fields"] == _EXPECTED_DEFAULT_FIELDS
     assert resolve_footer_config(
         {"display": {"runtime_footer": {"enabled": True}}}, "discord"
-    )["fields"] == _LEGACY_DEFAULT_FIELDS
+    )["fields"] == _EXPECTED_DEFAULT_FIELDS
 
 
 @pytest.mark.parametrize(

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -147,8 +147,8 @@ def test_format_footer_extended_fields_with_quota_and_underline():
         fetched_at=datetime.now(timezone.utc),
         plan="Team",
         windows=(
-            AccountUsageWindow(label="Session", used_percent=20, reset_at=None),
-            AccountUsageWindow(label="Weekly", used_percent=30, reset_at=None),
+            AccountUsageWindow(label="5h", used_percent=20, reset_at=None),
+            AccountUsageWindow(label="7d", used_percent=30, reset_at=None),
         ),
     )
     out = format_runtime_footer(
@@ -211,6 +211,29 @@ def test_format_footer_uses_provider_specific_compact_quota_labels():
         fields=("quota",),
     )
     assert out == "7d 60% · opus7d 50% · sonnet7d 40%"
+
+
+def test_format_footer_preserves_nonstandard_quota_durations():
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(label="15d", used_percent=10, reset_at=None),
+            AccountUsageWindow(label="17h", used_percent=20, reset_at=None),
+        ),
+    )
+
+    out = format_runtime_footer(
+        model="openai/gpt-5.6-sol",
+        provider="openai-codex",
+        context_tokens=0,
+        context_length=200_000,
+        account_usage=snapshot,
+        fields=("quota",),
+    )
+
+    assert out == "15d 90% · 17h 80%"
 
 
 def test_format_footer_includes_balance_details_for_quota():
@@ -397,8 +420,8 @@ def test_build_footer_passes_extended_runtime_metadata():
         fetched_at=datetime.now(timezone.utc),
         plan="Team",
         windows=(
-            AccountUsageWindow(label="Session", used_percent=20, reset_at=None),
-            AccountUsageWindow(label="Weekly", used_percent=30, reset_at=None),
+            AccountUsageWindow(label="5h", used_percent=20, reset_at=None),
+            AccountUsageWindow(label="7d", used_percent=30, reset_at=None),
         ),
     )
     out = build_footer_line(

--- a/tests/gateway/test_runtime_footer_usage_cache.py
+++ b/tests/gateway/test_runtime_footer_usage_cache.py
@@ -1,0 +1,93 @@
+"""Regression tests for runtime-footer provider/account/quota wiring helpers."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import gateway.run as gateway_run
+from agent.account_usage import AccountUsageSnapshot
+
+
+def test_footer_account_usage_cache_key_is_scoped_to_credential():
+    a = gateway_run._footer_account_usage_cache_key(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="token-a",
+    )
+    b = gateway_run._footer_account_usage_cache_key(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="token-b",
+    )
+    c = gateway_run._footer_account_usage_cache_key(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex/",
+        api_key="token-a",
+    )
+    assert a != b
+    assert a == c
+
+
+def test_fetch_footer_account_usage_cached_reuses_snapshot(monkeypatch):
+    gateway_run._FOOTER_ACCOUNT_USAGE_CACHE.clear()
+    calls = {"n": 0}
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=None,
+        plan="Plus",
+        windows=(),
+    )
+
+    def fake_fetch(provider, base_url=None, api_key=None):
+        calls["n"] += 1
+        assert provider == "openai-codex"
+        assert api_key == "runtime-token"
+        return snapshot
+
+    monkeypatch.setattr(gateway_run, "fetch_account_usage", fake_fetch)
+
+    first = gateway_run._fetch_footer_account_usage_cached(
+        "openai-codex",
+        base_url="https://example.invalid",
+        api_key="runtime-token",
+    )
+    second = gateway_run._fetch_footer_account_usage_cached(
+        "openai-codex",
+        base_url="https://example.invalid",
+        api_key="runtime-token",
+    )
+    assert first is snapshot
+    assert second is snapshot
+    assert calls["n"] == 1
+
+
+def test_fetch_footer_account_usage_cached_expires(monkeypatch):
+    gateway_run._FOOTER_ACCOUNT_USAGE_CACHE.clear()
+    calls = {"n": 0}
+
+    def fake_fetch(provider, base_url=None, api_key=None):
+        calls["n"] += 1
+        return calls["n"]
+
+    monkeypatch.setattr(gateway_run, "fetch_account_usage", fake_fetch)
+    monkeypatch.setattr(gateway_run, "_FOOTER_ACCOUNT_USAGE_TTL_SECONDS", 0.01)
+
+    first = gateway_run._fetch_footer_account_usage_cached("deepseek", api_key="k")
+    time.sleep(0.02)
+    second = gateway_run._fetch_footer_account_usage_cached("deepseek", api_key="k")
+    assert first == 1
+    assert second == 2
+    assert calls["n"] == 2
+
+
+def test_run_agent_result_includes_runtime_provider_fields():
+    """Static guard: both agent_result returns must expose runtime auth metadata."""
+    src = Path(gateway_run.__file__).read_text()
+    assert src.count('"provider": getattr(agent, "provider", None)') >= 2
+    assert src.count('"base_url": getattr(agent, "base_url", None)') >= 2
+    assert src.count('"api_key": getattr(agent, "api_key", None)') >= 2
+    assert "_fetch_footer_account_usage_cached" in src
+    assert "provider=_footer_provider" in src
+    assert "account_usage=_footer_account_usage" in src

--- a/tests/gateway/test_runtime_footer_usage_cache.py
+++ b/tests/gateway/test_runtime_footer_usage_cache.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import gateway.run as gateway_run
 from agent.account_usage import AccountUsageSnapshot
 
 
-def test_footer_account_usage_cache_key_is_scoped_to_credential():
+def _reset_cache():
+    with gateway_run._FOOTER_ACCOUNT_USAGE_LOCK:
+        gateway_run._FOOTER_ACCOUNT_USAGE_CACHE.clear()
+        gateway_run._FOOTER_ACCOUNT_USAGE_REFRESHING.clear()
+
+
+def test_footer_account_usage_cache_key_is_profile_and_credential_scoped(monkeypatch):
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: Path("/profiles/alice"))
     a = gateway_run._footer_account_usage_cache_key(
         "openai-codex",
         base_url="https://chatgpt.com/backend-api/codex",
@@ -25,13 +32,50 @@ def test_footer_account_usage_cache_key_is_scoped_to_credential():
         base_url="https://chatgpt.com/backend-api/codex/",
         api_key="token-a",
     )
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: Path("/profiles/bob"))
+    d = gateway_run._footer_account_usage_cache_key(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="token-a",
+    )
+
     assert a != b
     assert a == c
+    assert a != d
+    assert "token-a" not in repr(a)
 
 
-def test_fetch_footer_account_usage_cached_reuses_snapshot(monkeypatch):
-    gateway_run._FOOTER_ACCOUNT_USAGE_CACHE.clear()
-    calls = {"n": 0}
+def test_cold_cache_schedules_once_and_returns_immediately(monkeypatch):
+    _reset_cache()
+    started = []
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: Path("/profiles/alice"))
+    monkeypatch.setattr(gateway_run.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(
+        gateway_run,
+        "_start_footer_account_usage_refresh",
+        lambda *args: started.append(args),
+    )
+
+    first = gateway_run._fetch_footer_account_usage_cached(
+        "openai-codex", base_url="https://example.invalid", api_key="runtime-token"
+    )
+    second = gateway_run._fetch_footer_account_usage_cached(
+        "openai-codex", base_url="https://example.invalid", api_key="runtime-token"
+    )
+
+    assert first is None
+    assert second is None
+    assert len(started) == 1
+    assert started[0][1:] == (
+        "openai-codex",
+        "https://example.invalid",
+        "runtime-token",
+    )
+    _reset_cache()
+
+
+def test_fresh_cache_returns_snapshot_without_scheduling(monkeypatch):
+    _reset_cache()
     snapshot = AccountUsageSnapshot(
         provider="openai-codex",
         source="usage_api",
@@ -39,55 +83,98 @@ def test_fetch_footer_account_usage_cached_reuses_snapshot(monkeypatch):
         plan="Plus",
         windows=(),
     )
-
-    def fake_fetch(provider, base_url=None, api_key=None):
-        calls["n"] += 1
-        assert provider == "openai-codex"
-        assert api_key == "runtime-token"
-        return snapshot
-
-    monkeypatch.setattr(gateway_run, "fetch_account_usage", fake_fetch)
-
-    first = gateway_run._fetch_footer_account_usage_cached(
-        "openai-codex",
-        base_url="https://example.invalid",
-        api_key="runtime-token",
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: Path("/profiles/alice"))
+    key = gateway_run._footer_account_usage_cache_key(
+        "openai-codex", base_url="https://example.invalid", api_key="runtime-token"
     )
-    second = gateway_run._fetch_footer_account_usage_cached(
-        "openai-codex",
-        base_url="https://example.invalid",
-        api_key="runtime-token",
+    gateway_run._FOOTER_ACCOUNT_USAGE_CACHE[key] = (100.0, snapshot)
+    monkeypatch.setattr(gateway_run.time, "monotonic", lambda: 110.0)
+    monkeypatch.setattr(
+        gateway_run,
+        "_start_footer_account_usage_refresh",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("fresh cache refreshed")),
     )
-    assert first is snapshot
-    assert second is snapshot
-    assert calls["n"] == 1
+
+    result = gateway_run._fetch_footer_account_usage_cached(
+        "openai-codex", base_url="https://example.invalid", api_key="runtime-token"
+    )
+
+    assert result is snapshot
+    _reset_cache()
 
 
-def test_fetch_footer_account_usage_cached_expires(monkeypatch):
-    gateway_run._FOOTER_ACCOUNT_USAGE_CACHE.clear()
-    calls = {"n": 0}
+def test_stale_cache_returns_stale_snapshot_while_refreshing(monkeypatch):
+    _reset_cache()
+    snapshot = SimpleNamespace(windows=(SimpleNamespace(label="Session"),))
+    started = []
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: Path("/profiles/alice"))
+    key = gateway_run._footer_account_usage_cache_key(
+        "openai-codex", base_url="https://example.invalid", api_key="runtime-token"
+    )
+    gateway_run._FOOTER_ACCOUNT_USAGE_CACHE[key] = (1.0, snapshot)
+    monkeypatch.setattr(gateway_run.time, "monotonic", lambda: 500.0)
+    monkeypatch.setattr(
+        gateway_run,
+        "_start_footer_account_usage_refresh",
+        lambda *args: started.append(args),
+    )
 
-    def fake_fetch(provider, base_url=None, api_key=None):
-        calls["n"] += 1
-        return calls["n"]
+    result = gateway_run._fetch_footer_account_usage_cached(
+        "openai-codex", base_url="https://example.invalid", api_key="runtime-token"
+    )
 
-    monkeypatch.setattr(gateway_run, "fetch_account_usage", fake_fetch)
-    monkeypatch.setattr(gateway_run, "_FOOTER_ACCOUNT_USAGE_TTL_SECONDS", 0.01)
-
-    first = gateway_run._fetch_footer_account_usage_cached("deepseek", api_key="k")
-    time.sleep(0.02)
-    second = gateway_run._fetch_footer_account_usage_cached("deepseek", api_key="k")
-    assert first == 1
-    assert second == 2
-    assert calls["n"] == 2
+    assert result is snapshot
+    assert len(started) == 1
+    _reset_cache()
 
 
-def test_run_agent_result_includes_runtime_provider_fields():
-    """Static guard: both agent_result returns must expose runtime auth metadata."""
-    src = Path(gateway_run.__file__).read_text()
-    assert src.count('"provider": getattr(agent, "provider", None)') >= 2
-    assert src.count('"base_url": getattr(agent, "base_url", None)') >= 2
-    assert src.count('"api_key": getattr(agent, "api_key", None)') >= 2
-    assert "_fetch_footer_account_usage_cached" in src
-    assert "provider=_footer_provider" in src
-    assert "account_usage=_footer_account_usage" in src
+def test_refresh_uses_live_credential_and_updates_cache(monkeypatch):
+    _reset_cache()
+    calls = []
+    snapshot = SimpleNamespace(windows=(SimpleNamespace(label="Session"),))
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: Path("/profiles/alice"))
+    key = gateway_run._footer_account_usage_cache_key(
+        "openai-codex", base_url="https://example.invalid", api_key="runtime-token"
+    )
+    gateway_run._FOOTER_ACCOUNT_USAGE_REFRESHING.add(key)
+    monkeypatch.setattr(
+        gateway_run,
+        "fetch_account_usage",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or snapshot,
+    )
+    monkeypatch.setattr(gateway_run.time, "monotonic", lambda: 321.0)
+
+    gateway_run._refresh_footer_account_usage(
+        key, "openai-codex", "https://example.invalid", "runtime-token"
+    )
+
+    assert gateway_run._FOOTER_ACCOUNT_USAGE_CACHE[key] == (321.0, snapshot)
+    assert key not in gateway_run._FOOTER_ACCOUNT_USAGE_REFRESHING
+    assert calls == [
+        (
+            ("openai-codex",),
+            {"base_url": "https://example.invalid", "api_key": "runtime-token"},
+        )
+    ]
+    _reset_cache()
+
+
+def test_refresh_failure_preserves_last_good_snapshot(monkeypatch):
+    _reset_cache()
+    stale = SimpleNamespace(windows=(SimpleNamespace(label="Session"),))
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: Path("/profiles/alice"))
+    key = gateway_run._footer_account_usage_cache_key(
+        "openai-codex", base_url="https://example.invalid", api_key="runtime-token"
+    )
+    gateway_run._FOOTER_ACCOUNT_USAGE_CACHE[key] = (1.0, stale)
+    gateway_run._FOOTER_ACCOUNT_USAGE_REFRESHING.add(key)
+    monkeypatch.setattr(gateway_run, "fetch_account_usage", lambda *_a, **_kw: None)
+    monkeypatch.setattr(gateway_run.time, "monotonic", lambda: 500.0)
+
+    gateway_run._refresh_footer_account_usage(
+        key, "openai-codex", "https://example.invalid", "runtime-token"
+    )
+
+    assert gateway_run._FOOTER_ACCOUNT_USAGE_CACHE[key] == (500.0, stale)
+    assert key not in gateway_run._FOOTER_ACCOUNT_USAGE_REFRESHING
+    _reset_cache()

--- a/tests/gateway/test_runtime_footer_usage_cache.py
+++ b/tests/gateway/test_runtime_footer_usage_cache.py
@@ -45,6 +45,19 @@ def test_footer_account_usage_cache_key_is_profile_and_credential_scoped(monkeyp
     assert "token-a" not in repr(a)
 
 
+def test_footer_account_usage_cache_key_accepts_captured_profile_home(monkeypatch):
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: Path("/profiles/default"))
+
+    key = gateway_run._footer_account_usage_cache_key(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="token-a",
+        hermes_home=Path("/profiles/alice"),
+    )
+
+    assert key[0] == "/profiles/alice"
+
+
 def test_cold_cache_schedules_once_and_returns_immediately(monkeypatch):
     _reset_cache()
     started = []

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -49,6 +49,22 @@ class _RoutingClient:
         return _Response(self._payloads[url])
 
 
+
+class _RecordingClient:
+    def __init__(self, payload):
+        self._payload = payload
+        self.requests = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None):
+        self.requests.append((url, dict(headers or {})))
+        return _Response(self._payload)
+
 def test_fetch_account_usage_codex(monkeypatch):
     monkeypatch.setattr(
         "agent.account_usage.resolve_codex_runtime_credentials",
@@ -201,3 +217,90 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+def test_fetch_account_usage_anthropic_prefers_explicit_runtime_key_over_resolver(monkeypatch):
+    client = _RecordingClient(
+        {
+            "five_hour": {"utilization": 0.25},
+        }
+    )
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout=15.0: client)
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token",
+        lambda: "rotated-pool-token",
+    )
+
+    snapshot = fetch_account_usage("anthropic", api_key="runtime-token")
+
+    assert snapshot is not None
+    assert snapshot.provider == "anthropic"
+    assert client.requests[0][1]["Authorization"] == "Bearer runtime-token"
+
+def test_fetch_account_usage_custom_deepseek_base_url_is_supported(monkeypatch):
+    client = _RecordingClient(
+        {
+            "is_available": True,
+            "balance_infos": [
+                {
+                    "currency": "CNY",
+                    "total_balance": "25.50",
+                    "granted_balance": "0.00",
+                    "topped_up_balance": "25.50",
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout=10.0: client)
+
+    snapshot = fetch_account_usage(
+        "custom",
+        base_url="https://api.deepseek.com/beta/v1/",
+        api_key="deepseek-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.provider == "deepseek"
+    assert snapshot.details == ("Balance: ¥25.50 CNY (topped up ¥25.50)",)
+
+def test_fetch_account_usage_deepseek_balance_uses_official_endpoint(monkeypatch):
+    client = _RecordingClient(
+        {
+            "is_available": True,
+            "balance_infos": [
+                {
+                    "currency": "CNY",
+                    "total_balance": "110.00",
+                    "granted_balance": "10.00",
+                    "topped_up_balance": "100.00",
+                },
+                {
+                    "currency": "USD",
+                    "total_balance": "2.50",
+                    "granted_balance": "0.00",
+                    "topped_up_balance": "2.50",
+                },
+            ],
+        }
+    )
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout=10.0: client)
+
+    snapshot = fetch_account_usage(
+        "deepseek",
+        base_url="https://api.deepseek.com/v1",
+        api_key="deepseek-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.provider == "deepseek"
+    assert snapshot.source == "balance_api"
+    assert snapshot.details == (
+        "Balance: ¥110.00 CNY (granted ¥10.00, topped up ¥100.00)",
+        "Balance: $2.50 USD (topped up $2.50)",
+    )
+    assert client.requests == [
+        (
+            "https://api.deepseek.com/user/balance",
+            {"Authorization": "Bearer deepseek-token", "Accept": "application/json"},
+        )
+    ]

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -105,10 +105,38 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot is not None
     assert snapshot.plan == "Pro"
     assert len(snapshot.windows) == 2
-    assert snapshot.windows[0].label == "Session"
+    assert [window.label for window in snapshot.windows] == ["5h", "7d"]
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+
+
+def test_fetch_account_usage_codex_labels_single_primary_by_actual_duration(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "plan_type": "pro",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 95,
+                        "reset_at": 1_900_000_000,
+                        "limit_window_seconds": 604800,
+                    },
+                    "secondary_window": None,
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="access-token",
+    )
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [("7d", 95.0)]
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1867,7 +1867,7 @@ display:
   spinner_token_flow: true # CLI only: append live cumulative turn tokens to the spinner timer
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
-    fields: ["model", "context_pct", "cwd"]  # also: provider, account, context, quota; optional underline: true
+    fields: ["model", "context_pct", "cwd"]  # also: provider, account, context, quota, reasoning; optional underline: true
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   cli_rebuild_scrollback_on_redraw: false  # Classic CLI: also wipe terminal scrollback (CSI 3J) on /redraw / Ctrl+L / width-change resize recovery. Enable when a terminal/tmux stack stamps stale prompt chrome into scrollback on maximize/restore.
@@ -1976,7 +1976,7 @@ When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-cont
 display:
   runtime_footer:
     enabled: true
-    fields: ["provider", "account", "model", "context", "quota"]
+    fields: ["provider", "account", "model", "reasoning", "context", "quota"]
     underline: true
 ```
 
@@ -1985,6 +1985,7 @@ Supported `fields` (order is preserved; omit any field to hide it):
 | Field | What it shows |
 |-------|---------------|
 | `model` | Model id used for the turn |
+| `reasoning` | Compact reasoning-effort abbreviation (`off`/`min`/`low`/`med`/`high`/`xhi`/`max`/`ult`) |
 | `provider` | Provider / auth path that served the turn |
 | `account` | Compact account/plan label when available |
 | `context` | Absolute context usage (`used/limit`) |
@@ -2001,6 +2002,7 @@ Notes:
 - `quota` only renders windows a provider actually returns; providers without usage APIs stay silent for that field.
 - Account/quota lookups use the exact runtime credential that served the turn, so credential-pool rotation does not show another account's limits.
 - Quota results are cached briefly per credential so footer rendering does not hit provider usage APIs on every message.
+- `reasoning` shows the live turn effort from the agent runtime (including `/reasoning` overrides), abbreviated for mobile footers.
 - Unknown field names are ignored.
 - Per-platform overrides live under `display.platforms.<platform>.runtime_footer`.
 
@@ -2010,7 +2012,7 @@ Example footer appended to a Telegram/Discord/Slack/Feishu reply:
 
 ```
 ──────────────
-xai-oauth · lance*** · grok-4.5 · ctx 18.2k/256k · 5h 72% · 7d 41%
+xai-oauth · lance*** · grok-4.5 · ult · ctx 18.2k/256k · 5h 72% · 7d 41%
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean. When streaming already delivered the final text piecemeal, the footer may be sent as a separate trailing message.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2001,7 +2001,7 @@ Notes:
 - `underline: true` prepends a short separator line before the footer.
 - `quota` only renders windows a provider actually returns; providers without usage APIs stay silent for that field.
 - Account/quota lookups use the exact runtime credential that served the turn, so credential-pool rotation does not show another account's limits.
-- Quota results are cached briefly per credential so footer rendering does not hit provider usage APIs on every message.
+- Quota results are cached per profile and credential. Cold or stale entries refresh in the background; a cold cache omits quota on the first reply rather than delaying final-message delivery, while a transient refresh failure keeps the last valid snapshot.
 - `reasoning` shows the live turn effort from the agent runtime (including `/reasoning` overrides), abbreviated for mobile footers.
 - Unknown field names are ignored.
 - Per-platform overrides live under `display.platforms.<platform>.runtime_footer`.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1867,7 +1867,7 @@ display:
   spinner_token_flow: true # CLI only: append live cumulative turn tokens to the spinner timer
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
-    fields: ["model", "context_pct", "cwd"]  # also: provider, account, context, quota, reasoning; optional underline: true
+    fields: ["model", "reasoning", "context_pct", "cwd"]  # also: provider, account, context, quota; optional underline: true
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   cli_rebuild_scrollback_on_redraw: false  # Classic CLI: also wipe terminal scrollback (CSI 3J) on /redraw / Ctrl+L / width-change resize recovery. Enable when a terminal/tmux stack stamps stale prompt chrome into scrollback on maximize/restore.
@@ -1996,7 +1996,7 @@ Supported `fields` (order is preserved; omit any field to hide it):
 
 Notes:
 
-- Default fields remain `["model", "context_pct", "cwd"]` when `fields` is unset.
+- Default fields are `["model", "reasoning", "context_pct", "cwd"]` when `fields` is unset. `reasoning` is skipped silently when the active effort is unavailable.
 - `latency` is opt-in; fields whose data is unavailable are skipped silently.
 - `underline: true` prepends a short separator line before the footer.
 - `quota` only renders windows a provider actually returns; providers without usage APIs stay silent for that field.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1867,7 +1867,7 @@ display:
   spinner_token_flow: true # CLI only: append live cumulative turn tokens to the spinner timer
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
-    fields: ["model", "reasoning", "context_pct", "cwd"]  # also: provider, account, context, quota; optional underline: true
+    fields: ["model", "context_pct", "cwd"]  # also: provider, account, context, quota, reasoning; optional underline: true
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   cli_rebuild_scrollback_on_redraw: false  # Classic CLI: also wipe terminal scrollback (CSI 3J) on /redraw / Ctrl+L / width-change resize recovery. Enable when a terminal/tmux stack stamps stale prompt chrome into scrollback on maximize/restore.
@@ -1996,7 +1996,7 @@ Supported `fields` (order is preserved; omit any field to hide it):
 
 Notes:
 
-- Default fields are `["model", "reasoning", "context_pct", "cwd"]` when `fields` is unset. `reasoning` is skipped silently when the active effort is unavailable.
+- Default fields remain `["model", "context_pct", "cwd"]` when `fields` is unset.
 - `latency` is opt-in; fields whose data is unavailable are skipped silently.
 - `underline: true` prepends a short separator line before the footer.
 - `quota` only renders windows a provider actually returns; providers without usage APIs stay silent for that field.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1867,7 +1867,7 @@ display:
   spinner_token_flow: true # CLI only: append live cumulative turn tokens to the spinner timer
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    fields: ["model", "context_pct", "cwd"]  # also: provider, account, context, quota; optional underline: true
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   cli_rebuild_scrollback_on_redraw: false  # Classic CLI: also wipe terminal scrollback (CSI 3J) on /redraw / Ctrl+L / width-change resize recovery. Enable when a terminal/tmux stack stamps stale prompt chrome into scrollback on maximize/restore.
@@ -1970,35 +1970,50 @@ Focus view is **display-only**. It never edits conversation history, the system 
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. Off by default so replies stay clean; opt in when you want every gateway reply to carry provenance such as model, provider, account, context usage, or remaining quota.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # order shown; drop any to hide
+    fields: ["provider", "account", "model", "context", "quota"]
+    underline: true
 ```
 
-Supported fields:
+Supported `fields` (order is preserved; omit any field to hide it):
 
-| Field | Renders | Example |
-| --- | --- | --- |
-| `model` | Bare model id, vendor prefix dropped | `gpt-5.4` |
-| `context_pct` | Last-call context occupancy as a percent | `5%` |
-| `latency` | Wall-clock duration of the turn | `22s`, `1m05s` |
-| `cwd` | Home-relative working directory | `~` |
+| Field | What it shows |
+|-------|---------------|
+| `model` | Model id used for the turn |
+| `provider` | Provider / auth path that served the turn |
+| `account` | Compact account/plan label when available |
+| `context` | Absolute context usage (`used/limit`) |
+| `context_pct` | Context usage as a percentage |
+| `latency` | Wall-clock duration of the turn (`22s`, `1m05s`) |
+| `quota` | Compact remaining quota windows returned by the provider |
+| `cwd` | Working directory, with `$HOME` collapsed to `~` |
 
-The default field set is `["model", "context_pct", "cwd"]`. `latency` is opt-in — add it to `fields` to use it. Fields whose data is unavailable are skipped silently rather than rendering an empty slot.
+Notes:
 
-The `/footer` slash command toggles this at runtime in any session.
+- Default fields remain `["model", "context_pct", "cwd"]` when `fields` is unset.
+- `latency` is opt-in; fields whose data is unavailable are skipped silently.
+- `underline: true` prepends a short separator line before the footer.
+- `quota` only renders windows a provider actually returns; providers without usage APIs stay silent for that field.
+- Account/quota lookups use the exact runtime credential that served the turn, so credential-pool rotation does not show another account's limits.
+- Quota results are cached briefly per credential so footer rendering does not hit provider usage APIs on every message.
+- Unknown field names are ignored.
+- Per-platform overrides live under `display.platforms.<platform>.runtime_footer`.
 
-Example footer appended to a Telegram/Discord/Slack reply:
+The `/footer` slash command toggles the global footer setting at runtime in any session (`on|off|status`).
+
+Example footer appended to a Telegram/Discord/Slack/Feishu reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+──────────────
+xai-oauth · lance*** · grok-4.5 · ctx 18.2k/256k · 5h 72% · 7d 41%
 ```
 
-Only the **final** message of a turn gets the footer; interim updates stay clean.
+Only the **final** message of a turn gets the footer; interim updates stay clean. When streaming already delivered the final text piecemeal, the footer may be sent as a separate trailing message.
 
 ### Per-platform progress overrides
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1874,6 +1874,11 @@ display:
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
 
+When `quota` is enabled for DeepSeek, Hermes queries the balance endpoint using
+that provider's configured `base_url`. If the URL points to a third-party
+OpenAI-compatible proxy, the proxy receives the balance request and the
+configured API credential just as it receives normal model requests.
+
 ### Per-turn summary and spinner token flow
 
 `display.turn_summary` (default `true`) prints one dim accounting line after each **interactive CLI** turn, summarising what that turn actually did:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1216,7 +1216,7 @@ display:
   tool_preview_length: 0  # 工具调用预览的最大字符数（0 = 无限制，显示完整路径/命令）
   runtime_footer:         # Gateway：在最终回复中附加运行时上下文页脚
     enabled: false
-    fields: ["model", "reasoning", "context_pct", "cwd"]
+    fields: ["model", "context_pct", "cwd"]
   file_mutation_verifier: true    # 当本轮 write_file/patch 调用失败时附加建议性页脚
   language: en            # 静态消息的 UI 语言（审批提示、部分 gateway 回复）。en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
@@ -1266,7 +1266,7 @@ display:
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "reasoning", "context_pct", "cwd"]   # 启用后默认显示模型、思考程度、上下文占用和工作目录
+    fields: ["model", "context_pct", "cwd"]   # 支持字段：model、context_pct、cwd
 ```
 
 `/footer` 斜杠命令在任何会话中运行时切换此功能。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1216,7 +1216,7 @@ display:
   tool_preview_length: 0  # 工具调用预览的最大字符数（0 = 无限制，显示完整路径/命令）
   runtime_footer:         # Gateway：在最终回复中附加运行时上下文页脚
     enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    fields: ["model", "reasoning", "context_pct", "cwd"]
   file_mutation_verifier: true    # 当本轮 write_file/patch 调用失败时附加建议性页脚
   language: en            # 静态消息的 UI 语言（审批提示、部分 gateway 回复）。en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
@@ -1266,7 +1266,7 @@ display:
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # 支持字段：model、context_pct、cwd
+    fields: ["model", "reasoning", "context_pct", "cwd"]   # 启用后默认显示模型、思考程度、上下文占用和工作目录
 ```
 
 `/footer` 斜杠命令在任何会话中运行时切换此功能。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1216,10 +1216,12 @@ display:
   tool_preview_length: 0  # 工具调用预览的最大字符数（0 = 无限制，显示完整路径/命令）
   runtime_footer:         # Gateway：在最终回复中附加运行时上下文页脚
     enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    fields: ["model", "context_pct", "cwd"]  # 还支持：provider、account、context、quota、reasoning；可选 underline: true
   file_mutation_verifier: true    # 当本轮 write_file/patch 调用失败时附加建议性页脚
   language: en            # 静态消息的 UI 语言（审批提示、部分 gateway 回复）。en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
+
+启用 DeepSeek 的 `quota` 字段时，Hermes 会使用该 provider 配置的 `base_url` 请求余额接口。如果这里配置的是第三方 OpenAI 兼容代理，余额请求及配置的 API 凭证也会发送给该代理，这与普通模型请求的行为一致。
 
 ### 文件变更验证器
 


### PR DESCRIPTION
## What does this PR do?

This is a refreshed replacement for [NousResearch/hermes-agent#18188](https://github.com/NousResearch/hermes-agent/pull/18188), rebased onto the current upstream `main`.

It extends the opt-in runtime footer with model/reasoning metadata and provider account/quota information while preserving the legacy default footer. Quota refresh is non-blocking and uses stale-while-revalidate behavior so a slow or unavailable provider does not block message delivery.

The branch also carries the hardening originally proposed in [lancecheney/hermes-agent#1](https://github.com/lancecheney/hermes-agent/pull/1): routed-profile and credential-scoped cache isolation, in-flight deduplication, stale preservation on transient failures, bounded cache size, and removal of raw credentials from `agent_result`.

The original #18188 branch belongs to `lancecheney`, so it cannot be rebased from this account. This PR keeps the original open and provides a current-main review target without force-pushing another user's branch.

## Scope

- Runtime footer remains opt-in.
- Legacy default fields remain `model`, `context_pct`, and `cwd`.
- Explicit fields can include reasoning, provider account/quota data, reset windows, and related metadata.
- Account usage follows the configured provider/base URL behavior, including OpenAI-compatible proxies.
- Profile and credential boundaries are preserved for multiplexed gateways.

## Changes

- Extend runtime footer configuration and rendering.
- Add Codex window labels derived from the API's `limit_window_seconds`.
- Add provider account/quota lookup and compact reset formatting.
- Add non-blocking stale-while-revalidate quota caching.
- Preserve profile/credential isolation and avoid raw credential propagation.
- Update English and Chinese configuration documentation.
- Add and update focused regression tests.

## Validation

Rebased branch validation on Linux:

```text
Focused runtime-footer/account-usage suite: 82 passed, 0 failed
ruff: passed
py_compile: passed
git diff --check: passed
```

Focused command:

```text
uv run pytest -q tests/gateway/test_runtime_footer.py tests/gateway/test_runtime_footer_usage_cache.py tests/agent/test_account_usage.py tests/test_account_usage.py
```

## Review request

Please review this refreshed current-main branch as a replacement review target for #18188. If maintainers prefer to keep #18188 as the canonical PR, its owner can transfer or refresh that branch and close this replacement.
