### PR TITLE
fix(cron): isolate scheduled runs from chat prefill

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5993,29 +5993,35 @@ def run_job(
         # Resolution itself happens via _resolve_job_reasoning_config below
         # (per-job pin > agent.reasoning_overrides > agent.reasoning_effort).
 
-        # Prefill messages from env or config.yaml. The top-level
-        # prefill_messages_file key is canonical; agent.prefill_messages_file is
-        # retained as a legacy fallback for older CLI/godmode configs.
-        prefill_messages = None
-        agent_cfg = _cfg.get("agent", {}) if isinstance(_cfg.get("agent", {}), dict) else {}
-        prefill_file = (
-            os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
-            or _cfg.get("prefill_messages_file", "")
-            or agent_cfg.get("prefill_messages_file", "")
-        )
-        if prefill_file:
-            pfpath = Path(prefill_file).expanduser()
-            if not pfpath.is_absolute():
-                pfpath = _get_hermes_home() / pfpath
-            if pfpath.exists():
-                try:
-                    with open(pfpath, "r", encoding="utf-8") as _pf:
-                        prefill_messages = json.load(_pf)
-                    if not isinstance(prefill_messages, list):
-                        prefill_messages = None
-                except Exception as e:
-                    logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
-                    prefill_messages = None
+        # Cron runs are isolated from chat-style prefill by default. Operators
+        # using prefill for deliberate model priming can opt back in explicitly.
+        prefill_messages: Any = None
+        _cfg_dict: Any = _cfg if isinstance(_cfg, dict) else {}
+        _raw_cron_cfg = _cfg_dict.get("cron")
+        _cron_cfg = _raw_cron_cfg if isinstance(_raw_cron_cfg, dict) else {}
+        if _cron_cfg.get("inherit_prefill_messages") is True:
+            _raw_agent_cfg = _cfg_dict.get("agent")
+            agent_cfg = _raw_agent_cfg if isinstance(_raw_agent_cfg, dict) else {}
+            prefill_file = str(
+                os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
+                or _cfg_dict.get("prefill_messages_file", "")
+                or agent_cfg.get("prefill_messages_file", "")
+            )
+            if prefill_file:
+                pfpath = Path(prefill_file).expanduser()
+                if not pfpath.is_absolute():
+                    pfpath = _get_hermes_home() / pfpath
+                if pfpath.exists():
+                    try:
+                        with open(pfpath, "r", encoding="utf-8") as _pf:
+                            prefill_messages = json.load(_pf)
+                        if not isinstance(prefill_messages, list):
+                            prefill_messages = None
+                    except Exception as e:
+                        logger.warning(
+                            "Job '%s': failed to parse prefill messages file '%s': %s",
+                            job_id, pfpath, e,
+                        )
 
         # Max iterations — resolved through resolve_turn_limit() so that
         # agent.max_turns: none / unlimited → sys.maxsize sentinel, and

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2652,6 +2652,10 @@ DEFAULT_CONFIG = {
         # job. Interactive toolsets (messaging/clarify) stay denied in cron
         # context regardless of this setting.
         "allow_agent_scheduling": False,
+        # Keep scheduled runs isolated from global chat/few-shot prefill by
+        # default. Set true only when the same prefill is deliberately required
+        # for unattended model priming.
+        "inherit_prefill_messages": False,
         # Pre-dispatch configuration validation (T1-26): before constructing
         # any agent machinery for a job, verify the provider API key resolves
         # (unless a fallback chain is configured), attached skills are ready

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -653,6 +653,44 @@ class TestRunJobSessionPersistence:
             "memory toolset must not be policy-denied in cron"
         )
 
+    def test_run_job_does_not_inherit_chat_prefill_messages(self, tmp_path):
+        """Scheduled runs start from the stored job prompt, not chat prefill."""
+        prefill = [{"role": "user", "content": "Create the monitor routine"}]
+        (tmp_path / "prefill.json").write_text(json.dumps(prefill), encoding="utf-8")
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  default: test-model\nprefill_messages_file: prefill.json\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "isolated-context-job",
+            "name": "test",
+            "prompt": "Check the monitor for changes",
+        }
+
+        with self._run_job_patches(tmp_path) as (fake_db, mock_agent_cls):
+            run_job(job)
+
+        assert mock_agent_cls.call_args.kwargs.get("prefill_messages") is None
+
+    def test_run_job_can_explicitly_inherit_prefill_messages(self, tmp_path):
+        """Operators can opt cron into deliberate model-priming prefill."""
+        prefill = [{"role": "assistant", "content": "Few-shot model primer"}]
+        (tmp_path / "prefill.json").write_text(
+            json.dumps(prefill), encoding="utf-8"
+        )
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  default: test-model\n"
+            "prefill_messages_file: prefill.json\n"
+            "cron:\n  inherit_prefill_messages: true\n",
+            encoding="utf-8",
+        )
+        job = {"id": "primed-job", "name": "test", "prompt": "Run the monitor"}
+
+        with self._run_job_patches(tmp_path) as (fake_db, mock_agent_cls):
+            run_job(job)
+
+        assert mock_agent_cls.call_args.kwargs["prefill_messages"] == prefill
+
     def test_run_job_keeps_per_job_memory_toolset(self, tmp_path):
         """A per-job enabled_toolsets naming memory keeps it."""
         job = {

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -1023,6 +1023,11 @@ The storage uses atomic file writes so interrupted writes do not leave a partial
 Cron jobs run in a completely fresh agent session. The prompt must contain everything the agent needs that is not already provided by attached skills.
 :::
 
+Global prefill messages are excluded from cron runs by default so setup or
+few-shot chat context cannot change a scheduled instruction. If a model
+deliberately requires the same prefill for unattended runs, set
+`cron.inherit_prefill_messages: true` in `config.yaml`.
+
 **BAD:** `"Check on that server issue"`
 
 **GOOD:** `"SSH into server 192.168.1.100 as user 'deploy', check if nginx is running with 'systemctl status nginx', and verify https://example.com returns HTTP 200."`


### PR DESCRIPTION
## Summary

- isolate scheduled agents from global chat/few-shot prefill by default
- preserve deliberate unattended model priming behind `cron.inherit_prefill_messages: true`
- document the isolation contract and add regressions for both default and opt-in behavior

## Root cause

`cron.scheduler.run_job()` created a fresh session ID, but then loaded `HERMES_PREFILL_MESSAGES_FILE` / `prefill_messages_file` and passed those messages into `AIAgent`. A global prefill containing a setup exchange therefore preceded the stored cron prompt on every fire, making a monitor respond to setup instructions such as “create the routine” instead of running the monitor.

## Verification

- RED: the default-isolation regression failed before the fix because `AIAgent` received the setup message
- focused default + opt-in regressions: 2 passed
- `tests/cron/`: 1026 passed, 10 skipped
- Ruff on modified Python files: passed
- Python compile checks: passed
- `git diff --check`: passed
- independent re-review after preserving explicit model priming: no blockers

## Scope

Memory, SOUL identity, per-job skills, script output, `context_from`, model settings, and provider routing are unchanged. Operators who intentionally need the same global prefill in scheduled runs can opt in with:

```yaml
cron:
  inherit_prefill_messages: true
```
