### PR TITLE
fix(context): discover Hermes project files in subdirectories

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 # Same filenames as prompt_builder.py but we load ALL found (not first-wins)
 # since different subdirectories may use different conventions.
 _HINT_FILENAMES = [
+    ".hermes.md", "HERMES.md",
     "AGENTS.override.md",
     "AGENTS.md", "agents.md",
     "CLAUDE.md", "claude.md",

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -53,6 +53,21 @@ class TestSubdirectoryHintTracker:
         assert result is not None
         assert "Frontend rules" in result
 
+    @pytest.mark.parametrize("filename", [".hermes.md", "HERMES.md"])
+    def test_discovers_hermes_md(self, tmp_path, filename):
+        """Hermes project context must follow tools into subdirectories."""
+        project = tmp_path / "service"
+        project.mkdir()
+        (project / filename).write_text("Hermes project rules")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(project / "main.py")}
+        )
+
+        assert result is not None
+        assert "Hermes project rules" in result
+
     def test_no_duplicate_loading(self, project):
         """Same directory should not be loaded twice."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))


### PR DESCRIPTION
## Summary

- discover `.hermes.md` and `HERMES.md` when tools enter a subdirectory
- align progressive hint discovery with the filenames supported by the startup prompt builder
- seed their digests through the existing shared filename list, preserving deduplication

## Reproduction

A session starts above a project, then uses `read_file` inside a child directory that contains only `.hermes.md`.

```text
origin/main: result is None, canary loaded = false
PR branch:   result exists, canary loaded = true
```

This is a real setup on the reporting host: the agent starts in `/home/bernard`, while a child project uses `.hermes.md` as its highest-priority Hermes context. Before this patch, progressive discovery ignored that file and could load secondary `AGENTS.md` / `CLAUDE.md` guidance instead.

## Safety

The new files use the existing path for:

- context threat scanning
- 8,000-character truncation
- digest deduplication
- excluded-directory checks
- one-time directory loading

No new loader or precedence mechanism is introduced.

## Test plan

- [x] RED observed for `.hermes.md`
- [x] RED observed for `HERMES.md`
- [x] two targeted tests pass
- [x] `pytest tests/agent/test_subdirectory_hints.py tests/agent/test_subdirectory_hints_tilde.py` — 30 passed
- [x] standalone real-module canary changes from absent to loaded
- [x] `ruff check agent/subdirectory_hints.py tests/agent/test_subdirectory_hints.py`
- [x] `git diff --check`
