### PR TITLE
fix(ci): verify gh-image extension binary

### DIFF
--- a/.github/workflows/publish-e2e-evidence.yml
+++ b/.github/workflows/publish-e2e-evidence.yml
@@ -32,10 +32,17 @@ jobs:
           persist-credentials: false
 
       # v1.2.0 resolves to 44f4b93ecbbe22de6c45fa2f62f519aee564ca8c.
+      # Binary extensions require the release tag for gh --pin, so enforce the
+      # immutable linux-amd64 binary digest before any gh-image use.
       - name: Install gh-image
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh extension install drogers0/gh-image --pin v1.2.0
+        run: |
+          set -euo pipefail
+          gh extension install drogers0/gh-image --pin v1.2.0
+          GH_IMAGE_BIN="${XDG_DATA_HOME:-$HOME/.local/share}/gh/extensions/gh-image/gh-image"
+          echo "0505f8c46d63bd603a445fdbfdd6be45e75a80778d97f1edf3580697fa6b7919  $GH_IMAGE_BIN" \
+            | sha256sum --check -
 
       - name: Download and attach evidence
         env:


### PR DESCRIPTION
## What does this PR do?

Pins the executable content used by the privileged E2E-evidence publisher.

`gh-image` is a binary GitHub CLI extension, so `gh extension install --pin` accepts its release tag rather than a commit SHA. The workflow still requests `v1.2.0`, then verifies the installed Linux amd64 binary against the release asset's immutable SHA-256 before any `gh image` command can run.

## Why

The publisher runs through `workflow_run` with pull-request write access and later receives `GH_IMAGE_SESSION_TOKEN`. A mutable or replaced release asset should not execute in that job merely because its tag still says `v1.2.0`.

The pinned provenance is:

- tag `v1.2.0` → commit `44f4b93ecbbe22de6c45fa2f62f519aee564ca8c`
- `linux-amd64` SHA-256 → `0505f8c46d63bd603a445fdbfdd6be45e75a80778d97f1edf3580697fa6b7919`

This follows the repository's supply-chain pinning posture without changing the publisher's permissions or behavior.

## Related work

- #69699 introduced the inline evidence publisher.
- #69793 authenticated extension installation while retaining the release tag.
- No existing PR was found that verifies the installed extension content.

## Type of change

- [x] Security hardening
- [x] CI configuration
- [ ] Runtime behavior change

## How to test

- [x] Parsed `.github/workflows/publish-e2e-evidence.yml` with PyYAML.
- [x] Installed `drogers0/gh-image@v1.2.0` under an isolated `XDG_DATA_HOME` and verified the exact workflow path/hash command reports `gh-image: OK`.
- [x] `scripts/run_tests.sh tests/ci/test_publish_e2e_evidence.py tests/ci/test_classify_changes.py -q` — 65 passed.
- [x] `git diff --check`.

## Scope

This deliberately does not change evidence validation, upload behavior, tokens, or permissions. It only rejects unexpected `gh-image` executable bytes before use.
