### PR TITLE
docs: sync stale /background references with the /bg + /btw split

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/slash-commands.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/slash-commands.md
@@ -18,7 +18,8 @@ it. New commands land often; `/help` in-session is always authoritative.
 /rollback [N]            List/restore filesystem checkpoints
 /diff [mode] [--stat]    Git changes in cwd (staged|all|session modes)
 /snapshot [sub]          Create/restore Hermes config+state snapshots (CLI)
-/background (/bg) <p>    Run prompt in background
+/bg <prompt>              Run a prompt in a separate background session
+/btw <question>           Ask a side question about the current conversation without interrupting it
 /queue (/q) <prompt>     Queue prompt for next turn
 /steer <prompt>          Inject a message after the next tool call
 /agents (/tasks)         Show active agents and running tasks

--- a/tests/cli/test_cli_background_status_indicator.py
+++ b/tests/cli/test_cli_background_status_indicator.py
@@ -1,7 +1,7 @@
-"""Tests for the /background indicator in the CLI status bar.
+"""Tests for the /bg indicator in the CLI status bar.
 
 The classic prompt_toolkit status bar shows `▶ N` when N tasks launched via
-`/background` are still running. Source of truth is `self._background_tasks`
+`/bg` are still running. Source of truth is `self._background_tasks`
 (a Dict[str, threading.Thread]); entries are removed in the task thread's
 finally block, so len() reflects truly-running tasks.
 """
@@ -69,7 +69,7 @@ def test_fragments_omit_bg_segment_when_idle():
 # ── Background terminal-process indicator (⚙ N) ───────────────────────────
 # Source of truth is tools.process_registry.process_registry._running (a dict
 # of currently-running shell processes spawned by terminal(background=true)).
-# Distinct from /background tasks above: ▶ counts agent threads, ⚙ counts
+# Distinct from /bg tasks above: ▶ counts agent threads, ⚙ counts
 # shell processes. Both can be active simultaneously.
 
 
@@ -105,7 +105,7 @@ def _patch_process_registry(monkeypatch, count: int) -> None:
 # ── Background/async subagent indicator (⛓ N) ─────────────────────────────
 # Source of truth is tools.async_delegation.active_count() — the count of
 # delegate_task delegations (batch + background single) still in the
-# "running" state. Distinct from ▶ (/background agent threads) and ⚙ (shell
+# "running" state. Distinct from ▶ (/bg agent threads) and ⚙ (shell
 # processes); all three can be active at once.
 
 

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -235,7 +235,7 @@ The following commands are handled directly by the TUI client. Unrecognized comm
 
 ### Session (`session.ts`)
 `/model`, `/sessions` (aliases `/switch`, `/session`, `/resume`),
-`/background` (aliases `/bg`, `/btw`), `/image`, `/personality`,
+`/bg`, `/btw`, `/image`, `/personality`,
 `/compress`, `/branch` (alias `/fork`), `/voice`, `/skin`,
 `/indicator`, `/yolo`, `/reasoning`, `/fast`, `/busy`, `/verbose`, `/usage`
 


### PR DESCRIPTION
## What does this PR do?

`74a95a3ddf` promoted `/bg` and `/btw` to independent canonical commands and retired `/background` entirely — `hermes_cli/commands.py`'s `COMMAND_REGISTRY` has no `background` command or alias anymore. Three places still taught/described the old name.

## The bug

- **`skills/autonomous-ai-agents/hermes-agent/references/slash-commands.md`** — the bundled `hermes-agent` skill's own slash-command reference still had `/background (/bg) <p>    Run prompt in background`. The skill's `SKILL.md` explicitly routes the model here for "in-session slash commands" questions, so a model following its own bundled skill would emit the now-dead `/background <prompt>` and have no idea `/btw` (the side-question command) exists at all.
- **`ui-tui/README.md`** — listed `/btw` as an alias of `/background`, which is simply incorrect post-split: both `/bg` and `/btw` are independent, alias-free commands (verified against `COMMAND_REGISTRY`).
- **`tests/cli/test_cli_background_status_indicator.py`** — docstring and inline comments described the `▶` background-task status-bar indicator by the retired command name.

## What changed

Content-only fix, no behavior change:
- Split the one stale line in the skill reference doc into two, matching the wording and column alignment already used by `website/docs/reference/slash-commands.md` (which the rename commit did update correctly).
- Fixed the `ui-tui/README.md` alias listing.
- Updated the three `/background` mentions in the test file's docstring/comments to `/bg` (the internal `_background_tasks` attribute name is unrelated and correctly left alone — it's an implementation detail, not the user-facing command name).

## Testing

- `python3 -m py_compile tests/cli/test_cli_background_status_indicator.py` — compiles.
- `pytest tests/cli/test_cli_background_status_indicator.py` — 10 passed (comment-only change, no behavior affected).
- Repo-wide grep for any other stale `` `/background` `` references (as a slash command, not the unrelated `_background_tasks`/`background.complete` internal identifiers) — none remaining.

## Checklist

- [x] Root cause identified and fixed (not just a symptom)
- [x] No unrelated changes