### PR TITLE
fix(gateway): warn on missing scope only for Relay egress

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26098,19 +26098,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         scope_id = str(evt.get("scope_id") or "").strip() or None
         if scope_id is None and chat_type not in ("dm", "thread"):
-            # Reconstructed (non-persisted) source for a scoped chat with no
-            # scope discriminator: on a relay-fronted deployment the
-            # connector's fail-closed tenant guard may decline the reply
-            # unless user_id resolves it (resolveByUser). Don't fail here —
-            # DMs and author-bound scoped chats still route, and native
-            # adapters don't need scope_id — but say so, so a post-restart
-            # egress decline isn't silent.
-            logger.warning(
-                "Synthetic event source for %s chat=%s (%s) reconstructed "
-                "without scope_id; scoped relay egress may be declined by "
-                "the connector's tenant guard (user_id fallback only).",
-                platform_name, chat_id, chat_type,
+            # Only Relay egress needs a tenant scope. Native adapters route on
+            # their own authenticated platform connection, so warning for them
+            # is both noisy and misleading. Reuse the canonical resolver to
+            # preserve its native-first / Relay-fronting contract.
+            transport = resolve_delivery_transport(
+                platform,
+                self.config,
+                self.adapters,
             )
+            if transport is not None and transport.is_relay:
+                logger.warning(
+                    "Synthetic event source for %s chat=%s (%s) reconstructed "
+                    "without scope_id; scoped relay egress may be declined by "
+                    "the connector's tenant guard (user_id fallback only).",
+                    platform_name, chat_id, chat_type,
+                )
         return SessionSource(
             platform=platform,
             chat_id=chat_id,

--- a/tests/gateway/test_relay_delivery_followups.py
+++ b/tests/gateway/test_relay_delivery_followups.py
@@ -30,6 +30,7 @@ Four review findings on the original branch:
 """
 
 import asyncio
+import logging
 import os
 from datetime import datetime
 from types import SimpleNamespace
@@ -319,6 +320,49 @@ def test_fallback_source_reconstruction_without_scope_still_routes():
     assert source is not None
     assert source.scope_id is None
     assert source.user_id == "U1"
+
+
+def _scopeless_group_event():
+    return {
+        "session_key": "agent:main:discord:group:C123:U9",
+        "platform": "discord",
+        "chat_type": "group",
+        "chat_id": "C123",
+        "user_id": "U9",
+        "type": "async_delegation",
+    }
+
+
+def test_native_fallback_source_without_scope_does_not_warn(caplog):
+    """Native delivery has no relay tenant guard, so scope is irrelevant."""
+    runner = _fallback_runner()
+    runner.__dict__["config"] = SimpleNamespace(platforms={})
+    runner.__dict__["adapters"] = {Platform.DISCORD: object()}
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        source = runner._build_process_event_source(_scopeless_group_event())
+
+    assert source is not None
+    assert "scoped relay egress may be declined" not in caplog.text
+
+
+def test_relay_fronted_fallback_source_without_scope_still_warns(caplog):
+    """The original fail-closed relay diagnostic must remain actionable."""
+
+    class _Relay:
+        @staticmethod
+        def fronts_platform(platform):
+            return platform == Platform.DISCORD
+
+    runner = _fallback_runner()
+    runner.__dict__["config"] = SimpleNamespace(platforms={})
+    runner.__dict__["adapters"] = {Platform.RELAY: _Relay()}
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        source = runner._build_process_event_source(_scopeless_group_event())
+
+    assert source is not None
+    assert "scoped relay egress may be declined" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- resolve the actual delivery transport before warning about a missing tenant scope
- suppress the Relay-specific warning for native Discord/Slack/etc. adapters
- preserve the warning unchanged when Relay really fronts the logical platform

## Reproduction

A native Discord gateway receives synthetic background-process events for a group chat. The events have no `scope_id`, which is valid for the native adapter, but every event logs:

```text
scoped relay egress may be declined by the connector's tenant guard
```

Measured on the reporting host: 40 warnings in under five hours, while Discord is native and Relay is not configured. All corresponding loop replies delivered successfully.

## Before / after

```text
              origin/main   PR branch
native Discord      1 warning    0 warnings
Relay-fronted       1 warning    1 warning
```

The patch reuses `resolve_delivery_transport`, whose contract is native-first and Relay-only-when-fronted. It does not change source reconstruction, routing, authorization, provenance, or the fail-closed Relay diagnostic.

## Test plan

- [x] RED observed: native transport still emitted the Relay warning
- [x] Relay control remained green before the patch
- [x] two focused transport-contract tests pass
- [x] full `test_relay_delivery_followups.py` — 29 passed
- [x] delivery resolver + followups — 42 passed
- [x] standalone real-module before/after preserves the Relay warning
- [x] ruff clean
- [x] `git diff --check`
