### PR TITLE
fix(tools): restore setup_mcp's never-hand-edit instruction

### DIFF
--- a/tests/tools/test_setup_mcp_tool.py
+++ b/tests/tools/test_setup_mcp_tool.py
@@ -11,7 +11,15 @@ import json
 
 import pytest
 
-from tools.setup_mcp_tool import setup_mcp_tool
+from tools.setup_mcp_tool import SETUP_MCP_SCHEMA, setup_mcp_tool
+
+
+def test_schema_forbids_hand_editing_mcp_servers_config():
+    # Nothing else teaches the model this: the tool is desktop_ui-only, so
+    # without it a model could just write_file into mcp_servers config
+    # directly, bypassing the consent-card/OAuth flow this tool exists for.
+    assert "hand-edit" in SETUP_MCP_SCHEMA["description"]
+    assert "mcp_servers" in SETUP_MCP_SCHEMA["description"]
 
 
 def test_requires_desktop_callback():

--- a/tools/setup_mcp_tool.py
+++ b/tools/setup_mcp_tool.py
@@ -77,7 +77,8 @@ SETUP_MCP_SCHEMA = {
         "Propose an MCP server as an inline consent card (install a catalog "
         "entry, re-enable a disabled server, or run OAuth); blocks until the "
         "user acts. Use when they ask to add an MCP or a task clearly needs "
-        "a missing one. Never re-ask after a decline — on declined/"
+        "a missing one. Never hand-edit mcp_servers config for them — always "
+        "use this tool. Never re-ask after a decline — on declined/"
         "unanswered, continue without it. Catalog names: `hermes mcp "
         "catalog` in the terminal."
     ),


### PR DESCRIPTION
## What does this PR do?

Restores a safety instruction that was deleted based on an incorrect premise about where it was already taught.

## The bug

The desktop platform hint used to say:

> When the user asks to add, enable, or authorize an MCP server ... use the setup_mcp tool if it is available ... never hand-edit mcp_servers config for them.

`9d9f44d638` removed that sentence entirely, reasoning in its own commit message: "The setup_mcp sentence moved out entirely — its tool schema teaches the same trigger + consent-card + never-hand-edit rule on every call."

That premise is false. `SETUP_MCP_SCHEMA["description"]` in `tools/setup_mcp_tool.py` has never contained any "hand-edit" language — checked both the current schema and the schema as originally introduced (`adbc77eb50`). It only says "Never re-ask after a decline." Repo-wide grep for "hand-edit" confirms the only place this rule existed was the sentence that got deleted.

`setup_mcp` lives in the `desktop_ui` toolset only, and `agent/file_safety.py` has no runtime guard covering `mcp_servers` config specifically. So the deletion left a real gap: nothing tells a model it shouldn't just `write_file` into the mcp_servers config directly instead of routing through the consent-card/OAuth flow the tool exists to enforce.

## What changed

Restored the instruction directly in `SETUP_MCP_SCHEMA`'s description — completing the original commit's stated intent (move it to the schema) rather than reverting to the platform hint text, since the schema reaches every `setup_mcp` call on every platform where the tool is available, independent of future platform-hint wording changes.

Added a regression test (`test_schema_forbids_hand_editing_mcp_servers_config`) so a future prompt-diet pass can't silently drop this again without a test failing — there was no existing test guarding the schema's content, which is exactly how this regression shipped unnoticed.

## Testing

- `tests/tools/test_setup_mcp_tool.py` — 11 passed (10 pre-existing + 1 new).
- Mutation-verified: stashed the fix and confirmed the new test fails without it (`AssertionError: assert 'hand-edit' in '...'`).
- `tests/tools/test_desktop_tools_diet.py` — 7 passed, including the desktop tool-surface character budget test (`total < 10_500`); the added ~70 characters land well within budget.
- `tests/tui_gateway/test_gui_surface_toolsets.py` — 10 passed (name-membership only, unaffected by description text).
- `tests/run_agent/test_run_agent.py -k setup_mcp` — 1 passed (tool-name/args dispatch only, unaffected).

## Checklist

- [x] Root cause identified and fixed (not just a symptom)
- [x] Regression test added and mutation-verified
- [x] No unrelated changes