### PR TITLE
fix(kanban): don't let goal-mode finalize overwrite a successful block

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21214,6 +21214,14 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     def _block(reason: str) -> None:
         c = _kb.connect()
         try:
+            # Idempotent: a successful kanban_block/complete/review must not
+            # be overwritten by this synthetic finalize/budget block.
+            if _kb.goal_run_already_terminal(c, task_id, worker_run_id):
+                logger.info(
+                    "kanban goal loop: skip synthetic block for %s; run already terminal",
+                    task_id,
+                )
+                return
             _kb.block_task(
                 c,
                 task_id,

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -2184,14 +2184,18 @@ def run_kanban_goal_loop(
     is that turn's reply. From here we:
 
     1. Check whether the worker already terminated the task (called
-       ``kanban_complete`` / ``kanban_block``). If so, stop — nothing to do.
+       ``kanban_complete`` / ``kanban_block`` / ``kanban_request_review``).
+       If so, stop — nothing to do.
     2. Otherwise judge the latest response against ``goal_text`` (the card's
        title + body). ``continue`` → feed a continuation prompt and run
        another turn IN THE SAME SESSION via ``run_turn``. ``done`` but the
        task is still open → one explicit "call kanban_complete" nudge.
-    3. When the turn budget is exhausted and the worker still hasn't
-       terminated the task, ``block_fn`` is invoked so the card lands in a
+    3. When the turn budget is exhausted, or the judge still says ``done``
+       after that nudge, ``block_fn`` is invoked so the card lands in a
        sticky ``blocked`` state for human review (NOT a silent exit).
+       Finalization is idempotent: ``block_fn`` is skipped if a terminal
+       lifecycle action already succeeded, so a synthetic run cannot
+       replace the original summary/kind.
 
     This function performs NO SessionDB persistence — a worker process is
     ephemeral, so the turn budget lives in a local counter. It is fully
@@ -2221,6 +2225,70 @@ def run_kanban_goal_loop(
     turns_used = 1
     nudged_to_finalize = False
 
+    def _decision_for_status(status):
+        if status == "done":
+            return {
+                "outcome": "completed_by_worker",
+                "turns_used": turns_used,
+                "reason": "worker completed the task",
+            }
+        if status == "blocked":
+            return {
+                "outcome": "blocked_by_worker",
+                "turns_used": turns_used,
+                "reason": "worker blocked the task",
+            }
+        if status == "review":
+            return {
+                "outcome": "review_requested_by_worker",
+                "turns_used": turns_used,
+                "reason": "worker requested review",
+            }
+        if status == "changes_requested":
+            return {
+                "outcome": "changes_requested_by_reviewer",
+                "turns_used": turns_used,
+                "reason": "reviewer requested changes",
+            }
+        if status not in ("running", "ready"):
+            # Reclaimed / archived / unexpected — let the dispatcher own it.
+            return {
+                "outcome": "stopped",
+                "turns_used": turns_used,
+                "reason": f"status={status}",
+            }
+        return None
+
+    def _synthetic_block(reason_msg: str, outcome_reason: str, log_msg: str):
+        """Issue a synthetic block only if the worker has not already terminated.
+
+        Re-reads lifecycle status immediately before calling ``block_fn`` so a
+        successful ``kanban_block`` / ``kanban_complete`` cannot be overwritten
+        by the finalize/budget path (TOCTOU after a promote-to-ready).
+        """
+        try:
+            status = task_status_fn()
+        except Exception as exc:
+            _log(f"kanban goal loop: status check failed ({exc}); stopping")
+            return {"outcome": "stopped", "turns_used": turns_used, "reason": "status check failed"}
+        decision = _decision_for_status(status)
+        if decision is not None:
+            _log(
+                f"kanban goal loop: skip synthetic block for {task_id}; "
+                f"already terminal ({decision['outcome']})"
+            )
+            return decision
+        _log(log_msg)
+        try:
+            block_fn(reason_msg)
+        except Exception as exc:
+            _log(f"kanban goal loop: block_fn failed ({exc})")
+        return {
+            "outcome": "blocked_budget",
+            "turns_used": turns_used,
+            "reason": outcome_reason,
+        }
+
     while True:
         # Did the worker terminate the task itself this turn?
         try:
@@ -2229,25 +2297,26 @@ def run_kanban_goal_loop(
             _log(f"kanban goal loop: status check failed ({exc}); stopping")
             return {"outcome": "stopped", "turns_used": turns_used, "reason": "status check failed"}
 
-        if status == "done":
-            _log(f"kanban goal loop: task {task_id} completed by worker after {turns_used} turn(s)")
-            return {"outcome": "completed_by_worker", "turns_used": turns_used, "reason": "worker completed the task"}
-        if status == "blocked":
-            _log(f"kanban goal loop: task {task_id} blocked by worker after {turns_used} turn(s)")
-            return {"outcome": "blocked_by_worker", "turns_used": turns_used, "reason": "worker blocked the task"}
-        if status == "review":
-            # A legitimate worker-driven terminator (kanban_request_review),
-            # not an unexpected stop: the implementation is done and the task
-            # is awaiting a reviewer. Stop the loop cleanly.
-            _log(f"kanban goal loop: task {task_id} handed off for review by worker after {turns_used} turn(s)")
-            return {"outcome": "review_requested_by_worker", "turns_used": turns_used, "reason": "worker requested review"}
-        if status == "changes_requested":
-            _log(f"kanban goal loop: reviewer returned task {task_id} for changes after {turns_used} turn(s)")
-            return {"outcome": "changes_requested_by_reviewer", "turns_used": turns_used, "reason": "reviewer requested changes"}
-        if status not in ("running", "ready"):
-            # Reclaimed / archived / unexpected — let the dispatcher own it.
-            _log(f"kanban goal loop: task {task_id} status={status!r}; stopping")
-            return {"outcome": "stopped", "turns_used": turns_used, "reason": f"status={status}"}
+        decision = _decision_for_status(status)
+        if decision is not None:
+            outcome = decision["outcome"]
+            if outcome == "completed_by_worker":
+                _log(f"kanban goal loop: task {task_id} completed by worker after {turns_used} turn(s)")
+            elif outcome == "blocked_by_worker":
+                _log(f"kanban goal loop: task {task_id} blocked by worker after {turns_used} turn(s)")
+            elif outcome == "review_requested_by_worker":
+                _log(
+                    f"kanban goal loop: task {task_id} handed off for review "
+                    f"by worker after {turns_used} turn(s)"
+                )
+            elif outcome == "changes_requested_by_reviewer":
+                _log(
+                    f"kanban goal loop: reviewer returned task {task_id} "
+                    f"for changes after {turns_used} turn(s)"
+                )
+            else:
+                _log(f"kanban goal loop: task {task_id} status={status!r}; stopping")
+            return decision
 
         # Still open — judge whether the latest response satisfies the card.
         # The kanban worker loop has no wait-barrier concept (workers finish
@@ -2261,16 +2330,16 @@ def run_kanban_goal_loop(
         if verdict == "done":
             if nudged_to_finalize:
                 # Already asked once to call kanban_complete and it still
-                # didn't — block for review rather than spin.
-                _log(f"kanban goal loop: task {task_id} judged done but worker won't finalize; blocking")
-                try:
-                    block_fn(
+                # didn't — block for review rather than spin. Re-check first
+                # so a successful worker block is not overwritten.
+                return _synthetic_block(
+                    (
                         f"Goal-mode worker's output looked complete but it never "
                         f"called kanban_complete after a finalize nudge ({reason})."
-                    )
-                except Exception as exc:
-                    _log(f"kanban goal loop: block_fn failed ({exc})")
-                return {"outcome": "blocked_budget", "turns_used": turns_used, "reason": "judged done, never finalized"}
+                    ),
+                    "judged done, never finalized",
+                    f"kanban goal loop: task {task_id} judged done but worker won't finalize; blocking",
+                )
             prompt = KANBAN_GOAL_FINALIZE_TEMPLATE.format(reason=_truncate(reason, 400))
             nudged_to_finalize = True
         else:
@@ -2278,16 +2347,15 @@ def run_kanban_goal_loop(
 
         # Budget check BEFORE spending another turn.
         if turns_used >= max_turns:
-            _log(f"kanban goal loop: task {task_id} exhausted {turns_used}/{max_turns} turns; blocking")
-            try:
-                block_fn(
+            return _synthetic_block(
+                (
                     f"Goal-mode worker exhausted its turn budget "
                     f"({turns_used}/{max_turns}) without completing the task. "
                     f"Last judge verdict: {_truncate(reason, 300)}"
-                )
-            except Exception as exc:
-                _log(f"kanban goal loop: block_fn failed ({exc})")
-            return {"outcome": "blocked_budget", "turns_used": turns_used, "reason": "turn budget exhausted"}
+                ),
+                "turn budget exhausted",
+                f"kanban goal loop: task {task_id} exhausted {turns_used}/{max_turns} turns; blocking",
+            )
 
         # Run another turn in the same session.
         try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4924,6 +4924,51 @@ def goal_run_status(
     return task.status
 
 
+# Statuses the kanban goal loop treats as already-terminal. A successful
+# kanban_block / kanban_complete / review handoff must not be overwritten
+# by a later synthetic finalize block.
+GOAL_TERMINAL_STATUSES = frozenset(
+    {"done", "blocked", "review", "changes_requested", "superseded"}
+)
+GOAL_TERMINAL_RUN_OUTCOMES = frozenset(
+    {
+        "completed",
+        "review_requested",
+        "changes_requested",
+        "blocked",
+        "dependency_wait",
+    }
+)
+
+
+def goal_run_already_terminal(
+    conn: sqlite3.Connection,
+    task_id: str,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Return True if this worker run already performed a terminal action.
+
+    Goal-mode finalization must be idempotent once ``kanban_block`` /
+    ``kanban_complete`` / ``kanban_request_review`` has succeeded. After a
+    ``kind=dependency`` block the dispatcher may promote the card back to
+    ``ready``; ``goal_run_status`` still reports the original run as
+    ``blocked``. When ``expected_run_id`` is missing (legacy wrappers), a
+    prior *ended* terminal run is enough to refuse a synthetic replacement
+    that would overwrite the original summary/kind.
+    """
+    status = goal_run_status(conn, task_id, expected_run_id)
+    if status in GOAL_TERMINAL_STATUSES:
+        return True
+    if expected_run_id is not None:
+        return False
+    run = latest_run(conn, task_id)
+    return bool(
+        run is not None
+        and run.ended_at is not None
+        and run.outcome in GOAL_TERMINAL_RUN_OUTCOMES
+    )
+
+
 def heartbeat_claim(
     conn: sqlite3.Connection,
     task_id: str,

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -128,6 +128,258 @@ def test_loop_stops_when_worker_already_completed(monkeypatch):
     assert turns == []  # no extra turns
 
 
+def test_loop_stops_when_worker_already_blocked(monkeypatch):
+    _patch_judge(monkeypatch, ["done"])  # should never be consulted
+    turns = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=lambda p: turns.append(p) or "x",
+        task_status_fn=lambda: "blocked",
+        block_fn=lambda r: pytest.fail("should not block"),
+        first_response="blocked for review",
+    )
+    assert res["outcome"] == "blocked_by_worker"
+    assert turns == []
+
+
+def test_loop_skips_synthetic_block_if_worker_blocks_on_finalize_nudge(monkeypatch):
+    """Worker calls kanban_block during the finalize-nudge turn.
+
+    The loop must treat that as terminal and must not call block_fn.
+    """
+    _patch_judge(monkeypatch, ["done", "done"])
+    state = {"status": "running"}
+    turns = []
+
+    def _run_turn(prompt):
+        turns.append(prompt)
+        state["status"] = "blocked"
+        return "called kanban_block for review"
+
+    blocked = []
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=_run_turn,
+        task_status_fn=lambda: state["status"],
+        block_fn=blocked.append,
+        first_response="looks complete",
+        max_turns=5,
+    )
+    assert res["outcome"] == "blocked_by_worker"
+    assert len(turns) == 1
+    assert blocked == []
+
+
+def test_loop_still_blocks_when_worker_never_calls_terminal(monkeypatch):
+    """Holdout: worker exits without kanban_complete/block → synthetic block."""
+    _patch_judge(monkeypatch, ["done", "done"])
+    turns = []
+    blocked = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t1",
+        goal_text="do the thing",
+        run_turn=lambda p: turns.append(p) or "forgot to call the tool",
+        task_status_fn=lambda: "running",
+        block_fn=blocked.append,
+        first_response="looks complete",
+        max_turns=5,
+    )
+    assert res["outcome"] == "blocked_budget"
+    assert res["reason"] == "judged done, never finalized"
+    assert len(turns) == 1
+    assert blocked and "never called kanban_complete after a finalize nudge" in blocked[0]
+
+
+def _goal_loop_block_fn(task_id, expected_run_id):
+    """Mirror cli.py's goal-loop _block wrapper (idempotent finalizer)."""
+
+    def _block(reason: str) -> None:
+        with kb.connect() as conn:
+            if kb.goal_run_already_terminal(conn, task_id, expected_run_id):
+                return
+            kb.block_task(
+                conn,
+                task_id,
+                reason=reason,
+                expected_run_id=expected_run_id,
+            )
+
+    return _block
+
+
+def test_finalize_does_not_overwrite_worker_dependency_block(kanban_home, monkeypatch):
+    """Production bug: kanban_block(kind=dependency) then promote-to-ready.
+
+    Replay cards t_8812f1d4 / t_b121dde5: the worker recorded a
+    REVIEW-REQUIRED block, the dispatcher promoted the card back to
+    ready, and the goal-mode finalizer synthesized a second run that
+    overwrote the original summary/kind. Finalization must no-op.
+    """
+    review_reason = "REVIEW-REQUIRED: merge the repair PR before redeploy"
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Daily production deployment",
+            body="Ship the daily deploy or block for human review.",
+            assignee="replay-agent",
+            goal_mode=True,
+        )
+        claimed = kb.claim_task(conn, tid, claimer="replay-agent:test")
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert kb.block_task(
+            conn,
+            tid,
+            reason=review_reason,
+            kind="dependency",
+            expected_run_id=run_id,
+        )
+        kb.recompute_ready(conn)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status in ("ready", "todo")
+        assert kb.goal_run_status(conn, tid, run_id) == "blocked"
+        assert kb.goal_run_already_terminal(conn, tid, run_id)
+        # Legacy wrapper with no run id must still see the ended terminal run.
+        assert kb.goal_run_already_terminal(conn, tid, None)
+
+    _patch_judge(monkeypatch, ["done", "done"])
+    blocked_reasons: list[str] = []
+    inner_block = _goal_loop_block_fn(tid, run_id)
+
+    def _block(reason: str) -> None:
+        blocked_reasons.append(reason)
+        inner_block(reason)
+
+    def _status():
+        with kb.connect() as conn:
+            return kb.goal_run_status(conn, tid, run_id)
+
+    res = goals.run_kanban_goal_loop(
+        task_id=tid,
+        goal_text="Daily production deployment\n\nShip the daily deploy or block for human review.",
+        run_turn=lambda p: pytest.fail("must not run another turn after a terminal block"),
+        task_status_fn=_status,
+        block_fn=_block,
+        first_response="blocked pending human review of the repair PR",
+        max_turns=5,
+    )
+    assert res["outcome"] == "blocked_by_worker"
+    assert blocked_reasons == []
+
+    with kb.connect() as conn:
+        runs = list(
+            conn.execute(
+                "SELECT id, outcome, summary FROM task_runs WHERE task_id = ? ORDER BY id",
+                (tid,),
+            )
+        )
+        assert len(runs) == 1
+        assert runs[0]["outcome"] == "blocked"
+        assert runs[0]["summary"] == review_reason
+        latest = kb.latest_run(conn, tid)
+        assert latest is not None
+        assert latest.summary == review_reason
+        assert "never called kanban_complete" not in (latest.summary or "")
+
+
+def test_legacy_finalize_wrapper_does_not_synthesize_over_ended_block(kanban_home):
+    """Missing HERMES_KANBAN_RUN_ID must still refuse a synthetic replacement."""
+    review_reason = "REVIEW-REQUIRED: human eyes please"
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="needs review", assignee="worker")
+        claimed = kb.claim_task(conn, tid, claimer="worker:test")
+        assert claimed is not None
+        assert kb.block_task(
+            conn,
+            tid,
+            reason=review_reason,
+            kind="needs_input",
+            expected_run_id=claimed.current_run_id,
+        )
+        kb.recompute_ready(conn)
+
+    # Old cli.py wrapper: expected_run_id=None, no already-terminal guard.
+    # That path synthesized a zero-duration run and overwrote the summary.
+    # The new guard must no-op even without a run id.
+    with kb.connect() as conn:
+        assert kb.goal_run_already_terminal(conn, tid, None)
+        before = kb.latest_run(conn, tid)
+        assert before is not None
+        before_id = before.id
+        before_task = kb.get_task(conn, tid)
+        assert before_task is not None
+        before_kind = before_task.block_kind
+
+    _goal_loop_block_fn(tid, None)(
+        "Goal-mode worker's output looked complete but it never "
+        "called kanban_complete after a finalize nudge (looks done)."
+    )
+
+    with kb.connect() as conn:
+        runs = list(
+            conn.execute(
+                "SELECT id, summary FROM task_runs WHERE task_id = ? ORDER BY id",
+                (tid,),
+            )
+        )
+        assert len(runs) == 1
+        assert runs[0]["id"] == before_id
+        assert runs[0]["summary"] == review_reason
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.block_kind == before_kind
+
+
+def test_finalize_still_blocks_open_run_without_terminal_call(kanban_home, monkeypatch):
+    """Holdout: no worker terminal action → synthetic block still lands."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Finish the report",
+            body="acceptance: write the report",
+            assignee="worker",
+            goal_mode=True,
+        )
+        claimed = kb.claim_task(conn, tid, claimer="worker:test")
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert not kb.goal_run_already_terminal(conn, tid, run_id)
+
+    _patch_judge(monkeypatch, ["done", "done"])
+    blocked = []
+    inner_block = _goal_loop_block_fn(tid, run_id)
+
+    def _block(reason: str) -> None:
+        blocked.append(reason)
+        inner_block(reason)
+
+    def _status():
+        with kb.connect() as conn:
+            return kb.goal_run_status(conn, tid, run_id)
+
+    res = goals.run_kanban_goal_loop(
+        task_id=tid,
+        goal_text="Finish the report\n\nacceptance: write the report",
+        run_turn=lambda p: "I think I'm done but I forgot the tool",
+        task_status_fn=_status,
+        block_fn=_block,
+        first_response="the report looks finished",
+        max_turns=5,
+    )
+    assert res["outcome"] == "blocked_budget"
+    assert blocked and "never called kanban_complete" in blocked[0]
+    with kb.connect() as conn:
+        latest = kb.latest_run(conn, tid)
+        assert latest is not None
+        assert latest.outcome == "blocked"
+        assert "never called kanban_complete" in (latest.summary or "")
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Goal-mode finalization was not idempotent after a successful `kanban_block` / `kanban_complete`.

On Replay cards t_8812f1d4 and t_b121dde5, the worker recorded a real REVIEW-REQUIRED block (`kind=dependency`). The dispatcher then promoted the card back to `ready`. The goal loop treated that as still-open, judged the output complete, nudged once, and called `block_task` again. Because the original run had already ended, that second call synthesized a zero-duration run whose summary replaced the original handoff:

> Goal-mode worker's output looked complete but it never called kanban_complete after a finalize nudge (...)

That overwrite made review-required cards look actionable and inflated redispatch/audit counts.

Finalization is now a no-op once any terminal lifecycle action has succeeded for that worker run. The existing synthetic-block path is unchanged when the worker truly never called `kanban_complete` / `kanban_block`.

## Related Issue

No existing issue. Observed on live Replay kanban goal-mode workers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/kanban_db.py`: add `goal_run_already_terminal()` so a prior ended terminal run (including after dependency-wait promote-to-ready) is visible even when `HERMES_KANBAN_RUN_ID` is missing.
- `hermes_cli/goals.py`: re-check lifecycle status immediately before every synthetic `block_fn`; skip if the worker already terminated.
- `cli.py`: `_run_kanban_goal_loop_q` `_block` wrapper no-ops when the run is already terminal, so it cannot append a replacement run or clear `block_kind`.
- `tests/hermes_cli/test_kanban_goal_mode.py`: regressions for worker `kanban_block` then finalize, including the dependency-block + promote reproduction, plus holdouts for a worker that never calls a terminal action.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_kanban_goal_mode.py tests/hermes_cli/test_kanban_review_surfaces.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_db.py -q`
2. Confirm `test_finalize_does_not_overwrite_worker_dependency_block` and `test_legacy_finalize_wrapper_does_not_synthesize_over_ended_block` pass.
3. Confirm holdouts `test_loop_still_blocks_when_worker_never_calls_terminal` and `test_finalize_still_blocks_open_run_without_terminal_call` still synthesize a block.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `scripts/run_tests.sh` on the focused kanban files and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.3.1

### Documentation & Housekeeping

- [x] Docstrings updated; no config/docs/architecture/tool-schema changes

## Screenshots / Logs

Focused + related kanban suites: 93 tests passed, 1 skipped (windows_only).
