### PR TITLE
feat(google-workspace): expose Gmail profile identity

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -176,6 +176,9 @@ GAPI="python ${HERMES_HOME:-$HOME/.hermes}/skills/productivity/google-workspace/
 ### Gmail
 
 ```bash
+# Show the authenticated Gmail account identity
+$GAPI gmail profile
+
 # Search (returns JSON array with id, from, subject, date, snippet)
 $GAPI gmail search "is:unread" --max 10
 $GAPI gmail search "from:boss@company.com newer_than:1d"
@@ -291,6 +294,7 @@ $GAPI docs append DOC_ID --text "Additional content to append"
 
 All commands return JSON. Parse with `jq` or read directly. Key fields:
 
+- **Gmail profile**: `{emailAddress}`
 - **Gmail search**: `[{id, threadId, from, to, subject, date, snippet, labels}]`
 - **Gmail get**: `{id, threadId, from, to, subject, date, labels, body}`
 - **Gmail send/reply**: `{status: "sent", id, threadId}`

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -6,6 +6,7 @@ existing Hermes-facing JSON contract and falls back to the Python client
 libraries if `gws` is not installed.
 
 Usage:
+  python google_api.py gmail profile
   python google_api.py gmail search "is:unread" [--max 10]
   python google_api.py gmail get MESSAGE_ID
   python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello"
@@ -418,6 +419,27 @@ def gmail_reply(args):
 
     result = service.users().messages().send(userId="me", body=body).execute()
     print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", "")}, indent=2))
+
+
+def gmail_profile(args):
+    if _gws_binary():
+        result = _run_gws(
+            ["gmail", "users", "getProfile"],
+            params={"userId": "me"},
+        )
+    else:
+        service = build_service("gmail", "v1")
+        result = service.users().getProfile(userId="me").execute()
+
+    email_address = result.get("emailAddress") if isinstance(result, dict) else None
+    if not isinstance(email_address, str) or not email_address.strip():
+        print(
+            "ERROR: Gmail profile did not include an account identity.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    print(json.dumps({"emailAddress": email_address.strip()}, indent=2))
 
 
 
@@ -1083,6 +1105,9 @@ def main():
     p.add_argument("--body", required=True)
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
     p.set_defaults(func=gmail_reply)
+
+    p = gmail_sub.add_parser("profile")
+    p.set_defaults(func=gmail_profile)
 
     p = gmail_sub.add_parser("labels")
     p.set_defaults(func=gmail_labels)

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -136,6 +136,75 @@ def test_api_calendar_list_uses_events_list(api_module):
     assert params["calendarId"] == "primary"
 
 
+def test_api_gmail_profile_uses_gws_get_profile(api_module, capsys):
+    """gmail profile delegates to users.getProfile and emits only identity."""
+    completed = MagicMock(
+        returncode=0,
+        stdout=json.dumps(
+            {
+                "emailAddress": " sandbox@example.invalid ",
+                "messagesTotal": 12,
+                "threadsTotal": 8,
+                "historyId": "123",
+            }
+        ),
+        stderr="",
+    )
+
+    with patch.object(api_module.subprocess, "run", return_value=completed) as run:
+        api_module.gmail_profile(api_module.argparse.Namespace())
+
+    cmd = run.call_args.args[0]
+    assert cmd[:4] == ["/usr/bin/gws", "gmail", "users", "getProfile"]
+    params = json.loads(cmd[cmd.index("--params") + 1])
+    assert params == {"userId": "me"}
+    assert json.loads(capsys.readouterr().out) == {
+        "emailAddress": "sandbox@example.invalid"
+    }
+
+
+def test_api_gmail_profile_uses_python_client_fallback(api_module, capsys):
+    """gmail profile preserves the wrapper's Python-client fallback."""
+    request = MagicMock()
+    request.execute.return_value = {"emailAddress": "sandbox@example.invalid"}
+    users = MagicMock()
+    users.getProfile.return_value = request
+    service = MagicMock()
+    service.users.return_value = users
+    api_module._gws_binary = lambda: None
+
+    with patch.object(api_module, "build_service", return_value=service) as build:
+        api_module.gmail_profile(api_module.argparse.Namespace())
+
+    build.assert_called_once_with("gmail", "v1")
+    users.getProfile.assert_called_once_with(userId="me")
+    request.execute.assert_called_once_with()
+    assert json.loads(capsys.readouterr().out) == {
+        "emailAddress": "sandbox@example.invalid"
+    }
+
+
+def test_api_gmail_profile_fails_when_identity_is_missing(api_module, capsys):
+    """gmail profile fails closed instead of treating metadata as identity."""
+    with patch.object(api_module, "_run_gws", return_value={"messagesTotal": 12}):
+        with pytest.raises(SystemExit) as exc_info:
+            api_module.gmail_profile(api_module.argparse.Namespace())
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "account identity" in captured.err
+
+
+def test_api_main_dispatches_gmail_profile(api_module):
+    """The public CLI exposes gmail profile without additional arguments."""
+    with patch.object(api_module, "gmail_profile") as profile:
+        with patch.object(sys, "argv", ["google_api.py", "gmail", "profile"]):
+            api_module.main()
+
+    profile.assert_called_once()
+
+
 
 
 

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
@@ -188,6 +188,9 @@ GAPI="python ${HERMES_HOME:-$HOME/.hermes}/skills/productivity/google-workspace/
 ### Gmail
 
 ```bash
+# Show the authenticated Gmail account identity
+$GAPI gmail profile
+
 # Search (returns JSON array with id, from, subject, date, snippet)
 $GAPI gmail search "is:unread" --max 10
 $GAPI gmail search "from:boss@company.com newer_than:1d"
@@ -303,6 +306,7 @@ $GAPI docs append DOC_ID --text "Additional content to append"
 
 All commands return JSON. Parse with `jq` or read directly. Key fields:
 
+- **Gmail profile**: `{emailAddress}`
 - **Gmail search**: `[{id, threadId, from, to, subject, date, snippet, labels}]`
 - **Gmail get**: `{id, threadId, from, to, subject, date, labels, body}`
 - **Gmail send/reply**: `{status: "sent", id, threadId}`


### PR DESCRIPTION
## Summary

Expose the authenticated Gmail account identity through the existing Google Workspace wrapper so operators can verify account selection before broader operations.

- add a read-only gmail profile command for both the gws and Python-client paths
- normalize output to the emailAddress field and fail closed when identity is absent
- document the command in the bundled skill and generated user guide

## Manual test plan

- With an authenticated Gmail account and gws available, run the gmail profile command and confirm the JSON output contains only emailAddress.
- With gws unavailable and the Python Google client installed, run the same command and confirm it returns the same normalized output.