### PR TITLE
fix(plugins): validate plugin pack redirects

### DIFF
--- a/hermes_cli/plugin_packs.py
+++ b/hermes_cli/plugin_packs.py
@@ -45,6 +45,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List, Optional
+from urllib.parse import urlparse
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -62,6 +63,7 @@ _SECRET_KEY_RE = re.compile(
 _RESERVED_ENTRY_KEYS = frozenset({"granted_capabilities", "capabilities_consent"})
 
 _MAX_PACK_BYTES = 1 * 1024 * 1024  # a pack is a small manifest, not a payload
+_MAX_PACK_REDIRECTS = 5
 _FETCH_TIMEOUT = 15.0
 
 
@@ -264,17 +266,54 @@ def parse_pack(text: str, *, source: str = "<pack>") -> PluginPack:
     )
 
 
+# ---------------------------------------------------------------------------
+# Remote fetch
+# ---------------------------------------------------------------------------
+
+
+def _validate_pack_url(url: str) -> None:
+    """Require an HTTPS URL that passes the shared SSRF policy."""
+    from tools.url_safety import is_safe_url
+
+    if (urlparse(url).scheme or "").lower() != "https":
+        raise PackError("Pack URLs and redirects must use https://.")
+    if not is_safe_url(url):
+        raise PackError("Pack URL blocked by URL safety policy.")
+
+
+def _pack_redirect_guard(response: Any) -> None:
+    """Validate each redirect target before httpx follows it."""
+    from tools.url_safety import redirect_target_from_response
+
+    redirect_url = redirect_target_from_response(response)
+    if redirect_url:
+        _validate_pack_url(redirect_url)
+
+
 def load_pack(path_or_url: str) -> PluginPack:
     """Load a pack from a local file path or an ``https://`` URL."""
     if path_or_url.startswith("https://"):
         try:
-            import httpx
+            from tools.url_safety import create_ssrf_safe_client
 
-            resp = httpx.get(path_or_url, timeout=_FETCH_TIMEOUT, follow_redirects=True)
-            resp.raise_for_status()
-            text = resp.text
+            _validate_pack_url(path_or_url)
+            with create_ssrf_safe_client(
+                timeout=_FETCH_TIMEOUT,
+                follow_redirects=True,
+                max_redirects=_MAX_PACK_REDIRECTS,
+                event_hooks={"response": [_pack_redirect_guard]},
+            ) as client:
+                resp = client.get(path_or_url)
+                resp.raise_for_status()
+                text = resp.text
+        except PackError:
+            raise
         except Exception as exc:
-            raise PackError(f"Could not fetch pack from {path_or_url}: {exc}") from exc
+            # Do not echo a caller-supplied URL or transport exception: either
+            # may contain credentials from a userinfo/query-bearing URL.
+            raise PackError(
+                f"Could not fetch pack ({type(exc).__name__})."
+            ) from exc
         if len(text.encode("utf-8", errors="ignore")) > _MAX_PACK_BYTES:
             raise PackError("Pack payload exceeds the 1 MiB size limit.")
         return parse_pack(text, source=path_or_url)
@@ -293,6 +332,7 @@ def load_pack(path_or_url: str) -> PluginPack:
 # ---------------------------------------------------------------------------
 # Resolution (bare index names → owner/repo) + review screen
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class ResolvedPackPlugin:

--- a/tests/hermes_cli/test_plugin_packs.py
+++ b/tests/hermes_cli/test_plugin_packs.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import socket
 from types import SimpleNamespace
 from unittest import mock
 
@@ -167,6 +168,71 @@ def test_load_pack_rejects_insecure_url_schemes(tmp_path):
     with pytest.raises(PackError) as exc:
         load_pack("http://example.com/pack.yaml")
     assert "https" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "location, expected_urls",
+    [
+        ("https://127.0.0.1/private", ["https://public.example/pack.yaml"]),
+        ("https://10.0.0.1/private", ["https://public.example/pack.yaml"]),
+        ("https://169.254.1.1/metadata", ["https://public.example/pack.yaml"]),
+        ("http://public.example/insecure", ["https://public.example/pack.yaml"]),
+        (
+            "/redirected-pack.yaml",
+            [
+                "https://public.example/pack.yaml",
+                "https://public.example/redirected-pack.yaml",
+            ],
+        ),
+        (
+            "https://public.example/redirected-pack.yaml",
+            [
+                "https://public.example/pack.yaml",
+                "https://public.example/redirected-pack.yaml",
+            ],
+        ),
+    ],
+)
+def test_load_pack_redirects_only_to_safe_https_targets(
+    location, expected_urls, monkeypatch
+):
+    """Redirects are checked before a follow-up request is sent."""
+    import httpx
+
+    source_url = expected_urls[0]
+    requested_urls = []
+    payload = _pack_yaml()
+
+    def handler(request):
+        requested_urls.append(str(request.url))
+        if request.url.path == "/pack.yaml":
+            return httpx.Response(
+                302,
+                headers={"location": location},
+                request=request,
+            )
+        return httpx.Response(200, text=payload, request=request)
+
+    def fake_client(**kwargs):
+        return httpx.Client(transport=httpx.MockTransport(handler), **kwargs)
+
+    def fake_getaddrinfo(host, _port, *_args):
+        host = str(host).strip("[]")
+        address = host if host in {"127.0.0.1", "10.0.0.1", "169.254.1.1"} else "93.184.216.34"
+        family = socket.AF_INET6 if ":" in address else socket.AF_INET
+        sockaddr = (address, 0, 0, 0) if family == socket.AF_INET6 else (address, 0)
+        return [(family, socket.SOCK_STREAM, 6, "", sockaddr)]
+
+    monkeypatch.setattr("tools.url_safety.create_ssrf_safe_client", fake_client)
+    monkeypatch.setattr("socket.getaddrinfo", fake_getaddrinfo)
+
+    if expected_urls[-1] == source_url:
+        with pytest.raises(PackError):
+            load_pack(source_url)
+    else:
+        assert load_pack(source_url).name == "voice-pack"
+
+    assert requested_urls == expected_urls
 
 
 def test_load_pack_reads_local_file(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Makes remote plugin-pack loading validate the initial URL and every redirect before sending the next request.

The loader now:

- requires HTTPS on the initial request and every redirect hop;
- applies the shared URL-safety policy to reject loopback, private, link-local, and metadata destinations;
- uses the shared connect-time guarded `httpx` client;
- resolves and validates redirect `Location` values before `httpx` follows them;
- caps redirects at five;
- preserves valid public HTTPS absolute and relative redirects;
- keeps the existing timeout, 1 MiB payload limit, parsing, exact plugin-SHA requirement, and local-file behavior.

## Why

Plugin packs intentionally accept operator-supplied HTTPS URLs. The original loader used `follow_redirects=True` directly, so the initial scheme requirement did not apply to later destinations. This is robustness and network-boundary hardening for an explicit operator action, not an unauthenticated vulnerability claim.

## Related work

- #84988 introduced plugin packs and their supply-chain checks.
- #85057 sanitizes nested pack config but retains the original redirect behavior.
- Existing Skills Hub downloads already use the shared SSRF-safe client and per-hop URL policy; this change follows that established pattern.

## Type of change

- [x] Security hardening
- [x] Robustness fix
- [x] Tests

## How to test

Test-first evidence: the new redirect contract failed on the original loader because it followed redirects to loopback/private/link-local and HTTP destinations. It passed after applying the guarded client and per-hop validation.

The tests verify:

- loopback, RFC1918, and link-local redirects are rejected before a second request;
- HTTPS-to-HTTP downgrade is rejected;
- relative and absolute public HTTPS redirects still load a valid pack;
- requested URL order proves blocked targets are never contacted.

- [x] `scripts/run_tests.sh tests/hermes_cli/test_plugin_packs.py tests/tools/test_url_safety.py tests/hermes_cli/test_plugin_index_search.py -q` — 141 passed.
- [x] `git diff --check`.

## Scope

This does not change plugin installation, capability consent, pack configuration, plugin revision pinning, proxy configuration, or local pack files.
