### PR TITLE
test(video-gen): stub the lazy _fal_client global directly in fal tests

### DIFF
--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -161,9 +161,13 @@ class TestFamilyRouting:
         fake.submit = _submit  # type: ignore
         monkeypatch.setitem(sys.modules, "fal_client", fake)
 
-        # Reset the lazy global so it picks up our stub
+        # Point the lazy global straight at our stub. Going through
+        # sys.modules alone is not enough: import_fal_client() calls
+        # lazy_deps.ensure() first, which raises when the fal-client
+        # package is not installed (it is a lazy extra, absent from CI
+        # and fresh dev envs) — the stubbed import is never reached.
         from plugins.video_gen import fal as fal_plugin
-        fal_plugin._fal_client = None
+        monkeypatch.setattr(fal_plugin, "_fal_client", fake)
         # Also reset the managed client cache
         fal_plugin._managed_fal_video_client = None
         fal_plugin._managed_fal_video_client_config = None
@@ -532,7 +536,9 @@ class TestUpscalePass:
         monkeypatch.setitem(sys.modules, "fal_client", fake)
 
         from plugins.video_gen import fal as fal_plugin
-        fal_plugin._fal_client = None
+        # See TestFamilyRouting.with_fake_fal: set the lazy global directly;
+        # the sys.modules stub alone never survives lazy_deps.ensure().
+        monkeypatch.setattr(fal_plugin, "_fal_client", fake)
         fal_plugin._managed_fal_video_client = None
         fal_plugin._managed_fal_video_client_config = None
 

--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -161,11 +161,9 @@ class TestFamilyRouting:
         fake.submit = _submit  # type: ignore
         monkeypatch.setitem(sys.modules, "fal_client", fake)
 
-        # Point the lazy global straight at our stub. Going through
-        # sys.modules alone is not enough: import_fal_client() calls
-        # lazy_deps.ensure() first, which raises when the fal-client
-        # package is not installed (it is a lazy extra, absent from CI
-        # and fresh dev envs) — the stubbed import is never reached.
+        # Point the lazy global straight at our stub: import_fal_client()
+        # calls lazy_deps.ensure() first, which raises when the fal-client
+        # extra is absent (CI, fresh envs) — the sys.modules stub never gets read.
         from plugins.video_gen import fal as fal_plugin
         monkeypatch.setattr(fal_plugin, "_fal_client", fake)
         # Also reset the managed client cache


### PR DESCRIPTION
## Problem

The `with_fake_fal` fixtures stub `sys.modules['fal_client']` and reset `_fal_client = None` so the next `_load_fal_client()` re-imports. But `import_fal_client()` calls `lazy_deps.ensure()` first, which raises `FeatureUnavailable` when the fal-client extra isn't installed (CI, fresh dev envs) — the stubbed import is never reached and 8 tests fail.

## Repro on main

Without fal-client installed: `HERMES_DISABLE_LAZY_INSTALLS=1 pytest tests/plugins/video_gen/test_fal_plugin.py` → 8 failed (TestFamilyRouting ×5, TestUpscalePass ×3).

## Fix

Set the module-global `_fal_client` to the stub via `monkeypatch.setattr` in both fixtures — which also restores the previous value on teardown (the bare `= None` assignment leaked across tests).

## Testing

- No-fal-client env: 44 passed (was 8 failed) · with real fal-client installed: 44 passed
