### PR TITLE
test(gateway): gate Linux-only diagnostics tests with the linux_only marker

### DIFF
--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import os
 import signal
-import sys
 import time
 from pathlib import Path
 
@@ -89,7 +88,7 @@ class TestFormatters:
 # ---------------------------------------------------------------------------
 
 class TestSpawnAsyncDiagnostic:
-    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only diagnostic")
+    @pytest.mark.linux_only  # spawns GNU `timeout` + ps auxf/pstree//proc/dmesg
     def test_spawns_subprocess_and_writes_output(self, tmp_path):
         log_path = tmp_path / "diag.log"
         pid = sf.spawn_async_diagnostic(log_path, "SIGTERM", timeout_seconds=3.0)

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -8,9 +8,7 @@ import socket
 import pytest
 
 
-@pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
-)
+@pytest.mark.linux_only  # abstract Unix sockets ("\0"-prefixed) are Linux-only
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"
     receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)


### PR DESCRIPTION
## Problem

Two gateway tests pass their current `skipif` guards on macOS but fail there:

- `test_notify_supports_systemd_abstract_socket` gates on `hasattr(socket, 'AF_UNIX')` — macOS has it, but the test binds an abstract (`\0`-prefixed) socket address, a Linux-only feature → `OSError`.
- `TestSpawnAsyncDiagnostic.test_spawns_subprocess_and_writes_output` gates on `sys.platform == 'win32'`, but `spawn_async_diagnostic` shells out to GNU `timeout` + `ps auxf` / `pstree` / `/proc` / `dmesg`, none of which exist on stock macOS.

## Fix

Both tests now carry `@pytest.mark.linux_only` (registered in `pyproject.toml`, handled in `tests/conftest.py`), so they deselect cleanly off-Linux. On Linux nothing changes — both still run.

## Testing

- macOS: 15 passed, 2 skipped (was 2 failed); `tests/test_os_marker_gating.py` green · Linux marker semantics unchanged
