### PR TITLE
fix(providers): honor provider_routing on a custom:openrouter profile

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -844,6 +844,23 @@ class ChatCompletionsTransport(ProviderTransport):
         if profile_body:
             extra_body.update(profile_body)
 
+        # OpenRouter provider-routing also applies when a *custom* profile fronts
+        # an OpenRouter base_url (provider: custom:openrouter). The native
+        # OpenRouter profile emits body["provider"] from build_extra_body, but a
+        # generic CustomProfile does not — so provider_routing.only/ignore/order/
+        # sort would be silently dropped, OpenRouter price-sorts every turn, and
+        # prompt-cache prefix hits collapse on long sessions (#98186). Gate on the
+        # resolved base_url so non-OpenRouter custom providers never get the field,
+        # and never override a "provider" the profile already set.
+        if "provider" not in extra_body:
+            _routing_prefs = params.get("provider_preferences")
+            _routing_base_url = params.get("base_url")
+            if _routing_prefs and _routing_base_url:
+                from utils import base_url_host_matches
+
+                if base_url_host_matches(str(_routing_base_url).lower(), "openrouter.ai"):
+                    extra_body["provider"] = _routing_prefs
+
         # Profile's reasoning/thinking extra_body entries
         if extra_body_from_profile:
             extra_body.update(extra_body_from_profile)

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -241,6 +241,36 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["provider"] == {"only": ["openai"]}
 
+    def test_custom_profile_on_openrouter_base_url_injects_provider_prefs(self, transport):
+        """#98186: a custom profile pointed at an OpenRouter base_url must still
+        emit body["provider"] so provider_routing.only/ignore/order/sort holds
+        (a CustomProfile's build_extra_body returns {} and would otherwise drop
+        the lock, breaking prompt-cache continuity)."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="some/model", messages=msgs,
+            provider_profile=profile,
+            base_url="https://openrouter.ai/api/v1",
+            provider_preferences={"only": ["deepinfra"]},
+        )
+        assert kw["extra_body"]["provider"] == {"only": ["deepinfra"]}
+
+    def test_custom_profile_off_openrouter_does_not_inject_provider_prefs(self, transport):
+        """The injection is gated on the OpenRouter base_url — a custom provider
+        on any other endpoint must NOT receive the OpenRouter-only field."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="some/model", messages=msgs,
+            provider_profile=profile,
+            base_url="https://my-llm.example.com/v1",
+            provider_preferences={"only": ["deepinfra"]},
+        )
+        assert "provider" not in (kw.get("extra_body") or {})
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

A custom provider pointed at an OpenRouter base_url (`provider: custom:openrouter`)
resolves to `CustomProfile`, whose `build_extra_body` returns `{}` and never emits
`body["provider"]`. The transport's provider-routing injection only runs on the
legacy no-profile path (`build_kwargs` bypasses those flags when a profile is
present), so `provider_routing.only/ignore/order/sort` was silently dropped —
OpenRouter price-sorts every turn, the endpoint drifts, and prompt-cache prefix
hits collapse on long sessions.

Fix: in the profile path, inject `provider_preferences` into
`extra_body["provider"]` when the resolved `base_url` is OpenRouter and the profile
did not already set one. **Gated on the base_url**, so non-OpenRouter custom
providers never receive the OpenRouter-only field, and the native OpenRouter
profile (which sets it itself) is unaffected.

Credit to @wjmyjay5-beep for the diagnosis in #98186.

## Related Issue

Fixes #98186

## Type of Change

- [√] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py` — base_url-gated OpenRouter `provider`
  injection in `_build_kwargs_from_profile`.
- `tests/agent/transports/test_chat_completions.py` — inject / no-inject tests.

## How to Test

    pytest tests/agent/transports/test_chat_completions.py -q

59 pass. New tests: custom profile on an OpenRouter base_url injects
`provider`; a custom profile on any other base_url does not.

## Checklist

- [√] I've read the Contributing Guide
- [√] My commit messages follow Conventional Commits
- [√] I searched for existing PRs / issues
- [√] My PR contains only changes related to this fix
- [√ ] I've run `pytest tests/ -q` and all tests pass
- [√] I've added tests for my changes
- [√] I've tested on my platform: Windows 11