### PR TITLE
fix(desktop): preserve terminal startup output

### DIFF
--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -342,6 +342,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     }
   },
   terminal: {
+    attach: id => ipcRenderer.invoke('hermes:terminal:attach', id),
     cwd: id => ipcRenderer.invoke('hermes:terminal:cwd', id),
     dispose: id => ipcRenderer.invoke('hermes:terminal:dispose', id),
     resize: (id, size) => ipcRenderer.invoke('hermes:terminal:resize', id, size),

--- a/apps/desktop/electron/terminal-ipc.ts
+++ b/apps/desktop/electron/terminal-ipc.ts
@@ -13,6 +13,7 @@ import nodePty from 'node-pty'
 import { resolveTerminalConnectionForSender } from './connection-apply'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { buildInteractiveSshArgs } from './ssh-connection'
+import { createTerminalOutputGate } from './terminal-output-gate'
 import { buildWindowsInteractiveCommand } from './windows-remote-lifecycle'
 
 export interface TerminalIpcDeps {
@@ -312,12 +313,6 @@ export function registerTerminalIpc({
         )
       : nodePty.spawn(command, args, { cols, cwd, env: terminalShellEnv(), name: 'xterm-256color', rows })
 
-    terminalSessions.set(id, {
-      pty: ptyProcess,
-      webContentsId: event.sender.id,
-      ...(remote ? { sshScope: sshTarget.scope, remoteCwd: String(payload?.cwd || '') } : {})
-    })
-
     const send = (suffix, payload) => {
       if (event.sender.isDestroyed()) {
         return
@@ -326,14 +321,38 @@ export function registerTerminalIpc({
       event.sender.send(terminalChannel(id, suffix), payload)
     }
 
-    ptyProcess.onData(data => send('data', data))
+    const outputGate = createTerminalOutputGate({
+      onExitFlushed: () => terminalSessions.delete(id),
+      sendData: data => send('data', data),
+      sendExit: payload => send('exit', payload)
+    })
+
+    terminalSessions.set(id, {
+      outputGate,
+      pty: ptyProcess,
+      webContentsId: event.sender.id,
+      ...(remote ? { sshScope: sshTarget.scope, remoteCwd: String(payload?.cwd || '') } : {})
+    })
+
+    ptyProcess.onData(data => outputGate.data(data))
     ptyProcess.onExit(({ exitCode, signal }) => {
-      terminalSessions.delete(id)
-      send('exit', { code: exitCode, signal: signal || null })
+      outputGate.exit({ code: exitCode, signal: signal == null ? null : String(signal) })
     })
     event.sender.once('destroyed', () => disposeTerminalSession(id))
 
     return { cwd: remote ? null : cwd, id, shell: remote ? 'ssh' : name }
+  })
+
+  ipcMain.handle('hermes:terminal:attach', (event, id) => {
+    const sessionInfo = terminalSessions.get(String(id || ''))
+
+    if (!sessionInfo || sessionInfo.webContentsId !== event.sender.id) {
+      return false
+    }
+
+    sessionInfo.outputGate.attach()
+
+    return true
   })
 
   ipcMain.handle('hermes:terminal:write', (_event, id, data) => {

--- a/apps/desktop/electron/terminal-output-gate.test.ts
+++ b/apps/desktop/electron/terminal-output-gate.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { createTerminalOutputGate } from './terminal-output-gate'
+
+test('holds the initial shell prompt until the renderer attaches', () => {
+  const events: string[] = []
+
+  const gate = createTerminalOutputGate({
+    onExitFlushed: () => events.push('cleanup'),
+    sendData: data => events.push(`data:${data}`),
+    sendExit: payload => events.push(`exit:${payload.code}`)
+  })
+
+  gate.data('$ ')
+  assert.deepEqual(events, [])
+
+  gate.attach()
+  assert.deepEqual(events, ['data:$ '])
+
+  gate.data('pwd\r\n')
+  assert.deepEqual(events, ['data:$ ', 'data:pwd\r\n'])
+})
+
+test('flushes buffered output before an early shell exit', () => {
+  const events: string[] = []
+
+  const gate = createTerminalOutputGate({
+    onExitFlushed: () => events.push('cleanup'),
+    sendData: data => events.push(`data:${data}`),
+    sendExit: payload => events.push(`exit:${payload.code}:${payload.signal}`)
+  })
+
+  gate.data('startup failed\r\n')
+  gate.exit({ code: 1, signal: null })
+  assert.deepEqual(events, [])
+
+  gate.attach()
+  assert.deepEqual(events, ['data:startup failed\r\n', 'exit:1:null', 'cleanup'])
+})
+
+test('attach is idempotent and never replays startup output twice', () => {
+  const events: string[] = []
+
+  const gate = createTerminalOutputGate({
+    onExitFlushed: () => events.push('cleanup'),
+    sendData: data => events.push(`data:${data}`),
+    sendExit: payload => events.push(`exit:${payload.code}`)
+  })
+
+  gate.data('$ ')
+  gate.attach()
+  gate.attach()
+
+  assert.deepEqual(events, ['data:$ '])
+})

--- a/apps/desktop/electron/terminal-output-gate.ts
+++ b/apps/desktop/electron/terminal-output-gate.ts
@@ -1,0 +1,62 @@
+export interface TerminalExitPayload {
+  code: number | null
+  signal: string | null
+}
+
+interface TerminalOutputGateOptions {
+  onExitFlushed: () => void
+  sendData: (data: string) => void
+  sendExit: (payload: TerminalExitPayload) => void
+}
+
+const MAX_PENDING_OUTPUT = 1024 * 1024
+
+export function createTerminalOutputGate({ onExitFlushed, sendData, sendExit }: TerminalOutputGateOptions) {
+  let attached = false
+  let pendingData = ''
+  let pendingExit: TerminalExitPayload | null = null
+
+  const flushExit = (payload: TerminalExitPayload) => {
+    sendExit(payload)
+    onExitFlushed()
+  }
+
+  return {
+    attach(): void {
+      if (attached) {
+        return
+      }
+
+      attached = true
+
+      if (pendingData) {
+        sendData(pendingData)
+        pendingData = ''
+      }
+
+      if (pendingExit) {
+        const payload = pendingExit
+        pendingExit = null
+        flushExit(payload)
+      }
+    },
+    data(chunk: string): void {
+      if (attached) {
+        sendData(chunk)
+
+        return
+      }
+
+      pendingData = `${pendingData}${chunk}`.slice(-MAX_PENDING_OUTPUT)
+    },
+    exit(payload: TerminalExitPayload): void {
+      if (attached) {
+        flushExit(payload)
+
+        return
+      }
+
+      pendingExit = payload
+    }
+  }
+}

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -854,7 +854,7 @@ export function useTerminalSession({
         // user last `cd`'d; the main side falls back to the launch cwd (then
         // home) if that dir no longer exists.
         .start({ cols: term.cols, cwd: initialRestoreCwdRef.current || cwd, rows: term.rows })
-        .then(session => {
+        .then(async session => {
           if (disposed) {
             void terminalApi.dispose(session.id)
 
@@ -870,8 +870,6 @@ export function useTerminalSession({
           const initial = term.hasSelection() ? term.getSelection() : ''
           selectionRef.current = initial
           selectionLabelRef.current = initial ? terminalSelectionLabel(term, shellNameRef.current, initial) : ''
-
-          setStatus('open')
 
           cleanup.push(
             terminalApi.onData(session.id, data => {
@@ -891,6 +889,14 @@ export function useTerminalSession({
               }
             })
           )
+
+          const attached = await terminalApi.attach(session.id)
+
+          if (!attached) {
+            throw new Error('Terminal session disappeared before its output stream attached')
+          }
+
+          setStatus('open')
 
           window.requestAnimationFrame(() => {
             term.clearSelection() // drop any selection painted over transient boot rows

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -414,6 +414,7 @@ declare global {
         ) => Promise<{ root: string; label: string }[]>
       }
       terminal: {
+        attach: (id: string) => Promise<boolean>
         /** Best-effort current working directory of the live PTY child (POSIX
          *  only; null on Windows or when unavailable). Used to reopen a tab
          *  where the user last `cd`'d. */


### PR DESCRIPTION
## What does this PR do?

Prevents the embedded Desktop terminal from losing its initial shell output before the renderer is ready to receive it.

The Electron process now buffers PTY output and an early exit until the renderer installs both terminal listeners and explicitly attaches. The buffered events are then flushed once, in order. This fixes terminal tabs that can open as a blank pane when a fast shell emits its prompt before `terminal.start()` returns.

## Related Issue

No linked GitHub issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a bounded Electron-side output gate for pre-attach PTY data and exits.
- Added a narrow `terminal.attach` IPC handshake after renderer listeners are installed.
- Added regression coverage for initial prompt delivery, early exits, and idempotent attachment.

## How to Test

1. Run `npx vitest run electron/terminal-output-gate.test.ts --project electron` from `apps/desktop`.
2. Run `npm run typecheck` from `apps/desktop`.
3. Open a Desktop terminal repeatedly with a fast-starting shell and verify its initial prompt is always visible.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused Electron regression test: 3 passed. Desktop renderer, Electron, and E2E TypeScript projects typecheck successfully. Changed files pass ESLint.
