### PR TITLE
fix(desktop): align "Move to project" submenu with sidebar view filters

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -1,6 +1,9 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $dismissedAutoProjectIds, $sidebarProjectFilter } from '@/store/layout'
+import { $projectTree } from '@/store/projects'
 
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 
@@ -79,7 +82,11 @@ vi.mock('@/store/projects', () => ({
   $projectTree: atom<unknown[]>([]),
   moveSessionToProject: vi.fn(),
   projectIdForCwd: vi.fn(() => null),
-  projectRootCwd: vi.fn(() => '')
+  // Mirror the real store's rule: primary folder, else first repo with one.
+  projectRootCwd: vi.fn(
+    (node: { path?: null | string; repos?: { path?: null | string }[] }) =>
+      (node?.path || node?.repos?.find(repo => repo.path)?.path || '').trim()
+  )
 }))
 vi.mock('@/store/session', () => ({
   $activeSessionId: atom<null | string>(null),
@@ -286,5 +293,74 @@ describe('SessionActionsMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     expect(await screen.findByText('Session deleted')).toBeTruthy()
     expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+})
+
+// The "Move to project" submenu must offer the SAME project set the sidebar
+// overview shows: a dismissed auto-project and a project excluded by the
+// persisted sidebar filter must not be move targets. Drive the real
+// interaction: open the kebab menu, then click the submenu trigger (Radix
+// opens subs on click; the parent menu stays open). The real layout store is
+// loaded (no mock) so the real filterVisibleProjects + persistent atoms run.
+// Store mutations are wrapped in act() so the menu re-renders before asserting.
+describe('Move to project mirrors the sidebar view filters', () => {
+  async function openMoveToProjectSubmenu() {
+    renderMenu()
+
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    await screen.findByRole('menu')
+    const subTrigger = screen.getByRole('menuitem', { name: 'Move to project' })
+    fireEvent.click(subTrigger)
+  }
+
+  it('offers visible projects and hides dismissed auto-projects', async () => {
+    $projectTree.set([
+      { id: 'p-ghost', isAuto: false, isNoProject: false, label: 'Ghost Recon', path: 'H:/workspace/Projects/Ghost Recon Stage 2/.re', repos: [], sessionCount: 1 },
+      { id: 'p-x4', isAuto: true, isNoProject: false, label: 'x4-projects', path: 'C:/Users/gmkon/x4-projects', repos: [], sessionCount: 0 }
+    ])
+    $dismissedAutoProjectIds.set([])
+    $sidebarProjectFilter.set([])
+
+    await openMoveToProjectSubmenu()
+
+    // Both visible projects are move targets.
+    expect(await screen.findByRole('menuitem', { name: 'Ghost Recon' })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: 'x4-projects' })).toBeTruthy()
+
+    // Dismiss the auto-project in the sidebar: the menu must follow (the
+    // reported bug was that it did not).
+    act(() => $dismissedAutoProjectIds.set(['p-x4']))
+    expect(screen.queryByRole('menuitem', { name: 'x4-projects' })).toBeNull()
+    expect(screen.getByRole('menuitem', { name: 'Ghost Recon' })).toBeTruthy()
+
+    // Re-showing it restores the target.
+    act(() => $dismissedAutoProjectIds.set([]))
+    expect(await screen.findByRole('menuitem', { name: 'x4-projects' })).toBeTruthy()
+  })
+
+  it('hides projects excluded by the persisted sidebar project filter', async () => {
+    $projectTree.set([
+      { id: 'p-ghost', isAuto: false, isNoProject: false, label: 'Ghost Recon', path: 'H:/workspace/Projects/Ghost Recon Stage 2/.re', repos: [], sessionCount: 1 },
+      { id: 'p-ue5', isAuto: false, isNoProject: false, label: 'UE5 Tactical Shooter', path: 'G:/Projects/Unreal Projects/test2', repos: [], sessionCount: 2 }
+    ])
+    $dismissedAutoProjectIds.set([])
+    $sidebarProjectFilter.set([])
+
+    await openMoveToProjectSubmenu()
+
+    expect(await screen.findByRole('menuitem', { name: 'UE5 Tactical Shooter' })).toBeTruthy()
+
+    // Narrow the sidebar to Ghost Recon only: the menu must follow.
+    act(() => $sidebarProjectFilter.set(['p-ghost']))
+    expect(screen.queryByRole('menuitem', { name: 'UE5 Tactical Shooter' })).toBeNull()
+    expect(screen.getByRole('menuitem', { name: 'Ghost Recon' })).toBeTruthy()
+
+    // Clearing the filter restores the target.
+    act(() => $sidebarProjectFilter.set([]))
+    expect(await screen.findByRole('menuitem', { name: 'UE5 Tactical Shooter' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -30,6 +30,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
+import { $dismissedAutoProjectIds, $sidebarProjectFilter, filterVisibleProjects } from '@/store/layout'
 import { notify, notifyError } from '@/store/notifications'
 import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
 import {
@@ -149,14 +150,26 @@ function SessionColorSwatches({ sessionId }: { sessionId: string }) {
 // project's root — the fix for a chat created in the wrong folder. The current
 // owner and folderless projects (the Home bucket) are excluded: there is
 // nothing to move into.
+//
+// The sidebar's two view-state filters are applied here too, so the menu offers
+// exactly the projects the sidebar shows (dismissed auto-projects and the
+// persisted project filter). Without them a repo the user hid from the
+// overview still appears as a move target — the same set the user no longer
+// sees. The menu-only constraints (`projectRootCwd`, `!isNoProject`) stay: a
+// move destination must own a root folder.
 function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; sessionId: string; profile?: string }) {
   const { t } = useI18n()
   const p = t.sidebar.projects
   const tree = useStore($projectTree)
+  const dismissedAutoProjects = useStore($dismissedAutoProjectIds)
+  const projectFilter = useStore($sidebarProjectFilter)
   const session = useStore($sessions).find(s => sessionMatchesStoredId(s, sessionId))
   const cwd = session?.cwd?.trim() || ''
   const currentProjectId = cwd ? projectIdForCwd(cwd) : null
-  const targets = tree.filter(node => node.id !== currentProjectId && !node.isNoProject && projectRootCwd(node))
+
+  const targets = filterVisibleProjects(tree, dismissedAutoProjects)
+    .filter(node => !projectFilter.length || projectFilter.includes(node.id))
+    .filter(node => node.id !== currentProjectId && !node.isNoProject && projectRootCwd(node))
 
   if (targets.length === 0) {
     return <kit.Item disabled>{p.moveNoProjects}</kit.Item>


### PR DESCRIPTION
The "Move to project" submenu in the session kebab menu offered projects that are not visible in the sidebar project list: auto-projects the user dismissed and projects excluded by the persisted sidebar project filter. Both surfaces read the same $projectTree atom, but only the sidebar applied the view filters (filterVisibleProjects + $sidebarProjectFilter).

MoveToProjectItems now applies the same two view filters before its move-specific constraints (current-project exclusion, !isNoProject, projectRootCwd), so the submenu always offers exactly the project set the sidebar shows.

Tests: new cases in session-actions-menu.test.tsx drive the real Radix menu with the real layout store — a dismissed auto-project and a sidebar-filtered project disappear from the submenu and reappear when re-shown/cleared.

Verification: tsc --noEmit clean; vitest 8/8 in the menu test file; full npm run check (typecheck + eslint + UI suites).