### PR TITLE
fix(kanban): don't surface a stale summary while a newer run is active

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -12106,9 +12106,17 @@ def latest_summary(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
     for ties or unfinished rows). Returns None if no run has a summary.
     """
     row = conn.execute(
-        "SELECT summary FROM task_runs "
-        "WHERE task_id = ? AND summary IS NOT NULL AND summary != '' "
-        "ORDER BY COALESCE(ended_at, started_at) DESC, id DESC LIMIT 1",
+        "SELECT summary FROM task_runs AS t "
+        "WHERE t.task_id = ? AND t.summary IS NOT NULL AND t.summary != '' "
+        # Suppress an older run's summary while a newer run is still active
+        # (unfinished, no summary of its own yet). The task's current state is
+        # that newer run, so surfacing the old summary as "latest" makes a
+        # RUNNING task read as still blocked/complete (#98204).
+        "AND NOT EXISTS ("
+        " SELECT 1 FROM task_runs AS newer "
+        " WHERE newer.task_id = t.task_id AND newer.id > t.id "
+        " AND newer.ended_at IS NULL) "
+        "ORDER BY COALESCE(t.ended_at, t.started_at) DESC, t.id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
     return row["summary"] if row else None
@@ -12135,14 +12143,21 @@ def latest_summaries(
     rows = conn.execute(
         f"""
         SELECT task_id, summary FROM (
-            SELECT task_id, summary,
+            SELECT t.task_id AS task_id, t.summary AS summary,
                    ROW_NUMBER() OVER (
-                       PARTITION BY task_id
-                       ORDER BY COALESCE(ended_at, started_at) DESC, id DESC
+                       PARTITION BY t.task_id
+                       ORDER BY COALESCE(t.ended_at, t.started_at) DESC, t.id DESC
                    ) AS rn
-              FROM task_runs
-             WHERE task_id IN ({placeholders})
-               AND summary IS NOT NULL AND summary != ''
+              FROM task_runs AS t
+             WHERE t.task_id IN ({placeholders})
+               AND t.summary IS NOT NULL AND t.summary != ''
+               -- Same suppression as latest_summary(): drop a stale summary
+               -- while a newer run is still active (#98204).
+               AND NOT EXISTS (
+                   SELECT 1 FROM task_runs AS newer
+                   WHERE newer.task_id = t.task_id AND newer.id > t.id
+                     AND newer.ended_at IS NULL
+               )
         ) WHERE rn = 1
         """,
         ids,

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -29,6 +29,59 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def test_latest_summary_suppressed_while_newer_run_active(tmp_path):
+    """#98204: a stale blocked/completed summary must not surface as the latest
+    while a newer run is still active (unfinished, no summary of its own) —
+    otherwise a RUNNING task reads as still blocked. Once the newer run finishes
+    with its own summary, that summary becomes the latest."""
+    db_path = tmp_path / "kanban.db"
+    with kb.connect(db_path) as conn:
+        # Older run: blocked, ended, carries a summary.
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, started_at, ended_at, outcome, summary) "
+            "VALUES ('t1', 'blocked', 100, 150, 'blocked', ?)",
+            ("Production blocked: ring vs track 1.36:1",),
+        )
+        # Newer run: running, active (ended_at NULL), no summary yet.
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, started_at, ended_at, summary) "
+            "VALUES ('t1', 'running', 200, NULL, NULL)"
+        )
+        conn.commit()
+
+        # While the newer run is active, the stale summary is suppressed.
+        assert kb.latest_summary(conn, "t1") is None
+        assert kb.latest_summaries(conn, ["t1"]) == {}
+
+        # When the newer run completes with its own summary, that is the latest.
+        conn.execute(
+            "UPDATE task_runs SET ended_at = 250, status = 'completed', summary = ? "
+            "WHERE task_id = 't1' AND started_at = 200",
+            ("Done: corrected the ratio",),
+        )
+        conn.commit()
+        assert kb.latest_summary(conn, "t1") == "Done: corrected the ratio"
+        assert kb.latest_summaries(conn, ["t1"]) == {"t1": "Done: corrected the ratio"}
+
+
+def test_latest_summary_returns_newest_when_all_runs_finished(tmp_path):
+    """Control: with no active newer run, the newest available summary surfaces
+    exactly as before."""
+    db_path = tmp_path / "kanban.db"
+    with kb.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, started_at, ended_at, summary) "
+            "VALUES ('t2', 'completed', 100, 150, 'first')"
+        )
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, started_at, ended_at, summary) "
+            "VALUES ('t2', 'completed', 200, 250, 'second')"
+        )
+        conn.commit()
+        assert kb.latest_summary(conn, "t2") == "second"
+        assert kb.latest_summaries(conn, ["t2"]) == {"t2": "second"}
+
+
 def _init_git_repo(repo: Path) -> None:
     repo.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, text=True)


### PR DESCRIPTION
## What does this PR do?

`latest_summary()` / `latest_summaries()` returned the newest run that *has* a
summary. A newer, still-active run has no summary yet, so an older blocked/
completed run's summary surfaced as the task's LATEST SUMMARY — a RUNNING task
then reads as still blocked, and the dashboard drawer shows a stale blocker as
current (#98204).

Fix: suppress a run's summary when a more recently created run is still active
(`ended_at IS NULL`), in both the single and batch summary queries. Once the
newer run finishes with its own summary, that summary surfaces as before.

Scope: top-level Latest Summary only. The drawer's DEPENDENCIES ("Blocked by"
vs "Depends on") labeling raised later in the same issue is left for a separate
follow-up.

Credit to @MK-Henry for the diagnosis in #98204.

## Related Issue

Fixes #98204

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` — `latest_summary` and `latest_summaries` skip a
  stale summary while a newer run is still active.
- `tests/hermes_cli/test_kanban_db.py` — suppression + finished-run control tests.

## How to Test

    pytest tests/hermes_cli/test_kanban_db.py -k latest_summary -q

Both new tests pass: a stale blocked summary is suppressed while a newer run is
active; the newer run's own summary surfaces once it finishes.

## Checklist

- [√] I've read the Contributing Guide
- [√] My commit messages follow Conventional Commits
- [√] I searched for existing PRs / issues
- [√] My PR contains only changes related to this fix
- [√ ] I've run `pytest tests/ -q` and all tests pass
- [√] I've added tests for my changes
- [√] I've tested on my platform: Windows 11