### PR TITLE
fix(gateway): keep provider stall-watchdog kill notices out of chat

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -148,13 +148,19 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
-    # Provider stale/TTFB kill notices buffered by _buffer_status in
+    # Provider stall-watchdog kill notices buffered by _buffer_status in
     # agent/chat_completion_helpers.py and replayed through _emit_status when
     # a turn exhausts its attempts. The retry loop reconnects on its own, so
     # these belong in logs, not in a chat bubble. The mandatory "\d+s" duration
     # keeps ordinary assistant prose about providers/timeouts from matching.
-    r"|no\s+response\s+from\s+provider\s+for\s+\d+s\b"
-    r"|no\s+first\s+byte\s+from\s+provider\s+in\s+\d+s\b"
+    # All four shapes of the same watchdog family are listed together: which
+    # one fires depends only on WHEN the provider goes silent (before the first
+    # byte, mid-stream, non-streaming, Bedrock), so covering a subset would
+    # make chat noise depend on provider timing.
+    r"|no\s+response\s+from\s+provider\s+for\s+\d+s\b"  # (non-)streaming stale kill
+    r"|no\s+first\s+byte\s+from\s+provider\s+in\s+\d+s\b"  # codex TTFB kill
+    r"|codex\s+stream\s+sent\s+no\s+events\s+for\s+\d+s\b"  # codex post-TTFB idle kill
+    r"|no\s+events\s+from\s+bedrock\s+for\s+\d+s\b"  # bedrock stream stale kill
     rf"|{re.escape(COMPACTION_DONE_STATUS)}"
     r")",
     re.IGNORECASE | re.DOTALL,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -148,6 +148,13 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
+    # Provider stale/TTFB kill notices buffered by _buffer_status in
+    # agent/chat_completion_helpers.py and replayed through _emit_status when
+    # a turn exhausts its attempts. The retry loop reconnects on its own, so
+    # these belong in logs, not in a chat bubble. The mandatory "\d+s" duration
+    # keeps ordinary assistant prose about providers/timeouts from matching.
+    r"|no\s+response\s+from\s+provider\s+for\s+\d+s\b"
+    r"|no\s+first\s+byte\s+from\s+provider\s+in\s+\d+s\b"
     rf"|{re.escape(COMPACTION_DONE_STATUS)}"
     r")",
     re.IGNORECASE | re.DOTALL,

--- a/tests/gateway/test_provider_watchdog_status_delivery.py
+++ b/tests/gateway/test_provider_watchdog_status_delivery.py
@@ -1,0 +1,136 @@
+"""End-to-end buffer→surface delivery for provider stall-watchdog notices.
+
+``tests/gateway/test_telegram_noise_filter.py`` asserts the filter *predicate*.
+This module drives the REAL path a notice travels on terminal failure:
+
+    agent._buffer_status(...)          # agent/chat_completion_helpers.py
+      -> agent._flush_status_buffer()  # run_agent.py, on retry exhaustion
+        -> agent._emit_status(...)     # run_agent.py
+          -> agent.status_callback("lifecycle", ...)
+            -> _prepare_gateway_status_message(...)   # gateway/run.py (real)
+              -> adapter.send(...)                    # stubbed sink
+
+Only the adapter sink is stubbed, so a regression that keeps the regex green
+while changing what actually reaches a chat bubble fails here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.run import _prepare_gateway_status_message
+from run_agent import AIAgent
+from tests.gateway.test_telegram_noise_filter import (
+    BUFFERED_STATUS_MUST_SURVIVE,
+    CHAT_PLATFORMS,
+    PROVIDER_WATCHDOG_KILL_NOTICES,
+)
+
+
+def _agent_wired_to_surface(platform: str):
+    """A bare AIAgent whose status_callback is the real gateway filter.
+
+    Mirrors ``gateway/run.py:_status_callback_sync``: prepare the message, drop
+    it when the filter returns None, otherwise hand it to the adapter. Returns
+    ``(agent, bubbles, stdout_lines)`` — ``bubbles`` is what a chat user would
+    see, ``stdout_lines`` is the operator-facing CLI/log stream.
+    """
+    agent = object.__new__(AIAgent)
+    agent.log_prefix = ""
+    agent.suppress_status_output = False
+    agent._mute_post_response = False
+    agent._executing_tools = False
+
+    bubbles: list[str] = []
+    stdout_lines: list[str] = []
+    agent._print_fn = lambda *args, **kwargs: stdout_lines.append(
+        " ".join(str(a) for a in args)
+    )
+
+    def _status_callback(event_type: str, message: str) -> None:
+        prepared = _prepare_gateway_status_message(platform, event_type, message)
+        if prepared is None:
+            return
+        bubbles.append(prepared)
+
+    agent.status_callback = _status_callback
+    return agent, bubbles, stdout_lines
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+@pytest.mark.parametrize(
+    "notice", PROVIDER_WATCHDOG_KILL_NOTICES, ids=lambda m: m.strip()[:48]
+)
+def test_terminal_failure_keeps_watchdog_notice_out_of_chat(platform, notice):
+    """A flushed watchdog kill notice reaches stdout/logs but never a bubble."""
+    agent, bubbles, stdout_lines = _agent_wired_to_surface(platform)
+
+    agent._buffer_status(notice)
+    # Buffered only — nothing emitted while the retry loop is still trying.
+    assert bubbles == []
+    assert stdout_lines == []
+
+    # Terminal failure replays the buffer.
+    agent._flush_status_buffer()
+
+    assert bubbles == []
+    # The operator surface still gets it — this is suppression, not deletion.
+    assert stdout_lines == [notice]
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_terminal_failure_delivers_actionable_notices_only(platform):
+    """A realistic terminal ladder: noise dropped, actionable lines delivered.
+
+    The buffer holds what a real exhausted turn accumulates — watchdog kills
+    interleaved with the fallback switch and the final give-up line. The chat
+    user must end up with exactly the actionable subset, in order.
+    """
+    agent, bubbles, stdout_lines = _agent_wired_to_surface(platform)
+
+    fallback_notice, terminal_notice = (
+        BUFFERED_STATUS_MUST_SURVIVE[1],
+        BUFFERED_STATUS_MUST_SURVIVE[0],
+    )
+    for message in (
+        PROVIDER_WATCHDOG_KILL_NOTICES[2],  # codex TTFB kill
+        PROVIDER_WATCHDOG_KILL_NOTICES[4],  # codex post-TTFB idle kill
+        fallback_notice,
+        PROVIDER_WATCHDOG_KILL_NOTICES[1],  # streaming stale kill
+        terminal_notice,
+    ):
+        agent._buffer_status(message)
+
+    agent._flush_status_buffer()
+
+    assert bubbles == [fallback_notice, terminal_notice]
+    # Every line — noise included — is still on the operator surface.
+    assert len(stdout_lines) == 5
+
+
+@pytest.mark.parametrize(
+    "notice", PROVIDER_WATCHDOG_KILL_NOTICES, ids=lambda m: m.strip()[:48]
+)
+def test_successful_recovery_emits_nothing_anywhere(notice):
+    """When the retry loop recovers, the buffer is dropped, not flushed."""
+    agent, bubbles, stdout_lines = _agent_wired_to_surface("telegram")
+
+    agent._buffer_status(notice)
+    agent._clear_status_buffer()
+    agent._flush_status_buffer()
+
+    assert bubbles == []
+    assert stdout_lines == []
+
+
+@pytest.mark.parametrize(
+    "notice", PROVIDER_WATCHDOG_KILL_NOTICES, ids=lambda m: m.strip()[:48]
+)
+def test_programmatic_surface_receives_watchdog_notice_as_bubble(notice):
+    """API/webhook consumers keep the raw diagnostic on the delivery path too."""
+    agent, bubbles, _ = _agent_wired_to_surface("api_server")
+
+    agent._buffer_status(notice)
+    agent._flush_status_buffer()
+
+    assert bubbles == [notice]

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -60,6 +60,58 @@ NOISY_STATUS_MESSAGES = [
     ),
 ]
 
+# Provider stall-watchdog kill notices. Every one is recorded by
+# ``_buffer_status`` and replayed through ``_flush_status_buffer`` ->
+# ``_emit_status`` -> ``status_callback`` when a turn exhausts its attempts, so
+# they DO reach a chat surface. Which shape fires depends only on WHEN the
+# provider goes silent, so all four must be filtered identically — otherwise
+# chat noise depends on provider timing.
+PROVIDER_WATCHDOG_KILL_NOTICES = [
+    # agent/chat_completion_helpers.py:787 — non-streaming stale kill.
+    "⚠️ No response from provider for 150s (non-streaming, model: gpt-5.5). Aborting call.",
+    # agent/chat_completion_helpers.py:5211 — streaming stale kill.
+    (
+        "⚠️ No response from provider for 300s (model: gpt-5.5, "
+        "context: ~98,781 tokens). Reconnecting..."
+    ),
+    # agent/chat_completion_helpers.py:1670/1676 — codex TTFB kill.
+    "⚠️ No first byte from provider in 120s (codex stream, model: gpt-5.5). Reconnecting.",
+    (
+        "⚠️ No first byte from provider in 120s (codex stream, model: gpt-5.5). "
+        "Reconnecting. Provider accepted the connection but sent no events."
+    ),
+    # agent/chat_completion_helpers.py:1725 — codex post-TTFB idle kill.
+    (
+        "⚠️ Codex stream sent no events for 90s after first byte "
+        "(model: gpt-5.5). Reconnecting."
+    ),
+    # agent/chat_completion_helpers.py:3615 — bedrock stream stale kill.
+    (
+        "⚠️ No events from Bedrock for 300s "
+        "(model: anthropic.claude-sonnet-4-5-20250929-v1:0). Aborting..."
+    ),
+]
+
+# Notices that travel the SAME buffered-status path as
+# PROVIDER_WATCHDOG_KILL_NOTICES but MUST reach the user: the terminal
+# give-up message, the durable provider/model switch, and the work heartbeat.
+# A watchdog-filter alternative that widens into any of these silently turns a
+# failed turn into a turn that just stops replying.
+BUFFERED_STATUS_MUST_SURVIVE = [
+    # agent/chat_completion_helpers.py:5026 — terminal, user-actionable.
+    (
+        "❌ Connection to provider failed after 4 attempts. The provider may be "
+        "experiencing issues — try again in a moment."
+    ),
+    # agent/chat_completion_helpers.py:2856 — durable state change.
+    (
+        "⚠️ Model fallback: gpt-5.5 via openai unavailable (stream timeout); "
+        "using claude-opus-4-6 via anthropic."
+    ),
+    # gateway/run.py:29992 — work heartbeat.
+    "⏳ Working — 3 min",
+]
+
 # Messages that must NEVER be swallowed by the compression-noise filter:
 # deliberate carve-outs from routine-compression silence — manual /compress
 # feedback (manual_compression_feedback.py headlines) and abort/failure
@@ -121,14 +173,19 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
         assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
 
 
-def test_programmatic_surfaces_keep_raw_status():
+@pytest.mark.parametrize(
+    "message",
+    ["⏳ Retrying in 4.2s (attempt 1/3)..."] + PROVIDER_WATCHDOG_KILL_NOTICES,
+    ids=lambda m: m.strip()[:48],
+)
+def test_programmatic_surfaces_keep_raw_status(message):
     """Programmatic surfaces (local/api/webhook) must keep raw diagnostics.
 
     Negative case for the invariant: the chat-noise filter must not touch
-    CLI/TUI diagnostics, API JSON, or webhook payloads.
+    CLI/TUI diagnostics, API JSON, or webhook payloads. Parametrized over the
+    watchdog notices too, so widening the chat filter can never quietly strip
+    a timeout diagnostic from an API/webhook consumer.
     """
-    message = "⏳ Retrying in 4.2s (attempt 1/3)..."
-
     for platform in ("local", "api_server", "webhook", "msgraph_webhook"):
         assert (
             _prepare_gateway_status_message(platform, "lifecycle", message) == message
@@ -150,26 +207,10 @@ def test_all_chat_gateways_suppress_noise(platform, message):
 
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)
 @pytest.mark.parametrize(
-    "message",
-    [
-        # agent/chat_completion_helpers.py:787 — non-streaming stale kill.
-        "⚠️ No response from provider for 150s (non-streaming, model: gpt-5.5). Aborting call.",
-        # agent/chat_completion_helpers.py:5211 — streaming stale kill.
-        (
-            "⚠️ No response from provider for 300s (model: gpt-5.5, "
-            "context: ~98,781 tokens). Reconnecting..."
-        ),
-        # agent/chat_completion_helpers.py:1670/1676 — codex TTFB kill.
-        "⚠️ No first byte from provider in 120s (codex stream, model: gpt-5.5). Reconnecting.",
-        (
-            "⚠️ No first byte from provider in 120s (codex stream, model: gpt-5.5). "
-            "Reconnecting. Provider accepted the connection but sent no events."
-        ),
-    ],
-    ids=lambda m: m.strip()[:48],
+    "message", PROVIDER_WATCHDOG_KILL_NOTICES, ids=lambda m: m.strip()[:48]
 )
-def test_chat_gateways_suppress_provider_stale_kill_notices(platform, message):
-    """Provider stale/TTFB kill notices stay in logs, not chat bubbles.
+def test_chat_gateways_suppress_provider_watchdog_kill_notices(platform, message):
+    """Provider stall-watchdog kill notices stay in logs, not chat bubbles.
 
     ``_buffer_status`` records these in the retry buffer; ``_flush_status_buffer``
     replays them through ``_emit_status`` -> ``status_callback`` on terminal
@@ -180,20 +221,18 @@ def test_chat_gateways_suppress_provider_stale_kill_notices(platform, message):
     assert _prepare_gateway_status_message(platform, "lifecycle", message) is None
 
 
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
 @pytest.mark.parametrize(
-    "message",
-    [
-        "I hit an error: the request timed out, so I retried with a longer limit.",
-        "No response from the API docs endpoint was cached, so I fetched it live.",
-        "The provider for this dataset has no first byte order guarantee.",
-    ],
+    "message", BUFFERED_STATUS_MUST_SURVIVE, ids=lambda m: m.strip()[:48]
 )
-def test_provider_stale_kill_filter_keeps_assistant_prose(message):
-    """The new alternatives must not swallow ordinary assistant text."""
-    assert (
-        _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message)
-        == message
-    )
+def test_watchdog_filter_keeps_terminal_and_durable_notices(platform, message):
+    """The watchdog filter must not widen into the notices sharing its path.
+
+    The terminal give-up line, the fallback switch, and the heartbeat all reach
+    chat through the same ``status_callback``. Swallowing any of them turns a
+    failed turn into a silently unanswered one.
+    """
+    assert _prepare_gateway_status_message(platform, "lifecycle", message) == message
 
 
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -22,6 +22,7 @@ CHAT_PLATFORMS = [
     "telegram",
     "slack",
     "feishu",
+    "wecom",
 ]
 
 NOISY_STATUS_MESSAGES = [
@@ -145,6 +146,54 @@ def test_telegram_status_keeps_legitimate_heartbeat_messages(message):
 def test_all_chat_gateways_suppress_noise(platform, message):
     """Operational lifecycle/retry noise must be suppressed on every chat surface."""
     assert _prepare_gateway_status_message(platform, "warn", message) is None
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+@pytest.mark.parametrize(
+    "message",
+    [
+        # agent/chat_completion_helpers.py:787 — non-streaming stale kill.
+        "⚠️ No response from provider for 150s (non-streaming, model: gpt-5.5). Aborting call.",
+        # agent/chat_completion_helpers.py:5211 — streaming stale kill.
+        (
+            "⚠️ No response from provider for 300s (model: gpt-5.5, "
+            "context: ~98,781 tokens). Reconnecting..."
+        ),
+        # agent/chat_completion_helpers.py:1670/1676 — codex TTFB kill.
+        "⚠️ No first byte from provider in 120s (codex stream, model: gpt-5.5). Reconnecting.",
+        (
+            "⚠️ No first byte from provider in 120s (codex stream, model: gpt-5.5). "
+            "Reconnecting. Provider accepted the connection but sent no events."
+        ),
+    ],
+    ids=lambda m: m.strip()[:48],
+)
+def test_chat_gateways_suppress_provider_stale_kill_notices(platform, message):
+    """Provider stale/TTFB kill notices stay in logs, not chat bubbles.
+
+    ``_buffer_status`` records these in the retry buffer; ``_flush_status_buffer``
+    replays them through ``_emit_status`` -> ``status_callback`` on terminal
+    failure, so they DO reach a chat surface. The retry loop reconnects on its
+    own and the user already gets a "⏳ Working" heartbeat, so the raw
+    timeout/context diagnostics are operator noise here.
+    """
+    assert _prepare_gateway_status_message(platform, "lifecycle", message) is None
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "I hit an error: the request timed out, so I retried with a longer limit.",
+        "No response from the API docs endpoint was cached, so I fetched it live.",
+        "The provider for this dataset has no first byte order guarantee.",
+    ],
+)
+def test_provider_stale_kill_filter_keeps_assistant_prose(message):
+    """The new alternatives must not swallow ordinary assistant text."""
+    assert (
+        _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message)
+        == message
+    )
 
 
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)


### PR DESCRIPTION
## Summary

`_buffer_status` records the provider stall-watchdog kill notices in the retry buffer. On terminal failure `_flush_status_buffer` replays them through `_emit_status` → `status_callback` → `_prepare_gateway_status_message`, so they land in a chat bubble on every messaging surface:

```
⚠️ No response from provider for 150s (non-streaming, model: gpt-5.5). Aborting call.
⚠️ No first byte from provider in 120s (codex stream, model: gpt-5.5). Reconnecting.
⚠️ Codex stream sent no events for 90s after first byte (model: gpt-5.5). Reconnecting.
⚠️ No events from Bedrock for 300s (model: anthropic...). Aborting...
```

The retry loop reconnects on its own and the user already gets a `⏳ Working — N min` heartbeat, so the raw timeout/context-size diagnostics are operator noise on a chat surface. Every other notice from the same retry ladder is already suppressed by `_TELEGRAM_NOISY_STATUS_RE` — `Rate limited. Waiting Ns`, `Retrying in Ns`, `Max retries (N) exhausted`, `stream drop … retry N`. These four were the ones left through.

**Whole family, not a subset.** Which shape fires depends only on *when* the provider goes silent — before the first byte, mid-stream, non-streaming, or Bedrock. Covering a subset would make chat noise depend on provider timing: a Codex user hitting the TTFB cutoff would get silence, while the same user hitting the post-TTFB idle cutoff a second later would get a bubble.

## Changes

- `gateway/run.py` (+11/-2): four alternatives in `_TELEGRAM_NOISY_STATUS_RE`, one per emit site family. The mandatory `\d+s` duration keeps ordinary prose about providers and timeouts from matching.
- `tests/gateway/test_telegram_noise_filter.py`: shared `PROVIDER_WATCHDOG_KILL_NOTICES` / `BUFFERED_STATUS_MUST_SURVIVE` constants, suppression asserted across 4 chat platforms, plus a positive guard on the notices that share the same status path.
- `tests/gateway/test_provider_watchdog_status_delivery.py` (new, +130): end-to-end buffer→surface delivery test.

Emit sites covered:

| Notice | Emit site |
|---|---|
| `No response from provider for Ns` (non-streaming stale kill) | `agent/chat_completion_helpers.py:787` |
| `No response from provider for Ns` (streaming stale kill) | `agent/chat_completion_helpers.py:5211` |
| `No first byte from provider in Ns` (codex TTFB kill) | `agent/chat_completion_helpers.py:1670`, `:1676` |
| `Codex stream sent no events for Ns after first byte` (codex post-TTFB idle kill) | `agent/chat_completion_helpers.py:1725` |
| `No events from Bedrock for Ns` (bedrock stream stale kill) | `agent/chat_completion_helpers.py:3615` |

Programmatic surfaces (local/api/webhook/msgraph_webhook) are unaffected — they return before the filter via `_gateway_surface_passes_raw_text`. `test_programmatic_surfaces_keep_raw_status` is parametrized over every watchdog notice, so narrowing the chat filter can never quietly strip a timeout diagnostic from an API/webhook consumer.

## Notices that must survive the same path

The filter sits on the path that also carries notices the user needs. Each now has an explicit guard on all 4 chat platforms — a widened alternative that swallowed one of these would turn a failed turn into a turn that just stops replying:

| Notice | Emit site | Why it must reach chat |
|---|---|---|
| `❌ Connection to provider failed after N attempts…` | `chat_completion_helpers.py:5026` | terminal, user-actionable |
| `⚠️ Model fallback: X via Y unavailable…` | `chat_completion_helpers.py:2856` | durable state change |
| `⏳ Working — N min` | `gateway/run.py:29992` | work heartbeat |

## Test design note

An earlier revision of this PR had a negative test feeding ordinary assistant prose to `_prepare_gateway_status_message`. That test asserted nothing: the function's only caller is `_status_callback_sync` (`gateway/run.py:5426`), and `status_callback` is only ever invoked with `lifecycle` / `warn` / `compacted` — never assistant prose, which travels `_sanitize_gateway_final_response` instead. It has been replaced with the reachable negative cases in the table above.

`tests/gateway/test_provider_watchdog_status_delivery.py` drives the real chain with only the adapter sink stubbed:

```
_buffer_status → _flush_status_buffer → _emit_status
  → status_callback("lifecycle", …) → _prepare_gateway_status_message (real) → sink
```

It asserts four things: the notice reaches stdout/logs but produces no chat bubble (suppression, not deletion); a mixed terminal ladder delivers exactly the actionable subset in order; successful recovery (`_clear_status_buffer`) emits nothing on either surface; and `api_server` still receives the raw text through the same chain.

## Scope note

The same retry ladder also emits `API call failed (attempt N/M)`, `🔌 Provider:`, `🌐 Endpoint:`, `📝 Error:`, `⏱️ Elapsed:` and `💀 Final error:`. Those go through `_buffer_vprint` / `_vprint`, which `_flush_status_buffer` routes to `_vprint` → `_safe_print` → `_print_fn` (default `print`) → process stdout. The gateway never reassigns `_print_fn` for a session agent and never redirects stdout, so they cannot reach `_prepare_gateway_status_message`. Filtering them would be dead code, so this PR deliberately leaves them alone.

## Validation

| Check | Result |
|---|---|
| noise filter + delivery + `tests/run_agent/test_retry_status_buffer.py` | 270 passed, 0 failed |
| same files with only the 2 sibling regex alternatives reverted | 20 failed, 239 passed |
| `test_compression_progress_notices` + `test_turn_context_overflow_warning` + `test_compression_count_warning_36908` | 49 passed |
| `ruff check` on all 3 changed files | clean |
| `tests/gateway/` full run | 6727 passed, 26 failed, 18 skipped |

The 26 gateway failures are pre-existing on `main` (`delivery_ledger`, `whatsapp_bridge_pidfile`, `wecom_callback`, `scale_to_zero`, …). None of the 26 failing files reference `_prepare_gateway_status_message`, `_TELEGRAM_NOISY_STATUS_RE`, or any watchdog notice text (`grep -c` = 0 for each), so none are caused by this change.

## Context

Extracted from #9795 (closed as superseded by #96425). That branch bundled WeCom native streaming with unrelated fixes; this is the first of the focused resubmissions requested in the closing note. The WeCom-transport parts of #9795 are dropped — #96425 supersedes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
