### PR TITLE
fix(gateway): scope out-of-turn compression dedup reset to the live session task

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2721,7 +2721,16 @@ def compress_context(
         system_message: Current system prompt; used when compression needs a
             rebuilt cached prompt.
         approx_tokens: Pre-compression token estimate, logged for ops.
-        task_id: Tool task scope (used for clearing file-read dedup state).
+        task_id: Tool task scope the post-compaction dedup reset applies to
+            (``reset_file_dedup``/``reset_skill_view_dedup``). Gateway callers
+            MUST pass the live session row id — ``session_entry.session_id``,
+            the same task_id the main turn hands to ``run_conversation``: the
+            live turn records its tool-read dedup state under that id, and
+            resetting any other scope leaves those records pointing at pruned
+            context (#98206). ``None`` is not a valid scope here: both resets
+            treat it as "clear every task", which breaks concurrent-session
+            isolation. The ``"default"`` fallback is only correct for
+            non-gateway callers that have no per-session task scope.
         focus_topic: Optional focus string for guided compression — the
             summariser will prioritise preserving information related to
             this topic.  Inspired by Claude Code's ``/compact <focus>``.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20487,6 +20487,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             _hyg_msgs, "",
                                             approx_tokens=_approx_tokens,
                                             commit_fence=_hyg_commit_fence,
+                                            # The live turn's tool calls (and
+                                            # thus the skill_view/read_file dedup
+                                            # records) are scoped to the session
+                                            # row id — the same value the main
+                                            # turn passes as run_conversation's
+                                            # task_id. Reset under that key so a
+                                            # post-compression re-read returns
+                                            # full content instead of a dedup
+                                            # stub pointing at pruned context
+                                            # (#98206); the "default" task
+                                            # fallback clears nothing here.
+                                            task_id=session_entry.session_id,
                                         ),
                                     )
                                     try:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4658,6 +4658,13 @@ class GatewaySlashCommandsMixin:
                         focus_topic=focus_topic,
                         force=True,
                         defer_context_engine_notification=True,
+                        # Scope the dedup reset to the live session row id —
+                        # the same task_id the main gateway turn passes to
+                        # run_conversation. Without it the reset falls back to
+                        # the "default" task and a post-compression skill_view
+                        # can return a dedup stub pointing at pruned context
+                        # (#98206).
+                        task_id=session_entry.session_id,
                     )
                 )
 

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -102,6 +102,14 @@ async def test_compress_command_works_when_auto_compaction_disabled():
     assert "Compressed:" in result
     agent_instance._compress_context.assert_called_once()
     assert agent_instance._compress_context.call_args.kwargs.get("force") is True
+    # #98206: the live session row id must also ride along as task_id — the
+    # main gateway turn scopes tool dedup state (skill_view / read_file) to
+    # session_entry.session_id, so a manual compression that resets under the
+    # "default" fallback leaves the live session's dedup records in place and
+    # a post-compression skill_view returns a stub pointing at pruned context.
+    assert (
+        agent_instance._compress_context.call_args.kwargs.get("task_id") == "sess-1"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -235,9 +235,15 @@ async def test_session_hygiene_preserves_transcript_when_no_rotation(monkeypatch
             self._print_fn = None
             self.shutdown_memory_provider = MagicMock()
             self.close = MagicMock()
+            self.compress_task_id = None
             type(self).last_instance = self
 
         def _compress_context(self, messages, *_args, **_kwargs):
+            # Capture the task scope the gateway forwards (#98206): the dedup
+            # reset inside compress_context is only effective under the live
+            # session row id, the same task_id the main turn hands to
+            # run_conversation.
+            self.compress_task_id = _kwargs.get("task_id")
             # No session_db → cannot rotate: session_id is UNCHANGED, and this
             # is a failure-to-rotate, not an in-place success.
             return ([{"role": "assistant", "content": "summary only"}], None)
@@ -325,6 +331,12 @@ async def test_session_hygiene_preserves_transcript_when_no_rotation(monkeypatch
     assert result == "ok"
     # The transcript must NOT be rewritten — the original is preserved.
     runner.session_store.rewrite_transcript.assert_not_called()
+    # #98206: hygiene compaction must scope the dedup reset to the LIVE
+    # session row id ("sess-1" from this test's SessionEntry) — the same
+    # task_id the main turn passes to run_conversation. Under the "default"
+    # fallback the skill_view/read_file dedup records survive compression
+    # and a re-read returns a stub pointing at pruned context.
+    assert NonRotatingCompressAgent.last_instance.compress_task_id == "sess-1"
 
     # This run neither rotated nor compacted in place, so it did NOT recover
     # the session: the reset must NOT have been reached. Spying on the module

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -663,6 +663,81 @@ class TestDedupResetOnCompression(unittest.TestCase):
         # intercepted reads before they reached the counter
         self.assertNotIn("error", r3)
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_reset_is_scoped_across_concurrent_sessions(self, mock_ops):
+        """Compressing session A must not invalidate session B's dedup.
+
+        The gateway scopes each live turn's read dedup to its session row id
+        and forwards that id as compress_context(task_id=...) — the reset
+        must land on that scope only, even when repeated (out-of-turn /compress
+        followed by the hygiene sweep).
+        """
+        mock_ops.return_value = _make_fake_ops(
+            content="original content\n", file_size=18,
+        )
+        # Two concurrent sessions have both read the same file.
+        read_file_tool(self._tmpfile, task_id="sess-A")
+        read_file_tool(self._tmpfile, task_id="sess-B")
+        r_b_stub = json.loads(read_file_tool(self._tmpfile, task_id="sess-B"))
+        self.assertTrue(r_b_stub.get("dedup"), "B should dedup before any reset")
+
+        # Out-of-turn compression of session A resets only A's scope; a
+        # repeated reset (hygiene sweep after /compress) stays scoped too.
+        reset_file_dedup("sess-A")
+        reset_file_dedup("sess-A")
+
+        r_a = json.loads(read_file_tool(self._tmpfile, task_id="sess-A"))
+        self.assertNotEqual(r_a.get("dedup"), True,
+                            "A's post-compression read must return full content")
+        # B's records must survive untouched. Asserting the tracker directly:
+        # a third B read would hit the stub-loop guard (#15759), which is a
+        # different contract from scope isolation.
+        task_b = _read_tracker.get("sess-B")
+        self.assertTrue(
+            task_b and task_b.get("dedup"),
+            "B's dedup records must survive A's scoped reset — no "
+            "cross-session dedup invalidation")
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_rotated_scope_starts_fresh_after_reset(self, mock_ops):
+        """A rotated session's new row id must not inherit the old row's stub.
+
+        After rotation the next turn records under a brand-new row id; the
+        out-of-turn compression reset cleared the old row's records, and no
+        stale stub may follow the session into the new row.
+        """
+        mock_ops.return_value = _make_fake_ops(
+            content="original content\n", file_size=18,
+        )
+        read_file_tool(self._tmpfile, task_id="row-old")
+
+        # Out-of-turn compression resets the live (old) row's records.
+        reset_file_dedup("row-old")
+
+        # Rotation: the next turn reads under the brand-new row id.
+        r_new = json.loads(read_file_tool(self._tmpfile, task_id="row-new"))
+        self.assertNotEqual(r_new.get("dedup"), True,
+                            "new row id must not see the old row's dedup stub")
+        self.assertIn("content", r_new)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_bare_reset_clears_all_scopes_for_non_gateway_callers(self, mock_ops):
+        """reset_file_dedup() with no scope keeps the non-gateway fallback:
+        clear every task's records at once."""
+        mock_ops.return_value = _make_fake_ops(
+            content="original content\n", file_size=18,
+        )
+        read_file_tool(self._tmpfile, task_id="ng-1")
+        read_file_tool(self._tmpfile, task_id="ng-2")
+
+        reset_file_dedup()
+
+        for task in ("ng-1", "ng-2"):
+            r = json.loads(read_file_tool(self._tmpfile, task_id=task))
+            self.assertNotEqual(r.get("dedup"), True,
+                                f"task {task} must read full content after a "
+                                f"bare reset")
+
 
 # ---------------------------------------------------------------------------
 # Large-file hint

--- a/tests/tools/test_skill_view_dedup.py
+++ b/tests/tools/test_skill_view_dedup.py
@@ -92,3 +92,42 @@ class TestSkillViewDedup:
         # conversation_compression imports this lazily; keep the seam stable.
         from tools.skills_tool import reset_skill_view_dedup as f
         f(None)
+
+    def test_reset_is_scoped_across_concurrent_sessions(self, skills_home):
+        """Compressing session A must not invalidate session B's dedup (#98206).
+
+        The gateway forwards the live session row id as compress_context's
+        task_id, so an out-of-turn compression (repeated: /compress then the
+        hygiene sweep) clears only that session's records.
+        """
+        _view("demo-dedup-skill", task="sess-A")
+        _view("demo-dedup-skill", task="sess-B")
+        stub_b = _view("demo-dedup-skill", task="sess-B")
+        assert stub_b.get("dedup") is True
+
+        reset_skill_view_dedup("sess-A")
+        # Repeated reset stays scoped to A.
+        reset_skill_view_dedup("sess-A")
+
+        full_a = _view("demo-dedup-skill", task="sess-A")
+        assert "Step one" in full_a.get("content", "")
+        stub_b2 = _view("demo-dedup-skill", task="sess-B")
+        assert stub_b2.get("dedup") is True, (
+            "session B's unchanged view must stay deduped — no cross-session "
+            "dedup invalidation"
+        )
+
+    def test_rotated_scope_starts_fresh_after_reset(self, skills_home):
+        """A rotated session's new row id must not inherit the old row's stub.
+
+        The out-of-turn compression reset cleared the old row's records;
+        after rotation the next turn views under a brand-new row id and must
+        get full content, never a stub left over from the old row.
+        """
+        _view("demo-dedup-skill", task="row-old")
+
+        reset_skill_view_dedup("row-old")
+
+        fresh = _view("demo-dedup-skill", task="row-new")
+        assert fresh.get("dedup") is None
+        assert "Step one" in fresh.get("content", "")


### PR DESCRIPTION
## What does this PR do?

Fixes a post-compression lifecycle defect where `skill_view` (and `read_file`) could return an unchanged-content dedup stub referencing content that context compression had already pruned from model-visible context.

Root cause: the gateway's two out-of-turn compression entry points — the manual `/compress` command (`gateway/slash_commands.py`) and the session-hygiene sweep (`gateway/run.py`) — call `_compress_context` **without** `task_id`, so the dedup resets inside `compress_context` (`reset_skill_view_dedup` / `reset_file_dedup`) fall back to the "default" task scope. But live tool reads are keyed by `session_entry.session_id` — the same value the main gateway turn passes to `run_conversation` as its `task_id` (gateway/run.py: `_run_agent(session_id=session_entry.session_id)` → `TurnContext` → `task_id=ctx.session_id`). The fallback reset therefore clears nothing for the live session, and the next `skill_view` for an unchanged skill returns `content_returned: false` pointing at a `[SKILL_PRUNED]` placeholder.

This PR forwards `session_entry.session_id` on both entry points, scoping the reset to the same task key the live turn records dedup state under.

Note on the task key: it must be the session **row id** (`session_entry.session_id`, e.g. `20260829_231501_ab12cd34` per `_get_or_create_session_impl`), not the session *key* (`agent:main:telegram:group:...`). The session key never reaches `run_conversation`'s `task_id` on the live path, so resetting under it would miss the live records in the same way "default" does.

Both compression outcomes stay correct: on an **in-place** compaction the session id is unchanged, so the reset now actually clears the live records (this is the fix); on a **rotated** compaction the reset clears the old id's records (harmless) while the next turn starts under a fresh id that has no records to hit.

Credit: the task-ID hypothesis in #98206 was independently confirmed by @0xble (who could not open a cross-repo PR); this PR forwards `session_entry.session_id` rather than the session key for the reason above.

## Related Issue

Fixes #98206

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — hygiene sweep: pass `task_id=session_entry.session_id` to `_hyg_agent._compress_context` (was falling back to "default").
- `gateway/slash_commands.py` — `/compress` handler: pass `task_id=session_entry.session_id` to `tmp_agent._compress_context` (same fallback).
- `tests/gateway/test_compress_command.py` — extend the existing full-path `/compress` regression to assert the live session id rides along as `task_id`.
- `tests/gateway/test_session_hygiene.py` — extend the existing full-path hygiene regression (`_handle_message`) to capture and assert the forwarded `task_id`.

## How to Test

1. `python3 -m pytest tests/gateway/test_compress_command.py tests/gateway/test_session_hygiene.py tests/tools/test_skill_view_dedup.py tests/gateway/test_compress_focus.py -q` — Observed result: **34 passed**.
2. Fail-before check: with the two source changes stashed (tests kept), both regressions fail on `assert kwargs.get('task_id') == 'sess-1'` / the captured-task assertion; with the fix restored they pass.
3. `ruff check gateway/run.py gateway/slash_commands.py tests/gateway/test_compress_command.py tests/gateway/test_session_hygiene.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (behavioral fix covered by the regressions above).
