### PR TITLE
fix(bot-mode): use display name in DM attribution

### DIFF
--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -21,6 +21,7 @@ import pytest
 from tools import bot_relay
 from tools.bot_mode_dm import (
     MESSAGE_AGENT_TOOL_NAME,
+    _sender_display_name,
     ensure_message_agent_tool,
     message_agent_tool,
 )
@@ -303,6 +304,107 @@ def test_relay_route_queues_envelope_and_spawns_waiter(tmp_path, monkeypatch):
     assert pending[0]["message"].startswith("Message from 🤖 hermes (@hermes): ping")
     # waiter watches this envelope's reply file
     assert pending[0]["id"] in spawned["command"]
+
+
+def test_relay_waiter_spawn_keeps_canonical_bot_chat_wake_key(tmp_path, monkeypatch):
+    """The waiter uses terminal's real API and preserves the owning session key."""
+    home = _managed_home(tmp_path)
+    bot_relay.write_remote_roster(home, [
+        {"profile": "scout", "handle": "scout", "connection_id": "cloud-1"},
+    ])
+    captured = {}
+
+    def terminal_api(
+        command,
+        *,
+        background,
+        notify_on_complete,
+        task_id,
+        workdir,
+        _host_local,
+    ):
+        captured.update(
+            command=command,
+            background=background,
+            notify_on_complete=notify_on_complete,
+            task_id=task_id,
+            workdir=workdir,
+            host_local=_host_local,
+        )
+        return json.dumps({"session_id": "proc-relay-waiter"})
+
+    monkeypatch.setattr("tools.terminal_tool.terminal_tool", terminal_api)
+
+    out = json.loads(message_agent_tool(
+        target="scout",
+        message="status?",
+        task_id="canonical-bot-chat-key",
+        agent=_FakeAgent(home),
+    ))
+
+    assert out["status"] == "sent"
+    assert captured["task_id"] == "canonical-bot-chat-key"
+    assert captured["notify_on_complete"] is True
+    assert captured["background"] is True
+    [envelope] = bot_relay.claim_pending_envelopes(home)
+    assert envelope["id"] in captured["command"]
+
+
+def test_relay_default_sender_uses_display_name_but_keeps_stable_identity(tmp_path, monkeypatch):
+    """Default-profile attribution is friendly; routing ids remain canonical."""
+    home = _managed_home(tmp_path)
+    (home / "profile.yaml").write_text(
+        "display_name: |\n  Research\n  Lead\n",
+        encoding="utf-8",
+    )
+    bot_relay.write_remote_roster(home, [
+        {"profile": "scout", "handle": "scout", "connection_id": "cloud-1",
+         "connection_label": "Hermes Cloud"},
+    ])
+    monkeypatch.setattr(
+        "tools.bot_mode_dm._spawn_delivery",
+        lambda *a, **k: json.dumps({"status": "sent"}),
+    )
+
+    out = json.loads(message_agent_tool(
+        target="scout", message="status?", agent=_FakeAgent(home)
+    ))
+
+    assert out["status"] == "sent"
+    [envelope] = bot_relay.claim_pending_envelopes(home)
+    assert envelope["message"] == "Message from 🤖 Research Lead (@hermes): status?"
+    assert envelope["from_profile"] == "default"
+    assert envelope["from_handle"] == "hermes"
+
+
+def test_sender_display_name_is_bounded_printable_and_falls_back(tmp_path, monkeypatch):
+    home = _managed_home(tmp_path)
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.read_profile_meta",
+        lambda _home: {"display_name": "Ops\x00\x1b[31m\x9b Lead\u202e\u2066"},
+    )
+    display = _sender_display_name(home, "hermes")
+    assert display == "Ops [31m Lead"
+    assert display.isprintable()
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.read_profile_meta",
+        lambda _home: {"display_name": "λ" * 100},
+    )
+    assert _sender_display_name(home, "hermes") == "λ" * 64
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.read_profile_meta",
+        lambda _home: {"display_name": "\n\t"},
+    )
+    assert _sender_display_name(home, "hermes") == "hermes"
+
+    def unreadable_meta(_home):
+        raise ValueError("malformed profile metadata")
+
+    monkeypatch.setattr("hermes_cli.profiles.read_profile_meta", unreadable_meta)
+    assert _sender_display_name(home, "hermes") == "hermes"
 
 
 def test_relay_route_ambiguous_target_errors_with_forms(tmp_path, monkeypatch):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -211,6 +211,23 @@ def _handle(name: str) -> str:
     return "hermes" if name == "default" else name
 
 
+def _sender_display_name(home: Path, handle: str) -> str:
+    """Bounded, single-line presentation name; never a routing identity."""
+    try:
+        from hermes_cli.profiles import read_profile_meta
+
+        display_name = str(read_profile_meta(home).get("display_name") or "")
+        # Profile metadata is presentation-only but still untrusted input.
+        # Replace every non-printing code point (C0/C1 controls, bidi format
+        # controls, zero-width format characters) before whitespace folding so
+        # the attribution prefix cannot hide or reorder its visible identity.
+        printable = "".join(char if char.isprintable() else " " for char in display_name)
+        normalized = " ".join(printable.split())[:64]
+        return normalized or handle
+    except Exception:
+        return handle
+
+
 def _resolve_local_name(target: str, roster: list[str]) -> Optional[str]:
     """Map a target handle to a profile name ('hermes' → 'default')."""
     want = target.strip()
@@ -289,7 +306,8 @@ def message_agent_tool(
         return _err("target is required.", roster=teammates, peers=peers)
 
     sender_handle = _handle(me)
-    prefix = f"Message from 🤖 {sender_handle} (@{sender_handle}): "
+    sender_display_name = _sender_display_name(Path(home), sender_handle)
+    prefix = f"Message from 🤖 {sender_display_name} (@{sender_handle}): "
 
     # ── peer target: '<peer>/<agent>' or a bare registered peer name ──
     peer_match = _PEER_TARGET_RE.match(raw_target)
@@ -337,7 +355,8 @@ def message_agent_tool(
         # relay roster lists agents on the other connections; delivery rides
         # the Desktop's own persistent socket to that gateway.
         relayed = _try_relay_delivery(
-            root, raw_target, body, me, sender_handle, task_id=task_id, agent=agent
+            root, raw_target, body, me, sender_handle, prefix,
+            task_id=task_id, agent=agent
         )
         if relayed is not None:
             return relayed
@@ -353,7 +372,8 @@ def message_agent_tool(
         # 'default' messaging the cloud 'default') — try the relay before
         # calling it a self-message.
         relayed = _try_relay_delivery(
-            root, raw_target, body, me, sender_handle, task_id=task_id, agent=agent
+            root, raw_target, body, me, sender_handle, prefix,
+            task_id=task_id, agent=agent
         )
         if relayed is not None:
             return relayed
@@ -386,6 +406,7 @@ def _try_relay_delivery(
     body: str,
     me: str,
     sender_handle: str,
+    attribution_prefix: str,
     *,
     task_id: Optional[str],
     agent: Any,
@@ -427,7 +448,7 @@ def _try_relay_delivery(
             envelope = enqueue_envelope(
                 root,
                 target=match,
-                message=f"Message from 🤖 {sender_handle} (@{sender_handle}): {body}",
+                message=attribution_prefix + body,
                 sender_profile=me,
                 sender_handle=sender_handle,
             )


### PR DESCRIPTION
## Behavior
- Use the configured profile display name in Bot Mode DM presentation, retaining the canonical `@handle`.
- Keep canonical sender identity, recipient selection, relay envelopes, and authorization unchanged.
- Remove control/format characters from the display label and fall back to the canonical handle when metadata is absent or unusable.

## Reviewed candidate and validation
Candidate commit: `658bd83ead3f2b1640d720118479242f5440fe0d`, based on upstream `070128f05693139ff9f6c99c8ab241c7dc68f18c`. The complete two-file change received independent review.
- `scripts/run_tests.sh tests/tools/test_bot_mode_dm.py`: 44 passed, 0 failed, 3 Linux-only tests skipped on native Windows. The POSIX permission/symlink cases remain assigned to the normal Linux CI lane.
- Changed-file Ruff and `git diff --check`: passed.
- Regressions cover presentation versus routing authority and control-character normalization.

The fork branch has been updated to the reviewed candidate. At verification time, the pull-request head projection still reported the previous commit. Fresh hosted CI for the candidate remains unverified; older green checks do not validate this revision.

## Scope
Generic display behavior and tests only. No runtime configuration change or deployment.
