### PR TITLE
fix(skills): hard-exclude .library cold-storage dir and close .archive leak paths

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -75,9 +75,13 @@ def _category(fm: dict[str, Any], skill_md: Path) -> str:
 
 
 def _iter_skill_files(roots: list[tuple[str, Path]]):
+    from agent.skill_utils import is_excluded_skill_path
+
     for source, root in roots:
         if root.exists():
             for path in root.rglob("SKILL.md"):
+                if is_excluded_skill_path(path):
+                    continue
                 yield source, path
 
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -1233,6 +1233,16 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
             if d not in EXCLUDED_SKILL_DIRS
             and not (has_skill_md and d in SKILL_SUPPORT_DIRS)
         ]
+        # Symlink-aware exclusion: os.walk(followlinks=True) yields the
+        # symlink's lexical path, not the target's. A symlink whose target
+        # lives inside .archive/.library passes the lexical filter above.
+        # Check the resolved root to close this leak.
+        try:
+            resolved = Path(root).resolve()
+            if any(part in EXCLUDED_SKILL_DIRS for part in resolved.parts):
+                continue
+        except OSError:
+            pass
         if filename in files:
             matches.append(os.path.join(root, filename))
     for path in sorted(matches):

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -31,6 +31,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".github",
         ".hub",
         ".archive",
+        ".library",
         ".venv",
         "venv",
         "node_modules",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15196,7 +15196,11 @@ def _disable_unselected_skills(profile_dir: Path, keep: List[str]) -> int:
         installed: List[str] = []
         skills_root = profile_dir / "skills"
         if skills_root.is_dir():
+            from agent.skill_utils import is_excluded_skill_path
+
             for md in skills_root.rglob("SKILL.md"):
+                if is_excluded_skill_path(md):
+                    continue  # .archive/.library/... contents are not installed skills
                 installed.append(md.parent.name)
         cfg = load_config()
         disabled = get_disabled_skills(cfg)

--- a/tests/tools/test_skill_exclusion_hardening.py
+++ b/tests/tools/test_skill_exclusion_hardening.py
@@ -104,6 +104,28 @@ class TestSkillViewExcludedByName:
         )
         assert result["success"] is False
 
+    def test_symlink_into_excluded_dir_not_indexed(self, fake_skills, tmp_path):
+        """A symlink whose target lives inside an excluded dir is not indexed.
+
+        os.walk(followlinks=True) yields the symlink's lexical path, which does
+        not contain the excluded dir name. iter_skill_index_files now checks
+        the resolved root to close this leak.
+        """
+        link = tmp_path / "skills" / "linked-archived"
+        link.symlink_to(fake_skills["archived"])
+        found = [p.parent.name for p in iter_skill_index_files(tmp_path / "skills", "SKILL.md")]
+        assert "linked-archived" not in found
+
+    def test_excluded_name_shadowing_active_skill(self, fake_skills):
+        """An excluded skill with the same name as an active skill does not shadow it."""
+        # Create a same-named skill inside .library
+        shadow = fake_skills["skills_dir"] / ".library" / "shadow" / "active-skill"
+        shadow.mkdir(parents=True)
+        (shadow / "SKILL.md").write_text("---\nname: active-skill\n---\n# Shadow\n")
+        result = json.loads(skill_view("active-skill"))
+        assert result["success"] is True
+        assert "Active" in result.get("content", "")
+
 
 class TestLegacyScanGuards:
     def test_learning_graph_ignores_hidden_storage(self, fake_skills, monkeypatch):

--- a/tests/tools/test_skill_exclusion_hardening.py
+++ b/tests/tools/test_skill_exclusion_hardening.py
@@ -1,0 +1,117 @@
+"""Tests for hard-exclusion of hidden skill storage dirs (`.library`, `.archive`).
+
+Regression coverage for the discovery-exclusion hardening surfaced by issue
+#35800: dot-prefixed cold-storage dirs must be invisible to skill discovery,
+name resolution, and legacy rglob scans — and `skill_view` must not read a
+parked/archived skill by name.
+
+Explicit-path reads (`skill_view` with the full relative path inside an
+excluded dir) remain allowed: previewing a parked skill's SKILL.md before
+deciding to restore it is a legitimate workflow (`hermes curator restore`).
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent.skill_utils import is_excluded_skill_path, iter_skill_index_files
+from tools.skills_tool import skill_view
+
+
+@pytest.fixture()
+def fake_skills(tmp_path):
+    """Skills dir with an active skill, an archived skill, and a library skill."""
+    skills_dir = tmp_path / "skills"
+    active = skills_dir / "active-skill"
+    active.mkdir(parents=True)
+    (active / "SKILL.md").write_text("---\nname: active-skill\n---\n# Active\n")
+
+    archived = skills_dir / ".archive" / "2026-08" / "archived-skill"
+    archived.mkdir(parents=True)
+    (archived / "SKILL.md").write_text("---\nname: archived-skill\n---\n# Archived\n")
+
+    library = skills_dir / ".library" / "creative" / "parked-skill"
+    library.mkdir(parents=True)
+    (library / "SKILL.md").write_text("---\nname: parked-skill\n---\n# Parked\n")
+
+    # A legacy flat file parked in the library too.
+    (skills_dir / ".library" / "legacy-note.md").write_text("# legacy note\n")
+
+    with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+        yield {
+            "skills_dir": skills_dir,
+            "active": active,
+            "archived": archived,
+            "library": library,
+        }
+
+
+class TestExclusionMembership:
+    def test_library_is_excluded_dir(self):
+        from agent.skill_utils import EXCLUDED_SKILL_DIRS
+
+        assert ".library" in EXCLUDED_SKILL_DIRS
+
+    def test_is_excluded_skill_path_flags_library_and_archive(self, fake_skills):
+        sd = fake_skills["skills_dir"]
+        assert is_excluded_skill_path(sd / ".library" / "creative" / "parked-skill" / "SKILL.md") is True
+        assert is_excluded_skill_path(sd / ".archive" / "archived-skill" / "SKILL.md") is True
+        assert is_excluded_skill_path(sd / "active-skill" / "SKILL.md") is False
+
+
+class TestIndexInvisibility:
+    def test_iter_skill_index_files_skips_hidden_storage(self, fake_skills):
+        found = [p.parent.name for p in iter_skill_index_files(fake_skills["skills_dir"], "SKILL.md")]
+        assert "active-skill" in found
+        assert "archived-skill" not in found
+        assert "parked-skill" not in found
+
+
+class TestSkillViewExcludedByName:
+    def test_archived_skill_not_resolved_by_bare_name(self, fake_skills):
+        result = json.loads(skill_view("archived-skill"))
+        assert result["success"] is False
+
+    def test_parked_library_skill_not_resolved_by_bare_name(self, fake_skills):
+        result = json.loads(skill_view("parked-skill"))
+        assert result["success"] is False
+
+    def test_flat_md_in_library_not_resolved_by_name(self, fake_skills):
+        result = json.loads(skill_view("legacy-note"))
+        assert result["success"] is False
+
+    def test_active_skill_still_resolves(self, fake_skills):
+        result = json.loads(skill_view("active-skill"))
+        assert result["success"] is True
+
+    def test_explicit_relative_path_still_previews(self, fake_skills):
+        """Explicit-path reads stay allowed: preview-before-restore workflow."""
+        result = json.loads(skill_view(".archive/2026-08/archived-skill"))
+        assert result["success"] is True
+        assert "Archived" in result.get("content", "")
+
+    def test_skill_view_file_path_restricted_inside_excluded_dir(self, fake_skills):
+        """file_path within an explicitly-addressed excluded skill stays inside it."""
+        result = json.loads(
+            skill_view(".archive/2026-08/archived-skill", file_path="../.env")
+        )
+        assert result["success"] is False
+
+
+class TestLegacyScanGuards:
+    def test_learning_graph_ignores_hidden_storage(self, fake_skills, monkeypatch):
+        """agent.learning_graph._iter_skill_files must not yield excluded paths."""
+        from agent import learning_graph
+
+        roots = [("local", fake_skills["skills_dir"])]
+        yielded = [path.name for _, path in learning_graph._iter_skill_files(roots)]
+        # Only the active skill's SKILL.md is yielded (excluded dirs pruned).
+        assert yielded.count("SKILL.md") == 1
+
+    def test_blueprints_lookup_ignores_hidden_storage(self, fake_skills):
+        """tools.blueprints skill lookup must not match inside excluded dirs."""
+        from tools import blueprints
+
+        spec = blueprints.blueprint_spec_for_installed("archived-skill")
+        assert spec is None

--- a/tests/tools/test_skill_exclusion_hardening.py
+++ b/tests/tools/test_skill_exclusion_hardening.py
@@ -91,6 +91,12 @@ class TestSkillViewExcludedByName:
         assert result["success"] is True
         assert "Archived" in result.get("content", "")
 
+    def test_root_excluded_dir_names_not_resolved(self, fake_skills):
+        """The excluded dirs themselves are not addressable as bare names."""
+        for bare in (".archive", ".library"):
+            result = json.loads(skill_view(bare))
+            assert result["success"] is False, bare
+
     def test_skill_view_file_path_restricted_inside_excluded_dir(self, fake_skills):
         """file_path within an explicitly-addressed excluded skill stays inside it."""
         result = json.loads(

--- a/tools/blueprints.py
+++ b/tools/blueprints.py
@@ -154,7 +154,14 @@ def blueprint_spec_for_installed(skill_name: str) -> Optional[BlueprintSpec]:
 
     base = Path(SKILLS_DIR)
     # Skills live at skills/<category>/<name>/SKILL.md or skills/<name>/SKILL.md.
-    candidates = list(base.glob(f"**/{skill_name}/SKILL.md"))
+    # Excluded storage dirs (.archive/.library/...) are never blueprint sources.
+    from agent.skill_utils import is_excluded_skill_path
+
+    candidates = [
+        p
+        for p in base.glob(f"**/{skill_name}/SKILL.md")
+        if not is_excluded_skill_path(p)
+    ]
     for path in candidates:
         try:
             text = path.read_text(encoding="utf-8")

--- a/tools/skills_sync_client.py
+++ b/tools/skills_sync_client.py
@@ -533,6 +533,10 @@ def _all_local_skill_names() -> List[str]:
         for skill_md in root.rglob("SKILL.md"):
             if skill_md.is_symlink():
                 continue
+            from agent.skill_utils import is_excluded_skill_path
+
+            if is_excluded_skill_path(skill_md):
+                continue  # .archive/.library/... are not syncable installed skills
             name: Optional[str] = None
             try:
                 from tools.skill_usage import _read_skill_name
@@ -1712,6 +1716,10 @@ def list_org_skill_names() -> List[str]:
             return names
         for skill_md in root.rglob("SKILL.md"):
             rel = skill_md.parent.relative_to(root)
+            from agent.skill_utils import is_excluded_skill_path
+
+            if is_excluded_skill_path(skill_md):
+                continue  # .archive/.library/... are not org-shared skills
             if rel.parts:
                 names.append(str(rel).replace("\\", "/"))
     except Exception as e:

--- a/tools/skills_sync_client.py
+++ b/tools/skills_sync_client.py
@@ -530,11 +530,11 @@ def _all_local_skill_names() -> List[str]:
     try:
         if not root.exists():
             return []
+        from agent.skill_utils import is_excluded_skill_path
+
         for skill_md in root.rglob("SKILL.md"):
             if skill_md.is_symlink():
                 continue
-            from agent.skill_utils import is_excluded_skill_path
-
             if is_excluded_skill_path(skill_md):
                 continue  # .archive/.library/... are not syncable installed skills
             name: Optional[str] = None
@@ -1714,10 +1714,10 @@ def list_org_skill_names() -> List[str]:
         root = _org_dir() / org_id
         if not root.is_dir():
             return names
+        from agent.skill_utils import is_excluded_skill_path
+
         for skill_md in root.rglob("SKILL.md"):
             rel = skill_md.parent.relative_to(root)
-            from agent.skill_utils import is_excluded_skill_path
-
             if is_excluded_skill_path(skill_md):
                 continue  # .archive/.library/... are not org-shared skills
             if rel.parts:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1285,8 +1285,9 @@ def skill_view(
 
         # Explicit-path lookups (e.g. ".archive/2026-08/old-skill") may address
         # excluded storage dirs for one-off previews; bare names never resolve
-        # into excluded dirs (.archive/.library/...).
-        _explicit_lookup = "/" in name or "\\" in name or name.startswith(".")
+        # into excluded dirs (.archive/.library/...). A path separator is what
+        # makes a lookup "explicit" — a bare dot-prefixed name is still a name.
+        _explicit_lookup = "/" in name or "\\" in name
 
         for search_dir in all_dirs:
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -84,6 +84,7 @@ from utils import env_var_enabled
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS,
     is_skill_support_path as _is_skill_support_path,
+    is_excluded_skill_path as _is_excluded_skill_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -1282,18 +1283,28 @@ def skill_view(
             seen_md.add(key)
             candidates.append((sd, smd))
 
+        # Explicit-path lookups (e.g. ".archive/2026-08/old-skill") may address
+        # excluded storage dirs for one-off previews; bare names never resolve
+        # into excluded dirs (.archive/.library/...).
+        _explicit_lookup = "/" in name or "\\" in name or name.startswith(".")
+
         for search_dir in all_dirs:
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
-            # at the top of the dir).
+            # at the top of the dir). Excluded storage dirs are not addressable
+            # by NAME; only an explicit path into them previews content.
             direct_path = search_dir / name
             if (
-                not _is_skill_support_path(direct_path)
+                (
+                    not _is_excluded_skill_path(direct_path)
+                    or _explicit_lookup
+                )
                 and direct_path.is_dir()
                 and (direct_path / "SKILL.md").exists()
             ):
                 _record(direct_path, direct_path / "SKILL.md")
-            elif direct_path.with_suffix(".md").exists() and not _is_skill_support_path(
-                direct_path.with_suffix(".md")
+            elif direct_path.with_suffix(".md").exists() and (
+                not _is_excluded_skill_path(direct_path.with_suffix(".md"))
+                or _explicit_lookup
             ):
                 _record(None, direct_path.with_suffix(".md"))
 
@@ -1303,14 +1314,14 @@ def skill_view(
             if local_category_name:
                 categorized_path = search_dir / local_category_name
                 if (
-                    not _is_skill_support_path(categorized_path)
+                    not _is_excluded_skill_path(categorized_path)
                     and categorized_path.is_dir()
                     and (categorized_path / "SKILL.md").exists()
                 ):
                     _record(categorized_path, categorized_path / "SKILL.md")
                 elif categorized_path.with_suffix(
                     ".md"
-                ).exists() and not _is_skill_support_path(
+                ).exists() and not _is_excluded_skill_path(
                     categorized_path.with_suffix(".md")
                 ):
                     _record(None, categorized_path.with_suffix(".md"))
@@ -1333,11 +1344,12 @@ def skill_view(
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
-            # Exclude skill support docs: references/templates/assets/scripts
-            # are loaded through skill_view(skill, file_path=...) and must not
-            # shadow or collide with real skills that share the same basename.
+            # Exclude skill support docs (references/templates/assets/scripts —
+            # loaded through skill_view(skill, file_path=...) and must not
+            # shadow real skills sharing the basename) AND excluded storage
+            # dirs (.archive/.library/...), which are not addressable by name.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md" and not _is_skill_support_path(
+                if found_md.name != "SKILL.md" and not _is_excluded_skill_path(
                     found_md
                 ):
                     _record(None, found_md)


### PR DESCRIPTION
## Summary

Hidden cold-storage skill dirs must be invisible to skill discovery. The exclusion mechanism is centralized in `EXCLUDED_SKILL_DIRS` (`agent/skill_utils.py`), but seven scan sites bypassed it with raw `rglob`/`glob` or direct-path joins — so `.archive` (the curator's recoverable archive) leaked through them, and a proposed `.library` cold-storage dir (issue #35800) would have leaked identically.

This diff:

- Adds `.library` to `EXCLUDED_SKILL_DIRS` so the layout proposed in #35800 is hard-excluded from day one.
- Closes the seven bypass sites so hidden storage dirs are excluded everywhere:
  - `tools/skills_tool.py` — `skill_view` resolution Strategies 1/1b/3 now consult `is_excluded_skill_path`. **Bare names never resolve into excluded dirs; explicit path addresses still resolve**, preserving the preview-before-restore workflow for archived/parked skills (`hermes curator restore` unaffected).
  - `agent/learning_graph.py` — rglob walk prunes excluded paths.
  - `tools/blueprints.py` — blueprint lookup ignores excluded dirs.
  - `hermes_cli/web_server.py` — profile skill-disable scan no longer counts archived/library skills as installed (prevents archived skill names from being written into the disabled set).
  - `tools/skills_sync_client.py` — installed-skill and org-mirror listings skip excluded storage contents.
- Leaves `tools/credential_files.py` unchanged intentionally: it is a security scanner enumerating symlinks/credentials — scanning excluded dirs is desired there.

## Design note: bare names vs explicit paths

The one behavior change: `skill_view("archived-skill")` for a skill parked under `.archive/`/`.library/` no longer resolves when a legacy flat `<name>.md` match is the only candidate, and bare excluded dir names (`.archive`, `.library`) are not addressable. Explicit relative paths (`.archive/2026-08/old-skill`) still resolve, so an agent or user can preview a parked skill's `SKILL.md` before deciding to restore it. This split was flagged as a required condition in cross-vendor review of the approach (both reviewers conditioned the fix on preserving preview-before-restore).

## Testing

- New `tests/tools/test_skill_exclusion_hardening.py` (12 tests): RED-first (6 failed pre-fix, exactly the leak paths), all pass post-fix. Covers frozenset membership, index invisibility, bare-name resolution refusal (including bare `.archive`/`.library`), flat-md leaks, explicit-path preview, traversal inside excluded dirs, learning-graph and blueprints scans.
- Targeted regression: `test_skill_view_traversal`, `test_skill_view_path_check`, `test_skill_view_dedup`, `test_skill_utils`, `test_blueprints`, `test_learning_graph`(+render), `test_skills_sync`, `test_skills_sync_client`, `test_skills_tool`, `test_curator_archive_prune`, `test_curator_run` — 158 passed.

## Notes

The same hardening closes the `.archive` leak paths that issue #35800 identified ("`.archive` still leaks in some discovery paths"), so the librarian/cold-storage proposal there has a correct foundation. The librarian/compactor design discussion itself is larger than this diff and tracked on the issue.

Open question: should `skill_view`'s explicit-path preview inside excluded dirs eventually require an opt-in flag rather than being always available? Deferred as a UX decision — current behavior preserves the existing curator workflow.
