### PR TITLE
fix(desktop): strip custom: prefix from provider label in UI

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -11,7 +11,7 @@ import { releaseTypingFocus } from '@/components/ui/keyboard-first'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { ChevronDown } from '@/lib/icons'
-import { formatModelStatusLabel } from '@/lib/model-status-label'
+import { formatModelStatusLabel, displayProviderName } from '@/lib/model-status-label'
 import { cn } from '@/lib/utils'
 import { $currentModelSource, $defaultReasoningEffort, setModelPickerOpen } from '@/store/session'
 
@@ -127,8 +127,9 @@ export function ModelPill({
       )
     : PILL
 
-  const baseTitle = currentProvider
-    ? copy.modelTitle(currentProvider, currentModel || copy.modelNone)
+  const providerLabel = displayProviderName(currentProvider)
+  const baseTitle = providerLabel
+    ? copy.modelTitle(providerLabel, currentModel || copy.modelNone)
     : copy.switchModel
 
   const title = pinnedOverride ? `${baseTitle} — ${copy.modelPinned}` : baseTitle

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useI18n } from '@/i18n'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { modelSearchText } from '@/lib/model-search-text'
-import { currentPickerSelection } from '@/lib/model-status-label'
+import { currentPickerSelection, displayProviderName } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
 import type { ModelOptionProvider, ModelPricing } from '@/types/hermes'
 
@@ -102,7 +102,9 @@ export function ModelPickerDialog({
           <DialogTitle>{copy.title}</DialogTitle>
           <DialogDescription className="font-mono text-xs leading-relaxed">
             {copy.current} {optionsModel || currentModel || copy.unknown}
-            {optionsProvider || currentProvider ? ` · ${optionsProvider || currentProvider}` : ''}
+            {displayProviderName(optionsProvider || currentProvider)
+              ? ` · ${displayProviderName(optionsProvider || currentProvider)}`
+              : ''}
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { currentPickerSelection, displayModelName, formatModelStatusLabel } from './model-status-label'
+import { currentPickerSelection, displayModelName, displayProviderName, formatModelStatusLabel } from './model-status-label'
 import { reasoningEffortLabel } from './reasoning-effort'
 
 describe('model-status-label', () => {
@@ -68,6 +68,30 @@ describe('model-status-label', () => {
 
     it('falls back to the store while options are still loading', () => {
       expect(currentPickerSelection(store, undefined)).toEqual(store)
+    })
+  })
+
+  describe('displayProviderName', () => {
+    it('strips the custom:<key> wrapper to the config key', () => {
+      expect(displayProviderName('custom:yjs_github_artur')).toBe('yjs_github_artur')
+      expect(displayProviderName('custom:anymodel')).toBe('anymodel')
+    })
+
+    it('drops the bare "custom" token — corrupt state with no recoverable name', () => {
+      expect(displayProviderName('custom')).toBe('')
+      expect(displayProviderName('CUSTOM')).toBe('')
+      expect(displayProviderName(' Custom ')).toBe('')
+    })
+
+    it('passes canonical provider slugs through unchanged', () => {
+      expect(displayProviderName('openai-codex')).toBe('openai-codex')
+      expect(displayProviderName('kimi-coding')).toBe('kimi-coding')
+      expect(displayProviderName('anthropic')).toBe('anthropic')
+    })
+
+    it('collapses empty and whitespace-only input to empty', () => {
+      expect(displayProviderName('')).toBe('')
+      expect(displayProviderName('   ')).toBe('')
     })
   })
 })

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -95,6 +95,39 @@ export function displayModelName(model: string): string {
   return modelDisplayParts(model).name
 }
 
+/** Human-readable provider label.
+ *
+ *  Identity format for custom providers is ``custom:<config-key>`` (see
+ *  ``hermes_cli.runtime_provider.canonical_custom_identity``); the legacy
+ *  spellings are the bare key and plain ``custom``. The composer pill and the
+ *  picker dialog feed raw runtime state into a user-facing label, so without
+ *  a normalizer they show the protocol token (``custom``) instead of the
+ *  provider the user actually configured (#custom-provider-label).
+ *
+ *  Behavior:
+ *  - ``custom:<key>`` → ``<key>`` (the config key IS the user-facing name).
+ *  - the bare ``custom`` → empty string. That's corrupt state from a known
+ *    backend bug where the canonical identity was lost; showing the word
+ *    "custom" carries zero information, so callers should fall back to
+ *    their no-provider wording.
+ *  - everything else (canonical provider slugs like ``openai-codex``) is
+ *    returned trimmed and unchanged.
+ */
+export function displayProviderName(provider: string): string {
+  const raw = String(provider || '').trim()
+  if (!raw) {
+    return ''
+  }
+  const lower = raw.toLowerCase()
+  if (lower === 'custom') {
+    return ''
+  }
+  if (lower.startsWith('custom:')) {
+    return raw.slice('custom:'.length).trim()
+  }
+  return raw
+}
+
 /** Status bar trigger label — model name plus the live session state (effort/fast).
  *  `defaultEffort` is the profile's configured level, used when the surface has
  *  no explicit effort so the label never advertises a default the agent won't use. */


### PR DESCRIPTION
## Problem

When a custom provider is configured under the `providers:` key in ~/.hermes/config.yaml (e.g. `providers: yjs_github_artur: {...}`), the backend canonicalises the identity to `custom:<config-key>` (see `hermes_cli/providers.py::canonical_custom_identity` and `custom_provider_aliases`). The Desktop UI then renders this raw string verbatim:

- The composer model-pill tooltip showed `Model · custom: <model-name>`
- The model-picker dialog header showed `Current: <model> · custom`

In the `model.options` catalog the same providers correctly display their config-key as the human-facing name (slug=`yjs_github_artur`, name=`yjs_github_artur`), so showing `custom` to the user is both inconsistent and uninformative — the user cannot tell \*which\* of their custom providers is active.

A second, related path `state.provider === 'custom'` (no key suffix) is documented in `hermes_cli/providers.py` as a known '*corrupt state from a prior model-switch bug*' and is already normalised / fallback-healed at the backend. The UI should never surface it.

## Fix

Add a tiny pure helper `displayProviderName()` next to the existing `displayModelName()` in `apps/desktop/src/lib/model-status-label.ts`:

- `custom:<key>` → `<key>` (the config key IS the user-facing name)
- bare `custom` → empty string (corrupt: don't surface a meaningless label, let the caller fall back to its no-provider rendering)
- anything else passes through unchanged

Wire it at the two places that render the current provider for the user:

1. `apps/desktop/src/app/chat/composer/model-pill.tsx` — the tooltip on the model pill next to the input.
2. `apps/desktop/src/components/model-picker.tsx` — the `Current: …` dialog description.

## Tests

4 new cases in `apps/desktop/src/lib/model-status-label.test.ts` cover:
- `custom:<key>` strips the prefix
- bare `custom` drops to empty
- empty / whitespace input stays empty
- regular slugs pass through unchanged (incl. `custom-foo` which has no colon)

```
$ npx vitest run src/lib/model-status-label.test.ts
Test Files  1 passed (1)
     Tests  15 passed (15)
```

## Notes

- No backend change required: gateway continues to send the canonical `custom:<key>` identity (necessary for aliasing in `model.options`), the UI just formats it.
- The fix is a pure display layer — it does not affect model selection, provider detection, or session state persistence.
- Follows the existing `displayModelName()` pattern in the same file, mirroring the conventions established there.
