### PR TITLE
fix(tools): keep compound-background rewrites parseable when a statement follows the &

### DIFF
--- a/tests/tools/test_terminal_compound_background.py
+++ b/tests/tools/test_terminal_compound_background.py
@@ -100,3 +100,44 @@ class TestEdgeCases:
 
     def test_tabs_between_tokens(self):
         assert rewrite("A\t&&\tB\t&") == "A\t&&\t{ B\t& }"
+
+
+class TestStatementAfterBackground:
+    """A statement after the `&` needs a separator after the closing `}`.
+
+    bash requires a list terminator before the next command: ``{ B & } echo``
+    is a hard syntax error (``syntax error near unexpected token 'echo'``),
+    which is exactly how the #98222 kernel-spawn template died — the
+    rewritten ``cd … && nohup … & echo PID:$!`` never returned a PID, so
+    every execute_code call on docker/ssh/modal fell off the persistent
+    kernel. ``{ B & }; echo`` parses and keeps ``$!`` pointing at B.
+    """
+
+    def test_kernel_spawn_shape_gains_separator(self):
+        cmd = (
+            "cd /tmp/hermes_rkernel_04dcca && "
+            "nohup env -i python3 kernel_runner.py > runner.log 2>&1 & "
+            "echo PID:$!"
+        )
+        assert rewrite(cmd) == (
+            "cd /tmp/hermes_rkernel_04dcca && "
+            "{ nohup env -i python3 kernel_runner.py > runner.log 2>&1 & }; "
+            "echo PID:$!"
+        )
+
+
+    def test_simple_command_tail_gains_separator(self):
+        assert rewrite("A && B & echo done") == "A && { B & }; echo done"
+
+
+    def test_newline_tail_already_separates(self):
+        assert rewrite("A && B &\nC") == "A && { B & }\nC"
+
+
+    def test_comment_tail_already_separates(self):
+        assert rewrite("A && B & # note") == "A && { B & } # note"
+
+
+    def test_rewrite_with_tail_stays_idempotent(self):
+        once = rewrite("A && B & echo PID:$!")
+        assert rewrite(once) == once

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1017,7 +1017,20 @@ def _rewrite_compound_background(command: str) -> str:
         suffix = result[amp_pos + 1 :]
         # `{` needs a trailing space in bash; the closing `}` needs to be
         # preceded by `;` or `&` — we're providing `&` from the backgrounding.
-        result = prefix + "{ " + middle + "& }" + suffix
+        # A statement following the `&` on the same line additionally needs a
+        # list separator after the `}`: bash rejects `{ B & } echo` outright
+        # while `{ B & }; echo` keeps `$!` pointing at the backgrounded B
+        # (#98222 — the kernel-spawn `cd … && nohup … & echo PID:$!` template
+        # died on this exact syntax error). Newlines, `;`, `&&`/`||`, pipes,
+        # and comments already separate statements, so only plain commands
+        # get the injected `;`.
+        separator_needed = False
+        tail = suffix.lstrip(" \t")
+        if tail and not tail.startswith(("\n", ";", "&", "|", "#")):
+            separator_needed = True
+        result = prefix + "{ " + middle + "& }" + (
+            "; " + tail if separator_needed else suffix
+        )
 
     return result
 


### PR DESCRIPTION
## What does this PR do?

`_rewrite_compound_background` rewrote `A && B &` into `A && { B & }` to avoid the subshell-wait process leak, but when a statement followed the `&` on the same line the output was `A && { B & } echo PID:$!` — a hard bash syntax error (`syntax error near unexpected token 'echo'`), because a brace group needs a list terminator (`;`, `&`, or a newline) before the next command.

The remote-kernel spawn template used by `execute_code` on Docker/SSH/Modal backends is exactly this shape (`cd … && nohup … & echo PID:$!`), so the rewritten command failed on every call: no PID came back, the persistent kernel never spawned, and every `execute_code` call silently fell back to the per-call interpreter path (no variable/import persistence, one interpreter startup per call, plus a repeated warning). The corruption applied to **any** user command of the form `A && B & C` on those backends, since the rewrite is the default for `Environment.execute()`.

The fix injects `; ` after the closing `}` only when a plain command follows the `&`. Newlines, `;`, `&&`/`||`, `|`, and `#` comments already separate statements (or would be double-terminated), so they pass through untouched. `$!` still points at the backgrounded command, preserving the `echo PID:$!` contract.

## Related Issue

Fixes #98222

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py` — `_rewrite_compound_background`: when the text after the backgrounding `&` starts a new plain command, splice `; ` in place of the intervening whitespace so the brace group is properly terminated; tail shapes that already separate statements (`\n`, `;`, `&`, `|`, `#`) keep the old pass-through.
- `tests/tools/test_terminal_compound_background.py` — new `TestStatementAfterBackground`: the #98222 kernel-spawn shape, a minimal `A && B & echo done`, newline/comment tails staying unmodified, and idempotence of the rewrite with a tail.

## How to Test

1. `pytest tests/tools/test_terminal_compound_background.py -q` — 20 passed (15 pre-existing + 5 new), all pre-existing expected outputs unchanged.
2. `pytest tests/tools/test_terminal_tool.py -q` — 10 passed (neighbor rewriter tests unaffected).
3. End-to-end proof of the reported failure:
   - Pre-fix shape `cd /tmp && { nohup sleep 5 >/dev/null 2>&1 & } echo PID:$!` under `bash -c` exits 2 with `syntax error near unexpected token 'echo'` — the exact error from the issue.
   - Post-fix rewrite of `cd /tmp && nohup sleep 5 >/dev/null 2>&1 & echo PID:$!` produces `cd /tmp && { nohup sleep 5 >/dev/null 2>&1 & }; echo PID:$!`, which exits 0, prints `PID:<pid>`, and `ps -p <pid>` confirms the backgrounded `sleep` is alive.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), bash 3.2/5.x

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
