### PR TITLE
fix(terminal): keep a statement after background & valid after brace-group rewrite (#98222)

### DIFF
--- a/tests/tools/test_terminal_compound_background_tail.py
+++ b/tests/tools/test_terminal_compound_background_tail.py
@@ -1,0 +1,108 @@
+"""Regression tests for #98222: a statement following the background `&`
+(`A && B & C`) must survive the brace-group rewrite as valid bash.
+
+Context: the rewriter turned `A && B &` into `A && { B & }` — correct when
+the `&` ends the list, but the source `&` was also the *terminator* for
+whatever followed it. `A && { B & } echo x` is a syntax error, so the
+remote-kernel spawn template (`... & echo PID:$!`) died on every Docker /
+SSH / Modal `execute_code` call. The fix emits `A && { B & } ; echo x`.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from tools.terminal_tool import _rewrite_compound_background as rewrite
+
+_BASH = shutil.which("bash")
+
+
+def _valid_bash(cmd: str) -> bool:
+    return subprocess.run(
+        ["bash", "-n", "-c", cmd], capture_output=True, text=True
+    ).returncode == 0
+
+
+needs_bash = pytest.mark.skipif(_BASH is None, reason="bash not available")
+
+
+class TestStatementAfterBackground:
+    """`A && B & C` — the `&` terminated BOTH the job and the list."""
+
+    def test_kernel_spawn_template_stays_valid(self):
+        cmd = (
+            "cd /tmp/x && nohup env A=B python3 kernel_runner.py "
+            "> /tmp/x/runner.log 2>&1 & echo PID:$!"
+        )
+        out = rewrite(cmd)
+        assert "PID:$!" in out
+        if _BASH:
+            assert _valid_bash(out), out
+
+    def test_echo_after_amp_gets_separator(self):
+        assert rewrite("A && B & echo done") == "A && { B & } ; echo done"
+
+    def test_or_chain(self):
+        assert rewrite("A || B & echo done") == "A || { B & } ; echo done"
+
+    def test_statement_with_chain_after_amp(self):
+        assert rewrite("A && B & C && D") == "A && { B & } ; C && D"
+
+    def test_pid_output_after_fix_is_numeric(self):
+        # Real runtime: the echo must print the backgrounded job's PID.
+        out = rewrite(
+            "true && sleep 45 >/dev/null 2>&1 & echo GOTPID:$!"
+        )
+        r = subprocess.run(
+            ["bash", "-c", out], capture_output=True, text=True, timeout=15
+        )
+        subprocess.run(
+            ["bash", "-c", "pkill -f 'sleep 45' 2>/dev/null; true"], timeout=10
+        )
+        token = next((t for t in r.stdout.split() if t.startswith("GOTPID:")), "")
+        assert token[7:].isdigit(), f"rc={r.returncode} out={r.stdout!r} err={r.stderr!r}"
+
+
+class TestEndOfListUnchanged:
+    """When nothing follows the `&`, the old output form must not change."""
+
+    def test_end_of_string(self):
+        assert rewrite("A && B &") == "A && { B & }"
+
+    def test_newline_after_amp(self):
+        assert rewrite("A && B &\nnext") == "A && { B & }\nnext"
+
+    def test_multiline_mixed(self):
+        cmd = "A && B & echo x\nC && D &"
+        assert rewrite(cmd) == "A && { B & } ; echo x\nC && { D & }"
+
+
+@needs_bash
+class TestRuntimeSemantics:
+    def test_background_does_not_block_shell(self):
+        # The original subshell-wait bug class must stay fixed.
+        out = rewrite("true && sleep 30 >/dev/null 2>&1 &")
+        subprocess.run(["bash", "-c", out], capture_output=True, timeout=8)
+        subprocess.run(
+            ["bash", "-c", "pkill -f 'sleep 30' 2>/dev/null; true"], timeout=10
+        )
+
+    def test_and_semantics_preserved_with_trailing_stmt(self):
+        # A fails -> B never starts, but the trailing echo still runs.
+        out = rewrite("false && sleep 97 >/dev/null 2>&1 & echo SKIPPED")
+        r = subprocess.run(
+            ["bash", "-c", out], capture_output=True, text=True, timeout=10
+        )
+        chk = subprocess.run(
+            ["bash", "-c", "pgrep -f 'sleep 97' || true"],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert r.stdout.strip() == "SKIPPED"
+        assert chk.stdout.strip() == ""
+
+
+class TestIdempotence:
+    def test_rewriter_output_is_fixed_point(self):
+        once = rewrite("A && B & echo x")
+        assert rewrite(once) == once

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1017,7 +1017,17 @@ def _rewrite_compound_background(command: str) -> str:
         suffix = result[amp_pos + 1 :]
         # `{` needs a trailing space in bash; the closing `}` needs to be
         # preceded by `;` or `&` — we're providing `&` from the backgrounding.
-        result = prefix + "{ " + middle + "& }" + suffix
+        #
+        # If a statement *follows* the `&` (`A && B & C`), bash would parse
+        # `A && { B & } C` as a command list followed by a bare word — a
+        # syntax error (#98222; breaks the remote-kernel spawn template's
+        # `... & echo PID:$!`).  `&` is itself a list terminator, so the
+        # brace group needs `;` to close its list when a token follows —
+        # even after whitespace (`A && B & echo x` is invalid as written;
+        # the source `&` was the terminator the following word relied on).
+        # When only a newline/EOF follows, the group already ends the list.
+        sep = " ;" if suffix.strip() and "\n" not in suffix[: len(suffix) - len(suffix.lstrip())] else ""
+        result = prefix + "{ " + middle + "& }" + sep + suffix
 
     return result
 


### PR DESCRIPTION
## What does this PR do?

`_rewrite_compound_background` wraps `A && B &` tails as `A && { B & }` to avoid the subshell-wait leak (#68915). When a statement *follows* the `&` (`A && B & C`), the source `&` was also the terminator that following statement relied on — after the rewrite the bare word is stranded after `}`:

```
A && B & echo x  ->  A && { B & } echo x   (bash: syntax error near unexpected token `echo')
```

This kills every Docker/SSH/Modal `execute_code` remote-kernel spawn: the template in `tools/code_kernel_remote.py` ends `... & echo PID:$!`, the syntax error swallows the PID, the spawn returns `None`, and every call falls open to the per-call path (no persistence, interpreter restart per call). Blast radius is any `A && B & C` command on those backends, since `Environment.execute()` applies the rewrite by default.

The fix emits `A && { B & } ; C` when a token follows the `&` — `;` closes the brace group's command list. When the `&` ended the list (newline/EOF follows), output is byte-identical to today, so existing behavior is untouched.

Fixing the rewriter (rather than opting the spawn site out of the rewrite) repairs the whole class for every caller, and keeps the subshell-wait protection on commands that have a trailing statement — the skip-rewrite alternative would silently re-open the leak for `A && <long-running> & echo x`.

## Related Issue

Fixes #98222

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py` — `_rewrite_compound_background`: insert ` ;` between the closing brace group and the suffix when the suffix starts with a token before any newline. +11/−1.
- `tests/tools/test_terminal_compound_background_tail.py` — regression tests: the issue's kernel-spawn template stays valid; separator forms for `&&`/`||`/multi-statement tails; runtime check that `echo PID:$!` receives a numeric PID; end-of-list outputs unchanged (byte-exact); idempotence on the new output form; runtime semantics (`&&` short-circuit with trailing statement, background job does not block the shell).

## How to Test

1. Reproduce on main (unit-level, any platform with bash):
   ```python
   from tools.terminal_tool import _rewrite_compound_background as rw
   out = rw("cd /tmp && nohup server.py > log 2>&1 & echo PID:$!")
   # main: 'cd /tmp && { nohup server.py > log 2>&1 & } echo PID:$!'
   ```
   `bash -n -c "$out"` → `syntax error near unexpected token 'echo'` (the input itself parses fine).
2. On this branch, `bash -n` passes on every rewritten output, and the runtime behaves: `bash -c "$(python -c ...)"` prints `PID:<digits>` and `/proc/<pid>/cmdline` confirms the PID is the backgrounded job.
3. `pytest tests/tools/test_terminal_compound_background.py tests/tools/test_terminal_compound_background_tail.py -q` → 26 passed. On main, the 7 new `#98222` tests fail (red); on this branch all green.
4. Semantics verified by execution (Git bash 5.2.37, Windows 11): trailing `echo` sees `$!` of the job; `false && B & echo TAIL` → TAIL prints and B never starts; long-running `B` returns the shell in ~0.1s (subshell-wait class stays fixed); failing trailing statement propagates its own exit code.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: both compound-background files, `test_local_background_child_hang.py`, `test_process_registry.py` — the 9 `test_process_registry.py` failures are identical on unpatched main tip in the same venv, i.e. pre-existing on Windows, unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Git bash 5.2.37; the bug's backends run Linux bash — the `; ` separator is the canonical POSIX list terminator, verified with `bash -n` grammar and runtime behavior)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the rewriter runs on all backends; output change applies uniformly and is bash-grammar-neutral (`;` terminates a list on Linux/macOS bash too)
