### PR TITLE
fix(gateway): resend complete final when a stuck cursor freezes the partial

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2088,8 +2088,33 @@ class GatewayStreamConsumer:
         return self._clean_for_display(prefix)
 
     def _continuation_text(self, final_text: str) -> str:
-        """Return only the part of final_text the user has not already seen."""
+        """Return only the part of final_text the user has not already seen.
+
+        A visible prefix that ends with the streaming cursor is not reliable
+        delivered content: the cursor glyph is a synthetic tail that is not
+        part of ``final_text``, and a stuck cursor (left by a failed final
+        edit) means the user saw ``...pass`` while ``final_text`` is
+        ``...pass.``.  Computing a tail from that prefix would post a lone
+        ``.`` as a fresh message while the frozen ``...pass`` (with its
+        visible ``▉``) stays on screen — the duplicate/truncated-symptom.
+        When the prefix ends with the cursor, return the full ``final_text``
+        so the caller's fallback re-sends the complete answer and cleans up
+        the stale partial (its full-resend delete path).
+        """
         prefix = self._fallback_prefix or self._visible_prefix()
+        # The stuck cursor is only visible in the RAW last-sent text enough
+        # to matter; _visible_prefix() already stripped the glyph, so check
+        # the raw text directly.
+        if (
+            self.cfg.cursor
+            and self._last_sent_text
+            and self._last_sent_text.endswith(self.cfg.cursor)
+            and final_text != self._clean_for_display(
+                self._last_sent_text[: -len(self.cfg.cursor)]
+            ).strip()
+        ):
+            # Cursor-stuck prefix: not trustworthy content — resend all.
+            return final_text
         if prefix and final_text.startswith(prefix):
             return final_text[len(prefix):].lstrip()
         return final_text

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -516,6 +516,47 @@ class TestSegmentBreakOnToolBoundary:
         assert consumer._final_response_sent is True
 
     @pytest.mark.asyncio
+    async def test_fallback_final_full_resend_on_stuck_cursor_partial(self):
+        """A frozen partial left with a stuck streaming cursor (failed final
+        edit) must not produce a partial + lone tail: the cursor is not real
+        content, so the fallback re-sends the COMPLETE final and deletes the
+        stale partial — the user sees one coherent answer instead of a
+        truncated head + stray tail (the duplicate/truncated-symptom)."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_new"),
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.delete_message = AsyncMock(return_value=None)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(
+            edit_interval=0.01, buffer_threshold=5, cursor=" \u2589",
+        )
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        # Visible partial froze with a stuck cursor ("...scoring pass ▉") —
+        # the exact failed-final-edit scenario.  final_text adds the period.
+        consumer._message_id = "msg_partial"
+        consumer._last_sent_text = "Live ... scoring pass \u2589"
+
+        await consumer._send_fallback_final("Live ... scoring pass.")
+
+        # The COMPLETE final was re-sent as a fresh message...
+        sent_contents = [
+            c.kwargs.get("content", "") for c in adapter.send.call_args_list
+        ]
+        assert "Live ... scoring pass." in sent_contents
+        assert not any(
+            s.strip() == "." and "Live" not in s for s in sent_contents
+        ), "must not post a lone tail while the frozen partial stays"
+        # ...and the stale partial was deleted.
+        adapter.delete_message.assert_awaited_once_with("chat_123", "msg_partial")
+        assert consumer._final_response_sent is True
+
+    @pytest.mark.asyncio
     async def test_fallback_final_keeps_partial_after_tail_only_send(self):
         """When the fallback sends only the missing TAIL (visible prefix
         matches the final text), the partial message IS the head of the


### PR DESCRIPTION
## Problem

On Slack (edit-based streaming), a failed final edit can leave the streaming
cursor **stuck** on the visible partial: the user sees `"...scoring pass ▉"`
(truncated — the final `.` is missing), and the fallback then posts a **lone
`.`** as a fresh message while the frozen partial stays on screen. The result
is the "duplicated messages" symptom where the first message is missing its
last word.

## Root cause

`_continuation_text()` computes the tail from `_visible_prefix()`. When the
last edit failed, `_last_sent_text` is `"...scoring pass ▉"` — `_visible_prefix()`
strips the glyph but **keeps the cursor's leading space**, so the prefix is
`"...scoring pass "` and `final_text` (`"...scoring pass."`) starts with it →
continuation is the tail `"."`, posted as a new message. The frozen partial
(`...scoring pass` + stuck `▉`) is never cleaned up (the delete gate only
fires on a full-text resend).

## Fix

`_continuation_text()` now treats a visible prefix that ends with the cursor
as **untrustworthy**: the cursor is a synthetic tail that is not real
content. When `_last_sent_text` ends with the cursor (and the cursor-stripped
text is not the complete final), return the **full** `final_text` so the
fallback re-sends the complete answer and the existing full-resend delete
path removes the stale partial.

- Normal (cursor-free) partials: unchanged tail-only behavior.
- Stuck-cursor partial: full resend + delete → user sees one complete message.
- Split-turn reconcile / stale-finalize paths untouched (tests green).

## Tests

Added `test_fallback_final_full_resend_on_stuck_cursor_partial`, reproducing
the exact `"...scoring pass ▉"` → `"...scoring pass."` scenario and asserting
the complete final is re-sent and the partial deleted.

`tests/gateway/test_stream_consumer.py` (incl. new test) and
`tests/gateway/test_stale_finalize_suppression.py`: **83 passed**. Full
`tests/gateway/`: 6614 passed; 7 failures are pre-existing order-dependent
flakes (Discord send / session-store / Teams dotenv / Telegram polling),
unrelated to this change.