### PR TITLE
fix(telegram): make edit_message/delete_message replacement-aware

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5670,7 +5670,30 @@ class TelegramAdapter(BasePlatformAdapter):
         edits target the most recent visible message.
         """
         if not self._bot:
-            return SendResult(success=False, error="Not connected")
+            # The reconnect watcher may have retired this adapter and installed
+            # a connected replacement in runner.adapters. Mirror send()'s
+            # replacement-awareness (#94498) so in-flight progress/heartbeat
+            # edits resolve through the live adapter instead of failing as a
+            # permanent "Not connected" and fragmenting into fresh messages
+            # (#98228).
+            live = self._replacement_telegram_adapter()
+            if live is not None:
+                return await live.edit_message(
+                    chat_id, message_id, content, finalize=finalize, metadata=metadata,
+                )
+            if self._is_permanent_fatal() or not await self._wait_for_reconnection():
+                return SendResult(
+                    success=False,
+                    error="Not connected",
+                    retryable=not self._is_permanent_fatal(),
+                )
+            live = self._replacement_telegram_adapter()
+            if not self._bot and live is not None:
+                return await live.edit_message(
+                    chat_id, message_id, content, finalize=finalize, metadata=metadata,
+                )
+            if not self._bot:
+                return SendResult(success=False, error="Not connected", retryable=True)
 
         # Rich finalize (Bot API 10.1): when the completed content has
         # constructs the legacy MarkdownV2 edit degrades (tables → bullet
@@ -6081,7 +6104,20 @@ class TelegramAdapter(BasePlatformAdapter):
         caller leaves the preview in place and logs at debug level.
         """
         if not self._bot:
-            return False
+            # Retired adapter after a replacement reconnect: delegate cleanup to
+            # the live adapter so post-delivery deletion of temporary progress/
+            # heartbeat messages still succeeds (#98228). Mirrors send()/
+            # edit_message() replacement-awareness.
+            live = self._replacement_telegram_adapter()
+            if live is not None:
+                return await live.delete_message(chat_id, message_id)
+            if self._is_permanent_fatal() or not await self._wait_for_reconnection():
+                return False
+            live = self._replacement_telegram_adapter()
+            if not self._bot and live is not None:
+                return await live.delete_message(chat_id, message_id)
+            if not self._bot:
+                return False
         try:
             await self._bot.delete_message(
                 chat_id=normalize_telegram_chat_id(chat_id),

--- a/tests/gateway/test_telegram_send_reconnect_wait.py
+++ b/tests/gateway/test_telegram_send_reconnect_wait.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
 
@@ -117,6 +118,68 @@ async def test_send_permanent_fatal_fails_immediately_without_wait():
     )
 
     result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert result.error == "Not connected"
+    assert result.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_edit_message_delegates_to_replacement_when_already_live():
+    """#98228: an in-flight progress edit on a retired adapter must resolve
+    through the connected replacement instead of failing 'Not connected' and
+    fragmenting later progress into fresh messages."""
+    old = _make_adapter()
+    old._bot = None
+    live = _make_adapter()
+    live._bot = _connected_bot()
+    live.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="7"))
+    runner = MagicMock()
+    runner.adapters = {old.platform: live}
+    old.gateway_runner = runner
+    old._wait_for_reconnection = AsyncMock(
+        side_effect=AssertionError("must not wait when replacement is already live")
+    )
+
+    result = await old.edit_message("123", "7", "updated")
+
+    assert result.success is True
+    live.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_message_delegates_to_replacement_when_already_live():
+    """#98228: post-delivery cleanup on a retired adapter must delete through
+    the connected replacement so temporary progress/heartbeat messages don't
+    linger after a reconnect."""
+    old = _make_adapter()
+    old._bot = None
+    live = _make_adapter()
+    live._bot = _connected_bot()
+    live.delete_message = AsyncMock(return_value=True)
+    runner = MagicMock()
+    runner.adapters = {old.platform: live}
+    old.gateway_runner = runner
+    old._wait_for_reconnection = AsyncMock(
+        side_effect=AssertionError("must not wait when replacement is already live")
+    )
+
+    assert await old.delete_message("123", "7") is True
+    live.delete_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_edit_message_permanent_fatal_fails_closed_without_delegation():
+    """A permanently fatal (auth) failure must fail closed — never wait or
+    delegate across an incompatible identity."""
+    adapter = _make_adapter()
+    adapter._bot = None
+    adapter._set_fatal_error("telegram_auth_error", "invalid token", retryable=False)
+    adapter._wait_for_reconnection = AsyncMock(
+        side_effect=AssertionError("must not wait on permanent fatal")
+    )
+
+    result = await adapter.edit_message("123", "7", "updated")
 
     assert result.success is False
     assert result.error == "Not connected"


### PR DESCRIPTION
## What does this PR do?

When the reconnect watcher retires a disconnected Telegram adapter and installs
a connected replacement in `runner.adapters`, `send()` already delegates to it
(#94498) — but `edit_message()` and `delete_message()` still ran on the retired
adapter (`_bot is None`): edits returned a non-retryable "Not connected" and
deletes returned `False`. In-flight progress/heartbeat edits then fragmented
into fresh messages, and post-delivery cleanup left temporary messages behind
after a successful reconnect (#98228).

Fix: route both through the same replacement-awareness as `send()` — delegate to
the live adapter when present, otherwise wait for reconnection, and fail closed
on a permanent (auth) fatal instead of delegating across an incompatible
identity.

Credit to @0xble for the deterministic repro and diagnosis in #98228.

## Related Issue

Fixes #98228

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — `edit_message`/`delete_message`
  delegate to the replacement adapter, mirroring `send()`.
- `tests/gateway/test_telegram_send_reconnect_wait.py` — edit/delete delegation
  + permanent-fatal fail-closed tests.

## How to Test

    pytest tests/gateway/test_telegram_send_reconnect_wait.py -q

8 pass. The issue's standalone repro now delegates to the live adapter
(edit → success, delete → True) instead of failing "Not connected".

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs / issues
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11