### PR TITLE
fix(desktop): remote bot replies no longer die at the 30s relay deadline (#93911, salvage #93965)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/relay-deliver-budget.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay-deliver-budget.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+// #93911 review follow-up: the Desktop deadline for bot_relay.deliver mirrors
+// three backend numbers. Nothing in the type system links a TS constant to a
+// Python default, so this file is the seam: it reads the backend sources and
+// fails when a mirror drifts or the settlement margin stops being positive.
+// Without it, raising the backend turn timeout would silently reintroduce
+// #93911 — the client giving up before a valid typed settlement arrives.
+
+const relaySource = readFileSync(fileURLToPath(new URL('./relay.ts', import.meta.url)), 'utf8')
+const repoRoot = new URL('../../../../../', import.meta.url)
+const configDefaults = readFileSync(fileURLToPath(new URL('hermes_cli/config_defaults.py', repoRoot)), 'utf8')
+const relayHandler = readFileSync(fileURLToPath(new URL('tui_gateway/methods_bot_relay.py', repoRoot)), 'utf8')
+
+function tsConstant(name: string): number {
+  const match = relaySource.match(new RegExp(`const ${name} = ([0-9_]+)`))
+  expect(match, `${name} must stay a literal so this test can read it`).toBeTruthy()
+
+  return Number(match![1].replaceAll('_', ''))
+}
+
+describe('bot_relay.deliver budget mirrors', () => {
+  it('mirrors the backend turn-lock default', () => {
+    const lockWaitMatch = configDefaults.match(/"turn_wait_seconds":\s*(\d+)/)
+
+    expect(lockWaitMatch, 'bot_mode.turn_wait_seconds default must exist in config_defaults.py').toBeTruthy()
+    expect(tsConstant('RELAY_TURN_LOCK_WAIT_MS')).toBe(Number(lockWaitMatch![1]) * 1000)
+  })
+
+  it('mirrors the backend per-attempt turn timeout', () => {
+    const attemptTimeouts = [...relayHandler.matchAll(/timeout=(\d+)/g)].map(m => Number(m[1]))
+
+    expect(attemptTimeouts.length, 'expected the attempt and its policy-gated retry').toBeGreaterThanOrEqual(2)
+    // Every attempt shares one bound; if they ever diverge, the mirror below is
+    // no longer a faithful ceiling and this must be revisited deliberately.
+    expect(new Set(attemptTimeouts).size, `attempt timeouts diverged: ${attemptTimeouts}`).toBe(1)
+    expect(tsConstant('RELAY_TURN_ATTEMPT_MS')).toBe(attemptTimeouts[0] * 1000)
+    expect(tsConstant('RELAY_TURN_MAX_ATTEMPTS')).toBe(attemptTimeouts.length)
+  })
+
+  it('keeps the client deadline strictly greater than the backend ceiling', () => {
+    const margin = tsConstant('RELAY_DELIVER_SETTLEMENT_MARGIN_MS')
+
+    // Strictly greater, not equal: a backend that answers at its own limit
+    // still has to serialize and transport that answer.
+    expect(margin, 'settlement margin must be positive').toBeGreaterThan(0)
+
+    // The call site must pass the composed budget, not a bare literal.
+    const drain = relaySource.slice(
+      relaySource.indexOf('async function drainRelayOutboxes'),
+      relaySource.indexOf('export function startBotRelay')
+    )
+
+    expect(drain).toMatch(/'bot_relay\.deliver'[\s\S]{0,400}RELAY_DELIVER_TIMEOUT_MS/)
+    expect(drain).not.toMatch(/'bot_relay\.deliver'[\s\S]{0,400}\d{6,}/)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/relay-deliver-budget.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay-deliver-budget.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -10,10 +10,10 @@ import { describe, expect, it } from 'vitest'
 // Without it, raising the backend turn timeout would silently reintroduce
 // #93911 — the client giving up before a valid typed settlement arrives.
 
-const relaySource = readFileSync(fileURLToPath(new URL('./relay.ts', import.meta.url)), 'utf8')
-const repoRoot = new URL('../../../../../', import.meta.url)
-const configDefaults = readFileSync(fileURLToPath(new URL('hermes_cli/config_defaults.py', repoRoot)), 'utf8')
-const relayHandler = readFileSync(fileURLToPath(new URL('tui_gateway/methods_bot_relay.py', repoRoot)), 'utf8')
+const relaySource = readFileSync(join(process.cwd(), 'src/plugins/hermes-bots/relay.ts'), 'utf8')
+const repoRoot = join(process.cwd(), '..', '..')
+const configDefaults = readFileSync(join(repoRoot, 'hermes_cli/config_defaults.py'), 'utf8')
+const relayHandler = readFileSync(join(repoRoot, 'tui_gateway/methods_bot_relay.py'), 'utf8')
 
 function tsConstant(name: string): number {
   const match = relaySource.match(new RegExp(`const ${name} = ([0-9_]+)`))

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -33,6 +33,13 @@ const RELAY_ROSTER_INTERVAL_MS = 60_000
 // poll WAS the delivery path, which (before route retention) also meant a
 // fresh WebSocket dial + teardown per registered connection every 4s.
 const RELAY_DRAIN_INTERVAL_MS = 30_000
+// #93911: a delivered turn runs on the target gateway, so the client must
+// outlive the backend's own bound — worst case is the turn lock wait
+// (bot_mode.turn_wait_seconds, default 120s) plus a 600s turn, doubled when
+// the retry policy grants one bounded re-run (methods_bot_relay.py). Without
+// this the call fell to the pool's generic 30s deadline and every long turn
+// (Computer Use, deep research) came back as an unclassified failure.
+const RELAY_DELIVER_TIMEOUT_MS = 1_320_000
 // Push path (#93091): the gateway broadcasts `bot_relay.outbox.pending` when
 // an envelope lands on disk; a burst of signals inside this window collapses
 // to ONE drain. The interval poll above stays as the backstop for older
@@ -365,10 +372,15 @@ async function drainRelayOutboxes() {
         const attentionKey = `${target.id}::${String(envelope?.target_profile || '')}`
 
         try {
-          const res = await host.requestProfile<{ reply?: string }>(target.route, 'bot_relay.deliver', {
-            profile: String(envelope?.target_profile || ''),
-            message: String(envelope?.message || '')
-          })
+          const res = await host.requestProfile<{ reply?: string }>(
+            target.route,
+            'bot_relay.deliver',
+            {
+              profile: String(envelope?.target_profile || ''),
+              message: String(envelope?.message || '')
+            },
+            RELAY_DELIVER_TIMEOUT_MS
+          )
 
           clearBotAttention(attentionKey)
           await postReply({

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -34,12 +34,32 @@ const RELAY_ROSTER_INTERVAL_MS = 60_000
 // fresh WebSocket dial + teardown per registered connection every 4s.
 const RELAY_DRAIN_INTERVAL_MS = 30_000
 // #93911: a delivered turn runs on the target gateway, so the client must
-// outlive the backend's own bound — worst case is the turn lock wait
-// (bot_mode.turn_wait_seconds, default 120s) plus a 600s turn, doubled when
-// the retry policy grants one bounded re-run (methods_bot_relay.py). Without
-// this the call fell to the pool's generic 30s deadline and every long turn
-// (Computer Use, deep research) came back as an unclassified failure.
-const RELAY_DELIVER_TIMEOUT_MS = 1_320_000
+// outlive the backend's own bound. Without this the call fell to the pool's
+// generic 30s deadline and every long turn (Computer Use, deep research) came
+// back as an unclassified failure.
+//
+// The backend's MAXIMUM WORK budget is spelled out below. The client deadline
+// must be strictly GREATER than it: after those bounded waits the handler still
+// has to classify the failure, build and run the retry, classify/serialize the
+// terminal result, unwind the temp-file and lock scopes, and get the JSON-RPC
+// response back through the event loop. A call that consumes nearly all of the
+// work budget would otherwise lose the race to this timer by milliseconds and
+// reproduce #93911 at the upper boundary — the backend knowing a typed reason
+// while Desktop reports its generic timeout first.
+//
+// These three are mirrors of backend values, so a change there must not
+// silently invalidate this constant: relay-deliver-budget.test.ts reads
+// hermes_cli/config_defaults.py and tui_gateway/methods_bot_relay.py and fails
+// if the mirrors drift or the margin stops being positive.
+const RELAY_TURN_LOCK_WAIT_MS = 120_000 // bot_mode.turn_wait_seconds default
+const RELAY_TURN_ATTEMPT_MS = 600_000 // subprocess.run(..., timeout=600)
+const RELAY_TURN_MAX_ATTEMPTS = 2 // first attempt + the policy-gated re-run
+const RELAY_DELIVER_BACKEND_CEILING_MS =
+  RELAY_TURN_LOCK_WAIT_MS + RELAY_TURN_ATTEMPT_MS * RELAY_TURN_MAX_ATTEMPTS
+// Settlement + transport headroom on top of the ceiling, so a backend that
+// answers at its own limit still wins the race against this timer.
+const RELAY_DELIVER_SETTLEMENT_MARGIN_MS = 180_000
+const RELAY_DELIVER_TIMEOUT_MS = RELAY_DELIVER_BACKEND_CEILING_MS + RELAY_DELIVER_SETTLEMENT_MARGIN_MS
 // Push path (#93091): the gateway broadcasts `bot_relay.outbox.pending` when
 // an envelope lands on disk; a burst of signals inside this window collapses
 // to ONE drain. The interval poll above stays as the backstop for older

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -231,20 +231,26 @@ const $viewport = atom<ViewportRect>(readViewport())
 async function requestPluginProfile<T>(
   route: PluginProfileRoute | string,
   method: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  timeoutMs?: number
 ): Promise<T> {
   if (typeof route !== 'string') {
     if (!route.connectionId.trim() || !route.profile.trim() || !route.targetProfile.trim()) {
       throw new Error('Profile route must include connectionId, profile, and targetProfile')
     }
 
-    return requestGatewayForAgent<T>(route.connectionId, route.profile, method, params)
+    // Omit the bound entirely when unset so callers stay on the pool default.
+    return timeoutMs === undefined
+      ? requestGatewayForAgent<T>(route.connectionId, route.profile, method, params)
+      : requestGatewayForAgent<T>(route.connectionId, route.profile, method, params, timeoutMs)
   }
 
   const getAgentRoster = window.hermesDesktop?.getAgentRoster
 
   if (!getAgentRoster) {
-    return requestGatewayForProfile<T>(route, method, params)
+    return timeoutMs === undefined
+      ? requestGatewayForProfile<T>(route, method, params)
+      : requestGatewayForProfile<T>(route, method, params, timeoutMs)
   }
 
   const roster = await getAgentRoster()
@@ -256,7 +262,9 @@ async function requestPluginProfile<T>(
   // its live enumeration transiently failed. Any additional source requires a
   // descriptor because an undialed/unreachable source may expose the same name.
   if (soleLocalSource) {
-    return requestGatewayForProfile<T>(profile, method, params)
+    return timeoutMs === undefined
+      ? requestGatewayForProfile<T>(profile, method, params)
+      : requestGatewayForProfile<T>(profile, method, params, timeoutMs)
   }
 
   throw new Error(
@@ -1247,12 +1255,18 @@ export const host = {
   /** Gateway JSON-RPC through a credential-free route descriptor without
    *  foregrounding it. Passing a bare profile is the v1/local compatibility
    *  overload; registry callers must pass the descriptor so duplicate names
-   *  remain unambiguous. */
+   *  remain unambiguous.
+   *
+   *  `timeoutMs` opts one call out of the pool's generic deadline (#93911: a
+   *  method whose backend contract is minutes long, such as `bot_relay.deliver`,
+   *  otherwise dies at 30s and reports an unclassified failure). Leave it unset
+   *  to keep the default. */
   requestProfile: async <T>(
     route: PluginProfileRoute | string,
     method: string,
-    params: Record<string, unknown> = {}
-  ): Promise<T> => requestPluginProfile<T>(route, method, params),
+    params: Record<string, unknown> = {},
+    timeoutMs?: number
+  ): Promise<T> => requestPluginProfile<T>(route, method, params, timeoutMs),
 
   /** Pin a route's pooled gateway socket open across repeated `requestProfile`
    *  calls (#93594: the bot-relay drain loop was dialing and tearing down a

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -339,6 +339,42 @@ describe('connection-aware plugin host APIs', () => {
     expect(requestGatewayForProfile).not.toHaveBeenCalled()
   })
 
+  it('forwards an explicit timeout so long-running methods outlive the generic deadline', async () => {
+    // #93911: bot_relay.deliver's backend contract tolerates ~1320s (120s turn
+    // lock + a 600s turn, doubled by the bounded retry). Without a way to pass
+    // that bound through, every such call died at the pool's generic 30s
+    // deadline and surfaced as an unclassified failure.
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'remote-worker',
+      targetProfile: 'backend-worker'
+    }
+
+    await host.requestProfile(route, 'bot_relay.deliver', { message: 'hi', profile: 'backend-worker' }, 1_320_000)
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'source-a',
+      'remote-worker',
+      'bot_relay.deliver',
+      { message: 'hi', profile: 'backend-worker' },
+      1_320_000
+    )
+  })
+
+  it('leaves callers that pass no timeout on the pool default', async () => {
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'remote-worker',
+      targetProfile: 'backend-worker'
+    }
+
+    await host.requestProfile(route, 'profiles.list', {})
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('source-a', 'remote-worker', 'profiles.list', {})
+  })
+
   it('fails closed when a descriptor omits connection or target profile identity', async () => {
     await expect(
       host.requestProfile(

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -362,6 +362,68 @@ describe('connection-aware plugin host APIs', () => {
     )
   })
 
+  it('survives a backend that settles at its own ceiling, and only fails past the client deadline', async () => {
+    // #93911 review follow-up (adversarial): the failure mode is not "no
+    // timeout" but "a timeout equal to the backend's ceiling". Model the
+    // documented worst case on a virtual clock — the turn lock wait, a full
+    // timed attempt, the policy-gated re-run, and then the settlement the
+    // handler still has to serialize and transport — and assert that a
+    // deadline set AT the ceiling loses that race while one with margin wins.
+    const LOCK_WAIT_MS = 120_000
+    const ATTEMPT_MS = 600_000
+    const ATTEMPTS = 2
+    const CEILING_MS = LOCK_WAIT_MS + ATTEMPT_MS * ATTEMPTS
+    const SETTLEMENT_MS = 1_000
+
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'remote-worker',
+      targetProfile: 'backend-worker'
+    }
+
+    // A gateway that answers only after the full ceiling plus settlement, and
+    // aborts at whatever deadline the caller handed down.
+    const backendAtItsLimit = async (
+      _connectionId: string,
+      _profile: string,
+      _method: string,
+      _params: Record<string, unknown>,
+      timeoutMs?: number
+    ) =>
+      new Promise((resolve, reject) => {
+        setTimeout(() => resolve({ reply: 'delivered', reason: 'ok' }), CEILING_MS + SETTLEMENT_MS)
+
+        if (timeoutMs !== undefined) {
+          setTimeout(() => reject(new Error('request timed out')), timeoutMs)
+        }
+      })
+
+    vi.useFakeTimers()
+
+    try {
+      vi.mocked(requestGatewayForAgent).mockImplementation(backendAtItsLimit as never)
+
+      // Deadline exactly at the ceiling: the typed settlement loses the race.
+      const atCeiling = host.requestProfile(route, 'bot_relay.deliver', {}, CEILING_MS)
+      const atCeilingSettled = expect(atCeiling).rejects.toThrow(/timed out/)
+      await vi.advanceTimersByTimeAsync(CEILING_MS + SETTLEMENT_MS)
+      await atCeilingSettled
+
+      // Same backend, deadline with settlement margin: the answer gets through.
+      const withMargin = host.requestProfile(route, 'bot_relay.deliver', {}, CEILING_MS + SETTLEMENT_MS * 180)
+      const withMarginSettled = expect(withMargin).resolves.toEqual({
+        reason: 'ok',
+        reply: 'delivered'
+      })
+      await vi.advanceTimersByTimeAsync(CEILING_MS + SETTLEMENT_MS)
+      await withMarginSettled
+    } finally {
+      vi.useRealTimers()
+      vi.mocked(requestGatewayForAgent).mockReset()
+    }
+  })
+
   it('leaves callers that pass no timeout on the pool default', async () => {
     const route = {
       connectionId: 'source-a',


### PR DESCRIPTION
## Summary
Cross-connection bot relay deliveries from Desktop no longer time out at 30 seconds while the remote gateway is still legitimately running the turn — the `bot_relay.deliver` deadline now outlives the backend's full work budget (turn-lock wait + attempt + policy-gated retry) plus an explicit settlement margin. Salvage of #93965 by @maxmilian onto current main.

Root cause (#93911, reported again in the Discord thread with matching Desktop/VPS debug bundles): `host.requestProfile()` had no per-call timeout, so every routed plugin RPC fell to the gateway pool's generic 30s deadline. The remote bot received the message and replied, but Desktop had already given up on the relay call — intermittent "timeout" while the reply was actually produced.

## Changes
- `apps/desktop/src/sdk/index.ts`: thread an optional `timeoutMs` through `requestPluginProfile()` / `host.requestProfile()` into `requestGatewayForAgent()` / `requestGatewayForProfile()` (already accepted it); omitted entirely when unset so every other caller stays on the pool default.
- `apps/desktop/src/plugins/hermes-bots/relay.ts`: the `bot_relay.deliver` call passes a composed deadline — 120s turn-lock wait + 2 × 600s attempts (backend ceiling 1320s) + 180s settlement/transport margin = 1500s. Ported from the PR's `plugin.js` (deleted on main; relay now lives in `relay.ts`).
- `apps/desktop/src/plugins/hermes-bots/relay-deliver-budget.test.ts`: drift tripwire — reads `hermes_cli/config_defaults.py` and `tui_gateway/methods_bot_relay.py` and fails if a mirrored value drifts, attempt timeouts diverge, the margin stops being positive, or the call site regresses to a bare literal. Ported from the PR's node:test `.mjs` to vitest (the suite main actually runs).
- `apps/desktop/src/sdk/profile-routing.test.ts`: timeout-forwarding assertions on all three routing branches + adversarial virtual-clock regression (gateway answering after ceiling+settlement: ceiling-only deadline rejects, margined deadline resolves).

## Validation
| Check | Result |
|---|---|
| `relay-deliver-budget.test.ts` + `relay.test.ts` + `profile-routing.test.ts` | 74/74 pass |
| Sabotage run (`RELAY_TURN_ATTEMPT_MS` → 500_000) | tripwire fails as intended, restored |
| `npm run typecheck` (all three tsconfigs) | clean |

Contributor commits cherry-picked with authorship preserved. The review cycle on #93965 (blocker: 1320s was the ceiling itself, not something that outlives it) was already resolved by @maxmilian in the second commit; both are carried here. @fangliquanflq's #93964 independently hit the same defect class first and deserves credit on the record. The #92931 durable-relay rewrite must absorb this corrected arithmetic when it rebases (its `RELAY_DELIVERY_REQUEST_TIMEOUT_MS = 720_000` has the same defect).

## Infographic

![Bot relay delivery deadline — 30s generic timeout replaced by composed 25-min budget with drift tripwire](https://v3b.fal.media/files/b/0aa859cf/vHYJD34OfoKPGJ66dR7HS_chegITUW.png)
