### PR TITLE
fix(telegram): use cached config during adapter rebuild

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10841,9 +10841,8 @@ def _resolve_notifications_mode() -> str:
     mode = os.getenv("HERMES_TELEGRAM_NOTIFICATIONS", "")
     if not mode:
         try:
-            from gateway.config import load_gateway_config
-            from gateway.run import cfg_get
-            _gw_cfg = load_gateway_config()
+            from gateway.run import _load_gateway_config, cfg_get
+            _gw_cfg = _load_gateway_config()
             _raw = cfg_get(_gw_cfg, "display", "platforms", "telegram", "notifications")
             if _raw not in {None, ""}:
                 mode = str(_raw).strip().lower()

--- a/tests/gateway/test_telegram_adapter_build_config.py
+++ b/tests/gateway/test_telegram_adapter_build_config.py
@@ -1,0 +1,60 @@
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import (
+    _build_adapter,
+    _resolve_notifications_mode,
+)
+
+
+def test_adapter_build_uses_cached_gateway_config_not_full_loader(monkeypatch):
+    import gateway.config as gateway_config
+    import gateway.run as gateway_run
+
+    config = PlatformConfig(enabled=True, token="test-token")
+    monkeypatch.delenv("HERMES_TELEGRAM_NOTIFICATIONS", raising=False)
+    monkeypatch.setattr(
+        gateway_config,
+        "load_gateway_config",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("adapter construction must not use the full config loader")
+        ),
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"platforms": {"telegram": {"notifications": "all"}}}},
+    )
+
+    adapter = _build_adapter(config)
+
+    assert adapter._notifications_mode == "all"
+
+
+def test_notification_env_override_keeps_precedence(monkeypatch):
+    monkeypatch.setenv("HERMES_TELEGRAM_NOTIFICATIONS", "important")
+
+    assert _resolve_notifications_mode() == "important"
+
+
+def test_invalid_cached_mode_fails_closed(caplog, monkeypatch):
+    import gateway.run as gateway_run
+
+    monkeypatch.delenv("HERMES_TELEGRAM_NOTIFICATIONS", raising=False)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {"platforms": {"telegram": {"notifications": "unexpected"}}}
+        },
+    )
+
+    assert _resolve_notifications_mode() == "important"
+    assert "Unknown telegram notifications mode" in caplog.text
+
+
+def test_missing_mode_keeps_existing_default(monkeypatch):
+    import gateway.run as gateway_run
+
+    monkeypatch.delenv("HERMES_TELEGRAM_NOTIFICATIONS", raising=False)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+
+    assert _resolve_notifications_mode() == "important"


### PR DESCRIPTION
## Summary

Use the gateway's existing cached config loader when resolving Telegram notification mode during adapter construction, instead of reparsing the full gateway YAML configuration synchronously.

## Problem

Telegram adapter rebuilds can happen from the gateway reconnect path. `_resolve_notifications_mode()` currently calls `gateway.config.load_gateway_config()`, which opens and parses the full gateway config with PyYAML synchronously on the gateway event-loop thread.

This behavior was introduced as part of the platform plugin migration in `5600105478ffde29d7566b45421b100eaa29c4ef`. Before that migration, this path used the gateway's cached config semantics.

Under reconnect/rebuild conditions, a synchronous full YAML parse can stall the event loop and delay gateway health handling and recovery work.

## Fix

Restore the cached loader semantics by using the existing `gateway.run._load_gateway_config()` helper from `_resolve_notifications_mode()`.

The runtime change is intentionally small: 2 additions and 3 deletions.

## Tests

Adds focused regression coverage verifying that:

- Telegram adapter construction uses the cached gateway config and does not invoke the full config loader.
- `HERMES_TELEGRAM_NOTIFICATIONS` retains precedence.
- Invalid cached notification modes continue to fail closed to `important`.
- A missing notification mode preserves the existing `important` default.

Focused test run: 100 passed, 2 skipped, 0 failed. Ruff, formatting, compile, and diff checks also pass.