### PR TITLE
feat(browser): Brave Origin no longer misdetected — real-profile browsing + CDP connect (salvage #41505)

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -558,7 +558,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   timezone: 'IANA timezone identifier. Blank uses the system timezone.',
   browser: {
     useRealProfile:
-      "Local browsing uses your real logins. Hermes copies your default browser's profile (cookies, logins, preferences) into a managed snapshot and drives it with its packaged Chromium — your live profile is never opened directly, and the copy is refreshed from it on each run. Also lets the agent open a local real-profile session on request even when a cloud browser backend is configured. Only Chromium browsers (Chrome, Edge, Brave, Chromium) are supported; a non-Chromium default fails with a clear message. Off by default."
+      "Local browsing uses your real logins. Hermes copies your default browser's profile (cookies, logins, preferences) into a managed snapshot and drives it with its packaged Chromium — your live profile is never opened directly, and the copy is refreshed from it on each run. Also lets the agent open a local real-profile session on request even when a cloud browser backend is configured. Only Chromium browsers (Chrome, Edge, Brave, Brave Origin, Chromium) are supported; a non-Chromium default fails with a clear message. Off by default."
   },
   agent: {
     imageInputMode: 'Controls how image attachments are sent to the model.',

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -27,6 +27,7 @@ _DARWIN_APPS = (
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     "/Applications/Chromium.app/Contents/MacOS/Chromium",
     "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+    "/Applications/Brave Origin.app/Contents/MacOS/Brave Origin",
     "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
 )
 
@@ -37,6 +38,13 @@ _WINDOWS_BROWSER_GROUPS = (
         (("Chromium", "Application", "chrome.exe"), ("Chromium", "Application", "chromium.exe")),
     ),
     (("brave.exe", "brave"), (("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),)),
+    (
+        ("brave-origin.exe", "brave-origin"),
+        (
+            ("BraveSoftware", "Brave-Origin", "Application", "brave.exe"),
+            ("BraveSoftware", "Brave-Origin", "Application", "brave-origin.exe"),
+        ),
+    ),
     (("msedge.exe", "msedge"), (("Microsoft", "Edge", "Application", "msedge.exe"),)),
 )
 
@@ -53,7 +61,7 @@ _LINUX_BROWSER_GROUPS = (
         ("/usr/bin/chromium-browser", "/usr/bin/chromium"),
     ),
     (
-        ("brave-browser", "brave-browser-stable", "brave", "brave-origin", "brave-origin-nightly"),
+        ("brave-browser", "brave-browser-stable", "brave"),
         (
             "/usr/bin/brave-browser",
             "/usr/bin/brave-browser-stable",
@@ -61,9 +69,20 @@ _LINUX_BROWSER_GROUPS = (
             "/snap/bin/brave",
             "/opt/brave.com/brave/brave-browser",
             "/opt/brave.com/brave/brave",
+            "/opt/brave-bin/brave",
+        ),
+    ),
+    # Brave Origin is a SEPARATE product identity (side-by-side installable
+    # with Brave), so it gets its own group: the executable fallback in
+    # chromium_executable() matches by group, and mixing Origin binaries into
+    # the brave group would let a "brave" lookup resolve to the Origin binary
+    # (or vice versa) — driving the wrong browser's profile.
+    (
+        ("brave-origin", "brave-origin-nightly"),
+        (
+            "/usr/bin/brave-origin",
             "/opt/brave.com/brave-origin/brave-origin",
             "/opt/brave.com/brave-origin-nightly/brave-origin",
-            "/opt/brave-bin/brave",
         ),
     ),
     (
@@ -93,7 +112,12 @@ _LINUX_INSTALL_PATHS = tuple(path for _, paths in _LINUX_BROWSER_GROUPS for path
 # ---------------------------------------------------------------------------
 
 # Canonical Chromium browser keys we support for real-profile driving.
-_CHROMIUM_BROWSERS = ("chrome", "edge", "brave", "chromium")
+# ``brave-origin`` is Brave's standalone paid build: same Chromium core, but a
+# fully distinct install identity (BraveSoftware/Brave-Origin product path,
+# ``BraveOHTML`` ProgId, ``com.brave.Browser.origin`` bundle id) so it
+# side-by-side installs with regular Brave — its profile is NOT under
+# Brave-Browser and must never be conflated with the ``brave`` key.
+_CHROMIUM_BROWSERS = ("chrome", "edge", "brave", "chromium", "brave-origin")
 
 # Windows UserChoice ProgId prefixes → canonical browser key. Matched
 # case-insensitively by prefix so version suffixes (e.g. ``ChromeHTML.X``)
@@ -104,6 +128,9 @@ _CHROMIUM_BROWSERS = ("chrome", "edge", "brave", "chromium")
 _WINDOWS_PROGID_MAP = (
     ("chromehtml", "chrome"),
     ("msedgehtm", "edge"),
+    # Brave Origin stable is ``BraveOHTML`` (brave-core install_static). Listed
+    # before ``bravehtml`` for clarity; the prefixes don't collide either way.
+    ("braveohtml", "brave-origin"),
     ("bravehtml", "brave"),
     ("chromiumhtm", "chromium"),
 )
@@ -117,6 +144,9 @@ _WINDOWS_CHANNEL_PROGIDS = (
     "chromebhtml", "chromedhtml", "chromesshtml", "chromecanaryhtml",
     "msedgebhtml", "msedgedhtml", "msedgechtml",
     "bravebetahtml", "bravenightlyhtml",
+    # Brave Origin channels (brave-core install_static): Beta=BraveOBHTML,
+    # Dev=BraveODHTML, Nightly/SxS=BraveOSHTM (no trailing L — 10-char cap).
+    "braveobhtml", "braveodhtml", "braveoshtm",
 )
 
 # Linux xdg default-web-browser .desktop name fragments → canonical STABLE key.
@@ -128,6 +158,11 @@ _LINUX_DESKTOP_MAP = (
     ("google-chrome", "chrome"),
     ("com.google.chrome", "chrome"),
     ("chromium", "chromium"),
+    # ORDER MATTERS: ``brave-origin.desktop`` contains the bare ``brave``
+    # fragment, so the substring scan must hit the Origin entry first —
+    # otherwise an Origin default resolves to stable Brave and real-profile
+    # mode drives a DIFFERENT browser's profile (wrong-principal, #95549).
+    ("brave-origin", "brave-origin"),
     ("brave", "brave"),
     ("microsoft-edge", "edge"),
     ("com.microsoft.edge", "edge"),
@@ -141,6 +176,7 @@ _LINUX_CHANNEL_FRAGMENTS = (
     "com.google.chrome.beta", "com.google.chrome.dev", "com.google.chrome.canary",
     "microsoft-edge-beta", "microsoft-edge-dev", "microsoft-edge-canary",
     "brave-browser-beta", "brave-browser-nightly", "brave-browser-dev",
+    "brave-origin-beta", "brave-origin-nightly", "brave-origin-dev",
 )
 
 # Where sandboxed Linux packages keep the profile instead of $XDG_CONFIG_HOME.
@@ -161,6 +197,10 @@ _DARWIN_BUNDLE_MAP = (
     ("com.google.chrome", "chrome"),
     ("com.microsoft.edgemac", "edge"),
     ("com.brave.browser", "brave"),
+    # Brave Origin reuses the Brave bundle id with an ``.origin`` suffix
+    # (Homebrew cask: com.brave.Browser.origin). Exact matching keeps it from
+    # ever being read as plain ``com.brave.browser``.
+    ("com.brave.browser.origin", "brave-origin"),
     ("org.chromium.chromium", "chromium"),
 )
 
@@ -169,6 +209,8 @@ _DARWIN_CHANNEL_BUNDLES = (
     "com.google.chrome.beta", "com.google.chrome.dev", "com.google.chrome.canary",
     "com.microsoft.edgemac.beta", "com.microsoft.edgemac.dev", "com.microsoft.edgemac.canary",
     "com.brave.browser.beta", "com.brave.browser.nightly",
+    "com.brave.browser.origin.beta", "com.brave.browser.origin.dev",
+    "com.brave.browser.origin.nightly",
 )
 
 # Sentinel returned when the OS default is a recognized-but-unsupported
@@ -200,6 +242,11 @@ def _real_profile_relparts(browser: str) -> tuple:
             ("Chromium",),
             ("Chromium", "User Data"),
             "chromium",
+        ),
+        "brave-origin": (
+            ("BraveSoftware", "Brave-Origin"),
+            ("BraveSoftware", "Brave-Origin", "User Data"),
+            "BraveSoftware/Brave-Origin",
         ),
     }[browser]
 
@@ -258,6 +305,7 @@ def chromium_executable(browser: str, system: str | None = None) -> str | None:
             "chrome": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
             "chromium": "/Applications/Chromium.app/Contents/MacOS/Chromium",
             "brave": "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+            "brave-origin": "/Applications/Brave Origin.app/Contents/MacOS/Brave Origin",
             "edge": "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
         }[browser]
         return app if os.path.isfile(app) else None
@@ -266,6 +314,10 @@ def chromium_executable(browser: str, system: str | None = None) -> str | None:
             "chrome": (("Google", "Chrome", "Application", "chrome.exe"),),
             "chromium": (("Chromium", "Application", "chrome.exe"), ("Chromium", "Application", "chromium.exe")),
             "brave": (("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),),
+            "brave-origin": (
+                ("BraveSoftware", "Brave-Origin", "Application", "brave.exe"),
+                ("BraveSoftware", "Brave-Origin", "Application", "brave-origin.exe"),
+            ),
             "edge": (("Microsoft", "Edge", "Application", "msedge.exe"),),
         }[browser]
         bases = [
@@ -280,6 +332,7 @@ def chromium_executable(browser: str, system: str | None = None) -> str | None:
         "chrome": ("google-chrome", "google-chrome-stable"),
         "chromium": ("chromium-browser", "chromium"),
         "brave": ("brave-browser", "brave-browser-stable", "brave"),
+        "brave-origin": ("brave-origin",),
         "edge": ("microsoft-edge", "microsoft-edge-stable"),
     }[browser]
     for name in linux:

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -53,7 +53,7 @@ _LINUX_BROWSER_GROUPS = (
         ("/usr/bin/chromium-browser", "/usr/bin/chromium"),
     ),
     (
-        ("brave-browser", "brave-browser-stable", "brave"),
+        ("brave-browser", "brave-browser-stable", "brave", "brave-origin", "brave-origin-nightly"),
         (
             "/usr/bin/brave-browser",
             "/usr/bin/brave-browser-stable",
@@ -61,6 +61,8 @@ _LINUX_BROWSER_GROUPS = (
             "/snap/bin/brave",
             "/opt/brave.com/brave/brave-browser",
             "/opt/brave.com/brave/brave",
+            "/opt/brave.com/brave-origin/brave-origin",
+            "/opt/brave.com/brave-origin-nightly/brave-origin",
             "/opt/brave-bin/brave",
         ),
     ),

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -595,7 +595,7 @@ DEFAULT_CONFIG = {
         # never contends with the user's running browser. Turning this back off
         # deletes the snapshot store (~/.hermes/browser-profile/) so copied
         # credentials don't outlive consent. Only Chromium-family default
-        # browsers are supported (Chrome, Edge, Brave, Chromium); a non-Chromium
+        # browsers are supported (Chrome, Edge, Brave, Brave Origin, Chromium); a non-Chromium
         # default (e.g. Firefox) fails closed with a clear message. Default
         # false. Also gates the browser_exec ``local`` argument, which forces a
         # real-profile local session even under a cloud browser backend. Toggle

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13298,7 +13298,7 @@ def main():
     )
     browser_close.add_argument(
         "--browser",
-        help="Override detected default browser (chrome/edge/brave/chromium)",
+        help="Override detected default browser (chrome/edge/brave/brave-origin/chromium)",
     )
 
     def _dispatch_browser(_args):

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -72,6 +72,54 @@ class TestChromeDebugLaunch:
 
 
 
+    def test_linux_candidates_include_brave_origin_binary_name(self):
+        brave = "/usr/bin/brave-origin"
+
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: brave if name == "brave-origin" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == brave):
+            candidates = get_chrome_debug_candidates("Linux")
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert candidates == [brave]
+        assert command is not None
+        assert command.startswith(f"{brave} --remote-debugging-port=9222")
+
+    def test_linux_candidates_include_brave_origin_install_path(self):
+        brave = "/opt/brave.com/brave-origin/brave-origin"
+
+        with patch("hermes_cli.browser_connect.shutil.which", return_value=None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == brave):
+            candidates = get_chrome_debug_candidates("Linux")
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert candidates == [brave]
+        assert command is not None
+        assert command.startswith(f"{brave} --remote-debugging-port=9222")
+
+    def test_linux_candidates_include_brave_origin_nightly_binary_name(self):
+        brave = "/usr/bin/brave-origin-nightly"
+
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: brave if name == "brave-origin-nightly" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == brave):
+            candidates = get_chrome_debug_candidates("Linux")
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert candidates == [brave]
+        assert command is not None
+        assert command.startswith(f"{brave} --remote-debugging-port=9222")
+
+    def test_linux_candidates_include_brave_origin_nightly_install_path(self):
+        brave = "/opt/brave.com/brave-origin-nightly/brave-origin"
+
+        with patch("hermes_cli.browser_connect.shutil.which", return_value=None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == brave):
+            candidates = get_chrome_debug_candidates("Linux")
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert candidates == [brave]
+        assert command is not None
+        assert command.startswith(f"{brave} --remote-debugging-port=9222")
+
     def test_linux_candidates_include_official_brave_and_edge_stable_paths(self):
         brave = "/usr/bin/brave-browser-stable"
         edge = "/usr/bin/microsoft-edge-stable"

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -97,8 +97,11 @@ class TestDetectDefaultDarwin:
         [
             ("com.google.Chrome", "chrome"),
             ("com.brave.Browser", "brave"),
+            ("com.brave.Browser.origin", "brave-origin"),
             ("com.microsoft.edgemac", "edge"),
             ("org.chromium.Chromium", "chromium"),
+            ("com.brave.Browser.origin.beta", bc.UNSUPPORTED_CHANNEL),
+            ("com.brave.Browser.origin.nightly", bc.UNSUPPORTED_CHANNEL),
         ],
     )
     def test_bundle_map(self, bundle, expected):
@@ -122,6 +125,9 @@ class TestDetectDefaultLinux:
             ("org.chromium.Chromium.desktop", "chromium"),
             ("brave-browser.desktop", "brave"),
             ("com.brave.Browser.desktop", "brave"),
+            ("brave-origin.desktop", "brave-origin"),
+            ("brave-origin-beta.desktop", bc.UNSUPPORTED_CHANNEL),
+            ("brave-origin-nightly.desktop", bc.UNSUPPORTED_CHANNEL),
             ("microsoft-edge.desktop", "edge"),
             ("com.microsoft.Edge.desktop", "edge"),
             ("firefox.desktop", None),

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -42,6 +42,29 @@ class TestRealProfileResolvers:
         assert m["chromehtml"] == "chrome"
         assert m["msedgehtm"] == "edge"
         assert m["bravehtml"] == "brave"
+        assert m["braveohtml"] == "brave-origin"
+
+    def test_brave_origin_data_dirs(self):
+        import hermes_cli.browser_connect as bc
+        with patch.dict(os.environ, {"LOCALAPPDATA": r"C:\Users\T\AppData\Local"}, clear=False):
+            win = bc.real_profile_data_dir("brave-origin", "Windows")
+        assert win and win.endswith(ntpath.join("BraveSoftware", "Brave-Origin", "User Data"))
+        with patch.dict(os.environ, {"XDG_CONFIG_HOME": "/home/t/.config"}, clear=False):
+            assert (
+                bc.real_profile_data_dir("brave-origin", "Linux")
+                == "/home/t/.config/BraveSoftware/Brave-Origin"
+            )
+        mac = bc.real_profile_data_dir("brave-origin", "Darwin")
+        assert mac and mac.endswith("Library/Application Support/BraveSoftware/Brave-Origin")
+
+    def test_brave_origin_channel_progids_fail_closed(self):
+        import hermes_cli.browser_connect as bc
+        # Beta=BraveOBHTML, Dev=BraveODHTML, Nightly=BraveOSHTM must be caught
+        # by the channel list, and must be checked BEFORE the stable map — note
+        # none of them share the braveohtml stable prefix, but ordering is the
+        # invariant the detector relies on for the other families.
+        for chan in ("braveobhtml", "braveodhtml", "braveoshtm"):
+            assert chan in bc._WINDOWS_CHANNEL_PROGIDS
 
     def test_detect_default_non_chromium_is_none(self):
         import hermes_cli.browser_connect as bc

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1596,7 +1596,8 @@ def _real_profile_cdp() -> tuple:
         if browser is None:
             return None, (
                 "browser.use_real_profile is on, but your default browser is not a "
-                "supported Chromium browser (Chrome, Edge, Brave, Chromium). "
+                "supported Chromium browser (Chrome, Edge, Brave, Brave Origin, "
+                "Chromium). "
                 "Real-profile browsing requires a Chromium default; set one or turn "
                 "the toggle off."
             )
@@ -1610,7 +1611,8 @@ def _real_profile_cdp() -> tuple:
                 "browser.use_real_profile is on, but your default browser is a "
                 "pre-release Chromium channel (Beta / Dev / Canary), which "
                 "real-profile browsing does not support. Set your default to a "
-                "stable Chrome / Edge / Brave / Chromium, or turn the toggle off."
+                "stable Chrome / Edge / Brave / Brave Origin / Chromium, or turn "
+                "the toggle off."
             )
 
         # Reuse BEFORE writing anything. A shared copy-browser may already be up

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -206,7 +206,7 @@ losing unsaved tabs), then retries. If the profile is still locked after that
 to fully quit the browser — it won't loop or kill again on its own.
 :::
 
-- **Supported browsers:** Chrome, Edge, Brave, Chromium (whichever is your OS
+- **Supported browsers:** Chrome, Edge, Brave, Brave Origin, Chromium (whichever is your OS
   default). A non-Chromium default (e.g. Firefox) fails closed with a clear
   message rather than guessing.
 - **Works on any backend.** On a local backend it's automatic once the toggle

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -442,7 +442,7 @@ In the CLI, use:
 /browser disconnect              # Detach and return to cloud/local mode
 ```
 
-If a browser isn't already running with remote debugging, Hermes will attempt to auto-launch a supported Chromium-family browser with `--remote-debugging-port=9222`. Detection includes Brave, Google Chrome, Chromium, and Microsoft Edge, with common Linux install paths such as `/opt/brave-bin/brave` and `/snap/bin/brave`.
+If a browser isn't already running with remote debugging, Hermes will attempt to auto-launch a supported Chromium-family browser with `--remote-debugging-port=9222`. Detection includes Brave, Brave Origin/Nightly, Google Chrome, Chromium, and Microsoft Edge, with common Linux install paths and binary names such as `brave-origin`, `brave-origin-nightly`, `/opt/brave.com/brave-origin/brave-origin`, `/opt/brave.com/brave-origin-nightly/brave-origin`, `/opt/brave-bin/brave`, and `/snap/bin/brave`.
 
 :::tip
 To start a Chromium-family browser manually with CDP enabled, use a dedicated user-data-dir so the debug port actually comes up even if the browser is already running with your normal profile:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/browser.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/browser.md
@@ -287,7 +287,7 @@ CAMOFOX_ADOPT_EXISTING_TAB=true
 /browser disconnect              # Detach and return to cloud/local mode
 ```
 
-若浏览器尚未以远程调试模式运行，Hermes 将尝试自动启动支持的 Chromium 系浏览器并使用 `--remote-debugging-port=9222`。检测范围包括 Brave、Google Chrome、Chromium 和 Microsoft Edge，以及常见 Linux 安装路径（如 `/opt/brave-bin/brave` 和 `/snap/bin/brave`）。
+若浏览器尚未以远程调试模式运行，Hermes 将尝试自动启动支持的 Chromium 系浏览器并使用 `--remote-debugging-port=9222`。检测范围包括 Brave、Brave Origin/Nightly、Google Chrome、Chromium 和 Microsoft Edge，以及常见 Linux 安装路径和二进制名称（如 `brave-origin`、`brave-origin-nightly`、`/opt/brave.com/brave-origin/brave-origin`、`/opt/brave.com/brave-origin-nightly/brave-origin`、`/opt/brave-bin/brave` 和 `/snap/bin/brave`）。
 
 :::tip
 要手动启动带 CDP 的 Chromium 系浏览器，请使用专用的 user-data-dir，确保即使浏览器已以普通 profile 运行，调试端口也能正常开启：


### PR DESCRIPTION
## Summary
Brave Origin (Brave's standalone paid build) now works everywhere the other Chromium browsers do: real-profile browsing detects it as the OS default and snapshots its own profile, and `/browser connect` finds its binaries. Previously an Origin default was either misdetected as stable Brave on Linux (driving the WRONG browser's profile — the #95549 wrong-principal shape) or failed detection outright on Windows/macOS.

Salvages and extends PR #41505 by @H-Ali13381 (Linux CDP-connect detection, June 7) — his commit lands as-is with full authorship; this PR widens the fix to the real-profile machinery added later by #95620.

## Changes
- `hermes_cli/browser_connect.py`:
  - new canonical key `brave-origin` in `_CHROMIUM_BROWSERS`
  - Windows: `BraveOHTML` ProgId → brave-origin; channel ProgIds `BraveOBHTML`/`BraveODHTML`/`BraveOSHTM` fail closed (identifiers verified from brave-core `install_static/chromium_install_modes.h`)
  - macOS: `com.brave.Browser.origin` bundle id, exact match; `.beta`/`.dev`/`.nightly` bundles fail closed; `/Applications/Brave Origin.app` executable (verified via Homebrew cask)
  - Linux: `brave-origin.desktop` matched BEFORE the bare `brave` fragment — the substring scan otherwise resolved an Origin default to stable Brave; `brave-origin-{beta,nightly,dev}` fail closed
  - profile dirs: `BraveSoftware/Brave-Origin` (+ `User Data` on Windows) on all three OSes
  - `/browser connect` launch tables: Origin binaries split into their OWN group so a `brave` lookup can never resolve to the Origin binary (from #41505, restructured)
- `tools/browser_tool.py`, `hermes_cli/main.py`, `hermes_cli/config_defaults.py`, `apps/desktop/src/app/settings/constants.ts`: user-facing browser lists now name Brave Origin
- `website/docs` (+ zh-Hans): supported-browser lists and CDP detection docs updated

## Validation
| | Before (origin/main) | After |
|---|---|---|
| Linux `brave-origin.desktop` default | detected as `brave`, profile dir `…/Brave-Browser` (wrong browser) | `brave-origin`, `…/BraveSoftware/Brave-Origin` |
| Windows `BraveOHTML` ProgId | undetected (None) | `brave-origin` |
| macOS `com.brave.Browser.origin` | undetected (None) | `brave-origin` |
| Origin Beta/Dev/Nightly channels | n/a | fail closed (`UNSUPPORTED_CHANNEL`) |

**Live repro:** A/B run of the real detector functions (real imports, xdg output shapes) on origin/main vs this branch — before: `detected: brave` + Brave-Browser profile dir; after: `detected: brave-origin` + Brave-Origin dir on all three OSes. Tests: 125 passed across `test_browser_real_profile.py`, `test_browser_connect_default_chromium.py`, `test_cli_browser_connect.py`.

## Infographic

![Brave Origin support infographic](https://v3b.fal.media/files/b/0aa859ce/vFdybCl1ZOamH3WPT1vw__ygejR0TG.png)
