### PR TITLE
fix(slack): do not wake on unmentioned bot messages in force-mention channels

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6443,6 +6443,11 @@ class SlackAdapter(BasePlatformAdapter):
                     return
                 if allow_bots == "mentions" and not is_mentioned:
                     return
+        else:
+            # A message with no user id, or whose user is this bot, is not
+            # bot-to-bot traffic. Default the sender flag to False so the
+            # force-mention channel check below can rely on it being bound.
+            sender_is_bot_user = False
 
         if not is_one_to_one_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)
@@ -6499,6 +6504,21 @@ class SlackAdapter(BasePlatformAdapter):
                     return
             elif self._slack_strict_mention() and not is_mentioned:
                 return  # Strict mode: ignore until @-mentioned again
+            elif self._channel_forces_mention(channel_id) and not is_mentioned:
+                # Force-mention channel: an unmentioned message only reaches
+                # the bot when a human sent it (or one of the wake checks
+                # below approves it). Bot-to-bot traffic is suppressed here so
+                # a work channel shared with other bots does not become a
+                # free-for-all: a peer bot's status post or ack must not wake
+                # the agent. This is the "mature bot" behaviour for
+                # coordination channels.
+                if sender_is_bot_user:
+                    logger.debug(
+                        "[Slack] Ignoring unmentioned bot message in "
+                        "force-mention channel: channel=%s",
+                        channel_id,
+                    )
+                    return
             elif (
                 self._slack_thread_require_mention()
                 and is_thread_reply
@@ -9226,6 +9246,15 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _channel_forces_mention(self, channel_id: str) -> bool:
+        """Return True when a channel always requires a bot @mention.
+
+        A shortcut for the membership test against
+        ``_slack_require_mention_channels()`` used by the routing gate, so
+        the force-mention behaviour reads plainly at the call site.
+        """
+        return channel_id in self._slack_require_mention_channels()
 
     def _slack_mention_patterns(self) -> List["re.Pattern"]:
         """Compile optional regex wake-word patterns for channel triggers.

--- a/tests/gateway/test_slack_require_mention_channels.py
+++ b/tests/gateway/test_slack_require_mention_channels.py
@@ -157,3 +157,26 @@ async def test_forced_channel_wake_checks_still_apply(adapter):
     adapter.handle_message.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_forced_channel_ignores_unmentioned_bot_message(adapter):
+    """An unmentioned bot message never wakes the agent in a forced channel.
+
+    In a ``require_mention_channels`` channel, a peer bot's status post or
+    acknowledgement must not trigger a turn even when the message is a reply
+    in a thread the agent previously joined. Without this guard the channel
+    becomes a free-for-all: every bot-to-bot message in an ongoing thread
+    starts a new agent run.
+    """
+    adapter.config.extra["require_mention"] = False
+    adapter.config.extra["require_mention_channels"] = CHANNEL_ID
+    adapter._mentioned_threads.add("100.000")
+
+    event = _event("ack from peer bot", ts="101.000", thread_ts="100.000")
+    event["user"] = "U_PEER_BOT"
+    event["bot_id"] = "B_PEER_BOT"
+
+    await adapter._handle_slack_message(event)
+
+    adapter.handle_message.assert_not_called()
+
+


### PR DESCRIPTION
## Problem

A channel listed in `require_mention_channels` always requires an explicit bot @mention. However, an unmentioned message from a **peer bot** still auto-triggered a turn whenever a wake check approved it (previously mentioned thread, active session). In a coordination channel shared with other bots this made the adapter a free-for-all: every peer bot status post or acknowledgement inside an ongoing thread started a new agent run and burned model tokens.

## Change

In a force-mention channel, an unmentioned bot-authored message is dropped **before** the wake checks:

- `sender_is_bot_user` is now always bound (defaults to `False`) so the gate can rely on it.
- A new branch runs only when the channel is in `require_mention_channels` **and** the message is unmentioned **and** the sender is a bot: the message is ignored.
- Human senders keep the existing wake-check auto-follow contract (previously mentioned thread, active session).
- A direct @mention still reaches the bot regardless of sender.

## Why this scope

The fix is deliberately narrow. It does not change global behaviour, it does not affect channels without the `require_mention_channels` override, and it preserves the documented contract that wake checks still apply to human-initiated follow-ups. It only stops one class of unwanted turn: unmentioned, bot-authored traffic in channels that the operator has already declared "mention required."

## Tests

- New: `test_forced_channel_ignores_unmentioned_bot_message` — unmentioned peer bot message in a previously mentioned thread is ignored.
- Existing: `test_forced_channel_wake_checks_still_apply` — human thread follow-up still processed.
- Full Slack suite: 238 tests passed (test_slack.py + test_slack_require_mention_channels.py).
- Adjacent contract suites (ignore_other_user_mentions, wake_external_bot_messages, mention): 41 tests passed.
- `ruff check` clean; `py_compile` clean.