### PR TITLE
fix(gateway): block self-restart on a direct-spawn Windows gateway with no supervisor

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -518,7 +518,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         monkeypatch.setattr(tt, "_task_env_overrides", {})
         monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
         monkeypatch.setattr(
-            process_registry, "_is_gateway_process",
+            process_registry, "_is_gateway_process_or_unknown",
             lambda: inside_gateway,
         )
 
@@ -901,8 +901,54 @@ class TestTerminalToolBlocksUnsupervisedDirectSpawnGateway:
         monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", raising=False)
         monkeypatch.setattr(
-            "gateway.status.get_running_pid",
-            lambda *, cleanup_stale=False: os.getpid(),
+            "gateway.status.get_running_pid_identity_strict",
+            lambda pid_path: (os.getpid(), 123.0),
+        )
+
+        result = json.loads(tt.terminal_tool(command="hermes gateway restart"))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
+    def test_blocks_restart_on_unreadable_identity(self, monkeypatch):
+        """P1 (review, 2026-08-30): an unreadable PID/lock record is not
+        proof this process is NOT the gateway -- it is unproven. The hard
+        block must fail closed (still refuse) rather than let a transient
+        identity-read error grant the destructive command safe passage.
+        """
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env())
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+        def _raise(pid_path):
+            raise OSError("PID file unreadable")
+
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid_identity_strict", _raise
+        )
+
+        result = json.loads(tt.terminal_tool(command="hermes gateway restart"))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
+    def test_blocks_restart_on_malformed_identity_metadata(self, monkeypatch):
+        """P1 (review, 2026-08-30): an active-but-malformed PID/lock record
+        (the exact case ``get_running_pid_identity_strict`` raises for) must
+        also fail closed, not be read as "not the gateway"."""
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env())
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+        def _raise(pid_path):
+            raise RuntimeError("gateway PID or lock metadata is malformed")
+
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid_identity_strict", _raise
         )
 
         result = json.loads(tt.terminal_tool(command="hermes gateway restart"))
@@ -1913,7 +1959,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         monkeypatch.setattr(tt, "_task_env_overrides", {})
         monkeypatch.setattr(tt, "_get_env_config", lambda: {"env_type": "local", "cwd": "/tmp", "timeout": 60, "lifetime_seconds": 3600})
         monkeypatch.setattr(
-            process_registry, "_is_gateway_process",
+            process_registry, "_is_gateway_process_or_unknown",
             lambda: inside_gateway,
         )
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -518,7 +518,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         monkeypatch.setattr(tt, "_task_env_overrides", {})
         monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
         monkeypatch.setattr(
-            process_registry, "_is_supervised_gateway_process",
+            process_registry, "_is_gateway_process",
             lambda: inside_gateway,
         )
 
@@ -636,8 +636,8 @@ class TestTerminalToolGatewayLifecycleGuard:
         self, monkeypatch
     ):
         """#92560: CLI/TUI agent sessions inherit _HERMES_GATEWAY=1 from the
-        gateway but are NOT the gateway supervisor.  The env gate must not
-        fire for them — only for the actual gateway process (PID-file owner).
+        gateway but are not the gateway itself.  The env gate must not fire
+        for them — only for the actual gateway process (PID-file owner).
         """
         import tools.terminal_tool as tt
 
@@ -652,8 +652,8 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         # Simulate a CLI agent session: _HERMES_GATEWAY=1 is in the
         # environment (inherited from the gateway), but
-        # _is_supervised_gateway_process() returns False because the
-        # process does not own the gateway PID file.
+        # _is_gateway_process() returns False because the process does not
+        # own the gateway PID file.
         self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=False)
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
         monkeypatch.setattr(
@@ -852,6 +852,82 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 0
         assert calls == ["systemctl status nginx"]
+
+
+class TestTerminalToolBlocksUnsupervisedDirectSpawnGateway:
+    """#98221: a direct-spawn gateway with no external supervisor (no
+    systemd/launchd/schtasks wrapper -- e.g. a Windows Startup-folder VBS
+    launch) must still refuse to run a lifecycle command against itself.
+
+    The guard used to gate on ``_is_supervised_gateway_process()``, which
+    additionally required a supervisor marker (INVOCATION_ID / XPC_SERVICE_NAME
+    / HERMES_S6_SUPERVISED_CHILD / the external-supervisor env override).  A
+    direct-spawn gateway has none of those, so the guard never fired and
+    `hermes gateway restart` ran unblocked: it stopped the live gateway, and
+    the terminal tool's child process was interrupted before the replacement
+    start phase completed, leaving no gateway running at all.  This exercises
+    the real identity primitives (not a patched boolean) to prove the guard
+    now fires purely on live PID-file ownership.
+    """
+
+    def _minimal_config(self):
+        return {"env_type": "local", "cwd": "/tmp", "timeout": 60, "lifetime_seconds": 3600}
+
+    def _patch_env(self, monkeypatch, fake_env):
+        import tools.terminal_tool as tt
+        eid = "default"
+        monkeypatch.setattr(tt, "_active_environments", {eid: fake_env})
+        monkeypatch.setattr(tt, "_last_activity", {eid: 0.0})
+        monkeypatch.setattr(tt, "_task_env_overrides", {})
+        monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
+
+    def _make_fake_env(self):
+        class _FakeEnv:
+            env = {}
+            def execute(self, command, **kwargs):  # pragma: no cover
+                raise AssertionError("execute must not be reached")
+        return _FakeEnv()
+
+    def test_blocks_restart_with_no_supervisor_present(self, monkeypatch):
+        import tools.terminal_tool as tt
+
+        self._patch_env(monkeypatch, self._make_fake_env())
+
+        # Live gateway identity: _HERMES_GATEWAY=1 and this process owns the
+        # gateway PID file -- but no supervisor of any kind.
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+        monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", raising=False)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid(),
+        )
+
+        result = json.loads(tt.terminal_tool(command="hermes gateway restart"))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
+    def test_previously_this_shape_was_not_supervised(self, monkeypatch):
+        """Same identity as above must NOT satisfy the stricter supervised
+        probe -- confirms the fix widens the guard rather than loosening the
+        supervised check other call sites (systemd-scope isolation) rely on.
+        """
+        from tools.process_registry import _is_supervised_gateway_process
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+        monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", raising=False)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid(),
+        )
+
+        assert _is_supervised_gateway_process() is False
 
 
 # ---------------------------------------------------------------------------
@@ -1837,7 +1913,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         monkeypatch.setattr(tt, "_task_env_overrides", {})
         monkeypatch.setattr(tt, "_get_env_config", lambda: {"env_type": "local", "cwd": "/tmp", "timeout": 60, "lifetime_seconds": 3600})
         monkeypatch.setattr(
-            process_registry, "_is_supervised_gateway_process",
+            process_registry, "_is_gateway_process",
             lambda: inside_gateway,
         )
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1564,10 +1564,12 @@ def execute_code(
     # guard (#68289): without this, execute_code is a straight bypass — the
     # terminal() path refuses `launchctl bootout ai.hermes.gateway`, but the
     # identical command inside `os.system(...)` / `subprocess.run([...])`
-    # here sailed through and SIGTERM'd the gateway mid-task. Gated on
-    # PID-file ownership, not the inherited env marker (#92560).
-    from tools.process_registry import _is_supervised_gateway_process
-    if _is_supervised_gateway_process():
+    # here sailed through and SIGTERM'd the gateway mid-task. Gated on live
+    # PID-file ownership, not the inherited env marker (#92560) and not on
+    # external supervision (#98221) — a direct-spawn gateway with no
+    # supervisor is just as interruptible by its own lifecycle command.
+    from tools.process_registry import _is_gateway_process
+    if _is_gateway_process():
         from cron.lifecycle_guard import contains_gateway_lifecycle_command
         if contains_gateway_lifecycle_command(code):
             return tool_error(

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1568,8 +1568,8 @@ def execute_code(
     # PID-file ownership, not the inherited env marker (#92560) and not on
     # external supervision (#98221) — a direct-spawn gateway with no
     # supervisor is just as interruptible by its own lifecycle command.
-    from tools.process_registry import _is_gateway_process
-    if _is_gateway_process():
+    from tools.process_registry import _is_gateway_process_or_unknown
+    if _is_gateway_process_or_unknown():
         from cron.lifecycle_guard import contains_gateway_lifecycle_command
         if contains_gateway_lifecycle_command(code):
             return tool_error(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -255,28 +255,50 @@ def _systemd_run_user_scope_available() -> bool:
         return available
 
 
-def _is_supervised_gateway_process() -> bool:
-    """Return whether this process is in a supervised Hermes gateway runtime.
+def _is_gateway_process() -> bool:
+    """Return whether this process IS the live Hermes gateway.
 
-    Both supervisor markers and ``_HERMES_GATEWAY`` are inherited by every
-    descendant, and importing ``gateway.run`` also sets the latter. Require
-    this process to own the live gateway PID file as well. That keeps transient
-    systemd scopes limited to the gateway itself instead of terminal children
-    or unrelated interactive CLIs in the same supervised process tree.
+    ``_HERMES_GATEWAY`` is inherited by every descendant, and importing
+    ``gateway.run`` also sets it. Require this process to own the live
+    gateway PID file as well, so terminal children or unrelated interactive
+    CLIs in the same process tree are not mistaken for the gateway.
+
+    Unlike :func:`_is_supervised_gateway_process`, this does NOT require an
+    external supervisor. A direct-spawn gateway (no systemd/launchd/schtasks
+    wrapper -- e.g. a Windows Startup-folder VBS launch) is still the live
+    gateway: it can be killed by its own lifecycle command just as easily as
+    a supervised one, it just has nothing to bring it back afterwards (#98221).
     """
     if os.environ.get("_HERMES_GATEWAY") != "1":
         return False
 
     try:
-        from gateway.restart import is_gateway_supervisor_process
         from gateway.status import get_running_pid
 
-        return (
-            is_gateway_supervisor_process()
-            and get_running_pid(cleanup_stale=False) == os.getpid()
-        )
+        return get_running_pid(cleanup_stale=False) == os.getpid()
     except Exception as exc:
-        logger.debug("Could not verify supervised gateway process identity: %s", exc)
+        logger.debug("Could not verify gateway process identity: %s", exc)
+        return False
+
+
+def _is_supervised_gateway_process() -> bool:
+    """Return whether this process is in a supervised Hermes gateway runtime.
+
+    Builds on :func:`_is_gateway_process` (live PID-file ownership) with the
+    additional requirement of an external supervisor. Systemd-scope cgroup
+    isolation is the one thing here that actually needs supervision -- it
+    relies on the supervisor to keep the gateway's cgroup alive independently
+    of the scoped worker.
+    """
+    if not _is_gateway_process():
+        return False
+
+    try:
+        from gateway.restart import is_gateway_supervisor_process
+
+        return is_gateway_supervisor_process()
+    except Exception as exc:
+        logger.debug("Could not verify gateway supervisor identity: %s", exc)
         return False
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -281,6 +281,38 @@ def _is_gateway_process() -> bool:
         return False
 
 
+def _is_gateway_process_or_unknown() -> bool:
+    """Return True if this process is the live gateway, or identity is unproven.
+
+    Destructive lifecycle hard-blocks (terminal_tool / code_execution_tool)
+    must use this instead of :func:`_is_gateway_process`. That function
+    treats any read failure the same as "definitely not the gateway", but an
+    unreadable or malformed PID/lock record is not proof of that -- it is
+    just unproven. Collapsing "unproven" into the allow case would let the
+    destructive command this guard exists to refuse run unguarded on a
+    transient or malformed identity read. Non-destructive callers (systemd-
+    scope isolation, via :func:`_is_supervised_gateway_process`) are
+    unaffected: getting those wrong just skips an optimization, not a safety
+    check.
+    """
+    if os.environ.get("_HERMES_GATEWAY") != "1":
+        return False
+
+    try:
+        from gateway.status import _get_pid_path, get_running_pid_identity_strict
+
+        identity = get_running_pid_identity_strict(_get_pid_path())
+    except Exception as exc:
+        logger.debug(
+            "Could not verify gateway process identity, failing closed: %s", exc
+        )
+        return True
+
+    if identity is None:
+        return False
+    return identity[0] == os.getpid()
+
+
 def _is_supervised_gateway_process() -> bool:
     """Return whether this process is in a supervised Hermes gateway runtime.
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3074,17 +3074,18 @@ def terminal_tool(
         # never restart. This mirrors the `hermes gateway restart` guard in
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
-        # Gate on the SUPERVISED-gateway probe, not the raw _HERMES_GATEWAY
+        # Gate on live gateway PID-file ownership, not the raw _HERMES_GATEWAY
         # marker: gateway.run sets it at import time, so it leaks into every
         # process that merely imports gateway.run (hermes serve --isolated,
         # CLI, web server) which are NOT the gateway and must be able to
-        # restart it. A plain foreground `hermes gateway run` (env set, PID
-        # owned, no supervisor) now also PASSES this guard: intentional and
-        # harmless, since without a supervisor there is no KeepAlive to turn a
-        # self-restart into a respawn loop.
-        from tools.process_registry import _is_supervised_gateway_process
+        # restart it. This does NOT additionally require an external
+        # supervisor (#98221): a direct-spawn gateway with no
+        # systemd/launchd/schtasks wrapper (e.g. a Windows Startup-folder VBS
+        # launch) is interrupted by its own restart command just as surely as
+        # a supervised one — it just has no supervisor to bring it back.
+        from tools.process_registry import _is_gateway_process
 
-        if _is_supervised_gateway_process():
+        if _is_gateway_process():
             from cron.lifecycle_guard import (
                 _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3083,9 +3083,9 @@ def terminal_tool(
         # systemd/launchd/schtasks wrapper (e.g. a Windows Startup-folder VBS
         # launch) is interrupted by its own restart command just as surely as
         # a supervised one — it just has no supervisor to bring it back.
-        from tools.process_registry import _is_gateway_process
+        from tools.process_registry import _is_gateway_process_or_unknown
 
-        if _is_gateway_process():
+        if _is_gateway_process_or_unknown():
             from cron.lifecycle_guard import (
                 _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,


### PR DESCRIPTION
## What does this PR do?

Fixes #98221: on Windows, a gateway started by direct spawn (the installed
Startup-folder VBS launcher, no systemd/launchd/schtasks supervisor) can be
told by its own agent to run `hermes gateway restart` through the `terminal`
tool. The command is never blocked, so it stops the live gateway — and the
terminal tool's own child process is interrupted along with it before the
replacement gateway can start. The gateway never comes back; the user has to
start it manually.

## Root cause

`tools/terminal_tool.py` and `tools/code_execution_tool.py` both hard-block
gateway lifecycle commands (`hermes gateway restart|stop|uninstall`,
`systemctl`/`launchctl` equivalents) when running inside the gateway process,
via `tools/process_registry.py::_is_supervised_gateway_process()`. That check
requires **both** live gateway PID-file ownership **and** an external
supervisor marker (`INVOCATION_ID` for systemd, `XPC_SERVICE_NAME` for
launchd, etc.).

A direct-spawn Windows gateway owns the PID file but has no supervisor
marker, so the guard always evaluated to `False` for it — the block never
fired, and the destructive command ran unguarded.

## Changes Made

- `tools/process_registry.py`: split live gateway identity from external
  supervision. New `_is_gateway_process()` checks only `_HERMES_GATEWAY=1` +
  PID-file ownership. `_is_supervised_gateway_process()` is now built on top
  of it with the additional supervisor check, preserving its existing
  behavior for the systemd-scope cgroup isolation path (the one caller that
  actually needs supervision, unchanged).
- `tools/terminal_tool.py`: the lifecycle hard-block now gates on
  `_is_gateway_process()` instead of `_is_supervised_gateway_process()`.
- `tools/code_execution_tool.py`: same change, mirroring the terminal_tool
  guard as the file's existing comment already says it should.
- `tests/hermes_cli/test_gateway_restart_loop.py`: retargeted the existing
  terminal-tool guard tests' monkeypatch to `_is_gateway_process` (no
  behavior change to those tests — they already modeled "is this process the
  gateway" as a single boolean); added `TestTerminalToolBlocksUnsupervisedDirectSpawnGateway`,
  which exercises the real identity primitives (not a patched boolean) to
  prove the guard now fires for a live, unsupervised gateway, and that this
  identity still does **not** satisfy the stricter supervised check other
  callers rely on.

## Scope note

This is deliberately narrower than the earlier attempt at this issue (#95954,
closed unmerged). That PR's review correctly endorsed the same live-identity/
supervision split, but also asked for a tri-state identity result and for
`hermes_cli/gateway.py`'s own `stop`/`restart`/`uninstall` self-target guards
to move from PID-equality to process-ancestry, to close a *separate* bypass
where dynamically-constructed code in `execute_code` avoids the source-text
classifier entirely. That is a real, independent hardening problem, but it is
not what #98221 reports (a literal `hermes gateway restart` invoked through
the `terminal` tool), and `hermes_cli/gateway.py`'s own self-checks are not
the code path this specific report exercises — the terminal-tool-spawned CLI
process has a different PID than the gateway, so PID-equality there behaves
identically before and after this change. Fixing the deeper `execute_code`
bypass is left as a separate, follow-up piece of work.

## How to Test

Reproduction (matches the issue): with a gateway running via direct spawn on
Windows (no supervisor), have the agent run `hermes gateway restart` through
the `terminal` tool. Before this fix, the command executes and the gateway
never comes back. After this fix, the tool call is blocked with:

```
Blocked: command or referenced script cannot restart, stop, or uninstall the
gateway from inside the gateway process. ...
```

Automated regression:
```
uv run --isolated --with pytest python -m pytest \
  tests/hermes_cli/test_gateway_restart_loop.py -q
```

Proved the new regression test fails without the fix: stashed the three
source files, re-ran the suite, and confirmed
`TestTerminalToolBlocksUnsupervisedDirectSpawnGateway::test_blocks_restart_with_no_supervisor_present`
fails (`assert -1 == 1` — the command ran instead of being blocked), along
with every other test that patches the identity function under its old name.
Restored the fix and reran.

### Test output (with the fix)

```
$ uv run --isolated --with pytest python -m pytest tests/hermes_cli/test_gateway_restart_loop.py -q
299 passed in 3.69s

$ uv run --isolated --with pytest --with pytest-asyncio python -m pytest tests/hermes_cli/ -q -k gateway
810 passed, 18 skipped, 6940 deselected in 58.38s

$ uv run --isolated --with pytest python -m pytest tests/tools/test_process_registry.py tests/tools/test_code_execution.py tests/tools/test_code_execution_modes.py tests/tools/test_execute_code_approval_cluster.py tests/tools/test_approval.py -q
297 passed, 4 skipped, 7 subtests passed in 15.83s

$ uv run --isolated --with ruff ruff check tools/process_registry.py tools/terminal_tool.py tools/code_execution_tool.py tests/hermes_cli/test_gateway_restart_loop.py
All checks passed!
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs/issues and found no duplicate (see Scope
      note above re: the related, closed #95954)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_gateway_restart_loop.py -q` and
      the related tool/process-registry suites, all pass
- [x] I've added tests for the bug
- [ ] I've tested on Windows — not available in this environment; validated
      via the identity primitives directly (`gateway.status.get_running_pid`,
      the supervisor-marker env vars) rather than an end-to-end Windows run

### Documentation & Housekeeping

- [x] Documentation update — N/A; internal lifecycle safety behavior
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow/architecture
      contract changed
- [x] Cross-platform impact considered — this is specifically a Windows
      direct-spawn fix; POSIX supervised/unsupervised behavior is unchanged
      because `_is_gateway_process()` is a strict superset of what
      `_is_supervised_gateway_process()` already matched
- [x] Tool descriptions/schemas — N/A; no tool schema changed, only internal
      guard logic

## AI assistance disclosure

This PR was prepared with AI assistance (an autonomous coding agent), with
the root-cause analysis, scope decision, and test verification described
above performed and checked as part of that process.
