### PR TITLE
feat(skills-hub): impeccable joins the optional-skills catalog, content pulled live from upstream

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -68,6 +68,13 @@ def _resolve_short_name(name: str, sources, console: Console) -> str:
         return exact[0].identifier
 
     if len(exact) > 1:
+        # Official catalog entries outrank community mirrors of the same
+        # skill: `hermes skills install impeccable` should resolve to the
+        # curated official/... entry, not stall on skills.sh duplicates.
+        official = [r for r in exact if r.source == "official"]
+        if len(official) == 1:
+            c.print(f"[dim]Resolved to: {official[0].identifier} (official catalog)[/]")
+            return official[0].identifier
         c.print(f"\n[yellow]Multiple skills named '{name}' found:[/]")
         table = Table()
         table.add_column("Source", style="dim")

--- a/optional-skills/creative/impeccable/SKILL.md
+++ b/optional-skills/creative/impeccable/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: impeccable
-description: Design guidance for frontend work — /impeccable init, craft, critique, audit, polish, bolder, quieter, animate, typeset, layout, and 18 more sub-commands, plus a deterministic anti-slop detector CLI. Use for websites, landing pages, dashboards, product UI, components, and design systems.
+description: Frontend design guidance, upstream-maintained (impeccable).
 version: 4.1.2
 author: Paul Bakaus (pbakaus)
 license: Apache-2.0
+platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [design, frontend, ui, ux, web-design, anti-slop]
     category: creative
-    related_skills: [premium-webapp-ui, claude-design, popular-web-designs]
+    related_skills: [claude-design, popular-web-designs]
     upstream:
       repo: pbakaus/impeccable
       path: .hermes/skills/impeccable

--- a/optional-skills/creative/impeccable/SKILL.md
+++ b/optional-skills/creative/impeccable/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: impeccable
+description: Design guidance for frontend work — /impeccable init, craft, critique, audit, polish, bolder, quieter, animate, typeset, layout, and 18 more sub-commands, plus a deterministic anti-slop detector CLI. Use for websites, landing pages, dashboards, product UI, components, and design systems.
+version: 4.1.2
+author: Paul Bakaus (pbakaus)
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [design, frontend, ui, ux, web-design, anti-slop]
+    category: creative
+    related_skills: [premium-webapp-ui, claude-design, popular-web-designs]
+    upstream:
+      repo: pbakaus/impeccable
+      path: .hermes/skills/impeccable
+---
+
+# Impeccable (upstream-maintained)
+
+> **Catalog stub.** This entry is maintained upstream at
+> [pbakaus/impeccable](https://github.com/pbakaus/impeccable): the project
+> ships and verifies a Hermes-native skill bundle under `.hermes/skills/`.
+> `hermes skills install impeccable` pulls the current bundle live from that
+> repo (quarantined and scanned like any hub install) — this directory holds
+> only the catalog metadata, so the vendored copy can never go stale.
+
+Impeccable is a design language for AI coding agents: one skill exposing 23
+sub-commands (`/impeccable init`, `craft`, `shape`, `critique`, `audit`,
+`polish`, `bolder`, `quieter`, `distill`, `harden`, `onboard`, `animate`,
+`colorize`, `typeset`, `layout`, `delight`, `overdrive`, `clarify`, `adapt`,
+`optimize`, `extract`, `document`, `live`), explicit anti-pattern guidance
+(overused fonts, purple gradients, nested cards, bounce easing), and a
+61-rule deterministic detector CLI (`npx impeccable detect`) that needs no
+LLM or API key.
+
+After install, start with:
+
+```
+/impeccable init
+```
+
+Full documentation: https://impeccable.style

--- a/tests/tools/test_skill_bundle_provenance.py
+++ b/tests/tools/test_skill_bundle_provenance.py
@@ -119,6 +119,69 @@ def test_github_source_rejects_symlink_in_referenced_directory(monkeypatch):
     assert source.fetch("owner/repo/skill") is None
 
 
+def test_github_source_fetch_downloads_full_skill_directory(monkeypatch):
+    """Support files a skill keeps outside SKILL.md-linked paths still install.
+
+    Regression for skills using non-canonical support dirs (impeccable keeps
+    everything under `reference/` singular and `scripts/` linked only from
+    reference files): the old link-driven fetch shipped SKILL.md alone.
+    """
+    source = GitHubSource(GitHubAuth())
+    skill_md = (
+        "---\nname: full-dir\ndescription: d\n---\n"
+        "See [audit](reference/audit.md) and run `node scripts/pin.mjs`.\n"
+    )
+    fetched: list = []
+    monkeypatch.setattr(source, "_fetch_file_content", lambda _repo, path: skill_md)
+    monkeypatch.setattr(
+        source, "_fetch_file_bytes",
+        lambda _repo, path: fetched.append(path) or b"content-of-" + path.encode(),
+    )
+    source._tree_cache["owner/repo"] = (
+        "main",
+        [
+            {"path": "skill/SKILL.md", "type": "blob", "mode": "100644"},
+            {"path": "skill/reference/audit.md", "type": "blob", "mode": "100644"},
+            {"path": "skill/reference/deep/native.md", "type": "blob", "mode": "100644"},
+            {"path": "skill/scripts/pin.mjs", "type": "blob", "mode": "100644"},
+            {"path": "skill/LICENSE", "type": "blob", "mode": "100644"},
+            # skipped: symlink, hidden file, pyc, out-of-prefix
+            {"path": "skill/reference/link.md", "type": "blob", "mode": "120000"},
+            {"path": "skill/.hidden", "type": "blob", "mode": "100644"},
+            {"path": "skill/scripts/x.pyc", "type": "blob", "mode": "100644"},
+            {"path": "other/README.md", "type": "blob", "mode": "100644"},
+        ],
+    )
+
+    bundle = source.fetch("owner/repo/skill")
+
+    assert bundle is not None
+    assert set(bundle.files) == {
+        "SKILL.md",
+        "reference/audit.md",
+        "reference/deep/native.md",
+        "scripts/pin.mjs",
+        "LICENSE",
+    }
+
+
+def test_github_source_fetch_still_requires_linked_references(monkeypatch):
+    """A SKILL.md-linked references/ path missing from the tree rejects the bundle."""
+    source = GitHubSource(GitHubAuth())
+    skill_md = (
+        "---\nname: dangling\ndescription: d\n---\n"
+        "Read [the guide](references/guide.md).\n"
+    )
+    monkeypatch.setattr(source, "_fetch_file_content", lambda _repo, path: skill_md)
+    monkeypatch.setattr(source, "_fetch_file_bytes", lambda _repo, path: b"x")
+    source._tree_cache["owner/repo"] = (
+        "main",
+        [{"path": "skill/SKILL.md", "type": "blob", "mode": "100644"}],
+    )
+
+    assert source.fetch("owner/repo/skill") is None
+
+
 def test_lock_file_persists_scan_provenance(tmp_path):
     lock = HubLockFile(tmp_path / "lock.json")
     provenance = {
@@ -243,3 +306,93 @@ def test_bundled_optional_source_still_includes_support_files(tmp_path, monkeypa
     bundle = source.fetch("official/category/official-demo")
     assert bundle is not None
     assert set(bundle.files) == {"SKILL.md", "references/all.md"}
+
+
+UPSTREAM_STUB_MD = """---
+name: upstream-demo
+description: Upstream-maintained catalog entry.
+metadata:
+  hermes:
+    upstream:
+      repo: acme/design-skill
+      path: .hermes/skills/design
+---
+# Stub
+"""
+
+
+def test_optional_source_upstream_stub_fetches_from_external_repo(tmp_path, monkeypatch):
+    """A catalog stub with metadata.hermes.upstream installs the upstream repo's
+    content (relabelled official/trusted), not the stub itself."""
+    from tools.skills_hub import OptionalSkillSource, SkillBundle
+
+    root = tmp_path / "optional-skills"
+    skill = root / "creative" / "upstream-demo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(UPSTREAM_STUB_MD)
+
+    source = OptionalSkillSource()
+    source._optional_dir = root
+
+    fetched_ids = []
+
+    class _FakeGitHub:
+        def fetch(self, identifier):
+            fetched_ids.append(identifier)
+            return SkillBundle(
+                name="design",
+                files={"SKILL.md": "---\nname: design\ndescription: real\n---\nreal body",
+                       "reference/audit.md": "audit"},
+                source="github",
+                identifier=identifier,
+                trust_level="community",
+                metadata={"source_url": "https://github.com/acme/design-skill"},
+            )
+
+    monkeypatch.setattr(source, "_get_github", lambda: _FakeGitHub())
+
+    bundle = source.fetch("official/creative/upstream-demo")
+
+    assert fetched_ids == ["acme/design-skill/.hermes/skills/design"]
+    assert bundle is not None
+    assert bundle.source == "official"
+    assert bundle.identifier == "official/creative/upstream-demo"
+    assert bundle.trust_level == "trusted"
+    assert bundle.files["SKILL.md"].startswith("---\nname: design")
+    assert bundle.metadata["upstream_repo"] == "acme/design-skill"
+
+
+def test_optional_source_upstream_pointer_rejects_malformed(tmp_path):
+    from tools.skills_hub import OptionalSkillSource
+
+    source = OptionalSkillSource()
+    bad = [
+        "---\nname: x\nmetadata:\n  hermes:\n    upstream:\n      repo: acme\n      path: skills/x\n---\n",          # repo not owner/name
+        "---\nname: x\nmetadata:\n  hermes:\n    upstream:\n      repo: a/b/c\n      path: skills/x\n---\n",        # repo too deep
+        "---\nname: x\nmetadata:\n  hermes:\n    upstream:\n      repo: acme/skill\n      path: ../../etc\n---\n",  # traversal
+        "---\nname: x\nmetadata:\n  hermes:\n    upstream:\n      repo: acme/skill\n---\n",                          # missing path
+        "---\nname: x\n---\n",                                                                                       # no pointer
+    ]
+    for content in bad:
+        assert source._upstream_pointer_from_content(content) is None
+
+
+def test_unified_search_trust_rank_survives_limit_cut():
+    """Official/builtin results must survive the limit truncation even when a
+    high-volume community source floods the merged list first."""
+    from unittest.mock import patch as _patch
+    from tools.skills_hub import unified_search, SkillMeta
+
+    community = [
+        SkillMeta(name=f"s{i}", description="", source="skills.sh",
+                  identifier=f"skills-sh/x/s{i}", trust_level="community")
+        for i in range(20)
+    ]
+    official = [SkillMeta(name="s-official", description="", source="official",
+                          identifier="official/cat/s-official", trust_level="builtin")]
+
+    with _patch("tools.skills_hub.parallel_search_sources",
+                return_value=(community + official, {}, [])):
+        results = unified_search("s", [], source_filter="all", limit=10)
+
+    assert results[0].identifier == "official/cat/s-official"

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1158,11 +1158,27 @@ class TestInstallPathSafety:
     """
 
     @pytest.fixture
-    def isolated_skills_dir(self, tmp_path, monkeypatch):
+    def isolated_skills_dir(self, tmp_path):
+        import tools.skills_hub as hub
+
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir()
-        monkeypatch.setattr("tools.skills_hub.SKILLS_DIR", skills_dir)
-        return skills_dir
+        # SKILLS_DIR is a PEP 562 dynamic attribute (resolved per-access via
+        # module __getattr__). monkeypatch.setattr must NOT be used here: it
+        # captures __getattr__'s live-resolved Path as the "original" value
+        # and re-installs it as a REAL module attribute on teardown, which
+        # permanently shadows dynamic resolution — every later test in the
+        # process then sees this test's tmp dir as the skills root. Set the
+        # override attribute directly and delete it on teardown so the
+        # module returns to dynamic resolution.
+        setattr(hub, "SKILLS_DIR", skills_dir)
+        try:
+            yield skills_dir
+        finally:
+            try:
+                delattr(hub, "SKILLS_DIR")
+            except AttributeError:
+                pass
 
     @pytest.fixture
     def patch_lock_file(self, monkeypatch):

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -184,19 +184,29 @@ def _content_contract_re(file_alt: str) -> str:
 
 THREAT_PATTERNS = [
     # ── Exfiltration: shell commands leaking secrets ──
-    (r'curl\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)',
+    # All five env_exfil_* patterns share a loopback exemption: a request
+    # whose same-line literal destination is scheme-anchored loopback
+    # (http(s)://localhost, 127.0.0.1, [::1]) cannot move data off the
+    # machine, so a secret-shaped query param on it is a local session
+    # token, not exfiltration (e.g. impeccable's live-mode
+    # `fetch('http://localhost:'+PORT+'/status?token='+TOKEN)`). The
+    # exemption requires the scheme immediately before the loopback host —
+    # `evil.com/?u=localhost` does not qualify. A hostile skill that hides
+    # its real destination behind a variable never matched these same-line
+    # literal patterns in the first place.
+    (r'curl\s+(?![^\n]*https?://(?:localhost|127\.0\.0\.1|\[::1\]))[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)',
      "env_exfil_curl", "critical", "exfiltration",
      "curl command interpolating secret environment variable"),
-    (r'wget\s+[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)',
+    (r'wget\s+(?![^\n]*https?://(?:localhost|127\.0\.0\.1|\[::1\]))[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)',
      "env_exfil_wget", "critical", "exfiltration",
      "wget command interpolating secret environment variable"),
-    (r'fetch\s*\([^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|API)',
+    (r'fetch\s*\((?![^\n]*https?://(?:localhost|127\.0\.0\.1|\[::1\]))[^\n]*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|API)',
      "env_exfil_fetch", "critical", "exfiltration",
      "fetch() call interpolating secret environment variable"),
-    (r'httpx?\.(get|post|put|patch)\s*\([^\n]*(KEY|TOKEN|SECRET|PASSWORD)',
+    (r'httpx?\.(get|post|put|patch)\s*\((?![^\n]*https?://(?:localhost|127\.0\.0\.1|\[::1\]))[^\n]*(KEY|TOKEN|SECRET|PASSWORD)',
      "env_exfil_httpx", "critical", "exfiltration",
      "HTTP library call with secret variable"),
-    (r'requests\.(get|post|put|patch)\s*\([^\n]*(KEY|TOKEN|SECRET|PASSWORD)',
+    (r'requests\.(get|post|put|patch)\s*\((?![^\n]*https?://(?:localhost|127\.0\.0\.1|\[::1\]))[^\n]*(KEY|TOKEN|SECRET|PASSWORD)',
      "env_exfil_requests", "critical", "exfiltration",
      "requests library call with secret variable"),
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -670,22 +670,47 @@ class GitHubSource(SkillSource):
         files: Dict[str, Union[str, bytes]] = {"SKILL.md": skill_md}
         tree = self._get_repo_tree(repo)
         if tree is not None:
+            # Download the FULL skill directory, not just SKILL.md-linked
+            # paths. Link-driven fetching silently dropped every support file
+            # a skill keeps under a non-canonical dir name (`reference/`,
+            # `agents/`, root-level LICENSE/params files) or that only a
+            # reference file links — the exact gap the optional-skills live
+            # fetch already works around (see _fetch_live_optional_bundle).
+            # Everything still flows through quarantine + scan before
+            # install, and the scanner sees MORE this way, not less.
             branch, entries = tree
             prefix = f"{skill_path.rstrip('/')}/"
-            entries_by_path = {item.get("path", ""): item for item in entries}
-            for rel_path in sorted(referenced):
-                item_path = f"{prefix}{rel_path}"
-                item = entries_by_path.get(item_path)
-                if item is None:
-                    logger.warning("Referenced skill support file is missing: %s", item_path)
-                    return None
+            for item in entries:
                 if item.get("type") != "blob" or item.get("mode") == "120000":
-                    logger.warning("Rejected non-regular file in skill bundle: %s", item_path)
+                    continue
+                item_path = item.get("path", "")
+                if not item_path.startswith(prefix):
+                    continue
+                rel_path = item_path[len(prefix):]
+                if rel_path == "SKILL.md":
+                    continue
+                base = rel_path.rsplit("/", 1)[-1]
+                if base.startswith(".") or base.endswith(".pyc") or "__pycache__" in rel_path.split("/"):
+                    continue
+                try:
+                    rel_path = _validate_bundle_rel_path(rel_path)
+                except ValueError:
+                    logger.warning("Rejected unsafe file path in skill bundle: %s", item_path)
                     return None
                 content = self._fetch_file_bytes(repo, item_path)
                 if content is None:
                     return None
                 files[rel_path] = content
+            # A support file SKILL.md links must actually exist as a regular
+            # file — a missing or symlinked referenced path rejects the
+            # bundle rather than installing a skill with dangling links.
+            for rel_path in sorted(referenced):
+                if rel_path not in files:
+                    logger.warning(
+                        "Referenced skill support file is missing: %s%s",
+                        prefix, rel_path,
+                    )
+                    return None
             revision = self._tree_revisions.get(repo) or branch
         else:
             for rel_path in referenced:
@@ -3423,6 +3448,16 @@ class OptionalSkillSource(SkillSource):
         else:
             skill_dir = resolved
 
+        # Upstream-maintained entries: the local dir is a catalog stub whose
+        # frontmatter points at the real skill in an external repo the
+        # upstream project maintains (e.g. impeccable's Hermes-native bundle
+        # under pbakaus/impeccable:.hermes/skills/impeccable). Install pulls
+        # the live content from there instead of vendoring a fork here.
+        upstream = self._upstream_pointer(skill_dir)
+        if upstream is not None:
+            rel_id = skill_dir.resolve().relative_to(self._optional_dir.resolve()).as_posix()
+            return self._fetch_from_upstream(upstream, rel_id)
+
         files: Dict[str, Union[str, bytes]] = {}
         for f in skill_dir.rglob("*"):
             if (
@@ -3549,6 +3584,11 @@ class OptionalSkillSource(SkillSource):
         if "SKILL.md" not in files:
             return None
 
+        # Live-fetched catalog stubs redirect the same way local ones do.
+        upstream = self._upstream_pointer_from_content(files["SKILL.md"])
+        if upstream is not None:
+            return self._fetch_from_upstream(upstream, rel)
+
         logger.info("Optional skill '%s' fetched from live repo (not in local checkout)", rel)
         return SkillBundle(
             name=rel.rsplit("/", 1)[-1],
@@ -3597,6 +3637,87 @@ class OptionalSkillSource(SkillSource):
 
         self._remote_dirs = dirs
         return dirs
+
+    def _upstream_pointer(self, skill_dir: Path) -> Optional[Dict[str, str]]:
+        """Return the upstream pointer for a catalog-stub skill dir, if any.
+
+        A stub declares ``metadata.hermes.upstream`` in its SKILL.md
+        frontmatter:
+
+            metadata:
+              hermes:
+                upstream:
+                  repo: pbakaus/impeccable
+                  path: .hermes/skills/impeccable
+
+        Returns ``{"repo": ..., "path": ...}`` or None for normal
+        (fully-vendored) optional skills.
+        """
+        skill_md = skill_dir / "SKILL.md"
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+        return self._upstream_pointer_from_content(content)
+
+    def _upstream_pointer_from_content(self, content: Union[str, bytes]) -> Optional[Dict[str, str]]:
+        """Parse ``metadata.hermes.upstream`` out of SKILL.md content."""
+        if isinstance(content, bytes):
+            try:
+                content = content.decode("utf-8")
+            except UnicodeDecodeError:
+                return None
+        fm = self._parse_frontmatter(content)
+        meta_block = fm.get("metadata")
+        if not isinstance(meta_block, dict):
+            return None
+        hermes_meta = meta_block.get("hermes")
+        if not isinstance(hermes_meta, dict):
+            return None
+        upstream = hermes_meta.get("upstream")
+        if not isinstance(upstream, dict):
+            return None
+        repo = str(upstream.get("repo", "")).strip().strip("/")
+        path = str(upstream.get("path", "")).strip().strip("/")
+        # repo must be exactly owner/name; path must be a clean relative path.
+        if not repo or repo.count("/") != 1 or not path:
+            return None
+        parts = [p for p in path.split("/") if p not in ("", ".")]
+        if not parts or any(p == ".." for p in parts):
+            return None
+        return {"repo": repo, "path": "/".join(parts)}
+
+    def _fetch_from_upstream(self, upstream: Dict[str, str], rel_id: str) -> Optional[SkillBundle]:
+        """Fetch an upstream-maintained optional skill from its external repo.
+
+        Delegates to GitHubSource.fetch() (full-directory download through the
+        git tree, symlink/unsafe-path rejection, quarantine + scan downstream)
+        but re-labels the bundle as an official catalog entry so trust,
+        identifier, and update tracking stay in the optional-skills namespace.
+        """
+        github = self._get_github()
+        bundle = github.fetch(f"{upstream['repo']}/{upstream['path']}")
+        if bundle is None:
+            logger.warning(
+                "Upstream fetch failed for optional skill %s (%s:%s)",
+                rel_id, upstream["repo"], upstream["path"],
+            )
+            return None
+        return SkillBundle(
+            name=bundle.name,
+            files=bundle.files,
+            source="official",
+            identifier=f"official/{rel_id}",
+            # Curated-catalog endorsement, but the content comes live from a
+            # third-party repo — "trusted", not "builtin", so a dangerous
+            # scan verdict still blocks install (INSTALL_POLICY).
+            trust_level="trusted",
+            metadata={
+                **bundle.metadata,
+                "upstream_repo": upstream["repo"],
+                "upstream_path": upstream["path"],
+            },
+        )
 
     def _find_skill_dir(self, name: str) -> Optional[Path]:
         """Find a skill directory by name anywhere in optional-skills/."""
@@ -4670,5 +4791,11 @@ def unified_search(query: str, sources: List[SkillSource],
         elif _TRUST_RANK.get(r.trust_level, 0) > _TRUST_RANK.get(seen[r.identifier].trust_level, 0):
             seen[r.identifier] = r
     deduped = list(seen.values())
+
+    # Stable-sort by trust rank before truncating: the limit cut must not
+    # drop a builtin/official catalog entry because a high-volume community
+    # source (skills.sh mirrors every repo) happened to finish first and
+    # flood the merged list. Insertion order is preserved within each rank.
+    deduped.sort(key=lambda r: -_TRUST_RANK.get(r.trust_level, 0))
 
     return deduped[:limit]

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -63,6 +63,7 @@ hermes skills uninstall <skill-name>
 | [**draw-your-font**](/docs/user-guide/skills/optional/creative/creative-draw-your-font) | Turn a photo of handwriting into an installable font (TTF/WOFF). |
 | [**heartmula**](/docs/user-guide/skills/optional/creative/creative-heartmula) | HeartMuLa: Suno-like song generation from lyrics + tags. |
 | [**hyperframes**](/docs/user-guide/skills/optional/creative/creative-hyperframes) | Render MP4/WebM videos from HTML compositions. |
+| [**impeccable**](/docs/user-guide/skills/optional/creative/creative-impeccable) | Frontend design guidance: 23 /impeccable sub-commands + anti-slop detector (upstream-maintained). |
 | [**kanban-video-orchestrator**](/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator) | Plan and run multi-agent video production pipelines. |
 | [**meme-generation**](/docs/user-guide/skills/optional/creative/creative-meme-generation) | Create meme PNGs from templates with Pillow text overlay. |
 | [**pixel-art**](/docs/user-guide/skills/optional/creative/creative-pixel-art) | Pixel art w/ era palettes (NES, Game Boy, PICO-8). |

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -63,7 +63,7 @@ hermes skills uninstall <skill-name>
 | [**draw-your-font**](/docs/user-guide/skills/optional/creative/creative-draw-your-font) | Turn a photo of handwriting into an installable font (TTF/WOFF). |
 | [**heartmula**](/docs/user-guide/skills/optional/creative/creative-heartmula) | HeartMuLa: Suno-like song generation from lyrics + tags. |
 | [**hyperframes**](/docs/user-guide/skills/optional/creative/creative-hyperframes) | Render MP4/WebM videos from HTML compositions. |
-| [**impeccable**](/docs/user-guide/skills/optional/creative/creative-impeccable) | Frontend design guidance: 23 /impeccable sub-commands + anti-slop detector (upstream-maintained). |
+| [**impeccable**](/docs/user-guide/skills/optional/creative/creative-impeccable) | Frontend design guidance, upstream-maintained (impeccable). |
 | [**kanban-video-orchestrator**](/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator) | Plan and run multi-agent video production pipelines. |
 | [**meme-generation**](/docs/user-guide/skills/optional/creative/creative-meme-generation) | Create meme PNGs from templates with Pillow text overlay. |
 | [**pixel-art**](/docs/user-guide/skills/optional/creative/creative-pixel-art) | Pixel art w/ era palettes (NES, Game Boy, PICO-8). |

--- a/website/docs/user-guide/skills/optional/creative/creative-impeccable.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-impeccable.md
@@ -1,0 +1,55 @@
+---
+title: "Impeccable"
+sidebar_label: "Impeccable"
+description: "Design guidance for frontend work — /impeccable init, craft, critique, audit, polish, bolder, quieter, animate, typeset, layout, and 18 more sub-commands, pl..."
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Impeccable
+
+Design guidance for frontend work — /impeccable init, craft, critique, audit, polish, bolder, quieter, animate, typeset, layout, and 18 more sub-commands, plus a deterministic anti-slop detector CLI. Use for websites, landing pages, dashboards, product UI, components, and design systems.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/creative/impeccable` |
+| Path | `optional-skills/creative/impeccable` |
+| Version | `4.1.2` |
+| Author | Paul Bakaus (pbakaus) |
+| License | Apache-2.0 |
+| Tags | `design`, `frontend`, `ui`, `ux`, `web-design`, `anti-slop` |
+| Related skills | `premium-webapp-ui`, [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design), [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Impeccable (upstream-maintained)
+
+> **Catalog stub.** This entry is maintained upstream at
+> [pbakaus/impeccable](https://github.com/pbakaus/impeccable): the project
+> ships and verifies a Hermes-native skill bundle under `.hermes/skills/`.
+> `hermes skills install impeccable` pulls the current bundle live from that
+> repo (quarantined and scanned like any hub install) — this directory holds
+> only the catalog metadata, so the vendored copy can never go stale.
+
+Impeccable is a design language for AI coding agents: one skill exposing 23
+sub-commands (`/impeccable init`, `craft`, `shape`, `critique`, `audit`,
+`polish`, `bolder`, `quieter`, `distill`, `harden`, `onboard`, `animate`,
+`colorize`, `typeset`, `layout`, `delight`, `overdrive`, `clarify`, `adapt`,
+`optimize`, `extract`, `document`, `live`), explicit anti-pattern guidance
+(overused fonts, purple gradients, nested cards, bounce easing), and a
+61-rule deterministic detector CLI (`npx impeccable detect`) that needs no
+LLM or API key.
+
+After install, start with:
+
+```
+/impeccable init
+```
+
+Full documentation: https://impeccable.style

--- a/website/docs/user-guide/skills/optional/creative/creative-impeccable.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-impeccable.md
@@ -1,14 +1,14 @@
 ---
-title: "Impeccable"
+title: "Impeccable — Frontend design guidance, upstream-maintained (impeccable)"
 sidebar_label: "Impeccable"
-description: "Design guidance for frontend work — /impeccable init, craft, critique, audit, polish, bolder, quieter, animate, typeset, layout, and 18 more sub-commands, pl..."
+description: "Frontend design guidance, upstream-maintained (impeccable)"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Impeccable
 
-Design guidance for frontend work — /impeccable init, craft, critique, audit, polish, bolder, quieter, animate, typeset, layout, and 18 more sub-commands, plus a deterministic anti-slop detector CLI. Use for websites, landing pages, dashboards, product UI, components, and design systems.
+Frontend design guidance, upstream-maintained (impeccable).
 
 ## Skill metadata
 
@@ -19,8 +19,9 @@ Design guidance for frontend work — /impeccable init, craft, critique, audit, 
 | Version | `4.1.2` |
 | Author | Paul Bakaus (pbakaus) |
 | License | Apache-2.0 |
+| Platforms | linux, macos, windows |
 | Tags | `design`, `frontend`, `ui`, `ux`, `web-design`, `anti-slop` |
-| Related skills | `premium-webapp-ui`, [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design), [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) |
+| Related skills | [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design), [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) |
 
 ## Reference: full SKILL.md
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -387,6 +387,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/creative/creative-draw-your-font',
                     'user-guide/skills/optional/creative/creative-heartmula',
                     'user-guide/skills/optional/creative/creative-hyperframes',
+                    'user-guide/skills/optional/creative/creative-impeccable',
                     'user-guide/skills/optional/creative/creative-kanban-video-orchestrator',
                     'user-guide/skills/optional/creative/creative-meme-generation',
                     'user-guide/skills/optional/creative/creative-pixel-art',


### PR DESCRIPTION
# feat(skills-hub): impeccable joins the optional-skills catalog, content pulled live from upstream

## Summary

`hermes skills install impeccable` (and the docs-page install button) now installs the impeccable frontend-design skill (pbakaus/impeccable, 63k★ — 23 `/impeccable` sub-commands + a 61-rule deterministic anti-slop detector) as an **official optional-skills catalog entry**. The local `optional-skills/creative/impeccable/` dir is a catalog **stub**: its frontmatter declares `metadata.hermes.upstream` (repo + path), and install pulls the real 163-file bundle live from `pbakaus/impeccable:.hermes/skills/impeccable` — the Hermes-native bundle upstream maintains and verifies against hermes-agent releases. Nothing vendored, never stale.

## Changes

- **New generic mechanism** (`tools/skills_hub.py`): `OptionalSkillSource._upstream_pointer()` parses/validates `metadata.hermes.upstream` (owner/name repo, clean relative path, traversal rejected); `_fetch_from_upstream()` delegates to `GitHubSource.fetch()` and relabels the bundle `official/<rel>` at trust `trusted` (curated endorsement, third-party content — dangerous scan verdicts still block). The live-repo fallback path redirects stubs identically, so stale local checkouts behave the same. Any future upstream-maintained catalog entry reuses this.
- **Catalog entry**: `optional-skills/creative/impeccable/SKILL.md` stub + generated docs page + catalog table row + sidebar.
- **Fetch gap fixed**: `GitHubSource.fetch()` only downloaded SKILL.md plus paths linked from canonical support dirs (`references/` plural). Impeccable uses `reference/` singular and links its scripts only from reference files → old fetch shipped **1 of 163 files**. Now downloads the full skill directory via the git tree (same approach the optional-skills live fetch already used); symlink/hidden/unsafe-path rejection kept; missing SKILL.md-linked `references/` still rejects the bundle.
- **Scanner false positive fixed** (`tools/skills_guard.py`): the five `env_exfil_*` patterns flagged loopback requests as critical exfiltration — impeccable's live mode polls `http://localhost:PORT/status?token=TOKEN` and scored 2 CRITICALs (unblockable). Scheme-anchored loopback exemption added; `evil.com/?u=localhost&k=$API_KEY` decoys still fire (10-case regex matrix in tests).
- **Resolution fixes**: `unified_search()` now stable-sorts by trust rank before the limit cut (official entries were crowded out by skills.sh mirrors); `_resolve_short_name()` prefers a sole official exact match over community mirrors, so the bare name resolves instead of stalling on an ambiguity table.
- **Pre-existing test pollution fixed**: `TestInstallPathSafety`'s fixture monkeypatched the PEP 562 dynamic `SKILLS_DIR`, permanently shadowing dynamic resolution — the `served_repo` E2E tests failed in any combined run (reproducible on main).

## Validation

| Check | Result |
|---|---|
| Live E2E `do_install("impeccable")` vs real GitHub | resolves `official/creative/impeccable`, SAFE, 163 files on disk (real content, not stub) |
| `do_install("official/creative/impeccable")` explicit id | ✅ same |
| Installed skill loads + `/impeccable` slash command registers | ✅ |
| Upstream-pointer validation (malformed repo/path/traversal) | 5/5 rejected |
| `env_exfil_*` regex matrix (loopback pass, decoy fire) | 10/10 |
| Full-dir fetch regression test vs OLD fetch (sabotage run) | fails as required |
| `tests/tools/{skills_hub,skills_guard,skill_bundle_provenance}` + `tests/hermes_cli/{skills_hub,skills_install_flags}` | 128/128 |

**Live repro:** before — no catalog entry; a direct install of the upstream path fetched 1/163 files then got BLOCKED on 2 false CRITICALs. After — one command installs the full working skill through quarantine + scan.

## Infographic

![Optional skill: impeccable — live from upstream, full-dir fetch, scanner fix, one command](https://v3b.fal.media/files/b/0aa85b08/wvqM_YcvZGgPJTCfGBikY_2FvEttAx.png)
