### PR TITLE
fix(todo): Tasks panel stays live across merges, reconnects, and hidden tool progress (salvage #97815, #97811)

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/collapsed-indicator.test.tsx
@@ -22,6 +22,22 @@ describe('ComposerStatusStack collapsed todo indicator', () => {
     $todosBySession.set({})
   })
 
+  it('shows a running indicator while the todo group is expanded', () => {
+    $todosBySession.set({
+      'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]
+    })
+
+    render(
+      <MemoryRouter>
+        <ComposerStatusStack queue={null} sessionId="session-1" />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Wire the status stack')).toBeTruthy()
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
+    expect(screen.getByText('Tasks 0/1')).toBeTruthy()
+  })
+
   it('shows a running indicator next to the collapsed todo label', () => {
     $todosBySession.set({
       'session-1': [{ content: 'Wire the status stack', id: '1', status: 'in_progress' }]

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/tools.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/tools.ts
@@ -4,6 +4,7 @@ import { flashPetActivity, setPetActivity } from '@/store/pet'
 import { pruneDelegateFallbackSubagents, upsertSubagent } from '@/store/subagents'
 import { reportMcpToolResult } from '@/store/suggestion-providers/repair'
 import { invalidateSkillSuggestionIndex } from '@/store/suggestion-providers/skill'
+import { restoreSessionTodosFromSnapshot } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
 import { notifyWorkspaceChanged, toolChangedPath, toolMayMutateFiles } from '@/store/workspace-events'
@@ -16,6 +17,14 @@ import type { GatewayEventContext } from './types'
 export function handleToolEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, isActiveEvent, occurredAt } = ctx
   const { flushQueuedDeltas, nativeSubagentSessionsRef, sessionInterrupted, updateSessionState, upsertToolCall } = deps
+
+  if (event.type === 'todo.updated') {
+    if (sessionId && !sessionInterrupted(sessionId)) {
+      restoreSessionTodosFromSnapshot(sessionId, payload, true)
+    }
+
+    return true
+  }
 
   if (event.type === 'tool.generating') {
     // Announced while the model is still emitting the call's JSON, so it

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,7 +23,7 @@ import {
   generatedImageEchoSources,
   stripGeneratedImageEchoes
 } from '@/lib/generated-images'
-import { nextTodosFromToolEvent } from '@/lib/todos'
+import { nextTodosFromToolEvent, parseTodoRevision } from '@/lib/todos'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
@@ -465,7 +465,7 @@ export function useMessageStream({
         const todos = nextTodosFromToolEvent($todosBySession.get()[sessionId] ?? [], payload)
 
         if (todos) {
-          setSessionTodos(sessionId, todos)
+          setSessionTodos(sessionId, todos, parseTodoRevision(payload))
         }
       }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -23,12 +23,12 @@ import {
   generatedImageEchoSources,
   stripGeneratedImageEchoes
 } from '@/lib/generated-images'
-import { parseTodos } from '@/lib/todos'
+import { nextTodosFromToolEvent } from '@/lib/todos'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { upsertSubagent } from '@/store/subagents'
-import { setSessionTodos } from '@/store/todos'
+import { $todosBySession, setSessionTodos } from '@/store/todos'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -462,7 +462,7 @@ export function useMessageStream({
       // The composer status stack owns todo display now (no inline panel) —
       // mirror every todo state the tool reports into its session store.
       if (payload?.name === 'todo') {
-        const todos = parseTodos(payload.todos) ?? parseTodos(payload.result) ?? parseTodos(payload.args)
+        const todos = nextTodosFromToolEvent($todosBySession.get()[sessionId] ?? [], payload)
 
         if (todos) {
           setSessionTodos(sessionId, todos)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
@@ -56,4 +56,18 @@ describe('useMessageStream turn-end todo cleanup', () => {
 
     expect($todosBySession.get()[SID]).toBeUndefined()
   })
+
+  it('applies a dedicated todo snapshot immediately', () => {
+    mountStream()
+
+    act(() =>
+      stream.handleEvent({
+        payload: { revision: 3, todos: [todo('live', 'in_progress')] },
+        session_id: SID,
+        type: 'todo.updated'
+      })
+    )
+
+    expect($todosBySession.get()[SID]?.[0]?.id).toBe('live')
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -118,6 +118,7 @@ import {
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { forgetSessionUnread } from '@/store/session-unread'
 import { $archivedSessions } from '@/store/sidebar-archive'
+import { restoreSessionTodosFromSnapshot } from '@/store/todos'
 import {
   dropTranscriptTail,
   dropTranscriptTailEverywhere,
@@ -1173,6 +1174,8 @@ export function useSessionActions({
                   ? false
                   : resolveResumedBusy(activated.running ?? cachedViewState.busy, Boolean(latestCachedState?.busy))
 
+              restoreSessionTodosFromSnapshot(cachedRuntimeId, activated.todo_state, running)
+
               const activatedTurnStartedAt =
                 typeof activated.turn_started_at === 'number' && activated.turn_started_at > 0
                   ? activated.turn_started_at * 1000
@@ -1612,6 +1615,8 @@ export function useSessionActions({
           (resumed as { running?: boolean }).running,
           Boolean(sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.busy)
         )
+
+        restoreSessionTodosFromSnapshot(resumed.session_id, resumed.todo_state, resumedRunning)
 
         // Crash-survivable turn progress: fold a journaled in-flight tail
         // (persisted by use-session-state-cache while the turn streamed;

--- a/apps/desktop/src/components/chat/status-section.tsx
+++ b/apps/desktop/src/components/chat/status-section.tsx
@@ -7,7 +7,7 @@ interface StatusSectionProps {
    *  `Button` with `size="micro"` + `variant="text"` or `"link"`. */
   accessory?: ReactNode
   children: ReactNode
-  /** Optional inline status shown only while the group is collapsed. */
+  /** Optional inline status next to the label (running spinner, etc). */
   collapsedIndicator?: ReactNode
   defaultCollapsed?: boolean
   /** Optional glyph between the caret and the label (e.g. a `Codicon`). */
@@ -42,7 +42,7 @@ export function StatusSection({
           <DisclosureCaret className="shrink-0" open={!collapsed} size="1em" />
           {icon && <span className="flex shrink-0 items-center">{icon}</span>}
           <span className="min-w-0 truncate">{label}</span>
-          {collapsed && collapsedIndicator && <span className="flex shrink-0 items-center">{collapsedIndicator}</span>}
+          {collapsedIndicator && <span className="flex shrink-0 items-center">{collapsedIndicator}</span>}
         </button>
         {accessory && <div className="flex shrink-0 items-center gap-1">{accessory}</div>}
       </div>

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -71,6 +71,7 @@ export type GatewayEventPayload = {
   inline_diff?: string
   duration_s?: number
   todos?: unknown
+  revision?: number
   model?: string
   provider?: string
   reasoning_effort?: string

--- a/apps/desktop/src/lib/todos.test.ts
+++ b/apps/desktop/src/lib/todos.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { latestSessionTodos, parseTodos, todoTree } from './todos'
+import { latestSessionTodos, mergeTodoItems, nextTodosFromToolEvent, parseTodoPatch, parseTodos, todoTree } from './todos'
 
 describe('todoTree', () => {
   it('orders parents before children with depths', () => {
@@ -121,5 +121,79 @@ describe('latestSessionTodos', () => {
   it('returns null when no todo tool calls exist', () => {
     expect(latestSessionTodos([{ parts: [{ type: 'text', text: 'hi' }] }])).toBeNull()
     expect(latestSessionTodos([])).toBeNull()
+  })
+})
+
+describe('mergeTodoItems', () => {
+  const list = [
+    { content: 'Fix C', id: 'c', status: 'in_progress' as const },
+    { content: 'Fix D', id: 'd', status: 'pending' as const },
+    { content: 'Fix A', id: 'a', status: 'pending' as const }
+  ]
+
+  it('updates status by id and keeps the rest of the list', () => {
+    expect(mergeTodoItems(list, [{ id: 'c', status: 'completed' }])).toEqual([
+      { content: 'Fix C', id: 'c', status: 'completed' },
+      { content: 'Fix D', id: 'd', status: 'pending' },
+      { content: 'Fix A', id: 'a', status: 'pending' }
+    ])
+  })
+
+  it('appends a new item and fills missing content', () => {
+    expect(mergeTodoItems(list, [{ id: 'v', status: 'pending' }])).toEqual([
+      ...list,
+      { content: '(no description)', id: 'v', status: 'pending' }
+    ])
+  })
+})
+
+describe('nextTodosFromToolEvent', () => {
+  const current = [
+    { content: 'Fix C', id: 'c', status: 'pending' as const },
+    { content: 'Fix D', id: 'd', status: 'pending' as const }
+  ]
+
+  it('replaces from the full tool result', () => {
+    expect(
+      nextTodosFromToolEvent(current, {
+        todos: [
+          { content: 'Fix C', id: 'c', status: 'completed' },
+          { content: 'Fix D', id: 'd', status: 'in_progress' }
+        ]
+      })
+    ).toEqual([
+      { content: 'Fix C', id: 'c', status: 'completed' },
+      { content: 'Fix D', id: 'd', status: 'in_progress' }
+    ])
+  })
+
+  it('merges a status-only start payload instead of replacing the list', () => {
+    expect(
+      nextTodosFromToolEvent(current, {
+        args: { merge: true, todos: [{ id: 'c', status: 'completed' }] }
+      })
+    ).toEqual([
+      { content: 'Fix C', id: 'c', status: 'completed' },
+      { content: 'Fix D', id: 'd', status: 'pending' }
+    ])
+  })
+
+  it('does not wipe the list when a merge payload has no usable items', () => {
+    expect(nextTodosFromToolEvent(current, { args: { merge: true, todos: [] } })).toBeNull()
+  })
+
+  it('still replaces when merge is off', () => {
+    expect(
+      nextTodosFromToolEvent(current, {
+        args: { todos: [{ content: 'Only this', id: 'c', status: 'completed' }] }
+      })
+    ).toEqual([{ content: 'Only this', id: 'c', status: 'completed' }])
+  })
+})
+
+describe('parseTodoPatch', () => {
+  it('keeps status-only items that parseTodos would drop', () => {
+    expect(parseTodos([{ id: 'c', status: 'completed' }])).toEqual([])
+    expect(parseTodoPatch([{ id: 'c', status: 'completed' }])).toEqual([{ id: 'c', status: 'completed' }])
   })
 })

--- a/apps/desktop/src/lib/todos.test.ts
+++ b/apps/desktop/src/lib/todos.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { latestSessionTodos, mergeTodoItems, nextTodosFromToolEvent, parseTodoPatch, parseTodos, todoTree } from './todos'
+import { latestSessionTodos, mergeTodoItems, nextTodosFromToolEvent, parseTodoPatch, parseTodoRevision, parseTodos, todoTree } from './todos'
 
 describe('todoTree', () => {
   it('orders parents before children with depths', () => {
@@ -76,6 +76,19 @@ describe('parseTodos', () => {
     expect(parseTodos(undefined)).toBeNull()
     expect(parseTodos('not json')).toBeNull()
     expect(parseTodos({ message: 'no todos here' })).toBeNull()
+  })
+})
+
+describe('parseTodoRevision', () => {
+  it('parses direct and wrapped revisions', () => {
+    expect(parseTodoRevision({ revision: 3 })).toBe(3)
+    expect(parseTodoRevision({ result: '{"revision":4}' })).toBe(4)
+  })
+
+  it('rejects invalid revisions', () => {
+    expect(parseTodoRevision({ revision: -1 })).toBeNull()
+    expect(parseTodoRevision({ revision: 1.5 })).toBeNull()
+    expect(parseTodoRevision({ revision: '3' })).toBeNull()
   })
 })
 

--- a/apps/desktop/src/lib/todos.ts
+++ b/apps/desktop/src/lib/todos.ts
@@ -203,6 +203,32 @@ export function nextTodosFromToolEvent(
   return parseTodos(args)
 }
 
+function parseRevision(value: unknown, depth: number): null | number {
+  if (depth > 2) {
+    return null
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return parseRevision(JSON.parse(value), depth + 1)
+    } catch {
+      return null
+    }
+  }
+
+  if (!isRecord(value)) {
+    return null
+  }
+
+  if (typeof value.revision === 'number' && Number.isSafeInteger(value.revision) && value.revision >= 0) {
+    return value.revision
+  }
+
+  return Object.hasOwn(value, 'result') ? parseRevision(value.result, depth + 1) : null
+}
+
+export const parseTodoRevision = (value: unknown): null | number => parseRevision(value, 0)
+
 /** Latest parseable todo list from one message's aui content parts (tool-call
  *  parts named `todo`; live parts carry `todos`, hydrated ones args/result). */
 export function todosFromMessageContent(content: unknown): null | TodoItem[] {

--- a/apps/desktop/src/lib/todos.ts
+++ b/apps/desktop/src/lib/todos.ts
@@ -8,6 +8,14 @@ export interface TodoItem {
   status: TodoStatus
 }
 
+/** One item from a `merge: true` write. Content is optional so a status-only
+ *  patch still applies to an existing row. */
+export interface TodoPatch {
+  content?: string
+  id: string
+  status: TodoStatus
+}
+
 const STATUSES: readonly TodoStatus[] = ['pending', 'in_progress', 'completed', 'cancelled']
 
 const isRecord = (v: unknown): v is Record<string, unknown> => Boolean(v && typeof v === 'object' && !Array.isArray(v))
@@ -24,6 +32,24 @@ function parseArray(value: unknown[]): TodoItem[] {
     const parent = String(item.parent ?? '').trim()
 
     return id && content ? [{ content, id, status: item.status, ...(parent && parent !== id ? { parent } : {}) }] : []
+  })
+}
+
+function parsePatchArray(value: unknown[]): TodoPatch[] {
+  return value.flatMap(item => {
+    if (!isRecord(item) || !isStatus(item.status)) {
+      return []
+    }
+
+    const id = String(item.id ?? '').trim()
+
+    if (!id) {
+      return []
+    }
+
+    const content = String(item.content ?? '').trim()
+
+    return content ? [{ content, id, status: item.status }] : [{ id, status: item.status }]
   })
 }
 
@@ -99,6 +125,82 @@ export function todoTree(todos: readonly TodoItem[]): [TodoItem, number][] {
   }
 
   return out
+}
+
+function parsePatch(value: unknown, depth: number): null | TodoPatch[] {
+  if (depth > 2) {
+    return null
+  }
+
+  if (Array.isArray(value)) {
+    return parsePatchArray(value)
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return parsePatch(JSON.parse(value), depth + 1)
+    } catch {
+      return null
+    }
+  }
+
+  if (isRecord(value) && Object.hasOwn(value, 'todos')) {
+    return parsePatch(value.todos, depth + 1)
+  }
+
+  return null
+}
+
+export const parseTodoPatch = (value: unknown): null | TodoPatch[] => parsePatch(value, 0)
+
+export const todoArgsWantMerge = (args: unknown): boolean => isRecord(args) && args.merge === true
+
+/** Same as TodoStore.write(merge=True): update by id, append new items. */
+export function mergeTodoItems(current: readonly TodoItem[], patch: readonly TodoPatch[]): TodoItem[] {
+  const next = current.map(item => ({ ...item }))
+  const indexById = new Map(next.map((item, index) => [item.id, index]))
+
+  for (const item of patch) {
+    const index = indexById.get(item.id)
+
+    if (index === undefined) {
+      next.push({ content: item.content?.trim() || '(no description)', id: item.id, status: item.status })
+      indexById.set(item.id, next.length - 1)
+      continue
+    }
+
+    if (item.content) {
+      next[index].content = item.content
+    }
+
+    next[index].status = item.status
+  }
+
+  return next
+}
+
+/** Live tool event to the next list. `payload.todos` / `result` is the full
+ *  store, so replace. `args` with `merge: true` patches by id so a status-only
+ *  start event does not wipe the rest of the checklist. */
+export function nextTodosFromToolEvent(
+  current: readonly TodoItem[],
+  payload: { args?: unknown; arguments?: unknown; result?: unknown; todos?: unknown }
+): null | TodoItem[] {
+  const fromResult = parseTodos(payload.todos) ?? parseTodos(payload.result)
+
+  if (fromResult) {
+    return fromResult
+  }
+
+  const args = payload.args ?? payload.arguments
+
+  if (todoArgsWantMerge(args)) {
+    const patch = parseTodoPatch(args)
+
+    return patch && patch.length > 0 ? mergeTodoItems(current, patch) : null
+  }
+
+  return parseTodos(args)
 }
 
 /** Latest parseable todo list from one message's aui content parts (tool-call

--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -3,9 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TodoItem } from '@/lib/todos'
 
 import {
+  $todoRevisionsBySession,
   $todosBySession,
   clearActiveSessionTodos,
   clearSessionTodos,
+  restoreSessionTodosFromSnapshot,
   setSessionTodos,
   todosForHydration
 } from './todos'
@@ -101,5 +103,35 @@ describe('todosForHydration (stale-active guard on restore)', () => {
 
   it('returns null when there is nothing stored', () => {
     expect(todosForHydration(null)).toBeNull()
+  })
+})
+
+describe('revisioned snapshots', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    clearSessionTodos('s1')
+  })
+
+  afterEach(() => {
+    clearSessionTodos('s1')
+    vi.useRealTimers()
+  })
+
+  it('rejects a snapshot older than the latest live update', () => {
+    setSessionTodos('s1', [todo('new', 'in_progress')], 5)
+    setSessionTodos('s1', [todo('old', 'pending')], 4)
+
+    expect($todosBySession.get().s1?.[0]?.id).toBe('new')
+    expect($todoRevisionsBySession.get().s1).toBe(5)
+  })
+
+  it('restores an active snapshot only while the session is running', () => {
+    const snapshot = { revision: 7, todos: [todo('active', 'in_progress')] }
+
+    restoreSessionTodosFromSnapshot('s1', snapshot, false)
+    expect($todosBySession.get().s1).toBeUndefined()
+
+    restoreSessionTodosFromSnapshot('s1', snapshot, true)
+    expect($todosBySession.get().s1?.[0]?.id).toBe('active')
   })
 })

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -2,7 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import { keyedTimeouts } from '@/lib/keyed-timeouts'
 import { stableRecord } from '@/lib/stable-array'
-import type { TodoItem } from '@/lib/todos'
+import { parseTodoRevision, parseTodos, type TodoItem } from '@/lib/todos'
 
 import { $sessions, lineageAliases } from './session'
 import { $sessionStates } from './session-states'
@@ -17,6 +17,7 @@ import { $sessionStates } from './session-states'
  *   above the composer forever.
  */
 export const $todosBySession = atom<Record<string, TodoItem[]>>({})
+export const $todoRevisionsBySession = atom<Record<string, number>>({})
 
 export const todoListActive = (todos: readonly TodoItem[]) =>
   todos.some(t => t.status === 'pending' || t.status === 'in_progress')
@@ -69,8 +70,31 @@ export function todosForHydration(todos: readonly TodoItem[] | null): TodoItem[]
 const FINISHED_LINGER_MS = 4_000
 const clearTimers = keyedTimeouts()
 
-export function setSessionTodos(sid: string, todos: TodoItem[]) {
+function acceptRevision(sid: string, revision?: null | number): boolean {
+  const revisions = $todoRevisionsBySession.get()
+  const current = revisions[sid]
+
+  if (revision == null) {
+    return current == null
+  }
+
+  if (current != null && revision < current) {
+    return false
+  }
+
+  if (current !== revision) {
+    $todoRevisionsBySession.set({ ...revisions, [sid]: revision })
+  }
+
+  return true
+}
+
+export function setSessionTodos(sid: string, todos: TodoItem[], revision?: null | number) {
   if (!sid) {
+    return
+  }
+
+  if (!acceptRevision(sid, revision)) {
     return
   }
 
@@ -78,21 +102,32 @@ export function setSessionTodos(sid: string, todos: TodoItem[]) {
   $todosBySession.set({ ...$todosBySession.get(), [sid]: todos })
 
   if (!todoListActive(todos)) {
-    clearTimers.schedule(sid, FINISHED_LINGER_MS, () => clearSessionTodos(sid))
+    clearTimers.schedule(sid, FINISHED_LINGER_MS, () => dropSessionTodos(sid, false))
   }
 }
 
-export function clearSessionTodos(sid: string) {
+function dropSessionTodos(sid: string, forgetRevision: boolean) {
   clearTimers.cancel(sid)
 
   const map = $todosBySession.get()
 
-  if (!(sid in map)) {
-    return
+  if (sid in map) {
+    const { [sid]: _drop, ...rest } = map
+    $todosBySession.set(rest)
   }
 
-  const { [sid]: _drop, ...rest } = map
-  $todosBySession.set(rest)
+  if (forgetRevision) {
+    const revisions = $todoRevisionsBySession.get()
+
+    if (sid in revisions) {
+      const { [sid]: _drop, ...rest } = revisions
+      $todoRevisionsBySession.set(rest)
+    }
+  }
+}
+
+export function clearSessionTodos(sid: string) {
+  dropSessionTodos(sid, true)
 }
 
 // Drop a still-active todo list (any pending/in_progress item) — used at turn
@@ -107,5 +142,25 @@ export function clearActiveSessionTodos(sid: string) {
     return
   }
 
-  clearSessionTodos(sid)
+  dropSessionTodos(sid, false)
+}
+
+/** Apply a session.resume/activate or todo.updated full snapshot. Idle
+ * sessions keep the existing stale-active guard; running sessions restore the
+ * active plan because the backend has proved that turn is still live. */
+export function restoreSessionTodosFromSnapshot(sid: string, snapshot: unknown, running: boolean) {
+  const todos = parseTodos(snapshot)
+
+  if (!sid || todos === null) {
+    return
+  }
+
+  const revision = parseTodoRevision(snapshot)
+  const visible = running ? todos : todosForHydration(todos)
+
+  if (visible !== null) {
+    setSessionTodos(sid, visible, revision)
+  } else if (acceptRevision(sid, revision)) {
+    dropSessionTodos(sid, false)
+  }
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -683,6 +683,12 @@ export interface SessionResumeResponse {
   session_key?: string
   started_at?: number
   status?: string
+  /** Latest full task snapshot. Revisions let the renderer reject a response
+   * that raced with a newer live update. */
+  todo_state?: {
+    revision?: number
+    todos?: unknown
+  }
   /** Epoch seconds the current turn started, or null when idle. */
   turn_started_at?: number | null
 }

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -14,6 +14,7 @@ export type GatewayEventName =
   | 'tool.progress'
   | 'tool.complete'
   | 'tool.generating'
+  | 'todo.updated'
   | 'clarify.request'
   | 'approval.request'
   | 'sudo.request'

--- a/run_agent.py
+++ b/run_agent.py
@@ -4790,6 +4790,7 @@ class AIAgent:
 
         # Walk history backwards to find the most recent todo tool response
         last_todo_response = None
+        last_todo_revision = 0
         for idx in range(len(history) - 1, -1, -1):
             msg = history[idx]
             if msg.get("role") != "tool":
@@ -4815,15 +4816,32 @@ class AIAgent:
                 data = json.loads(content)
                 if "todos" in data and isinstance(data["todos"], list):
                     last_todo_response = data["todos"]
+                    last_todo_revision = data.get("revision", 1)
                     break
             except (json.JSONDecodeError, TypeError):
                 continue
 
-        if last_todo_response:
-            # Replay the items into the store (replace mode)
-            self._todo_store.write(last_todo_response, merge=False)
-            if not self.quiet_mode:
-                self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
+        if last_todo_response is not None:
+            # Restore only when history carries a newer revision than the
+            # store already holds (a live store re-hydrated in place must not
+            # be rolled back by older history). Sessions that predate
+            # revisions default to 1 so they still hydrate. Empty lists
+            # matter: they are an authoritative clear after an earlier
+            # non-empty plan.
+            current_revision = int(
+                self._todo_store.snapshot().get("revision", 0) or 0
+            )
+            try:
+                history_revision = max(0, int(last_todo_revision or 0))
+            except (TypeError, ValueError):
+                history_revision = 1
+            if history_revision > current_revision:
+                self._todo_store.restore(
+                    last_todo_response,
+                    revision=history_revision,
+                )
+                if not self.quiet_mode:
+                    self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
         _set_interrupt(False)
 
     @classmethod

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -904,6 +904,56 @@ class TestHydrateTodoStore:
             agent._hydrate_todo_store(history)
         assert not agent._todo_store.has_items()
 
+    def test_newer_live_revision_wins_over_history(self, agent):
+        agent._todo_store.restore(
+            [{"id": "db", "content": "Current", "status": "in_progress"}],
+            revision=5,
+        )
+        history = [
+            self._assistant_todo_call(),
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": json.dumps(
+                    {
+                        "todos": [
+                            {"id": "old", "content": "Old", "status": "pending"}
+                        ],
+                        "revision": 4,
+                    }
+                ),
+            },
+        ]
+
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+
+        assert agent._todo_store.snapshot()["revision"] == 5
+        assert agent._todo_store.read()[0]["id"] == "db"
+
+    def test_history_recovers_newer_snapshot(self, agent):
+        history = [
+            self._assistant_todo_call(),
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": json.dumps(
+                    {
+                        "todos": [
+                            {"id": "new", "content": "Recovered", "status": "pending"}
+                        ],
+                        "revision": 2,
+                    }
+                ),
+            },
+        ]
+
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+
+        assert agent._todo_store.snapshot()["revision"] == 2
+        assert agent._todo_store.read()[0]["id"] == "new"
+
 
 
 

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -130,11 +130,36 @@ class TestTodoToolFunction:
         result = json.loads(todo_tool(store=store))
         assert result["summary"]["total"] == 1
         assert result["summary"]["pending"] == 1
+        assert result["revision"] == 1
 
 
     def test_no_store_returns_error(self):
         result = json.loads(todo_tool())
         assert "error" in result
+
+
+class TestTodoStoreSnapshots:
+    def test_revision_only_advances_when_state_changes(self):
+        store = TodoStore()
+        items = [{"id": "1", "content": "Task", "status": "pending"}]
+
+        store.write(items)
+        first = store.snapshot()
+        store.write(items)
+
+        assert first["revision"] == 1
+        assert store.snapshot() == first
+
+    def test_restore_adopts_a_trusted_revision(self):
+        store = TodoStore()
+        store.restore(
+            [{"id": "1", "content": "Task", "status": "pending"}], revision=7
+        )
+
+        assert store.snapshot()["revision"] == 7
+
+        store.write([{"id": "1", "content": "Task", "status": "completed"}])
+        assert store.snapshot()["revision"] == 8
 
 
 class TestTodoStoreBounds:

--- a/tests/tui_gateway/test_todo_state_events.py
+++ b/tests/tui_gateway/test_todo_state_events.py
@@ -1,0 +1,80 @@
+"""Todo snapshots bypass optional tool-progress display settings."""
+
+import json
+
+import tui_gateway.server as server
+
+
+def test_todo_completion_always_emits_snapshot_and_compat_event(monkeypatch):
+    sid = "todo-state-test"
+    events = []
+    session = {
+        "agent": None,
+        "edit_snapshots": {},
+        "tool_started_at": {},
+        "tool_progress_mode": "off",
+    }
+    monkeypatch.setitem(server._sessions, sid, session)
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: False)
+    monkeypatch.setattr(server, "_tool_lifecycle_required_for_ui", lambda _name: False)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, event_sid, payload=None: events.append(
+            (event, event_sid, payload)
+        ),
+    )
+
+    state = {
+        "todos": [{"id": "1", "content": "Work", "status": "in_progress"}],
+        "revision": 9,
+    }
+    server._on_tool_complete(sid, "call-1", "todo", {}, json.dumps(state))
+
+    assert [event[0] for event in events] == ["tool.complete", "todo.updated"]
+    assert events[-1] == ("todo.updated", sid, state)
+    assert session["todo_state"] == state
+
+
+def test_non_todo_completion_stays_suppressed_when_progress_is_off(monkeypatch):
+    sid = "ordinary-tool-test"
+    events = []
+    monkeypatch.setitem(
+        server._sessions,
+        sid,
+        {
+            "agent": None,
+            "edit_snapshots": {},
+            "tool_started_at": {},
+            "tool_progress_mode": "off",
+        },
+    )
+    monkeypatch.setattr(server, "_tool_progress_enabled", lambda _sid: False)
+    monkeypatch.setattr(server, "_tool_lifecycle_required_for_ui", lambda _name: False)
+    monkeypatch.setattr(server, "_emit", lambda *args: events.append(args))
+
+    server._on_tool_complete(sid, "call-1", "terminal", {}, "ok")
+
+    assert events == []
+
+
+def test_live_snapshot_prefers_the_highest_revision():
+    class Store:
+        @staticmethod
+        def snapshot():
+            return {"todos": [], "revision": 4}
+
+    class Agent:
+        _todo_store = Store()
+
+    session = {
+        "agent": Agent(),
+        "todo_state": {
+            "todos": [{"id": "1", "content": "Current", "status": "pending"}],
+            "revision": 5,
+        },
+    }
+
+    payload = server._attach_todo_state({}, session)
+
+    assert payload["todo_state"]["revision"] == 5

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -2,10 +2,11 @@
 """
 Todo Tool Module - Planning & Task Management
 
-Provides an in-memory task list the agent uses to decompose complex tasks,
-track progress, and maintain focus across long conversations. The state
-lives on the AIAgent instance (one per session) and is re-injected into
-the conversation after context compression events.
+Provides an in-memory, revisioned task list the agent uses to decompose
+complex tasks, track progress, and maintain focus across long conversations.
+The state lives on the AIAgent instance (one per session), is re-injected into
+the conversation after context compression events, and every write bumps a
+monotonic revision so UI clients can reject stale updates.
 
 Design:
 - Single `todo` tool: provide `todos` param to write, omit to read
@@ -15,7 +16,7 @@ Design:
 """
 
 import json
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 # Valid status values for todo items
@@ -56,6 +57,7 @@ class TodoStore:
 
     def __init__(self):
         self._items: List[Dict[str, str]] = []
+        self._revision = 0
 
     def write(self, todos: List[Dict[str, Any]], merge: bool = False) -> List[Dict[str, str]]:
         """
@@ -66,6 +68,7 @@ class TodoStore:
             merge: if False, replace the entire list. If True, update
                    existing items by id and append new ones.
         """
+        before = self.read()
         if not merge:
             # Replace mode: new list entirely
             self._items = self._normalize_order(
@@ -113,6 +116,8 @@ class TodoStore:
         if len(self._items) > MAX_TODO_ITEMS:
             self._items = self._items[:MAX_TODO_ITEMS]
         self._sanitize_parents(self._items)
+        if self._items != before:
+            self._revision += 1
         return self.read()
 
     def read(self) -> List[Dict[str, str]]:
@@ -122,6 +127,26 @@ class TodoStore:
     def has_items(self) -> bool:
         """Check if there are any items in the list."""
         return bool(self._items)
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return the full state clients can reconcile atomically."""
+        return {"todos": self.read(), "revision": self._revision}
+
+    def restore(
+        self,
+        todos: List[Dict[str, Any]],
+        *,
+        revision: Any = 0,
+    ) -> List[Dict[str, str]]:
+        """Restore a trusted snapshot without manufacturing a new revision."""
+        self._items = self._normalize_order(
+            [self._validate(t) for t in self._dedupe_by_id(todos)]
+        )[:MAX_TODO_ITEMS]
+        try:
+            self._revision = max(0, int(revision or 0))
+        except (TypeError, ValueError):
+            self._revision = 0
+        return self.read()
 
     def format_for_injection(self) -> Optional[str]:
         """
@@ -330,6 +355,7 @@ def todo_tool(
 
     return json.dumps({
         "todos": items,
+        "revision": store.snapshot()["revision"],
         "summary": {
             "total": len(items),
             "pending": pending,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -565,10 +565,8 @@ def _(rid, params: dict) -> dict:
                 target = tip
                 found = db.get_session(target) or found
 
-        # A full snapshot is cheap to read and makes every resume path an
-        # authoritative recovery point for task UI state, including deferred
-        # agent builds and reconnects that missed the live event.
-        resume_todo_state = _read_persisted_todo_state(db, target)
+        # Todo snapshots are derived from each path's already-loaded history
+        # (see _todo_state_from_history) — no extra transcript read here.
 
         # Every interactive resume path materializes the model history, even when
         # omit_messages suppresses the response copy. Count the complete lineage
@@ -690,7 +688,7 @@ def _(rid, params: dict) -> dict:
                 close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
                 profile_home=profile_home,
                 lazy=True,
-                todo_state=resume_todo_state,
+                todo_state=_todo_state_from_history(history),
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -762,7 +760,6 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
-                todo_state=resume_todo_state,
             )
             record["resume_history_ready"] = threading.Event()
             record["resume_hydrating"] = True
@@ -862,7 +859,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
-                todo_state=resume_todo_state,
+                todo_state=_todo_state_from_history(history),
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -473,17 +473,20 @@ def _(rid, params: dict) -> dict:
                     history = live.get("history") or []
                     return _ok(
                         rid,
-                        {
-                            "session_id": live_sid,
-                            "stored_session_id": str(live.get("session_key") or ""),
-                            "message_count": len(history),
-                            "messages": [] if omit_messages else _history_to_messages(history),
-                            "info": {
-                                "model": _resolve_model(),
-                                "lazy": True,
-                                "profile_name": profile or "",
+                        _attach_todo_state(
+                            {
+                                "session_id": live_sid,
+                                "stored_session_id": str(live.get("session_key") or ""),
+                                "message_count": len(history),
+                                "messages": [] if omit_messages else _history_to_messages(history),
+                                "info": {
+                                    "model": _resolve_model(),
+                                    "lazy": True,
+                                    "profile_name": profile or "",
+                                },
                             },
-                        },
+                            live,
+                        ),
                     )
 
                 # Stranded-session adoption (#93296 follow-up): before session
@@ -561,6 +564,11 @@ def _(rid, params: dict) -> dict:
             if tip and tip != target:
                 target = tip
                 found = db.get_session(target) or found
+
+        # A full snapshot is cheap to read and makes every resume path an
+        # authoritative recovery point for task UI state, including deferred
+        # agent builds and reconnects that missed the live event.
+        resume_todo_state = _read_persisted_todo_state(db, target)
 
         # Every interactive resume path materializes the model history, even when
         # omit_messages suppresses the response copy. Count the complete lineage
@@ -682,6 +690,7 @@ def _(rid, params: dict) -> dict:
                 close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
                 profile_home=profile_home,
                 lazy=True,
+                todo_state=resume_todo_state,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -704,19 +713,22 @@ def _(rid, params: dict) -> dict:
             messages = [] if omit_messages else _history_to_messages(display_history)
             return _ok(
                 rid,
-                {
-                    "session_id": sid,
-                    "resumed": target,
-                    "message_count": len(display_history) if omit_messages else len(messages),
-                    "messages": messages,
-                    "messages_omitted": omit_messages,
-                    "info": _lazy_resume_info(cwd, profile=profile),
-                    "inflight": None,
-                    "running": child_running,
-                    "session_key": target,
-                    "started_at": record["created_at"],
-                    "status": "streaming" if child_running else "idle",
-                },
+                _attach_todo_state(
+                    {
+                        "session_id": sid,
+                        "resumed": target,
+                        "message_count": len(display_history) if omit_messages else len(messages),
+                        "messages": messages,
+                        "messages_omitted": omit_messages,
+                        "info": _lazy_resume_info(cwd, profile=profile),
+                        "inflight": None,
+                        "running": child_running,
+                        "session_key": target,
+                        "started_at": record["created_at"],
+                        "status": "streaming" if child_running else "idle",
+                    },
+                    record,
+                ),
             )
 
         # Desktop can ask for a bounded acknowledgement and hydrate the display
@@ -750,6 +762,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                todo_state=resume_todo_state,
             )
             record["resume_history_ready"] = threading.Event()
             record["resume_hydrating"] = True
@@ -765,24 +778,27 @@ def _(rid, params: dict) -> dict:
             _schedule_session_cap_enforcement()
             return _ok(
                 rid,
-                {
-                    "session_id": sid,
-                    "resumed": target,
-                    "message_count": record["resume_message_count"],
-                    "messages": [],
-                    "hydrating": True,
-                    "info": _lazy_resume_info(
-                        cwd,
-                        model=model_override.get("model") or "",
-                        provider=overrides.get("provider_override") or "",
-                        profile=profile,
-                    ),
-                    "inflight": None,
-                    "running": False,
-                    "session_key": target,
-                    "started_at": record["created_at"],
-                    "status": "resuming",
-                },
+                _attach_todo_state(
+                    {
+                        "session_id": sid,
+                        "resumed": target,
+                        "message_count": record["resume_message_count"],
+                        "messages": [],
+                        "hydrating": True,
+                        "info": _lazy_resume_info(
+                            cwd,
+                            model=model_override.get("model") or "",
+                            provider=overrides.get("provider_override") or "",
+                            profile=profile,
+                        ),
+                        "inflight": None,
+                        "running": False,
+                        "session_key": target,
+                        "started_at": record["created_at"],
+                        "status": "resuming",
+                    },
+                    record,
+                ),
             )
 
         # Cold resume default: register the live session and read its stored
@@ -846,6 +862,7 @@ def _(rid, params: dict) -> dict:
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                todo_state=resume_todo_state,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -875,7 +892,7 @@ def _(rid, params: dict) -> dict:
             }
             if auto_continue is not None:
                 payload["auto_continue"] = auto_continue
-            return _ok(rid, payload)
+            return _ok(rid, _attach_todo_state(payload, record))
 
         # Build the agent OUTSIDE the lock — _make_agent can block for seconds
         # (MCP discovery, prompt/skill build, AIAgent construction). Holding
@@ -1077,7 +1094,7 @@ def _(rid, params: dict) -> dict:
     }
     if auto_continue is not None:
         payload["auto_continue"] = auto_continue
-    return _ok(rid, payload)
+    return _ok(rid, _attach_todo_state(payload, session))
 
 
 @method("session.cwd.set")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7645,31 +7645,34 @@ def _attach_todo_state(payload: dict, session: dict) -> dict:
     return payload
 
 
-def _read_persisted_todo_state(db, session_id: str) -> dict | None:
-    """Derive the latest todo snapshot from the session's stored transcript.
+def _todo_state_from_history(history) -> dict | None:
+    """Derive the latest todo snapshot from an already-loaded transcript.
 
     Used by resume paths that answer before an AIAgent (and its live
-    TodoStore) exists. The canonical todo tool results already persist in the
-    session DB as ordinary tool messages, so the latest one paired with an
-    assistant ``todo`` tool call IS the durable snapshot — no side table.
+    TodoStore) exists. The canonical todo tool results already persist in
+    conversation history as ordinary tool messages, so the latest one paired
+    with an assistant ``todo`` tool call IS the durable snapshot — no side
+    table and no extra transcript read (each resume path passes the history
+    it already loaded).
     """
-    getter = getattr(db, "get_messages_as_conversation", None)
-    if not callable(getter):
+    if not isinstance(history, list) or not history:
         return None
     try:
         from tools.todo_tool import MAX_TODO_RESULT_CHARS
 
-        raw = getter(session_id, include_ancestors=True)
-        history: list = list(raw) if isinstance(raw, list) else []
         todo_call_ids: set[str] = set()
         for msg in history:
+            if not isinstance(msg, dict):
+                continue
             for call in msg.get("tool_calls") or []:
                 if (call.get("function") or {}).get("name") == "todo":
                     cid = call.get("id")
                     if cid:
                         todo_call_ids.add(cid)
+        if not todo_call_ids:
+            return None
         for msg in reversed(history):
-            if msg.get("role") != "tool":
+            if not isinstance(msg, dict) or msg.get("role") != "tool":
                 continue
             if msg.get("tool_call_id") not in todo_call_ids:
                 continue
@@ -7686,7 +7689,7 @@ def _read_persisted_todo_state(db, session_id: str) -> dict | None:
                 continue
         return None
     except Exception:
-        logger.debug("failed to read persisted todo state", exc_info=True)
+        logger.debug("failed to derive todo state from history", exc_info=True)
         return None
 
 
@@ -10508,6 +10511,11 @@ def _schedule_resume_hydration(
                 session["display_history_prefix"] = prefix
                 session["resume_hydrating"] = False
                 session["resume_message_count"] = len(display_history)
+            # Deferred resumes answered before the transcript existed; cache
+            # the derived todo snapshot now so later payload attaches carry it.
+            todo_state = _todo_state_from_history(history)
+            if todo_state is not None and session.get("todo_state") is None:
+                session["todo_state"] = todo_state
             session["resume_history_ready"].set()
             _emit(
                 "session.resume_progress",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3263,6 +3263,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # Session DB row deferred to first run_conversation() call.
             # pending_title applied post-first-message (see cli.exec handler).
             current["agent"] = agent
+            _session_todo_state(current)
             # Baseline for the per-turn config sync; the profile home
             # override is still active here.
             current["config_model_seen"] = _config_model_target()
@@ -7603,6 +7604,92 @@ def _tool_summary(name: str, result: str, duration_s: float | None) -> str | Non
     return f"{text}{suffix}" if text else None
 
 
+def _normalize_todo_state(value: object) -> dict | None:
+    """Return a client-safe full todo snapshot or ``None`` when malformed."""
+    if not isinstance(value, dict) or not isinstance(value.get("todos"), list):
+        return None
+    try:
+        revision = max(0, int(value.get("revision") or 0))
+    except (TypeError, ValueError):
+        return None
+    return {"todos": list(value["todos"]), "revision": revision}
+
+
+def _session_todo_state(session: dict) -> dict | None:
+    """Return the newest live/cached todo snapshot for a runtime session."""
+    cached = _normalize_todo_state(session.get("todo_state"))
+    live = None
+    agent = session.get("agent")
+    store = getattr(agent, "_todo_store", None)
+    snapshot = getattr(store, "snapshot", None)
+    if callable(snapshot):
+        try:
+            live = _normalize_todo_state(snapshot())
+        except Exception:
+            logger.debug("failed to read live todo state", exc_info=True)
+
+    if live is not None and (
+        cached is None or live["revision"] >= cached["revision"]
+    ):
+        cached = live
+    if cached is not None:
+        session["todo_state"] = cached
+    return cached
+
+
+def _attach_todo_state(payload: dict, session: dict) -> dict:
+    """Attach the authoritative todo snapshot to a session response."""
+    state = _session_todo_state(session)
+    if state is not None:
+        payload["todo_state"] = state
+    return payload
+
+
+def _read_persisted_todo_state(db, session_id: str) -> dict | None:
+    """Derive the latest todo snapshot from the session's stored transcript.
+
+    Used by resume paths that answer before an AIAgent (and its live
+    TodoStore) exists. The canonical todo tool results already persist in the
+    session DB as ordinary tool messages, so the latest one paired with an
+    assistant ``todo`` tool call IS the durable snapshot — no side table.
+    """
+    getter = getattr(db, "get_messages_as_conversation", None)
+    if not callable(getter):
+        return None
+    try:
+        from tools.todo_tool import MAX_TODO_RESULT_CHARS
+
+        raw = getter(session_id, include_ancestors=True)
+        history: list = list(raw) if isinstance(raw, list) else []
+        todo_call_ids: set[str] = set()
+        for msg in history:
+            for call in msg.get("tool_calls") or []:
+                if (call.get("function") or {}).get("name") == "todo":
+                    cid = call.get("id")
+                    if cid:
+                        todo_call_ids.add(cid)
+        for msg in reversed(history):
+            if msg.get("role") != "tool":
+                continue
+            if msg.get("tool_call_id") not in todo_call_ids:
+                continue
+            content = msg.get("content", "")
+            if (
+                not isinstance(content, str)
+                or len(content) > MAX_TODO_RESULT_CHARS
+                or '"todos"' not in content
+            ):
+                continue
+            try:
+                return _normalize_todo_state(json.loads(content))
+            except Exception:
+                continue
+        return None
+    except Exception:
+        logger.debug("failed to read persisted todo state", exc_info=True)
+        return None
+
+
 def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
     session = _sessions.get(sid)
     if session is not None:
@@ -7659,13 +7746,15 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
         result_text = _tool_result_text(result)
         if result_text:
             payload["result_text"] = result_text
+    todo_state = None
     if name == "todo":
-        try:
-            data = json.loads(result)
-            if isinstance(data, dict) and isinstance(data.get("todos"), list):
-                payload["todos"] = data.get("todos")
-        except Exception:
-            pass
+        todo_state = _normalize_todo_state(payload.get("result"))
+        if todo_state is not None:
+            payload.update(todo_state)
+            if session is not None:
+                cached = _normalize_todo_state(session.get("todo_state"))
+                if cached is None or todo_state["revision"] >= cached["revision"]:
+                    session["todo_state"] = todo_state
     try:
         from agent.display import render_edit_diff_with_delta
 
@@ -7680,8 +7769,18 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
             payload["inline_diff"] = "\n".join(rendered)
     except Exception:
         pass
-    if _tool_progress_enabled(sid) or payload.get("inline_diff") or _tool_lifecycle_required_for_ui(name):
+    if (
+        _tool_progress_enabled(sid)
+        or payload.get("inline_diff")
+        or _tool_lifecycle_required_for_ui(name)
+        or name == "todo"
+    ):
         _emit("tool.complete", sid, payload)
+    # Task state is application data, not optional tool-progress chrome. A
+    # dedicated full-snapshot event lets every client reconcile immediately
+    # without interpreting provider text or partial merge arguments.
+    if todo_state is not None:
+        _emit("todo.updated", sid, todo_state)
 
 
 def _on_tool_progress(
@@ -8872,6 +8971,7 @@ def _init_session(
             # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
             "transport": current_transport() or _stdio_transport,
         }
+        _session_todo_state(_sessions[sid])
     _init_owns_db = False
     if session_db is not None:
         db = session_db
@@ -10244,6 +10344,7 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    todo_state: dict | None = None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
@@ -10280,6 +10381,7 @@ def _deferred_session_record(
         "source": source,
         "tool_progress_mode": _load_tool_progress_mode(),
         "tool_started_at": {},
+        "todo_state": todo_state,
         "transport": current_transport() or _stdio_transport,
     }
 
@@ -10709,7 +10811,7 @@ def _live_session_payload(
         payload["pending_approval"] = approval
     if clarify := _pending_clarify_request_payload(sid):
         payload["pending_clarify"] = clarify
-    return payload
+    return _attach_todo_state(payload, session)
 
 
 def _main_runtime_from_agent(agent) -> dict | None:


### PR DESCRIPTION
## Summary

The desktop Tasks panel now stays correct across `merge: true` patches, tool-progress display settings, and session resume/reconnect — with **no new DB tables**.

Salvages the schema-free core of #97815 by @itsflownium and incorporates the focused desktop fix from #97811 by @Adolanium (his commit preserved with authorship). The `session_todo_state` table + copy-on-write lineage machinery from the original PR is intentionally dropped: canonical todo tool results already persist in conversation history, so resume paths derive the snapshot from the stored transcript instead of a parallel store.

Root causes fixed:
1. `tool.start` for a `merge: true` todo write was applied as a full replace, so a one-item status patch collapsed the panel to `Tasks 1/1` (or hid it).
2. `tool.complete` is optional display chrome — suppressed tool progress meant the panel silently froze.
3. Resume/reconnect never re-sent todo state; a renderer restart lost the panel entirely.

## Changes

- `tools/todo_tool.py`: TodoStore gains a monotonic in-memory `revision` (bumped only on real change); the tool result returns it; `restore()` adopts a trusted revision without manufacturing a new one
- `tui_gateway/server.py`: dedicated `todo.updated` full-snapshot event emitted on every todo tool completion, bypassing optional tool-progress display settings; session payloads attach the newest live/cached snapshot; `_read_persisted_todo_state()` derives the resume snapshot from the stored transcript (paired-tool-call check mirrors the GHSA-5g4g-6jrg-mw3g hydration guard)
- `tui_gateway/methods_session.py`: every resume/activate response carries `todo_state`
- `run_agent.py`: history hydration is revision-arbitrated — older history can no longer roll back a newer live store
- desktop: `merge: true` patches merge by id (status-only updates keep the rest of the list), per-session revision store rejects stale updates, `todo.updated` + resume snapshots restore the panel, running indicator stays visible while the Tasks section is expanded

## Validation

| Check | Result |
|---|---|
| `tests/tools/test_todo_tool.py` + `tests/tui_gateway/test_todo_state_events.py` | 21/21 pass |
| `tests/run_agent/test_run_agent.py` | 281/281 pass |
| Desktop vitest (4 todo suites) | 37/37 pass |
| Desktop `tsc --noEmit` | clean |
| E2E vs real SessionDB (temp HERMES_HOME) | transcript-derived resume snapshot OK; forged bare tool message rejected; revision monotonicity OK |
| ruff | clean |

Addresses the live-panel half of #19477 (restart persistence of the *panel*; agent-side state was already recoverable from history).

## Credits

- @itsflownium — #97815: revision design, `todo.updated` event, resume attach (salvaged, slimmed)
- @Adolanium — #97811: desktop merge-instead-of-replace fix (commit preserved)

## Infographic

![Live task state, no new tables](https://v3b.fal.media/files/b/0aa85a1f/ZfCTXmeh9dmvTIHzl2fB7_Q4W4H5j2.png)
