### PR TITLE
fix(cron): 'every hour' and 'every day' schedules no longer error (salvage #97783)

### DIFF
--- a/contributors/emails/salch-cred@users.noreply.github.com
+++ b/contributors/emails/salch-cred@users.noreply.github.com
@@ -1,0 +1,1 @@
+salch-cred

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -782,13 +782,14 @@ def parse_duration(s: str) -> int:
         "30m" → 30
         "2h" → 120
         "1d" → 1440
+        "hour" → 60 (bare unit, no leading number)
     """
     s = s.strip().lower()
-    match = re.match(r'^(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
+    match = re.match(r'^(\d*)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
     if not match:
         raise ValueError(f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'")
     
-    value = int(match.group(1))
+    value = int(match.group(1)) if match.group(1) else 1
     unit = match.group(2)[0]  # First char: m, h, or d
     
     multipliers = {'m': 1, 'h': 60, 'd': 1440}

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -787,7 +787,10 @@ def parse_duration(s: str) -> int:
     s = s.strip().lower()
     match = re.match(r'^(\d*)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
     if not match:
-        raise ValueError(f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'")
+        raise ValueError(
+            f"Invalid duration: '{s}'. Use format like '30m', '2h', '1d', "
+            "or a bare unit like 'hour' (defaults to 1)."
+        )
     
     value = int(match.group(1)) if match.group(1) else 1
     unit = match.group(2)[0]  # First char: m, h, or d

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -41,9 +41,28 @@ class TestParseDuration:
         assert parse_duration("120minutes") == 120
 
 
+    def test_bare_units_default_to_one(self):
+        assert parse_duration("hour") == 60
+        assert parse_duration("hr") == 60
+        assert parse_duration("h") == 60
+        assert parse_duration("minute") == 1
+        assert parse_duration("m") == 1
+        assert parse_duration("day") == 1440
+        assert parse_duration("d") == 1440
+
+    def test_every_bare_unit_schedule(self):
+        result = parse_schedule("every hour")
+        assert result["kind"] == "interval"
+        assert result["minutes"] == 60
+        result = parse_schedule("every day")
+        assert result["kind"] == "interval"
+        assert result["minutes"] == 1440
+
     def test_invalid_raises(self):
         with pytest.raises(ValueError):
             parse_duration("abc")
+        with pytest.raises(ValueError):
+            parse_duration("hourx")
         with pytest.raises(ValueError):
             parse_duration("30x")
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
`cronjob create` schedules like `"every hour"` and `"every day"` now parse instead of raising `Invalid duration: 'hour'` — the quantity defaults to 1 when the leading number is omitted.

Salvage of #97783 by @salch-cred, authorship preserved via cherry-pick.

## Changes
- `cron/jobs.py`: `parse_duration()` regex digit made optional (`\d+` → `\d*`), missing quantity defaults to 1; error message now mentions bare units (@salch-cred, 2 commits)
- `tests/cron/test_jobs.py`: new coverage for bare units (`hour`→60, `day`→1440, `h`, `m`), `every hour`/`every day` schedules, and rejection of `hourx` (follow-up)
- `contributors/emails/`: attribution marker (included by the author)

## Validation
| Input | Before (origin/main, real import) | After |
|---|---|---|
| `parse_schedule("every hour")` | ValueError | `{kind: interval, minutes: 60}` |
| `parse_schedule("every day")` | ValueError | `{kind: interval, minutes: 1440}` |
| `parse_duration("")` / `"sec"` / `"hourx"` | ValueError | ValueError (unchanged) |
| `"30m"` / `"2h"` | 30 / 120 | 30 / 120 (unchanged) |

Live repro: A/B run against real `cron.jobs` imports from an origin/main worktree vs this branch. Targeted tests: 9/9 passed (`tests/cron/test_jobs.py -k "ParseDuration or ParseSchedule"`).

## Infographic

![Cron bare duration units infographic](https://v3b.fal.media/files/b/0aa85a32/DiDSGd8c3rwAXvmaoX_sk_ENX03Ayo.png)
