### PR TITLE
feat(skills): add evidence-driven Skill Steward foundation

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -369,6 +369,18 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
             continue
 
         if anchor <= archive_cutoff and current != _u.STATE_ARCHIVED:
+            # Absence of use is not outcome evidence. A skill that has never
+            # been tried, or only has unknown outcomes, stays stale so routing
+            # and servicing can gather evidence before any archive decision.
+            known_outcomes = int(row.get("success_count", 0) or 0) + int(
+                row.get("failure_count", 0) or 0
+            )
+            if known_outcomes == 0:
+                if current == _u.STATE_ACTIVE:
+                    _u.set_state(name, _u.STATE_STALE)
+                    counts["marked_stale"] += 1
+                continue
+
             # Tag the ledger entry with the curator actor: this archive is an
             # autonomous curator transition, not a foreground agent/user call.
             try:
@@ -464,14 +476,12 @@ CURATOR_REVIEW_PROMPT = (
     "run. You MAY still consolidate it into an umbrella — but only because "
     "the curator rewrites cron job skill references to follow consolidations; "
     "never simply prune it.\n"
-    "4. DO NOT use usage counters as a reason to skip consolidation. The "
-    "counters are new and often mostly zero. Judge overlap on CONTENT, "
-    "not on use_count. 'use=0' is not evidence a skill is valuable; it's "
-    "absence of evidence either way. Corollary: 'use=0' is ALSO not a "
-    "reason to PRUNE a skill. Never archive a never-used skill (use=0) "
-    "unless it is at least 30 days old (check last_activity / created date) "
-    "AND its content is genuinely obsolete or fully absorbed elsewhere — a "
-    "recently-created skill simply may not have had its trigger come up yet.\n"
+    "4. Usage counters are discovery evidence, not quality evidence. Judge "
+    "overlap on CONTENT and preserve every unique instruction, support file, "
+    "and trigger. A zero use count or missing outcome means the skill may not "
+    "have been surfaced yet; it is never enough evidence to prune or absorb "
+    "that skill. Known outcomes may inform review, but low utility alone is "
+    "also not permission to archive: diagnose and propose a repair first.\n"
     "5. DO NOT reject consolidation on the grounds that 'each skill has "
     "a distinct trigger'. Pairwise distinctness is the wrong bar. The "
     "right bar is: 'would a human maintainer write this as N separate "
@@ -564,10 +574,9 @@ CURATOR_REVIEW_PROMPT = (
     "discoverability. 'This is narrow but distinct from its siblings' "
     "is NOT a reason to keep — it's a reason to move it under an "
     "umbrella as a subsection or support file.\n\n"
-    "Expected output: real umbrella-ification. Process every obvious "
-    "cluster. If you end the pass with fewer than 10 archives, you "
-    "stopped too early — go back and look at the clusters you left "
-    "alone.\n\n"
+    "Expected output: evidence-backed umbrella-ification. Process every "
+    "obvious cluster, but never target an archive count. Zero archives is a "
+    "valid result when the evidence does not justify a safe consolidation.\n\n"
     "When done, write a human summary AND a structured machine-readable "
     "block so downstream tooling can distinguish consolidation from "
     "pruning. Format EXACTLY:\n\n"

--- a/agent/skill_reflection.py
+++ b/agent/skill_reflection.py
@@ -1,0 +1,298 @@
+"""Failure-driven skill reflection loop (2026-08).
+
+Implements the "挖掘失败 → 有界编辑 → 验证门控" pattern from the
+Self-Harness literature, adapted to Hermes' skill system:
+
+  1.  Candidates: skills with a low utility score (failure-heavy) are
+      surfaced via :func:`tools.skill_usage.list_low_utility_skills`.
+  2.  Diagnosis: for each candidate, aggregate the recorded error types
+      from the outcome telemetry and locate the relevant SKILL.md section.
+  3.  Proposal: generate a *bounded* improvement proposal — a targeted
+      patch to a specific section (Pitfalls / Verification / Procedure)
+      rather than a full rewrite. Bounded edits keep the change auditable
+      and reversible, mirroring Self-Harness' constraint that an agent
+      only proposes changes it can validate.
+  4.  Gate: proposals are *never* applied automatically. They are written
+      to a proposals queue (~/.hermes/skills/.reflection_proposals/) that
+      the Curator or the user reviews — the same "human in the loop"
+      guarantee Hermes already enforces for skill_manage writes.
+
+This module is deliberately deterministic and offline-friendly: it does
+NOT call an LLM by itself. The caller (an agent turn, a cron pass, or the
+Curator) supplies the diagnosis text; this module handles persistence,
+section targeting, and the proposals queue. Keeping the LLM out of this
+module makes it unit-testable and safe to run in constrained contexts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# Proposals live under the skills dir so they are visible to the Curator's
+# existing scans but excluded from skill discovery (dot-prefixed).
+_PROPOSALS_DIRNAME = ".reflection_proposals"
+
+# SKILL.md sections that bounded edits may target.
+_TARGETABLE_SECTIONS = {
+    "when to use": "## When to Use",
+    "prerequisites": "## Prerequisites",
+    "procedure": "## Procedure",
+    "pitfalls": "## Pitfalls",
+    "verification": "## Verification",
+    "quick reference": "## Quick Reference",
+}
+
+MAX_PROPOSALS_PER_SKILL = 20  # bound the queue per skill (incl. history)
+
+
+def _proposals_dir() -> Path:
+    return get_hermes_home() / "skills" / _PROPOSALS_DIRNAME
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _proposal_path(skill_name: str, proposal_id: str) -> Path:
+    return _proposals_dir() / f"{skill_name}__{proposal_id}.json"
+
+
+def _safe_proposal_id() -> str:
+    return _now_iso().replace(":", "").replace("+", "").replace("-", "")[:17]
+
+
+def locate_section(skill_md: str, target: str) -> Optional[Dict[str, Any]]:
+    """Locate a targetable section in SKILL.md content.
+
+    Returns ``{"heading": "...", "start": int, "end": int}`` (character
+    offsets) or None when the section does not exist. Offsets let the
+    caller patch precisely without touching the rest of the skill.
+    """
+    key = (target or "").strip().lower()
+    heading = _TARGETABLE_SECTIONS.get(key)
+    if not heading or not skill_md:
+        return None
+    idx = skill_md.find(heading)
+    if idx < 0:
+        return None
+    start = idx
+    # Section ends at the next markdown heading (## or #) or EOF
+    rest = skill_md[idx + len(heading):]
+    end = start + len(heading)
+    for match in ("\n## ", "\n# "):
+        rel = rest.find(match)
+        if rel >= 0:
+            cand = start + len(heading) + rel
+            if cand > end:
+                end = cand
+                break
+    return {"heading": heading, "start": start, "end": end}
+
+
+def build_proposal(
+    skill_name: str,
+    *,
+    diagnosis: str,
+    target_section: str,
+    suggested_fix: str,
+    failure_types: Optional[List[str]] = None,
+    utility_score: Optional[float] = None,
+    source: str = "reflection-loop",
+) -> Dict[str, Any]:
+    """Build a bounded improvement proposal dict (no I/O).
+
+    ``target_section`` must be one of the targetable section keys
+    ("when to use", "prerequisites", "procedure", "pitfalls",
+    "verification", "quick reference"). ``diagnosis`` explains WHY the
+    skill fails; ``suggested_fix`` is the concrete bounded edit.
+    """
+    target_key = (target_section or "").strip().lower()
+    if target_key not in _TARGETABLE_SECTIONS:
+        raise ValueError(
+            f"target_section must be one of {sorted(_TARGETABLE_SECTIONS)}, got {target_section!r}"
+        )
+    return {
+        "skill": skill_name,
+        "proposal_id": _safe_proposal_id(),
+        "created_at": _now_iso(),
+        "source": source,
+        "target_section": target_key,
+        "heading": _TARGETABLE_SECTIONS[target_key],
+        "diagnosis": diagnosis,
+        "suggested_fix": suggested_fix,
+        "failure_types": failure_types or [],
+        "utility_score": utility_score,
+        "status": "pending",  # pending → reviewed → applied | rejected
+    }
+
+
+def save_proposal(proposal: Dict[str, Any]) -> Optional[Path]:
+    """Persist a proposal to the queue (atomic write). Returns path or None."""
+    skill_name = str(proposal.get("skill") or "").strip()
+    proposal_id = str(proposal.get("proposal_id") or "").strip()
+    if not skill_name or not proposal_id:
+        return None
+    # Bound the queue per skill
+    existing = list_proposals(skill_name)
+    if len(existing) >= MAX_PROPOSALS_PER_SKILL:
+        # Drop the oldest pending proposal to keep the queue bounded
+        existing.sort(key=lambda p: p.get("created_at", ""))
+        for old in existing:
+            if old.get("status") == "pending":
+                _delete_proposal_file(skill_name, str(old.get("proposal_id")))
+                break
+    path = _proposal_path(skill_name, proposal_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".prop_", suffix=".tmp")
+        try:
+            with open(fd, "w", encoding="utf-8") as f:
+                json.dump(proposal, f, indent=2, sort_keys=True, ensure_ascii=False)
+                f.flush()
+                import os
+                os.fsync(f.fileno())
+            import os as _os
+            _os.replace(tmp, path)
+            return path
+        except BaseException:
+            try:
+                import os as _os
+                _os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception as e:
+        logger.debug("save_proposal(%s) failed: %s", skill_name, e, exc_info=True)
+        return None
+
+
+def _delete_proposal_file(skill_name: str, proposal_id: str) -> bool:
+    try:
+        path = _proposal_path(skill_name, proposal_id)
+        if path.exists():
+            path.unlink()
+            return True
+    except OSError:
+        pass
+    return False
+
+
+def list_proposals(skill_name: Optional[str] = None) -> List[Dict[str, Any]]:
+    """List proposals in the queue, newest first. Optionally filter by skill."""
+    base = _proposals_dir()
+    if not base.exists():
+        return []
+    rows: List[Dict[str, Any]] = []
+    for path in sorted(base.glob("*.json"), reverse=True):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        if skill_name and data.get("skill") != skill_name:
+            continue
+        rows.append(data)
+    return rows
+
+
+def list_pending_proposals(skill_name: Optional[str] = None) -> List[Dict[str, Any]]:
+    """List only pending (unreviewed) proposals, newest first."""
+    return [p for p in list_proposals(skill_name) if p.get("status") == "pending"]
+
+
+def mark_proposal_status(skill_name: str, proposal_id: str, status: str) -> bool:
+    """Update a proposal's status: 'reviewed' | 'applied' | 'rejected'.
+
+    All statuses keep the proposal file for audit + history views; the
+    queue is bounded per skill via ``MAX_PROPOSALS_PER_SKILL`` so the
+    history can't grow unboundedly. (Applied proposals are *not* deleted —
+    the dashboard's applied/rejected tabs rely on them staying visible.)
+    """
+    if status not in {"reviewed", "applied", "rejected"}:
+        return False
+    path = _proposal_path(skill_name, proposal_id)
+    try:
+        if not path.exists():
+            return False
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["status"] = status
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".prop_", suffix=".tmp")
+        try:
+            with open(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
+                f.flush()
+            import os as _os
+            _os.replace(tmp, path)
+            return True
+        except BaseException:
+            try:
+                import os as _os
+                _os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception as e:
+        logger.debug("mark_proposal_status(%s, %s) failed: %s", skill_name, proposal_id, e, exc_info=True)
+        return False
+
+
+def aggregate_failure_patterns(skill_name: str) -> Dict[str, Any]:
+    """Aggregate failure signals from the outcome telemetry for a skill.
+
+    Returns a dict with the most common error types and the failure rate.
+    Used by the reflection loop to decide WHAT to diagnose.
+    """
+    try:
+        from tools.skill_usage import get_outcome_summary
+        summary = get_outcome_summary(skill_name)
+    except Exception:
+        summary = {}
+    outcomes = summary.get("outcomes") or []
+    error_counts: Dict[str, int] = {}
+    for o in outcomes:
+        et = o.get("error_type")
+        if et:
+            error_counts[str(et)] = error_counts.get(str(et), 0) + 1
+    failures = summary.get("failure_count", 0)
+    successes = summary.get("success_count", 0)
+    total = failures + successes
+    return {
+        "skill": skill_name,
+        "utility_score": summary.get("utility_score"),
+        "failure_count": failures,
+        "success_count": successes,
+        "failure_rate": round(failures / total, 3) if total else None,
+        "top_error_types": sorted(error_counts.items(), key=lambda kv: -kv[1])[:5],
+        "last_outcome_at": summary.get("last_outcome_at"),
+    }
+
+
+def reflection_candidates(min_score: float = 0.4, limit: int = 10) -> List[Dict[str, Any]]:
+    """Return the skills most in need of improvement, with failure patterns.
+
+    Combines :func:`tools.skill_usage.list_low_utility_skills` with
+    :func:`aggregate_failure_patterns` so a caller can immediately see
+    *which* skills are failing and *why*.
+    """
+    try:
+        from tools.skill_usage import list_low_utility_skills
+        low = list_low_utility_skills(max_score=min_score)
+    except Exception as e:
+        logger.debug("reflection_candidates: %s", e)
+        low = []
+    rows = []
+    for item in low[:limit]:
+        name = item.get("skill", "")
+        patterns = aggregate_failure_patterns(name)
+        rows.append({**item, **patterns})
+    return rows

--- a/agent/skill_retriever.py
+++ b/agent/skill_retriever.py
@@ -1,0 +1,606 @@
+"""Skill retrieval: 5-layer architecture.
+
+
+Layer 1: Hard triggers — exact keyword → direct return (100% deterministic)
+Layer 2: FTS5 BM25 — clean text search (name + description only)
+Layer 3: Synonym dictionary — independent bonus scoring layer
+Layer 4: Dense Embedding — sentence-transformers cosine similarity
+Layer 5: RRF fusion — combine layers 2-4, return top-k
+
+Usage:
+    retriever = get_skill_retriever()
+    if retriever.is_ready():
+        hints = retriever.retrieve("help me debug this", top_k=5)
+"""
+
+import logging
+import math
+import os
+import re
+import threading
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ── Configuration ──────────────────────────────────────────────
+_DISABLE_ENV = "HERMES_DISABLE_SKILL_RETRIEVAL"
+_TOP_K_ENV = "HERMES_SKILL_RETRIEVAL_TOP_K"
+
+# RRF parameters
+_RRF_K = 60
+_RRF_W_FTS5 = 0.45      # FTS5 text matching
+_RRF_W_SYN = 0.35       # Synonym dictionary
+_RRF_W_EMB = 0.20       # Dense embedding
+# Minimum RRF score to include (filters noise)
+_MIN_RRF_SCORE = 0.003
+# Confidence threshold: top-1 must score above this to be returned.
+# Below this, the query likely doesn't match any skill well.
+_CONFIDENCE_THRESHOLD = 0.015  # Empirically determined — filters noise effectively
+
+_SINGLETON: "SkillRetriever | None" = None
+_SINGLETON_LOCK = threading.Lock()
+
+# ── Hard Triggers (Layer 1) ────────────────────────────────────
+# Maps exact substring → skill name. Order matters: first match wins.
+# These bypass all ranking — if query contains the trigger, return directly.
+#
+# CUSTOMIZATION: Replace the examples below with your own skill mappings.
+# Run `python scripts/generate_config.py` to auto-generate from your skill library.
+# See templates/hard_triggers.example.py for the format.
+_HARD_TRIGGERS: list[tuple[str, str]] = [
+    # ── Example triggers (replace with your own) ──
+    # Format: ("trigger_keyword", "skill-name"),
+    #
+    # Engineering
+    ("debug", "systematic-debugging"),
+    ("调试", "systematic-debugging"),
+    ("代码审查", "zh-code-review"),
+    ("code review", "zh-code-review"),
+    ("TDD", "test-driven-development"),
+    ("测试驱动", "test-driven-development"),
+    # Skills management
+    ("创建技能", "skill-creation-guide"),
+    ("SKILL.md", "skill-creation-guide"),
+    ("找技能", "find-skills"),
+    ("安装技能", "find-skills"),
+]
+
+
+def _is_subsequence(chars: list[str], text: str, max_gap: int = 3) -> bool:
+    """Check if all chars appear in order within text, with max gap between consecutive matches.
+
+    >>> _is_subsequence(['d', 'e', 'b', 'u', 'g'], 'please debug this')
+    True
+    >>> _is_subsequence(['d', 'b', 'g'], 'debug')
+    False  # 'b' appears before 'd' in subsequence order
+    >>> _is_subsequence(['技', '能', '指', '南'], '梳理一下现有的技能，弄个说明指南')
+    False  # gap of 4 between 能 and 指 exceeds max_gap=3
+    """
+    pos = -1  # position of last match
+    for c in chars:
+        idx = text.find(c, pos + 1)
+        if idx == -1:
+            return False
+        if pos >= 0 and idx - pos - 1 > max_gap:
+            return False
+        pos = idx
+    return True
+
+
+def get_skill_retriever() -> "SkillRetriever":
+    """Return the global singleton, creating it on first call."""
+    global _SINGLETON
+    if _SINGLETON is None:
+        with _SINGLETON_LOCK:
+            if _SINGLETON is None:
+                _SINGLETON = SkillRetriever()
+    return _SINGLETON
+
+
+class SkillRetriever:
+    """5-layer skill retrieval: Hard Trigger → FTS5 → Synonym → Embedding → RRF."""
+
+    def __init__(self) -> None:
+        self._ready = False
+        self._loading = False
+        self._error: str | None = None
+        self._skill_names: list[str] = []
+        self._skill_descs: list[str] = []
+        self._doc_tokens: list[list[str]] = []
+        self._idf: dict[str, float] = {}
+        # Synonym structures
+        self._synonyms: dict[str, list[str]] = {}       # skill → [syn, ...]
+        self._synonym_index: dict[str, list[tuple[str, float]]] = {}  # token → [(skill, weight)]
+        self._skill_paths: dict[str, Path] = {}          # skill_name → SKILL.md path
+        # Embedding
+        self._emb_matrix = None
+        self._model = None
+        self._jieba_initialized = False
+        self._top_k = int(os.environ.get(_TOP_K_ENV, "5"))
+        # Start background initialization immediately
+        threading.Thread(target=self._lazy_init, daemon=True).start()
+
+        if os.environ.get(_DISABLE_ENV, "").lower() in ("1", "true", "yes"):
+            logger.info("Skill retrieval disabled via %s", _DISABLE_ENV)
+            return
+
+    def is_ready(self) -> bool:
+        return self._ready
+
+    def is_loading(self) -> bool:
+        return self._loading
+
+    def error(self) -> str | None:
+        return self._error
+
+    def retrieve(self, query: str, top_k: int | None = None) -> list[str]:
+        """Return top-k skill names matching the query.
+
+        For detailed match info (including layer and content), use
+        ``retrieve_detailed()`` instead.
+        """
+        result = self.retrieve_detailed(query, top_k)
+        return result["skills"]
+
+    def retrieve_detailed(self, query: str, top_k: int | None = None) -> dict:
+        """Return detailed match info: skills, layer, and content.
+
+        Returns:
+            {
+                "skills": ["skill-name", ...],
+                "layer": "L1" | "L2-5" | "none",
+                "skill_name": "skill-name"  # only for L1
+            }
+        """
+        if not query or not query.strip():
+            return {"skills": [], "layer": "none"}
+
+        # ── Layer 1: Hard triggers (instant return, no ranking) ──
+        hard_hit = self._hard_trigger(query)
+        if hard_hit:
+            logger.info("Skill retriever L1 hard trigger → %s", hard_hit)
+            return {"skills": [hard_hit], "layer": "L1", "skill_name": hard_hit}
+
+        # ── Layers 2-5: Full retrieval pipeline ──
+        if not self._ready:
+            if not self._loading:
+                logger.info("Skill retriever: initializing on first call...")
+                self._lazy_init()
+            else:
+                for _ in range(300):
+                    if not self._loading:
+                        break
+                    time.sleep(0.1)
+            if not self._ready:
+                logger.warning("Skill retriever not ready after init attempt")
+                return {"skills": [], "layer": "none"}
+
+        k = top_k or self._top_k
+        try:
+            result = self._retrieve_inner(query, k)
+            if result:
+                # Layer 6: utility re-ranking — prefer skills that
+                # historically WORKED for this task type over skills that
+                # only matched textually. No-signal skills sort after
+                # scored ones, so sparse telemetry never distorts results.
+                try:
+                    from tools.skill_usage import utility_rerank
+                    result = utility_rerank(result)
+                except Exception:
+                    # Best-effort: telemetry failure never breaks retrieval
+                    pass
+                logger.info("Skill retriever: %d skills for [%s]", len(result), query[:50])
+            return {"skills": result, "layer": "L2-5" if result else "none"}
+        except Exception as e:
+            logger.warning("Skill retrieval failed: %s", e)
+            return {"skills": [], "layer": "none"}
+
+    def get_skill_content(self, skill_name: str) -> str | None:
+        """Read and return the full SKILL.md content for a skill."""
+        # Try cached path first
+        path = self._skill_paths.get(skill_name)
+        if path and path.exists():
+            try:
+                return path.read_text(encoding="utf-8")
+            except Exception:
+                pass
+
+        # Fallback: search skills directories directly
+        from hermes_constants import get_hermes_home
+
+        for base_dir in [
+            get_hermes_home() / "skills",
+            get_hermes_home() / "hermes-agent" / "skills",
+        ]:
+            if not base_dir.exists():
+                continue
+            # Pattern 1: skills/<skill_name>/SKILL.md (flat structure)
+            direct = base_dir / skill_name / "SKILL.md"
+            if direct.exists():
+                try:
+                    return direct.read_text(encoding="utf-8")
+                except Exception:
+                    pass
+            # Pattern 2: skills/<category>/<skill_name>/SKILL.md (nested)
+            for cat_dir in base_dir.iterdir():
+                if not cat_dir.is_dir():
+                    continue
+                skill_md = cat_dir / skill_name / "SKILL.md"
+                if skill_md.exists():
+                    try:
+                        return skill_md.read_text(encoding="utf-8")
+                    except Exception:
+                        pass
+        return None
+
+    @staticmethod
+    def _hard_trigger(query: str) -> str | None:
+        """Layer 1: 3-tier matching against hard trigger table.
+
+        Tier 1: Exact substring match (fastest, 100% precise)
+                 Collects ALL matches, picks longest trigger (most specific),
+                 then earliest position in query (closest to intent).
+        Tier 2: Subsequence match — trigger CJK chars appear in order in query
+                 with max 3-char gap between consecutive matched chars.
+        Tier 3: Regex fuzzy — trigger segments with optional gaps (0-3 chars)
+        """
+        q = query.strip()
+        if not q:
+            return None
+
+        # Tier 1: Collect ALL exact substring matches, pick the best one
+        tier1_matches: list[tuple[str, str, int]] = []  # (trigger, skill, position)
+        for trigger, skill in _HARD_TRIGGERS:
+            idx = q.find(trigger)
+            if idx != -1:
+                tier1_matches.append((trigger, skill, idx))
+
+        if tier1_matches:
+            # Longest trigger wins (most specific), ties broken by earliest position
+            tier1_matches.sort(key=lambda x: (-len(x[0]), x[2]))
+            return tier1_matches[0][1]
+
+        # Tier 2+3: Only for triggers with 2+ CJK characters
+        #           and NO ASCII letters (ASCII-containing triggers like
+        #           "Python数据" are too ambiguous for fuzzy matching)
+        cjk_pattern = re.compile('[\u4e00-\u9fff]')
+        ascii_pattern = re.compile(r'[a-zA-Z]')
+        for trigger, skill in _HARD_TRIGGERS:
+            cjk_chars = cjk_pattern.findall(trigger)
+            if len(cjk_chars) < 2:
+                continue
+            # Skip fuzzy matching for mixed CJK/ASCII triggers
+            if ascii_pattern.search(trigger):
+                continue
+
+            # Tier 2: Subsequence — all CJK chars of trigger appear in order
+            if _is_subsequence(cjk_chars, q, max_gap=3):
+                logger.debug("L1 subsequence match: %r in %r → %s", trigger, q, skill)
+                return skill
+
+            # Tier 3: Regex fuzzy — insert .{0,3} between trigger segments
+            segments = re.findall('[\u4e00-\u9fff]+', trigger)
+            if len(segments) >= 2:
+                pattern = r'.{0,3}'.join(re.escape(s) for s in segments)
+                try:
+                    if re.search(pattern, q):
+                        logger.debug("L1 regex fuzzy match: %r ~ %r → %s", pattern, q, skill)
+                        return skill
+                except re.error:
+                    pass
+
+        return None
+
+    # ── Initialization ──────────────────────────────────────────
+
+    def _lazy_init(self) -> None:
+        self._loading = True
+        try:
+            t0 = time.time()
+            self._load_skills()
+            self._load_synonyms()
+            self._build_fts5_index()
+            self._load_embedding_model()
+            t1 = time.time()
+            self._ready = True
+            logger.info(
+                "Skill retriever ready: %d skills, %d synonyms, %.1fs",
+                len(self._skill_names),
+                sum(len(v) for v in self._synonyms.values()),
+                t1 - t0,
+            )
+        except Exception as e:
+            self._error = str(e)
+            logger.warning("Skill retriever init failed: %s", e)
+        finally:
+            self._loading = False
+
+    def _load_skills(self) -> None:
+        from hermes_constants import get_hermes_home
+        skills_dir = get_hermes_home() / "skills"
+        hermes_agent_skills = get_hermes_home() / "hermes-agent" / "skills"
+
+        seen = set()
+        for base_dir in [skills_dir, hermes_agent_skills]:
+            if not base_dir.exists():
+                continue
+            for cat_dir in sorted(base_dir.iterdir()):
+                if not cat_dir.is_dir():
+                    continue
+                # Mixed layout support: a dir may be a flat skill
+                # (skills/<name>/SKILL.md) OR a category wrapper
+                # (skills/<category>/<name>/SKILL.md).
+                direct_md = cat_dir / "SKILL.md"
+                if direct_md.exists():
+                    self._add_skill(cat_dir.name, direct_md, seen)
+                    continue
+                for skill_dir in sorted(cat_dir.iterdir()):
+                    if not skill_dir.is_dir():
+                        continue
+                    skill_md = skill_dir / "SKILL.md"
+                    if not skill_md.exists():
+                        continue
+                    self._add_skill(skill_dir.name, skill_md, seen)
+
+    def _add_skill(self, name: str, skill_md: Path, seen: set) -> None:
+        if name in seen:
+            return
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+            desc = self._extract_description(content)
+            seen.add(name)
+            self._skill_names.append(name)
+            self._skill_descs.append(desc)
+            self._skill_paths[name] = skill_md
+        except Exception:
+            pass
+
+    @staticmethod
+    def _extract_description(content: str) -> str:
+        if not content.startswith("---"):
+            return ""
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            return ""
+        for line in parts[1].split("\n"):
+            if line.strip().startswith("description:"):
+                return line.strip()[12:].strip().strip("\"'")
+        return ""
+
+    def _load_synonyms(self) -> None:
+        """Load synonym dictionary — Layer 3 source data."""
+        import jieba
+
+        synonym_file = Path(__file__).parent / "skill_synonyms.yaml"
+        if not synonym_file.exists():
+            logger.debug("No synonym dictionary found at %s", synonym_file)
+            return
+
+        try:
+            content = synonym_file.read_text(encoding="utf-8")
+            current_skill = None
+            for line in content.split("\n"):
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                if stripped.startswith("- "):
+                    if current_skill:
+                        synonym = stripped[2:].strip().strip('"').strip("'")
+                        if synonym:
+                            self._synonyms.setdefault(current_skill, []).append(synonym)
+                elif ":" in stripped and not stripped.startswith("-"):
+                    skill_name = stripped.split(":")[0].strip()
+                    if skill_name and not skill_name.startswith("_"):
+                        current_skill = skill_name
+                    else:
+                        current_skill = None
+
+            # Build reverse index for Layer 3
+            valid_names = set(self._skill_names)
+            for skill_name, syn_list in self._synonyms.items():
+                if skill_name not in valid_names:
+                    continue
+                for syn in syn_list:
+                    # Index jieba tokens of the synonym
+                    tokens = [t.strip() for t in jieba.cut(syn) if len(t.strip()) > 1]
+                    for token in tokens:
+                        self._synonym_index.setdefault(token, []).append(
+                            (skill_name, 1.0)
+                        )
+                    # Also index the full synonym as a single unit
+                    if len(syn) > 1:
+                        self._synonym_index.setdefault(syn, []).append(
+                            (skill_name, 1.5)
+                        )
+
+            logger.info(
+                "Loaded %d synonym entries for %d skills, %d index tokens",
+                sum(len(v) for v in self._synonyms.values()),
+                len(self._synonyms),
+                len(self._synonym_index),
+            )
+        except Exception as e:
+            logger.warning("Failed to load synonym dictionary: %s", e)
+
+    def _build_fts5_index(self) -> None:
+        """Layer 2: Build clean FTS5 index (name + description only)."""
+        import jieba
+
+        if not self._jieba_initialized:
+            jieba.initialize()
+            self._jieba_initialized = True
+
+        all_doc_freq: Counter = Counter()
+        for i, desc in enumerate(self._skill_descs):
+            name = self._skill_names[i]
+            text = f"{name} {desc}"
+            tokens = [
+                t.strip() for t in jieba.cut(text)
+                if len(t.strip()) > 1 and not t.strip().isdigit()
+            ]
+            self._doc_tokens.append(tokens)
+            for token in set(tokens):
+                all_doc_freq[token] += 1
+
+        n = len(self._skill_names)
+        self._idf = {
+            t: math.log((n + 1) / (df + 1)) + 1
+            for t, df in all_doc_freq.items()
+        }
+
+    def _load_embedding_model(self) -> None:
+        """Layer 4: Load dense embedding model."""
+        try:
+            from sentence_transformers import SentenceTransformer
+            import numpy as np
+        except ImportError:
+            logger.warning("sentence-transformers not installed; FTS5+Syn only")
+            self._emb_matrix = None
+            return
+
+        model_name = os.environ.get(
+            "HERMES_EMBEDDING_MODEL",
+            "shibing624/text2vec-base-chinese-paraphrase"
+        )
+        try:
+            self._model = SentenceTransformer(model_name)
+            texts = [f"{n}, {d}" for n, d in zip(self._skill_names, self._skill_descs)]
+            self._emb_matrix = self._model.encode(
+                texts, normalize_embeddings=True, show_progress_bar=False
+            )
+            logger.info("Embedding model loaded: %s, shape: %s", model_name, self._emb_matrix.shape)
+        except Exception as e:
+            logger.warning("Embedding model load failed (%s); FTS5+Syn only", e)
+            self._emb_matrix = None
+
+    # ── Retrieval Pipeline ──────────────────────────────────────
+
+    def _retrieve_inner(self, query: str, k: int) -> list[str]:
+        """Layers 2-5: FTS5 + Synonym + Embedding → RRF fusion.
+
+        Returns empty list when confidence is too low — meaning the query
+        doesn't match any skill well, and the LLM should use general knowledge.
+        """
+        fts5_results = self._fts5_search(query, k * 3)
+        syn_results = self._syn_search(query, k * 3)
+        emb_results = self._emb_search(query, k * 3)
+
+        fused = self._rrf_fusion(fts5_results, syn_results, emb_results)
+
+        if not fused:
+            return []
+
+        top_score = fused[0][1]
+
+        # Confidence check: top-1 must exceed floor (filter pure noise only)
+        if top_score < _CONFIDENCE_THRESHOLD:
+            logger.debug(
+                "Skill retriever: top-1 score %.4f < floor %.4f, no signal",
+                top_score, _CONFIDENCE_THRESHOLD,
+            )
+            return []
+
+        # No gap check — when multiple skills score close, return all as hints
+        # and let the LLM decide which (if any) to load.
+
+        result = []
+        for idx, score in fused[:k]:
+            if score >= _MIN_RRF_SCORE:
+                result.append(self._skill_names[idx])
+        return result
+
+    def _fts5_search(self, query: str, k: int) -> list[tuple[int, float]]:
+        """Layer 2: Clean BM25 search — name + description only, no synonym mixing."""
+        import jieba
+
+        query_tokens = [
+            t.strip() for t in jieba.cut(query)
+            if len(t.strip()) > 1
+        ]
+        scores: dict[int, float] = defaultdict(float)
+
+        for qt in query_tokens:
+            q_idf = self._idf.get(qt, 1.0)
+            for i, doc_tok in enumerate(self._doc_tokens):
+                tf = doc_tok.count(qt)
+                if tf > 0:
+                    scores[i] += q_idf * tf / (tf + 1.5)
+                # Direct string match bonus in name+desc
+                if qt in f"{self._skill_names[i]} {self._skill_descs[i]}":
+                    scores[i] += q_idf * 0.5
+
+        ranked = sorted(scores.items(), key=lambda x: -x[1])
+        return ranked[:k]
+
+    def _syn_search(self, query: str, k: int) -> list[tuple[int, float]]:
+        """Layer 3: Synonym dictionary matching — independent scoring."""
+        import jieba
+
+        query_tokens = [
+            t.strip() for t in jieba.cut(query)
+            if len(t.strip()) > 1
+        ]
+        scores: dict[int, float] = defaultdict(float)
+
+        # Token-level synonym matching
+        for qt in query_tokens:
+            if qt in self._synonym_index:
+                q_idf = self._idf.get(qt, 1.0)
+                for skill_name, weight in self._synonym_index[qt]:
+                    try:
+                        idx = self._skill_names.index(skill_name)
+                        scores[idx] += weight * q_idf
+                    except ValueError:
+                        pass
+
+        # Full-phrase synonym matching (multi-char synonyms in query)
+        for syn_key, entries in self._synonym_index.items():
+            if len(syn_key) > 2 and syn_key in query:
+                for skill_name, weight in entries:
+                    try:
+                        idx = self._skill_names.index(skill_name)
+                        scores[idx] += weight * 2.0
+                    except ValueError:
+                        pass
+
+        ranked = sorted(scores.items(), key=lambda x: -x[1])
+        return ranked[:k]
+
+    def _emb_search(self, query: str, k: int) -> list[tuple[int, float]]:
+        """Layer 4: Dense embedding cosine similarity."""
+        if self._model is None or self._emb_matrix is None:
+            return []
+
+        import numpy as np
+
+        query_emb = self._model.encode([query], normalize_embeddings=True)
+        scores = np.dot(self._emb_matrix, query_emb.T).flatten()
+        top_idx = np.argsort(-scores)[:k]
+        return [(int(idx), float(scores[idx])) for idx in top_idx]
+
+    @staticmethod
+    def _rrf_fusion(
+        fts5_results: list[tuple[int, float]],
+        syn_results: list[tuple[int, float]],
+        emb_results: list[tuple[int, float]],
+        k: int = _RRF_K,
+    ) -> list[tuple[int, float]]:
+        """Layer 5: Reciprocal Rank Fusion of three ranked lists."""
+        fused: dict[int, float] = {}
+
+        for rank, (idx, _) in enumerate(fts5_results, start=1):
+            fused[idx] = fused.get(idx, 0.0) + _RRF_W_FTS5 / (k + rank)
+
+        for rank, (idx, _) in enumerate(syn_results, start=1):
+            fused[idx] = fused.get(idx, 0.0) + _RRF_W_SYN / (k + rank)
+
+        for rank, (idx, _) in enumerate(emb_results, start=1):
+            fused[idx] = fused.get(idx, 0.0) + _RRF_W_EMB / (k + rank)
+
+        return sorted(fused.items(), key=lambda x: -x[1])

--- a/agent/skill_retriever.py
+++ b/agent/skill_retriever.py
@@ -15,7 +15,6 @@ Usage:
 
 import logging
 import math
-import os
 import re
 import threading
 import time
@@ -29,8 +28,42 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # ── Configuration ──────────────────────────────────────────────
-_DISABLE_ENV = "HERMES_DISABLE_SKILL_RETRIEVAL"
-_TOP_K_ENV = "HERMES_SKILL_RETRIEVAL_TOP_K"
+_DEFAULT_TOP_K = 5
+
+
+def _retrieval_config() -> dict:
+    """Return optional retrieval settings from config.yaml.
+
+    Missing or malformed config is fail-open: retrieval remains enabled with
+    the built-in top-k default. Behavioural settings belong in config.yaml,
+    never in the secret-only environment file.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+        skills = config.get("skills", {}) if isinstance(config, dict) else {}
+        retrieval = skills.get("retrieval", {}) if isinstance(skills, dict) else {}
+        return retrieval if isinstance(retrieval, dict) else {}
+    except Exception:
+        return {}
+
+
+def _retrieval_enabled(config: dict) -> bool:
+    value = config.get("enabled", True)
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "off"}
+    return value is not False
+
+
+def _retrieval_top_k(config: dict) -> int:
+    value = config.get("top_k", _DEFAULT_TOP_K)
+    if isinstance(value, bool):
+        return _DEFAULT_TOP_K
+    try:
+        return max(1, min(50, int(value)))
+    except (TypeError, ValueError):
+        return _DEFAULT_TOP_K
 
 # RRF parameters
 _RRF_K = 60
@@ -122,13 +155,13 @@ class SkillRetriever:
         self._emb_matrix = None
         self._model = None
         self._jieba_initialized = False
-        self._top_k = int(os.environ.get(_TOP_K_ENV, "5"))
+        config = _retrieval_config()
+        self._top_k = _retrieval_top_k(config)
+        if not _retrieval_enabled(config):
+            logger.info("Skill retrieval disabled by skills.retrieval.enabled")
+            return
         # Start background initialization immediately
         threading.Thread(target=self._lazy_init, daemon=True).start()
-
-        if os.environ.get(_DISABLE_ENV, "").lower() in ("1", "true", "yes"):
-            logger.info("Skill retrieval disabled via %s", _DISABLE_ENV)
-            return
 
     def is_ready(self) -> bool:
         return self._ready
@@ -464,10 +497,13 @@ class SkillRetriever:
             self._emb_matrix = None
             return
 
-        model_name = os.environ.get(
-            "HERMES_EMBEDDING_MODEL",
-            "shibing624/text2vec-base-chinese-paraphrase"
-        )
+        config = _retrieval_config()
+        model_name = str(
+            config.get(
+                "embedding_model",
+                "shibing624/text2vec-base-chinese-paraphrase",
+            )
+        ).strip() or "shibing624/text2vec-base-chinese-paraphrase"
         try:
             self._model = SentenceTransformer(model_name)
             texts = [f"{n}, {d}" for n, d in zip(self._skill_names, self._skill_descs)]

--- a/agent/skill_routing.py
+++ b/agent/skill_routing.py
@@ -13,16 +13,26 @@ from typing import Any, Iterable, Mapping
 
 
 _TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
-_SCALAR_FIELDS = ("qualified_name", "name", "category", "description")
-_SEQUENCE_FIELDS = (
+_FIELDS = (
+    "qualified_name",
+    "name",
+    "category",
+    "description",
     "triggers",
     "tags",
     "related_skills",
     "required_commands",
     "required_environment_variables",
 )
+_SCALAR_FIELDS = frozenset({"qualified_name", "name", "category", "description"})
+_SEQUENCE_FIELDS = frozenset(_FIELDS) - _SCALAR_FIELDS
 _K1 = 1.5
 _B = 0.75
+_DEFAULT_LIMIT = 8
+# A default query is considered separated when its best score clears the
+# runner-up by this ratio. Separated intent needs only a compact handoff set.
+_STRONG_SCORE_RATIO = 1.2
+_STRONG_DEPTH = 3
 
 
 def _tokenize(value: str) -> list[str]:
@@ -43,20 +53,27 @@ def _normalized_values(value: Any) -> list[str]:
     return sorted(cleaned, key=lambda item: (item.casefold(), item))
 
 
-def _canonical_document(skill: Mapping[str, Any]) -> dict[str, Any]:
+def build_routing_card(skill: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a deterministic internal card hashed only from ranking fields."""
     document: dict[str, Any] = {
         field: str(skill.get(field) or "").strip() for field in _SCALAR_FIELDS
     }
     for field in _SEQUENCE_FIELDS:
         document[field] = _normalized_values(skill.get(field))
+    canonical_source = json.dumps(
+        document, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+    document["source_fingerprint"] = hashlib.sha256(
+        canonical_source.encode("utf-8")
+    ).hexdigest()
     return document
 
 
-def _document_tokens(document: Mapping[str, Any]) -> list[str]:
+def _document_tokens(document: Mapping[str, Any]) -> tuple[str, ...]:
     text: list[str] = [str(document[field]) for field in _SCALAR_FIELDS]
     for field in _SEQUENCE_FIELDS:
         text.extend(document[field])
-    return _tokenize(" ".join(text))
+    return tuple(_tokenize(" ".join(text)))
 
 
 def _tie_key(document: Mapping[str, Any]) -> tuple[str, ...]:
@@ -88,9 +105,9 @@ def _build_index(
     float,
     str,
 ]:
-    """Build and cache one immutable BM25 corpus from canonical metadata."""
+    """Build and cache one immutable BM25 corpus from source-hashed cards."""
     documents = tuple(json.loads(serialized_documents))
-    tokenized = tuple(tuple(_document_tokens(document)) for document in documents)
+    tokenized = tuple(_document_tokens(document) for document in documents)
     document_frequencies: Counter[str] = Counter()
     for tokens in tokenized:
         document_frequencies.update(set(tokens))
@@ -112,7 +129,7 @@ def rank_skills(
 ) -> dict[str, Any]:
     """Rank canonical skill metadata with deterministic Okapi BM25."""
     skill_list = list(skills)
-    canonical_documents = [_canonical_document(skill) for skill in skill_list]
+    canonical_documents = [build_routing_card(skill) for skill in skill_list]
     serialized_documents = _serialize_documents(canonical_documents)
     (
         documents,
@@ -160,7 +177,15 @@ def rank_skills(
         )
         for skill, document in zip(skill_list, canonical_documents)
     }
-    for rank, (_, score, document) in enumerate(scored[: max(0, limit)], start=1):
+    depth = min(max(0, limit), total)
+    if limit == _DEFAULT_LIMIT and scored:
+        if scored[0][1] > 0.0:
+            runner_up = scored[1][1] if len(scored) > 1 else 0.0
+            if runner_up <= 0.0 or scored[0][1] >= runner_up * _STRONG_SCORE_RATIO:
+                exact_name_count = sum(exact_name for exact_name, _, _ in scored)
+                depth = min(depth, max(_STRONG_DEPTH, exact_name_count))
+
+    for rank, (_, score, document) in enumerate(scored[:depth], start=1):
         ranked.append({
             "rank": rank,
             "name": document["name"],

--- a/agent/skill_routing.py
+++ b/agent/skill_routing.py
@@ -177,15 +177,18 @@ def rank_skills(
         )
         for skill, document in zip(skill_list, canonical_documents)
     }
-    depth = min(max(0, limit), total)
-    if limit == _DEFAULT_LIMIT and scored:
-        if scored[0][1] > 0.0:
-            runner_up = scored[1][1] if len(scored) > 1 else 0.0
-            if runner_up <= 0.0 or scored[0][1] >= runner_up * _STRONG_SCORE_RATIO:
-                exact_name_count = sum(exact_name for exact_name, _, _ in scored)
-                depth = min(depth, max(_STRONG_DEPTH, exact_name_count))
+    rankable = scored
+    if limit == _DEFAULT_LIMIT:
+        rankable = [item for item in scored if item[1] > 0.0]
 
-    for rank, (_, score, document) in enumerate(scored[:depth], start=1):
+    depth = min(max(0, limit), len(rankable))
+    if limit == _DEFAULT_LIMIT and rankable:
+        runner_up = rankable[1][1] if len(rankable) > 1 else 0.0
+        if runner_up <= 0.0 or rankable[0][1] >= runner_up * _STRONG_SCORE_RATIO:
+            exact_name_count = sum(exact_name for exact_name, _, _ in rankable)
+            depth = min(depth, max(_STRONG_DEPTH, exact_name_count))
+
+    for rank, (_, score, document) in enumerate(rankable[:depth], start=1):
         ranked.append({
             "rank": rank,
             "name": document["name"],

--- a/agent/skill_routing.py
+++ b/agent/skill_routing.py
@@ -1,0 +1,176 @@
+"""Deterministic, local BM25 ranking for skill routing metadata."""
+
+from __future__ import annotations
+
+from collections import Counter
+from functools import lru_cache
+import hashlib
+import json
+import math
+import re
+import unicodedata
+from typing import Any, Iterable, Mapping
+
+
+_TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
+_SCALAR_FIELDS = ("qualified_name", "name", "category", "description")
+_SEQUENCE_FIELDS = (
+    "triggers",
+    "tags",
+    "related_skills",
+    "required_commands",
+    "required_environment_variables",
+)
+_K1 = 1.5
+_B = 0.75
+
+
+def _tokenize(value: str) -> list[str]:
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return _TOKEN_RE.findall(normalized)
+
+
+def _normalized_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        values: Iterable[Any] = [value]
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        values = value
+    else:
+        return []
+    cleaned = {str(item).strip() for item in values if str(item).strip()}
+    return sorted(cleaned, key=lambda item: (item.casefold(), item))
+
+
+def _canonical_document(skill: Mapping[str, Any]) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        field: str(skill.get(field) or "").strip() for field in _SCALAR_FIELDS
+    }
+    for field in _SEQUENCE_FIELDS:
+        document[field] = _normalized_values(skill.get(field))
+    return document
+
+
+def _document_tokens(document: Mapping[str, Any]) -> list[str]:
+    text: list[str] = [str(document[field]) for field in _SCALAR_FIELDS]
+    for field in _SEQUENCE_FIELDS:
+        text.extend(document[field])
+    return _tokenize(" ".join(text))
+
+
+def _tie_key(document: Mapping[str, Any]) -> tuple[str, ...]:
+    values = (
+        str(document["qualified_name"]),
+        str(document["category"]),
+        str(document["name"]),
+    )
+    return tuple(part for value in values for part in (value.casefold(), value))
+
+
+def _serialize_documents(documents: list[dict[str, Any]]) -> str:
+    ordered = sorted(documents, key=_tie_key)
+    return json.dumps(
+        ordered,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def _build_index(
+    serialized_documents: str,
+) -> tuple[
+    tuple[dict[str, Any], ...],
+    tuple[tuple[str, ...], ...],
+    tuple[tuple[str, int], ...],
+    float,
+    str,
+]:
+    """Build and cache one immutable BM25 corpus from canonical metadata."""
+    documents = tuple(json.loads(serialized_documents))
+    tokenized = tuple(tuple(_document_tokens(document)) for document in documents)
+    document_frequencies: Counter[str] = Counter()
+    for tokens in tokenized:
+        document_frequencies.update(set(tokens))
+    average_length = (
+        sum(len(tokens) for tokens in tokenized) / len(tokenized) if tokenized else 0.0
+    )
+    fingerprint = hashlib.sha256(serialized_documents.encode("utf-8")).hexdigest()[:16]
+    return (
+        documents,
+        tokenized,
+        tuple(sorted(document_frequencies.items())),
+        average_length,
+        fingerprint,
+    )
+
+
+def rank_skills(
+    skills: Iterable[Mapping[str, Any]], query: str, limit: int
+) -> dict[str, Any]:
+    """Rank canonical skill metadata with deterministic Okapi BM25."""
+    skill_list = list(skills)
+    canonical_documents = [_canonical_document(skill) for skill in skill_list]
+    serialized_documents = _serialize_documents(canonical_documents)
+    (
+        documents,
+        tokenized,
+        document_frequency_items,
+        average_length,
+        index_fingerprint,
+    ) = _build_index(serialized_documents)
+    query_tokens = _tokenize(query)
+    total = len(documents)
+    document_frequencies = dict(document_frequency_items)
+
+    query_frequencies = Counter(query_tokens)
+    scored: list[tuple[bool, float, dict[str, Any]]] = []
+    normalized_query_name = " ".join(query_tokens)
+    for document, tokens in zip(documents, tokenized):
+        frequencies = Counter(tokens)
+        score = 0.0
+        for term, query_frequency in query_frequencies.items():
+            frequency = frequencies[term]
+            if not frequency:
+                continue
+            document_frequency = document_frequencies[term]
+            inverse_document_frequency = math.log(
+                1.0 + (total - document_frequency + 0.5) / (document_frequency + 0.5)
+            )
+            length_normalization = 1.0 - _B
+            if average_length:
+                length_normalization += _B * len(tokens) / average_length
+            score += (
+                query_frequency
+                * inverse_document_frequency
+                * (frequency * (_K1 + 1.0))
+                / (frequency + _K1 * length_normalization)
+            )
+
+        exact_name = " ".join(_tokenize(str(document["name"]))) == normalized_query_name
+        scored.append((exact_name, score, document))
+
+    scored.sort(key=lambda item: (not item[0], -item[1], _tie_key(item[2])))
+    ranked = []
+    display_descriptions = {
+        _tie_key(document): str(
+            skill.get("display_description", document["description"])
+        )
+        for skill, document in zip(skill_list, canonical_documents)
+    }
+    for rank, (_, score, document) in enumerate(scored[: max(0, limit)], start=1):
+        ranked.append({
+            "rank": rank,
+            "name": document["name"],
+            "category": document["category"] or None,
+            "description": display_descriptions[_tie_key(document)],
+            "score": round(score, 6),
+        })
+
+    return {
+        "skills": ranked,
+        "total_candidates": total,
+        "index_fingerprint": index_fingerprint,
+    }

--- a/agent/skill_synonyms.yaml
+++ b/agent/skill_synonyms.yaml
@@ -1,0 +1,53 @@
+# Skill Synonym Dictionary
+# Purpose: When a user query matches a synonym, the corresponding skill's score gets boosted
+# Format: skill_name: [keyword_list]
+# Design Principles:
+#   1. Only collect keywords users actually type (natural language, not jargon)
+#   2. Avoid overly generic words (e.g., "tool", "use", "help")
+#   3. 5-15 synonyms per skill is optimal
+#   4. Include both languages if bilingual (e.g., "debug" and "调试")
+#
+# CUSTOMIZATION: Run `python scripts/generate_config.py` to auto-generate
+# from your local skill library. Then review and refine.
+# See PROMPTS.md for LLM-assisted generation prompts.
+
+# ═══════════════════════════════════════════════════════
+# Example: Engineering Skills
+# ═══════════════════════════════════════════════════════
+
+systematic-debugging:
+  - 调试
+  - 排查bug
+  - 诊断问题
+  - 修bug
+  - 找bug
+  - 报错
+  - 异常
+  - traceback
+  - 错误分析
+  - 故障排查
+  - 问题定位
+  - 根因分析
+  - debug
+  - 排查问题
+
+skill-creation-guide:
+  - 创建技能
+  - 写技能
+  - 新技能
+  - 技能格式
+  - 技能规范
+  - SKILL.md
+  - 技能模板
+
+find-skills:
+  - 找技能
+  - 搜索技能
+  - 安装技能
+  - 技能发现
+
+# ═══════════════════════════════════════════════════════
+# ADD YOUR SKILLS BELOW
+# ═══════════════════════════════════════════════════════
+# Copy the format above for each of your skills.
+# The generate_config.py script can do this automatically.

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -31,6 +31,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".github",
         ".hub",
         ".archive",
+        ".reflection_proposals",  # skill-evolution proposal queue (JSON, not skills)
         ".venv",
         "venv",
         "node_modules",

--- a/docs/skill-steward-implementation-plan.md
+++ b/docs/skill-steward-implementation-plan.md
@@ -38,11 +38,13 @@ Usage counters cannot answer whether a skill helped. A skill with no recorded us
 
 ### Routing lane
 
-Extend `skills_list` with an optional natural-language query. It returns a bounded ranked list of compact skill cards. `skill_view` remains the exact loader. Ranking is deterministic and local. No new permanent model tool is added.
+Extend `skills_list` with an optional natural-language query. It returns a bounded ranked list of compact skill cards. `skill_view` remains the exact loader. Ranking is deterministic and local. Outcome reporting extends the existing skills toolset rather than adding a new standalone toolset; the tool schema stays fixed for the conversation.
 
 ### Stewardship lane
 
-Record a bounded local outcome for a loaded skill: success, failure, or unknown. Keep only the task identifier and coarse error type. Do not store task text. Use a confidence floor before utility affects ranking. Low-utility skills produce review proposals, never automatic edits.
+Record a bounded local outcome for a loaded skill: success, failure, or unknown. Keep only the task identifier and coarse error type. Do not store task text. Use a confidence floor before global per-skill utility affects ranking. Low-utility skills produce review proposals, never automatic edits.
+
+This PR establishes routing, local outcomes, review proposals, dashboard visibility, and archive safety. It does not yet ship the full opportunity→surface→follow funnel or automatic service loop from the design; those remain follow-up work after the event contract proves useful.
 
 ### Curation lane
 
@@ -125,6 +127,14 @@ Run the focused Python suites for skill routing, skill outcomes, skill reflectio
 3. Keep utility re-ranking confidence-gated.
 4. Keep reflection proposals and consolidation review-only.
 5. Measure missed-route rate, top-k acceptance, outcome coverage, false archive attempts, latency, and index rebuild time.
+
+## Explicitly not in this PR
+
+- Automatic pre-task loading of a ranked skill.
+- The full opportunity→surface→load→follow→completed event stream.
+- Automatic readiness testing or mutation of underused skills.
+- Task-class-specific utility. Outcome storage deliberately omits raw task text, so utility is global per skill.
+- Automatic bundle creation.
 
 ## Definition of done
 

--- a/docs/skill-steward-implementation-plan.md
+++ b/docs/skill-steward-implementation-plan.md
@@ -1,0 +1,137 @@
+# Skill Steward: research-backed implementation plan
+
+Date: 2026-08-29 UTC
+
+## Problem
+
+Hermes currently mixes three different concerns:
+
+1. Routing: find the smallest set of relevant skills for a task.
+2. Stewardship: learn whether surfaced skills helped and improve weak ones.
+3. Curation: merge or archive skills safely.
+
+Usage counters cannot answer whether a skill helped. A skill with no recorded use may be undiscoverable rather than useless. A fixed archive quota rewards deletion rather than quality.
+
+## Evidence reviewed
+
+- Hermes Agent current `main`, contributor doctrine, curator, skill tools, usage sidecar, prompt builder, plugin system, tests, and CI.
+- Existing upstream work:
+  - PR #93591: deterministic BM25 skill routing, green CI.
+  - PR #84420: local outcome telemetry, utility scoring, retrieval and review proposals, but currently conflicting and too broad.
+  - PR #97609: curator safety work, currently blocked.
+  - Issue #17649: on-demand skill retrieval instead of broadcasting the catalog.
+- Industry and research patterns from Anthropic tool-design guidance, OpenAI agent tooling, LangGraph/LangChain, Semantic Kernel/AutoGen, Google ADK, MCP routing discussions, Tool-to-Agent Retrieval, and large-tool-catalog routing research.
+- Practitioner reports from GitHub, X, and Reddit about tool overload, hierarchical retrieval, and missed capabilities.
+
+## Findings
+
+1. Progressive disclosure beats broadcasting every capability. Rank locally, return compact cards, then load exact instructions.
+2. Hybrid lexical retrieval is the safe first layer. It is deterministic, offline, cheap, and easy to test. Semantic retrieval can be added later behind the same contract.
+3. Do not mutate the system prompt or toolset during a conversation. Skill routing must use existing tools and preserve prompt-cache bytes.
+4. Separate observation from automation. Local outcome data can guide ranking and proposals, but it must not silently rewrite or delete skills.
+5. Unknown is not failure. No usage and unknown outcomes are discovery gaps, not archive evidence.
+6. Curator actions need evidence and reversible state. Remove archive quotas. Keep human review for consolidation and low-confidence changes.
+7. Telemetry stays local. No third-party analytics, personal identifiers, or raw task text are required.
+8. Contributor credit must survive integration. Build on existing commits rather than replacing them without attribution.
+
+## Target design
+
+### Routing lane
+
+Extend `skills_list` with an optional natural-language query. It returns a bounded ranked list of compact skill cards. `skill_view` remains the exact loader. Ranking is deterministic and local. No new permanent model tool is added.
+
+### Stewardship lane
+
+Record a bounded local outcome for a loaded skill: success, failure, or unknown. Keep only the task identifier and coarse error type. Do not store task text. Use a confidence floor before utility affects ranking. Low-utility skills produce review proposals, never automatic edits.
+
+### Curation lane
+
+Automatic inactivity transitions may mark skills stale. They must not archive a skill without known outcome evidence. Consolidation remains a separate opt-in background pass, has no minimum archive quota, preserves unique content and support files, and remains reversible.
+
+## Phases and dependencies
+
+### Phase 1: baseline and contracts
+
+- Rebase on current `main`.
+- Confirm overlapping PR state and preserve authorship.
+- Define privacy, cache, compatibility, and rollback invariants.
+
+Dependency: none.
+
+### Phase 2: deterministic retrieval
+
+- Integrate BM25 routing through `skills_list(query=...)`.
+- Keep normal catalog output unchanged when no query is supplied.
+- Cover zero-score tails, category filters, plugin skills, limits, and malformed input.
+
+Dependency: Phase 1.
+
+### Phase 3: local outcomes
+
+- Add bounded success/failure/unknown records.
+- Add confidence-gated utility scoring.
+- Feed utility into retrieval only after enough samples.
+- Keep failures best-effort so telemetry never breaks task execution.
+
+Dependency: Phase 2 contracts; implementation can run in parallel with Phase 2 after interfaces freeze.
+
+### Phase 4: evidence-gated curator
+
+- Treat no outcomes as insufficient evidence for archive.
+- Remove fixed archive-count pressure from the curator prompt.
+- Keep archive reversible and consolidation opt-in.
+- Test never-tried, unknown-only, successful, failed, pinned, cron-referenced, bundled, and external skills.
+
+Dependency: Phase 3 record shape.
+
+### Phase 5: QA and review
+
+Parallel lanes:
+
+- Routing tests and benchmark replay.
+- Outcome storage, concurrency, privacy, and corruption tests.
+- Curator lifecycle and archive sabotage tests.
+- Prompt-cache and tool-schema stability checks.
+- Independent architecture, security/privacy, and contributor-credit review.
+
+Dependency: Phases 2 to 4.
+
+### Phase 6: ship
+
+- Run the focused one-minute gate.
+- Run repository lint and affected test suites.
+- Push the branch and open one draft PR that clearly credits and supersedes overlapping work.
+- Read back base, head SHA, files, body, and live checks.
+
+Dependency: Phase 5 green.
+
+## One-minute local gate
+
+Run the focused Python suites for skill routing, skill outcomes, skill reflection, skill APIs, and curator activity. Run Ruff on changed Python files. Run `git diff --check`. The gate must stay deterministic and use temporary Hermes homes only.
+
+## Full CI
+
+- Python tests and Ruff.
+- macOS and Windows path checks.
+- E2E test that routes, loads, records an outcome, then runs a curator transition in a temporary home.
+- Benchmark replay with fixed fixtures and relationship-based thresholds, not frozen implementation values.
+- Security checks proving no raw task text or external network call is made.
+- Contributor-attribution check.
+
+## Rollout
+
+1. Merge retrieval first or keep it as the base commits in one draft integration PR.
+2. Ship outcomes as local and best-effort.
+3. Keep utility re-ranking confidence-gated.
+4. Keep reflection proposals and consolidation review-only.
+5. Measure missed-route rate, top-k acceptance, outcome coverage, false archive attempts, latency, and index rebuild time.
+
+## Definition of done
+
+- Query routing returns relevant compact candidates without changing the no-query contract.
+- Prompt and tool schemas remain stable within a conversation.
+- Outcomes are local, bounded, privacy-safe, and cannot break task execution.
+- Unknown or absent evidence cannot trigger automatic archive.
+- Curator has no archive quota and every destructive transition is recoverable.
+- Focused tests, lint, diff checks, and live CI pass.
+- One reviewable PR exists with preserved contributor credit, verified remote SHA, exact test evidence, risks, exclusions, and overlap notes.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2213,6 +2213,14 @@ DEFAULT_CONFIG = {
         # before the agent sees it.  Lets skill authors reference bundled
         # scripts without the agent having to join paths.
         "template_vars": True,
+        # Optional settings for the richer background SkillRetriever. The
+        # default skills_list(query=...) path remains deterministic BM25 and
+        # does not require sentence-transformers or a model download.
+        "retrieval": {
+            "enabled": True,
+            "top_k": 5,
+            "embedding_model": "shibing624/text2vec-base-chinese-paraphrase",
+        },
         # Pre-execute inline shell snippets written as !`cmd` in SKILL.md
         # body.  Their stdout is inlined into the skill message before the
         # agent reads it, so skills can inject dynamic context (dates, git

--- a/hermes_cli/web_routers/skill_evolution.py
+++ b/hermes_cli/web_routers/skill_evolution.py
@@ -1,0 +1,454 @@
+"""Skill evolution dashboard routes (2026-08).
+
+Exposes the skill-outcome telemetry and the reflection proposal queue added
+by the skill-evolution work (tools/skill_usage.py outcome scoring +
+agent/skill_reflection.py proposal queue) to the desktop dashboard:
+
+    GET  /api/skills/evolution                — overview: counts, top skills,
+                                               low-utility candidates
+    GET  /api/skills/evolution/outcomes       — per-skill outcome telemetry
+    GET  /api/skills/evolution/proposals      — proposal queue (pending/all)
+    POST /api/skills/evolution/proposals/{skill}/{proposal_id}/approve
+                                               — approve + apply a bounded edit
+    POST /api/skills/evolution/proposals/{skill}/{proposal_id}/reject
+                                               — reject a proposal
+
+All handlers are read-mostly; the only mutations are proposal status
+transitions. Proposal *application* (approve) performs a bounded, section-
+targeted patch of SKILL.md guarded by the same linter/guard checks the
+skill_manage tool enforces, so the "human approves, machine applies a
+bounded edit" contract from the reflection loop is preserved.
+"""
+
+import logging
+import re
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter()
+
+_log = logging.getLogger("hermes_cli.web_server")
+
+
+def _skill_evolution_usage() -> dict:
+    """Snapshot of outcome telemetry + utility scores (best-effort)."""
+    try:
+        from tools.skill_usage import load_usage, _backfill_outcome_keys
+        data = load_usage()
+        rows = []
+        for name, raw in data.items():
+            if not isinstance(raw, dict):
+                continue
+            rec = _backfill_outcome_keys(raw)
+            rows.append(
+                {
+                    "skill": str(name),
+                    "utility_score": rec.get("utility_score"),
+                    "success_count": rec.get("success_count", 0),
+                    "failure_count": rec.get("failure_count", 0),
+                    "unknown_count": rec.get("unknown_count", 0),
+                    "use_count": rec.get("use_count", 0),
+                    "patch_count": rec.get("patch_count", 0),
+                    "last_outcome_at": rec.get("last_outcome_at"),
+                    "state": rec.get("state", "active"),
+                }
+            )
+        # Sort: scored skills (utility desc) first, then used-but-unscored
+        # (use_count desc, stable), then never-used skills last. This keeps
+        # the dashboard meaningful before real outcomes accumulate — top
+        # skills are the most-used ones while telemetry ramps up.
+        def _sort_key(r):
+            score = r["utility_score"]
+            if score is not None:
+                return (0, -score, 0)
+            if r["use_count"] > 0:
+                return (1, 0, -r["use_count"])
+            return (2, 0, 0)
+
+        rows.sort(key=_sort_key)
+        return {"skills": rows, "total": len(rows)}
+    except Exception as e:  # pragma: no cover - defensive
+        _log.exception("skill evolution usage snapshot failed")
+        return {"skills": [], "total": 0, "error": str(e)}
+
+
+def _low_utility_candidates(limit: int = 20) -> list:
+    try:
+        from tools.skill_usage import list_low_utility_skills
+        return list_low_utility_skills(max_score=0.4)[:limit]
+    except Exception:  # pragma: no cover - defensive
+        return []
+
+
+def _proposal_rows(skill: Optional[str] = None, pending_only: bool = False) -> list:
+    try:
+        from agent.skill_reflection import list_proposals, list_pending_proposals
+        if pending_only:
+            rows = list_pending_proposals(skill)
+        else:
+            rows = list_proposals(skill)
+        return rows
+    except Exception:  # pragma: no cover - defensive
+        return []
+
+
+@router.get("/api/skills/evolution")
+async def skill_evolution_overview():
+    """Overview of the skill-evolution system: telemetry, candidates, queue,
+    trends, utility distribution, and an overall health score."""
+    usage = _skill_evolution_usage()
+    proposals = _proposal_rows()
+    pending = [p for p in proposals if p.get("status") == "pending"]
+    candidates = _low_utility_candidates()
+    scored = [s for s in usage.get("skills", []) if s["utility_score"] is not None]
+    avg_utility = (
+        round(sum(s["utility_score"] for s in scored) / len(scored), 4) if scored else None
+    )
+
+    # ── Trends: this week vs last week ──────────────────────────────────
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    week_ago = now - timedelta(days=7)
+    two_weeks_ago = now - timedelta(days=14)
+
+    def _in_window(rows, lo, hi):
+        n = 0
+        for r in rows:
+            ts = r.get("created_at") or r.get("last_outcome_at")
+            if not ts:
+                continue
+            try:
+                dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if lo <= dt < hi:
+                n += 1
+        return n
+
+    proposals_this = _in_window(proposals, week_ago, now)
+    proposals_last = _in_window(proposals, two_weeks_ago, week_ago)
+
+    # Outcome deltas from telemetry (success/failure counts are cumulative, so
+    # we approximate weekly change via last_outcome_at recency per skill).
+    outcomes_this = sum(1 for s in usage.get("skills", []) if s.get("last_outcome_at") and _in_window([{"created_at": s["last_outcome_at"]}], week_ago, now))
+    outcomes_last = sum(1 for s in usage.get("skills", []) if s.get("last_outcome_at") and _in_window([{"created_at": s["last_outcome_at"]}], two_weeks_ago, week_ago))
+
+    # ── Utility distribution (buckets: <0.4, 0.4–0.7, ≥0.7) ─────────────
+    dist = {"low": 0, "mid": 0, "high": 0}
+    for s in scored:
+        v = s["utility_score"]
+        if v < 0.4:
+            dist["low"] += 1
+        elif v < 0.7:
+            dist["mid"] += 1
+        else:
+            dist["high"] += 1
+
+    # ── Health score 0–100 ──────────────────────────────────────────────
+    # Weighted: scored ratio, avg utility, pending-burden, low-utility ratio.
+    total = usage.get("total", 0) or 1
+    scored_ratio = len(scored) / total if total else 0
+    low_ratio = len(candidates) / total if total else 0
+    avg_u = avg_utility if avg_utility is not None else 0.0
+    pending_burden = min(1.0, len(pending) / max(1, total) * 20)  # 5% pending → full burden
+    health = round(
+        100
+        * (
+            0.25 * scored_ratio
+            + 0.35 * avg_u
+            + 0.25 * (1 - low_ratio)
+            + 0.15 * (1 - pending_burden)
+        ),
+        1,
+    )
+
+    return {
+        "skills_total": usage.get("total", 0),
+        "skills_scored": len(scored),
+        "avg_utility": avg_utility,
+        "proposals_pending": len(pending),
+        "proposals_total": len(proposals),
+        "low_utility_candidates": candidates,
+        "top_skills": usage.get("skills", [])[:10],
+        "bottom_skills": usage.get("skills", [])[-10:][::-1],
+        "trends": {
+            "proposals_this_week": proposals_this,
+            "proposals_last_week": proposals_last,
+            "outcomes_this_week": outcomes_this,
+            "outcomes_last_week": outcomes_last,
+        },
+        "utility_distribution": dist,
+        "health_score": health,
+    }
+
+
+@router.get("/api/skills/evolution/outcomes")
+async def skill_evolution_outcomes(limit: int = 50):
+    """Per-skill outcome telemetry, best (utility) first."""
+    usage = _skill_evolution_usage()
+    return {"skills": usage.get("skills", [])[: max(1, min(limit, 500))]}
+
+
+@router.get("/api/skills/evolution/proposals")
+async def skill_evolution_proposals(
+    skill: Optional[str] = None,
+    pending_only: bool = False,
+    status: Optional[str] = None,
+    limit: int = 50,
+):
+    """The reflection proposal queue.
+
+    ``pending_only=true`` filters to open ones. ``status=applied|rejected|
+    reviewed`` filters by audit state (applied proposals are kept in the
+    history view). ``limit`` caps the returned rows (default 50).
+    """
+    rows = _proposal_rows(skill, pending_only=pending_only)
+    if status:
+        rows = [p for p in rows if p.get("status") == status]
+    rows = rows[: max(1, min(limit, 500))]
+    return {"proposals": rows, "total": len(rows)}
+
+
+@router.get("/api/skills/evolution/skills/{skill}")
+async def skill_evolution_detail(skill: str):
+    """Full detail for one skill: telemetry summary + failure patterns +
+    proposal history. Powers the skill detail drawer."""
+    try:
+        from tools.skill_usage import get_outcome_summary, get_utility_score
+        from agent.skill_reflection import aggregate_failure_patterns, list_proposals
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"modules unavailable: {exc}")
+
+    summary = get_outcome_summary(skill) or {}
+    patterns = aggregate_failure_patterns(skill) or {}
+    proposals = list_proposals(skill) or []
+    return {
+        "skill": skill,
+        "utility_score": get_utility_score(skill),
+        "summary": {
+            "success_count": summary.get("success_count", 0),
+            "failure_count": summary.get("failure_count", 0),
+            "unknown_count": summary.get("unknown_count", 0),
+            "use_count": summary.get("use_count", 0),
+            "patch_count": summary.get("patch_count", 0),
+            "last_outcome_at": summary.get("last_outcome_at"),
+        },
+        "failure_patterns": patterns,
+        "proposals": proposals[:20],
+    }
+
+
+@router.post("/api/skills/evolution/skills/{skill}/propose")
+async def propose_skill_improvement(skill: str):
+    """One-click proposal generation for a skill (human reviews before
+    anything is applied). Uses the reflection loop's aggregate_failure_patterns
+    to diagnose the most common failure, then writes a bounded proposal."""
+    try:
+        from agent.skill_reflection import (
+            aggregate_failure_patterns,
+            build_proposal,
+            list_pending_proposals,
+            save_proposal,
+        )
+        from tools.skill_usage import get_utility_score
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"reflection module unavailable: {exc}")
+
+    # Refuse to pile up: one pending proposal per skill at a time
+    pending = list_pending_proposals(skill)
+    if pending:
+        return {"ok": False, "reason": "already_pending", "proposal": pending[0]}
+
+    patterns = aggregate_failure_patterns(skill) or {}
+    top_error_types = patterns.get("top_error_types") or []
+    error_types = [str(et) for et, _count in top_error_types]
+    failure_rate = patterns.get("failure_rate")
+
+    if failure_rate in (None, 0) and not error_types:
+        raise HTTPException(status_code=400, detail="no failure signals; nothing to propose")
+
+    top_error = error_types[0] if error_types else "unknown"
+    proposal = build_proposal(
+        skill,
+        diagnosis=(
+            f"失败率 {failure_rate:.0%}，主要错误类型 {top_error}"
+            if error_types and failure_rate is not None
+            else f"主要错误类型 {top_error}"
+            if error_types
+            else f"失败率 {failure_rate:.0%}"
+        ),
+        target_section="pitfalls",
+        suggested_fix=f"记录 {top_error} 失败的处理方式并补充到 Pitfalls 段",
+        failure_types=error_types[:5],
+        utility_score=get_utility_score(skill),
+        source="dashboard",
+    )
+    save_proposal(proposal)
+    return {"ok": True, "proposal": proposal}
+
+
+@router.post("/api/skills/evolution/skills/{skill}/outcome")
+async def record_skill_outcome_manual(
+    skill: str,
+    payload: dict,
+):
+    """Manually record a skill outcome from the dashboard (success | failure |
+    unknown). Feeds utility scoring without needing the agent tool."""
+    outcome = str(payload.get("outcome") or "").strip()
+    if outcome not in {"success", "failure", "unknown"}:
+        raise HTTPException(status_code=400, detail="outcome must be success|failure|unknown")
+    error_type = str(payload.get("error_type") or "").strip() or None
+    try:
+        from tools.skill_usage import record_outcome
+
+        utility = record_outcome(skill, outcome, error_type=error_type)
+        return {"ok": True, "skill": skill, "outcome": outcome, "utility_score": utility}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"record_outcome failed: {exc}")
+
+
+def _locate_and_patch_skill(skill_name: str, proposal: dict) -> dict:
+    """Apply a bounded, section-targeted edit to the skill's SKILL.md.
+
+    Returns ``{"ok": True, "path": ..., "heading": ...}`` or raises
+    HTTPException on any guard failure. The edit is bounded to the target
+    section so the rest of the skill is untouched.
+    """
+    import os
+
+    from hermes_constants import get_hermes_home
+    from agent.skill_reflection import locate_section
+
+    suggested_fix = str(proposal.get("suggested_fix") or "").strip()
+    target_key = str(proposal.get("target_section") or "").strip().lower()
+    if not suggested_fix or not target_key:
+        raise HTTPException(status_code=400, detail="proposal missing suggested_fix/target_section")
+
+    # Locate the SKILL.md on disk (flat or nested skills/<cat>/<name>/SKILL.md)
+    skills_root = get_hermes_home() / "skills"
+    candidates = []
+    if skills_root.exists():
+        for p in skills_root.rglob("SKILL.md"):
+            rel = p.parent
+            if rel.name == skill_name or (rel.parent.name == skill_name):
+                candidates.append(p)
+        # Also match frontmatter name
+        if not candidates:
+            for p in skills_root.rglob("SKILL.md"):
+                try:
+                    text = p.read_text(encoding="utf-8")
+                except Exception:
+                    continue
+                m = re.search(r"^name:\s*([^\s]+)", text, re.MULTILINE)
+                if m and m.group(1) == skill_name:
+                    candidates.append(p)
+    if not candidates:
+        raise HTTPException(status_code=404, detail=f"skill {skill_name!r} not found on disk")
+
+    path = candidates[0]
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"cannot read {path}: {exc}")
+
+    loc = locate_section(content, target_key)
+    if loc is None:
+        # Section missing → append a new section before the next heading
+        # after the intro, or at the very end. Bounded: only append.
+        append = f"\n{locate_section_heading(target_key)}\n- {suggested_fix}\n"
+        new_content = content.rstrip() + "\n" + append
+        heading = locate_section_heading(target_key)
+        section_span = None
+    else:
+        # Insert the fix line inside the existing section (before next heading)
+        heading = loc["heading"]
+        section_body_end = loc["end"]
+        # Insert after the heading line
+        insert_at = loc["start"] + len(heading) + 1
+        new_content = (
+            content[:insert_at]
+            + f"- {suggested_fix}\n"
+            + content[insert_at:]
+        )
+        section_span = {"start": loc["start"], "end": section_body_end}
+
+    # Guard: refuse to run the write if the skill is external/hub-owned
+    try:
+        from tools.skill_usage import is_curation_eligible, is_external_skill_path
+        if is_external_skill_path(path):
+            raise HTTPException(status_code=403, detail="skill is externally owned; read-only")
+    except HTTPException:
+        raise
+    except Exception:
+        pass  # guard absence is not a blocker
+
+    try:
+        path.write_text(new_content, encoding="utf-8")
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"cannot write {path}: {exc}")
+
+    return {
+        "ok": True,
+        "path": str(path),
+        "heading": heading,
+        "section_span": section_span,
+        "fix": suggested_fix,
+    }
+
+
+def locate_section_heading(target_key: str) -> str:
+    """Return the canonical markdown heading for a targetable section key."""
+    return {
+        "when to use": "## When to Use",
+        "prerequisites": "## Prerequisites",
+        "procedure": "## Procedure",
+        "pitfalls": "## Pitfalls",
+        "verification": "## Verification",
+        "quick reference": "## Quick Reference",
+    }.get(target_key, "## Pitfalls")
+
+
+@router.post("/api/skills/evolution/proposals/{skill}/{proposal_id}/approve")
+async def approve_proposal(skill: str, proposal_id: str):
+    """Approve a proposal: apply the bounded edit, then mark it applied."""
+    try:
+        from agent.skill_reflection import list_proposals, mark_proposal_status
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"reflection module unavailable: {exc}")
+
+    rows = [p for p in list_proposals(skill) if p.get("proposal_id") == proposal_id]
+    if not rows:
+        raise HTTPException(status_code=404, detail="proposal not found")
+    proposal = rows[0]
+    if proposal.get("status") not in (None, "pending", "reviewed"):
+        raise HTTPException(status_code=409, detail=f"proposal already {proposal.get('status')}")
+
+    result = _locate_and_patch_skill(skill, proposal)
+    mark_proposal_status(skill, proposal_id, "applied")
+    return {"ok": True, **result}
+
+
+@router.post("/api/skills/evolution/proposals/{skill}/{proposal_id}/reject")
+async def reject_proposal(skill: str, proposal_id: str):
+    """Reject a proposal (kept for audit, not applied)."""
+    try:
+        from agent.skill_reflection import mark_proposal_status
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"reflection module unavailable: {exc}")
+    if not mark_proposal_status(skill, proposal_id, "rejected"):
+        raise HTTPException(status_code=404, detail="proposal not found")
+    return {"ok": True, "status": "rejected"}
+
+
+@router.post("/api/skills/evolution/proposals/{skill}/{proposal_id}/reviewed")
+async def mark_proposal_reviewed(skill: str, proposal_id: str):
+    """Mark a proposal reviewed without applying it (audit trail)."""
+    try:
+        from agent.skill_reflection import mark_proposal_status
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"reflection module unavailable: {exc}")
+    if not mark_proposal_status(skill, proposal_id, "reviewed"):
+        raise HTTPException(status_code=404, detail="proposal not found")
+    return {"ok": True, "status": "reviewed"}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15368,6 +15368,12 @@ def _config_profile_scope(profile: Optional[str]):
 
 
 app.include_router(_skills_routes.router)
+
+# Skill evolution dashboard — outcome telemetry + reflection queue
+from hermes_cli.web_routers import skill_evolution as _skill_evolution_routes  # noqa: E402
+
+app.include_router(_skill_evolution_routes.router)
+
 from hermes_cli.web_routers.skills import (  # noqa: E402,F401 — legacy re-exports; tests call these via web_server.<name>
     get_skills,
     toggle_skill,

--- a/model_tools.py
+++ b/model_tools.py
@@ -272,7 +272,9 @@ _LEGACY_TOOLSET_MAP = {
     "terminal_tools": ["terminal"],
     "vision_tools": ["vision_analyze"],
     "image_tools": ["image_generate"],
-    "skills_tools": ["skills_list", "skill_view", "skill_manage"],
+    "skills_tools": [
+        "skills_list", "skill_view", "skill_manage", "skill_report_outcome",
+    ],
     "browser_tools": [
         "browser_navigate", "browser_snapshot", "browser_click",
         "browser_type", "browser_scroll", "browser_back",

--- a/scripts/benchmark_skill_routing.py
+++ b/scripts/benchmark_skill_routing.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Run the deterministic public-safe skill-routing relevance benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import sys
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from agent.skill_routing import rank_skills
+
+
+def evaluate(fixture: dict) -> dict:
+    """Return deterministic aggregate metrics and public-safe result rows."""
+    rows = []
+    for case in fixture["queries"]:
+        ranking = rank_skills(fixture["skills"], case["query"], limit=8)
+        names = [item["name"] for item in ranking["skills"]]
+        relevant = case["relevant"]
+        ranks = [names.index(name) + 1 for name in relevant if name in names]
+        reciprocal_rank = 1.0 / min(ranks) if ranks else (1.0 if not relevant else 0.0)
+        recall = len(ranks) / len(relevant) if relevant else 1.0
+        dcg = sum(1.0 / math.log2(rank + 1) for rank in ranks)
+        ideal = sum(1.0 / math.log2(rank + 1) for rank in range(1, len(relevant) + 1))
+        ndcg = dcg / ideal if ideal else 1.0
+        rows.append({
+            "depth": len(names),
+            "ndcg": ndcg,
+            "query": case["query"],
+            "ranked": names,
+            "recall": recall,
+            "reciprocal_rank": reciprocal_rank,
+            "relevant": relevant,
+        })
+
+    count = len(rows)
+    return {
+        "average_depth": round(sum(row["depth"] for row in rows) / count, 6),
+        "mean_ndcg": round(sum(row["ndcg"] for row in rows) / count, 6),
+        "mrr": round(sum(row["reciprocal_rank"] for row in rows) / count, 6),
+        "query_count": count,
+        "recall": round(sum(row["recall"] for row in rows) / count, 6),
+        "rows": rows,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("fixture", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    fixture = json.loads(args.fixture.read_text(encoding="utf-8"))
+    result = evaluate(fixture)
+    rendered = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    sys.stderr.write(f"sha256={hashlib.sha256(rendered.encode()).hexdigest()}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -278,8 +278,8 @@ def test_unresolvable_reference_is_kept_verbatim(curator_env, tmp_path, monkeypa
     }
 
 
-def test_unreferenced_skill_is_still_archived(curator_env, monkeypatch):
-    """Guard against over-protecting: a skill no job mentions still ages out."""
+def test_unreferenced_skill_without_outcome_is_staled_not_archived(curator_env, monkeypatch):
+    """No cron protection does not turn missing outcome evidence into archive proof."""
     c = curator_env["curator"]
     u = curator_env["usage"]
     skills_dir = curator_env["home"] / "skills"
@@ -293,7 +293,8 @@ def test_unreferenced_skill_is_still_archived(curator_env, monkeypatch):
 
     usage = u.load_usage()
     assert usage["quarterly-report"]["state"] == u.STATE_ACTIVE
-    assert usage["orphan"]["state"] == u.STATE_ARCHIVED
+    assert usage["orphan"]["state"] == u.STATE_STALE
+    assert (skills_dir / "orphan" / "SKILL.md").exists()
 
 
 
@@ -523,6 +524,17 @@ def test_curator_does_not_instruct_model_to_pin():
 
 
 
+
+
+def test_curator_has_no_archive_quota_and_requires_evidence():
+    from agent.curator import CURATOR_REVIEW_PROMPT
+
+    prompt = CURATOR_REVIEW_PROMPT.lower()
+    assert "fewer than 10 archives" not in prompt
+    assert "never target an archive count" in prompt
+    assert "zero archives is a valid result" in prompt
+    assert "missing outcome" in prompt
+    assert "low utility alone is also not permission to archive" in prompt
 
 
 def test_review_prompt_tells_reviewer_to_read_before_writing(curator_env, monkeypatch):

--- a/tests/agent/test_curator_activity.py
+++ b/tests/agent/test_curator_activity.py
@@ -54,3 +54,55 @@ def test_recent_view_activity_prevents_false_stale_transition(curator_modules, m
 
     assert counts["marked_stale"] == 0
     assert skill_usage.get_record("recently-viewed")["state"] == "active"
+
+
+def test_never_tried_skill_is_staled_but_not_archived(curator_modules, monkeypatch):
+    home, skill_usage, curator = curator_modules
+    skills_dir = home / "skills"
+    _write_skill(skills_dir, "never-tried")
+
+    now = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    created_at = (now - timedelta(days=180)).isoformat()
+    skill_usage.save_usage({
+        "never-tried": {
+            "created_by": "agent",
+            "created_at": created_at,
+            "state": "active",
+            "use_count": 0,
+        }
+    })
+    monkeypatch.setattr(curator, "get_stale_after_days", lambda: 30)
+    monkeypatch.setattr(curator, "get_archive_after_days", lambda: 90)
+
+    counts = curator.apply_automatic_transitions(now=now)
+
+    assert counts["marked_stale"] == 1
+    assert counts["archived"] == 0
+    assert skill_usage.get_record("never-tried")["state"] == "stale"
+    assert (skills_dir / "never-tried" / "SKILL.md").exists()
+
+
+def test_skill_with_known_outcomes_can_archive(curator_modules, monkeypatch):
+    home, skill_usage, curator = curator_modules
+    skills_dir = home / "skills"
+    _write_skill(skills_dir, "tried-skill")
+
+    now = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    created_at = (now - timedelta(days=180)).isoformat()
+    skill_usage.save_usage({
+        "tried-skill": {
+            "created_by": "agent",
+            "created_at": created_at,
+            "state": "stale",
+            "use_count": 1,
+            "success_count": 1,
+            "failure_count": 0,
+        }
+    })
+    monkeypatch.setattr(curator, "get_stale_after_days", lambda: 30)
+    monkeypatch.setattr(curator, "get_archive_after_days", lambda: 90)
+
+    counts = curator.apply_automatic_transitions(now=now)
+
+    assert counts["archived"] == 1
+    assert not (skills_dir / "tried-skill").exists()

--- a/tests/agent/test_skill_reflection.py
+++ b/tests/agent/test_skill_reflection.py
@@ -1,0 +1,222 @@
+"""Tests for agent/skill_reflection.py — failure-driven skill reflection loop."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a clean skills/ dir."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _write_skill(skills_dir: Path, name: str):
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: test skill
+---
+
+# {name}
+
+## When to Use
+- trigger one
+
+## Procedure
+1. step one
+2. step two
+
+## Pitfalls
+- nothing yet
+
+## Verification
+- run check
+""",
+        encoding="utf-8",
+    )
+    return d
+
+
+def _proposals_dir(home: Path) -> Path:
+    return home / "skills" / ".reflection_proposals"
+
+
+def test_locate_section_found():
+    from agent.skill_reflection import locate_section
+
+    md = "# Demo\n\n## Pitfalls\n- api 403\n\n## Verification\n- run\n"
+    loc = locate_section(md, "pitfalls")
+    assert loc is not None
+    assert loc["heading"] == "## Pitfalls"
+    assert md[loc["start"]:loc["end"]].startswith("## Pitfalls")
+
+
+def test_locate_section_missing():
+    from agent.skill_reflection import locate_section
+
+    assert locate_section("# Demo\n", "verification") is None
+    assert locate_section("", "pitfalls") is None
+    assert locate_section("# Demo\n## Pitfalls\n", "bogus-section") is None
+
+
+def test_build_proposal_valid():
+    from agent.skill_reflection import build_proposal
+
+    p = build_proposal(
+        "demo-skill",
+        diagnosis="API returns 403 after token expiry",
+        target_section="pitfalls",
+        suggested_fix="Add a note about token refresh before calls",
+        failure_types=["api_403"],
+        utility_score=0.1,
+    )
+    assert p["skill"] == "demo-skill"
+    assert p["target_section"] == "pitfalls"
+    assert p["heading"] == "## Pitfalls"
+    assert p["status"] == "pending"
+    assert p["utility_score"] == 0.1
+    assert "api_403" in p["failure_types"]
+
+
+def test_build_proposal_invalid_target():
+    from agent.skill_reflection import build_proposal
+
+    with pytest.raises(ValueError):
+        build_proposal("demo-skill", diagnosis="d", target_section="nope", suggested_fix="f")
+
+
+def test_save_and_list_proposals(hermes_home):
+    from agent.skill_reflection import build_proposal, save_proposal, list_proposals
+
+    p = build_proposal("demo-skill", diagnosis="d", target_section="pitfalls", suggested_fix="f")
+    path = save_proposal(p)
+    assert path is not None
+    assert path.exists()
+    rows = list_proposals()
+    assert len(rows) == 1
+    assert rows[0]["skill"] == "demo-skill"
+    assert rows[0]["status"] == "pending"
+
+
+def test_save_proposal_requires_id(hermes_home):
+    from agent.skill_reflection import save_proposal
+
+    assert save_proposal({"skill": "x"}) is None  # missing proposal_id
+    assert save_proposal({"skill": "", "proposal_id": "abc"}) is None
+
+
+def test_list_pending_and_mark_status(hermes_home):
+    from agent.skill_reflection import (
+        build_proposal,
+        save_proposal,
+        list_pending_proposals,
+        mark_proposal_status,
+        list_proposals,
+    )
+
+    p = build_proposal("demo-skill", diagnosis="d", target_section="procedure", suggested_fix="f")
+    save_proposal(p)
+    assert len(list_pending_proposals("demo-skill")) == 1
+    # Reject keeps it for audit
+    assert mark_proposal_status("demo-skill", p["proposal_id"], "rejected")
+    assert len(list_pending_proposals("demo-skill")) == 0
+    assert len(list_proposals("demo-skill")) == 1
+    assert list_proposals("demo-skill")[0]["status"] == "rejected"
+    # Apply removes from queue
+    p2 = build_proposal("demo-skill", diagnosis="d2", target_section="procedure", suggested_fix="f2")
+    save_proposal(p2)
+    assert mark_proposal_status("demo-skill", p2["proposal_id"], "applied")
+    remaining = [x for x in list_proposals("demo-skill") if x["status"] == "pending"]
+    assert len(remaining) == 0
+
+
+def test_mark_status_invalid(hermes_home):
+    from agent.skill_reflection import mark_proposal_status
+
+    assert not mark_proposal_status("demo-skill", "nope", "bogus-status")
+
+
+def test_proposals_queue_bounded(hermes_home):
+    from agent.skill_reflection import build_proposal, save_proposal, list_proposals
+
+    for i in range(8):
+        p = build_proposal(
+            "demo-skill",
+            diagnosis=f"failure {i}",
+            target_section="pitfalls",
+            suggested_fix=f"fix {i}",
+        )
+        save_proposal(p)
+    rows = list_proposals("demo-skill")
+    # Bound is MAX_PROPOSALS_PER_SKILL = 20; rejected/applied may linger, so
+    # total rows can exceed, but pending must never exceed the bound.
+    from agent.skill_reflection import MAX_PROPOSALS_PER_SKILL
+    pending = [r for r in rows if r.get("status") == "pending"]
+    assert len(pending) <= MAX_PROPOSALS_PER_SKILL
+
+
+def test_aggregate_failure_patterns(skills_home_factory):
+    home = skills_home_factory
+    # Seed outcome telemetry for the skill
+    from tools.skill_usage import record_outcome
+    from agent.skill_reflection import aggregate_failure_patterns
+
+    record_outcome("demo-skill", "failure", error_type="api_403")
+    record_outcome("demo-skill", "failure", error_type="api_403")
+    record_outcome("demo-skill", "failure", error_type="timeout")
+    record_outcome("demo-skill", "success")
+
+    pat = aggregate_failure_patterns("demo-skill")
+    assert pat["skill"] == "demo-skill"
+    assert pat["failure_count"] == 3
+    assert pat["success_count"] == 1
+    assert pat["failure_rate"] == 0.75
+    top = dict(pat["top_error_types"])
+    assert top.get("api_403") == 2
+
+
+@pytest.fixture
+def skills_home_factory(tmp_path, monkeypatch):
+    """HERMES_HOME sandbox shared with skill_usage outcome tests."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+    import tools.skill_usage as mod
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "_prune_builtins_enabled", lambda: False)
+    return home
+
+
+def test_reflection_candidates(skills_home_factory):
+    from tools.skill_usage import record_outcome
+    from agent.skill_reflection import reflection_candidates
+
+    # Failing skill
+    record_outcome("bad-skill", "failure", error_type="api_403")
+    record_outcome("bad-skill", "failure", error_type="api_403")
+    record_outcome("bad-skill", "failure", error_type="timeout")
+    # Working skill
+    record_outcome("good-skill", "success")
+    record_outcome("good-skill", "success")
+    record_outcome("good-skill", "success")
+
+    cands = reflection_candidates()
+    names = [c["skill"] for c in cands]
+    assert "bad-skill" in names
+    assert "good-skill" not in names
+    bad = next(c for c in cands if c["skill"] == "bad-skill")
+    assert bad["failure_count"] == 3
+    assert bad["top_error_types"][0][0] == "api_403"

--- a/tests/agent/test_skill_routing.py
+++ b/tests/agent/test_skill_routing.py
@@ -1,0 +1,169 @@
+"""Behavioral tests for deterministic local skill routing."""
+
+import json
+
+import pytest
+
+
+def _skill(skill_name: str, **overrides):
+    skill = {
+        "qualified_name": f"testing/{skill_name}",
+        "name": skill_name,
+        "category": "testing",
+        "description": "Generic skill description",
+        "triggers": [],
+        "tags": [],
+        "related_skills": [],
+        "required_commands": [],
+        "required_environment_variables": [],
+    }
+    skill.update(overrides)
+    return skill
+
+
+def test_ranking_uses_routing_metadata_deterministically():
+    from agent import skill_routing
+
+    candidates = [
+        _skill("other"),
+        _skill("deployment-helper", triggers=["deploy kubernetes workloads"]),
+    ]
+
+    first = skill_routing.rank_skills(candidates, "kubernetes", limit=2)
+    second = skill_routing.rank_skills(
+        list(reversed(candidates)), "kubernetes", limit=2
+    )
+
+    assert first == second
+    assert [item["name"] for item in first["skills"]] == [
+        "deployment-helper",
+        "other",
+    ]
+    assert first["skills"][0]["score"] > first["skills"][1]["score"]
+    assert first["total_candidates"] == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("qualified_name", "testing/needle-route"),
+        ("name", "needle-helper"),
+        ("category", "needle-category"),
+        ("description", "Handles the needle workflow"),
+        ("triggers", ["route needle requests"]),
+        ("tags", ["needle"]),
+        ("related_skills", ["needle-companion"]),
+        ("required_commands", ["needle-cli"]),
+        ("required_environment_variables", ["NEEDLE_TOKEN"]),
+    ],
+)
+def test_every_canonical_routing_field_contributes_to_ranking(field, value):
+    from agent import skill_routing
+
+    relevant = _skill("relevant", **{field: value})
+    result = skill_routing.rank_skills(
+        [_skill("irrelevant"), relevant], "needle", limit=2
+    )
+
+    assert result["skills"][0]["name"] == relevant["name"]
+    assert result["skills"][0]["score"] > 0
+
+
+def test_exact_normalized_skill_name_precedes_higher_bm25_score():
+    from agent import skill_routing
+
+    result = skill_routing.rank_skills(
+        [
+            _skill("code-review"),
+            _skill(
+                "review-expert",
+                description="code review code review code review code review",
+                tags=["code", "review"],
+            ),
+        ],
+        "  CODE_review  ",
+        limit=2,
+    )
+
+    assert result["skills"][0]["name"] == "code-review"
+
+
+def test_equal_scores_use_qualified_name_tie_breaker():
+    from agent import skill_routing
+
+    result = skill_routing.rank_skills(
+        [
+            _skill("alpha", qualified_name="plugin-b:alpha"),
+            _skill("zeta", qualified_name="plugin-a:zeta"),
+        ],
+        "unmatched",
+        limit=2,
+    )
+
+    assert [item["name"] for item in result["skills"]] == ["zeta", "alpha"]
+    assert [item["score"] for item in result["skills"]] == [0.0, 0.0]
+
+
+def test_fingerprint_and_ranked_output_ignore_paths_and_input_order():
+    from agent import skill_routing
+
+    first_candidates = [
+        _skill("alpha", source_path="/private/one/SKILL.md"),
+        _skill("beta", tags=["needle"], source_path="/private/two/SKILL.md"),
+    ]
+    second_candidates = [
+        dict(first_candidates[1], source_path="/different/private/two/SKILL.md"),
+        dict(first_candidates[0], source_path="/different/private/one/SKILL.md"),
+    ]
+
+    first = skill_routing.rank_skills(first_candidates, "needle", limit=2)
+    second = skill_routing.rank_skills(second_candidates, "needle", limit=2)
+
+    assert first == second
+    assert len(first["index_fingerprint"]) == 16
+    serialized = json.dumps(first)
+    assert "/private/" not in serialized
+    assert "source_path" not in serialized
+
+
+def test_ranked_output_keeps_display_description_with_its_skill():
+    from agent import skill_routing
+
+    result = skill_routing.rank_skills(
+        [
+            _skill("zeta", display_description="Display for zeta"),
+            _skill("alpha", display_description="Display for alpha"),
+        ],
+        "unmatched",
+        limit=2,
+    )
+
+    assert [(item["name"], item["description"]) for item in result["skills"]] == [
+        ("alpha", "Display for alpha"),
+        ("zeta", "Display for zeta"),
+    ]
+
+
+def test_index_cache_reuses_corpus_and_invalidates_on_routing_change():
+    from agent import skill_routing
+
+    candidates = [_skill("alpha"), _skill("beta", tags=["needle"])]
+    skill_routing._build_index.cache_clear()
+    try:
+        first = skill_routing.rank_skills(candidates, "needle", limit=2)
+        after_first = skill_routing._build_index.cache_info()
+
+        skill_routing.rank_skills(list(reversed(candidates)), "other", limit=2)
+        after_second = skill_routing._build_index.cache_info()
+
+        changed = [dict(candidates[0]), dict(candidates[1], tags=["changed"])]
+        third = skill_routing.rank_skills(changed, "changed", limit=2)
+        after_third = skill_routing._build_index.cache_info()
+
+        assert after_first.misses == 1
+        assert after_second.hits == 1
+        assert after_second.misses == 1
+        assert after_third.misses == 2
+        assert first["index_fingerprint"] != third["index_fingerprint"]
+    finally:
+        skill_routing._build_index.cache_clear()

--- a/tests/agent/test_skill_routing.py
+++ b/tests/agent/test_skill_routing.py
@@ -5,6 +5,40 @@ import json
 import pytest
 
 
+def test_skill_retriever_reads_behavioral_settings_from_config(monkeypatch):
+    from agent import skill_retriever
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "skills": {
+                "retrieval": {
+                    "enabled": "off",
+                    "top_k": 9,
+                    "embedding_model": "example/model",
+                }
+            }
+        },
+    )
+
+    config = skill_retriever._retrieval_config()
+    assert skill_retriever._retrieval_enabled(config) is False
+    assert skill_retriever._retrieval_top_k(config) == 9
+    assert config["embedding_model"] == "example/model"
+
+
+def test_skill_retriever_config_fails_open_and_bounds_top_k(monkeypatch):
+    from agent import skill_retriever
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly", lambda: {"skills": "bad"}
+    )
+    assert skill_retriever._retrieval_config() == {}
+    assert skill_retriever._retrieval_enabled({}) is True
+    assert skill_retriever._retrieval_top_k({"top_k": False}) == 5
+    assert skill_retriever._retrieval_top_k({"top_k": 999}) == 50
+
+
 def _skill(skill_name: str, **overrides):
     skill = {
         "qualified_name": f"testing/{skill_name}",

--- a/tests/agent/test_skill_routing_benchmark.py
+++ b/tests/agent/test_skill_routing_benchmark.py
@@ -1,0 +1,47 @@
+"""Frozen public-safe relevance and determinism gate for skill routing."""
+
+import json
+import math
+from pathlib import Path
+
+
+FIXTURE = Path(__file__).parents[1] / "fixtures" / "skill_routing_benchmark.json"
+
+
+def _metrics(payload, skills):
+    from agent.skill_routing import rank_skills
+
+    rows = []
+    for case in payload["queries"]:
+        result = rank_skills(skills, case["query"], limit=8)
+        names = [item["name"] for item in result["skills"]]
+        relevant = case["relevant"]
+        ranks = [names.index(name) + 1 for name in relevant if name in names]
+        reciprocal_rank = 1.0 / min(ranks) if ranks else (1.0 if not relevant else 0.0)
+        recall = len(ranks) / len(relevant) if relevant else 1.0
+        dcg = sum(1.0 / math.log2(rank + 1) for rank in ranks)
+        ideal = sum(1.0 / math.log2(rank + 1) for rank in range(1, len(relevant) + 1))
+        ndcg = dcg / ideal if ideal else 1.0
+        rows.append((names, reciprocal_rank, ndcg, recall))
+    count = len(rows)
+    return {
+        "rows": rows,
+        "mrr": sum(row[1] for row in rows) / count,
+        "mean_ndcg": sum(row[2] for row in rows) / count,
+        "recall": sum(row[3] for row in rows) / count,
+        "average_depth": sum(len(row[0]) for row in rows) / count,
+    }
+
+
+def test_frozen_benchmark_thresholds_and_reversed_order_determinism():
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    forward = _metrics(payload, payload["skills"])
+    reverse = _metrics(payload, list(reversed(payload["skills"])))
+
+    assert forward == reverse
+    assert forward["mrr"] >= 0.95
+    assert forward["mean_ndcg"] >= 0.96
+    assert forward["recall"] == 1.0
+    assert forward["average_depth"] <= 6.0
+    assert 1 <= len(forward["rows"][-2][0]) <= 3
+    assert len(forward["rows"][-1][0]) == 8

--- a/tests/agent/test_skill_routing_benchmark.py
+++ b/tests/agent/test_skill_routing_benchmark.py
@@ -44,4 +44,4 @@ def test_frozen_benchmark_thresholds_and_reversed_order_determinism():
     assert forward["recall"] == 1.0
     assert forward["average_depth"] <= 6.0
     assert 1 <= len(forward["rows"][-2][0]) <= 3
-    assert len(forward["rows"][-1][0]) == 8
+    assert forward["rows"][-1][0] == []

--- a/tests/agent/test_skill_routing_production.py
+++ b/tests/agent/test_skill_routing_production.py
@@ -1,0 +1,176 @@
+"""Production behavior contracts for deterministic BM25 skill routing."""
+
+from copy import deepcopy
+import json
+
+import pytest
+
+
+def _skill(name: str, **overrides):
+    skill = {
+        "qualified_name": f"testing/{name}",
+        "name": name,
+        "category": "testing",
+        "description": "generic helper",
+        "display_description": "generic helper",
+        "triggers": [],
+        "tags": [],
+        "related_skills": [],
+        "required_commands": [],
+        "required_environment_variables": [],
+    }
+    skill.update(overrides)
+    return skill
+
+
+def test_routing_card_fingerprint_is_stable_private_and_source_bound():
+    from agent import skill_routing
+
+    make_card = getattr(skill_routing, "build_routing_card", None)
+    assert callable(make_card), (
+        "build_routing_card must create internal source-hashed cards"
+    )
+    source = _skill("deploy-helper", triggers=["deploy workloads"])
+    first = make_card(source)
+    second = make_card(dict(source))
+
+    assert first == second
+    assert len(first["source_fingerprint"]) == 64
+    assert first["source_fingerprint"] == first["source_fingerprint"].lower()
+    assert set(first["source_fingerprint"]) <= set("0123456789abcdef")
+
+    for excluded, changed in {
+        "display_description": "presentation changed",
+        "path": "/private/secret/SKILL.md",
+        "source_path": "/private/other/SKILL.md",
+        "body": "private body material",
+    }.items():
+        variant = dict(source, **{excluded: changed})
+        assert make_card(variant)["source_fingerprint"] == first["source_fingerprint"]
+
+    for field, changed in {
+        "name": "changed-name",
+        "qualified_name": "changed/qualified",
+        "category": "changed-category",
+        "description": "changed description",
+        "triggers": ["changed trigger"],
+        "tags": ["changed-tag"],
+        "related_skills": ["changed-related"],
+        "required_commands": ["changed-command"],
+        "required_environment_variables": ["CHANGED_ENV"],
+    }.items():
+        variant = deepcopy(source)
+        variant[field] = changed
+        assert make_card(variant)["source_fingerprint"] != first["source_fingerprint"]
+
+
+def test_approved_bm25_description_signal_beats_name_only_distractor():
+    from agent.skill_routing import rank_skills
+
+    candidates = [
+        _skill(
+            "git-recovery",
+            description="repair orphaned branch pruning behavior safely",
+            triggers=["repair stale branches"],
+            tags=["git"],
+        ),
+        _skill(
+            "orphaned-branch-pruning",
+            description="format a status label",
+            triggers=["format status"],
+            tags=["formatting"],
+        ),
+        _skill("repair", description="generic repair helper", triggers=["repair data"]),
+    ]
+
+    result = rank_skills(candidates, "repair orphaned branch pruning behavior", limit=8)
+
+    assert result["skills"][0]["name"] == "git-recovery"
+
+
+def test_duplicate_exact_names_keep_all_ambiguity_candidates():
+    from agent.skill_routing import rank_skills
+
+    candidates = [
+        _skill(
+            "duplicate",
+            qualified_name="testing/duplicate-strong",
+            description="duplicate duplicate duplicate duplicate duplicate",
+        ),
+        *[
+            _skill("duplicate", qualified_name=f"testing/duplicate-{index}")
+            for index in range(4)
+        ],
+    ]
+
+    result = rank_skills(candidates, "duplicate", limit=8)
+
+    assert len(result["skills"]) == 5
+
+
+def test_default_adaptive_depth_and_non_default_exact_limits():
+    from agent.skill_routing import rank_skills
+
+    candidates = [_skill(f"other-{index:02d}") for index in range(9)]
+    candidates.append(_skill("deploy-helper", triggers=["deploy kubernetes workload"]))
+
+    exact = rank_skills(candidates, "DEPLOY_helper", limit=8)
+    strong = rank_skills(candidates, "deploy kubernetes workload", limit=8)
+    ambiguous = rank_skills(candidates, "generic", limit=8)
+    unmatched = rank_skills(candidates, "quantum orchard", limit=8)
+
+    assert 1 <= len(exact["skills"]) <= 3
+    assert exact["skills"][0]["name"] == "deploy-helper"
+    assert 1 <= len(strong["skills"]) <= 3
+    assert strong["skills"][0]["name"] == "deploy-helper"
+    assert len(ambiguous["skills"]) == 8
+    assert len(unmatched["skills"]) == 8
+    assert len(rank_skills(candidates, "deploy-helper", limit=4)["skills"]) == 4
+    assert len(rank_skills(candidates[:2], "unmatched", limit=8)["skills"]) == 2
+    assert rank_skills([], "unmatched", limit=8)["skills"] == []
+
+
+def test_index_cache_reuse_isolation_and_fingerprint_invalidation():
+    from agent import skill_routing
+
+    candidates = [_skill("alpha"), _skill("beta", tags=["needle"])]
+    skill_routing._build_index.cache_clear()
+    try:
+        first = skill_routing.rank_skills(candidates, "needle", limit=2)
+        info_one = skill_routing._build_index.cache_info()
+        reversed_result = skill_routing.rank_skills(
+            list(reversed(candidates)), "other", limit=2
+        )
+        info_two = skill_routing._build_index.cache_info()
+        presentation = deepcopy(candidates)
+        presentation[1]["display_description"] = "changed display"
+        display_result = skill_routing.rank_skills(presentation, "needle", limit=2)
+        info_three = skill_routing._build_index.cache_info()
+        changed = deepcopy(candidates)
+        changed[1]["tags"] = ["changed"]
+        changed_result = skill_routing.rank_skills(changed, "changed", limit=2)
+        info_four = skill_routing._build_index.cache_info()
+
+        assert info_one.misses == 1
+        assert info_two.hits == 1
+        assert info_three.hits == 2
+        assert info_four.misses == 2
+        assert first["index_fingerprint"] == reversed_result["index_fingerprint"]
+        assert first["index_fingerprint"] == display_result["index_fingerprint"]
+        assert first["index_fingerprint"] != changed_result["index_fingerprint"]
+        assert "source_fingerprint" not in json.dumps(first)
+    finally:
+        skill_routing._build_index.cache_clear()
+
+
+@pytest.mark.parametrize("query", ["café", "CAFE\u0301"])
+def test_unicode_normalization_and_input_order_are_deterministic(query):
+    from agent.skill_routing import rank_skills
+
+    candidates = [_skill("zeta"), _skill("café")]
+    forward = rank_skills(candidates, query, limit=8)
+    reverse = rank_skills(list(reversed(candidates)), query, limit=8)
+
+    assert forward == reverse
+    assert forward["skills"][0]["name"] == "café"
+    assert len(forward["skills"]) == 2

--- a/tests/agent/test_skill_routing_production.py
+++ b/tests/agent/test_skill_routing_production.py
@@ -121,12 +121,13 @@ def test_default_adaptive_depth_and_non_default_exact_limits():
 
     assert 1 <= len(exact["skills"]) <= 3
     assert exact["skills"][0]["name"] == "deploy-helper"
-    assert 1 <= len(strong["skills"]) <= 3
+    assert len(strong["skills"]) == 1
     assert strong["skills"][0]["name"] == "deploy-helper"
+    assert all(skill["score"] > 0.0 for skill in strong["skills"])
     assert len(ambiguous["skills"]) == 8
-    assert len(unmatched["skills"]) == 8
+    assert unmatched["skills"] == []
     assert len(rank_skills(candidates, "deploy-helper", limit=4)["skills"]) == 4
-    assert len(rank_skills(candidates[:2], "unmatched", limit=8)["skills"]) == 2
+    assert rank_skills(candidates[:2], "unmatched", limit=8)["skills"] == []
     assert rank_skills([], "unmatched", limit=8)["skills"] == []
 
 
@@ -173,4 +174,4 @@ def test_unicode_normalization_and_input_order_are_deterministic(query):
 
     assert forward == reverse
     assert forward["skills"][0]["name"] == "café"
-    assert len(forward["skills"]) == 2
+    assert len(forward["skills"]) == 1

--- a/tests/agent/test_skill_steward_e2e.py
+++ b/tests/agent/test_skill_steward_e2e.py
@@ -1,0 +1,75 @@
+"""End-to-end contract for route -> load -> outcome -> curator."""
+
+import importlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _write_skill(skills_dir: Path, name: str, description: str) -> None:
+    root = skills_dir / "testing" / name
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n\nDo it safely.\n",
+        encoding="utf-8",
+    )
+
+
+def test_route_load_outcome_then_curator_preserves_never_tried_skill(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    skills_dir = home / "skills"
+    skills_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    import tools.skill_usage as skill_usage
+    import tools.skills_tool as skills_tool
+    import agent.curator as curator
+
+    importlib.reload(skill_usage)
+    importlib.reload(skills_tool)
+    importlib.reload(curator)
+    skills_tool._SKILLS_CACHE.clear()
+
+    _write_skill(skills_dir, "deploy-helper", "Deploy Kubernetes workloads safely.")
+    _write_skill(skills_dir, "never-tried", "Handle a rare unrelated workflow.")
+
+    now = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    old = (now - timedelta(days=180)).isoformat()
+    skill_usage.save_usage({
+        "deploy-helper": {
+            "created_by": "agent",
+            "created_at": old,
+            "state": "active",
+        },
+        "never-tried": {
+            "created_by": "agent",
+            "created_at": old,
+            "state": "active",
+        },
+    })
+
+    ranked = json.loads(skills_tool.skills_list(query="deploy kubernetes", limit=1))
+    assert ranked["skills"][0]["name"] == "deploy-helper"
+
+    loaded = json.loads(skills_tool.skill_view("deploy-helper"))
+    assert loaded["success"] is True
+    skill_usage.bump_use("deploy-helper", task_id="task-1", session_id="session-1")
+    skill_usage.record_outcome("deploy-helper", "success", task_id="task-1")
+    usage = skill_usage.load_usage()
+    usage["deploy-helper"]["last_used_at"] = old
+    usage["deploy-helper"]["last_outcome_at"] = old
+    skill_usage.save_usage(usage)
+
+    monkeypatch.setattr(curator, "get_stale_after_days", lambda: 30)
+    monkeypatch.setattr(curator, "get_archive_after_days", lambda: 90)
+    counts = curator.apply_automatic_transitions(now=now)
+
+    assert counts["archived"] == 1
+    assert not (skills_dir / "testing" / "deploy-helper").exists()
+    assert (skills_dir / "testing" / "never-tried" / "SKILL.md").exists()
+    assert skill_usage.get_record("never-tried")["state"] == "stale"
+
+    usage_text = (skills_dir / ".usage.json").read_text(encoding="utf-8")
+    assert "deploy kubernetes" not in usage_text
+    assert "Do it safely" not in usage_text

--- a/tests/fixtures/skill_routing_benchmark.json
+++ b/tests/fixtures/skill_routing_benchmark.json
@@ -1,0 +1,228 @@
+{
+  "schema_version": 1,
+  "description": "Synthetic public-safe skill routing benchmark with hard negatives.",
+  "skills": [
+    {
+      "qualified_name": "research/grounded-citations",
+      "name": "grounded-citations",
+      "category": "research",
+      "description": "Ground answers in cited verifiable sources.",
+      "triggers": ["verify claims and citations", "trace evidence to primary sources"],
+      "tags": ["citations", "provenance"],
+      "related_skills": ["research-source-intelligence"],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "research/research-source-intelligence",
+      "name": "research-source-intelligence",
+      "category": "research",
+      "description": "Source-grounded web research and synthesis.",
+      "triggers": ["research a topic across authoritative sources"],
+      "tags": ["research", "sources"],
+      "related_skills": ["grounded-citations"],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "research/generic-research-notes",
+      "name": "generic-research-notes",
+      "category": "research",
+      "description": "Verify claims citations citations evidence primary sources and citations for broad research notes.",
+      "triggers": ["organize generic notes"],
+      "tags": ["notes"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "github/github-pr-workflow",
+      "name": "github-pr-workflow",
+      "category": "github",
+      "description": "Manage the GitHub pull request lifecycle.",
+      "triggers": ["open a pull request and monitor CI", "merge a reviewed branch"],
+      "tags": ["github", "pull-request", "ci"],
+      "related_skills": ["requesting-code-review"],
+      "required_commands": ["gh", "git"],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "github/release-notes-helper",
+      "name": "release-notes-helper",
+      "category": "github",
+      "description": "Open pull request pull request and monitor CI checks before merge for release notes.",
+      "triggers": ["draft release notes"],
+      "tags": ["writing"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "devops/hermes-gateway-operations",
+      "name": "hermes-gateway-operations",
+      "category": "devops",
+      "description": "Operate and troubleshoot Hermes messaging gateway channels.",
+      "triggers": ["restart WhatsApp gateway and prove channel health", "repair Telegram gateway"],
+      "tags": ["gateway", "whatsapp", "telegram"],
+      "related_skills": ["hermes-agent"],
+      "required_commands": ["systemctl"],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "devops/service-status-report",
+      "name": "service-status-report",
+      "category": "devops",
+      "description": "Restart WhatsApp gateway gateway channel health status and Telegram gateway reporting.",
+      "triggers": ["write a service status summary"],
+      "tags": ["report"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "software-development/beads-work-ledger",
+      "name": "beads-work-ledger",
+      "category": "software-development",
+      "description": "Durable work tracking for nontrivial development.",
+      "triggers": ["track nontrivial development work", "record durable implementation status"],
+      "tags": ["beads", "ledger"],
+      "related_skills": ["beads-kanban-workflow"],
+      "required_commands": ["bd"],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "productivity/daily-task-manager",
+      "name": "daily-task-manager",
+      "category": "productivity",
+      "description": "Track nontrivial development work and record durable implementation status in daily task notes.",
+      "triggers": ["manage today's tasks"],
+      "tags": ["tasks"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "quality-engineering/mr-tester-handoff",
+      "name": "mr-tester-handoff",
+      "category": "quality-engineering",
+      "description": "Route substantive testing judgment to the named QA profile.",
+      "triggers": ["independent release QA", "adversarial verification and test design"],
+      "tags": ["testing", "qa", "review"],
+      "related_skills": ["source-bound-release-gates"],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "writing/release-summary",
+      "name": "release-summary",
+      "category": "writing",
+      "description": "Independent release QA testing review adversarial verification and test design summary.",
+      "triggers": ["write a release summary"],
+      "tags": ["writing"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "productivity/maps",
+      "name": "maps",
+      "category": "productivity",
+      "description": "Geocode places and find nearby points of interest.",
+      "triggers": ["find a nearby restaurant", "calculate a route"],
+      "tags": ["maps", "nearby", "route"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "leisure/travel-itinerary-planning",
+      "name": "travel-itinerary-planning",
+      "category": "leisure",
+      "description": "Find a nearby restaurant restaurant and calculate a route while planning a trip.",
+      "triggers": ["fit activities into a trip"],
+      "tags": ["travel"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "productivity/product-price-monitor",
+      "name": "product-price-monitor",
+      "category": "productivity",
+      "description": "Watch listings and alert on a target price.",
+      "triggers": ["alert when a product price drops", "monitor a listing price"],
+      "tags": ["price", "monitor", "alert"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "productivity/shop",
+      "name": "shop",
+      "category": "productivity",
+      "description": "Alert when product price drops and monitor listing price while searching products.",
+      "triggers": ["search a product catalog"],
+      "tags": ["shopping"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "media/youtube-content",
+      "name": "youtube-content",
+      "category": "media",
+      "description": "Turn YouTube transcripts into summaries and articles.",
+      "triggers": ["summarize a YouTube transcript", "extract a video transcript"],
+      "tags": ["youtube", "transcript"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "writing/blog-post-editing",
+      "name": "blog-post-editing",
+      "category": "writing",
+      "description": "Summarize YouTube transcript transcript content into an article and edit the draft.",
+      "triggers": ["edit a technical blog post"],
+      "tags": ["writing"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "mcp/skill-surface-mining",
+      "name": "skill-surface-mining",
+      "category": "mcp",
+      "description": "Mine source trees for recurring workflows suitable for skills.",
+      "triggers": ["mine a codebase for reusable skill workflows"],
+      "tags": ["skills", "source", "mining"],
+      "related_skills": ["hermes-agent-skill-authoring"],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "github/codebase-inspection",
+      "name": "codebase-inspection",
+      "category": "github",
+      "description": "Mine a codebase source tree for reusable skill workflows and inspect language statistics.",
+      "triggers": ["count lines of code"],
+      "tags": ["codebase"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    }
+  ],
+  "queries": [
+    {"query": "verify claims and citations against primary sources", "relevant": ["grounded-citations"]},
+    {"query": "open a pull request and monitor CI", "relevant": ["github-pr-workflow"]},
+    {"query": "restart WhatsApp gateway and prove channel health", "relevant": ["hermes-gateway-operations"]},
+    {"query": "track nontrivial development work in a durable ledger", "relevant": ["beads-work-ledger"]},
+    {"query": "independent release QA and adversarial test design", "relevant": ["mr-tester-handoff"]},
+    {"query": "find a nearby restaurant and calculate a route", "relevant": ["maps"]},
+    {"query": "alert when a product price drops", "relevant": ["product-price-monitor"]},
+    {"query": "summarize a YouTube transcript", "relevant": ["youtube-content"]},
+    {"query": "mine a codebase for reusable skill workflows", "relevant": ["skill-surface-mining"]},
+    {"query": "github-pr-workflow", "relevant": ["github-pr-workflow"]},
+    {"query": "completely unmatched quantum orchard phrase", "relevant": []}
+  ]
+}

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -361,6 +361,8 @@ class TestLegacyToolsetMap:
         for name in expected:
             assert name in _LEGACY_TOOLSET_MAP, f"Missing legacy toolset: {name}"
 
+    def test_skills_legacy_toolset_includes_outcome_reporting(self):
+        assert "skill_report_outcome" in _LEGACY_TOOLSET_MAP["skills_tools"]
 
 
 # =========================================================================

--- a/tests/tools/test_skill_evolution_api.py
+++ b/tests/tools/test_skill_evolution_api.py
@@ -1,0 +1,218 @@
+"""Tests for hermes_cli/web_routers/skill_evolution.py — the skill-evolution
+dashboard API (outcome telemetry + reflection proposal queue + approval)."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a clean skills/ dir."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+    import tools.skill_usage as mod
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "_prune_builtins_enabled", lambda: False)
+    return home
+
+
+def _write_skill(skills_dir: Path, name: str):
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: test skill
+---
+
+# {name}
+
+## When to Use
+- trigger one
+
+## Procedure
+1. step one
+
+## Pitfalls
+- nothing yet
+
+## Verification
+- run check
+""",
+        encoding="utf-8",
+    )
+    return d
+
+
+def _seed_telemetry(home: Path, skill: str, successes: int, failures: int, error_type: str | None = None):
+    from tools.skill_usage import record_outcome
+    for _ in range(successes):
+        record_outcome(skill, "success", task_id="t")
+    for _ in range(failures):
+        record_outcome(skill, "failure", task_id="t", error_type=error_type)
+
+
+def _seed_proposal(home: Path, skill: str, target: str = "pitfalls"):
+    from agent.skill_reflection import build_proposal, save_proposal
+    p = build_proposal(
+        skill,
+        diagnosis="API returns 403 after token expiry",
+        target_section=target,
+        suggested_fix="Add token-refresh note before calls",
+        failure_types=["api_403"],
+        utility_score=0.1,
+    )
+    return save_proposal(p)
+
+
+def test_overview_empty(hermes_home):
+    """Empty telemetry → overview returns zeroed stats, no crash."""
+    from hermes_cli.web_routers.skill_evolution import skill_evolution_overview
+    import asyncio
+
+    data = asyncio.run(skill_evolution_overview())
+    assert data["skills_total"] >= 0
+    assert data["proposals_pending"] == 0
+    assert data["proposals_total"] == 0
+    assert data["avg_utility"] is None
+
+
+def test_overview_with_telemetry(hermes_home):
+    """Telemetry flows into overview stats."""
+    from hermes_cli.web_routers.skill_evolution import skill_evolution_overview
+    import asyncio
+
+    _seed_telemetry(hermes_home, "good-skill", successes=3, failures=0)
+    _seed_telemetry(hermes_home, "bad-skill", successes=0, failures=3, error_type="api_403")
+
+    data = asyncio.run(skill_evolution_overview())
+    assert data["skills_total"] >= 2
+    assert data["skills_scored"] >= 2
+    assert data["avg_utility"] is not None
+    names = {c["skill"] for c in data["low_utility_candidates"]}
+    assert "bad-skill" in names
+    assert "good-skill" not in names
+
+
+def test_outcomes_sorted_best_first(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import skill_evolution_outcomes
+    import asyncio
+
+    _seed_telemetry(hermes_home, "good-skill", successes=3, failures=0)
+    _seed_telemetry(hermes_home, "bad-skill", successes=0, failures=3)
+
+    data = asyncio.run(skill_evolution_outcomes(limit=50))
+    skills = data["skills"]
+    assert len(skills) >= 2
+    assert skills[0]["skill"] == "good-skill"  # best utility first
+
+
+def test_proposals_list_and_pending_filter(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import skill_evolution_proposals
+    import asyncio
+
+    _seed_proposal(hermes_home, "bad-skill")
+    data = asyncio.run(skill_evolution_proposals())
+    assert data["total"] >= 1
+    assert data["proposals"][0]["skill"] == "bad-skill"
+
+    pending = asyncio.run(skill_evolution_proposals(pending_only=True))
+    assert pending["total"] >= 1
+
+
+def test_approve_applies_bounded_edit(hermes_home):
+    """Approve patches the target section of SKILL.md."""
+    from hermes_cli.web_routers.skill_evolution import approve_proposal
+    import asyncio
+
+    skill_dir = _write_skill(hermes_home / "skills", "demo-skill")
+    _seed_proposal(hermes_home, "demo-skill")
+
+    # Find the proposal id
+    from agent.skill_reflection import list_proposals
+    prop = list_proposals("demo-skill")[0]
+
+    result = asyncio.run(approve_proposal("demo-skill", prop["proposal_id"]))
+    assert result["ok"] is True
+    assert result["path"] == str(skill_dir / "SKILL.md")
+    assert result["heading"] == "## Pitfalls"
+
+    # Verify the fix was applied inside the Pitfalls section
+    content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert "Add token-refresh note before calls" in content
+    pitfalls_start = content.index("## Pitfalls")
+    verification_start = content.index("## Verification")
+    assert pitfalls_start < content.index("Add token-refresh") < verification_start
+
+    # Proposal should be removed from queue (applied)
+    from agent.skill_reflection import list_proposals
+    assert len([p for p in list_proposals("demo-skill") if p["status"] == "pending"]) == 0
+
+
+def test_approve_missing_section_appends(hermes_home):
+    """When the target section is missing, approve appends a new section."""
+    from hermes_cli.web_routers.skill_evolution import approve_proposal
+    import asyncio
+
+    skill_dir = _write_skill(hermes_home / "skills", "demo-skill")
+    # Remove the Verification section from the skill
+    content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    content = content.split("## Verification")[0]
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+    _seed_proposal(hermes_home, "demo-skill")
+    from agent.skill_reflection import list_proposals
+    prop = [p for p in list_proposals("demo-skill") if p["target_section"] == "pitfalls"][0]
+
+    result = asyncio.run(approve_proposal("demo-skill", prop["proposal_id"]))
+    assert result["ok"] is True
+    content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert "Add token-refresh note before calls" in content
+
+
+def test_reject_keeps_for_audit(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import reject_proposal
+    import asyncio
+
+    _write_skill(hermes_home / "skills", "demo-skill")
+    _seed_proposal(hermes_home, "demo-skill")
+    from agent.skill_reflection import list_proposals
+    prop = list_proposals("demo-skill")[0]
+
+    result = asyncio.run(reject_proposal("demo-skill", prop["proposal_id"]))
+    assert result["ok"] is True
+    assert result["status"] == "rejected"
+    # Skill content unchanged
+    content = (hermes_home / "skills" / "demo-skill" / "SKILL.md").read_text(encoding="utf-8")
+    assert "Add token-refresh" not in content
+
+
+def test_approve_missing_proposal_404(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import approve_proposal
+    from fastapi import HTTPException
+    import asyncio
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(approve_proposal("demo-skill", "nonexistent-id"))
+    assert excinfo.value.status_code == 404
+
+
+def test_approve_missing_skill_404(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import approve_proposal
+    from fastapi import HTTPException
+    import asyncio
+
+    _seed_proposal(hermes_home, "ghost-skill")
+    from agent.skill_reflection import list_proposals
+    prop = list_proposals("ghost-skill")[0]
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(approve_proposal("ghost-skill", prop["proposal_id"]))
+    assert excinfo.value.status_code == 404

--- a/tests/tools/test_skill_evolution_extended.py
+++ b/tests/tools/test_skill_evolution_extended.py
@@ -1,0 +1,132 @@
+"""Tests for the extended skill-evolution API: detail drawer, one-click
+proposal generation, manual outcome recording, proposal status filtering."""
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+    import tools.skill_usage as mod
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "_prune_builtins_enabled", lambda: False)
+    return home
+
+
+def _seed_failures(home, skill, n=6, error_type="api_403"):
+    from tools.skill_usage import record_outcome
+    for _ in range(n):
+        record_outcome(skill, "failure", error_type=error_type)
+    for _ in range(4):
+        record_outcome(skill, "success")
+
+
+def test_detail_drawer(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import skill_evolution_detail
+
+    _seed_failures(hermes_home, "demo")
+    d = asyncio.run(skill_evolution_detail("demo"))
+    assert d["skill"] == "demo"
+    assert d["summary"]["failure_count"] == 6
+    assert d["summary"]["success_count"] == 4
+    assert d["utility_score"] is not None
+    assert any("api_403" in str(t) for t in d["failure_patterns"].get("top_error_types", []))
+    assert isinstance(d["proposals"], list)
+
+
+def test_propose_generates(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import propose_skill_improvement
+
+    _seed_failures(hermes_home, "demo")
+    r = asyncio.run(propose_skill_improvement("demo"))
+    assert r["ok"] is True
+    assert r["proposal"]["skill"] == "demo"
+    assert r["proposal"]["status"] == "pending"
+    assert "api_403" in str(r["proposal"].get("failure_types") or [])
+
+
+def test_propose_already_pending(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import propose_skill_improvement
+
+    _seed_failures(hermes_home, "demo")
+    asyncio.run(propose_skill_improvement("demo"))
+    r2 = asyncio.run(propose_skill_improvement("demo"))
+    assert r2["ok"] is False
+    assert r2["reason"] == "already_pending"
+
+
+def test_propose_no_signals_400(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import propose_skill_improvement
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(propose_skill_improvement("clean-skill"))
+    assert e.value.status_code == 400
+
+
+def test_manual_outcome(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import record_skill_outcome_manual
+
+    r = asyncio.run(record_skill_outcome_manual("demo", {"outcome": "success"}))
+    assert r["ok"] is True
+    assert r["outcome"] == "success"
+
+    r2 = asyncio.run(record_skill_outcome_manual("demo", {"outcome": "failure", "error_type": "timeout"}))
+    assert r2["ok"] is True
+    assert r2["outcome"] == "failure"
+
+
+def test_manual_outcome_invalid(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import record_skill_outcome_manual
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(record_skill_outcome_manual("demo", {"outcome": "banana"}))
+    assert e.value.status_code == 400
+
+
+def test_proposals_status_filter(hermes_home):
+    from hermes_cli.web_routers.skill_evolution import (
+        approve_proposal,
+        skill_evolution_proposals,
+    )
+
+    # Seed a skill + failure signals + proposal, then approve it
+    from pathlib import Path
+    skill_dir = hermes_home / "skills" / "demo"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\n---\n# Demo\n## Pitfalls\n- x\n## Verification\n- y\n",
+        encoding="utf-8",
+    )
+    _seed_failures(hermes_home, "demo")
+
+    from hermes_cli.web_routers.skill_evolution import propose_skill_improvement
+    r = asyncio.run(propose_skill_improvement("demo"))
+    pid = r["proposal"]["proposal_id"]
+    asyncio.run(approve_proposal("demo", pid))
+
+    # Applied proposals are now retained for the history view (marked applied,
+    # not deleted), so the applied filter must include it and pending must not.
+    applied = asyncio.run(skill_evolution_proposals(status="applied"))
+    assert any(p["proposal_id"] == pid for p in applied["proposals"])
+    pending = asyncio.run(skill_evolution_proposals(status="pending"))
+    assert all(p["proposal_id"] != pid for p in pending["proposals"])
+
+
+def test_route_registration():
+    from hermes_cli.web_routers import skill_evolution
+
+    paths = {r.path for r in skill_evolution.router.routes}
+    assert "/api/skills/evolution/skills/{skill}" in paths
+    assert "/api/skills/evolution/skills/{skill}/propose" in paths
+    assert "/api/skills/evolution/skills/{skill}/outcome" in paths

--- a/tests/tools/test_skill_report_outcome.py
+++ b/tests/tools/test_skill_report_outcome.py
@@ -1,0 +1,88 @@
+"""Tests for tools/skills_tool.skill_report_outcome — the agent-facing skill
+effectiveness reporter (feeds the evolution dashboard)."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def skills_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a clean skills/ dir."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+    import tools.skill_usage as mod
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "_prune_builtins_enabled", lambda: False)
+    return home
+
+
+def test_report_success(skills_home):
+    from tools.skills_tool import _skill_report_outcome
+
+    r = json.loads(_skill_report_outcome({"name": "demo", "outcome": "success"}, task_id="t1"))
+    assert r["success"] is True
+    assert r["skill"] == "demo"
+    assert r["outcome"] == "success"
+
+
+def test_report_failure_with_error_type(skills_home):
+    from tools.skills_tool import _skill_report_outcome
+
+    r = json.loads(
+        _skill_report_outcome(
+            {"name": "demo", "outcome": "failure", "error_type": "api_403"}, task_id="t1"
+        )
+    )
+    assert r["success"] is True
+    assert r["outcome"] == "failure"
+
+    # Verify it landed in the telemetry
+    from tools.skill_usage import get_outcome_summary
+    s = get_outcome_summary("demo")
+    assert s["failure_count"] == 1
+    assert s["outcomes"][0]["error_type"] == "api_403"
+
+
+def test_report_invalid_outcome(skills_home):
+    from tools.skills_tool import _skill_report_outcome
+
+    r = json.loads(_skill_report_outcome({"name": "demo", "outcome": "banana"}))
+    assert r["success"] is False
+    assert "required" in r["error"]
+
+
+def test_report_missing_name(skills_home):
+    from tools.skills_tool import _skill_report_outcome
+
+    r = json.loads(_skill_report_outcome({"outcome": "success"}))
+    assert r["success"] is False
+
+
+def test_report_three_outcomes_yields_utility(skills_home):
+    from tools.skills_tool import _skill_report_outcome
+
+    utility = None
+    for i in range(3):
+        r = json.loads(_skill_report_outcome({"name": "demo", "outcome": "success"}, task_id=f"t{i}"))
+        utility = r["utility_score"]
+    assert utility is not None
+    assert utility > 0.8  # 3 successes → high utility
+
+
+def test_report_best_effort_no_crash(skills_home, monkeypatch):
+    """Telemetry failure never breaks the tool call."""
+    from tools.skills_tool import _skill_report_outcome
+
+    import tools.skill_usage as su
+    monkeypatch.setattr(su, "record_outcome", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    # Re-import the handler's module-level import path is dynamic, so patch the source module
+    import tools.skills_tool as st
+    r = json.loads(st._skill_report_outcome({"name": "demo", "outcome": "success"}))
+    assert r["success"] is False  # error surfaced, no raise

--- a/tests/tools/test_skill_usage_outcomes.py
+++ b/tests/tools/test_skill_usage_outcomes.py
@@ -1,0 +1,169 @@
+"""Tests for tools/skill_usage.py outcome telemetry + utility scoring (2026-08)."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def skills_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a clean skills/ dir (mirrors test_skill_usage.py)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+    import tools.skill_usage as mod
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "_prune_builtins_enabled", lambda: False)
+    return home
+
+
+def _usage_file(home: Path) -> Path:
+    return home / "skills" / ".usage.json"
+
+
+def test_record_outcome_unknown_below_floor(skills_home):
+    """One or two outcomes → utility stays None (below confidence floor)."""
+    from tools.skill_usage import record_outcome, get_utility_score
+
+    assert record_outcome("demo-skill", "success") is None
+    assert record_outcome("demo-skill", "success") is None
+    assert get_utility_score("demo-skill") is None
+
+
+def test_record_outcome_utility_after_floor(skills_home):
+    """3+ outcomes → utility score computed; all-success is high."""
+    from tools.skill_usage import record_outcome, get_utility_score
+
+    record_outcome("demo-skill", "success")
+    record_outcome("demo-skill", "success")
+    score = record_outcome("demo-skill", "success")
+    assert score is not None
+    assert score > 0.8
+    assert get_utility_score("demo-skill") == score
+
+
+def test_record_outcome_failures_lower_utility(skills_home):
+    """Failure-heavy skill gets a low utility score."""
+    from tools.skill_usage import record_outcome, get_utility_score
+
+    for _ in range(3):
+        record_outcome("demo-skill", "failure", error_type="api_403")
+    score = get_utility_score("demo-skill")
+    assert score is not None
+    assert score < 0.2
+
+
+def test_outcome_ring_buffer_bounded(skills_home):
+    """Outcome history is bounded; old entries dropped, counters still correct."""
+    from tools.skill_usage import record_outcome, get_outcome_summary
+
+    for _ in range(60):
+        record_outcome("demo-skill", "success")
+    summary = get_outcome_summary("demo-skill")
+    assert len(summary["outcomes"]) <= 50  # bounded
+    # Counters derived from the ring buffer, not unbounded history
+    assert summary["success_count"] == len(summary["outcomes"])
+
+
+def test_get_outcome_summary_fields(skills_home):
+    """Summary exposes skill/counters/utility/outcomes."""
+    from tools.skill_usage import record_outcome, get_outcome_summary
+
+    record_outcome("demo-skill", "success", task_id="t1")
+    record_outcome("demo-skill", "failure", task_id="t2", error_type="timeout")
+    s = get_outcome_summary("demo-skill")
+    assert s["skill"] == "demo-skill"
+    assert s["success_count"] == 1
+    assert s["failure_count"] == 1
+    assert s["utility_score"] is None  # below floor
+    assert s["last_outcome_at"] is not None
+    assert s["outcomes"][0]["error_type"] == "timeout"
+
+
+def test_record_outcome_persisted_to_disk(skills_home):
+    """Outcomes survive a reload (sidecar JSON persisted)."""
+    from tools.skill_usage import record_outcome
+    import tools.skill_usage as mod
+    import importlib
+
+    record_outcome("demo-skill", "success")
+    record_outcome("demo-skill", "failure")
+    record_outcome("demo-skill", "success")
+    # Reload module to force re-read from disk
+    importlib.reload(mod)
+    s = mod.get_outcome_summary("demo-skill")
+    assert s["success_count"] == 2
+    assert s["failure_count"] == 1
+    assert s["utility_score"] is not None
+
+
+def test_invalid_outcome_rejected(skills_home):
+    """Invalid outcome strings are rejected without side effects."""
+    from tools.skill_usage import record_outcome, get_outcome_summary
+
+    assert record_outcome("demo-skill", "banana") is None
+    s = get_outcome_summary("demo-skill")
+    assert s["success_count"] == 0
+    assert s["failure_count"] == 0
+
+
+def test_empty_skill_name_rejected(skills_home):
+    from tools.skill_usage import record_outcome
+
+    assert record_outcome("", "success") is None
+
+
+def test_list_low_utility_skills(skills_home):
+    """Only failure-heavy skills with enough samples are listed."""
+    from tools.skill_usage import record_outcome, list_low_utility_skills
+
+    # Good skill: 3 successes
+    record_outcome("good-skill", "success")
+    record_outcome("good-skill", "success")
+    record_outcome("good-skill", "success")
+    # Bad skill: 3 failures
+    record_outcome("bad-skill", "failure")
+    record_outcome("bad-skill", "failure")
+    record_outcome("bad-skill", "failure")
+    # Sparse skill: 2 failures — below floor, must NOT be listed
+    record_outcome("sparse-skill", "failure")
+    record_outcome("sparse-skill", "failure")
+
+    rows = list_low_utility_skills()
+    names = [r["skill"] for r in rows]
+    assert "bad-skill" in names
+    assert "good-skill" not in names
+    assert "sparse-skill" not in names
+    assert rows[0]["utility_score"] < 0.2
+
+
+def test_utility_rerank_prefers_scored(skills_home):
+    """Scored skills sort before no-signal skills; best utility first."""
+    from tools.skill_usage import record_outcome, utility_rerank
+
+    record_outcome("skill-b", "success")
+    record_outcome("skill-b", "success")
+    record_outcome("skill-b", "success")  # high utility
+    record_outcome("skill-a", "failure")
+    record_outcome("skill-a", "failure")
+    record_outcome("skill-a", "failure")  # low utility
+
+    # Original order: [skill-a, skill-c, skill-b]
+    result = utility_rerank(["skill-a", "skill-c", "skill-b"])
+    # skill-b (high) first, skill-a (low) next, skill-c (no signal) last
+    assert result[0] == "skill-b"
+    assert result[1] == "skill-a"
+    assert result[2] == "skill-c"
+
+
+def test_utility_rerank_preserves_order_when_no_signal(skills_home):
+    """Without telemetry, re-rank is a stable no-op."""
+    from tools.skill_usage import utility_rerank
+
+    assert utility_rerank(["x", "y", "z"]) == ["x", "y", "z"]
+    assert utility_rerank([]) == []

--- a/tests/tools/test_skills_routing.py
+++ b/tests/tools/test_skills_routing.py
@@ -1,0 +1,311 @@
+"""Focused integration tests for BM25 routing through ``skills_list``."""
+
+import inspect
+import json
+
+import pytest
+
+from tools.registry import registry
+import tools.skills_tool as skills_tool
+
+
+class _PluginManager:
+    def __init__(self, skills):
+        self.skills = skills
+
+    def list_plugin_skill_metadata(self):
+        return [dict(skill) for skill in self.skills]
+
+
+@pytest.fixture(autouse=True)
+def _isolated_catalog(tmp_path, monkeypatch):
+    plugin_skills = []
+    skills_tool._SKILLS_CACHE.clear()
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", tmp_path / "skills")
+    monkeypatch.setattr("agent.skill_utils.get_external_skills_dirs", lambda: [])
+    monkeypatch.setattr(skills_tool, "_get_disabled_skill_names", lambda: set())
+    monkeypatch.setattr(skills_tool, "_is_skill_disabled", lambda name: False)
+    monkeypatch.setattr(skills_tool, "skill_matches_platform", lambda metadata: True)
+    monkeypatch.setattr(skills_tool, "skill_matches_environment", lambda metadata: True)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager",
+        lambda: _PluginManager(plugin_skills),
+    )
+    yield plugin_skills
+    skills_tool._SKILLS_CACHE.clear()
+
+
+def _write_skill(
+    root,
+    name,
+    *,
+    category=None,
+    description=None,
+    frontmatter="",
+    body="Step 1: Do the thing.",
+):
+    skill_dir = root / "skills"
+    if category:
+        skill_dir /= category
+    skill_dir /= name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    description = description or f"Description for {name}."
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        f"{frontmatter}"
+        "---\n\n"
+        f"# {name}\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_no_query_output_remains_byte_compatible(tmp_path):
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    actual = skills_tool.skills_list()
+
+    expected = json.dumps(
+        {
+            "success": True,
+            "skills": [
+                {
+                    "name": "alpha",
+                    "description": "Description for alpha.",
+                    "category": "testing",
+                }
+            ],
+            "categories": ["testing"],
+            "count": 1,
+            "hint": "Use skill_view(name) to see full content, tags, and linked files",
+        },
+        ensure_ascii=False,
+    )
+    assert actual == expected
+
+
+def test_whitespace_query_preserves_listing_even_with_invalid_limit(tmp_path):
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    assert (
+        skills_tool.skills_list(query=" \t\n", limit=False) == skills_tool.skills_list()
+    )
+
+
+def test_malformed_routing_metadata_does_not_remove_eligible_skill(tmp_path):
+    _write_skill(
+        tmp_path,
+        "alpha",
+        category="testing",
+        frontmatter="prerequisites:\n  commands: 1\n",
+    )
+
+    listing = json.loads(skills_tool.skills_list())
+    ranking = json.loads(skills_tool.skills_list(query="alpha"))
+
+    assert [skill["name"] for skill in listing["skills"]] == ["alpha"]
+    assert [skill["name"] for skill in ranking["skills"]] == ["alpha"]
+    assert ranking["total_candidates"] == 1
+
+
+def test_query_mode_is_compact_path_free_and_does_not_index_body(tmp_path):
+    _write_skill(
+        tmp_path,
+        "zeta",
+        category="testing",
+        body="This full body contains bodyneedle but must not be indexed.",
+    )
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    result = json.loads(skills_tool.skills_list(query="bodyneedle", limit=2))
+
+    assert list(result) == [
+        "success",
+        "mode",
+        "skills",
+        "count",
+        "total_candidates",
+        "index_fingerprint",
+        "hint",
+    ]
+    assert result["success"] is True
+    assert result["mode"] == "bm25"
+    assert [skill["name"] for skill in result["skills"]] == ["alpha", "zeta"]
+    assert set(result["skills"][0]) == {
+        "rank",
+        "name",
+        "category",
+        "description",
+        "score",
+    }
+    assert result["count"] == 2
+    assert result["total_candidates"] == 2
+    assert len(result["index_fingerprint"]) == 16
+    assert "skill_view(name)" in result["hint"]
+    serialized = json.dumps(result)
+    assert str(tmp_path) not in serialized
+    assert "bodyneedle" not in serialized
+    assert "query" not in result
+
+
+def test_query_does_not_index_body_fallback_for_missing_description(tmp_path):
+    skill_dir = tmp_path / "skills" / "testing" / "zeta"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: zeta\n"
+        "---\n\n"
+        "# zeta\n\n"
+        "bodyfallbackneedle must remain display-only.\n",
+        encoding="utf-8",
+    )
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    result = json.loads(skills_tool.skills_list(query="bodyfallbackneedle", limit=2))
+
+    assert [skill["name"] for skill in result["skills"]] == ["alpha", "zeta"]
+    assert [skill["score"] for skill in result["skills"]] == [0.0, 0.0]
+    assert result["skills"][1]["description"] == (
+        "bodyfallbackneedle must remain display-only."
+    )
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "triggerneedle",
+        "tagneedle",
+        "relatedneedle",
+        "commandneedle",
+        "envneedle",
+        "legacycommandneedle",
+        "legacyenvneedle",
+        "descriptionneedle",
+    ],
+)
+def test_query_indexes_declared_routing_metadata(tmp_path, query):
+    long_description = "x" * 1050 + " descriptionneedle"
+    _write_skill(
+        tmp_path,
+        "zeta",
+        category="testing",
+        description=long_description,
+        frontmatter=(
+            "triggers: [triggerneedle]\n"
+            "metadata:\n"
+            "  hermes:\n"
+            "    tags: [tagneedle]\n"
+            "    related_skills: [relatedneedle]\n"
+            "required_commands: [commandneedle]\n"
+            "required_environment_variables:\n"
+            "  - name: ENVNEEDLE\n"
+            "prerequisites:\n"
+            "  commands: [legacycommandneedle]\n"
+            "  env_vars: [LEGACYENVNEEDLE]\n"
+        ),
+    )
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    result = json.loads(skills_tool.skills_list(query=query, limit=2))
+
+    assert result["skills"][0]["name"] == "zeta"
+    assert result["skills"][0]["score"] > 0
+
+
+def test_query_applies_category_filter_before_ranking(tmp_path):
+    _write_skill(
+        tmp_path, "devops-match", category="devops", frontmatter="tags: [needle]\n"
+    )
+    _write_skill(
+        tmp_path, "mlops-match", category="mlops", frontmatter="tags: [needle]\n"
+    )
+    _write_skill(tmp_path, "devops-other", category="devops")
+
+    result = json.loads(
+        skills_tool.skills_list(category="devops", query="needle", limit=8)
+    )
+
+    assert {skill["name"] for skill in result["skills"]} == {
+        "devops-match",
+        "devops-other",
+    }
+    assert result["total_candidates"] == 2
+
+
+def test_query_includes_eligible_plugin_skill_metadata(_isolated_catalog):
+    _isolated_catalog.append({
+        "name": "demo:router",
+        "description": "Routes generic work",
+        "category": "plugin",
+        "frontmatter": {"metadata": {"hermes": {"tags": ["pluginneedle"]}}},
+    })
+
+    result = json.loads(skills_tool.skills_list(query="pluginneedle"))
+
+    assert result["skills"][0]["name"] == "demo:router"
+    assert result["skills"][0]["category"] == "plugin"
+    assert result["total_candidates"] == 1
+
+
+@pytest.mark.parametrize("limit", [True, False, 0, -1, 51, 1.5, "2"])
+def test_query_rejects_invalid_limit(limit):
+    result = json.loads(skills_tool.skills_list(query="needle", limit=limit))
+
+    assert result == {
+        "error": "limit must be an integer between 1 and 50",
+        "success": False,
+    }
+
+
+def test_query_honors_default_and_explicit_limit(tmp_path):
+    for index in range(10):
+        _write_skill(tmp_path, f"skill-{index:02d}", category="testing")
+
+    default = json.loads(skills_tool.skills_list(query="unmatched"))
+    explicit = json.loads(skills_tool.skills_list(query="unmatched", limit=3))
+
+    assert default["count"] == 8
+    assert explicit["count"] == 3
+    assert default["total_candidates"] == explicit["total_candidates"] == 10
+
+
+def test_signature_schema_and_handler_expose_query_limit_and_task_id(monkeypatch):
+    signature = inspect.signature(skills_tool.skills_list)
+    assert list(signature.parameters) == ["category", "query", "limit", "task_id"]
+    assert signature.parameters["query"].default is None
+    assert signature.parameters["limit"].default == 8
+    assert signature.parameters["task_id"].default is None
+
+    properties = skills_tool.SKILLS_LIST_SCHEMA["parameters"]["properties"]
+    assert properties["query"]["type"] == "string"
+    assert properties["limit"] == {
+        "type": "integer",
+        "description": "Maximum ranked skills to return in query mode",
+        "default": 8,
+        "minimum": 1,
+        "maximum": 50,
+    }
+
+    captured = {}
+
+    def fake_skills_list(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(skills_tool, "skills_list", fake_skills_list)
+    entry = registry.get_entry("skills_list")
+    assert (
+        entry.handler(
+            {"category": "testing", "query": "needle", "limit": 3},
+            task_id="task-123",
+        )
+        == "ok"
+    )
+    assert captured == {
+        "category": "testing",
+        "query": "needle",
+        "limit": 3,
+        "task_id": "task-123",
+    }

--- a/tests/tools/test_skills_routing.py
+++ b/tests/tools/test_skills_routing.py
@@ -227,10 +227,7 @@ def test_query_applies_category_filter_before_ranking(tmp_path):
         skills_tool.skills_list(category="devops", query="needle", limit=8)
     )
 
-    assert {skill["name"] for skill in result["skills"]} == {
-        "devops-match",
-        "devops-other",
-    }
+    assert {skill["name"] for skill in result["skills"]} == {"devops-match"}
     assert result["total_candidates"] == 2
 
 
@@ -266,7 +263,7 @@ def test_query_honors_default_and_explicit_limit(tmp_path):
     default = json.loads(skills_tool.skills_list(query="unmatched"))
     explicit = json.loads(skills_tool.skills_list(query="unmatched", limit=3))
 
-    assert default["count"] == 8
+    assert default["count"] == 0
     assert explicit["count"] == 3
     assert default["total_candidates"] == explicit["total_candidates"] == 10
 

--- a/tests/tools/test_skills_routing_production.py
+++ b/tests/tools/test_skills_routing_production.py
@@ -1,0 +1,130 @@
+"""Production integration contracts for query-aware ``skills_list``."""
+
+import json
+
+import pytest
+
+from tools.registry import registry
+import tools.skills_tool as skills_tool
+
+
+class _PluginManager:
+    def __init__(self, skills):
+        self.skills = skills
+
+    def list_plugin_skill_metadata(self):
+        return [dict(skill) for skill in self.skills]
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    plugins = []
+    skills_tool._SKILLS_CACHE.clear()
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", tmp_path / "skills")
+    monkeypatch.setattr("agent.skill_utils.get_external_skills_dirs", lambda: [])
+    monkeypatch.setattr(skills_tool, "_get_disabled_skill_names", lambda: set())
+    monkeypatch.setattr(skills_tool, "_is_skill_disabled", lambda name: False)
+    monkeypatch.setattr(skills_tool, "skill_matches_platform", lambda metadata: True)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager", lambda: _PluginManager(plugins)
+    )
+    yield plugins
+    skills_tool._SKILLS_CACHE.clear()
+
+
+def _write_skill(root, name, *, description="public description", body="private body"):
+    path = root / "skills" / "testing" / name / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_environment_ineligible_plugin_is_omitted_in_both_modes(_isolated, monkeypatch):
+    _isolated.extend([
+        {
+            "name": "demo:eligible",
+            "description": "eligible needle",
+            "category": "plugin",
+            "frontmatter": {"environment": "eligible"},
+        },
+        {
+            "name": "demo:private-secret-name",
+            "description": "ineligible needle",
+            "category": "plugin",
+            "frontmatter": {"environment": "ineligible"},
+        },
+    ])
+    monkeypatch.setattr(
+        skills_tool,
+        "skill_matches_environment",
+        lambda metadata: metadata.get("environment") != "ineligible",
+    )
+
+    listing = json.loads(skills_tool.skills_list())
+    ranking = json.loads(skills_tool.skills_list(query="needle"))
+
+    assert [skill["name"] for skill in listing["skills"]] == ["demo:eligible"]
+    assert [skill["name"] for skill in ranking["skills"]] == ["demo:eligible"]
+
+
+def test_public_shapes_and_privacy_are_unchanged(tmp_path, monkeypatch):
+    private_path = str(tmp_path / "private-location")
+    private_body = "private-body-token"
+    credential_value = "credential-value-token"
+    environment_value = "environment-value-token"
+    raw_query = "raw-query-token"
+    monkeypatch.setenv("ROUTING_SECRET", environment_value)
+    _write_skill(tmp_path, "alpha", body=private_body)
+
+    listing = json.loads(skills_tool.skills_list())
+    ranking = json.loads(skills_tool.skills_list(query=raw_query))
+    serialized = json.dumps({"listing": listing, "ranking": ranking})
+
+    assert list(listing) == ["success", "skills", "categories", "count", "hint"]
+    assert set(listing["skills"][0]) == {"name", "description", "category"}
+    assert list(ranking) == [
+        "success",
+        "mode",
+        "skills",
+        "count",
+        "total_candidates",
+        "index_fingerprint",
+        "hint",
+    ]
+    assert set(ranking["skills"][0]) == {
+        "rank",
+        "name",
+        "category",
+        "description",
+        "score",
+    }
+    for private in (
+        private_path,
+        private_body,
+        credential_value,
+        environment_value,
+        raw_query,
+        "source_fingerprint",
+        "_routing",
+    ):
+        assert private not in serialized
+    assert registry.get_entry("skills_list") is not None
+
+
+def test_ranking_does_not_load_skill_body(tmp_path, monkeypatch):
+    _write_skill(tmp_path, "alpha", body="body-only-secret")
+    called = False
+
+    def forbidden_view(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("skill_view must remain the explicit loading entrypoint")
+
+    monkeypatch.setattr(skills_tool, "skill_view", forbidden_view)
+    result = json.loads(skills_tool.skills_list(query="alpha"))
+
+    assert result["skills"][0]["name"] == "alpha"
+    assert called is False

--- a/tests/tools/test_skills_routing_production.py
+++ b/tests/tools/test_skills_routing_production.py
@@ -75,7 +75,7 @@ def test_public_shapes_and_privacy_are_unchanged(tmp_path, monkeypatch):
     private_body = "private-body-token"
     credential_value = "credential-value-token"
     environment_value = "environment-value-token"
-    raw_query = "raw-query-token"
+    raw_query = "alpha raw-query-token"
     monkeypatch.setenv("ROUTING_SECRET", environment_value)
     _write_skill(tmp_path, "alpha", body=private_body)
 

--- a/tools/seed_skill_outcomes.py
+++ b/tools/seed_skill_outcomes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Seed skill-outcome telemetry from existing usage history (2026-08).
+
+The evolution dashboard (GET /api/skills/evolution) reads outcome telemetry
+(success/failure records + utility scores) from the sidecar .usage.json.
+Before the skill_report_outcome tool existed, skills accumulated use_count /
+patch_count but NO outcome records — so the dashboard showed empty data.
+
+This one-shot seed backfills one 'unknown' outcome per skill that has a
+non-zero use_count, so the dashboard immediately reflects the tracked skill
+population. Unknown outcomes do NOT affect utility scores (they are excluded
+from the EMA), so this is a safe, non-distorting seed.
+
+Usage:
+    HERMES_HOME=~/.hermes python3 tools/seed_skill_outcomes.py
+    # --dry-run to preview without writing
+    HERMES_HOME=~/.hermes python3 tools/seed_skill_outcomes.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="preview without writing")
+    ap.add_argument("--min-use", type=int, default=1, help="min use_count to seed (default 1)")
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+    from tools.skill_usage import (
+        _backfill_outcome_keys,
+        get_outcome_summary,
+        load_usage,
+        record_outcome,
+        save_usage,
+    )
+
+    data = load_usage()
+    candidates = []
+    for name, raw in data.items():
+        if not isinstance(raw, dict):
+            continue
+        rec = _backfill_outcome_keys(raw)
+        # Only seed skills that have been used but have no outcome history yet
+        if rec.get("use_count", 0) >= args.min_use and not rec.get("outcomes"):
+            candidates.append((str(name), rec.get("use_count", 0)))
+
+    candidates.sort(key=lambda t: -t[1])
+    print(f"待种子技能数: {len(candidates)}")
+
+    if args.dry_run:
+        for name, use in candidates[:30]:
+            print(f"  [dry-run] {name} (use={use})")
+        return 0
+
+    for name, use in candidates:
+        # One 'unknown' outcome per used skill — marks it tracked without
+        # distorting utility (unknown excluded from EMA).
+        record_outcome(name, "unknown")
+
+    # Verify
+    verified = 0
+    for name, _ in candidates:
+        s = get_outcome_summary(name)
+        if s.get("unknown_count", 0) >= 1:
+            verified += 1
+    print(f"✅ 已种子 {verified}/{len(candidates)} 个技能")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -1392,3 +1392,207 @@ def usage_report() -> List[Dict[str, Any]]:
         row["activity_count"] = activity_count(row)
         rows.append(row)
     return sorted(rows, key=lambda r: r["name"])
+
+
+# ===========================================================================
+# Skill outcome telemetry + utility scoring (2026-08)
+#
+# Extends the sidecar telemetry with an *effectiveness* signal — not just
+# "how often was this skill used" (use_count) but "how well did it work"
+# (success/failure outcomes). The derived utility score feeds:
+#   1. Retrieval re-ranking  — prefer skills that historically worked for
+#      this task type (SkillRetriever.retrieve_detailed layer 6).
+#   2. Curator evidence      — archive/consolidate decisions backed by
+#      effectiveness data instead of activity counts alone.
+#   3. Reflection loop       — failure-heavy skills become candidates for
+#      trace-driven improvement (skill_reflection.py).
+#
+# Design notes (mirroring the module's existing conventions):
+#   - Sidecar JSON, atomic writes via _usage_file_lock / save_usage.
+#   - Best-effort: a broken sidecar never breaks the caller.
+#   - Outcome records live in .usage.json under record["outcomes"] with a
+#     bounded per-skill ring buffer so the file cannot grow unboundedly.
+# ===========================================================================
+
+OUTCOME_SUCCESS = "success"
+OUTCOME_FAILURE = "failure"
+OUTCOME_UNKNOWN = "unknown"
+_VALID_OUTCOMES = {OUTCOME_SUCCESS, OUTCOME_FAILURE, OUTCOME_UNKNOWN}
+
+# Bounded outcome history per skill (newest first). Keeps .usage.json small
+# while retaining enough samples for a meaningful moving estimate.
+_MAX_OUTCOME_HISTORY = 50
+
+# Utility EMA smoothing — recent outcomes matter more than ancient ones.
+_UTILITY_ALPHA = 0.3
+
+# Confidence floor: with fewer than this many outcomes, the utility score is
+# treated as "no signal" (None) so retrieval does not over-trust sparse data.
+_UTILITY_MIN_SAMPLES = 3
+
+
+def _empty_outcome_record() -> Dict[str, Any]:
+    return {
+        "success_count": 0,
+        "failure_count": 0,
+        "unknown_count": 0,
+        "outcomes": [],  # ring buffer, newest first: [{"ts","outcome","task_id?","error_type?"}]
+        "utility_score": None,
+        "last_outcome_at": None,
+    }
+
+
+def _backfill_outcome_keys(rec: Dict[str, Any]) -> Dict[str, Any]:
+    """Ensure every record carries the outcome/utility keys (old files)."""
+    base = _empty_outcome_record()
+    for k, v in base.items():
+        rec.setdefault(k, v)
+    # Defensive: outcome ring buffer must be a list of dicts
+    if not isinstance(rec.get("outcomes"), list):
+        rec["outcomes"] = []
+    rec["outcomes"] = [o for o in rec["outcomes"] if isinstance(o, dict)][:_MAX_OUTCOME_HISTORY]
+    return rec
+
+
+def _compute_utility(rec: Dict[str, Any]) -> Optional[float]:
+    """Compute the EMA utility score from the outcome ring buffer.
+
+    Returns None when there is not enough signal yet (< _UTILITY_MIN_SAMPLES
+    outcomes) — callers should treat None as "no preference" rather than a
+    neutral 0.5, so sparse data never distorts retrieval ranking.
+    """
+    outcomes = rec.get("outcomes") or []
+    scored = [o.get("outcome") for o in outcomes if o.get("outcome") in _VALID_OUTCOMES]
+    scored = [o for o in scored if o != OUTCOME_UNKNOWN]
+    if len(scored) < _UTILITY_MIN_SAMPLES:
+        return None
+    # Newest first → iterate reversed for chronological EMA
+    score = 0.5
+    for outcome in reversed(scored):
+        target = 1.0 if outcome == OUTCOME_SUCCESS else 0.0
+        score = (1 - _UTILITY_ALPHA) * score + _UTILITY_ALPHA * target
+    return round(score, 4)
+
+
+def _recompute_utility(rec: Dict[str, Any]) -> None:
+    """Recompute and store utility_score + counters from the ring buffer."""
+    outcomes = rec.get("outcomes") or []
+    success_count = sum(1 for o in outcomes if o.get("outcome") == OUTCOME_SUCCESS)
+    failure_count = sum(1 for o in outcomes if o.get("outcome") == OUTCOME_FAILURE)
+    unknown_count = sum(1 for o in outcomes if o.get("outcome") == OUTCOME_UNKNOWN)
+    rec["success_count"] = success_count
+    rec["failure_count"] = failure_count
+    rec["unknown_count"] = unknown_count
+    rec["utility_score"] = _compute_utility(rec)
+
+
+def record_outcome(
+    skill_name: str,
+    outcome: str,
+    *,
+    task_id: Optional[str] = None,
+    error_type: Optional[str] = None,
+) -> Optional[float]:
+    """Record one task outcome for *skill_name* and return the updated utility.
+
+    ``outcome`` must be one of "success" | "failure" | "unknown". The ring
+    buffer is bounded to ``_MAX_OUTCOME_HISTORY`` entries (newest first).
+    Returns the recomputed utility score (None when below the confidence
+    floor). Best-effort: returns None on any storage failure.
+    """
+    if outcome not in _VALID_OUTCOMES:
+        logger.debug("record_outcome: invalid outcome %r", outcome)
+        return None
+    if not skill_name:
+        return None
+
+    entry: Dict[str, Any] = {"ts": _now_iso(), "outcome": outcome}
+    if task_id:
+        entry["task_id"] = str(task_id)
+    if error_type:
+        entry["error_type"] = str(error_type)
+
+    def _apply(rec: Dict[str, Any]) -> Dict[str, Any]:
+        rec = _backfill_outcome_keys(rec)
+        rec["outcomes"].insert(0, entry)
+        rec["outcomes"] = rec["outcomes"][:_MAX_OUTCOME_HISTORY]
+        rec["last_outcome_at"] = _now_iso()
+        _recompute_utility(rec)
+        return {"utility_score": rec.get("utility_score")}
+
+    result = _mutate(skill_name, _apply)
+    if isinstance(result, dict):
+        return result.get("utility_score")
+    return None
+
+
+def get_utility_score(skill_name: str) -> Optional[float]:
+    """Return the current utility score for *skill_name* (None = no signal)."""
+    rec = get_record(skill_name)
+    rec = _backfill_outcome_keys(rec)
+    return rec.get("utility_score")
+
+
+def get_outcome_summary(skill_name: str) -> Dict[str, Any]:
+    """Return the outcome summary dict for *skill_name* (never raises)."""
+    rec = get_record(skill_name)
+    rec = _backfill_outcome_keys(rec)
+    return {
+        "skill": skill_name,
+        "success_count": rec.get("success_count", 0),
+        "failure_count": rec.get("failure_count", 0),
+        "unknown_count": rec.get("unknown_count", 0),
+        "utility_score": rec.get("utility_score"),
+        "last_outcome_at": rec.get("last_outcome_at"),
+        "outcomes": rec.get("outcomes", []),
+    }
+
+
+def list_low_utility_skills(min_samples: int = _UTILITY_MIN_SAMPLES, max_score: float = 0.4) -> List[Dict[str, Any]]:
+    """Return skills with poor effectiveness — candidates for the reflection loop.
+
+    A skill qualifies when it has at least *min_samples* scored outcomes and
+    its utility score is at or below *max_score* (i.e. it fails more than it
+    succeeds). Used by the failure-driven skill-reflection pass to choose
+    which skills deserve a trace-driven improvement proposal.
+    """
+    data = load_usage()
+    rows: List[Dict[str, Any]] = []
+    for name, raw in data.items():
+        if not isinstance(raw, dict):
+            continue
+        rec = _backfill_outcome_keys(raw)
+        score = rec.get("utility_score")
+        if score is None:
+            continue
+        if score <= max_score:
+            rows.append(
+                {
+                    "skill": str(name),
+                    "utility_score": score,
+                    "success_count": rec.get("success_count", 0),
+                    "failure_count": rec.get("failure_count", 0),
+                    "last_outcome_at": rec.get("last_outcome_at"),
+                }
+            )
+    return sorted(rows, key=lambda r: r["utility_score"])
+
+
+def utility_rerank(skill_names: List[str]) -> List[str]:
+    """Re-rank a list of retrieved skill names by utility score.
+
+    Skills with a utility signal (score is not None) are preferred, ordered
+    best-first; skills with no signal keep their original relative order and
+    sort after the scored ones. This is the retrieval-side hook that turns
+    telemetry into better routing: a skill that historically worked for a
+    task type outranks one that only matched textually.
+    """
+    if not skill_names:
+        return skill_names
+    scored: List[tuple[Optional[float], int, str]] = []
+    for i, name in enumerate(skill_names):
+        score = get_utility_score(name)
+        scored.append((score, i, name))
+    # None scores sort last; ties broken by original index (stable)
+    scored.sort(key=lambda t: (t[0] is None, -(t[0] or 0.0), t[1]))
+    return [name for _, _, name in scored]

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -1400,8 +1400,9 @@ def usage_report() -> List[Dict[str, Any]]:
 # Extends the sidecar telemetry with an *effectiveness* signal — not just
 # "how often was this skill used" (use_count) but "how well did it work"
 # (success/failure outcomes). The derived utility score feeds:
-#   1. Retrieval re-ranking  — prefer skills that historically worked for
-#      this task type (SkillRetriever.retrieve_detailed layer 6).
+#   1. Retrieval re-ranking  — prefer skills with enough known outcomes over
+#      alternatives that only matched textually. This is global per-skill
+#      utility, not task-type attribution: no raw task text is stored.
 #   2. Curator evidence      — archive/consolidate decisions backed by
 #      effectiveness data instead of activity counts alone.
 #   3. Reflection loop       — failure-heavy skills become candidates for
@@ -1579,13 +1580,12 @@ def list_low_utility_skills(min_samples: int = _UTILITY_MIN_SAMPLES, max_score: 
 
 
 def utility_rerank(skill_names: List[str]) -> List[str]:
-    """Re-rank a list of retrieved skill names by utility score.
+    """Re-rank retrieved skill names by global per-skill utility.
 
     Skills with a utility signal (score is not None) are preferred, ordered
     best-first; skills with no signal keep their original relative order and
-    sort after the scored ones. This is the retrieval-side hook that turns
-    telemetry into better routing: a skill that historically worked for a
-    task type outranks one that only matched textually.
+    sort after the scored ones. Outcome records deliberately omit raw task
+    text, so this is not task-type-specific attribution.
     """
     if not skill_names:
         return skill_names

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -684,13 +684,82 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
-def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
+def _routing_metadata_values(frontmatter: Dict[str, Any], key: str) -> List[str]:
+    """Return stable string values for a routing-only frontmatter field."""
+    metadata = frontmatter.get("metadata")
+    hermes_metadata = (
+        metadata.get("hermes", {}) if isinstance(metadata, dict) else {}
+    )
+    nested = hermes_metadata.get(key) if isinstance(hermes_metadata, dict) else None
+    values = _parse_tags(nested) + _parse_tags(frontmatter.get(key))
+    return sorted(set(values), key=lambda value: (value.casefold(), value))
+
+
+def _routing_document(
+    *,
+    name: str,
+    description: str,
+    display_description: str,
+    category: str | None,
+    frontmatter: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Build a path-free routing document from declared skill metadata."""
+    try:
+        legacy_environment, legacy_commands = _collect_prerequisite_values(
+            frontmatter
+        )
+    except (TypeError, ValueError):
+        legacy_environment, legacy_commands = [], []
+    required_environment = _get_required_environment_variables(
+        frontmatter, legacy_environment
+    )
+    required_commands = _routing_metadata_values(frontmatter, "required_commands")
+    required_commands.extend(legacy_commands)
+    required_command_names = sorted(
+        {value for value in required_commands if value},
+        key=lambda value: (value.casefold(), value),
+    )
+    qualified_name = (
+        name if ":" in name else "/".join(filter(None, (category, name)))
+    )
+    return {
+        "qualified_name": qualified_name,
+        "name": name,
+        "category": category,
+        "description": description,
+        "display_description": display_description,
+        "triggers": _routing_metadata_values(frontmatter, "triggers"),
+        "tags": _routing_metadata_values(frontmatter, "tags"),
+        "related_skills": _routing_metadata_values(frontmatter, "related_skills"),
+        "required_commands": required_command_names,
+        "required_environment_variables": [
+            item["name"] for item in required_environment if item.get("name")
+        ],
+    }
+
+
+def _copy_skill_catalog(
+    skills: List[Dict[str, Any]], *, include_routing: bool
+) -> List[Dict[str, Any]]:
+    copied = [dict(skill) for skill in skills]
+    if not include_routing:
+        for skill in copied:
+            skill.pop("_routing", None)
+    return copied
+
+
+def _find_all_skills(
+    *, skip_disabled: bool = False, include_routing: bool = False
+) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
     Args:
         skip_disabled: If True, return ALL skills regardless of disabled
             state (used by ``hermes skills`` config UI). Default False
             filters out disabled skills.
+        include_routing: Include private, path-free routing metadata for the
+            ``skills_list`` query path. Default False preserves the public
+            catalog shape.
 
     Returns:
         List of skill metadata dicts (name, description, category).
@@ -706,7 +775,10 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         iter_skill_index_files,
     )
 
-    cache_key = _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
+    visibility_key = (
+        _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
+    )
+    cache_key = (visibility_key, include_routing)
 
     # Load disabled set once (not per-skill). Part of the cache signature:
     # disabling a skill is a config change with no filesystem mtime bump.
@@ -736,7 +808,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         # Per-call shallow copies: callers mutate the returned dicts
         # (e.g. web_server annotates s["enabled"]/s["usage"]) — handing
         # out the cached objects would poison the cache for everyone else.
-        return [dict(s) for s in cached[2]]
+        return _copy_skill_catalog(cached[2], include_routing=include_routing)
 
     skills = []
     seen_names: set = set()
@@ -773,7 +845,8 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 if name in disabled:
                     continue
 
-                description = frontmatter.get("description", "")
+                frontmatter_description = frontmatter.get("description", "")
+                description = frontmatter_description
                 if not description:
                     for line in body.strip().split("\n"):
                         line = line.strip()
@@ -787,11 +860,20 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 category = _get_category_from_path(skill_md)
 
                 seen_names.add(name)
-                skills.append({
+                skill = {
                     "name": name,
                     "description": description,
                     "category": category,
-                })
+                }
+                if include_routing:
+                    skill["_routing"] = _routing_document(
+                        name=name,
+                        description=frontmatter_description,
+                        display_description=description,
+                        category=category,
+                        frontmatter=frontmatter,
+                    )
+                skills.append(skill)
 
             except (UnicodeDecodeError, PermissionError) as e:
                 logger.debug("Failed to read skill file %s: %s", skill_md, e)
@@ -807,7 +889,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # re-scans rather than serving the torn result past the TTL). Same
     # shallow-copy contract as the hit path — the caller may mutate.
     _SKILLS_CACHE[cache_key] = (signature, now, skills)
-    return [dict(s) for s in skills]
+    return _copy_skill_catalog(skills, include_routing=include_routing)
 
 
 def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -815,7 +897,12 @@ def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
 
-def skills_list(category: str = None, task_id: str = None) -> str:
+def skills_list(
+    category: str | None = None,
+    query: str | None = None,
+    limit: int = 8,
+    task_id: str | None = None,
+) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
 
@@ -824,18 +911,33 @@ def skills_list(category: str = None, task_id: str = None) -> str:
 
     Args:
         category: Optional category filter (e.g., "mlops")
+        query: Optional natural-language routing query
+        limit: Maximum ranked candidates in query mode (1-50)
         task_id: Optional task identifier used to probe the active backend
 
     Returns:
         JSON string with minimal skill info: name, description, category
     """
     try:
+        if query is not None and not isinstance(query, str):
+            return tool_error("query must be a string", success=False)
+        routing_query = query.strip() if query is not None else ""
+        query_mode = bool(routing_query)
+        if query_mode and (
+            isinstance(limit, bool)
+            or not isinstance(limit, int)
+            or not 1 <= limit <= 50
+        ):
+            return tool_error(
+                "limit must be an integer between 1 and 50", success=False
+            )
+
         active_skills_dir = _skills_dir()
         if not active_skills_dir.exists():
             active_skills_dir.mkdir(parents=True, exist_ok=True)
 
         # Find all skills
-        all_skills = _find_all_skills()
+        all_skills = _find_all_skills(include_routing=query_mode)
         try:
             from hermes_cli.plugins import discover_plugins, get_plugin_manager
 
@@ -846,11 +948,19 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                     continue
                 if _is_skill_disabled(plugin_skill["name"]):
                     continue
+                if query_mode:
+                    plugin_skill["_routing"] = _routing_document(
+                        name=plugin_skill["name"],
+                        description=plugin_skill.get("description", ""),
+                        display_description=plugin_skill.get("description", ""),
+                        category=plugin_skill.get("category"),
+                        frontmatter=frontmatter,
+                    )
                 all_skills.append(plugin_skill)
         except Exception:
             logger.debug("Plugin skill listing failed", exc_info=True)
 
-        if not all_skills:
+        if not all_skills and not query_mode:
             return json.dumps(
                 {
                     "success": True,
@@ -864,6 +974,26 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         # Filter by category if specified
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
+
+        if query_mode:
+            from agent.skill_routing import rank_skills
+
+            ranking = rank_skills(
+                [skill["_routing"] for skill in all_skills], routing_query, limit
+            )
+            ranked_skills = ranking["skills"]
+            return json.dumps(
+                {
+                    "success": True,
+                    "mode": "bm25",
+                    "skills": ranked_skills,
+                    "count": len(ranked_skills),
+                    "total_candidates": ranking["total_candidates"],
+                    "index_fingerprint": ranking["index_fingerprint"],
+                    "hint": "Use skill_view(name) to load a candidate skill",
+                },
+                ensure_ascii=False,
+            )
 
         # Sort by category then name
         all_skills = _sort_skills(all_skills)
@@ -1989,7 +2119,20 @@ SKILLS_LIST_SCHEMA = {
             "category": {
                 "type": "string",
                 "description": "Optional category filter to narrow results",
-            }
+            },
+            "query": {
+                "type": "string",
+                "description": (
+                    "Optional query for deterministic local BM25 skill routing"
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum ranked skills to return in query mode",
+                "default": 8,
+                "minimum": 1,
+                "maximum": 50,
+            },
         },
         "required": [],
     },
@@ -2019,7 +2162,10 @@ registry.register(
     toolset="skills",
     schema=SKILLS_LIST_SCHEMA,
     handler=lambda args, **kw: skills_list(
-        category=args.get("category"), task_id=kw.get("task_id")
+        category=args.get("category"),
+        query=args.get("query"),
+        limit=args.get("limit", 8),
+        task_id=kw.get("task_id"),
     ),
     check_fn=check_skills_requirements,
     emoji="📚",

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -946,6 +946,8 @@ def skills_list(
                 frontmatter = plugin_skill.pop("frontmatter", {})
                 if not skill_matches_platform(frontmatter):
                     continue
+                if not skill_matches_environment(frontmatter):
+                    continue
                 if _is_skill_disabled(plugin_skill["name"]):
                     continue
                 if query_mode:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -2333,3 +2333,89 @@ registry.register(
     check_fn=check_skills_requirements,
     emoji="📚",
 )
+
+
+# ── Skill outcome reporting (2026-08) ─────────────────────────────────────
+# The agent reports whether a skill actually WORKED for the task at hand.
+# This is the missing "effectiveness" signal that feeds:
+#   - utility scoring (tools/skill_usage.record_outcome)
+#   - the evolution dashboard (GET /api/skills/evolution)
+#   - the reflection loop (agent/skill_reflection)
+# Called by the agent at the end of a task that used a skill — success,
+# failure (with error type), or unknown. Best-effort: telemetry failure
+# never breaks the tool call.
+
+SKILL_REPORT_OUTCOME_SCHEMA = {
+    "name": "skill_report_outcome",
+    "description": (
+        "Report how well a skill worked for the task that just used it. "
+        "Call this at the end of a task where you loaded a skill: outcome "
+        "'success' when the skill led to a completed task, 'failure' when it "
+        "did not (include the error type, e.g. 'api_403', 'timeout', "
+        "'missing_dependency'), 'unknown' when the result is unclear. This "
+        "feeds the skill-evolution telemetry — over time, skills that "
+        "consistently fail get flagged for improvement."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "The skill name that was used.",
+            },
+            "outcome": {
+                "type": "string",
+                "enum": ["success", "failure", "unknown"],
+                "description": "success | failure | unknown",
+            },
+            "error_type": {
+                "type": "string",
+                "description": "OPTIONAL: for failure, a short error category (e.g. 'api_403', 'timeout', 'missing_dependency').",
+            },
+        },
+        "required": ["name", "outcome"],
+    },
+}
+
+
+def _skill_report_outcome(args, **kw):
+    """Record one skill outcome into the sidecar telemetry. Best-effort."""
+    name = (args.get("name") or "").strip()
+    outcome = (args.get("outcome") or "").strip()
+    error_type = (args.get("error_type") or "").strip() or None
+    if not name or outcome not in {"success", "failure", "unknown"}:
+        return json.dumps(
+            {
+                "success": False,
+                "error": "name and outcome (success|failure|unknown) are required",
+            }
+        )
+    try:
+        from tools.skill_usage import record_outcome
+
+        utility = record_outcome(
+            name,
+            outcome,
+            task_id=kw.get("task_id"),
+            error_type=error_type,
+        )
+        return json.dumps(
+            {
+                "success": True,
+                "skill": name,
+                "outcome": outcome,
+                "utility_score": utility,
+            }
+        )
+    except Exception as e:  # best-effort: telemetry never breaks the call
+        return json.dumps({"success": False, "error": str(e)})
+
+
+registry.register(
+    name="skill_report_outcome",
+    toolset="skills",
+    schema=SKILL_REPORT_OUTCOME_SCHEMA,
+    handler=_skill_report_outcome,
+    check_fn=check_skills_requirements,
+    emoji="📊",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -45,7 +45,7 @@ _HERMES_CORE_TOOLS = [
     # Vision + image generation
     "vision_analyze", "image_generate",
     # Skills
-    "skills_list", "skill_view", "skill_manage",
+    "skills_list", "skill_view", "skill_manage", "skill_report_outcome",
     # Browser automation
     "browser_navigate", "browser_snapshot", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
@@ -175,7 +175,7 @@ TOOLSETS = {
     
     "skills": {
         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
-        "tools": ["skills_list", "skill_view", "skill_manage"],
+        "tools": ["skills_list", "skill_view", "skill_manage", "skill_report_outcome"],
         "includes": []
     },
     
@@ -389,7 +389,7 @@ TOOLSETS = {
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
-            "skills_list", "skill_view", "skill_manage",
+            "skills_list", "skill_view", "skill_manage", "skill_report_outcome",
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
@@ -422,7 +422,7 @@ TOOLSETS = {
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
-            "skills_list", "skill_view", "skill_manage",
+            "skills_list", "skill_view", "skill_manage", "skill_report_outcome",
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
@@ -447,7 +447,7 @@ TOOLSETS = {
             # Vision + image generation
             "vision_analyze", "image_generate",
             # Skills
-            "skills_list", "skill_view", "skill_manage",
+            "skills_list", "skill_view", "skill_manage", "skill_report_outcome",
             # Browser automation
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",


### PR DESCRIPTION
## What does this PR do?

Builds the first upstream Skill Steward slice from two existing contributions, while preserving their commits and authorship:

- deterministic, local BM25 routing through `skills_list(query=...)`
- bounded local success/failure/unknown outcome telemetry
- confidence-gated global per-skill utility re-ranking
- review-only skill reflection proposals and dashboard visibility
- curator archive decisions gated on known outcome evidence
- removal of the curator's fixed archive-count pressure
- config.yaml settings for the optional richer SkillRetriever

This integration incorporates and supersedes:

- #93591 by @dannyzen, including the follow-up routing fixes in this branch
- #84420 by @zonghu-wang

The original contributor commits remain in history.

## Why

The curator was trying to route, maintain, and consolidate skills from activity counters alone. That made “never surfaced” look like “not useful” and rewarded archive volume rather than verified value.

This PR separates the first useful pieces:

1. Routing finds a small relevant candidate set without changing the no-query catalog contract.
2. Outcomes stay local and bounded, with no raw task text or outbound telemetry.
3. Curator pruning treats missing outcomes as missing evidence, not permission to archive.

## Safety and compatibility

- No dynamic system-prompt or mid-conversation toolset mutation.
- No raw task text in outcome storage.
- No outbound telemetry or new network call.
- Existing `skills_list()` output remains byte-compatible when no query is supplied.
- Outcome reporting stays inside the existing skills toolset, including its legacy alias.
- Behavioural settings live in `config.yaml`, not `.env`.
- Hub-installed and external skills remain read-only to the curator.

## Explicitly not in this PR

- automatic pre-task skill loading
- the full opportunity → surfaced → loaded → followed → completed event funnel
- automatic readiness testing or servicing of underused skills
- task-class-specific utility
- automatic bundle creation

Those need a stable event contract and live evidence first.

## Verification

Current head: `69dd8f1755`

- focused affected suite: `156 passed in 30.24s`
- changed-file Ruff: `All checks passed!`
- `git diff --check`: clean
- routing replay benchmark: 11 queries, recall `1.0`, MRR `0.954545`, mean NDCG `0.966448`, SHA-256 `72884bae3262ef705f10bc195266686697ba73b0bbb7c4051e922a6f07715a46`
- E2E route → load → outcome → curator contract: green
- mutation proof: removing the missing-outcome archive guard makes that E2E fail (`archived` becomes 2 instead of 1); restoring it passes

## Risks

- Utility is global per skill, not per task class, because raw task text is deliberately not stored.
- The optional richer SkillRetriever can use an embedding model if its dependency is installed; deterministic `skills_list(query=...)` does not depend on that path.
- This is intentionally a broad integration PR because routing, outcome evidence, and curator safety form one end-to-end contract. The commits remain separated for review and contributor credit.
