### PR TITLE
fix(desktop): clear a removed connection's cookie jar on removal

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -266,7 +266,7 @@ import {
 import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
-import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
+import { cookieJarToClearOnRemoval, LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
 import { createParentStartMarkerResolver, parentWatchdogEnv } from './parent-process-identity'
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
 import {
@@ -14705,7 +14705,21 @@ ipcMain.handle('hermes:connections:save', async (_event, payload) => {
 ipcMain.handle('hermes:connections:remove', async (_event, id) => {
   const key = String(id || '')
   managedConnectionUpdateGate.assertCanMutate(key)
-  const registry = removeConnection(readDesktopConnectionsRegistry(), key)
+  const before = readDesktopConnectionsRegistry()
+  const cookieUrlToClear = cookieJarToClearOnRemoval(key, before)
+
+  // Clear the removed connection's cookie jar before its registry entry is
+  // gone. clearOauthSession() re-resolves the partition from the on-disk
+  // registry, so this must run before writeDesktopConnectionsRegistry() below
+  // removes the entry that resolution depends on. Otherwise a later re-add of
+  // the same URL inherits whatever cookies were left behind — often a
+  // long-since-invalidated session — and the UI reports "Signed in" from the
+  // stale jar without the login window ever running (#98242).
+  if (cookieUrlToClear) {
+    await clearOauthSession(cookieUrlToClear)
+  }
+
+  const registry = removeConnection(before, key)
   writeDesktopConnectionsRegistry(registry)
   // Tear down anything the removed connection still had running: pooled
   // backends under its composite keys and any ssh tunnel scopes it owned.

--- a/apps/desktop/electron/oauth-partition.test.ts
+++ b/apps/desktop/electron/oauth-partition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
+import { cookieJarToClearOnRemoval, LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
 
 // #92183 — two basic-auth (cookie-flow) gateways registered in the v2
 // connections registry must not share one cookie jar. Chromium cookie jars
@@ -140,5 +140,36 @@ describe('resolveOauthPartition (#92183 per-connection cookie jars)', () => {
     const got = resolveOauthPartition('https://gw-a.example.com', { registry: reg })
 
     expect(got).toContain('alpha')
+  })
+})
+
+// #98242 — re-adding a removed remote gateway flashed "Signed in" and skipped
+// the login page. Removing a connection never cleared its cookie jar, so
+// re-registering the same URL (most commonly as the new primary, which rides
+// the shared legacy jar) inherited stale cookies from the old, already-dead
+// session and read as signed in without ever running the login flow.
+describe('cookieJarToClearOnRemoval (#98242 stale session on re-add)', () => {
+  it('names the URL of a removed cookie-auth (oauth/basic) connection', () => {
+    const reg = registry('conn-a', [remote('conn-a', 'https://gw.example.com')])
+
+    expect(cookieJarToClearOnRemoval('conn-a', reg)).toBe('https://gw.example.com')
+  })
+
+  it('returns null for a token-auth connection (never rode a cookie jar)', () => {
+    const reg = registry('local', [remote('conn-a', 'https://gw.example.com', { authMode: 'token' })])
+
+    expect(cookieJarToClearOnRemoval('conn-a', reg)).toBeNull()
+  })
+
+  it('returns null for the local connection', () => {
+    const reg = registry('local', [{ id: 'local', kind: 'local' }])
+
+    expect(cookieJarToClearOnRemoval('local', reg)).toBeNull()
+  })
+
+  it('returns null for an id that is not in the registry', () => {
+    const reg = registry('local', [remote('conn-a', 'https://gw.example.com')])
+
+    expect(cookieJarToClearOnRemoval('conn-b', reg)).toBeNull()
   })
 })

--- a/apps/desktop/electron/oauth-partition.ts
+++ b/apps/desktop/electron/oauth-partition.ts
@@ -91,13 +91,16 @@ function sanitizePartitionComponent(id: string): string {
 /**
  * The base URL whose cookie jar must be cleared when connection `id` is
  * removed from the registry, or null if the connection never rode a cookie
- * jar. Must be resolved from the registry snapshot taken BEFORE the entry is
- * removed: whether it lived on the shared legacy jar (primary) or its own
- * connection-scoped jar (secondary) depends on the entry still being present,
- * and that answer is wrong once it is gone. Left uncleared, a removed
- * connection's session cookies persist until a later connection resolves to
- * the same jar (most commonly: re-adding the same URL as primary), which then
- * inherits a stale, possibly already-invalidated session (#98242).
+ * jar. `authMode === 'oauth'` is the only cookie-flow value (see the module
+ * header): it covers dashboard basic/password providers too, so no separate
+ * check is needed for them. Must be resolved from the registry snapshot taken
+ * BEFORE the entry is removed: whether it lived on the shared legacy jar
+ * (primary) or its own connection-scoped jar (secondary) depends on the entry
+ * still being present, and that answer is wrong once it is gone. Left
+ * uncleared, a removed connection's session cookies persist until a later
+ * connection resolves to the same jar (most commonly: re-adding the same URL
+ * as primary), which then inherits a stale, possibly already-invalidated
+ * session (#98242).
  */
 export function cookieJarToClearOnRemoval(id: string, registry: PartitionRegistrySnapshot | null | undefined): string | null {
   const connections = registry && Array.isArray(registry.connections) ? registry.connections : []

--- a/apps/desktop/electron/oauth-partition.ts
+++ b/apps/desktop/electron/oauth-partition.ts
@@ -89,6 +89,30 @@ function sanitizePartitionComponent(id: string): string {
 }
 
 /**
+ * The base URL whose cookie jar must be cleared when connection `id` is
+ * removed from the registry, or null if the connection never rode a cookie
+ * jar. Must be resolved from the registry snapshot taken BEFORE the entry is
+ * removed: whether it lived on the shared legacy jar (primary) or its own
+ * connection-scoped jar (secondary) depends on the entry still being present,
+ * and that answer is wrong once it is gone. Left uncleared, a removed
+ * connection's session cookies persist until a later connection resolves to
+ * the same jar (most commonly: re-adding the same URL as primary), which then
+ * inherits a stale, possibly already-invalidated session (#98242).
+ */
+export function cookieJarToClearOnRemoval(id: string, registry: PartitionRegistrySnapshot | null | undefined): string | null {
+  const connections = registry && Array.isArray(registry.connections) ? registry.connections : []
+  const entry = connections.find((c: any) => c && typeof c === 'object' && c.id === id)
+
+  if (!entry || (entry as any).kind !== 'remote' || (entry as any).authMode !== 'oauth') {
+    return null
+  }
+
+  const url = (entry as any).url
+
+  return typeof url === 'string' && url ? url : null
+}
+
+/**
  * Decide the Electron session partition a cookie-authenticated request against
  * `requestUrl` must ride. See the module header for the rules.
  */


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop app flashing "Signed in" and skipping the login page when
a remote gateway connection is removed and then re-added at the same URL,
while the actual connection still fails.

Root cause: `hermes:connections:remove` tore down the removed connection's
pooled backends and SSH tunnels, but never cleared its Electron session
cookies. A primary v2 registry connection rides the shared legacy oauth
partition (`persist:hermes-remote-oauth`), so removing it and later
re-registering the same URL as the new primary inherits whatever cookies
were left behind in that shared jar — often a session that is already
invalid server-side (revoked, expired, or from before a credential change).
`hasLiveOauthSession()`'s cookie-presence check then reports "connected"
immediately, so the settings/reconnect UI shows "Signed in" and never opens
the login window, while the authoritative check (the ws-ticket mint at
actual connect time) still fails — matching the reported symptom exactly,
including that wiping `connections.json` and the native token store did
not help, since neither of those touches Electron's separate cookie-jar
storage for the partition.

## Related Issue

Fixes #98242

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/oauth-partition.ts` — add `cookieJarToClearOnRemoval(id, registry)`,
  a pure decision of which URL's cookie jar must be cleared when a connection
  is removed (covers both the shared legacy jar for a primary connection and
  the per-connection jar for a secondary), or `null` when the connection
  never used cookie auth.
- `apps/desktop/electron/main.ts` — `hermes:connections:remove` now clears
  the removed connection's cookie jar (via the existing `clearOauthSession`)
  *before* writing the registry without that entry, since partition
  resolution depends on the entry still being present.
- `apps/desktop/electron/oauth-partition.test.ts` — regression tests for
  `cookieJarToClearOnRemoval` covering a cookie-auth (oauth/basic) remote, a
  token-auth remote (should not clear), the local connection, and an unknown
  id.

## How to Test

1. `npm ci --workspace apps/desktop --include-workspace-root`
2. `npx vitest run electron/oauth-partition.test.ts --project electron` (from `apps/desktop`)
3. `npx tsc -p apps/desktop/tsconfig.electron.json --noEmit`
4. `npx eslint apps/desktop/electron/oauth-partition.ts apps/desktop/electron/oauth-partition.test.ts apps/desktop/electron/main.ts`

### Test output

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Confirmed the 4 new tests fail without the fix (temporarily reverted
`oauth-partition.ts`/`main.ts` to HEAD while keeping the new test file):

```
FAIL electron/oauth-partition.test.ts > cookieJarToClearOnRemoval (#98242 stale session on re-add) > names the URL of a removed cookie-auth (oauth/basic) connection
TypeError: cookieJarToClearOnRemoval is not a function
 Test Files  1 failed (1)
      Tests  4 failed | 11 passed (15)
```

Also ran the full electron vitest project (`npx vitest run --project electron`
from `apps/desktop`): **1958 passed, 6 skipped, 0 failed** — no regressions.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my change, and verified they fail without the fix
- [x] Ran typecheck (`tsc -p tsconfig.electron.json --noEmit`) and lint (`eslint`) on touched files — clean

## AI assistance disclosure

This fix (investigation, patch, and tests) was authored with the assistance
of an AI coding agent (Claude), with the resulting diff reviewed before
opening this PR.
