### PR TITLE
fix(uninstall): fall back to platform-default home for profile-redirected HERMES_HOME

### DIFF
--- a/hermes_cli/gui_uninstall.py
+++ b/hermes_cli/gui_uninstall.py
@@ -40,7 +40,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, _get_platform_default_hermes_home
 
 from hermes_cli.colors import Colors, color
 
@@ -170,6 +170,13 @@ def agent_is_installed(hermes_home: Path) -> bool:
         return True
     if (agent_root / "venv").is_dir() or (agent_root / ".venv").is_dir():
         return True
+    # Profile redirect: when the active profile points HERMES_HOME at a
+    # data-only profile dir (no agent code by design), fall back to the
+    # platform default home where the shared agent actually lives. Without
+    # this the desktop uninstall panel hides the remove-agent options.
+    default_root = _get_platform_default_hermes_home()
+    if hermes_home != default_root:
+        return agent_is_installed(default_root)
     return False
 
 


### PR DESCRIPTION
## Summary
`agent_is_installed()` in `hermes_cli/gui_uninstall.py` returned `False` when the active profile points `HERMES_HOME` at a **data-only profile dir** (no agent code by design). With a profile-based install, the desktop **uninstall panel hid the remove-agent options** because the profile home has no agent root/venv.

Fix: when `hermes_home` differs from the platform default, fall back to `_get_platform_default_hermes_home()` and recurse, since that is where the shared agent actually lives.

## Problem
- Profile (e.g. `enlil`) redirects `HERMES_HOME` to a data-only profile dir.
- `agent_is_installed(profile_home)` checks for an agent root/venv there — none exists.
- Uninstall panel therefore hides the remove-agent actions for profile-based installs.

## Change
- Add `_get_platform_default_hermes_home` import.
- In `agent_is_installed()`, if `hermes_home != default_root`, recurse on the default home.

```diff
+    default_root = _get_platform_default_hermes_home()
+    if hermes_home != default_root:
+        return agent_is_installed(default_root)
```

## Test Plan
- [ ] `git diff --check` clean
- [ ] Verify uninstall panel shows remove-agent options under a profile-based install
- [ ] Current suite: `hermes_cli` uninstall/install tests pass