### PR TITLE
fix(kanban): break goal-judge deadlock on same-card review requests

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2311,7 +2311,20 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
         return None
 
 
-def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Optional[str]:
+# Kept in sync with tools/kanban_tools.py's copy of this note (#98160).
+_REVIEW_READINESS_NOTE = (
+    "\n\nJudging note: this checks whether the implementation work described "
+    "above is finished and ready to hand off to a reviewer — it does not "
+    "check whether the card as a whole is done. If the card's own criteria "
+    "call for a reviewer to approve or close out the work, treat that as a "
+    "later step outside this check: do not withhold DONE merely because "
+    "reviewer/approval evidence is absent."
+)
+
+
+def _goal_mode_handoff_rejection(
+    task: Optional[kb.Task], evidence: str, *, handoff: str = "complete"
+) -> Optional[str]:
     """Apply the goal judge to every terminal worker handoff, including review."""
     if task is None or not task.goal_mode:
         return None
@@ -2326,11 +2339,15 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Opti
 
     from hermes_cli.goals import judge_goal
 
+    goal = f"{task.title}\n\n{task.body or ''}".strip()
+    if handoff == "review":
+        goal = f"{goal}{_REVIEW_READINESS_NOTE}"
+
     verdict = "done"
     reason = ""
     try:
         verdict, reason, _, _, _ = judge_goal(
-            goal=f"{task.title}\n\n{task.body or ''}".strip(),
+            goal=goal,
             last_response=evidence.strip(),
         )
     except Exception as judge_exc:
@@ -2535,6 +2552,7 @@ def _cmd_request_review(args: argparse.Namespace) -> int:
         rejection = _goal_mode_handoff_rejection(
             kb.get_task(conn, tid),
             summary or "",
+            handoff="review",
         )
         if rejection is not None:
             print(

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2341,6 +2341,12 @@ def _goal_mode_handoff_rejection(
 
     goal = f"{task.title}\n\n{task.body or ''}".strip()
     if handoff == "review":
+        # judge_goal truncates its goal argument to 2000 chars before sending
+        # it to the judge; reserve room here so a long title/body can't push
+        # the note itself past that limit and silently drop it (#98160).
+        budget = 2000 - len(_REVIEW_READINESS_NOTE)
+        if len(goal) > budget:
+            goal = goal[:budget]
         goal = f"{goal}{_REVIEW_READINESS_NOTE}"
 
     verdict = "done"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -264,6 +264,69 @@ def test_request_review_goal_mode_asks_judge_about_implementation_not_review(
     assert "Goal completion rejected by judge" in d2.get("error", "")
 
 
+def test_request_review_goal_mode_note_survives_long_body(monkeypatch, tmp_path):
+    """A goal-mode card with a long title+body (routine: task.body has an
+    8 KB budget elsewhere) must not silently lose the review-scoping note to
+    judge_goal's own 2000-char truncation. Regression for #98160 follow-up:
+    the note used to be appended AFTER title+body, so long cards consumed
+    the whole 2000-char budget before the note was ever reached.
+
+    This deliberately does NOT mock ``judge_goal`` itself (that would bypass
+    its real ``_truncate(goal, 2000)`` call and pass regardless of the bug)
+    — it mocks the LLM transport underneath so the real truncation runs and
+    the prompt actually sent to the model can be inspected.
+    """
+    from unittest.mock import patch
+
+    long_body = "Acceptance criteria:\n" + "\n".join(
+        f"- Bullet point {i} describing a specific requirement in detail."
+        for i in range(60)
+    )
+    assert len(long_body) > 1800  # confirm this body is realistically long
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path, body=long_body)
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        run_id = kb.get_task(conn, tid).current_run_id
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
+
+    captured = {}
+
+    class _FakeMsg:
+        content = ""
+
+    class _FakeChoice:
+        message = _FakeMsg()
+
+    class _FakeResp:
+        choices = [_FakeChoice()]
+
+    def _fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        prompt = next(
+            (m["content"] for m in kwargs.get("messages", []) if m["role"] == "user"), ""
+        )
+        note_present = "do not withhold DONE merely because" in prompt
+        _FakeMsg.content = json.dumps({
+            "done": note_present,
+            "reason": "implementation evidence present" if note_present
+            else "no reviewer approval evidence yet",
+        })
+        return _FakeResp()
+
+    with patch("agent.auxiliary_client.call_llm", side_effect=_fake_call_llm):
+        out = kt._handle_request_review({"summary": "Implemented X; ready for review."})
+
+    assert captured, "judge_goal never reached the LLM transport"
+    d = json.loads(out)
+    assert d.get("ok") is True, d
+
+
 def test_block_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_block({"reason": "need clarification"})
@@ -277,7 +340,7 @@ def test_block_happy_path(worker_env):
         conn.close()
 
 
-def _make_goal_mode_worker_env(monkeypatch, tmp_path):
+def _make_goal_mode_worker_env(monkeypatch, tmp_path, body="Must achieve X."):
     """Set up an isolated HERMES_HOME with one claimed goal_mode task,
     matching the pattern used by the kanban_complete judge gate tests."""
     from pathlib import Path as _Path
@@ -296,7 +359,7 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
     try:
         goal_task_id = kb.create_task(
             conn, title="goal-mode-block-test", assignee="test-worker",
-            body="Must achieve X.", goal_mode=True,
+            body=body, goal_mode=True,
         )
         kb.claim_task(conn, goal_task_id)
     finally:

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -215,6 +215,55 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
         conn2.close()
 
 
+def test_request_review_goal_mode_asks_judge_about_implementation_not_review(
+    monkeypatch, tmp_path
+):
+    """A goal-mode card whose acceptance criteria require same-card review
+    must not deadlock: judging kanban_request_review with the exact same
+    question as kanban_complete ("is the whole card, including review,
+    done?") can never pass on an implementer's summary alone, since review
+    hasn't happened yet — and can't until review is requested. The judge
+    call for a review handoff must instead ask whether the implementation is
+    ready to hand off, without requiring reviewer/approval evidence.
+    Regression for #98160."""
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        run_id = kb.get_task(conn, tid).current_run_id
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    # A judge that withholds DONE for missing reviewer evidence UNLESS the
+    # goal text itself says that's not required for this check — i.e. it
+    # reacts to the reframing, not to which tool called it.
+    def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
+        if "do not withhold DONE merely because" in goal:
+            return "done", "implementation evidence present", False, None, False
+        return "continue", "no reviewer approval evidence yet", False, None, False
+
+    monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
+
+    out = kt._handle_request_review({"summary": "Implemented X; ready for review."})
+    d = json.loads(out)
+    assert d.get("ok") is True, d
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "review"
+    finally:
+        conn.close()
+
+    # kanban_complete must remain gated by the unscoped question — this fix
+    # only reframes review handoffs, it doesn't weaken completion enforcement.
+    out2 = kt._handle_complete({"summary": "Implemented X."})
+    d2 = json.loads(out2)
+    assert "Goal completion rejected by judge" in d2.get("error", "")
+
+
 def test_block_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_block({"reason": "need clarification"})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -251,15 +251,37 @@ def _goal_judge_available() -> bool:
     return client is not None and bool(model)
 
 
-def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
+# Appended to the judge's goal text only for a review handoff. A goal-mode
+# card whose own acceptance criteria require same-card review can never
+# satisfy the full-goal judge from an implementer's summary alone — that
+# reviewer step hasn't happened yet, and can't until review is requested.
+# This note keeps the judge gate (vague/absent evidence is still rejected)
+# while scoping it to "is the implementation ready for review", not "has the
+# whole card (including review) been achieved" (#98160).
+_REVIEW_READINESS_NOTE = (
+    "\n\nJudging note: this checks whether the implementation work described "
+    "above is finished and ready to hand off to a reviewer — it does not "
+    "check whether the card as a whole is done. If the card's own criteria "
+    "call for a reviewer to approve or close out the work, treat that as a "
+    "later step outside this check: do not withhold DONE merely because "
+    "reviewer/approval evidence is absent."
+)
+
+
+def _goal_mode_handoff_rejection(
+    task, evidence: str, *, handoff: str = "complete"
+) -> Optional[str]:
     """Return a rejection reason when a goal-mode terminal handoff is premature."""
     if not task or not task.goal_mode or not _goal_judge_available():
         return None
+    goal = f"{task.title}\n\n{task.body or ''}".strip()
+    if handoff == "review":
+        goal = f"{goal}{_REVIEW_READINESS_NOTE}"
     verdict = "done"
     reason = ""
     try:
         verdict, reason, _, _, _ = judge_goal(
-            goal=f"{task.title}\n\n{task.body or ''}".strip(),
+            goal=goal,
             last_response=evidence.strip(),
         )
     except Exception as judge_exc:
@@ -937,7 +959,7 @@ def _handle_request_review(args: dict, **kw) -> str:
         kb, conn = _connect(board=board)
         try:
             task = kb.get_task(conn, tid)
-            rejection = _goal_mode_handoff_rejection(task, summary)
+            rejection = _goal_mode_handoff_rejection(task, summary, handoff="review")
             if rejection is not None:
                 return tool_error(
                     f"Goal review handoff rejected by judge: {rejection}. "

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -276,6 +276,12 @@ def _goal_mode_handoff_rejection(
         return None
     goal = f"{task.title}\n\n{task.body or ''}".strip()
     if handoff == "review":
+        # judge_goal truncates its goal argument to 2000 chars before sending
+        # it to the judge; reserve room here so a long title/body can't push
+        # the note itself past that limit and silently drop it (#98160).
+        budget = 2000 - len(_REVIEW_READINESS_NOTE)
+        if len(goal) > budget:
+            goal = goal[:budget]
         goal = f"{goal}{_REVIEW_READINESS_NOTE}"
     verdict = "done"
     reason = ""


### PR DESCRIPTION
## What does this PR do?

A goal-mode Kanban card whose own acceptance criteria require same-card
review can deadlock permanently. `kanban_request_review` and
`kanban_complete` both gate goal-mode handoffs on the identical question
put to the auxiliary judge: *"is the whole card (title + body) done,
given this evidence?"* For a card that requires reviewer sign-off before
being "done," that question can never pass from an implementer's summary
alone — the review hasn't happened yet, and it can't happen until
`kanban_request_review` succeeds. The result observed in the issue: the
judge rejects `kanban_request_review` for lacking reviewer-approval
evidence, and rejects `kanban_complete` for the same reason — the worker
can only block for a human, and a manual side-channel (creating a
separate read-only review card, completing it, then hand-closing the
original) is needed to escape.

This scopes the judge question asked at a **review** handoff to
"is the implementation ready to hand off to a reviewer," instructing it
not to withhold `DONE` merely because reviewer/approval evidence is
absent. `kanban_complete` is untouched and keeps asking the original,
unscoped question — a worker still cannot bypass real completion
evidence by routing through `kanban_request_review` first, since the
reviewer's own eventual `kanban_complete` still runs the full check.

**Follow-up fix from review:** the scoping note was originally appended
*after* `title + body`, and `judge_goal` truncates its `goal` argument to
2000 characters before it ever reaches the judge. For a card whose
title+body already runs long — routine, since `task.body` has an 8 KB
budget elsewhere in the codebase — the note (or its operative sentence)
was silently cut off, so `kanban_request_review` would still be judged
against the original unscoped question for exactly the moderately
detailed, explicit-review-required cards this PR targets. Fixed by
reserving a budget for the note (`2000 - len(note)` chars) and truncating
title+body to that budget *before* appending the note, in both duplicate
copies of the gate, so the full note always survives within
`judge_goal`'s own 2000-char limit.

## Related Issue

Fixes #98160

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/kanban_tools.py` — `_goal_mode_handoff_rejection` takes a
  `handoff` kwarg (`"complete"` default, `"review"` for
  `kanban_request_review`); when `"review"`, a note is appended to the
  goal text sent to the judge scoping the question to implementation
  readiness rather than full-card completion. Title+body is now
  truncated to a reserved budget first so the note itself can never be
  cut off by `judge_goal`'s 2000-char limit.
- `hermes_cli/kanban.py` — the CLI's independent copy of the same gate
  (used by `hermes kanban request-review` / `/kanban request-review`)
  gets the identical `handoff="review"` scoping and budget reservation,
  so the CLI path and the tool-call path stay consistent.
- `tests/tools/test_kanban_tools.py` — two regression tests:
  - a mock-judge test proving `kanban_request_review` succeeds on
    implementation-only evidence while `kanban_complete` remains gated
    exactly as before;
  - a test with a realistic long card body (>1800 chars title+body) that
    patches the LLM transport underneath the *real* `judge_goal` (not
    `judge_goal` itself, which would bypass its truncation and mask the
    bug) and asserts the review-scoping note is still present in the
    prompt actually sent to the model after truncation.

## How to Test

```
python -m pytest tests/tools/test_kanban_tools.py -q
python -m pytest tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_review_surfaces.py tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_goal_mode.py -q
```

Result: `34 passed` (kanban_tools alone). Combined run across all six
files above: `91 passed, 2 failed` — the 2 failures
(`ModuleNotFoundError: No module named 'fastapi'` and `'acp'`) are
pre-existing missing-dependency errors in this sandbox, unrelated to
this change; confirmed identical on unmodified `HEAD` before this
commit.

**Proof the new truncation-regression test fails without the fix:**
reverted `tools/kanban_tools.py` and `hermes_cli/kanban.py` to the prior
commit (test file kept as-is) and reran the new test alone:

```
FAILED tests/tools/test_kanban_tools.py::test_request_review_goal_mode_note_survives_long_body
AssertionError: {'error': 'Goal review handoff rejected by judge: no reviewer approval evidence yet. ...'}
```

Then restored the fix and reran — passes (`34 passed`, full suite green).

Also ran:
- `python -m ruff check tools/kanban_tools.py hermes_cli/kanban.py tests/tools/test_kanban_tools.py` → `All checks passed!`
- `python scripts/check-windows-footguns.py tools/kanban_tools.py hermes_cli/kanban.py tests/tools/test_kanban_tools.py` → `✓ No Windows footguns found (3 file(s) scanned).`
- `git diff --check` → clean

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (checked #95181, #97429, #46485, #86732 — none touch the goal-judge gate on `kanban_request_review`)
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes

## AI assistance disclosure

This PR was prepared by an autonomous Claude-based coding agent (Claude Code) operating against this repository, including the diagnosis, fix, and test. A human reviews and controls what merges.
