### PR TITLE
fix(models): resolve Ollama Cloud probe credentials through the auth-store seam

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4043,7 +4043,29 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         # safe source for the chat picker, including its empty/failure result.
         return _fetch_deepinfra_models(force_refresh=force_refresh) or []
     if normalized == "ollama-cloud":
-        live = fetch_ollama_cloud_models(force_refresh=force_refresh)
+        # Resolve the credential through the auth-store seam (registry env
+        # vars, preferring ~/.hermes/.env over the inherited process env,
+        # then the credential pool) instead of leaving the probe on
+        # fetch_ollama_cloud_models()'s bare os.environ fallback: desktop and
+        # service processes are launched from the GUI and inherit no shell
+        # exports, so a key the user logged in with never reached the live
+        # probe there and every stale refresh regressed the cache to the
+        # models.dev subset (#98243).
+        ollama_cloud_key = ""
+        ollama_cloud_base = ""
+        try:
+            from hermes_cli.auth import resolve_api_key_provider_credentials
+
+            creds = resolve_api_key_provider_credentials("ollama-cloud")
+            ollama_cloud_key = str(creds.get("api_key") or "").strip()
+            ollama_cloud_base = str(creds.get("base_url") or "").strip()
+        except Exception:
+            pass
+        live = fetch_ollama_cloud_models(
+            api_key=ollama_cloud_key or None,
+            base_url=ollama_cloud_base or None,
+            force_refresh=force_refresh,
+        )
         if live:
             return live
     if normalized in ("openai", "openai-api"):
@@ -6445,6 +6467,20 @@ def fetch_ollama_cloud_models(
     if live_models or mdev_models:
         seen: set[str] = set()
         merged: list[str] = []
+        if not live_models:
+            # An empty live probe (no resolvable credential, network outage)
+            # means models.dev is the only fresh source here — and it is a
+            # SUBSET of the live catalog. Letting it overwrite a previously
+            # fetched cache would silently drop every model models.dev hasn't
+            # synced yet, and the refreshed cached_at would then hide the
+            # loss from every picker for the next TTL window (#98243). Seed
+            # the merge with the stale entry so a failed probe can only ever
+            # ADD models.
+            stale_entry = _load_ollama_cloud_cache(ignore_ttl=True)
+            for m in (stale_entry or {}).get("models") or []:
+                if m and m not in seen:
+                    seen.add(m)
+                    merged.append(m)
         for m in live_models:
             if m and m not in seen:
                 seen.add(m)

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -347,3 +347,123 @@ class TestOllamaCloudSuffixStripping:
         assert _strip_ollama_cloud_suffix("qwen3-coder:480b-cloud") == "qwen3-coder:480b"
         assert _strip_ollama_cloud_suffix("nemotron-3-nano:30b") == "nemotron-3-nano:30b"
         assert _strip_ollama_cloud_suffix("") == ""
+
+
+# ── Credential Resolution & Cache Preservation (#98243) ──
+
+class TestOllamaCloudCredentialResolution:
+    """provider_model_ids must feed the live probe with the auth-store credential.
+
+    Desktop/service processes are launched from the GUI and inherit no shell
+    exports, so an OLLAMA_API_KEY the user logged in with (in ~/.hermes/.env
+    or the credential pool) never reached the probe when it only consulted
+    os.environ — the cache then regressed to the models.dev subset and the
+    picker dropped models the CLI still listed (#98243).
+    """
+
+    def test_provider_model_ids_passes_auth_store_key_to_probe(self, tmp_path, monkeypatch):
+        import os as _os
+
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        # The fake credential lives in the environment, matching how the
+        # auth-store seam surfaces a real key to the resolver.
+        monkeypatch.setenv("MOCK_AUTHSTORE_OLLAMA_KEY", "authstore-key")
+
+        def _fake_resolve(pid):
+            return {
+                "api_key": _os.environ["MOCK_AUTHSTORE_OLLAMA_KEY"],
+                "base_url": "https://ollama.com/v1",
+            }
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            side_effect=_fake_resolve,
+        ) as mock_resolve, \
+             patch("hermes_cli.models.fetch_api_models", return_value=["deepseek-v4-flash:0731"]) as mock_fetch, \
+             patch("agent.models_dev.fetch_models_dev", return_value={}):
+            result = provider_model_ids("ollama-cloud", force_refresh=True)
+
+        mock_resolve.assert_called_once_with("ollama-cloud")
+        assert mock_fetch.call_args.args[0] == "authstore-key"
+        assert "deepseek-v4-flash:0731" in result
+
+    def test_provider_model_ids_survives_auth_resolution_failure(self, tmp_path, monkeypatch):
+        """A failing auth resolution falls back to the env-key path, not an exception."""
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "env-key")
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            side_effect=Exception("auth store unreadable"),
+        ), \
+             patch("hermes_cli.models.fetch_api_models", return_value=["glm-5.3"]) as mock_fetch, \
+             patch("agent.models_dev.fetch_models_dev", return_value={}):
+            result = provider_model_ids("ollama-cloud", force_refresh=True)
+
+        assert mock_fetch.call_args.args[0] == "env-key"
+        assert "glm-5.3" in result
+
+
+class TestOllamaCloudFailedProbeCachePreservation:
+    """An empty live probe must not overwrite the cache with the models.dev subset."""
+
+    def test_failed_probe_keeps_cached_models(self, tmp_path, monkeypatch):
+        import json
+        import time as _time
+
+        from hermes_cli.models import fetch_ollama_cloud_models, _ollama_cloud_cache_path
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+
+        cache_path = _ollama_cloud_cache_path()
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps({
+            "models": ["deepseek-v4-flash:0731", "mistral-large-3:675b"],
+            "cached_at": _time.time() - 7200,
+        }))
+
+        mock_mdev = {"ollama-cloud": {"models": {"glm-5": {"tool_call": True}}}}
+        with patch("hermes_cli.models.fetch_api_models", return_value=[]), \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert "glm-5" in result
+        assert "deepseek-v4-flash:0731" in result
+        assert "mistral-large-3:675b" in result
+
+        saved = json.loads(cache_path.read_text())
+        assert "deepseek-v4-flash:0731" in saved["models"]
+        assert "mistral-large-3:675b" in saved["models"]
+
+    def test_successful_probe_still_replaces_cache(self, tmp_path, monkeypatch):
+        """A successful live probe remains authoritative: dropped models stay dropped."""
+        import json
+        import time as _time
+
+        from hermes_cli.models import fetch_ollama_cloud_models, _ollama_cloud_cache_path
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+
+        cache_path = _ollama_cloud_cache_path()
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps({
+            "models": ["retired-model"],
+            "cached_at": _time.time() - 7200,
+        }))
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.5:397b"]), \
+             patch("agent.models_dev.fetch_models_dev", return_value={}):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert result == ["qwen3.5:397b"]
+        assert "retired-model" not in result
+
+        saved = json.loads(cache_path.read_text())
+        assert saved["models"] == ["qwen3.5:397b"]


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop model picker dropping models that are present in the Ollama Cloud cache (#98243). The root cause is that the Ollama Cloud live `/v1/models` probe only consulted `os.environ['OLLAMA_API_KEY']`. Desktop/service processes are launched from the GUI and inherit no shell exports, so a key the user logged in with (saved in `~/.hermes/.env` or the credential pool) never reached the probe there. When the cache went stale, the fetch regressed to the models.dev subset and — worse — **overwrote** the complete cache with that subset and refreshed `cached_at`, hiding cached models (including the currently selected one, e.g. `deepseek-v4-flash:0731`) from the desktop picker while the CLI picker, running from the user's shell, still listed them.

Two changes:

1. `provider_model_ids('ollama-cloud')` now resolves `api_key`/`base_url` through `resolve_api_key_provider_credentials` (registry env vars — preferring `~/.hermes/.env` over the inherited process env — then the credential pool), the same seam the `nous` and `stepfun` branches in this function already use. The bare `os.environ` fallback inside `fetch_ollama_cloud_models` is preserved as the last resort.
2. `fetch_ollama_cloud_models` no longer lets an empty live probe overwrite a previously fetched cache with the models.dev subset: when the probe comes back empty, the stale entry (TTL-ignored) seeds the merge, so a failed probe can only ever add models. A successful live probe remains fully authoritative.

## Related Issue

Fixes #98243

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` — `provider_model_ids` ollama-cloud branch: resolve the probe credential via the auth-store seam instead of the process-env-only fallback.
- `hermes_cli/models.py` — `fetch_ollama_cloud_models`: seed the merge with the stale cache entry when the live probe is empty, so the models.dev subset can no longer silently replace a complete cached catalog.
- `tests/hermes_cli/test_ollama_cloud_provider.py` — regression tests: auth-store key reaches the probe; auth-resolution failure degrades to the env path; a failed probe preserves cached models (in the return value and on disk); a successful probe still replaces the cache.

## How to Test

1. `python -m pytest tests/hermes_cli/test_ollama_cloud_provider.py tests/hermes_cli/test_models.py tests/hermes_cli/test_cached_fetch_api_models.py tests/hermes_cli/test_configured_builtin_models.py tests/hermes_cli/test_model_cache_swr.py -q` — Observed result: 142 passed (27 + 102 + 13).
2. Simulate the desktop environment: with `OLLAMA_API_KEY` unset in the process env but a resolvable key in the auth store, `provider_model_ids('ollama-cloud')` should pass the resolved key to the live probe — covered by `test_provider_model_ids_passes_auth_store_key_to_probe`, should pass.
3. With no resolvable credential and a stale on-disk cache containing e.g. `deepseek-v4-flash:0731`, `fetch_ollama_cloud_models(force_refresh=True)` should keep that model in both its return value and the persisted cache — covered by `test_failed_probe_keeps_cached_models`, should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no skill changes in this PR.

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_ollama_cloud_provider.py -q
27 passed in 11.39s
```