### PR TITLE
fix(agent): recognize dingbat emoji as a natural response ending

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1775,10 +1775,18 @@ class AIAgent:
         if stripped.endswith('^'):
             return True
         last = stripped[-1]
+        # An emoji may carry a trailing variation selector (U+FE0E/U+FE0F);
+        # judge the base character so "✅️" is treated like "✅".
+        if ord(last) in (0xFE0E, 0xFE0F) and len(stripped) >= 2:
+            last = stripped[-2]
         if last in '.!?:)"\']}。！？：）】」』》^':
             return True
-        # Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.)
-        if ord(last) >= 0x1F300:
+        # Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.).
+        # The >= U+1F300 check alone misses the Miscellaneous Symbols and
+        # Dingbats blocks (U+2600–U+27BF), which include very common terminal
+        # emoji such as ✅ ✔ ☑ ❤ (#98255).
+        code = ord(last)
+        if code >= 0x1F300 or 0x2600 <= code <= 0x27BF:
             return True
         return False
 

--- a/tests/run_agent/test_natural_response_ending.py
+++ b/tests/run_agent/test_natural_response_ending.py
@@ -1,0 +1,34 @@
+"""_has_natural_response_ending must recognize common terminal emoji.
+
+The truncation heuristic (_should_treat_stop_as_truncated) treats a reply with
+no "natural ending" as a truncation signal and injects the output-limit
+continuation nudge. The emoji check only covered U+1F300+, missing the
+Miscellaneous Symbols and Dingbats blocks (U+2600–U+27BF) — so a completed reply
+ending in ✅ ✔ ☑ ❤ was falsely flagged as truncated and re-fired the nudge
+(#98255).
+"""
+import pytest
+
+from run_agent import AIAgent
+
+_ending = AIAgent._has_natural_response_ending
+
+
+@pytest.mark.parametrize("text", ["✅", "✔", "☑", "❤", "Looks good ✅", "Deployed ✅️"])
+def test_dingbat_emoji_endings_are_natural(text):
+    # U+2600–U+27BF sits below the U+1F300 block; the trailing variation
+    # selector on "✅️" must not defeat the check either.
+    assert _ending(text) is True
+
+
+@pytest.mark.parametrize("text", ["Done 🎉", "answer.", "really?", "yes：", "```"])
+def test_existing_natural_endings_unchanged(text):
+    assert _ending(text) is True
+
+
+@pytest.mark.parametrize("text", ["bare word", "no ending here", ""])
+def test_unpunctuated_endings_unchanged(text):
+    # The bare-word behavior is intentionally left unchanged — whether an
+    # unpunctuated reply should count as "finished" is a separate design
+    # question raised in #98255. This pins that this fix does not alter it.
+    assert _ending(text) is False


### PR DESCRIPTION
## What does this PR do?

`_has_natural_response_ending` treated a reply as unfinished unless it ended in
terminal punctuation or an emoji `>= U+1F300`. That range misses the
Miscellaneous Symbols and Dingbats blocks (U+2600–U+27BF) — including very
common terminal emoji like ✅ ✔ ☑ ❤ — so a completed reply ending in one was
misclassified as truncated, firing the output-length continuation nudge and
poisoning session history (#98255).

Fix: extend the emoji check to U+2600–U+27BF and ignore a trailing emoji
variation selector (U+FE0E/U+FE0F) so "✅️" is judged on its base character.

The bare-word / unpunctuated-ending behavior is **intentionally left unchanged** —
whether an unpunctuated reply should count as finished is a separate design
question raised in the issue (it guards real truncation detection), so it's out
of scope for this focused fix.

Credit to @Dayspace07 for the deterministic repro in #98255.

## Related Issue

Fixes #98255 (emoji half; the bare-word heuristic is left for maintainer decision)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` — `_has_natural_response_ending` recognizes U+2600–U+27BF and
  trailing variation selectors.
- `tests/run_agent/test_natural_response_ending.py` — emoji, existing-ending,
  and unchanged-bare-word tests.

## How to Test

    pytest tests/run_agent/test_natural_response_ending.py -q

14 pass. A reply ending in ✅/✔/☑/❤/✅️ is now a natural ending; punctuation and
U+1F300+ emoji are unchanged; bare-word endings are unchanged.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs / issues
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11