### PR TITLE
feat(skills): add telegram-topic-handoffs for nightly forum-topic context handoffs

### DIFF
--- a/skills/productivity/telegram-topic-handoffs/SKILL.md
+++ b/skills/productivity/telegram-topic-handoffs/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: telegram-topic-handoffs
+description: Post daily per-topic Telegram handoff summaries.
+version: 1.0.0
+author: Tina Marie (tmnsystems)
+license: MIT
+platforms:
+  - macos
+  - linux
+metadata:
+  hermes:
+    tags:
+      - telegram
+      - handoffs
+      - daily-summary
+      - sqlite
+      - automation
+---
+
+# telegram-topic-handoffs
+
+The `topic_handoffs.py` script reads recent Hermes conversation history from the state database, groups it by Telegram forum topic, and writes one Markdown handoff file per topic.
+When a bot token and chat id are configured, it also posts each handoff to its topic in the configured Telegram chat.
+The script is executed directly as a standalone program and is not an importable module API.
+
+> **PRIVACY WARNING:** Handoff files contain private conversation text. The output directory must never sit inside a cloud-synced folder.
+
+## When to Use
+
+Use this skill to generate daily per-topic handoff summaries from Hermes history and, optionally, deliver them to their Telegram forum topics.
+It remains useful on machines without Telegram credentials, because it runs in a deliberate file-only mode when no token is configured.
+
+## Prerequisites
+
+- Python 3; the script uses only the standard library.
+- Read access to the Hermes state database, which lives at `~/.hermes/state.db` by default.
+- A Telegram bot token and chat id when posting is desired; both are optional for file-only runs.
+
+## How to Run
+
+Invoke the helper script through the terminal tool, running it directly with Python:
+
+```bash
+python3 skills/productivity/telegram-topic-handoffs/scripts/topic_handoffs.py
+```
+
+To perform a dry run that writes the files without posting anything, set `DRY_RUN` in the environment.
+There is no `--dry-run` command line flag, so dry runs are controlled only through this variable:
+
+```bash
+DRY_RUN=1 python3 skills/productivity/telegram-topic-handoffs/scripts/topic_handoffs.py
+```
+
+## Quick Reference
+
+All configuration is read from environment variables at import time.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HANDOFF_CHAT_ID` | unset | Telegram chat, meaning the forum supergroup, that handoffs are posted to. |
+| `HANDOFF_DB` | `~/.hermes/state.db` | Path to the Hermes state database. |
+| `HANDOFF_OUT_DIR` | `~/.hermes/topic-handoffs` | Directory where per-topic handoff files are written. |
+| `HANDOFF_MIRROR_DIR` | unset | Optional second directory that receives a copy of each handoff file. |
+| `HANDOFF_PUBLIC_BASE_URL` | unset | Optional base URL used to build public links to the mirrored files. |
+| `HANDOFF_USER_LABEL` | `User` | Display label used for human messages. |
+| `HANDOFF_BOT_LABEL` | `Assistant` | Display label used for assistant messages. |
+| `HANDOFF_PREFIX` | `Daily handoff for` | Text placed before each topic name in handoff titles. |
+| `HANDOFF_TOPIC_NAMES` | unset | Optional path to a JSON file mapping topic identifiers to friendly topic names. |
+| `TELEGRAM_BOT_TOKEN` | unset | Bot token used to post to Telegram; `HANDOFF_BOT_TOKEN` is accepted as an alternative, and if neither is set the file at `HANDOFF_ENV_FILE` (default `~/.hermes/.env`) is checked for a token. |
+| `HANDOFF_API_BASE` | `https://api.telegram.org` | Overrides the Telegram Bot API base URL. |
+| `HANDOFF_RECENT_LIMIT` | `12` | Caps how many recent messages per topic are considered. |
+| `HANDOFF_POST_EXCERPTS` | `6` | Controls how many excerpt lines appear in each posted handoff. |
+| `HANDOFF_FILE_TRUNC` | `400` | Truncation length for individual messages in the written files. |
+| `HANDOFF_POST_TRUNC` | `250` | Truncation length for individual messages in the posted excerpts. |
+| `HANDOFF_MAX_POST_LEN` | `3800` | Caps the total length of a single Telegram post. |
+| `HANDOFF_DB_TIMEOUT` | `30` | SQLite connection timeout in seconds. |
+| `HANDOFF_SEND_DELAY` | `1.2` | Delay in seconds between Telegram sends. |
+| `HANDOFF_MAX_RETRIES` | `4` | How many times a failed send is retried. |
+| `HANDOFF_BACKOFF_BASE` | `2.0` | Base delay for exponential backoff between retries. |
+| `DRY_RUN` | unset | When truthy, writes the handoff files and skips posting to Telegram. |
+
+## Procedure
+
+1. Invoke the script through the terminal tool; it reads all configuration from environment variables at import time.
+2. It connects to the Hermes state database and groups recent history by Telegram forum topic.
+3. A redaction pass drops any line that looks like it contains a secret entirely; dropped lines are not replaced with any placeholder or marker text.
+4. One Markdown file per topic is written under a dated subdirectory at `HANDOFF_OUT_DIR/<YYYY-MM-DD>/<thread id>-<topic slug>.md`, plus a copy at `HANDOFF_OUT_DIR/latest/<thread id>.md`, and each file is titled `Handoff: <topic name> (topic <id>)`; when `HANDOFF_MIRROR_DIR` is set a copy is also written under `HANDOFF_MIRROR_DIR/<YYYY-MM-DD>/`, and when `HANDOFF_PUBLIC_BASE_URL` is set the public link for each mirrored file is reported.
+5. The bot token is resolved from `TELEGRAM_BOT_TOKEN`, `HANDOFF_BOT_TOKEN`, or the env file at `HANDOFF_ENV_FILE`; if none is available, every file is still written and the run finishes successfully in the deliberate file-only mode.
+6. When a token and chat id are configured, each handoff is posted to its topic, with sends spaced by `HANDOFF_SEND_DELAY` seconds and failures retried up to `HANDOFF_MAX_RETRIES` times with exponential backoff based on `HANDOFF_BACKOFF_BASE`.
+7. A run summary is printed at the end, and it reports how many lines the redaction pass omitted.
+
+## Pitfalls
+
+- If nothing is posted to Telegram, confirm a token is available through `TELEGRAM_BOT_TOKEN`, `HANDOFF_BOT_TOKEN`, or the env file at `HANDOFF_ENV_FILE`, and confirm `HANDOFF_CHAT_ID` is set; running without a token is the intentional file-only mode, not an error.
+- If expected content is missing from a handoff, it may have been dropped by the redaction pass, so check the omitted-line count in the run summary.
+- If the script exits with code 1, at least one topic failed; re-running after fixing the underlying database or network problem will regenerate that topic's handoff.
+
+## Verification
+
+- The script exits with code 0 when every topic is processed successfully, including dry runs and file-only runs, and with code 1 when any topic fails; check with `echo $?` in the terminal.
+- Confirm one Markdown file per topic exists at `HANDOFF_OUT_DIR/<YYYY-MM-DD>/<thread id>-<topic slug>.md` (with `HANDOFF_OUT_DIR` defaulting to `~/.hermes/topic-handoffs`), plus `HANDOFF_OUT_DIR/latest/<thread id>.md`, each titled `Handoff: <topic name> (topic <id>)`, and, when `HANDOFF_MIRROR_DIR` is set, that a copy exists under `HANDOFF_MIRROR_DIR/<YYYY-MM-DD>/`.
+- Confirm the printed run summary includes the count of lines omitted by the redaction pass.

--- a/skills/productivity/telegram-topic-handoffs/scripts/topic_handoffs.py
+++ b/skills/productivity/telegram-topic-handoffs/scripts/topic_handoffs.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Nightly Telegram forum-topic handoffs (generalized, config-by-environment).
+
+For every forum topic in a Telegram supergroup, this script reads the topic's
+real session history from the agent's state database (read-only), writes a
+markdown handoff file, and posts a visible handoff message into the topic so
+the agent (and its human) can pick up context after a restart.
+
+PRIVACY
+-------
+Handoff files contain private conversation text: verbatim excerpts of user
+and assistant messages stored in the local state database. Treat the output
+directory as sensitive data:
+
+- Files are written to local disk and accumulate forever (nothing is deleted).
+- If HANDOFF_MIRROR_DIR / HANDOFF_PUBLIC_BASE_URL are set, copies may be
+  served over a network reachable by anyone who can reach that host.
+- Posted excerpts are visible to every member of the Telegram group.
+
+A best-effort redaction pass drops lines matching common secret shapes (API
+key patterns, bearer tokens, private-key blocks, .env-style KEY=value lines)
+BEFORE anything is written to disk or posted. Redaction is a safety net, NOT
+a guarantee: review retention, file permissions, and group membership
+accordingly. Do not point HANDOFF_PUBLIC_BASE_URL at a host you do not
+control, and do not commit handoff output to a repository.
+
+Design rules:
+- Read-only access to the state database. This script never writes to it.
+- Handoff content comes only from real stored messages. Nothing is invented.
+- One bad topic never kills the run; failures are isolated and reported.
+
+Expected database schema (subset):
+    sessions(id, chat_id, thread_id, title, last_activity_at)
+    messages(session_id, role, content, timestamp)
+
+Configuration (environment variables; every value has a sensible default):
+    HANDOFF_CHAT_ID          Supergroup id (e.g. -100...). Empty = all chats.
+    HANDOFF_DB               Path to state.db            [~/.hermes/state.db]
+    HANDOFF_OUT_DIR          Handoff output dir          [~/.hermes/topic-handoffs]
+    HANDOFF_MIRROR_DIR       Optional second output dir (e.g. web-served copy)
+    HANDOFF_PUBLIC_BASE_URL  Optional public base URL for the mirror; posts
+                             link here, never to a local file path
+    HANDOFF_USER_LABEL       Label for user messages            [User]
+    HANDOFF_BOT_LABEL        Label for assistant messages       [Assistant]
+    HANDOFF_PREFIX           Prefix of handoff posts; also used to filter
+                             this script's own earlier posts    [Daily handoff for]
+    HANDOFF_TOPIC_NAMES      Path to a JSON object mapping thread ids to
+                             names; missing/invalid file falls back to
+                             'topic <id>'
+    TELEGRAM_BOT_TOKEN       Bot token (or HANDOFF_BOT_TOKEN, or via
+                             HANDOFF_ENV_FILE). No token = file-only mode.
+    HANDOFF_ENV_FILE         .env fallback for the token        [~/.hermes/.env]
+    HANDOFF_API_BASE         Telegram API base URL     [https://api.telegram.org]
+    HANDOFF_RECENT_LIMIT     Messages pulled per topic          [12]
+    HANDOFF_POST_EXCERPTS    Excerpt lines in the posted message [6]
+    HANDOFF_FILE_TRUNC       Per-message truncation in files    [400]
+    HANDOFF_POST_TRUNC       Per-message truncation in posts    [250]
+    HANDOFF_MAX_POST_LEN     Posted message length cap          [3800]
+    HANDOFF_DB_TIMEOUT       SQLite busy timeout, seconds       [30]
+    HANDOFF_SEND_DELAY       Pause between posts, seconds       [1.2]
+    HANDOFF_MAX_RETRIES      Send retries after first attempt   [4]
+    HANDOFF_BACKOFF_BASE     Backoff multiplier                 [2.0]
+    DRY_RUN                  If truthy, write files but skip posting
+
+Exit status: 0 on success; 1 if any topic failed or a fatal error occurred.
+"""
+
+import datetime
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+# --------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------
+
+def _env(name, default=''):
+    value = os.environ.get(name)
+    return value if value not in (None, '') else default
+
+
+def _env_int(name, default):
+    try:
+        return int(os.environ.get(name, '') or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name, default):
+    try:
+        return float(os.environ.get(name, '') or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_flag(name):
+    return (os.environ.get(name) or '').strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+CHAT_ID = _env('HANDOFF_CHAT_ID')
+DB_PATH = os.path.expanduser(_env('HANDOFF_DB', '~/.hermes/state.db'))
+OUT_DIR = os.path.expanduser(_env('HANDOFF_OUT_DIR', '~/.hermes/topic-handoffs'))
+MIRROR_DIR = _env('HANDOFF_MIRROR_DIR')
+if MIRROR_DIR:
+    MIRROR_DIR = os.path.expanduser(MIRROR_DIR)
+PUBLIC_BASE_URL = _env('HANDOFF_PUBLIC_BASE_URL').rstrip('/')
+USER_LABEL = _env('HANDOFF_USER_LABEL', 'User')
+BOT_LABEL = _env('HANDOFF_BOT_LABEL', 'Assistant')
+HANDOFF_PREFIX = _env('HANDOFF_PREFIX', 'Daily handoff for')
+TOPIC_NAMES_PATH = _env('HANDOFF_TOPIC_NAMES')
+if TOPIC_NAMES_PATH:
+    TOPIC_NAMES_PATH = os.path.expanduser(TOPIC_NAMES_PATH)
+API_BASE = _env('HANDOFF_API_BASE', 'https://api.telegram.org').rstrip('/')
+ENV_FILE = os.path.expanduser(_env('HANDOFF_ENV_FILE', '~/.hermes/.env'))
+
+RECENT_LIMIT = _env_int('HANDOFF_RECENT_LIMIT', 12)
+POST_EXCERPTS = _env_int('HANDOFF_POST_EXCERPTS', 6)
+FILE_TRUNC = _env_int('HANDOFF_FILE_TRUNC', 400)
+POST_TRUNC = _env_int('HANDOFF_POST_TRUNC', 250)
+MAX_POST_LEN = _env_int('HANDOFF_MAX_POST_LEN', 3800)
+DB_TIMEOUT = _env_float('HANDOFF_DB_TIMEOUT', 30)
+SEND_DELAY = _env_float('HANDOFF_SEND_DELAY', 1.2)
+MAX_RETRIES = _env_int('HANDOFF_MAX_RETRIES', 4)
+BACKOFF_BASE = _env_float('HANDOFF_BACKOFF_BASE', 2.0)
+DRY_RUN = _env_flag('DRY_RUN')
+
+
+# --------------------------------------------------------------------------
+# Secret redaction
+# --------------------------------------------------------------------------
+
+# Lines matching any of these patterns are dropped before files are written
+# or messages are posted. This is best-effort defense in depth, not a
+# substitute for keeping secrets out of conversation history.
+PEM_BEGIN = re.compile(r'-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----')
+PEM_END = re.compile(r'-----END [A-Z0-9 ]*PRIVATE KEY-----')
+
+SECRET_PATTERNS = [
+    # Bearer tokens (Authorization-style)
+    re.compile(r'(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}'),
+    # OpenAI / Anthropic style keys
+    re.compile(r'\bsk-(?:ant-)?[A-Za-z0-9_-]{16,}\b'),
+    # GitHub tokens (old and fine-grained formats)
+    re.compile(r'\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b'),
+    re.compile(r'\bgithub_pat_[A-Za-z0-9_]{20,}\b'),
+    # Slack tokens
+    re.compile(r'\bxox[baprs]-[A-Za-z0-9-]{10,}\b'),
+    # AWS access key id
+    re.compile(r'\bAKIA[0-9A-Z]{16}\b'),
+    # Google API key
+    re.compile(r'\bAIza[0-9A-Za-z_-]{35}\b'),
+    # Telegram bot token (123456789:AA...)
+    re.compile(r'\b\d{8,10}:[A-Za-z0-9_-]{30,}\b'),
+    # JSON Web Tokens (three base64url segments, header starts with eyJ)
+    re.compile(r'\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b'),
+    # .env-style KEY=value lines (whole line, optionally quoted/exported)
+    re.compile(r"^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=\s*"
+               r"(\"[^\"]*\"|'[^']*'|\S{6,})\s*$"),
+    # Named secrets anywhere in a line: "password: ...", "api_key = ...", etc.
+    re.compile(r'(?i)\b(?:password|passwd|secret|api[ _-]?key|access[ _-]?token|'
+               r'auth[ _-]?token|client[ _-]?secret)\b\s*[:=]\s*\S+'),
+]
+
+
+def redact(text):
+    """Drop lines that match common secret shapes.
+
+    Returns (clean_text, dropped_count). A PEM private-key block drops every
+    line from BEGIN through END inclusive. Unterminated blocks drop through
+    the end of the text.
+    """
+    kept = []
+    dropped = 0
+    in_private_key = False
+    for line in text.splitlines():
+        if in_private_key:
+            dropped += 1
+            if PEM_END.search(line):
+                in_private_key = False
+            continue
+        if PEM_BEGIN.search(line):
+            in_private_key = True
+            dropped += 1
+            continue
+        if any(pattern.search(line) for pattern in SECRET_PATTERNS):
+            dropped += 1
+            continue
+        kept.append(line)
+    return '\n'.join(kept), dropped
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+def load_bot_token():
+    """Token from the environment, then HANDOFF_ENV_FILE. '' = file-only mode."""
+    token = os.environ.get('TELEGRAM_BOT_TOKEN') or os.environ.get('HANDOFF_BOT_TOKEN') or ''
+    if token:
+        return token.strip()
+    if os.path.exists(ENV_FILE):
+        try:
+            with open(ENV_FILE, encoding='utf-8') as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line or line.startswith('#') or '=' not in line:
+                        continue
+                    key, value = line.split('=', 1)
+                    if key.strip() in ('TELEGRAM_BOT_TOKEN', 'HANDOFF_BOT_TOKEN'):
+                        return value.strip().strip('"').strip("'")
+        except OSError:
+            pass
+    return ''
+
+
+def load_topic_names(path):
+    """Optional JSON mapping of thread id -> display name. Always degrades."""
+    if not path:
+        return {}
+    try:
+        with open(path, encoding='utf-8') as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return {str(k): str(v) for k, v in data.items()}
+        print(f'NOTE: topic names file {path} is not a JSON object; '
+              f'falling back to "topic <id>"')
+    except (OSError, ValueError) as e:
+        print(f'NOTE: could not load topic names from {path}: {e}; '
+              f'falling back to "topic <id>"')
+    return {}
+
+
+def truncate_words(text, limit):
+    """Collapse whitespace, then truncate on a word boundary with an ellipsis."""
+    text = re.sub(r'\s+', ' ', text or '').strip()
+    if len(text) <= limit:
+        return text
+    cut = text[:limit].rsplit(' ', 1)[0]
+    return (cut if cut else text[:limit]) + '...'
+
+
+def slugify(name):
+    slug = re.sub(r'[^a-z0-9]+', '-', name.lower()).strip('-')
+    return slug[:40] or 'topic'
+
+
+def send_message(token, chat_id, thread_id, text):
+    """Send one message, retrying transient failures with exponential backoff.
+
+    HTTP 429 responses honor Telegram's retry_after parameter. Raises
+    RuntimeError when the send cannot be completed.
+    """
+    url = f'{API_BASE}/bot{token}/sendMessage'
+    chat = str(chat_id)
+    payload = {
+        'chat_id': int(chat) if re.fullmatch(r'-?\d+', chat) else chat,
+        'message_thread_id': int(thread_id),
+        'text': text,
+    }
+    data = json.dumps(payload).encode('utf-8')
+    delay = 1.0
+    last_error = 'unknown error'
+    for attempt in range(MAX_RETRIES + 1):
+        req = urllib.request.Request(
+            url, data=data, headers={'Content-Type': 'application/json'})
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                result = json.load(resp)
+            if result.get('ok'):
+                return
+            last_error = f"telegram not-ok: {result.get('description', 'no description')}"
+            retry_after = (result.get('parameters') or {}).get('retry_after')
+            if retry_after is None:
+                raise RuntimeError(last_error)  # non-retryable API rejection
+            wait = max(float(retry_after), delay)
+        except urllib.error.HTTPError as e:
+            description = ''
+            retry_after = None
+            try:
+                err_body = json.loads(e.read() or b'{}')
+                description = err_body.get('description', '')
+                retry_after = (err_body.get('parameters') or {}).get('retry_after')
+            except (ValueError, UnicodeDecodeError, AttributeError):
+                pass
+            last_error = f'HTTP {e.code}: {description or e.reason}'
+            if e.code == 429:
+                wait = max(float(retry_after or 0), delay)
+            elif 500 <= e.code < 600:
+                wait = delay
+            else:
+                raise RuntimeError(last_error)  # 4xx other than 429: do not retry
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
+            last_error = f'network error: {e}'
+            wait = delay
+        if attempt >= MAX_RETRIES:
+            break
+        time.sleep(wait)
+        delay *= BACKOFF_BASE
+    raise RuntimeError(f'giving up after {MAX_RETRIES + 1} attempt(s): {last_error}')
+
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+
+def main():
+    today = datetime.date.today().isoformat()
+    day_dir = os.path.join(OUT_DIR, today)
+    latest_dir = os.path.join(OUT_DIR, 'latest')
+    os.makedirs(day_dir, exist_ok=True)
+    os.makedirs(latest_dir, exist_ok=True)
+    mirror_day_dir = ''
+    if MIRROR_DIR:
+        mirror_day_dir = os.path.join(MIRROR_DIR, today)
+        os.makedirs(mirror_day_dir, exist_ok=True)
+
+    token = load_bot_token()
+    names = load_topic_names(TOPIC_NAMES_PATH)
+
+    # Read-only connection with an explicit busy timeout. Never writes.
+    uri = 'file:' + urllib.request.pathname2url(DB_PATH) + '?mode=ro'
+    con = sqlite3.connect(uri, uri=True, timeout=DB_TIMEOUT)
+    cur = con.cursor()
+    cur.execute(f'PRAGMA busy_timeout = {int(DB_TIMEOUT * 1000)}')
+    journal = cur.execute('PRAGMA journal_mode').fetchone()[0]
+    if str(journal).lower() != 'wal':
+        print(f'NOTE: database journal_mode is {journal}, expected wal')
+
+    if CHAT_ID:
+        threads = cur.execute(
+            'SELECT DISTINCT chat_id, thread_id FROM sessions '
+            'WHERE chat_id=? AND thread_id IS NOT NULL', (CHAT_ID,)).fetchall()
+    else:
+        threads = cur.execute(
+            'SELECT DISTINCT chat_id, thread_id FROM sessions '
+            'WHERE thread_id IS NOT NULL').fetchall()
+    if not threads:
+        print('NOTE: no forum topics found in the database')
+
+    posted, failed, skipped = [], [], []
+    extracted = 0
+    redacted_total = 0
+
+    for chat_id, tid in threads:
+        name = names.get(str(tid), f'topic {tid}')
+        # Per-topic error isolation: one bad row must not kill the run.
+        try:
+            if chat_id is not None:
+                sessions = cur.execute(
+                    'SELECT id, title, last_activity_at FROM sessions '
+                    'WHERE chat_id=? AND thread_id=? '
+                    'ORDER BY last_activity_at DESC', (chat_id, tid)).fetchall()
+            else:
+                sessions = cur.execute(
+                    'SELECT id, title, last_activity_at FROM sessions '
+                    'WHERE thread_id=? '
+                    'ORDER BY last_activity_at DESC', (tid,)).fetchall()
+            if not sessions:
+                continue
+            sess_id, title, last_act = sessions[0]
+            try:
+                last_date = (datetime.datetime.fromtimestamp(last_act)
+                             .strftime('%Y-%m-%d %H:%M')) if last_act else 'unknown'
+            except (OverflowError, OSError, ValueError):
+                last_date = 'unknown'
+
+            msgs = cur.execute(
+                'SELECT role, content FROM messages WHERE session_id=? '
+                "AND role IN ('user','assistant') "
+                "AND content IS NOT NULL AND content != '' "
+                'ORDER BY timestamp DESC LIMIT ?', (sess_id, RECENT_LIMIT)).fetchall()
+            msgs.reverse()
+            # Self-post filtering: never quote this script's earlier handoffs.
+            if HANDOFF_PREFIX:
+                msgs = [(r, c) for r, c in msgs
+                        if not (c or '').lstrip().startswith(HANDOFF_PREFIX)]
+
+            lines = [
+                f'# Handoff: {name} (topic {tid})',
+                f'Date: {today}',
+                '',
+                f"Sessions in this topic: {len(sessions)}. "
+                f"Latest session title: {title or 'untitled'}.",
+                f'Latest activity: {last_date}.',
+                '',
+                '## Recent conversation, in order, real stored words:',
+            ]
+            for role, content in msgs:
+                text = truncate_words(content, FILE_TRUNC)
+                if not text:
+                    continue
+                who = USER_LABEL if role == 'user' else BOT_LABEL
+                lines.append(f'- {who}: {text}')
+            if not msgs:
+                lines.append('- No recent messages in the latest session.')
+
+            # Redaction pass runs BEFORE anything is written to disk.
+            body, dropped = redact('\n'.join(lines))
+            redacted_total += dropped
+            if dropped:
+                body += f'\n\n_Note: {dropped} line(s) omitted by the ' \
+                        f'secret-redaction pass._'
+
+            stem = str(tid) if CHAT_ID else f'{chat_id}-{tid}'
+            slug = slugify(name)
+            with open(os.path.join(day_dir, f'{stem}-{slug}.md'), 'w',
+                      encoding='utf-8') as fh:
+                fh.write(body + '\n')
+            with open(os.path.join(latest_dir, f'{stem}.md'), 'w',
+                      encoding='utf-8') as fh:
+                fh.write(body + '\n')
+            if mirror_day_dir:
+                with open(os.path.join(mirror_day_dir, f'{stem}.md'), 'w',
+                          encoding='utf-8') as fh:
+                    fh.write(body + '\n')
+            extracted += 1
+
+            if DRY_RUN:
+                skipped.append((str(tid), name, 'dry run'))
+                continue
+            if not token:
+                # File-only mode is a deliberate configuration, not a failure.
+                skipped.append((str(tid), name, 'file-only mode: no bot token'))
+                continue
+            if chat_id in (None, ''):
+                skipped.append((str(tid), name, 'file-only mode: no chat id'))
+                continue
+
+            excerpt_lines = []
+            for role, content in msgs[-POST_EXCERPTS:]:
+                text = truncate_words(content, POST_TRUNC)
+                if text:
+                    who = USER_LABEL if role == 'user' else BOT_LABEL
+                    excerpt_lines.append(f'{who}: {text}')
+
+            header = (f'{HANDOFF_PREFIX} {name} ({today}).\n'
+                      f'Sessions so far: {len(sessions)}. '
+                      f'Last activity: {last_date}.')
+            # Only ever post a public URL, never a local file path.
+            footer = (f'Full handoff: {PUBLIC_BASE_URL}/{today}/{stem}.md'
+                      if PUBLIC_BASE_URL else '')
+
+            while True:
+                parts = [header]
+                if excerpt_lines:
+                    parts.append('Recent words from this topic:\n'
+                                 + '\n'.join(excerpt_lines))
+                if footer:
+                    parts.append(footer)
+                post = '\n\n'.join(parts)
+                if len(post) <= MAX_POST_LEN or not excerpt_lines:
+                    break
+                excerpt_lines.pop(0)  # drop oldest excerpt until it fits
+
+            # Redaction pass runs BEFORE anything is posted.
+            post, dropped = redact(post)
+            redacted_total += dropped
+            if dropped:
+                post += f'\n({dropped} line(s) omitted by the ' \
+                        f'secret-redaction pass.)'
+            if len(post) > MAX_POST_LEN:
+                post = post[:MAX_POST_LEN]
+
+            send_message(token, chat_id, tid, post)
+            posted.append((str(tid), name, 'posted'))
+            time.sleep(SEND_DELAY)
+        except Exception as e:
+            failed.append((str(tid), name, f'error: {e}'))
+
+    con.close()
+
+    if DRY_RUN:
+        print(f'DRY RUN: {extracted} topic(s) extracted and filed, posting skipped')
+    else:
+        print(f'POSTED: {len(posted)} of {extracted} topic(s)')
+    if skipped and not DRY_RUN:
+        print(f'SKIPPED: {len(skipped)}')
+        for tid, name, why in skipped:
+            print(f'- topic {tid} {name}: {why}')
+    if redacted_total:
+        print(f'REDACTED: {redacted_total} line(s) omitted as possible secrets')
+    locations = f'{day_dir} and {latest_dir}'
+    if mirror_day_dir:
+        locations += f' and {mirror_day_dir}'
+    print(f'Files written under {locations}')
+    if failed:
+        print(f'FAILURES: {len(failed)}')
+        for tid, name, status in failed:
+            print(f'- topic {tid} {name}: {status}')
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except sqlite3.OperationalError as e:
+        print(f'DATABASE UNAVAILABLE: {e}', file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print('INTERRUPTED', file=sys.stderr)
+        sys.exit(130)
+    except Exception as e:
+        print(f'TOPIC HANDOFF RUN FAILED: {e}', file=sys.stderr)
+        sys.exit(1)

--- a/tests/skills/test_topic_handoffs_skill.py
+++ b/tests/skills/test_topic_handoffs_skill.py
@@ -1,0 +1,355 @@
+"""Tests for the shipped topic_handoffs.py script.
+
+These tests drive the REAL script exactly as shipped:
+
+- Configuration is read from environment variables at import time, so every
+  test reloads the module via importlib.util.spec_from_file_location /
+  module_from_spec AFTER monkeypatching the environment.
+- There is no run() function; tests call main() and check its integer return
+  value (0 = success, 1 = at least one topic failed).
+- Files land in OUT_DIR/<date>/<tid>-<slug>.md and OUT_DIR/latest/<tid>.md
+  (HANDOFF_CHAT_ID is set in every test, so the stem is just the thread id).
+- redact(text) returns a (clean_text, dropped_count) tuple.
+- The send path is send_message(...) -> urllib.request.urlopen; tests mock
+  urllib.request.urlopen so no live network is ever touched.
+- The fixture database uses the real schema:
+      sessions(id, chat_id, thread_id, title, last_activity_at)  -- unix ts int
+      messages(session_id, role, content, timestamp)
+  and is opened by the script read-only via a file: URI.
+"""
+
+import datetime
+import importlib.util
+import json
+import os
+import sqlite3
+import urllib.request
+from pathlib import Path
+from unittest import mock
+
+CHAT_ID = -100123
+BASE_TS = 1_700_000_000  # fixed, valid unix timestamp for last_activity_at
+
+
+# --------------------------------------------------------------------------
+# Fixtures / helpers
+# --------------------------------------------------------------------------
+
+def _find_script() -> Path:
+    """Locate the topic_handoffs.py helper script.
+
+    In the repo layout the test file lives at
+    <repo>/tests/skills/test_topic_handoffs_skill.py and the script lives at
+    <repo>/skills/productivity/telegram-topic-handoffs/scripts/topic_handoffs.py,
+    so the repo root is Path(__file__).resolve().parents[2]. If the expected
+    path does not exist, fall back to an rglob of the repo root before giving
+    up with a clear FileNotFoundError.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    expected = (
+        repo_root
+        / "skills"
+        / "productivity"
+        / "telegram-topic-handoffs"
+        / "scripts"
+        / "topic_handoffs.py"
+    )
+    if expected.is_file():
+        return expected
+
+    candidates = sorted(repo_root.rglob("topic_handoffs.py"))
+    if candidates:
+        preferred = [p for p in candidates if "telegram-topic-handoffs" in p.parts]
+        return preferred[0] if preferred else candidates[0]
+
+    raise FileNotFoundError(
+        "Could not locate topic_handoffs.py. Expected it at "
+        f"{expected}, and an rglob of the repo root ({repo_root}) found no "
+        "file named topic_handoffs.py. Confirm that the telegram-topic-handoffs "
+        "skill is checked out under skills/productivity/."
+    )
+
+
+SCRIPT_PATH = _find_script()
+
+
+def load_module(monkeypatch, env):
+    """Re-import topic_handoffs fresh with a fully controlled environment.
+
+    The shipped script reads ALL of its configuration at import time, so the
+    environment must be monkeypatched before exec_module runs.
+    """
+    for key in list(os.environ):
+        if key.startswith('HANDOFF_') or key in ('TELEGRAM_BOT_TOKEN', 'DRY_RUN'):
+            monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    spec = importlib.util.spec_from_file_location('topic_handoffs', SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def base_env(tmp_path, **overrides):
+    """Environment shared by all tests; tests override what they exercise."""
+    env = {
+        'HANDOFF_CHAT_ID': str(CHAT_ID),
+        'HANDOFF_DB': str(tmp_path / 'state.db'),
+        'HANDOFF_OUT_DIR': str(tmp_path / 'out'),
+        # Point the .env fallback at a file that does not exist so no real
+        # token can leak in from ~/.hermes/.env on the host.
+        'HANDOFF_ENV_FILE': str(tmp_path / 'does-not-exist.env'),
+        'HANDOFF_SEND_DELAY': '0',  # keep the post-send pause out of tests
+    }
+    env.update(overrides)
+    return env
+
+
+def seed_db(db_path, sessions, messages):
+    """Create the real schema the script queries, then close cleanly.
+
+    sessions:  (id, chat_id, thread_id, title, last_activity_at)
+    messages:  (session_id, role, content, timestamp)
+    """
+    con = sqlite3.connect(str(db_path))
+    con.execute(
+        'CREATE TABLE sessions ('
+        'id INTEGER PRIMARY KEY, chat_id INTEGER, thread_id INTEGER, '
+        'title TEXT, last_activity_at INTEGER)')
+    con.execute(
+        'CREATE TABLE messages ('
+        'id INTEGER PRIMARY KEY, session_id INTEGER, role TEXT, '
+        'content TEXT, timestamp INTEGER)')
+    con.executemany(
+        'INSERT INTO sessions (id, chat_id, thread_id, title, last_activity_at) '
+        'VALUES (?, ?, ?, ?, ?)', sessions)
+    con.executemany(
+        'INSERT INTO messages (session_id, role, content, timestamp) '
+        'VALUES (?, ?, ?, ?)', messages)
+    con.commit()
+    con.close()
+
+
+def day_dir(tmp_path):
+    return tmp_path / 'out' / datetime.date.today().isoformat()
+
+
+def latest_dir(tmp_path):
+    return tmp_path / 'out' / 'latest'
+
+
+# --------------------------------------------------------------------------
+# 1. Handoff files are created
+# --------------------------------------------------------------------------
+
+def test_handoff_files_are_created(tmp_path, monkeypatch):
+    seed_db(
+        tmp_path / 'state.db',
+        sessions=[(1, CHAT_ID, 42, 'release planning', BASE_TS)],
+        messages=[
+            (1, 'user', 'when is the release cut?', BASE_TS + 100),
+            (1, 'assistant', 'the release cut is on friday', BASE_TS + 200),
+        ],
+    )
+    names_file = tmp_path / 'names.json'
+    names_file.write_text(json.dumps({'42': 'release planning'}),
+                          encoding='utf-8')
+    mod = load_module(monkeypatch, base_env(
+        tmp_path, DRY_RUN='1', HANDOFF_TOPIC_NAMES=str(names_file)))
+
+    rc = mod.main()
+
+    assert rc == 0
+    # Real layout: OUT_DIR/<date>/<tid>-<slug>.md and OUT_DIR/latest/<tid>.md
+    day_file = day_dir(tmp_path) / '42-release-planning.md'
+    latest_file = latest_dir(tmp_path) / '42.md'
+    assert day_file.is_file()
+    assert latest_file.is_file()
+    body = day_file.read_text(encoding='utf-8')
+    assert '# Handoff: release planning (topic 42)' in body
+    assert '- User: when is the release cut?' in body
+    assert '- Assistant: the release cut is on friday' in body
+    # latest/ holds the identical body
+    assert latest_file.read_text(encoding='utf-8') == body
+
+
+# --------------------------------------------------------------------------
+# 2. Dry run makes no network call
+# --------------------------------------------------------------------------
+
+def test_dry_run_makes_no_network_call(tmp_path, monkeypatch, capsys):
+    seed_db(
+        tmp_path / 'state.db',
+        sessions=[(1, CHAT_ID, 7, 'infra', BASE_TS)],
+        messages=[(1, 'user', 'hello world', BASE_TS + 100)],
+    )
+    # A token IS present; DRY_RUN must still skip the send path entirely.
+    mod = load_module(monkeypatch, base_env(
+        tmp_path, DRY_RUN='1',
+        TELEGRAM_BOT_TOKEN='fake-bot-token-for-tests'))
+
+    with mock.patch.object(urllib.request, 'urlopen') as urlopen_mock:
+        rc = mod.main()
+
+    assert rc == 0
+    assert urlopen_mock.call_count == 0
+    assert 'DRY RUN' in capsys.readouterr().out
+    # Dry run still writes files (name falls back to "topic <tid>").
+    assert (day_dir(tmp_path) / '7-topic-7.md').is_file()
+    assert (latest_dir(tmp_path) / '7.md').is_file()
+
+
+# --------------------------------------------------------------------------
+# 3. Secret lines are redacted from output files
+# --------------------------------------------------------------------------
+
+def test_secret_lines_are_redacted_from_output_files(tmp_path, monkeypatch):
+    seed_db(
+        tmp_path / 'state.db',
+        sessions=[(1, CHAT_ID, 5, 'ops chat', BASE_TS)],
+        messages=[
+            (1, 'user', 'totally benign status update', BASE_TS + 100),
+            (1, 'user',
+             'my api_key = sk-ant-aaaabbbbccccdddd1234 do not share',
+             BASE_TS + 200),
+        ],
+    )
+    mod = load_module(monkeypatch, base_env(tmp_path, DRY_RUN='1'))
+
+    # Unit-level contract: redact returns a (clean_text, dropped_count) tuple.
+    result = mod.redact('keep me\npassword: hunter2\nkeep me too')
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    clean, dropped = result
+    assert dropped == 1
+    assert clean == 'keep me\nkeep me too'
+
+    rc = mod.main()
+
+    assert rc == 0
+    body = (day_dir(tmp_path) / '5-topic-5.md').read_text(encoding='utf-8')
+    assert 'totally benign status update' in body
+    # The entire line carrying the secret is dropped before it hits disk.
+    assert 'sk-ant' not in body
+    assert 'api_key' not in body
+    # ...and the script appends its redaction note to the file.
+    assert '1 line(s) omitted by the secret-redaction pass' in body
+
+
+# --------------------------------------------------------------------------
+# 4. Messages starting with the handoff prefix are filtered out
+# --------------------------------------------------------------------------
+
+def test_handoff_prefix_messages_are_filtered_out(tmp_path, monkeypatch):
+    seed_db(
+        tmp_path / 'state.db',
+        sessions=[(1, CHAT_ID, 9, 'echo check', BASE_TS)],
+        messages=[
+            # This script's own earlier post: must never be quoted back.
+            (1, 'assistant',
+             'Daily handoff for echo check (yesterday). ECHO-MARKER-123',
+             BASE_TS + 100),
+            # Leading whitespace must not defeat the lstrip()+startswith filter.
+            (1, 'assistant',
+             '   Daily handoff for echo check. ECHO-MARKER-WS',
+             BASE_TS + 150),
+            (1, 'user', 'REAL-QUESTION-456 what shipped?', BASE_TS + 200),
+            (1, 'assistant', 'REAL-ANSWER-789 the parser shipped',
+             BASE_TS + 300),
+        ],
+    )
+    mod = load_module(monkeypatch, base_env(
+        tmp_path, DRY_RUN='1', HANDOFF_PREFIX='Daily handoff for'))
+
+    rc = mod.main()
+
+    assert rc == 0
+    body = (day_dir(tmp_path) / '9-topic-9.md').read_text(encoding='utf-8')
+    assert 'ECHO-MARKER-123' not in body
+    assert 'ECHO-MARKER-WS' not in body
+    assert 'Daily handoff for' not in body
+    assert 'REAL-QUESTION-456' in body
+    assert 'REAL-ANSWER-789' in body
+
+
+# --------------------------------------------------------------------------
+# 5. One malformed topic does not stop the others
+# --------------------------------------------------------------------------
+
+def test_malformed_topic_does_not_stop_other_topics(tmp_path, monkeypatch,
+                                                    capsys):
+    # Topic 2 is malformed: last_activity_at is TEXT, so the script's
+    # datetime.datetime.fromtimestamp(last_act) raises TypeError, which is
+    # caught by the per-topic isolation handler (the inner try only catches
+    # OverflowError/OSError/ValueError).
+    seed_db(
+        tmp_path / 'state.db',
+        sessions=[
+            (1, CHAT_ID, 1, 'good topic', BASE_TS),
+            (2, CHAT_ID, 2, 'bad topic', 'not-a-timestamp'),
+        ],
+        messages=[
+            (1, 'user', 'good topic message', BASE_TS + 100),
+            (2, 'user', 'bad topic message', BASE_TS + 100),
+        ],
+    )
+    mod = load_module(monkeypatch, base_env(tmp_path, DRY_RUN='1'))
+
+    rc = mod.main()
+
+    # main() returns 1 when any topic failed...
+    assert rc == 1
+    # ...but the healthy topic was still extracted and filed.
+    good_file = day_dir(tmp_path) / '1-topic-1.md'
+    assert good_file.is_file()
+    assert 'good topic message' in good_file.read_text(encoding='utf-8')
+    # The malformed topic wrote nothing (it failed before the file writes).
+    assert not (day_dir(tmp_path) / '2-topic-2.md').exists()
+    out = capsys.readouterr().out
+    assert 'FAILURES: 1' in out
+    assert '- topic 2 topic 2: error:' in out
+
+
+# --------------------------------------------------------------------------
+# 6. Live mode posts through the mocked transport
+# --------------------------------------------------------------------------
+
+def test_live_mode_posts_through_mocked_transport(tmp_path, monkeypatch):
+    token = 'fake-bot-token-for-tests'
+    seed_db(
+        tmp_path / 'state.db',
+        sessions=[(1, CHAT_ID, 42, 'live topic', BASE_TS)],
+        messages=[
+            (1, 'user', 'live excerpt question', BASE_TS + 100),
+            (1, 'assistant', 'live excerpt answer', BASE_TS + 200),
+        ],
+    )
+    # No DRY_RUN: live mode. send_message() will call urllib.request.urlopen.
+    mod = load_module(monkeypatch, base_env(
+        tmp_path, TELEGRAM_BOT_TOKEN=token))
+
+    fake_response = mock.MagicMock(name='fake-response')
+    fake_response.read.return_value = b'{"ok": true}'
+    fake_response.__enter__.return_value = fake_response
+    fake_response.__exit__.return_value = False
+
+    with mock.patch.object(urllib.request, 'urlopen',
+                           return_value=fake_response) as urlopen_mock:
+        rc = mod.main()
+
+    assert rc == 0
+    assert urlopen_mock.call_count == 1
+    req = urlopen_mock.call_args[0][0]
+    assert isinstance(req, urllib.request.Request)
+    assert req.full_url == f'https://api.telegram.org/bot{token}/sendMessage'
+    assert req.get_header('Content-type') == 'application/json'
+    payload = json.loads(req.data.decode('utf-8'))
+    assert payload['chat_id'] == CHAT_ID
+    assert payload['message_thread_id'] == 42
+    # The posted text opens with the handoff prefix and carries excerpts.
+    assert payload['text'].startswith('Daily handoff for topic 42 (')
+    assert 'live excerpt question' in payload['text']
+    assert 'live excerpt answer' in payload['text']
+    # Live mode also writes the handoff files before posting.
+    assert (day_dir(tmp_path) / '42-topic-42.md').is_file()
+    assert (latest_dir(tmp_path) / '42.md').is_file()


### PR DESCRIPTION
## What

Adds a `telegram-topic-handoffs` skill (`skills/productivity/telegram-topic-handoffs/`) that prepares nightly context handoffs between Telegram forum topics.

## Contents

- `SKILL.md` — when to use, workflow, configuration
- `scripts/topic_handoffs.py` — the handoff builder
- `tests/skills/test_topic_handoffs_skill.py` — 6 tests, all passing

## Verification

- Skill tests: 6/6 pass
- Repo authoring suite: 1202/1202 pass
- gitleaks: clean