### PR TITLE
fix(desktop): show the variant tag in model picker rows

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -105,4 +105,18 @@ describe('the catalog owns model curation', () => {
 
     expect($modelVisibilityOpen.get()).toBe(true)
   })
+
+  it('keeps a base model and its -thinking variant distinguishable in the row label', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [{ models: ['claude-opus-4.8', 'claude-opus-4.8-thinking'], name: 'Anthropic', slug: 'anthropic' }]
+    })
+
+    renderMenu()
+
+    const rows = await screen.findAllByRole('menuitem', { name: /Opus 4\.8/i })
+    const labels = rows.map(row => row.textContent)
+
+    expect(labels).toHaveLength(2)
+    expect(new Set(labels).size).toBe(2)
+  })
 })

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -406,7 +406,7 @@ export function ModelCatalogMenu({
                         : null
 
                     const isCurrent = activeId !== null
-                    const name = modelDisplayParts(family.id).name
+                    const { name, tag } = modelDisplayParts(family.id)
                     const caps = group.provider.capabilities?.[family.id]
 
                     // Effective settings for this row: the live choice when it's
@@ -455,6 +455,7 @@ export function ModelCatalogMenu({
                         >
                           <span className="min-w-0 flex-1 truncate">
                             <HighlightMatches query={search} text={name} />
+                            {tag ? <span className="text-(--ui-text-tertiary)"> {tag}</span> : null}
                             {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
                           </span>
                           {isCurrent ? (


### PR DESCRIPTION
## What does this PR do?

Restores the variant tag (`Fast` / `Thinking` / `Preview` / `Latest`) that
`modelDisplayParts()` already extracts, but that the desktop model picker
(`model-catalog-menu.tsx`) silently drops when rendering each row. A base
model and its `-thinking` (etc.) sibling currently render **identical row
text**, so they're indistinguishable in the picker — even though the exact
same tag is already rendered correctly one dialog over, in the Edit Models
visibility list (`model-visibility-dialog.tsx`).

This is the "at minimum" fix called out in the issue: showing the full
provider-prefixed canonical slug is a larger product decision left to a
maintainer, but not dropping data the picker already computes is not.

## Related Issue

Fixes #98122

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/shell/model-catalog-menu.tsx`: destructure `{ name, tag }`
  from `modelDisplayParts(family.id)` instead of only `.name`, and render the
  tag next to the name (same treatment `model-visibility-dialog.tsx` already
  gives it).
- `apps/desktop/src/app/shell/model-catalog-menu.test.tsx`: new test asserting
  a base model and its `-thinking` variant produce distinguishable row labels.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/shell/model-catalog-menu.test.tsx`
2. Open the composer model picker for a provider whose catalog includes a
   `-thinking`/`-preview`/`-latest` sibling of a model already shown (e.g.
   `claude-opus-4.8` + `claude-opus-4.8-thinking`) — the two rows now read
   differently instead of both showing `Opus 4.8`.

### Proof

Test added in this PR, run against the code on `main` (fix reverted via
`git checkout HEAD~1 -- apps/desktop/src/app/shell/model-catalog-menu.tsx`):

```
FAIL  |ui| src/app/shell/model-catalog-menu.test.tsx > the catalog owns model curation > keeps a base model and its -thinking variant distinguishable in the row label
AssertionError: expected 1 to be 2 // Object.is equality
- Expected: 2
+ Received: 1
```

Same test with the fix applied:

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Also ran, with the fix applied:
- `npx eslint src/app/shell/model-catalog-menu.tsx src/app/shell/model-catalog-menu.test.tsx` — clean
- `npx tsc -p . --noEmit` — clean (whole `apps/desktop` project)
- `npx vitest run --project ui src/app/shell` — 10 files / 74 tests passed

(The full `npm run test:ui` suite — ~2500+ test files across the whole
desktop app — did not finish inside a 10-minute foreground budget in this
sandbox; that appears to be pre-existing suite runtime, not something this
2-line change affects, and the directly relevant directory finished cleanly
in ~14s.)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested via jsdom/vitest only, not a live
      Electron build

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas touched

---
Drafted with AI assistance (Claude Code); test run output above is real,
from this sandbox.
