### PR TITLE
docs(computer-use): browser-route and grant references match the shipped tool (salvage #96156)

### DIFF
--- a/skills/autonomous-ai-agents/computer-use/SKILL.md
+++ b/skills/autonomous-ai-agents/computer-use/SKILL.md
@@ -115,7 +115,7 @@ Returned fields (present when the driver supports them):
 - `effect`: `"confirmed"` (driver read the result back — done), `"unverifiable"`
   (delivered, but confirm it yourself by re-capturing), or `"suspected_noop"`
   (ran but almost certainly did nothing).
-- `escalation`: `{recommended: "px" | "foreground" | "page", reason}` — present
+- `escalation`: `{recommended: "px" | "foreground", reason}` — present
   only when there's a next rung to try.
 - `code`: a structured refusal like `"background_unavailable"` or
   `"foreground_unsupported"`.
@@ -131,10 +131,7 @@ Walk it in order:
 3. **Pixel, background.** After `effect:"suspected_noop"` or a structured
    refusal recommends `"px"` (or a `degraded` capture has no elements), click
    by `coordinate=[x,y]` instead of `element`.
-4. **Typed page.** When `escalation.recommended == "page"` and the exact
-   browser-page contract below is available, use the namespaced typed route
-   before native foreground. This is not the legacy `page` workflow.
-5. **Foreground.** After `effect:"suspected_noop"`,
+4. **Foreground.** After `effect:"suspected_noop"`,
    `code:"background_unavailable"`, or a verified pixel no-op,
    re-issue the SAME action with `delivery_mode="foreground"`. This briefly
    raises the window and restores focus after; pair with `bring_to_front=True`
@@ -142,7 +139,7 @@ Walk it in order:
    (it's a visible focus change) and is only appropriate when the user isn't
    actively working. Classic cases: Electron/Chromium consent dialogs (e.g.
    tldraw offline's "Run Script"), DirectInput games, raw-input canvases.
-6. **Keystrokes verified-lost on a KDE/Qt editor → use the app's own I/O.**
+5. **Keystrokes verified-lost on a KDE/Qt editor → use the app's own I/O.**
    Some Qt text components (KTextEditor: Kate, KWrite, KDevelop) discard
    SYNTHETIC X keystrokes entirely — foreground `type` reports ok
    ("Typed N characters into the focused widget", `effect:"unverifiable"`)
@@ -170,62 +167,16 @@ NOT conclude "cua-driver can't drive this app" — climb the ladder. If
 action schema lacks that property; choose another verified rung without
 inferring support from the executable's reported version.
 
-## Typed browser page rung
+## Page content is a separate toolset
 
-For page content in a supported GUI browser, the same `computer_use` tool
-exposes namespaced `cua_browser_*` actions. They do not collide with other
-browser tools. The contract is capability-based:
-
-1. Discover the exact native browser `(pid, window_id)` with `list_windows` or
-   native capture, then call `cua_browser_state` with both values.
-2. Continue only when it returns `status:"ok"`, `binding_quality:"exact"`, and
-   `mutation_allowed:true`. Select an opaque `tab_id` from that response.
-3. Call `cua_browser_state` with the `tab_id` for a fresh `semantic_v2`
-   snapshot. Use only refs from that newest snapshot and only for their
-   declared actions.
-4. Use the matching namespaced action (`cua_browser_click`,
-   `cua_browser_type`, `cua_browser_navigate`, or `cua_browser_pointer`).
-   Trusted input is the default. `input_route="dom_event"` is an explicit
-   trust downgrade; never choose it silently after a refusal.
-5. Every mutation invalidates refs. Take a fresh state snapshot before another
-   typed action. Never chain actions from remembered refs.
-
-`cua_browser_prepare` is a separate approved setup action. Driver-owned
-`isolated_new`/`isolated_named` profiles require explicit `allow_launch=true`.
-An `existing_profile` is decided by cua-driver's immutable permission mode.
-Prefer `isolated_new` unless the task genuinely needs the user's signed-in
-session — attaching to an existing profile exposes its live pages, cookies,
-and storage over the browser protocol.
-
-Authorization paths for `existing_profile`:
-
-1. **Config grant (standard and unrestricted modes).** When
-   `computer_use.grant_existing_profile: true` is set, the runtime is
-   launched pre-authorized in standard mode (`--grant existing-profile`) and
-   Hermes applies the same host-side floor in unrestricted mode. If it is not
-   set, both modes fail closed. Tell the user to flip that config key and
-   restart the session if they want this; do not retry or work around it.
-2. **Bounded manifest.** When `computer_use.permission_mode: bounded` is
-   configured with a reviewed `capability_manifest`, prepares inside the
-   manifest's scope succeed without prompts and everything else fails closed.
-
-Explicit Hermes YOLO (`--yolo`, `/yolo`, or `approvals.mode: off`) launches an
-unrestricted runtime with no runtime Cua approval prompts, but it does not
-substitute for `grant_existing_profile: true`.
-
-These settings belong to runtime launch. The agent cannot add or change them
-after the runtime starts. Without the applicable grant or bounded manifest,
-`existing_profile` fails closed. Report the refusal and name the config key;
-do not retry, downgrade trust, or work around it.
-
-Every MCP transport owns a private lifecycle session inside the runtime. The
-public session name only labels cursor identity and session-scoped state. It
-does not select, share, or keep a runtime alive.
-
-Use the native capture/AX/pixel/foreground ladder for browser chrome, browser
-permission UI, OS prompts, native dialogs, extension surfaces, unsupported
-engines, and any typed route that cannot prove exact binding or mutation
-permission. `cua_browser_dialog` covers page JavaScript dialogs only.
+`computer_use` is desktop-only: it does not expose a typed route for browser
+page content (no `cua_browser_*` actions). For reading or acting on a page's
+DOM — navigation, clicking a link by text, typed input into a form field —
+use the separate `browser_navigate`/`browser_click`/`browser_type`/`browser_snapshot`
+tools (or `browser_exec` when the Browser Use CLI backend is active); their
+own schemas document the current contract. Reserve `computer_use` for browser
+*chrome* (the address bar, permission prompts, extension popups, native
+dialogs) and anything else on screen that isn't page content.
 
 ### Key shortcuts vary per platform
 
@@ -331,7 +282,7 @@ in your conversation context.
 | `cua-driver not installed` | Run `hermes computer-use install`, or `hermes tools` and enable Computer Use |
 | Captures consistently return empty / "no on-screen window" | On Linux: DISPLAY may not be set (X11) or you're on pure Wayland — ask the user to run `hermes computer-use doctor`. On Windows: you may be in Session 0 (SSH session) instead of the interactive desktop — see the cua-driver `WINDOWS.md` deep-dive |
 | Element index stale ("Element N not in cache") | SOM indices are only valid until the next `capture`. Re-capture before clicking. The wrapper carries opaque `element_token`s for stale-detection; you'll see an explicit error rather than a wrong click |
-| Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), typed page route when exact, then foreground. Browser chrome/native prompts remain native. Don't conclude the app is undrivable |
+| Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), then foreground. Browser chrome/native prompts remain native; page content is a separate toolset. Don't conclude the app is undrivable |
 | Type text disappears into a terminal emulator | cua-driver detects terminals (Ghostty, iTerm2, Terminal.app, Windows Terminal, mintty, etc.) and routes through key-event synthesis — should "just work" on a recent cua-driver. If it doesn't, ask the user to run `hermes computer-use doctor` |
 | `blocked pattern in type text` | You tried to `type` a shell command matching the dangerous-pattern block list (`curl ... \| bash`, `sudo rm -rf`, etc.). Break the command up or reconsider |
 | Anything else weird | **First action: ask the user to run `hermes computer-use doctor`.** It runs the cua-driver `health_report` MCP tool and prints a structured per-check matrix. Their output tells you (and them) exactly what's wrong |

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1485,7 +1485,7 @@ Registering raw Cua MCP tools is an alternative when you need Cua's low-level
 tool vocabulary. `cua-driver skills install` detects Hermes and links Cua's
 skill pack into the Hermes skills directory automatically.
 
-Permission mode, capability-manifest approval, and the existing-profile grant
+Permission mode and capability-manifest approval
 belong to runtime launch. In bounded mode Hermes passes Cua's canonical
 `--capability-manifest` and `--approve-capability-manifest` flags. Every MCP
 transport owns a private lifecycle session inside its runtime. Public session

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -122,11 +122,11 @@ computer_use:
 ```
 
 Hermes then launches the cua-driver runtime with the trusted-launcher grant
-(`--grant existing-profile`), and
-`cua_browser_prepare` with an existing profile succeeds against the exact
-`(pid, window_id)` the agent proves. Leave it `false` (the default) and
-existing-profile attachment fails closed; driver-owned isolated profiles work
-either way and are what the agent prefers.
+(`--grant existing-profile`), and the standard capture/click/type actions
+succeed against the exact `(pid, window_id)` of that signed-in window. Leave
+it `false` (the default) and existing-profile attachment fails closed;
+driver-owned isolated profiles work either way and are what the agent
+prefers.
 
 ### Bounded mode for repeatable automation
 

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -99,34 +99,19 @@ or add `computer_use` to your enabled toolsets in `~/.hermes/config.yaml`.
 ## Permission modes and logged-in browser profiles
 
 Hermes maps its existing approval UX onto cua-driver's immutable runtime
-modes. Permission mode, capability manifest approval, and the existing-profile
-grant are launch settings. They cannot change after the runtime starts:
+modes. Permission mode and capability manifest approval are launch settings.
+They cannot change after the runtime starts:
 
-| Hermes session | cua-driver mode | Human intervention | `existing_profile` |
-|---|---|---|---|
-| Manual or smart approvals (default) | `standard` | Normal Hermes approvals; Cua stops at its protected boundary | Refuses unless `computer_use.grant_existing_profile: true` (one-time config opt-in) |
-| `computer_use.permission_mode: bounded` + reviewed manifest | private `bounded` daemon | You review and approve the capability manifest once, at launch | Allowed only within the manifest's declared profiles/origins/tools; everything else fails closed |
-| `--yolo`, `/yolo`, or `approvals.mode: off` | private `unrestricted` daemon | One explicit Hermes risk acceptance; no runtime Cua prompts | Refuses unless `computer_use.grant_existing_profile: true`; YOLO does not substitute for this grant |
+| Hermes session | cua-driver mode | Human intervention |
+|---|---|---|
+| Manual or smart approvals (default) | `standard` | Normal Hermes approvals; Cua stops at its protected boundary |
+| `computer_use.permission_mode: bounded` + reviewed manifest | private `bounded` daemon | You review and approve the capability manifest once, at launch |
+| `--yolo`, `/yolo`, or `approvals.mode: off` | private `unrestricted` daemon | One explicit Hermes risk acceptance; no runtime Cua prompts |
 
-### Attaching to your signed-in browser
-
-The agent can drive a Chrome/Edge window you already have open — including a
-signed-in profile — **without restarting the browser, copying the profile, or
-touching your tabs**. Because DevTools access exposes that profile's live
-pages, cookies, and storage, cua-driver requires an explicit human grant that
-ordinary tool approval cannot substitute for. You opt in once, in config.yaml:
-
-```yaml
-computer_use:
-  grant_existing_profile: true
-```
-
-Hermes then launches the cua-driver runtime with the trusted-launcher grant
-(`--grant existing-profile`), and the standard capture/click/type actions
-succeed against the exact `(pid, window_id)` of that signed-in window. Leave
-it `false` (the default) and existing-profile attachment fails closed;
-driver-owned isolated profiles work either way and are what the agent
-prefers.
+Browser work — including pages in a signed-in profile — goes through the
+`browser` toolset (`browser_exec`), not `computer_use`. The former
+`computer_use.grant_existing_profile` opt-in was removed along with the typed
+browser route; a leftover key in config.yaml is ignored.
 
 ### Bounded mode for repeatable automation
 
@@ -167,14 +152,13 @@ public session name is only a label for cursor identity and session-scoped
 state. It does not select, share, or keep a runtime alive. Turning `/yolo` off,
 resetting or closing the Hermes session, cancellation cleanup, or process exit
 closes that transport session. Hermes also stops private runtimes that it
-launched for bounded, unrestricted, or existing-profile access. One Hermes
-conversation cannot change another runtime's mode or grants. On macOS, a
-standard runtime with an existing-profile grant uses a fresh CuaDriver.app
-daemon on a private socket. Bounded and unrestricted modes use a private
+launched for bounded or unrestricted access. One Hermes
+conversation cannot change another runtime's mode or grants. Bounded and
+unrestricted modes use a private
 embedded service under the Hermes host identity.
 
 `smart` approval remains `standard`: an LLM classification cannot stand in for
-a reviewed manifest or a launch-time grant.
+a reviewed manifest.
 
 <div class="alert alert--warning">
 
@@ -444,7 +428,6 @@ Permission mode and manifest (see
 computer_use:
   permission_mode: standard        # standard (default) | bounded
   capability_manifest: ""          # capability manifest path, required for bounded
-  grant_existing_profile: false    # opt-in: attach in standard or unrestricted mode
 ```
 
 Override the driver binary path (tests / CI / local builds):

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
@@ -1,14 +1,14 @@
 ---
-title: "Computer Use — Drive the desktop in the background without stealing focus"
+title: "Computer Use — Drive the desktop background-first; escalate on signal"
 sidebar_label: "Computer Use"
-description: "Drive the desktop in the background without stealing focus"
+description: "Drive the desktop background-first; escalate on signal"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Computer Use
 
-Drive the desktop in the background without stealing focus.
+Drive the desktop background-first; escalate on signal.
 
 ## Skill metadata
 
@@ -131,7 +131,7 @@ Returned fields (present when the driver supports them):
 - `effect`: `"confirmed"` (driver read the result back — done), `"unverifiable"`
   (delivered, but confirm it yourself by re-capturing), or `"suspected_noop"`
   (ran but almost certainly did nothing).
-- `escalation`: `{recommended: "px" | "foreground" | "page", reason}` — present
+- `escalation`: `{recommended: "px" | "foreground", reason}` — present
   only when there's a next rung to try.
 - `code`: a structured refusal like `"background_unavailable"` or
   `"foreground_unsupported"`.
@@ -147,10 +147,7 @@ Walk it in order:
 3. **Pixel, background.** After `effect:"suspected_noop"` or a structured
    refusal recommends `"px"` (or a `degraded` capture has no elements), click
    by `coordinate=[x,y]` instead of `element`.
-4. **Typed page.** When `escalation.recommended == "page"` and the exact
-   browser-page contract below is available, use the namespaced typed route
-   before native foreground. This is not the legacy `page` workflow.
-5. **Foreground.** After `effect:"suspected_noop"`,
+4. **Foreground.** After `effect:"suspected_noop"`,
    `code:"background_unavailable"`, or a verified pixel no-op,
    re-issue the SAME action with `delivery_mode="foreground"`. This briefly
    raises the window and restores focus after; pair with `bring_to_front=True`
@@ -158,6 +155,17 @@ Walk it in order:
    (it's a visible focus change) and is only appropriate when the user isn't
    actively working. Classic cases: Electron/Chromium consent dialogs (e.g.
    tldraw offline's "Run Script"), DirectInput games, raw-input canvases.
+5. **Keystrokes verified-lost on a KDE/Qt editor → use the app's own I/O.**
+   Some Qt text components (KTextEditor: Kate, KWrite, KDevelop) discard
+   SYNTHETIC X keystrokes entirely — foreground `type` reports ok
+   ("Typed N characters into the focused widget", `effect:"unverifiable"`)
+   but a fresh AX capture shows the text never arrived, and raw XTest fails
+   identically (proven live, Aug 2026 — it is the toolkit, not the driver;
+   the same foreground route works on kcalc/Chrome). After ONE such
+   verified-lost round trip, stop retrying input rungs: write the file with
+   terminal/file tools and let the editor reload it, or drive the app's
+   DBus/CLI interface. Never loop the ladder against a surface that
+   verifiably swallows synthetic input.
 
 ```
 computer_use(action="click", element=7)
@@ -175,62 +183,16 @@ NOT conclude "cua-driver can't drive this app" — climb the ladder. If
 action schema lacks that property; choose another verified rung without
 inferring support from the executable's reported version.
 
-## Typed browser page rung
+## Page content is a separate toolset
 
-For page content in a supported GUI browser, the same `computer_use` tool
-exposes namespaced `cua_browser_*` actions. They do not collide with other
-browser tools. The contract is capability-based:
-
-1. Discover the exact native browser `(pid, window_id)` with `list_windows` or
-   native capture, then call `cua_browser_state` with both values.
-2. Continue only when it returns `status:"ok"`, `binding_quality:"exact"`, and
-   `mutation_allowed:true`. Select an opaque `tab_id` from that response.
-3. Call `cua_browser_state` with the `tab_id` for a fresh `semantic_v2`
-   snapshot. Use only refs from that newest snapshot and only for their
-   declared actions.
-4. Use the matching namespaced action (`cua_browser_click`,
-   `cua_browser_type`, `cua_browser_navigate`, or `cua_browser_pointer`).
-   Trusted input is the default. `input_route="dom_event"` is an explicit
-   trust downgrade; never choose it silently after a refusal.
-5. Every mutation invalidates refs. Take a fresh state snapshot before another
-   typed action. Never chain actions from remembered refs.
-
-`cua_browser_prepare` is a separate approved setup action. Driver-owned
-`isolated_new`/`isolated_named` profiles require explicit `allow_launch=true`.
-An `existing_profile` is decided by cua-driver's immutable permission mode.
-Prefer `isolated_new` unless the task genuinely needs the user's signed-in
-session. Attaching to an existing profile exposes its live pages, cookies,
-and storage over the browser protocol.
-
-Authorization paths for `existing_profile`:
-
-1. **Config grant (standard and unrestricted modes).** When
-   `computer_use.grant_existing_profile: true` is set, the runtime is
-   launched pre-authorized in standard mode (`--grant existing-profile`) and
-   Hermes applies the same host-side floor in unrestricted mode. If it is not
-   set, both modes fail closed. Tell the user to set that config key and
-   restart the session if they want this. Do not retry or work around it.
-2. **Bounded manifest.** When `computer_use.permission_mode: bounded` is
-   configured with a reviewed `capability_manifest`, prepares inside the
-   manifest's scope succeed without prompts and everything else fails closed.
-
-Explicit Hermes YOLO (`--yolo`, `/yolo`, or `approvals.mode: off`) launches an
-unrestricted runtime with no runtime Cua approval prompts, but it does not
-substitute for `grant_existing_profile: true`.
-
-These settings belong to runtime launch. The agent cannot add or change them
-after the runtime starts. Without the applicable grant or bounded manifest,
-`existing_profile` fails closed. Report the refusal and name the config key;
-do not retry, downgrade trust, or work around it.
-
-Every MCP transport owns a private lifecycle session inside the runtime. The
-public session name only labels cursor identity and session-scoped state. It
-does not select, share, or keep a runtime alive.
-
-Use the native capture/AX/pixel/foreground ladder for browser chrome, browser
-permission UI, OS prompts, native dialogs, extension surfaces, unsupported
-engines, and any typed route that cannot prove exact binding or mutation
-permission. `cua_browser_dialog` covers page JavaScript dialogs only.
+`computer_use` is desktop-only: it does not expose a typed route for browser
+page content (no `cua_browser_*` actions). For reading or acting on a page's
+DOM — navigation, clicking a link by text, typed input into a form field —
+use the separate `browser_navigate`/`browser_click`/`browser_type`/`browser_snapshot`
+tools (or `browser_exec` when the Browser Use CLI backend is active); their
+own schemas document the current contract. Reserve `computer_use` for browser
+*chrome* (the address bar, permission prompts, extension popups, native
+dialogs) and anything else on screen that isn't page content.
 
 ### Key shortcuts vary per platform
 
@@ -336,7 +298,7 @@ in your conversation context.
 | `cua-driver not installed` | Run `hermes computer-use install`, or `hermes tools` and enable Computer Use |
 | Captures consistently return empty / "no on-screen window" | On Linux: DISPLAY may not be set (X11) or you're on pure Wayland — ask the user to run `hermes computer-use doctor`. On Windows: you may be in Session 0 (SSH session) instead of the interactive desktop — see the cua-driver `WINDOWS.md` deep-dive |
 | Element index stale ("Element N not in cache") | SOM indices are only valid until the next `capture`. Re-capture before clicking. The wrapper carries opaque `element_token`s for stale-detection; you'll see an explicit error rather than a wrong click |
-| Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), typed page route when exact, then foreground. Browser chrome/native prompts remain native. Don't conclude the app is undrivable |
+| Click had no effect | Read the structured verdict. `effect:"unverifiable"` → fresh capture/state before retry, even with an escalation hint. `effect:"suspected_noop"` or a structured refusal → climb the recommended ladder: coordinate (px), then foreground. Browser chrome/native prompts remain native; page content is a separate toolset. Don't conclude the app is undrivable |
 | Type text disappears into a terminal emulator | cua-driver detects terminals (Ghostty, iTerm2, Terminal.app, Windows Terminal, mintty, etc.) and routes through key-event synthesis — should "just work" on a recent cua-driver. If it doesn't, ask the user to run `hermes computer-use doctor` |
 | `blocked pattern in type text` | You tried to `type` a shell command matching the dangerous-pattern block list (`curl ... \| bash`, `sudo rm -rf`, etc.). Break the command up or reconsider |
 | Anything else weird | **First action: ask the user to run `hermes computer-use doctor`.** It runs the cua-driver `health_report` MCP tool and prints a structured per-check matrix. Their output tells you (and them) exactly what's wrong |


### PR DESCRIPTION
## Summary

Docs no longer teach the removed computer-use browser path: the deleted `cua_browser_*` typed-browser route is gone from the skill and its mirrored docs (salvage of #96156 by @nftpoetrist), and every remaining `grant_existing_profile` reference — removed from code in #98057 — is swept out of the feature page and CLI reference.

## Changes

- `skills/autonomous-ai-agents/computer-use/SKILL.md` + mirrored bundled-skill doc: remove the deleted typed browser-page route guidance (@nftpoetrist's commit, authorship preserved)
- `website/docs/user-guide/features/computer-use.md`: drop the existing-profile grant column/section/config example; note that browser work (including signed-in profiles) goes through `browser_exec` and a leftover config key is ignored
- `website/docs/reference/cli-commands.md`: drop the existing-profile grant from the launch-settings sentence

## Validation

| Check | Result |
|---|---|
| `git grep grant_existing_profile -- skills website` | only the "was removed" note remains |
| `git grep cua_browser -- skills website` | only "no `cua_browser_*` actions" disclaimers remain |
| Attribution audit | all emails mapped |

Closes #96156 (salvaged with credit).

## Infographic

![Docs: retired browser grant removed](https://v3b.fal.media/files/b/0aa85a96/f-WQSQWp7sy9RZhKUUPzq_cquEY5P3.png)
