### PR TITLE
Qwen Cloud picker gains qwen3.8-max + 4 more missing models (salvage #87808)

### DIFF
--- a/contributors/emails/icocode@users.noreply.github.com
+++ b/contributors/emails/icocode@users.noreply.github.com
@@ -1,0 +1,1 @@
+icocode

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -641,16 +641,22 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        # Qwen 千问系列 (DashScope / Qwen Cloud)
+        "qwen3.8-max",
         "qwen3.7-max",
         "qwen3.7-plus",
         "qwen3.6-plus",
+        "qwen3.6-flash",
         "kimi-k2.5",
         "qwen3.5-plus",
         "qwen3-coder-plus",
         "qwen3-coder-next",
-        # Third-party models available on coding-intl
+        # Third-party models available on coding-intl / DashScope
+        "glm-5.2",
         "glm-5",
         "glm-4.7",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
         "MiniMax-M2.5",
     ],
     # Alibaba DashScope (China) — same platform as alibaba, domestic endpoint

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -662,15 +662,20 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Alibaba DashScope (China) — same platform as alibaba, domestic endpoint
     # (dashscope.aliyuncs.com); same catalog as the international tier.
     "alibaba-cn": [
+        "qwen3.8-max",
         "qwen3.7-max",
         "qwen3.7-plus",
         "qwen3.6-plus",
+        "qwen3.6-flash",
         "kimi-k2.5",
         "qwen3.5-plus",
         "qwen3-coder-plus",
         "qwen3-coder-next",
+        "glm-5.2",
         "glm-5",
         "glm-4.7",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
         "MiniMax-M2.5",
     ],
     # Alibaba Coding Plan — same platform as alibaba (DashScope coding-intl),


### PR DESCRIPTION
## Summary

The Qwen Cloud (`alibaba`) picker now lists five models the DashScope catalog has offered for weeks but our curated list was missing — `qwen3.8-max`, `qwen3.6-flash`, `glm-5.2`, `deepseek-v4-pro`, `deepseek-v4-flash-0731`. Salvage of PR #87808 by @icocode, plus a follow-up mirroring the additions onto `alibaba-cn` (registered since #73345, same catalog).

All five verified present in the live models.dev catalog for the alibaba providers.

## Changes

- `hermes_cli/models.py`: five additions to the `alibaba` curated list (icocode's commit, authorship preserved); same five mirrored onto `alibaba-cn`.
- `contributors/emails/`: attribution mapping for @icocode.

## Validation

| check | result |
|---|---|
| models.dev live catalog contains all 5 slugs | yes (checked today) |
| real-import: both lists load, 15 models each | pass |
| `scripts/run_tests.sh tests/providers/ tests/hermes_cli/test_api_key_providers.py` | 184 passed, 0 failed |

## Infographic

![Qwen Cloud catalog: 5 new models](https://v3b.fal.media/files/b/0aa85aa9/mwi-7NEbNdEPGw72i2cj0_7fahetA2.png)
