### PR TITLE
fix(runtime): provider switch, fallback, and recovery keep request settings in sync (#75091, salvage #75139 #60062)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -3105,6 +3105,7 @@ def init_agent(
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
+        "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1486,6 +1486,7 @@ def try_recover_primary_transport(
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
+        agent.request_overrides = dict(rt.get("request_overrides") or {})
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -1748,6 +1749,7 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
+        agent.request_overrides = dict(rt.get("request_overrides") or {})
         agent._client_kwargs = dict(rt["client_kwargs"])
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3241,6 +3241,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_config": dict(agent.reasoning_config) if getattr(agent, "reasoning_config", None) else None,
         "reasoning_echo_flag": getattr(agent, "_reasoning_echo_flag", False),
+        # Request-level overrides (extra_body etc.) must travel with the
+        # switched-to identity; without this, a post-switch transport
+        # recovery or fallback restore would resurrect the PRE-switch
+        # overrides via the stale init-time snapshot (#75091 seam).
+        "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2842,6 +2842,31 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             )
             # Keep whatever reasoning_config was active — don't break the fallback swap.
 
+        # Re-resolve extra_body for the fallback provider (Closes #75091).
+        # The primary's provider-specific extra_body (e.g. reasoning_effort)
+        # must not ride along onto the fallback provider, which is a different
+        # API that may reject those fields.  Clear the stale extra_body first,
+        # then re-resolve from the fallback provider's config.
+        try:
+            from agent.agent_init import _merge_custom_provider_extra_body
+            _custom_providers = getattr(agent, "_custom_providers", None) or []
+            # Strip the primary's extra_body so it doesn't contaminate the
+            # fallback (existing_extra_body in _merge wins on conflict).
+            _overrides = dict(getattr(agent, "request_overrides", {}) or {})
+            _overrides.pop("extra_body", None)
+            agent.request_overrides = _overrides
+            _merge_custom_provider_extra_body(agent, _custom_providers)
+            logger.info(
+                "Fallback %s: extra_body resolved: %s",
+                agent.model,
+                (getattr(agent, "request_overrides", {}) or {}).get("extra_body"),
+            )
+        except Exception as _eb_err:
+            logger.debug(
+                "Failed to resolve extra_body for fallback %s; keeping current: %s",
+                agent.model, _eb_err,
+            )
+
         # Keep the prompt's self-identity in sync with the model actually
         # answering, so "what model are you?" doesn't report the primary.
         rewrite_prompt_model_identity(agent, fb_model, fb_provider)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2674,6 +2674,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         old_model = agent.model
         old_provider = agent.provider
+        old_base_url = agent.base_url
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -2843,18 +2844,49 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             # Keep whatever reasoning_config was active — don't break the fallback swap.
 
         # Re-resolve extra_body for the fallback provider (Closes #75091).
-        # The primary's provider-specific extra_body (e.g. reasoning_effort)
-        # must not ride along onto the fallback provider, which is a different
-        # API that may reject those fields.  Clear the stale extra_body first,
-        # then re-resolve from the fallback provider's config.
+        # The OLD provider's custom_providers-contributed extra_body (e.g. a
+        # vendor-specific reasoning toggle) must not ride along onto the
+        # fallback provider, which is a different API that may reject those
+        # fields.  Removal is KEY-SCOPED: only keys the old provider's
+        # custom_providers entry contributed (value unchanged since init)
+        # are dropped; the fallback provider's own extra_body is then merged
+        # back in.  Caller/profile-provided extra_body keys
+        # (request_overrides passed at init, which win over provider config
+        # per _merge_custom_provider_extra_body precedence) MUST survive the
+        # swap untouched.
         try:
-            from agent.agent_init import _merge_custom_provider_extra_body
+            from agent.agent_init import (
+                _custom_provider_extra_body_for_agent,
+                _merge_custom_provider_extra_body,
+            )
             _custom_providers = getattr(agent, "_custom_providers", None) or []
-            # Strip the primary's extra_body so it doesn't contaminate the
-            # fallback (existing_extra_body in _merge wins on conflict).
+            # What did the OLD provider's config contribute?
+            _old_provider_eb = _custom_provider_extra_body_for_agent(
+                provider=old_provider,
+                model=old_model,
+                base_url=old_base_url,
+                custom_providers=_custom_providers,
+            ) or {}
             _overrides = dict(getattr(agent, "request_overrides", {}) or {})
-            _overrides.pop("extra_body", None)
-            agent.request_overrides = _overrides
+            _existing_eb = _overrides.get("extra_body")
+            if isinstance(_existing_eb, dict) and _old_provider_eb:
+                _scrubbed = dict(_existing_eb)
+                for _k, _v in _old_provider_eb.items():
+                    # Drop only keys the old provider contributed: the value
+                    # must still match what its config injected — a caller
+                    # override of the same key would have won at init and
+                    # differ, so it survives.  Keys the new provider
+                    # redefines are re-added with the NEW provider's value
+                    # by the merge below.
+                    if _k in _scrubbed and _scrubbed[_k] == _v:
+                        _scrubbed.pop(_k)
+                if _scrubbed:
+                    _overrides["extra_body"] = _scrubbed
+                else:
+                    _overrides.pop("extra_body", None)
+                agent.request_overrides = _overrides
+            # Merge in the fallback provider's own extra_body (existing
+            # caller-provided keys win on conflict inside the merge helper).
             _merge_custom_provider_extra_body(agent, _custom_providers)
             logger.info(
                 "Fallback %s: extra_body resolved: %s",

--- a/contributors/emails/adamfortuna1324@gmail.com
+++ b/contributors/emails/adamfortuna1324@gmail.com
@@ -1,0 +1,1 @@
+0xAdamFortuna

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -30,7 +30,12 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+def _make_agent(
+    fallback_model=None,
+    provider="custom",
+    base_url="https://my-llm.example.com/v1",
+    request_overrides=None,
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
@@ -45,6 +50,7 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
             "agent.context_compressor.get_model_context_length",
             return_value=200_000,
         ),
+        patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
     ):
         agent = AIAgent(
             api_key="test-key-12345678",
@@ -54,6 +60,7 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            request_overrides=dict(request_overrides or {}),
         )
         agent.client = MagicMock()
         return agent
@@ -82,6 +89,13 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["api_mode"] == agent.api_mode
         assert "client_kwargs" in rt
         assert "compressor_context_length" in rt
+
+    def test_snapshot_includes_request_overrides(self):
+        overrides = {"extra_body": {"reasoning": {"effort": "medium"}}}
+        agent = _make_agent(request_overrides=overrides)
+        rt = agent._primary_runtime
+        assert rt["request_overrides"] == overrides
+        assert rt["request_overrides"] is not agent.request_overrides
 
     def test_snapshot_includes_compressor_state(self):
         agent = _make_agent()
@@ -279,6 +293,19 @@ class TestRestorePrimaryRuntime:
             agent._restore_primary_runtime()
 
         assert agent._use_prompt_caching == original_caching
+
+    def test_restores_request_overrides(self):
+        original_overrides = {"extra_body": {"reasoning": {"effort": "medium"}}}
+        agent = _make_agent(request_overrides=original_overrides)
+        agent._fallback_activated = True
+        agent.request_overrides = {"extra_body": {"fallback_only": True}}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent.request_overrides == original_overrides
+        assert agent.request_overrides is not agent._primary_runtime["request_overrides"]
 
     def test_restore_skips_cross_provider_pool_entry(self):
         """Restore must not swap in a fallback provider credential for the primary runtime."""
@@ -551,6 +578,21 @@ class TestTryRecoverPrimaryTransport:
 
         assert result is True
 
+    def test_recovery_restores_request_overrides(self):
+        original_overrides = {"extra_body": {"reasoning": {"effort": "medium"}}}
+        agent = _make_agent(provider="custom", request_overrides=original_overrides)
+        error = _make_transport_error("ReadTimeout")
+        agent.request_overrides = {"extra_body": {"fallback_only": True}}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+        assert agent.request_overrides == original_overrides
+        assert agent.request_overrides is not agent._primary_runtime["request_overrides"]
 
 
 

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -790,3 +790,79 @@ class TestRateLimitCooldown:
 
         # second call should not have extended the cooldown
         assert second_cooldown == first_cooldown
+
+
+# =============================================================================
+# request_overrides travels through the switch_model snapshot (#75091 seam)
+# =============================================================================
+
+
+class TestSwitchModelRequestOverridesSnapshot:
+    """switch_model rebuilds _primary_runtime; it must carry request_overrides
+    so a post-switch transport recovery or fallback restore reinstates the
+    switched-to identity's overrides, not a stale or empty set."""
+
+    def _switch(self, agent, **kwargs):
+        from agent.agent_runtime_helpers import switch_model
+
+        with (
+            patch("run_agent.OpenAI", return_value=MagicMock()),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=128_000,
+            ),
+        ):
+            switch_model(
+                agent,
+                new_model=kwargs.get("new_model", "gpt-4o"),
+                new_provider=kwargs.get("new_provider", "openai"),
+                base_url=kwargs.get("base_url", "https://api.openai.com/v1"),
+                api_key=kwargs.get("api_key", "sk-test-1234567890"),
+            )
+
+    def test_switch_snapshot_carries_request_overrides(self):
+        overrides = {"extra_body": {"reasoning": {"effort": "high"}}}
+        agent = _make_agent(request_overrides=overrides)
+        self._switch(agent)
+        rt = agent._primary_runtime
+        assert rt.get("request_overrides") == overrides
+        assert rt["request_overrides"] is not agent.request_overrides
+
+    def test_switch_then_recover_restores_current_overrides(self):
+        """After /model switch, a transport recovery must reinstate the
+        overrides that were live at switch time — not drop them."""
+        overrides = {"extra_body": {"reasoning": {"effort": "high"}}}
+        agent = _make_agent(provider="custom", request_overrides=overrides)
+        self._switch(
+            agent,
+            new_model="local-model",
+            new_provider="custom",
+            base_url="https://my-llm.example.com/v1",
+        )
+        # A fallback activation mid-turn clobbers the live overrides…
+        agent.request_overrides = {"extra_body": {"fallback_only": True}}
+        error = _make_transport_error("ReadTimeout")
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+        assert result is True
+        # …and recovery restores the switch-time snapshot.
+        assert agent.request_overrides == overrides
+
+    def test_switch_then_restore_restores_current_overrides(self):
+        overrides = {"extra_body": {"reasoning": {"effort": "high"}}}
+        agent = _make_agent(provider="custom", request_overrides=overrides)
+        self._switch(
+            agent,
+            new_model="local-model",
+            new_provider="custom",
+            base_url="https://my-llm.example.com/v1",
+        )
+        agent._fallback_activated = True
+        agent.request_overrides = {"extra_body": {"fallback_only": True}}
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+        assert result is True
+        assert agent.request_overrides == overrides

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -414,3 +414,91 @@ class TestFallbackChainDedup:
         assert called == [("xai", "grok-4.5")]
         assert agent.provider == "xai"
         assert agent.model == "grok-4.5"
+
+
+# ── extra_body re-resolution on fallback activation (#75091) ─────────────
+
+
+class TestFallbackExtraBodyReResolution:
+    """Fallback activation must re-resolve extra_body key-scoped.
+
+    The old provider's custom_providers-contributed extra_body keys are
+    stale on the new backend and must be dropped; caller-provided
+    request_overrides keys must survive; the fallback provider's own
+    extra_body must be merged in (salvage of #75139).
+    """
+
+    OLD_URL = "https://old-llm.example.com/v1"
+    FB_URL = "https://fb-llm.example.com/v1"
+
+    def _agent_with_custom_providers(self, caller_extra_body=None):
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom:fbprov",
+                "model": "fb-model",
+                "base_url": self.FB_URL,
+            },
+        )
+        agent.provider = "custom"
+        agent.model = "old-model"
+        agent.base_url = self.OLD_URL
+        agent._custom_providers = [
+            {
+                "name": "oldprov",
+                "base_url": self.OLD_URL,
+                "extra_body": {"enable_thinking": True, "old_only": 1},
+            },
+            {
+                "provider_key": "fbprov",
+                "base_url": self.FB_URL,
+                "extra_body": {"top_k": 20},
+            },
+        ]
+        # Simulate the init-time merge: provider extra_body + caller keys
+        # (caller wins on conflict — agent_init._merge_custom_provider_extra_body).
+        merged = {"enable_thinking": True, "old_only": 1}
+        merged.update(caller_extra_body or {})
+        agent.request_overrides = {"extra_body": merged}
+        return agent
+
+    def _activate(self, agent):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url=self.FB_URL), "fb-model"),
+        ), patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=128_000,
+        ):
+            assert agent._try_activate_fallback() is True
+
+    def test_stale_provider_keys_removed_and_new_provider_merged(self):
+        agent = self._agent_with_custom_providers()
+        self._activate(agent)
+        eb = agent.request_overrides.get("extra_body") or {}
+        # Old provider's contributed keys are gone.
+        assert "enable_thinking" not in eb
+        assert "old_only" not in eb
+        # Fallback provider's own extra_body is applied.
+        assert eb.get("top_k") == 20
+
+    def test_caller_override_keys_survive_fallback(self):
+        agent = self._agent_with_custom_providers(
+            caller_extra_body={"reasoning": {"effort": "high"}, "enable_thinking": False},
+        )
+        self._activate(agent)
+        eb = agent.request_overrides.get("extra_body") or {}
+        # Pure caller key survives untouched.
+        assert eb.get("reasoning") == {"effort": "high"}
+        # Caller redefined a key the old provider also set (caller won at
+        # init: False != True) — the caller's value must survive key-scoped
+        # removal.
+        assert eb.get("enable_thinking") is False
+        # But the key the old provider alone contributed is dropped.
+        assert "old_only" not in eb
+        assert eb.get("top_k") == 20
+
+    def test_non_extra_body_overrides_untouched(self):
+        agent = self._agent_with_custom_providers()
+        agent.request_overrides["temperature"] = 0.2
+        self._activate(agent)
+        assert agent.request_overrides.get("temperature") == 0.2


### PR DESCRIPTION
Salvages **#75139** (@RelaxJonh) and draft **#60062** (@0xAdamFortuna) into one PR closing the provider-identity-change re-resolution seam: `request_overrides` / `extra_body` now travel correctly through **fallback activation**, **transport recovery**, **primary restore**, and **/model switch**.

Fixes #75091

![infographic](https://v3b.fal.media/files/b/0aa85a9d/yZtAWbSjBO04Qt6mJ__ty_QmoWjZGD.png)

## The seam

Three identity-change paths each dropped or leaked request-level settings:

1. **Fallback activation** (`try_activate_fallback`, `agent/chat_completion_helpers.py`) re-resolved only `reasoning_config` (#21256) — the old provider's `custom_providers` `extra_body` (e.g. `enable_thinking`) rode along onto the fallback provider, a different API that may reject those fields (#75091).
2. **`_primary_runtime` snapshot** (`agent/agent_init.py`) omitted `request_overrides`, so `try_recover_primary_transport` and `restore_primary_runtime` silently kept whatever the fallback had left behind.
3. **`switch_model`'s live snapshot rebuild** (`agent/agent_runtime_helpers.py`) also omitted it, so a post-switch recovery/restore would reinstate stale (pre-switch) or empty overrides.

## What each commit does

| Commit | Author | Change |
|---|---|---|
| `1bdce79ba6` | @RelaxJonh (cherry-picked from #75139) | Re-resolve `extra_body` in `try_activate_fallback` via `_merge_custom_provider_extra_body` |
| `e7f70651f0` | @0xAdamFortuna (cherry-picked from #60062, rebased across ~1k-line offset drift) | `request_overrides` in the init-time `_primary_runtime` snapshot + restore in `try_recover_primary_transport` / `restore_primary_runtime`, with deep-copy isolation tests |
| `b1632721d9` | maintainer follow-up | **Key-scoped** removal instead of #75139's blanket `pop("extra_body")`: only keys the OLD provider's `custom_providers` entry contributed (value unchanged since the init-time merge) are dropped; caller/profile-provided keys survive, matching the caller-over-provider precedence in `agent_init._merge_custom_provider_extra_body`. Also extends #60062 to the `switch_model` snapshot. Adds activation-level + switch-then-recover/restore tests |
| `2aac16a846` | chore | contributor email mapping |

Why key-scoped matters: `request_overrides={"extra_body": {...}}` passed at agent init (caller/profile) wins over provider config at merge time; the blanket pop would have destroyed those caller settings on every fallback swap. The scrub compares each old-provider key's current value against what its config contributed — a caller override of the same key differs (caller won at init) and survives.

## Cache safety

None of these paths mutate past context or rebuild the system prompt — fallback/recovery/restore/switch here only change **outbound request kwargs** (`request_overrides` → `extra_body`). Prompt-cache prefix stability is unaffected.

## Validation

| Check | Result |
|---|---|
| `tests/run_agent/test_provider_fallback.py` (incl. 3 new activation-level tests: stale-key removal, caller-override preservation, non-extra_body overrides untouched) | 29 passed |
| `tests/run_agent/test_primary_runtime_restore.py` (incl. #60062's 3 tests + 3 new switch-then-recover / switch-then-restore tests) | 35 passed |
| Adjacent suites: `test_fallback_reasoning_override`, `test_switch_model_reasoning_override`, `test_switch_model_context`, `test_switch_model_rollback`, `test_fallback_api_mode_preservation`, `test_conversation_fallback_state`, `test_fallback_credential_isolation` | 98 passed total |
| Sabotage check: all three touched source files reverted to `origin/main`, new tests re-run | 8 failed as expected (RED); restored → 64 passed (GREEN); fix markers grep-verified in every changed file after the round-trip |

Live repro: on current main, activating a fallback from a `custom_providers` entry with `extra_body: {enable_thinking: true}` onto an OpenAI-compatible fallback keeps `enable_thinking` in every outbound request (`Fallback ... extra_body` never re-resolved — only `reasoning_config` is, `chat_completion_helpers.py` L2823); with this branch the stale key is dropped and the fallback entry's own `extra_body` is applied.

Credit: @RelaxJonh for the fallback-activation fix and issue diagnosis (#75091), @0xAdamFortuna for the snapshot/restore half. Both commits are preserved with original authorship.
