### PR TITLE
fix(webhook): restore provider contracts and safe readiness

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -68,6 +68,29 @@ from gateway.response_filters import is_autonomous_silence_response
 logger = logging.getLogger(__name__)
 
 
+def _payload_delivery_id(
+    route_name: str, payload: Any, body: bytes
+) -> Optional[str]:
+    """Return a retry key for one exact body carrying a stable resource ID.
+
+    A provider's top-level ``id`` is often a resource ID rather than an event
+    delivery ID. Include the raw-body digest so exact retries deduplicate while
+    distinct events about the same resource continue through the pipeline.
+    """
+    if not isinstance(payload, dict):
+        return None
+    payload_id = payload.get("id")
+    if isinstance(payload_id, bool) or not isinstance(payload_id, (str, int)):
+        return None
+    if isinstance(payload_id, str) and not payload_id:
+        return None
+    return "payload-id:" + json.dumps(
+        [route_name, payload_id, hashlib.sha256(body).hexdigest()],
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
 def _is_webhook_silence_response(content: Any) -> bool:
     """Whether an agent response means "deliberately say nothing".
 
@@ -288,6 +311,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # Content-Length and would otherwise bypass the header check below.
         app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/webhooks/{route_name}", self._handle_webhook_readiness)
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
         # Multi-profile multiplexing: a /p/<profile>/webhooks/<route> prefix
         # routes the inbound event to that profile. Same handler; the profile is
@@ -296,6 +320,9 @@ class WebhookAdapter(BasePlatformAdapter):
         # when gateway.multiplex_profiles is on (the handler validates).
         app.router.add_post(
             "/p/{profile}/webhooks/{route_name}", self._handle_webhook
+        )
+        app.router.add_get(
+            "/p/{profile}/webhooks/{route_name}", self._handle_webhook_readiness
         )
 
         self._runner = web.AppRunner(app)
@@ -502,6 +529,29 @@ class WebhookAdapter(BasePlatformAdapter):
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
         return web.json_response({"status": "ok", "platform": "webhook"})
+
+    async def _handle_webhook_readiness(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """Confirm that a webhook route is registered without processing it."""
+        self._reload_dynamic_routes()
+        profile = self._resolve_request_profile(request)
+        if profile is _PROFILE_REJECTED:
+            return web.json_response(
+                {"error": "Unknown or unconfigured profile"}, status=404
+            )
+        route_name = request.match_info.get("route_name", "")
+        route_config = self._routes.get(route_name)
+        if not route_config:
+            return web.json_response({"error": "Unknown webhook route"}, status=404)
+        request_profile = profile if isinstance(profile, str) else None
+        if not self._route_allows_profile(route_config, request_profile):
+            return web.json_response({"error": "Unknown webhook route"}, status=404)
+        if route_config.get("enabled", True) is False:
+            return web.json_response(
+                {"error": f"Route disabled: {route_name}"}, status=403
+            )
+        return web.json_response({"status": "ready"})
 
     def _reload_dynamic_routes(self) -> None:
         """Reload agent-created subscriptions from disk if the file changed."""
@@ -750,8 +800,10 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Check event type filter
         event_type = (
-            request.headers.get("X-GitHub-Event", "")
+            request.headers.get("Linear-Event", "")
+            or request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
+            or request.headers.get("X-Event-Type", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
             or "unknown"
@@ -842,14 +894,19 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
+        # Trusted provider delivery headers take priority. Providers such as
+        # Circleback omit them but retry a stable top-level payload ID.
         delivery_id = request.headers.get(
             "X-GitHub-Delivery",
             request.headers.get(
                 "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                request.headers.get("X-Request-ID", ""),
             ),
         )
+        if not delivery_id:
+            delivery_id = _payload_delivery_id(route_name, payload, raw_body)
+        if not delivery_id:
+            delivery_id = str(int(time.time() * 1000))
 
         # ── Idempotency ─────────────────────────────────────────
         # Skip duplicate deliveries (webhook retries).
@@ -1174,19 +1231,21 @@ class WebhookAdapter(BasePlatformAdapter):
             ).hexdigest()
             return _hmac_str_equal(v2_sig, expected_v2)
 
-        # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>
-        # (deprecated — no replay protection, since the signature only
-        # covers the body: a captured (body, signature) pair replays
-        # indefinitely with no timestamp binding it to a specific delivery.)
-        # Only reachable when X-Webhook-Signature-V2 was not sent at all —
-        # see the guard above.
-        generic_sig = request.headers.get("X-Webhook-Signature", "")
-        if generic_sig:
-            expected = hmac.new(
-                secret.encode(), body, hashlib.sha256
-            ).hexdigest()
+        # Generic/provider HMAC-SHA256 signatures (legacy body-only; no replay
+        # protection). Providers differ by header name and may prefix the hex
+        # digest with ``sha256=``.
+        expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        for header_name in (
+            "X-Webhook-Signature",
+            "Attio-Signature",
+            "X-Attio-Signature",
+            "X-Signature",
+        ):
+            signature = _header(header_name)
+            if not signature:
+                continue
             route_name = request.match_info.get("route_name", "")
-            if route_name not in self._v1_signature_warned:
+            if header_name == "X-Webhook-Signature" and route_name not in self._v1_signature_warned:
                 self._v1_signature_warned.add(route_name)
                 logger.warning(
                     "[webhook] Route '%s' uses legacy body-only HMAC (no "
@@ -1196,7 +1255,7 @@ class WebhookAdapter(BasePlatformAdapter):
                     "'<timestamp>.<body>').",
                     route_name,
                 )
-            return _hmac_str_equal(generic_sig, expected)
+            return _hmac_str_equal(signature.removeprefix("sha256="), expected)
 
         # No recognised signature header but secret is configured → reject
         logger.debug(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2490,8 +2490,23 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         from toolsets import validate_toolset
         from hermes_cli.toolset_validation import validate_platform_toolsets
 
+        raw_config = read_raw_config()
+        dynamic_toolset_names = {"no_mcp"}
+        known_plugins = raw_config.get("known_plugin_toolsets") or {}
+        if isinstance(known_plugins, dict):
+            for names in known_plugins.values():
+                if isinstance(names, list):
+                    dynamic_toolset_names.update(
+                        name for name in names if isinstance(name, str) and name
+                    )
+        mcp_servers = raw_config.get("mcp_servers") or {}
+        if isinstance(mcp_servers, dict):
+            dynamic_toolset_names.update(str(name) for name in mcp_servers)
+
         ts_warnings = validate_platform_toolsets(
-            read_raw_config().get("platform_toolsets"), validate_toolset
+            raw_config.get("platform_toolsets"),
+            validate_toolset,
+            additional_valid_names=dynamic_toolset_names,
         )
         for w in ts_warnings:
             results["warnings"].append(w)

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -12,12 +12,14 @@ significant debugging to find. Surfacing invalid toolset names (and the
 zero-tools end state) loudly turns that silent failure into an actionable one.
 """
 
+from collections.abc import Collection
 from typing import Callable, List
 
 
 def validate_platform_toolsets(
     platform_toolsets: object,
     is_valid_toolset: Callable[[str], bool],
+    additional_valid_names: Collection[str] = (),
 ) -> List[str]:
     """Return human-readable warnings for a ``platform_toolsets`` mapping.
 
@@ -37,7 +39,10 @@ def validate_platform_toolsets(
         platform_toolsets: The raw ``platform_toolsets`` value from config. Only
             ``dict`` values carry toolset entries; anything else yields no
             warnings (nothing to validate).
-        is_valid_toolset: Predicate returning ``True`` for a known toolset name.
+        is_valid_toolset: Predicate returning ``True`` for a known static
+            toolset name.
+        additional_valid_names: Dynamic names that are valid platform entries,
+            such as plugin toolsets, MCP server names, and ``no_mcp``.
 
     Returns:
         A list of warning strings (empty when everything is valid).
@@ -46,13 +51,15 @@ def validate_platform_toolsets(
     if not isinstance(platform_toolsets, dict) or not platform_toolsets:
         return warnings
 
+    additional_valid = set(additional_valid_names)
+
     valid_count = 0
     for platform, raw in platform_toolsets.items():
         names = raw if isinstance(raw, list) else [raw]
         for name in names:
             if not isinstance(name, str) or not name:
                 continue
-            if is_valid_toolset(name):
+            if is_valid_toolset(name) or name in additional_valid:
                 valid_count += 1
                 continue
             suggestion = f"hermes-{platform}"

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -73,6 +73,7 @@ def _create_app(adapter: WebhookAdapter) -> web.Application:
     # Mirror connect(): client_max_size enforces the cap on chunked bodies.
     app = web.Application(client_max_size=adapter._max_body_bytes)
     app.router.add_get("/health", adapter._handle_health)
+    app.router.add_get("/webhooks/{route_name}", adapter._handle_webhook_readiness)
     app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
     return app
 
@@ -175,6 +176,31 @@ class TestValidateSignature:
         req = _mock_request(headers={"linear-signature": sig})
 
         assert adapter._validate_signature(req, body, "real-secret") is False
+
+    @pytest.mark.parametrize("header", [
+        "X-Signature",
+        "Attio-Signature",
+        "X-Attio-Signature",
+    ])
+    def test_provider_body_hmac_signatures_accept(self, header):
+        adapter = _make_adapter()
+        body = b'{"id":"meeting-123","type":"meeting.completed"}'
+        secret = "provider-signing-secret"
+        signature = _generic_signature(body, secret)
+
+        req = _mock_request(headers={header: signature})
+
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_provider_body_hmac_sha256_prefix_accepts(self):
+        adapter = _make_adapter()
+        body = b'{"id":"meeting-123"}'
+        secret = "provider-signing-secret"
+        signature = "sha256=" + _generic_signature(body, secret)
+
+        req = _mock_request(headers={"X-Signature": signature})
+
+        assert adapter._validate_signature(req, body, secret) is True
 
 
     def test_non_ascii_svix_signature_rejected(self):
@@ -487,6 +513,46 @@ class TestPayloadFilters:
 class TestHTTPHandling:
 
     @pytest.mark.asyncio
+    async def test_registered_route_get_is_side_effect_free_readiness(self):
+        adapter = _make_adapter(
+            routes={"circleback": {"secret": "secret", "prompt": "private"}}
+        )
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.get("/webhooks/circleback")
+            payload = await response.json()
+
+        assert response.status == 200
+        assert payload == {"status": "ready"}
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_route_get_returns_404(self):
+        adapter = _make_adapter(routes={"known": {"prompt": "ok"}})
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.get("/webhooks/missing")
+            payload = await response.json()
+
+        assert response.status == 404
+        assert payload == {"error": "Unknown webhook route"}
+
+    @pytest.mark.asyncio
+    async def test_disabled_route_get_is_not_ready(self):
+        adapter = _make_adapter(
+            routes={"paused": {"enabled": False, "secret": "secret", "prompt": "x"}}
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.get("/webhooks/paused")
+
+        assert response.status == 403
+
+    @pytest.mark.asyncio
     async def test_unknown_route_returns_404(self):
         """POST to an unknown route returns 404."""
         adapter = _make_adapter(routes={"real": {"secret": _INSECURE_NO_AUTH, "prompt": "x"}})
@@ -519,6 +585,55 @@ class TestHTTPHandling:
 
 
 class TestIdempotency:
+
+    @pytest.mark.asyncio
+    async def test_retries_without_delivery_header_use_payload_id(self):
+        secret = "circleback-secret"
+        adapter = _make_adapter(
+            routes={"circleback": {"secret": secret, "prompt": "meeting {id}"}}
+        )
+        adapter.handle_message = AsyncMock()
+        body = b'{"id":"meeting-stable-id"}'
+        headers = {"X-Signature": _generic_signature(body, secret)}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post("/webhooks/circleback", data=body, headers=headers)
+            retry = await cli.post("/webhooks/circleback", data=body, headers=headers)
+            retry_payload = await retry.json()
+            await asyncio.sleep(0)
+
+        assert first.status == 202
+        assert retry.status == 200
+        assert retry_payload["status"] == "duplicate"
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_same_payload_id_with_changed_event_body_is_not_duplicate(self):
+        secret = "circleback-secret"
+        adapter = _make_adapter(
+            routes={"events": {"secret": secret, "prompt": "event {id}"}}
+        )
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            statuses = []
+            for event_type in ("meeting.created", "meeting.completed"):
+                body = json.dumps(
+                    {"id": "same-resource-id", "type": event_type},
+                    separators=(",", ":"),
+                ).encode()
+                response = await cli.post(
+                    "/webhooks/events",
+                    data=body,
+                    headers={"X-Signature": _generic_signature(body, secret)},
+                )
+                statuses.append(response.status)
+            await asyncio.sleep(0)
+
+        assert statuses == [202, 202]
+        assert adapter.handle_message.await_count == 2
 
     @pytest.mark.asyncio
     async def test_duplicate_delivery_id_returns_200(self):
@@ -952,6 +1067,10 @@ class TestMultiplexProfileWebhookAuthentication:
     @staticmethod
     def _app(adapter):
         app = _create_app(adapter)
+        app.router.add_get(
+            "/p/{profile}/webhooks/{route_name}",
+            adapter._handle_webhook_readiness,
+        )
         app.router.add_post(
             "/p/{profile}/webhooks/{route_name}",
             adapter._handle_webhook,
@@ -1010,6 +1129,31 @@ class TestMultiplexProfileWebhookAuthentication:
                 headers=headers,
             )
             assert default_profile.status == 404
+
+    @pytest.mark.asyncio
+    async def test_readiness_is_bound_to_named_profile(
+        self, tmp_path, monkeypatch
+    ):
+        adapter = _make_adapter(
+            routes={
+                "circleback": {
+                    "profile": "worker",
+                    "secret": "worker-secret",
+                    "prompt": "meeting",
+                }
+            },
+            host="127.0.0.1",
+        )
+        self._configure_profiles(adapter, tmp_path, monkeypatch)
+
+        async with TestClient(TestServer(self._app(adapter))) as cli:
+            worker = await cli.get("/p/worker/webhooks/circleback")
+            other = await cli.get("/p/other/webhooks/circleback")
+            bare = await cli.get("/webhooks/circleback")
+
+        assert worker.status == 200
+        assert other.status == 404
+        assert bare.status == 404
 
 
 def test_route_profile_validation_fails_closed():

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -46,5 +46,21 @@ def test_mixed_valid_and_invalid_flags_only_the_invalid():
     assert "unknown toolset 'bogus'" in warnings[0]
 
 
+def test_dynamic_platform_entries_are_accepted():
+    cfg = {
+        "webhook": ["beca-webhook"],
+        "cron": ["no_mcp"],
+        "discord": ["attio"],
+    }
+
+    warnings = validate_platform_toolsets(
+        cfg,
+        _is_valid,
+        additional_valid_names={"beca-webhook", "no_mcp", "attio"},
+    )
+
+    assert warnings == []
+
+
 
 


### PR DESCRIPTION
## Summary
- accept Circleback/Attio provider HMAC headers and provider event headers
- add side-effect-free GET readiness with profile and disabled-route authorization
- deduplicate exact body retries without suppressing changed events that share a resource ID
- accept plugin, MCP server, and `no_mcp` passthrough entries in platform-toolset migration validation

## Verification
- `pytest -q tests/gateway/test_webhook_adapter.py tests/hermes_cli/test_toolset_validation.py` (49 passed)
- `ruff check` on all changed files
- `git diff --check`
- three independent review rounds; final verdict PASS
- live Circleback provider request returned 202 and produced exactly one wake receipt

## Notes
No secrets or provider payload contents are logged. Payload fallback keys include only route, scalar ID, and SHA-256 of the exact raw body.