### PR TITLE
fix(cron): Desktop's advertised natural schedules now parse (#51975, salvage #51598 #52504)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -917,7 +917,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         rest = schedule[6:].strip()
         cron_expr = _natural_every_to_cron(rest)
         if cron_expr is not None:
-            if not HAS_CRONITER:
+            if not _ensure_croniter():
                 raise ValueError(
                     "Weekday/time schedules like 'every monday 9am' require the "
                     "'croniter' package. Install with: pip install croniter"
@@ -937,7 +937,27 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             "minutes": minutes,
             "display": f"every {minutes}m"
         }
-    
+
+    # No-"every" natural day/time phrases advertised by the Desktop dialog:
+    # "weekdays at 9am", "monday at 9:30", "daily at 7am" (#51975). Reuse the
+    # same helper — the phrase shape is identical without the "every " prefix.
+    cron_expr = _natural_every_to_cron(schedule_lower)
+    if cron_expr is not None:
+        if not _ensure_croniter():
+            raise ValueError(
+                "Weekday/time schedules like 'weekdays at 9am' require the "
+                "'croniter' package. Install with: pip install croniter"
+            )
+        try:
+            croniter(cron_expr)
+        except Exception as e:
+            raise ValueError(f"Invalid schedule '{original}': {e}")
+        return {
+            "kind": "cron",
+            "expr": cron_expr,
+            "display": original,
+        }
+
     # Check for cron expression (5 or 6 space-separated fields)
     # Cron fields: minute hour day month weekday [year]
     parts = schedule.split()

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -794,9 +794,97 @@ def parse_duration(s: str) -> int:
     
     value = int(match.group(1)) if match.group(1) else 1
     unit = match.group(2)[0]  # First char: m, h, or d
-    
+
     multipliers = {'m': 1, 'h': 60, 'd': 1440}
     return value * multipliers[unit]
+
+
+# Natural-language day-spec phrases for the documented "every monday 9am" /
+# "every day at 9am" schedule forms. Cron weekday numbering is
+# 0=Sunday … 6=Saturday (croniter's default).
+_WEEKDAY_TO_CRON_DOW = {
+    "sunday": "0", "sun": "0",
+    "monday": "1", "mon": "1",
+    "tuesday": "2", "tue": "2", "tues": "2",
+    "wednesday": "3", "wed": "3", "weds": "3",
+    "thursday": "4", "thu": "4", "thur": "4", "thurs": "4",
+    "friday": "5", "fri": "5",
+    "saturday": "6", "sat": "6",
+}
+
+# Keyword day-specs that expand to a cron weekday field.
+_DAYSPEC_TO_CRON_DOW = {
+    "day": "*", "daily": "*", "everyday": "*",
+    "weekday": "1-5", "weekdays": "1-5",
+    "weekend": "0,6", "weekends": "0,6",
+}
+
+
+def _parse_clock_time(text: str) -> Optional[tuple]:
+    """Parse a wall-clock time into a ``(hour, minute)`` 24-hour tuple.
+
+    Accepts ``9am``, ``9:30am``, ``9 am``, ``14:00``, ``7`` (bare hour, 24h),
+    ``noon``/``midday``, and ``midnight``. Returns None when the text is not a
+    recognized clock time so the caller can reject the schedule cleanly.
+    """
+    t = text.strip().lower().replace(" ", "")
+    if not t:
+        return None
+    if t in ("noon", "midday"):
+        return (12, 0)
+    if t == "midnight":
+        return (0, 0)
+    match = re.match(r'^(\d{1,2})(?::(\d{2}))?(am|pm)?$', t)
+    if not match:
+        return None
+    hour = int(match.group(1))
+    minute = int(match.group(2) or 0)
+    meridiem = match.group(3)
+    if meridiem:
+        if not 1 <= hour <= 12:
+            return None
+        if meridiem == "am":
+            hour = 0 if hour == 12 else hour
+        else:  # pm
+            hour = 12 if hour == 12 else hour + 12
+    if hour > 23 or minute > 59:
+        return None
+    return (hour, minute)
+
+
+def _natural_every_to_cron(rest: str) -> Optional[str]:
+    """Convert a documented ``every <when> [at] <time>`` phrase to a 5-field
+    cron expression, or None when *rest* is not such a phrase.
+
+    Examples::
+
+        "monday 9am"      -> "0 9 * * 1"
+        "day at 9am"      -> "0 9 * * *"
+        "weekday at 9am"  -> "0 9 * * 1-5"
+
+    Returning None lets ``parse_schedule`` fall back to the interval
+    (``every 30m``) path, so existing duration schedules are unaffected.
+    """
+    tokens = rest.lower().split()
+    if not tokens:
+        return None
+    day_token = tokens[0]
+    dow = _WEEKDAY_TO_CRON_DOW.get(day_token) or _DAYSPEC_TO_CRON_DOW.get(day_token)
+    if dow is None:
+        return None
+
+    time_tokens = tokens[1:]
+    # Optional "at" separator: "every day at 9am".
+    if time_tokens and time_tokens[0] == "at":
+        time_tokens = time_tokens[1:]
+    if not time_tokens:
+        return None
+
+    parsed = _parse_clock_time(" ".join(time_tokens))
+    if parsed is None:
+        return None
+    hour, minute = parsed
+    return f"{minute} {hour} * * {dow}"
 
 
 def parse_schedule(schedule: str) -> Dict[str, Any]:
@@ -814,17 +902,36 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         "2h"               → once in 2 hours
         "every 30m"        → recurring every 30 minutes
         "every 2h"         → recurring every 2 hours
+        "every monday 9am" → recurring weekly (cron)
+        "every day at 9am" → recurring daily (cron)
         "0 9 * * *"        → cron expression
         "2026-02-03T14:00" → once at timestamp
     """
     schedule = schedule.strip()
     original = schedule
     schedule_lower = schedule.lower()
-    
-    # "every X" pattern → recurring interval
+
+    # "every X" pattern → recurring interval, OR a documented natural-language
+    # day/time phrase ("every monday 9am", "every day at 9am") → cron.
     if schedule_lower.startswith("every "):
-        duration_str = schedule[6:].strip()
-        minutes = parse_duration(duration_str)
+        rest = schedule[6:].strip()
+        cron_expr = _natural_every_to_cron(rest)
+        if cron_expr is not None:
+            if not HAS_CRONITER:
+                raise ValueError(
+                    "Weekday/time schedules like 'every monday 9am' require the "
+                    "'croniter' package. Install with: pip install croniter"
+                )
+            try:
+                croniter(cron_expr)
+            except Exception as e:
+                raise ValueError(f"Invalid schedule '{original}': {e}")
+            return {
+                "kind": "cron",
+                "expr": cron_expr,
+                "display": original,
+            }
+        minutes = parse_duration(rest)
         return {
             "kind": "interval",
             "minutes": minutes,
@@ -894,6 +1001,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         f"Invalid schedule '{original}'. Use:\n"
         f"  - Duration: '30m', '2h', '1d' (one-shot)\n"
         f"  - Interval: 'every 30m', 'every 2h' (recurring)\n"
+        f"  - Weekly/daily: 'every monday 9am', 'every day at 9am' (recurring)\n"
         f"  - Cron: '0 9 * * *' (cron expression)\n"
         f"  - Timestamp: '2026-02-03T14:00:00' (one-shot at time)"
     )

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -960,9 +960,13 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
 
     # Check for cron expression (5 or 6 space-separated fields)
     # Cron fields: minute hour day month weekday [year]
+    # Allow letters so named months/weekdays (JAN-DEC, MON-SUN, incl. ranges
+    # and lists like MON-FRI or MON,WED,FRI) are routed to croniter, which
+    # supports them. The previous digit-only pattern silently rejected these
+    # valid expressions as "Invalid schedule".
     parts = schedule.split()
     if len(parts) >= 5 and all(
-        re.match(r'^[\d\*\-,/]+$', p) for p in parts[:5]
+        re.match(r'^[A-Za-z\d\*\-,/]+$', p) for p in parts[:5]
     ):
         if not _ensure_croniter():
             raise ValueError("Cron expressions require 'croniter' package. Install with: pip install croniter")

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -861,19 +861,40 @@ def _natural_every_to_cron(rest: str) -> Optional[str]:
         "monday 9am"      -> "0 9 * * 1"
         "day at 9am"      -> "0 9 * * *"
         "weekday at 9am"  -> "0 9 * * 1-5"
+        "monday, wednesday at 9am" -> "0 9 * * 1,3"
 
     Returning None lets ``parse_schedule`` fall back to the interval
     (``every 30m``) path, so existing duration schedules are unaffected.
     """
-    tokens = rest.lower().split()
+    tokens = rest.lower().replace(",", " ").split()
     if not tokens:
         return None
-    day_token = tokens[0]
-    dow = _WEEKDAY_TO_CRON_DOW.get(day_token) or _DAYSPEC_TO_CRON_DOW.get(day_token)
-    if dow is None:
-        return None
 
-    time_tokens = tokens[1:]
+    # Consume one or more leading day tokens: a keyword spec ("weekdays"),
+    # a single weekday, or a comma/"and"-separated weekday list
+    # ("monday, wednesday at 9am").
+    day_token = tokens[0]
+    dow = _DAYSPEC_TO_CRON_DOW.get(day_token)
+    idx = 1
+    if dow is None:
+        days = []
+        while idx <= len(tokens):
+            tok = tokens[idx - 1]
+            if tok == "and":
+                idx += 1
+                continue
+            mapped = _WEEKDAY_TO_CRON_DOW.get(tok)
+            if mapped is None:
+                break
+            if mapped not in days:
+                days.append(mapped)
+            idx += 1
+        if not days:
+            return None
+        dow = ",".join(days)
+        idx -= 1
+
+    time_tokens = tokens[idx:]
     # Optional "at" separator: "every day at 9am".
     if time_tokens and time_tokens[0] == "at":
         time_tokens = time_tokens[1:]

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -94,6 +94,86 @@ class TestParseSchedule:
         assert result["minutes"] == 120
 
 
+    # ---- Natural-language weekday/daily phrases → cron (issue: documented
+    # "every monday 9am" format was rejected because the "every" branch only
+    # accepted durations). ----
+
+    def test_every_weekday_time_becomes_cron(self):
+        pytest.importorskip("croniter")
+        result = parse_schedule("every monday 9am")
+        assert result["kind"] == "cron"
+        assert result["expr"] == "0 9 * * 1"
+        # Display preserves the user's natural phrasing.
+        assert result["display"] == "every monday 9am"
+
+    def test_every_sunday_maps_to_zero(self):
+        pytest.importorskip("croniter")
+        # Cron weekday numbering puts Sunday at 0.
+        assert parse_schedule("every sunday 9am")["expr"] == "0 9 * * 0"
+
+    def test_every_weekday_abbreviations(self):
+        pytest.importorskip("croniter")
+        assert parse_schedule("every mon 9am")["expr"] == "0 9 * * 1"
+        assert parse_schedule("every fri 5pm")["expr"] == "0 17 * * 5"
+
+    def test_every_day_keyword_is_daily(self):
+        pytest.importorskip("croniter")
+        assert parse_schedule("every day at 9am")["expr"] == "0 9 * * *"
+        assert parse_schedule("every day 7am")["expr"] == "0 7 * * *"
+
+    def test_every_weekday_keyword_is_business_days(self):
+        pytest.importorskip("croniter")
+        assert parse_schedule("every weekday at 9am")["expr"] == "0 9 * * 1-5"
+
+    def test_every_weekend_keyword(self):
+        pytest.importorskip("croniter")
+        assert parse_schedule("every weekend at 10am")["expr"] == "0 10 * * 0,6"
+
+    def test_every_time_formats(self):
+        pytest.importorskip("croniter")
+        # 24-hour, explicit minutes, noon/midnight, bare hour.
+        assert parse_schedule("every monday 14:30")["expr"] == "30 14 * * 1"
+        assert parse_schedule("every monday 9:05am")["expr"] == "5 9 * * 1"
+        assert parse_schedule("every monday noon")["expr"] == "0 12 * * 1"
+        assert parse_schedule("every monday midnight")["expr"] == "0 0 * * 1"
+        assert parse_schedule("every monday at 7")["expr"] == "0 7 * * 1"
+
+    def test_every_12_hour_boundaries(self):
+        pytest.importorskip("croniter")
+        # 12am is midnight (00:00), 12pm is noon (12:00).
+        assert parse_schedule("every monday 12am")["expr"] == "0 0 * * 1"
+        assert parse_schedule("every monday 12pm")["expr"] == "0 12 * * 1"
+
+    def test_every_weekday_time_is_case_insensitive(self):
+        pytest.importorskip("croniter")
+        assert parse_schedule("Every Monday 9AM")["expr"] == "0 9 * * 1"
+
+    def test_every_weekday_schedule_computes_next_run(self):
+        pytest.importorskip("croniter")
+        # End-to-end: the produced cron schedule is usable by compute_next_run.
+        schedule = parse_schedule("every monday 9am")
+        next_run = compute_next_run(schedule)
+        assert next_run is not None
+        dt = datetime.fromisoformat(next_run)
+        assert dt.weekday() == 0  # Python: Monday == 0
+        assert (dt.hour, dt.minute) == (9, 0)
+
+    def test_every_duration_still_interval(self):
+        # The interval path must keep working unchanged.
+        assert parse_schedule("every 30m")["kind"] == "interval"
+        assert parse_schedule("every 1d")["minutes"] == 1440
+
+    def test_every_weekday_without_time_raises(self):
+        # A weekday with no time is ambiguous — reject rather than guess.
+        with pytest.raises(ValueError):
+            parse_schedule("every monday")
+
+    def test_every_invalid_time_raises(self):
+        with pytest.raises(ValueError):
+            parse_schedule("every monday 25am")
+        with pytest.raises(ValueError):
+            parse_schedule("every monday 9pm pizza")
+
     def test_cron_expression(self):
         pytest.importorskip("croniter")
         result = parse_schedule("0 9 * * *")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -180,6 +180,25 @@ class TestParseSchedule:
         assert result["kind"] == "cron"
         assert result["expr"] == "0 9 * * *"
 
+    def test_cron_named_weekdays_and_months(self):
+        # Named months/weekdays (and ranges/lists) are valid cron and must
+        # route to croniter, not be rejected as "Invalid schedule".
+        pytest.importorskip("croniter")
+        for expr in (
+            "0 9 * * MON",
+            "*/15 9-17 * * MON-FRI",
+            "0 9 1 JAN *",
+            "0 9 * * MON,WED,FRI",
+        ):
+            result = parse_schedule(expr)
+            assert result["kind"] == "cron", expr
+            assert result["expr"] == expr
+
+    def test_invalid_named_cron_still_rejected(self):
+        pytest.importorskip("croniter")
+        with pytest.raises(ValueError):
+            parse_schedule("0 9 * * FUNDAY")
+
     def test_iso_timestamp(self):
         result = parse_schedule("2030-01-15T14:00:00")
         assert result["kind"] == "once"

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -129,6 +129,28 @@ class TestParseSchedule:
         pytest.importorskip("croniter")
         assert parse_schedule("every weekend at 10am")["expr"] == "0 10 * * 0,6"
 
+    def test_no_every_prefix_natural_forms(self):
+        # The Desktop dialog advertises these WITHOUT the "every" prefix
+        # (#51975 repro): they must parse identically.
+        pytest.importorskip("croniter")
+        assert parse_schedule("weekdays at 9am")["expr"] == "0 9 * * 1-5"
+        assert parse_schedule("monday at 9:30")["expr"] == "30 9 * * 1"
+        assert parse_schedule("daily at 7am")["expr"] == "0 7 * * *"
+
+    def test_weekday_list_forms(self):
+        # Comma/"and"-separated day lists from the #51975 repro.
+        pytest.importorskip("croniter")
+        assert parse_schedule("Monday, Wednesday at 9am")["expr"] == "0 9 * * 1,3"
+        assert parse_schedule("monday and friday at 5pm")["expr"] == "0 17 * * 1,5"
+        assert parse_schedule("every tue, thu 8am")["expr"] == "0 8 * * 2,4"
+
+    def test_natural_form_negatives_still_reject(self):
+        pytest.importorskip("croniter")
+        with pytest.raises(ValueError):
+            parse_schedule("monday banana at 9am")
+        with pytest.raises(ValueError):
+            parse_schedule("funday at 9am")
+
     def test_every_time_formats(self):
         pytest.importorskip("croniter")
         # 24-hour, explicit minutes, noon/midnight, bare hour.

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,44 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_with_natural_weekday_schedule(self):
+        # The documented "every monday 9am" form must create a real cron job
+        # through the tool path, not error out (issue: parser rejected it).
+        pytest.importorskip("croniter")
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Weekly report",
+                schedule="every monday 9am",
+                name="Weekly Report",
+            )
+        )
+        assert created["success"] is True
+        # Display keeps the user's natural phrasing.
+        assert created["schedule"] == "every monday 9am"
+        # A recurring job must have a computed next run.
+        assert created["next_run_at"]
+
+        # The stored schedule is a cron expression.
+        from cron.jobs import get_job
+        stored = get_job(created["job_id"])
+        assert stored["schedule"]["kind"] == "cron"
+        assert stored["schedule"]["expr"] == "0 9 * * 1"
+
+    def test_update_to_natural_weekday_schedule(self):
+        pytest.importorskip("croniter")
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        job_id = created["job_id"]
+
+        updated = json.loads(
+            cronjob(action="update", job_id=job_id, schedule="every day at 9am")
+        )
+        assert updated["success"] is True
+        assert updated["job"]["schedule"] == "every day at 9am"
+
+        from cron.jobs import get_job
+        assert get_job(job_id)["schedule"]["expr"] == "0 9 * * *"
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1969,8 +1969,7 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "description": "For create: the full self-contained prompt (paired with any skills as the task instruction). For run: optional transient context for that single fire (never persisted)."
             },
             "schedule": {
-                "type": "string",
-                "description": "REQUIRED for create. '30m' (every 30 minutes), 'every 2h', cron syntax '0 9 * * *' (daily 9am), or an ISO timestamp for one-shot ('2026-06-01T09:00:00')."
+                "t                "description": "REQUIRED for create. '30m' (every 30 minutes), 'every 2h', 'every monday 9am' / 'every day at 9am' (recurring weekly/daily), cron syntax '0 9 * * *' (daily 9am), or an ISO timestamp for one-shot ('2026-06-01T09:00:00')."
             },
             "name": {
                 "type": "string",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1969,7 +1969,8 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "description": "For create: the full self-contained prompt (paired with any skills as the task instruction). For run: optional transient context for that single fire (never persisted)."
             },
             "schedule": {
-                "t                "description": "REQUIRED for create. '30m' (every 30 minutes), 'every 2h', 'every monday 9am' / 'every day at 9am' (recurring weekly/daily), cron syntax '0 9 * * *' (daily 9am), or an ISO timestamp for one-shot ('2026-06-01T09:00:00')."
+                "type": "string",
+                "description": "REQUIRED for create. '30m' (every 30 minutes), 'every 2h', 'every monday 9am' / 'every day at 9am' (recurring weekly/daily), cron syntax '0 9 * * *' (daily 9am), or an ISO timestamp for one-shot ('2026-06-01T09:00:00')."
             },
             "name": {
                 "type": "string",

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -788,13 +788,28 @@ The agent's final response is automatically delivered to the job's `deliver:` ta
 every 30m    → Every 30 minutes
 every 2h     → Every 2 hours
 every 1d     → Every day
+every hour   → Every hour (bare unit = 1)
 ```
+
+### Natural day/time schedules (recurring)
+
+```text
+every monday 9am         → Weekly, Mondays at 9:00 AM
+every day at 9am         → Daily at 9:00 AM
+weekdays at 9am          → Weekdays at 9:00 AM
+weekends at 10am         → Saturdays and Sundays at 10:00 AM
+daily at 7am             → Daily at 7:00 AM
+monday, wednesday at 9am → Mondays and Wednesdays at 9:00 AM
+```
+
+Times accept `9am`, `9:30pm`, `14:00`, bare 24-hour hours (`at 7`), `noon`, and `midnight`. These forms compile to cron expressions internally (they require the `croniter` package, installed by default).
 
 ### Cron expressions
 
 ```text
 0 9 * * *       → Daily at 9:00 AM
 0 9 * * 1-5     → Weekdays at 9:00 AM
+0 9 * * MON-FRI → Weekdays at 9:00 AM (named weekdays/months accepted)
 0 */6 * * *     → Every 6 hours
 30 8 1 * *      → First of every month at 8:30 AM
 0 0 * * 0       → Every Sunday at midnight


### PR DESCRIPTION
## Summary
Documented natural-language cron schedules now parse — `weekdays at 9am`, `every monday 9am`, `every day at 9am`, `monday, wednesday at 9am`, and named-field cron (`0 9 * * MON-FRI`) all previously raised `Invalid schedule` even though the Desktop dialog advertises them. Fixes #51975.

Consolidated salvage: #51598 (@Drexuxux, canonical parser), #52504 (@devorun, named cron fields), covering the scope of #52034 (@lin-hongkuan) and closed-superseded #51997.

## Changes
- `cron/jobs.py`: `every <day> [at] <time>` → cron conversion with weekday/dayspec maps and 12/24-hour clock parsing (@Drexuxux); named months/weekdays routed to croniter (@devorun); follow-ups: no-`every` prefix forms (`weekdays at 9am` — the exact Desktop repro), comma/`and` weekday lists, `HAS_CRONITER` → `_ensure_croniter()` (lazy-import refactor landed after the PR was cut)
- `tools/cronjob_tools.py`: schedule description teaches the new forms
- `tests/`: 30+ new cases across parser, tool create/update path, and negatives
- `website/docs/user-guide/features/cron.md`: natural schedule forms + named cron fields documented

## Validation
| Input | Before (origin/main, real import) | After |
|---|---|---|
| `weekdays at 9am` (Desktop repro) | ValueError | cron `0 9 * * 1-5` |
| `Monday, Wednesday at 9am` (repro) | ValueError | cron `0 9 * * 1,3` |
| `every monday 9am` (repro) | ValueError | cron `0 9 * * 1` |
| `0 9 * * MON-FRI` | ValueError | cron, croniter-validated |
| `0 9 * * FUNDAY` | ValueError | ValueError (unchanged) |
| `every 30m` / `30m` / ISO | unchanged | unchanged |

Live repro: A/B against real `cron.jobs` imports, origin/main worktree vs branch. Targeted tests: 107/107 passed (`tests/cron/test_jobs.py`, `tests/tools/test_cronjob_tools.py`).

## Infographic

![Natural cron schedules infographic](https://v3b.fal.media/files/b/0aa85abb/NvUs5faUchINa1J6Q5UAR_EBZ7p2Fp.png)
