### PR TITLE
fix(cron): bare '30m' schedules recur as documented; 'in 30m' is the one-shot (salvage #78928)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -919,8 +919,8 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         - For "cron": "expr" (cron expression)
     
     Examples:
-        "30m"              → once in 30 minutes
-        "2h"               → once in 2 hours
+        "30m"              → every 30 minutes (recurring)
+        "2h"               → every 2 hours (recurring)
         "every 30m"        → recurring every 30 minutes
         "every 2h"         → recurring every 2 hours
         "every monday 9am" → recurring weekly (cron)
@@ -1030,14 +1030,32 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         except ValueError as e:
             raise ValueError(f"Invalid timestamp '{schedule}': {e}")
     
-    # Duration like "30m", "2h", "1d" → one-shot from now
-    try:
-        minutes = parse_duration(schedule)
+    # Duration like "30m", "2h", "1d" → RECURRING interval, matching the
+    # documented tool contract ("30m (every 30 minutes)"). Previously this
+    # returned kind="once", silently creating a one-shot job for a schedule
+    # the schema documents as recurring — an agent passing '30m' for "every
+    # 30 minutes" got a job that ran once and died (cron contract bug, fixed
+    # 2026-08-04). Explicit one-shot-by-duration is "in 30m"/"in 2h".
+    if schedule_lower.startswith("in "):
+        duration_str = schedule[3:].strip()
+        try:
+            minutes = parse_duration(duration_str)
+        except ValueError:
+            raise ValueError(
+                f"Invalid duration '{duration_str}' after 'in '. Use e.g. 'in 30m', 'in 2h'."
+            )
         run_at = _hermes_now() + timedelta(minutes=minutes)
         return {
             "kind": "once",
             "run_at": run_at.isoformat(),
-            "display": f"once in {original}"
+            "display": f"once in {duration_str}",
+        }
+    try:
+        minutes = parse_duration(schedule)
+        return {
+            "kind": "interval",
+            "minutes": minutes,
+            "display": f"every {minutes}m",
         }
     except ValueError:
         pass
@@ -2229,7 +2247,28 @@ def create_job(
     """
     parsed_schedule = parse_schedule(schedule)
 
-    # Normalize repeat: treat 0 or negative values as None (infinite)
+    # Normalize repeat: treat 0 or negative values as None (infinite).
+    # Also coerce the documented string forms ('forever' -> None,
+    # 'once' -> 1, numeric strings -> int) — the tool schema exposes repeat
+    # as an integer but agents legitimately pass the user-facing strings
+    # 'forever'/'once', which previously died with
+    # "'<=' not supported between instances of 'str' and 'int'"
+    # (#66824/#64520/#7142). Coerce here so every entry point (tool, CLI,
+    # API, dashboard) inherits the fix.
+    if isinstance(repeat, str):
+        repeat_str = repeat.strip().lower()
+        if repeat_str in ("forever", "infinite", "inf", "none", ""):
+            repeat = None
+        elif repeat_str in ("once", "one", "1x"):
+            repeat = 1
+        else:
+            try:
+                repeat = int(repeat_str)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid repeat value {repeat!r}: use an integer, "
+                    f"'forever', or 'once'."
+                )
     if repeat is not None and repeat <= 0:
         repeat = None
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1062,9 +1062,9 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     
     raise ValueError(
         f"Invalid schedule '{original}'. Use:\n"
-        f"  - Duration: '30m', '2h', '1d' (one-shot)\n"
-        f"  - Interval: 'every 30m', 'every 2h' (recurring)\n"
-        f"  - Weekly/daily: 'every monday 9am', 'every day at 9am' (recurring)\n"
+        f"  - Interval: '30m', 'every 30m', 'every 2h' (recurring)\n"
+        f"  - One-shot delay: 'in 30m', 'in 2h' (fires once)\n"
+        f"  - Weekly/daily: 'every monday 9am', 'weekdays at 9am' (recurring)\n"
         f"  - Cron: '0 9 * * *' (cron expression)\n"
         f"  - Timestamp: '2026-02-03T14:00:00' (one-shot at time)"
     )

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -39,7 +39,7 @@ def test_claim_oneshot_cannot_be_double_claimed(temp_home):
     """A one-shot can't be double-claimed (the fresh claim blocks the retry)."""
     from cron.jobs import create_job, claim_job_for_fire
 
-    job = create_job(prompt="x", schedule="30m", name="o")
+    job = create_job(prompt="x", schedule="in 30m", name="o")
     assert claim_job_for_fire(job["id"]) is True
     assert claim_job_for_fire(job["id"]) is False
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -76,11 +76,24 @@ class TestParseDuration:
 # =========================================================================
 
 class TestParseSchedule:
-    def test_duration_becomes_once(self):
+    def test_bare_duration_becomes_recurring_interval(self):
+        """Contract: bare '30m' means EVERY 30 minutes (tool schema says so).
+
+        Regression for the cron contract bug (2026-08-04): parse_schedule
+        returned kind='once' for bare durations, so an agent passing '30m'
+        for 'every 30 minutes' silently got a one-shot job that ran once and
+        died. The documented tool contract (tools/cronjob_tools.py) says
+        '30m' (every 30 minutes) — the code now honors it.
+        """
         result = parse_schedule("30m")
+        assert result["kind"] == "interval"
+        assert result["minutes"] == 30
+        assert "run_at" not in result
+
+    def test_in_duration_becomes_once(self):
+        """Explicit one-shot by duration: 'in 30m' fires once in 30 minutes."""
+        result = parse_schedule("in 30m")
         assert result["kind"] == "once"
-        assert "run_at" in result
-        # run_at should be a valid ISO timestamp string ~30 minutes from now
         run_at_str = result["run_at"]
         assert isinstance(run_at_str, str)
         run_at = datetime.fromisoformat(run_at_str)
@@ -359,7 +372,7 @@ class TestJobCRUD:
         assert job["id"]
         assert job["prompt"] == "Check server status"
         assert job["enabled"] is True
-        assert job["schedule"]["kind"] == "once"
+        assert job["schedule"]["kind"] == "interval"
 
         fetched = get_job(job["id"])
         assert fetched is not None
@@ -379,8 +392,25 @@ class TestJobCRUD:
 
 
     def test_auto_repeat_for_once(self, tmp_cron_dir):
-        job = create_job(prompt="One-shot", schedule="1h")
+        job = create_job(prompt="One-shot", schedule="in 1h")
         assert job["repeat"]["times"] == 1
+
+    def test_repeat_string_forms_coerced(self, tmp_cron_dir):
+        """Agents pass 'forever'/'once' as repeat — must coerce, not TypeError.
+
+        Regression for #66824/#64520/#7142: repeat='forever' died with
+        "'<=' not supported between instances of 'str' and 'int'". The tool
+        schema documents repeat as an integer but user-facing forms are
+        strings; coerce at create_job so every entry point inherits it.
+        """
+        forever = create_job(prompt="Str forever", schedule="every 1h", repeat="forever")
+        assert forever["repeat"]["times"] is None  # None = infinite
+        once = create_job(prompt="Str once", schedule="every 1h", repeat="once")
+        assert once["repeat"]["times"] == 1
+        three = create_job(prompt="Str 3", schedule="every 1h", repeat="3")
+        assert three["repeat"]["times"] == 3
+        with pytest.raises(ValueError, match="Invalid repeat"):
+            create_job(prompt="Bad", schedule="every 1h", repeat="banana")
 
     def test_rejects_stale_past_one_shot_at_creation(self, tmp_cron_dir, monkeypatch):
         now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)
@@ -569,7 +599,7 @@ class TestMarkJobRun:
 
     def test_repeat_limit_retains_completed_record(self, tmp_cron_dir):
         """A finished one-shot must stay inspectable, not vanish from the store."""
-        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        job = create_job(prompt="Once", schedule="in 30m", repeat=1)
         mark_job_run(job["id"], success=True)
         updated = get_job(job["id"])
         assert updated is not None, "completed one-shot was deleted from jobs.json"
@@ -580,7 +610,7 @@ class TestMarkJobRun:
 
     def test_repeat_limit_retains_delivery_error(self, tmp_cron_dir):
         """A one-shot whose delivery failed must keep the error on its record."""
-        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        job = create_job(prompt="Once", schedule="in 30m", repeat=1)
         mark_job_run(
             job["id"], success=True,
             delivery_error="platform 'telegram' not configured",
@@ -592,7 +622,7 @@ class TestMarkJobRun:
 
     def test_completed_oneshot_visible_in_list(self, tmp_cron_dir):
         """list_jobs(include_disabled=True) surfaces the completed record."""
-        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        job = create_job(prompt="Once", schedule="in 30m", repeat=1)
         mark_job_run(job["id"], success=True, delivery_error="send failed: 502")
         listed = {j["id"]: j for j in list_jobs(include_disabled=True)}
         assert job["id"] in listed
@@ -603,7 +633,7 @@ class TestMarkJobRun:
 
     def test_completed_oneshot_not_due(self, tmp_cron_dir):
         """A retained completed one-shot must never be dispatched again."""
-        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        job = create_job(prompt="Once", schedule="in 30m", repeat=1)
         mark_job_run(job["id"], success=True)
         assert job["id"] not in {j["id"] for j in get_due_jobs()}
 
@@ -708,7 +738,7 @@ class TestAdvanceNextRun:
 
     def test_skips_oneshot_job(self, tmp_cron_dir):
         """One-shot jobs should NOT be advanced — they need to retry on restart."""
-        job = create_job(prompt="Run once", schedule="30m")
+        job = create_job(prompt="Run once", schedule="in 30m")
         original_next = get_job(job["id"])["next_run_at"]
 
         result = advance_next_run(job["id"])
@@ -1166,7 +1196,7 @@ class TestCronOutputRetention:
         d.mkdir(parents=True, exist_ok=True)
         names = [f"2026-06-25_10-00-{i:02d}.md" for i in range(count)]
         for n in names:
-            (d / n).write_text("x")
+            (d / n).write_text("x", encoding="utf-8")
         return names
 
     def test_prune_keeps_newest_n(self, tmp_path):
@@ -1646,7 +1676,7 @@ class TestAdvanceNextRuns:
     def _make_due(self, tmp_cron_dir, n_recurring=3, n_oneshot=1):
         rec = [create_job(prompt=f"rec {i}", schedule="every 1h")
                for i in range(n_recurring)]
-        one = [create_job(prompt=f"one {i}", schedule="30m")
+        one = [create_job(prompt=f"one {i}", schedule="in 30m")
                for i in range(n_oneshot)]
         jobs = load_jobs()
         old = (datetime.now() - timedelta(minutes=5)).isoformat()
@@ -1712,7 +1742,7 @@ class TestCompletedOneshotRetentionSweep:
 
     def _completed_oneshot(self, age_days: float):
         """Create a one-shot, complete it, and backdate its last_run_at."""
-        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        job = create_job(prompt="Once", schedule="in 30m", repeat=1)
         mark_job_run(job["id"], success=True, delivery_error="boom")
         stamp = (
             datetime.now(timezone.utc) - timedelta(days=age_days)

--- a/tests/cron/test_oneshot_dispatch_failure_run_claim.py
+++ b/tests/cron/test_oneshot_dispatch_failure_run_claim.py
@@ -39,7 +39,7 @@ def cron_store(tmp_path, monkeypatch):
 
 
 def _make_oneshot(claimed: bool = True) -> dict:
-    job = jobs_mod.create_job(prompt="remind me", schedule="30m")
+    job = jobs_mod.create_job(prompt="remind me", schedule="in 30m")
     if claimed:
         jobs = jobs_mod.load_jobs()
         for j in jobs:

--- a/tests/cron/test_terminal_job_rearm.py
+++ b/tests/cron/test_terminal_job_rearm.py
@@ -32,7 +32,7 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 
 def test_completed_oneshot_trigger_is_refused_and_disk_record_is_unchanged(tmp_cron_dir):
-    job = create_job("done", "30m", name="done", repeat=1)
+    job = create_job("done", "in 30m", name="done", repeat=1)
     mark_job_run(job["id"], success=True)
     before = copy.deepcopy(load_jobs())
 
@@ -53,7 +53,7 @@ def test_exhausted_recurring_job_trigger_is_refused(tmp_cron_dir):
 
 def test_wedged_claimed_oneshot_remains_triggerable(tmp_cron_dir):
     now = datetime.now(timezone.utc)
-    job = create_job("wedged", "30m", repeat=2)
+    job = create_job("wedged", "in 30m", repeat=2)
     record = get_job(job["id"])
     record.update({
         "run_claim": {"at": now.isoformat(), "by": "dead-worker"},
@@ -89,7 +89,7 @@ def test_terminal_jobs_are_not_due_or_advanced(tmp_cron_dir):
 
 
 def test_terminal_refusal_survives_reload(tmp_cron_dir):
-    job = create_job("done", "30m", repeat=1)
+    job = create_job("done", "in 30m", repeat=1)
     mark_job_run(job["id"], success=True)
     before = copy.deepcopy(load_jobs())
     assert get_job(job["id"])["state"] == "completed"
@@ -100,7 +100,7 @@ def test_terminal_refusal_survives_reload(tmp_cron_dir):
 
 
 def test_update_cannot_reactivate_terminal_record(tmp_cron_dir):
-    job = create_job("done", "30m", repeat=1)
+    job = create_job("done", "in 30m", repeat=1)
     mark_job_run(job["id"], success=True)
     with pytest.raises(ValueError, match="terminal"):
         update_job(job["id"], {"enabled": True})
@@ -111,7 +111,7 @@ def test_update_cannot_reactivate_terminal_record(tmp_cron_dir):
 def test_rearm_completed_oneshot_restores_schedule_and_preserves_history(tmp_cron_dir):
     from cron.jobs import rearm_oneshot
 
-    job = create_job("done", "30m", repeat=3)
+    job = create_job("done", "in 30m", repeat=3)
     mark_job_run(job["id"], success=True)
     finished = get_job(job["id"])
     run_at = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
@@ -135,7 +135,7 @@ def test_rearm_refuses_recurring_and_live_claim(tmp_cron_dir):
     with pytest.raises(ValueError, match="one-shot"):
         rearm_oneshot(recurring["id"], future)
 
-    oneshot = create_job("claimed", "30m")
+    oneshot = create_job("claimed", "in 30m")
     record = get_job(oneshot["id"])
     record["run_claim"] = {"at": datetime.now(timezone.utc).isoformat(), "by": "live"}
     save_jobs([record])
@@ -234,7 +234,7 @@ class TestRecurringJobStuckInErrorStateIsRecoverable:
         """Control: the fix must not weaken protection for a genuinely
         terminal state=completed job — only state=error recurring jobs are
         exempted."""
-        job = create_job("done", "30m", repeat=1)
+        job = create_job("done", "in 30m", repeat=1)
         mark_job_run(job["id"], success=True)
         assert get_job(job["id"])["state"] == "completed"
 

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -742,7 +742,7 @@ async def test_trigger_cron_job_returns_completed_snapshot_for_retained_oneshot(
         "worker_alpha",
         "create_job",
         prompt="run once",
-        schedule="30m",
+        schedule="in 30m",
         name="completed-trigger-job",
     )
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -176,11 +176,11 @@ class TestCronTimezone:
         _reset_hermes_time_cache()
         os.environ.pop("HERMES_TIMEZONE", None)
 
-    def test_parse_schedule_duration_uses_tz_aware_now(self):
-        """parse_schedule('30m') should produce a tz-aware run_at."""
+    def test_parse_schedule_one_shot_duration_uses_tz_aware_now(self):
+        """parse_schedule('in 30m') should produce a tz-aware run_at."""
         os.environ["HERMES_TIMEZONE"] = "Asia/Kolkata"
         from cron.jobs import parse_schedule
-        result = parse_schedule("30m")
+        result = parse_schedule("in 30m")
         run_at = datetime.fromisoformat(result["run_at"])
         # The stored timestamp should be tz-aware
         assert run_at.tzinfo is not None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1970,7 +1970,8 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for create. '30m' (every 30 minutes), 'every 2h', 'every monday 9am' / 'every day at 9am' (recurring weekly/daily), cron syntax '0 9 * * *' (daily 9am), or an ISO timestamp for one-shot ('2026-06-01T09:00:00')."
+                "type": "string",
+                "description": "REQUIRED for create. Schedule forms: (1) recurring interval — '30m', 'every 2h', 'every hour' (EVERY 30 minutes / 2 hours / hour, forever by default); (2) explicit one-shot by duration — 'in 30m', 'in 2h' (fires ONCE that far from now; use this for 'remind me in N minutes' — do NOT hand-compute an absolute timestamp); (3) natural day/time — 'every monday 9am', 'weekdays at 9am', 'every day at 9am' (recurring weekly/daily); (4) cron syntax — '0 9 * * *' (daily 9am); (5) absolute one-shot — ISO timestamp '2026-06-01T09:00:00'."
             },
             "name": {
                 "type": "string",

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -46,7 +46,7 @@ Cron-run sessions cannot recursively create more cron jobs. Hermes disables cron
 ### In chat with `/cron`
 
 ```bash
-/cron add 30m "Remind me to check the build"
+/cron add "in 30m" "Remind me to check the build"
 /cron add "every 2h" "Check server status"
 /cron add "every 1h" "Summarize new feed items" --skill blogwatcher
 /cron add "every 1h" "Use both skills and combine the result" --skill blogwatcher --skill maps
@@ -779,14 +779,15 @@ The agent's final response is automatically delivered to the job's `deliver:` ta
 ### Relative delays (one-shot)
 
 ```text
-30m     → Run once in 30 minutes
-2h      → Run once in 2 hours
-1d      → Run once in 1 day
+in 30m  → Run once in 30 minutes
+in 2h   → Run once in 2 hours
+in 1d   → Run once in 1 day
 ```
 
 ### Intervals (recurring)
 
 ```text
+30m          → Every 30 minutes (bare durations are recurring)
 every 30m    → Every 30 minutes
 every 2h     → Every 2 hours
 every 1d     → Every day
@@ -827,7 +828,7 @@ Times accept `9am`, `9:30pm`, `14:00`, bare 24-hour hours (`at 7`), `noon`, and 
 
 | Schedule type | Default repeat | Behavior |
 |--------------|----------------|----------|
-| One-shot (`30m`, timestamp) | 1 | Runs once |
+| One-shot (`in 30m`, timestamp) | 1 | Runs once |
 | Interval (`every 2h`) | forever | Runs until removed |
 | Cron expression | forever | Runs until removed |
 


### PR DESCRIPTION
## Summary
Bare durations now honor the documented cron contract: `'30m'` creates a recurring interval (every 30 minutes) instead of a one-shot that silently ran once and died; the explicit one-shot form is `'in 30m'`. Also fixes `repeat="forever"`/`"once"`/`"3"` string forms, which previously crashed create_job with `'<=' not supported between instances of 'str' and 'int'` (#66824/#64520/#7142).

Salvage of #78928 by @andrexibiza, stacked on #98271 (natural schedules). Also supersedes the docs-only #53739 (@marcelopaniza) — the `in 30m` form preserves the "remind me in N minutes" case his PR flagged.

## Changes
- `cron/jobs.py`: bare durations → `kind: interval`; new `in <duration>` one-shot form; `repeat` string coercion at the `create_job` chokepoint (@andrexibiza)
- `tools/cronjob_tools.py`: schedule description rewritten to teach the corrected contract, merged with the natural-schedule forms
- `cron/jobs.py` parse error + `website/docs` updated to the corrected contract (follow-ups)
- Tests updated across parser/create/repeat paths (@andrexibiza)

## Validation
| Input | Before (origin/main, real import) | After |
|---|---|---|
| `parse_schedule("30m")` | `kind: once` (ran once, died) | `kind: interval, 30 min` |
| `parse_schedule("in 30m")` | ValueError | `kind: once` |
| `create_job(repeat="forever")` | TypeError | `times: None` (infinite) |
| `create_job(repeat="banana")` | TypeError | ValueError with guidance |
| ISO timestamps | one-shot | one-shot (unchanged) |

Live repro: A/B against real `cron.jobs` imports, origin/main worktree vs branch. Targeted tests: 193/193 passed (`tests/cron/`, `tests/tools/test_cronjob_tools.py`, `tests/test_timezone.py`).

Note: stacked on #98271 — merge that first; this PR's diff collapses to the contract change after it lands.

## Infographic

![Cron schedule contract infographic](https://v3b.fal.media/files/b/0aa85ae3/YPyoDS4wh3d-L5js3nX62_Y8LUQkod.png)
