### PR TITLE
fix(gateway): custom-provider extra_body survives gateway turns and /model switches (#54922, salvage #39429 #52432 #53765)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2848,6 +2848,29 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     return client
 
 
+def _apply_switched_provider_request_overrides(agent, new_provider):
+    """Re-derive the switched-to provider's ``request_overrides`` onto a live agent.
+
+    A ``custom_providers`` entry can carry an ``extra_body`` (e.g.
+    ``chat_template_kwargs`` to toggle a local model's thinking). The gateway
+    rebuild path carries this via ``request_overrides``; an *in-place* swap
+    (CLI / TUI ``/model``) must re-derive it for the new provider, otherwise the
+    previous provider's ``extra_body`` lingers. Non-provider overrides
+    (``service_tier`` / ``speed`` from ``/fast``) are preserved.
+    """
+    from hermes_cli.runtime_provider import (
+        _get_named_custom_provider,
+        _custom_provider_request_overrides,
+    )
+    cp = _get_named_custom_provider(new_provider)
+    new_ro = _custom_provider_request_overrides(cp) if cp else None
+    overrides = dict(getattr(agent, "request_overrides", {}) or {})
+    overrides.pop("extra_body", None)
+    if new_ro and new_ro.get("extra_body"):
+        overrides["extra_body"] = new_ro["extra_body"]
+    agent.request_overrides = overrides
+
+
 def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
     """Switch the model/provider in-place for a live agent.
 
@@ -3277,6 +3300,13 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         ]
     agent._fallback_chain = fallback_chain
     agent._fallback_model = fallback_chain[0] if fallback_chain else None
+
+    # Apply the switched-to provider's request_overrides (custom_providers
+    # extra_body, e.g. chat_template_kwargs). See helper for rationale.
+    try:
+        _apply_switched_provider_request_overrides(agent, new_provider)
+    except Exception:
+        logger.debug("switch_model: request_overrides re-derivation failed", exc_info=True)
 
     logger.info(
         "Model switched in-place: %s (%s) -> %s (%s)",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2854,20 +2854,42 @@ def _apply_switched_provider_request_overrides(agent, new_provider):
     A ``custom_providers`` entry can carry an ``extra_body`` (e.g.
     ``chat_template_kwargs`` to toggle a local model's thinking). The gateway
     rebuild path carries this via ``request_overrides``; an *in-place* swap
-    (CLI / TUI ``/model``) must re-derive it for the new provider, otherwise the
-    previous provider's ``extra_body`` lingers. Non-provider overrides
-    (``service_tier`` / ``speed`` from ``/fast``) are preserved.
+    (CLI / TUI ``/model``) must re-derive it for the switched-to provider,
+    otherwise the previous provider's ``extra_body`` lingers.
+
+    The switched-to entry is matched by **provider key, base_url, and model** —
+    the same condition ``agent_init._merge_custom_provider_extra_body`` applies
+    at build time — via the shared ``_custom_provider_extra_body_for_agent``
+    matcher. Matching by name alone would let a *different* model selected at the
+    same named endpoint inherit an ``extra_body`` configured for another model.
+    A stale ``extra_body`` is always cleared when the switched-to provider/model
+    resolves none; non-provider overrides (``service_tier`` / ``speed`` from
+    ``/fast``) are preserved.
     """
-    from hermes_cli.runtime_provider import (
-        _get_named_custom_provider,
-        _custom_provider_request_overrides,
+    from agent.agent_init import _custom_provider_extra_body_for_agent
+
+    # Prefer the init-time cache (agent_init stores ``agent._custom_providers``
+    # right where it runs its own _merge_custom_provider_extra_body); fall back
+    # to a fresh load only if a caller built the agent without it.
+    custom_providers = getattr(agent, "_custom_providers", None)
+    if custom_providers is None:
+        try:
+            from hermes_cli.config import load_config, get_compatible_custom_providers
+            custom_providers = get_compatible_custom_providers(load_config())
+        except Exception:
+            custom_providers = []
+
+    new_extra_body = _custom_provider_extra_body_for_agent(
+        provider=new_provider,
+        model=getattr(agent, "model", "") or "",
+        base_url=getattr(agent, "base_url", "") or "",
+        custom_providers=custom_providers or [],
     )
-    cp = _get_named_custom_provider(new_provider)
-    new_ro = _custom_provider_request_overrides(cp) if cp else None
+
     overrides = dict(getattr(agent, "request_overrides", {}) or {})
-    overrides.pop("extra_body", None)
-    if new_ro and new_ro.get("extra_body"):
-        overrides["extra_body"] = new_ro["extra_body"]
+    overrides.pop("extra_body", None)  # always drop the previous provider's extra_body
+    if new_extra_body:
+        overrides["extra_body"] = dict(new_extra_body)
     agent.request_overrides = overrides
 
 

--- a/contributors/emails/abtion@outlook.com
+++ b/contributors/emails/abtion@outlook.com
@@ -1,0 +1,1 @@
+gitabtion

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5998,7 +5998,23 @@ class TurnRunner:
         agent.event_callback = ctx._event_callback_sync
         agent.reasoning_config = reasoning_config
         agent.service_tier = self._runner._service_tier
-        agent.request_overrides = turn_route.get("request_overrides") or {}
+        # Merge, never overwrite: init-time request overrides (e.g. a custom
+        # provider's extra_body merged at agent construction) must survive
+        # every reused-agent turn.  Drop only the PREVIOUS turn's routing
+        # overrides (fast-mode service_tier/speed) before layering this
+        # turn's route overrides on top, so stale per-turn values never
+        # linger while construction-time values persist.
+        request_overrides = dict(getattr(agent, "request_overrides", {}) or {})
+        previous_turn_overrides = dict(
+            getattr(agent, "_gateway_turn_request_overrides", {}) or {}
+        )
+        for key, value in previous_turn_overrides.items():
+            if request_overrides.get(key) == value:
+                request_overrides.pop(key, None)
+        turn_request_overrides = dict(turn_route.get("request_overrides") or {})
+        request_overrides.update(turn_request_overrides)
+        agent.request_overrides = request_overrides
+        agent._gateway_turn_request_overrides = turn_request_overrides
         # Must-deliver notes for THIS turn ride the current user message
         # (api_content sidecar), never the system prompt: staged by
         # _handle_message_with_agent (auto-reset note, first-contact

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2969,6 +2969,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
         "max_tokens": max_tokens,
     }
 
@@ -3109,7 +3110,21 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
     }
+
+
+def _deep_merge_request_overrides(base: Optional[dict], override: Optional[dict]) -> dict:
+    """Merge request_overrides dicts, deep-merging nested dictionaries."""
+    from hermes_cli.config import _deep_merge
+
+    base_dict = dict(base or {})
+    override_dict = dict(override or {})
+    if not base_dict:
+        return override_dict
+    if not override_dict:
+        return base_dict
+    return _deep_merge(base_dict, override_dict)
 
 
 def _credential_pool_for_provider(provider: Optional[str]):
@@ -3167,6 +3182,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
+                    "request_overrides": dict(runtime.get("request_overrides") or {}),
                     "model": entry.get("model"),
                 }
             except Exception as fb_exc:
@@ -8459,6 +8475,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "credential_pool": runtime_kwargs.get("credential_pool"),
             "max_tokens": runtime_kwargs.get("max_tokens"),
         }
+        base_request_overrides = dict(runtime_kwargs.get("request_overrides") or {})
         route = {
             "model": model,
             "runtime": runtime,
@@ -8475,14 +8492,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
-            route["request_overrides"] = {}
+            route["request_overrides"] = base_request_overrides
             return route
 
         try:
             overrides = resolve_fast_mode_overrides(route["model"])
         except Exception:
             overrides = None
-        route["request_overrides"] = overrides or {}
+        route["request_overrides"] = _deep_merge_request_overrides(
+            base_request_overrides,
+            overrides or {},
+        )
         return route
 
     def _sync_session_model_from_agent(self, session_id: str, agent: Any) -> None:
@@ -27409,6 +27429,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 override["api_key"] = runtime.get("api_key")
                 override["api_mode"] = runtime.get("api_mode")
                 override["credential_pool"] = runtime.get("credential_pool")
+                override["request_overrides"] = dict(
+                    runtime.get("request_overrides") or {}
+                )
                 if not override.get("base_url"):
                     override["base_url"] = runtime.get("base_url")
             except Exception:
@@ -27443,6 +27466,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             val = override.get(key)
             if val is not None:
                 runtime_kwargs[key] = val
+        override_request_overrides = override.get("request_overrides")
+        if isinstance(override_request_overrides, dict):
+            runtime_kwargs["request_overrides"] = _deep_merge_request_overrides(
+                runtime_kwargs.get("request_overrides"),
+                override_request_overrides,
+            )
         if (
             runtime_kwargs.get("api_key")
             and runtime_kwargs.get("credential_pool") is None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8348,6 +8348,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "api_mode": override.get("api_mode"),
                 "max_tokens": override.get("max_tokens"),
                 "credential_pool": override.get("credential_pool"),
+                "request_overrides": override.get("request_overrides"),
             }
             if override_runtime.get("api_key"):
                 if override_runtime.get("credential_pool") is None:
@@ -27501,12 +27502,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             val = override.get(key)
             if val is not None:
                 runtime_kwargs[key] = val
-        override_request_overrides = override.get("request_overrides")
-        if isinstance(override_request_overrides, dict):
-            runtime_kwargs["request_overrides"] = _deep_merge_request_overrides(
-                runtime_kwargs.get("request_overrides"),
-                override_request_overrides,
-            )
+        # request_overrides reflects the switched-to provider; apply whenever
+        # the override recorded it (even as None) so switching to a provider
+        # without configured overrides clears a stale value left by the
+        # default provider's runtime resolution.
+        if "request_overrides" in override:
+            override_request_overrides = override.get("request_overrides")
+            if isinstance(override_request_overrides, dict) and override_request_overrides:
+                runtime_kwargs["request_overrides"] = dict(override_request_overrides)
+            else:
+                runtime_kwargs["request_overrides"] = override_request_overrides
         if (
             runtime_kwargs.get("api_key")
             and runtime_kwargs.get("credential_pool") is None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2971,6 +2971,11 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "credential_pool": runtime.get("credential_pool"),
         "request_overrides": dict(runtime.get("request_overrides") or {}),
         "max_tokens": max_tokens,
+        # Per-provider request_overrides (e.g. a custom_providers ``extra_body``
+        # carrying ``chat_template_kwargs``) resolved by resolve_runtime_provider().
+        # Must flow through to the per-turn route or the provider's configured
+        # request body never reaches the model on the gateway path.
+        "request_overrides": runtime.get("request_overrides"),
     }
 
 
@@ -3184,6 +3189,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "credential_pool": runtime.get("credential_pool"),
                     "request_overrides": dict(runtime.get("request_overrides") or {}),
                     "model": entry.get("model"),
+                    "request_overrides": runtime.get("request_overrides"),
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -8477,6 +8483,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled and the model supports Priority Processing / Anthropic fast
         mode, attach `request_overrides` so the API call is marked
         accordingly.
+
+        Per-provider ``request_overrides`` resolved by
+        ``resolve_runtime_provider`` (e.g. a ``custom_providers`` ``extra_body``
+        carrying ``chat_template_kwargs``) are preserved here and merged *under*
+        the fast-mode overrides, so a provider's configured request body still
+        reaches the model on the gateway turn path.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
@@ -8506,6 +8518,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
         }
 
+        # Provider-level request_overrides (e.g. a custom_providers extra_body)
+        # resolved upstream by resolve_runtime_provider().  These were being
+        # dropped by the runtime whitelist above, so a custom provider's
+        # configured extra_body (chat_template_kwargs, etc.) never reached the
+        # model on the gateway path -- only /fast service-tier overrides did.
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
             route["request_overrides"] = base_request_overrides
@@ -8515,6 +8532,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             overrides = resolve_fast_mode_overrides(route["model"])
         except Exception:
             overrides = None
+        # Fast-mode overrides (service_tier / speed) are top-level keys and do
+        # not collide with extra_body; deep-merge them over the provider overrides.
         route["request_overrides"] = _deep_merge_request_overrides(
             base_request_overrides,
             overrides or {},

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2009,6 +2009,7 @@ class GatewaySlashCommandsMixin:
                             "api_key": result.api_key,
                             "base_url": result.base_url,
                             "api_mode": result.api_mode,
+                            "request_overrides": dict(result.request_overrides or {}),
                         }
 
                         # Write-through the non-secret parts to the session
@@ -2321,6 +2322,7 @@ class GatewaySlashCommandsMixin:
                 "api_key": result.api_key,
                 "base_url": result.base_url,
                 "api_mode": result.api_mode,
+                "request_overrides": dict(result.request_overrides or {}),
             }
             if one_turn:
                 if not hasattr(self, "_pending_one_turn_model_restores"):

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2185,6 +2185,22 @@ def switch_model(
     if hermes_warn:
         warnings.append(hermes_warn)
 
+    # Carry the switched provider's request_overrides (e.g. a custom_providers
+    # ``extra_body`` such as chat_template_kwargs) so a ``/model`` switch to a
+    # custom provider applies it on the gateway, matching the default-provider
+    # path. resolve_runtime_provider surfaces these for named custom providers.
+    request_overrides = None
+    try:
+        from hermes_cli.runtime_provider import (
+            _get_named_custom_provider,
+            _custom_provider_request_overrides,
+        )
+        _cp_for_ro = _get_named_custom_provider(target_provider)
+        if _cp_for_ro:
+            request_overrides = _custom_provider_request_overrides(_cp_for_ro) or None
+    except Exception:
+        request_overrides = None
+
     # --- Build result ---
     return ModelSwitchResult(
         success=True,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -620,6 +620,7 @@ class ModelSwitchResult:
     api_key: str = ""
     base_url: str = ""
     api_mode: str = ""
+    request_overrides: Optional[dict] = None
     error_message: str = ""
     warning_message: str = ""
     provider_label: str = ""
@@ -2192,6 +2193,7 @@ def switch_model(
         api_key=api_key,
         base_url=base_url,
         api_mode=api_mode,
+        request_overrides=dict(request_overrides or {}),
         warning_message=" | ".join(warnings) if warnings else "",
         provider_label=provider_label,
         resolved_via_alias=resolved_alias,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1497,6 +1497,7 @@ def switch_model(
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
     resolved_alias = ""
+    request_overrides: dict = {}
     new_model = raw_input.strip()
     target_provider = current_provider
     resolved_moa_preset = False

--- a/tests/agent/test_switch_model_request_overrides.py
+++ b/tests/agent/test_switch_model_request_overrides.py
@@ -1,0 +1,52 @@
+"""Regression tests for the in-place /model switch (CLI/TUI) carrying a custom
+provider's request_overrides (extra_body) — _apply_switched_provider_request_overrides.
+
+Before the fix, agent_runtime_helpers.switch_model() swapped model/provider/
+base_url/api_key in place but never touched request_overrides, so a /model
+switch to a thinking-enabled custom provider in the TUI/CLI kept the old
+provider's extra_body.
+"""
+
+import agent.agent_runtime_helpers as arh
+
+
+class _Agent:
+    pass
+
+
+def test_switch_applies_new_provider_extra_body(monkeypatch):
+    a = _Agent()
+    a.request_overrides = {"service_tier": "priority"}  # pre-existing /fast override
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_named_custom_provider",
+        lambda name: {"name": "main-think",
+                      "extra_body": {"chat_template_kwargs": {"enable_thinking": True}}},
+    )
+    arh._apply_switched_provider_request_overrides(a, "custom:main-think")
+    assert a.request_overrides["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
+    assert a.request_overrides["service_tier"] == "priority"  # preserved
+
+
+def test_switch_to_noncustom_clears_stale_extra_body(monkeypatch):
+    a = _Agent()
+    a.request_overrides = {
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": True}},
+        "service_tier": "priority",
+    }
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_named_custom_provider", lambda name: None
+    )
+    arh._apply_switched_provider_request_overrides(a, "anthropic")
+    assert "extra_body" not in a.request_overrides  # stale extra_body cleared
+    assert a.request_overrides["service_tier"] == "priority"  # preserved
+
+
+def test_switch_from_none_overrides(monkeypatch):
+    a = _Agent()
+    a.request_overrides = None
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_named_custom_provider",
+        lambda name: {"name": "main", "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+    )
+    arh._apply_switched_provider_request_overrides(a, "custom:main")
+    assert a.request_overrides == {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}

--- a/tests/agent/test_switch_model_request_overrides.py
+++ b/tests/agent/test_switch_model_request_overrides.py
@@ -5,6 +5,11 @@ Before the fix, agent_runtime_helpers.switch_model() swapped model/provider/
 base_url/api_key in place but never touched request_overrides, so a /model
 switch to a thinking-enabled custom provider in the TUI/CLI kept the old
 provider's extra_body.
+
+The switched-to entry is matched by provider key + base_url + model (the same
+condition agent_init._merge_custom_provider_extra_body uses at build time), so a
+*different* model selected at the same named endpoint does not inherit an
+extra_body configured for another model.
 """
 
 import agent.agent_runtime_helpers as arh
@@ -14,39 +19,99 @@ class _Agent:
     pass
 
 
-def test_switch_applies_new_provider_extra_body(monkeypatch):
+# Two entries share the same named endpoint / base_url but pin different models —
+# the exact case a name-only match got wrong.
+CUSTOM_PROVIDERS = [
+    {
+        "name": "main-think",
+        "base_url": "http://10.0.0.1:8000/v1",
+        "model": "think-model",
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": True}},
+    },
+    {
+        "name": "main-plain",
+        "base_url": "http://10.0.0.1:8000/v1",
+        "model": "plain-model",
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+    },
+]
+
+
+def _agent(*, model, base_url, request_overrides, custom_providers=CUSTOM_PROVIDERS):
     a = _Agent()
-    a.request_overrides = {"service_tier": "priority"}  # pre-existing /fast override
-    monkeypatch.setattr(
-        "hermes_cli.runtime_provider._get_named_custom_provider",
-        lambda name: {"name": "main-think",
-                      "extra_body": {"chat_template_kwargs": {"enable_thinking": True}}},
+    # switch_model() sets these on the live agent before calling the helper.
+    a.model = model
+    a.base_url = base_url
+    a.provider = "custom"
+    a.request_overrides = request_overrides
+    a._custom_providers = custom_providers  # init-time cache the helper reads
+    return a
+
+
+def test_switch_applies_matched_provider_extra_body():
+    """Switching to the matching provider+model applies its extra_body and
+    preserves non-provider overrides (service_tier/speed from /fast)."""
+    a = _agent(
+        model="think-model",
+        base_url="http://10.0.0.1:8000/v1",
+        request_overrides={"service_tier": "priority"},
     )
     arh._apply_switched_provider_request_overrides(a, "custom:main-think")
     assert a.request_overrides["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
     assert a.request_overrides["service_tier"] == "priority"  # preserved
 
 
-def test_switch_to_noncustom_clears_stale_extra_body(monkeypatch):
-    a = _Agent()
-    a.request_overrides = {
-        "extra_body": {"chat_template_kwargs": {"enable_thinking": True}},
-        "service_tier": "priority",
-    }
-    monkeypatch.setattr(
-        "hermes_cli.runtime_provider._get_named_custom_provider", lambda name: None
+def test_switch_to_noncustom_clears_stale_extra_body():
+    """Switching to a built-in provider clears the previous provider's extra_body."""
+    a = _agent(
+        model="claude-x",
+        base_url="https://api.anthropic.com",
+        request_overrides={
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": True}},
+            "service_tier": "priority",
+        },
     )
     arh._apply_switched_provider_request_overrides(a, "anthropic")
     assert "extra_body" not in a.request_overrides  # stale extra_body cleared
     assert a.request_overrides["service_tier"] == "priority"  # preserved
 
 
-def test_switch_from_none_overrides(monkeypatch):
-    a = _Agent()
-    a.request_overrides = None
-    monkeypatch.setattr(
-        "hermes_cli.runtime_provider._get_named_custom_provider",
-        lambda name: {"name": "main", "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}},
+def test_switch_from_none_overrides():
+    """A None request_overrides is handled and gets the matched extra_body."""
+    a = _agent(
+        model="plain-model",
+        base_url="http://10.0.0.1:8000/v1",
+        request_overrides=None,
     )
-    arh._apply_switched_provider_request_overrides(a, "custom:main")
+    arh._apply_switched_provider_request_overrides(a, "custom:main-plain")
     assert a.request_overrides == {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}
+
+
+def test_switch_to_different_model_same_endpoint_does_not_inherit():
+    """Review regression: selecting a *different* model while naming a custom
+    provider must NOT inherit that provider's extra_body when the models differ.
+
+    'main-think' pins 'think-model'. Selecting 'plain-model' under
+    custom:main-think must not carry enable_thinking=True — the model-aware
+    matcher rejects the mismatch and the stale extra_body is cleared. (A
+    name-only match would have wrongly carried it over.)
+    """
+    a = _agent(
+        model="plain-model",  # differs from main-think's pinned 'think-model'
+        base_url="http://10.0.0.1:8000/v1",
+        request_overrides={"extra_body": {"chat_template_kwargs": {"enable_thinking": True}}},
+    )
+    arh._apply_switched_provider_request_overrides(a, "custom:main-think")
+    assert "extra_body" not in a.request_overrides  # not inherited; stale cleared
+
+
+def test_switch_endpoint_mismatch_does_not_inherit():
+    """A matching provider *name* but a different base_url must not match either
+    (endpoint identity is part of the condition)."""
+    a = _agent(
+        model="think-model",
+        base_url="http://10.9.9.9:8000/v1",  # different endpoint than the entry
+        request_overrides={"extra_body": {"chat_template_kwargs": {"enable_thinking": True}}},
+    )
+    arh._apply_switched_provider_request_overrides(a, "custom:main-think")
+    assert "extra_body" not in a.request_overrides  # base_url mismatch -> cleared

--- a/tests/gateway/test_custom_provider_request_overrides.py
+++ b/tests/gateway/test_custom_provider_request_overrides.py
@@ -1,0 +1,220 @@
+"""Regression tests for gateway preservation of provider-derived request_overrides.
+
+Named custom providers can return request_overrides (for example
+``extra_body.text.verbosity`` for OpenAI Responses). The gateway must preserve
+those overrides on the runtime path and merge fast-mode overrides on top rather
+than replacing them with an empty dict.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+class _CapturingAgent:
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+        self.request_overrides = dict(kwargs.get("request_overrides") or {})
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner.session_store = None
+    runner.config = None
+    runner._voice_mode = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._service_tier = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._background_tasks = set()
+    runner._session_db = None
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._pending_approvals = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    return runner
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="ou_test",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="tester",
+    )
+
+
+def test_resolve_runtime_agent_kwargs_preserves_request_overrides(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda: {
+            "api_key": "***",
+            "base_url": "https://example.test/v1",
+            "provider": "custom",
+            "api_mode": "codex_responses",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+            "request_overrides": {
+                "extra_body": {"text": {"verbosity": "low"}},
+            },
+        },
+    )
+
+    result = gateway_run._resolve_runtime_agent_kwargs()
+
+    assert result["request_overrides"] == {
+        "extra_body": {"text": {"verbosity": "low"}},
+    }
+
+
+def test_turn_route_preserves_provider_request_overrides_without_fast_mode():
+    runner = _make_runner()
+    runner._service_tier = None
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://example.test/v1",
+        "provider": "custom",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "request_overrides": {
+            "extra_body": {"text": {"verbosity": "low"}},
+        },
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "hi",
+        "gpt-5.4",
+        runtime_kwargs,
+    )
+
+    assert route["request_overrides"] == {
+        "extra_body": {"text": {"verbosity": "low"}},
+    }
+
+
+def test_turn_route_merges_fast_mode_with_provider_request_overrides():
+    runner = _make_runner()
+    runner._service_tier = "priority"
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://example.test/v1",
+        "provider": "custom",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "request_overrides": {
+            "extra_body": {"text": {"verbosity": "low"}},
+        },
+    }
+
+    with patch(
+        "hermes_cli.models.resolve_fast_mode_overrides",
+        return_value={"service_tier": "priority"},
+    ):
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner,
+            "hi",
+            "gpt-5.4",
+            runtime_kwargs,
+        )
+
+    assert route["request_overrides"] == {
+        "extra_body": {"text": {"verbosity": "low"}},
+        "service_tier": "priority",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_agent_preserves_provider_request_overrides_on_gateway_path(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom",
+            "api_mode": "codex_responses",
+            "base_url": "https://example.test/v1",
+            "api_key": "***",
+            "request_overrides": {
+                "extra_body": {"text": {"verbosity": "low"}},
+            },
+        },
+    )
+    _install_fake_agent(monkeypatch)
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    runner = _make_runner()
+    source = _make_source()
+    session_key = "agent:main:feishu:dm:ou_test"
+
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda _source: SimpleNamespace(session_id="session-1"),
+        load_transcript=lambda _session_id: [],
+    )
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["request_overrides"] == {
+        "extra_body": {"text": {"verbosity": "low"}},
+    }

--- a/tests/gateway/test_custom_provider_request_overrides.py
+++ b/tests/gateway/test_custom_provider_request_overrides.py
@@ -218,3 +218,90 @@ async def test_run_agent_preserves_provider_request_overrides_on_gateway_path(mo
     assert _CapturingAgent.last_init["request_overrides"] == {
         "extra_body": {"text": {"verbosity": "low"}},
     }
+
+@pytest.mark.asyncio
+async def test_reused_agent_turn_merges_request_overrides_not_overwrite(monkeypatch):
+    """Merge-not-overwrite regression (salvaged from PR #52432).
+
+    A cached/reused gateway agent must keep its init-time request_overrides
+    (custom-provider extra_body) across turns: a /fast turn layers
+    service_tier ON TOP, and the following normal turn drops only the stale
+    fast-mode key while the provider extra_body survives.
+    """
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom",
+            "api_mode": "codex_responses",
+            "base_url": "https://example.test/v1",
+            "api_key": "***",
+            "request_overrides": {
+                "extra_body": {"text": {"verbosity": "low"}},
+            },
+        },
+    )
+    _install_fake_agent(monkeypatch)
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    runner = _make_runner()
+    source = _make_source()
+    session_key = "agent:main:feishu:dm:ou_test"
+
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda _source: SimpleNamespace(session_id="session-1"),
+        load_transcript=lambda _session_id: [],
+    )
+
+    seen_agents = []
+    orig_init = _CapturingAgent.__init__
+
+    def _tracking_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        seen_agents.append(self)
+
+    monkeypatch.setattr(_CapturingAgent, "__init__", _tracking_init)
+
+    async def run_turn():
+        return await runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key=session_key,
+        )
+
+    # Turn 1: /fast active — provider extra_body AND service_tier both present.
+    # The turn path re-resolves the tier per session, so stub the resolver.
+    tier_box = {"tier": "priority"}
+    runner._resolve_session_service_tier = lambda *a, **k: tier_box["tier"]
+    with patch(
+        "hermes_cli.models.resolve_fast_mode_overrides",
+        return_value={"service_tier": "priority"},
+    ):
+        result = await run_turn()
+    assert result["final_response"] == "ok"
+    assert len(seen_agents) == 1
+    agent = seen_agents[0]
+    assert agent.request_overrides == {
+        "extra_body": {"text": {"verbosity": "low"}},
+        "service_tier": "priority",
+    }
+
+    # Turn 2: back to normal — the SAME cached agent must drop only the stale
+    # fast-mode key; the init-time provider extra_body survives the refresh.
+    tier_box["tier"] = None
+    result = await run_turn()
+    assert result["final_response"] == "ok"
+    assert len(seen_agents) == 1, "agent should be reused from the gateway cache"
+    assert agent.request_overrides == {
+        "extra_body": {"text": {"verbosity": "low"}},
+    }

--- a/tests/gateway/test_model_command_request_overrides.py
+++ b/tests/gateway/test_model_command_request_overrides.py
@@ -1,0 +1,94 @@
+"""Regression tests for gateway /model preserving named-custom request_overrides."""
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._session_db = None
+    runner._evict_cached_agent = lambda _session_key: None
+    runner.session_store = None
+    return runner
+
+
+def _make_event(text="/model"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="ou_test",
+            chat_type="dm",
+            user_id="user-1",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_stores_request_overrides_for_named_custom_provider(
+    tmp_path,
+    monkeypatch,
+):
+    import gateway.run as gateway_run
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """
+model:
+  default: gpt-5.4
+  provider: openai-codex
+providers: {}
+custom_providers:
+  - name: Local (127.0.0.1:4141)
+    base_url: http://127.0.0.1:4141/v1
+    model: rotator-openrouter-coding
+    extra_body:
+      text:
+        verbosity: low
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: ModelSwitchResult(
+            success=True,
+            new_model="rotator-openrouter-coding",
+            target_provider="custom:local-(127.0.0.1:4141)",
+            provider_changed=True,
+            api_key="no-key-required",
+            base_url="http://127.0.0.1:4141/v1",
+            api_mode="codex_responses",
+            request_overrides={
+                "extra_body": {"text": {"verbosity": "low"}},
+            },
+            provider_label="Local (127.0.0.1:4141)",
+            is_global=False,
+        ),
+    )
+
+    runner = _make_runner()
+    event = _make_event("/model rotator-openrouter-coding --provider custom:local-(127.0.0.1:4141)")
+
+    result = await runner._handle_model_command(event)
+
+    assert result is not None
+    session_key = runner._session_key_for_source(event.source)
+    assert runner._session_model_overrides[session_key]["request_overrides"] == {
+        "extra_body": {"text": {"verbosity": "low"}},
+    }

--- a/tests/gateway/test_turn_request_overrides.py
+++ b/tests/gateway/test_turn_request_overrides.py
@@ -1,0 +1,91 @@
+"""Regression tests: the gateway must preserve a custom provider's
+``request_overrides`` on per-turn agent config.
+
+A ``custom_providers`` entry can carry an ``extra_body`` (e.g.
+``chat_template_kwargs`` to toggle a local model's thinking).
+``resolve_runtime_provider`` surfaces it as ``request_overrides`` on the
+resolved runtime dict, but the gateway used to rebuild the runtime from a
+fixed key whitelist that omitted it -- so the provider's configured
+``extra_body`` never reached the model on the gateway path, and only
+``/fast`` service-tier overrides survived.
+"""
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+PROVIDER_OVERRIDES = {"extra_body": {"chat_template_kwargs": {"enable_thinking": True}}}
+
+
+def _runtime_kwargs(**extra):
+    base = {
+        "api_key": "no-key-required",
+        "base_url": "http://10.0.0.1:8000/v1",
+        "provider": "custom",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "max_tokens": None,
+    }
+    base.update(extra)
+    return base
+
+
+def _runner(service_tier=None):
+    runner = object.__new__(GatewayRunner)
+    runner._service_tier = service_tier
+    return runner
+
+
+def test_provider_request_overrides_preserved_without_service_tier():
+    """No /fast: the provider's extra_body must pass straight through."""
+    runner = _runner(service_tier=None)
+    rk = _runtime_kwargs(request_overrides=PROVIDER_OVERRIDES)
+    route = runner._resolve_turn_agent_config("hi", "main", rk)
+    assert route["request_overrides"] == PROVIDER_OVERRIDES
+    # A copy, not an alias into runtime_kwargs.
+    assert route["request_overrides"] is not rk["request_overrides"]
+
+
+def test_provider_request_overrides_merged_under_fast_mode(monkeypatch):
+    """/fast active: provider extra_body AND the service-tier marker both survive."""
+    monkeypatch.setattr(
+        "hermes_cli.models.resolve_fast_mode_overrides",
+        lambda model_id: {"service_tier": "priority"},
+    )
+    runner = _runner(service_tier="priority")
+    rk = _runtime_kwargs(request_overrides=PROVIDER_OVERRIDES)
+    route = runner._resolve_turn_agent_config("hi", "main", rk)
+    assert route["request_overrides"]["extra_body"] == PROVIDER_OVERRIDES["extra_body"]
+    assert route["request_overrides"]["service_tier"] == "priority"
+
+
+def test_no_provider_overrides_yields_empty():
+    """Regression: absent provider overrides, behaviour is unchanged ({})."""
+    runner = _runner(service_tier=None)
+    route = runner._resolve_turn_agent_config("hi", "main", _runtime_kwargs())
+    assert route["request_overrides"] == {}
+
+
+def test_resolve_runtime_agent_kwargs_carries_request_overrides(monkeypatch):
+    """The module-level runtime resolver must not drop request_overrides."""
+    import gateway.run as gateway_run
+
+    fake_runtime = {
+        "api_key": "k",
+        "base_url": "http://10.0.0.1:8000/v1",
+        "provider": "custom",
+        "api_mode": "chat_completions",
+        "request_overrides": PROVIDER_OVERRIDES,
+    }
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda *a, **k: dict(fake_runtime),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config", lambda: {}
+    )
+    rk = gateway_run._resolve_runtime_agent_kwargs()
+    assert rk["request_overrides"] == PROVIDER_OVERRIDES

--- a/tests/gateway/test_turn_request_overrides.py
+++ b/tests/gateway/test_turn_request_overrides.py
@@ -89,3 +89,52 @@ def test_resolve_runtime_agent_kwargs_carries_request_overrides(monkeypatch):
     )
     rk = gateway_run._resolve_runtime_agent_kwargs()
     assert rk["request_overrides"] == PROVIDER_OVERRIDES
+
+
+# --- /model session-override follow-up: request_overrides must survive a switch ---
+
+def test_session_override_applies_request_overrides():
+    """A /model switch to a custom provider carries its extra_body into runtime."""
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {
+        "sess1": {
+            "model": "thinkmodel",
+            "provider": "custom",
+            "api_key": "k",
+            "base_url": "http://10.0.0.1:8000/v1",
+            "api_mode": "chat_completions",
+            "request_overrides": PROVIDER_OVERRIDES,
+        }
+    }
+    rk = _runtime_kwargs()  # default resolution carried no overrides
+    model, out = runner._apply_session_model_override("sess1", "oldmodel", rk)
+    assert model == "thinkmodel"
+    assert out["request_overrides"] == PROVIDER_OVERRIDES
+
+
+def test_session_override_clears_stale_request_overrides():
+    """Switching to a provider with no overrides clears a stale value."""
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {
+        "sess1": {
+            "model": "plain",
+            "provider": "openrouter",
+            "api_key": "k",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+            "request_overrides": None,
+        }
+    }
+    rk = _runtime_kwargs(request_overrides=PROVIDER_OVERRIDES)  # stale, from default
+    _, out = runner._apply_session_model_override("sess1", "old", rk)
+    assert out.get("request_overrides") is None
+
+
+def test_session_override_absent_is_noop():
+    """No override for the session leaves runtime_kwargs untouched."""
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {}
+    rk = _runtime_kwargs(request_overrides=PROVIDER_OVERRIDES)
+    model, out = runner._apply_session_model_override("nope", "keepme", rk)
+    assert model == "keepme"
+    assert out["request_overrides"] == PROVIDER_OVERRIDES

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1351,6 +1351,8 @@ extra_body:
     enable_thinking: false
 ```
 
+The configured `extra_body` follows the provider everywhere: it is merged at agent construction, **survives every gateway turn** (including turns where `/fast` layers `service_tier`/`speed` overrides on top — those merge over your `extra_body` rather than replacing it), and is **re-derived on `/model` switches** — switching to a named custom provider applies its `extra_body`, and switching away clears it so it never leaks to another provider.
+
 The `hermes model` → Custom Endpoint wizard now prompts for the API mode explicitly and persists your answer to `config.yaml` (as `transport` on the provider entry). URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 
 **Native vision for custom-provider models.** If your custom endpoint serves a vision-capable model that isn't in models.dev, set `model.supports_vision: true` so Hermes routes attached images natively (as `image_url` parts) instead of pre-processing them through `vision_analyze`. Single knob — no need to also set `agent.image_input_mode: native`.


### PR DESCRIPTION
![PR infographic](https://v3b.fal.media/files/b/0aa85aec/sGjobhiP5p11GGnQqFNgA_sekq80dG.png)

Fixes #54922. Consolidated salvage of #39429, #52432, and #53765 — three overlapping fixes for the same defect family: a named custom provider's `request_overrides` (its configured `extra_body`, e.g. `chat_template_kwargs.enable_thinking`) was silently dropped on the gateway turn path and on `/model` switches.

## What was broken on main

- `gateway/run.py::_resolve_turn_agent_config` rebuilt the turn runtime dict from a fixed key whitelist that omitted `request_overrides`, and set `route["request_overrides"] = {}` when no service tier was active — so a custom provider's `extra_body` never reached the model on gateway turns; only `/fast` overrides did.
- The reused-agent turn refresh did `agent.request_overrides = turn_route.get("request_overrides") or {}` — unconditionally clobbering the init-time extra_body merged by `agent_init._merge_custom_provider_extra_body` on every cached-agent turn.
- `hermes_cli/model_switch.py` / `gateway/slash_commands.py` had zero `request_overrides` handling, so a `/model` switch to a custom provider ignored its `extra_body` (and switching away left a stale one on in-place CLI/TUI switches).

## Semantics: merge, never overwrite

Turn-route overrides (`/fast` `service_tier`/`speed`) deep-merge **over** init-time custom-provider `extra_body`; absent turn overrides leave init-time values intact; on the next normal turn only the previous turn's stale routing keys are evicted (tracked in `agent._gateway_turn_request_overrides`). On `/model`, the switched-to provider's overrides are re-derived by provider + base_url + model (the same matcher `agent_init` uses at build time), so a different model at the same endpoint never inherits another model's `extra_body`, and switching to a provider without one clears the stale value.

## Salvaged work — credit in order of earliest submission

| PR | Author | Submitted | Contribution |
|----|--------|-----------|--------------|
| #39429 | @CharZhou | Jun 5 | Base: thread `request_overrides` through runtime resolution, fallback projection, session `/model` state, restart rehydration, and the turn-route merge (`_deep_merge_request_overrides`), + `ModelSwitchResult.request_overrides` |
| #52432 | @gitabtion | Jun 25 | Merge-not-overwrite at the reused-agent refresh (re-applied at the code's post-TurnRunner location, authorship preserved via commit author + Co-authored-by) |
| #53765 | @apollo-orbit-dev | Jun 27 | In-place CLI/TUI switch path (`agent_runtime_helpers._apply_switched_provider_request_overrides` with the model+base_url-aware matcher) + regression suites `test_turn_request_overrides.py` / `test_switch_model_request_overrides.py` |

Dropped hunks: #53765's `tui_gateway/server.py` + `tests/test_tui_gateway_server.py` changes — main already preserves overrides on the TUI session rebuild/resume path.

## Validation

| Check | Result |
|-------|--------|
| Salvaged + new regression tests (4 files, 21 tests) | ✅ 21 passed |
| Sabotage (gateway/run.py, model_switch.py, slash_commands.py, agent_runtime_helpers.py reverted to origin/main) | ✅ 16/21 fail as expected |
| Adjacent suites (`test_fast_command`, `test_model_command_flat_string_config`, `test_model_switch_persistence`, moa/arcee switch tests) | ✅ 48 passed |
| E2E A/B (real temp HERMES_HOME, custom provider with extra_body, no mocks) | ✅ see below |
| ruff check on touched files | ✅ All checks passed |
| Windows footgun checker on touched files | ✅ clean |

**Live repro:** on origin/main, a real config.yaml with `providers: { main-think: { extra_body: { chat_template_kwargs: { enable_thinking: true } } } }` resolves to `runtime_kwargs.request_overrides = null`, turn route `{}` (or `{service_tier}` under `/fast`), and `ModelSwitchResult` has no `request_overrides` field; on this branch the same config yields the extra_body on the runtime kwargs, on the turn route (merged with `service_tier` under `/fast`), and on the `/model` switch result.

E2E A/B (same script, real imports, temp `HERMES_HOME`):

```
A (origin/main):   runtime_kwargs.request_overrides = null
                   turn_route (no fast)            = {}
                   turn_route (fast)               = {"service_tier": "priority"}
                   ModelSwitchResult               = <<FIELD MISSING>>
B (this branch):   runtime_kwargs.request_overrides = {"extra_body": {"chat_template_kwargs": {"enable_thinking": true}}}
                   turn_route (no fast)            = {"extra_body": {...enable_thinking...}}
                   turn_route (fast)               = {"extra_body": {...}, "service_tier": "priority"}
                   ModelSwitchResult               = {"extra_body": {...enable_thinking...}}
```

Docs updated in the same PR: `website/docs/integrations/providers.md` now states `extra_body` survives gateway turns (merging under `/fast`) and is re-derived/cleared on `/model` switches.
