### PR TITLE
Background review accepts profile-configured extra tools via opt-in whitelist (closes #44672, salvage #82146)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1563,6 +1563,37 @@ def _run_review_in_thread(
             # deny message below names that substitute so one denial
             # redirects the model instead of a storm.
             review_whitelist |= {"read_file", "search_files"}
+            # Profile-configured opt-in tools (#44672, salvage #82146 by
+            # @BrinShadewater): ``auxiliary.background_review.extra_tools``
+            # admits named parent tools to the review whitelist — e.g. a
+            # human-gated proposal tool or a memory-provider write surface.
+            # Default-empty; a listed tool must already exist in the parent's
+            # inherited schema (the whitelist can only admit, never advertise),
+            # and everything unlisted stays denied. Read from task_cfg (the
+            # auxiliary.background_review block already loaded for this spawn)
+            # so no extra config I/O happens per review.
+            configured_extra_tools: set = set()
+            try:
+                _extra_raw = _background_review_task_config(task_cfg).get(
+                    "extra_tools", []
+                )
+                if isinstance(_extra_raw, list):
+                    configured_extra_tools = {
+                        name.strip()
+                        for name in _extra_raw
+                        if isinstance(name, str) and name.strip()
+                    }
+                    review_whitelist |= configured_extra_tools
+            except Exception:
+                logger.debug(
+                    "background_review extra_tools parse failed", exc_info=True
+                )
+            _extra_deny_note = (
+                " Configured extra tools also allowed: "
+                + ", ".join(sorted(configured_extra_tools)) + "."
+                if configured_extra_tools
+                else ""
+            )
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(
@@ -1570,7 +1601,8 @@ def _run_review_in_thread(
                     "{tool_name}. Allowed here: skill_view/skills_list/"
                     "read_file/search_files to read, "
                     "skill_manage(action='patch'|...) to change skills, and "
-                    "memory for notes. Do not retry {tool_name}."
+                    "memory for notes." + _extra_deny_note
+                    + " Do not retry {tool_name}."
                 ),
             )
             try:
@@ -1598,6 +1630,14 @@ def _run_review_in_thread(
                             + "\n\nYou can only call memory and skill "
                             "management tools. Other tools will be denied "
                             "at runtime — do not attempt them."
+                            + (
+                                " Exception — these configured tools are "
+                                "also allowed: "
+                                + ", ".join(sorted(configured_extra_tools))
+                                + "."
+                                if configured_extra_tools
+                                else ""
+                            )
                         ),
                         conversation_history=_review_history,
                     )

--- a/contributors/emails/brin@shadewaterlabs.com
+++ b/contributors/emails/brin@shadewaterlabs.com
@@ -1,0 +1,2 @@
+BrinShadewater
+# PR #82146

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -202,7 +202,66 @@ def test_read_file_outside_review_does_not_mark(tmp_path):
     assert not _background_review_has_read(target)
 
 
+def test_background_review_whitelist_includes_configured_extra_tools(
+    tmp_path, monkeypatch
+):
+    """A profile may opt a specific proposal tool into background review.
 
+    The review fork inherits the parent's full tool schema for cache parity,
+    but runtime dispatch remains denied unless the tool is also present in the
+    thread-local whitelist.  This config hook lets profiles grant a narrowly
+    scoped, human-gated proposal tool without enabling unrelated side effects.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n"
+        "  background_review:\n"
+        "    extra_tools:\n"
+        "      - propose_shared_memory\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
+    import run_agent
+    from hermes_cli import config as config_module
+    from hermes_cli import plugins as _plugins
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    config_module._RAW_CONFIG_CACHE.clear()
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+
+    def _capture_run_conversation(self, *, user_message, **kwargs):
+        captured["review_prompt"] = user_message
+        return {"final_response": "Nothing to save."}
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(
+             run_agent.AIAgent,
+             "run_conversation",
+             _capture_run_conversation,
+         ), \
+         patch.object(run_agent.AIAgent, "shutdown_memory_provider", lambda self: None), \
+         patch.object(run_agent.AIAgent, "close", lambda self: None), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "propose_shared_memory" in captured["whitelist"]
+    assert "terminal" not in captured["whitelist"]
+    assert "propose_shared_memory" in captured["review_prompt"]
 
 

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -350,6 +350,25 @@ Fork usage is persisted in `session_model_usage` with `task='background_review'`
 and a completion line is written to `agent.log`
 (`Background review complete: thread=bg-review calls=… in=… out=… result=…`).
 
+### Allowing a narrowly scoped extra review tool (`extra_tools`)
+
+Background review can use memory, skill-management, and read-only file tools
+by default. If a profile provides another tool that is safe for unattended
+review, opt it in by name:
+
+```yaml
+auxiliary:
+  background_review:
+    extra_tools:
+      - propose_shared_memory
+```
+
+The tool must already be available to the parent agent; this setting only adds
+it to the review fork's runtime whitelist. It does not enable arbitrary tools,
+and tools not listed here remain denied. Keep the list narrow and prefer tools
+that stage a proposal for human review rather than applying external or
+destructive changes directly. The default is an empty list.
+
 ## Controlling skill writes (`skills.write_approval`)
 
 Skills use the same on/off gate, but the review UX differs because a


### PR DESCRIPTION
## Summary
Background review gains `auxiliary.background_review.extra_tools` — a default-empty, opt-in list that admits named parent tools to the review fork's dispatch whitelist (salvage of #82146 by @BrinShadewater, closes #44672). Nothing changes without config; a listed tool must already exist in the parent's inherited schema (the whitelist can only admit, never advertise), so `tools[]` and cache parity are untouched.

## Changes
- `agent/background_review.py`: parse `extra_tools` from the already-loaded `task_cfg` (no extra config I/O per review), union into the runtime whitelist; deny message and the fork's instruction both name the configured tools.
- Contributor's regression test carried (real temp `HERMES_HOME` config → tool admitted, terminal still denied, prompt names the tool) — adapted to the current whitelist site.
- `website/docs/user-guide/features/memory.md`: new `extra_tools` section, merged alongside the newer `enabled` section.

Salvage notes: cherry-picked @BrinShadewater's commits (authorship preserved); conflicts resolved against the `build_cache_parity_fork()` refactor (#97974) and the read-tools whitelist + substitute-naming deny message (#98254) — the extra-tools note now appends to that message instead of replacing it. Config read collapsed onto `task_cfg` per the existing single-config-read pattern.

## Validation
| scenario | whitelist result |
|---|---|
| no config (default) | `propose_shared_memory` DENIED; read_file baseline intact |
| `extra_tools: [propose_shared_memory]` | tool ADMITTED; `terminal` still denied; deny message + fork prompt name it |

**Live repro:** real config.yaml in a temp `HERMES_HOME` driven through the actual `_run_review_in_thread` whitelist-build path (only `run_conversation` stubbed) — both rows above confirmed live. 76 tests green across all background-review suites including the carried regression test.

## Infographic

![extra tools opt-in](https://v3b.fal.media/files/b/0aa85af1/aZ8UsU9ZOlbUlsL6sDpNC_6g4Go652.png)
