### PR TITLE
fix(linux): keep venv python in desktop entry Exec

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,11 +78,11 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            argv = [str(sys.executable), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(sys.executable), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 


### PR DESCRIPTION
## Problem

On uv-managed installs the generated Linux desktop entry is unusable: clicking the icon does nothing at all. Launching `hermes desktop` from a terminal works fine, which makes the failure look like a desktop-environment issue rather than a Hermes one.

It fails silently because the entry sets `Terminal=false`, so the traceback never reaches the user.

## Cause

`resolve_exec_command()` builds the `Exec=` line with `Path(sys.executable).resolve()`.

On a uv-managed install, `venv/bin/python` is a **symlink** to the base interpreter. `.resolve()` follows that symlink, so the `Exec=` line ends up pointing at the bare interpreter outside the venv — undoing exactly the venv membership the function exists to preserve. The comment above the line states the intent correctly ("sys.executable is the interpreter actually running Hermes (the venv one), so prefix it explicitly"); `.resolve()` defeats it.

The launcher then dies on the first third-party import:

```
ModuleNotFoundError: No module named 'yaml'
```

## Reproduction

Install via the uv-based installer, then:

```console
$ venv/bin/python -c "import sys; from pathlib import Path; \
    print(sys.executable); print(Path(sys.executable).resolve())"
~/.hermes/hermes-agent/venv/bin/python
~/.local/share/uv/python/cpython-3.11.16-linux-x86_64-gnu/bin/python3.11

$ venv/bin/python -c "import yaml"                      # ok
$ ~/.local/share/uv/python/.../bin/python3.11 -c "import yaml"
ModuleNotFoundError: No module named 'yaml'
```

The second path is what lands in `Exec=`.

Running the generated `Exec=` line in a launcher-like environment reproduces the silent failure:

```console
$ env -i HOME=$HOME DISPLAY=:0 PATH=/usr/local/bin:/usr/bin:/bin \
    <resolved-interpreter> ~/.hermes/hermes-agent/hermes desktop
ModuleNotFoundError: No module named 'yaml'
```

Because the entry is regenerated on each launch, editing `~/.local/share/applications/hermes.desktop` by hand is overwritten on the next start — which is why this reads to users as "it worked once, then stopped".

## Fix

Drop `.resolve()` in the two `argv` constructions so the venv path is kept as-is. `_needs_interpreter()` is left untouched: its `.resolve()` is used for shebang comparison, which is a different question.

## Verification

With the patch, the regenerated entry reads:

```
Exec=~/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main desktop
```

and `gtk-launch hermes` — the same path the icon takes — starts the app normally. Tested on Linux Mint (Cinnamon, X11), Hermes Agent v0.20.6, uv-based git install.

## Notes

Refs #90292, #94058. Also reported as #97983, #94564, and #92882 (the `ModuleNotFoundError` symptom). Confirmations on the linked issues span CachyOS/KDE, Ubuntu/GNOME and Mint/Cinnamon, so this does not look distribution-specific.
