### PR TITLE
feat(desktop): render Kanban descriptions as Markdown

### DIFF
--- a/apps/desktop/src/plugins/kanban/drawer-markdown.test.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer-markdown.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { DescriptionSection } from './drawer'
+
+vi.mock('./ui', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>()
+
+  return {
+    ...actual,
+    useKanban: () => ({
+      cancelEdit: 'Cancel edit',
+      description: 'Description',
+      editDescription: 'Edit description',
+      noDescription: 'No description',
+      save: 'Save'
+    })
+  }
+})
+
+afterEach(cleanup)
+
+describe('Kanban task description', () => {
+  it('renders stored Markdown as formatted content', () => {
+    render(
+      <DescriptionSection
+        body={'# Human review snapshot\n\n**Accountable human:** Mark\n\n- Approve\n- Hold'}
+        onSave={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Human review snapshot' })).toBeTruthy()
+    expect(screen.getByText('Accountable human:')).toBeTruthy()
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+    expect(screen.queryByText(/^# Human review snapshot$/)).toBeNull()
+  })
+
+  it('keeps the original Markdown available in edit mode', () => {
+    const body = '# Human review snapshot\n\n**Accountable human:** Mark'
+    render(<DescriptionSection body={body} onSave={vi.fn()} />)
+
+    fireEvent.click(screen.getByLabelText('Edit description'))
+
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(body)
+  })
+
+  it('does not expose unsafe HTML or link protocols', () => {
+    const { container } = render(
+      <DescriptionSection
+        body={
+          '<script>alert(1)</script><img src=x onerror=alert(1)>\n\n[safe](https://example.com/path)\n\n[x](javascript:alert(1))\n\n[y](file:///etc/passwd)'
+        }
+        onSave={vi.fn()}
+      />
+    )
+
+    const safeLink = screen.getByRole('link', { name: 'safe' })
+    expect(safeLink.getAttribute('href')).toBe('https://example.com/path')
+    expect(safeLink.classList.contains('ref')).toBe(true)
+    expect(safeLink.getAttribute('rel')).toBe('noopener noreferrer')
+    expect(safeLink.getAttribute('target')).toBe('_blank')
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('[onerror]')).toBeNull()
+    expect(container.querySelector('a[href^="javascript:"]')).toBeNull()
+    expect(container.querySelector('a[href^="file:"]')).toBeNull()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   cn,
   Codicon,
+  CompactMarkdown,
   compactNumber,
   DropdownMenu,
   DropdownMenuContent,
@@ -355,7 +356,13 @@ function CommentComposer({
   )
 }
 
-function DescriptionSection({ body, onSave }: { body: null | string | undefined; onSave: (body: string) => void }) {
+export function DescriptionSection({
+  body,
+  onSave
+}: {
+  body: null | string | undefined
+  onSave: (body: string) => void
+}) {
   const k = useKanban()
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState('')
@@ -397,7 +404,7 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
           </Button>
         </div>
       ) : body ? (
-        <p className="whitespace-pre-wrap text-[0.8125rem] text-(--ui-text-secondary)">{body}</p>
+        <CompactMarkdown className="text-[0.8125rem] text-(--ui-text-secondary)" text={body} />
       ) : (
         <p className="text-[0.8125rem] text-(--ui-text-quaternary)">{k.noDescription}</p>
       )}

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1476,6 +1476,9 @@ export { SkillsView } from '@/app/skills'
  *  renders anywhere (a plugin dialog); pass a live `gateway` (see
  *  `host.getGateway()`) and an optional `profile` to scope it to one bot. */
 export { McpTab } from '@/app/skills/mcp-tab'
+/** Opinionated compact Markdown renderer with Desktop typography, safe external
+ *  link routing, and overflow handling for dense plugin surfaces. */
+export { CompactMarkdown } from '@/components/chat/compact-markdown'
 /** The oversized Collapse lettering an empty chat is titled with — core writes
  *  "HERMES AGENT" with it, a `chat.empty` contribution writes its own name. */
 export { Wordmark } from '@/components/chat/wordmark'


### PR DESCRIPTION
## What does this PR do?

Kanban task descriptions now render stored Markdown in the Desktop task drawer instead of showing Markdown markers as plain text. Edit mode still exposes and saves the exact raw Markdown source.

The implementation reuses Desktop's existing `CompactMarkdown` renderer rather than introducing a second Markdown stack, preserving the renderer/backend boundary and the established link/sanitization behavior.

## Related Issue

No linked issue. Searches of open and closed issues and PRs found no duplicate for Kanban description Markdown rendering.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/kanban/drawer.tsx`
  - Render read-only descriptions with `CompactMarkdown`.
  - Preserve the existing raw Markdown edit/save path and empty state.
- `apps/desktop/src/sdk/index.ts`
  - Export the shared renderer through `@hermes/plugin-sdk` for bundled Desktop plugins.
- `apps/desktop/src/plugins/kanban/drawer-markdown.test.tsx`
  - Cover semantic Markdown rendering, raw-source edit preservation, unsafe HTML/protocol removal, and safe HTTPS link behavior.

## How to Test

1. Enable the bundled Kanban plugin and open `/kanban`.
2. Create a task whose description contains a heading, list, bold text, inline/fenced code, a table, and an HTTPS link.
3. Open the task drawer and verify the content renders as Markdown rather than raw syntax.
4. Enter edit mode and verify the textarea contains the exact original Markdown.
5. Run:
   ```bash
   cd apps/desktop
   npx vitest run --project ui src/plugins/kanban/drawer-markdown.test.tsx
   npm run check
   npm run build
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see the baseline-only local failure noted below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux x86_64 (kernel 7.1.9-arch1-2), Python 3.11.16, Node 22.23.2, npm 10.9.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing documentation contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only reuse of an existing shared primitive; no OS APIs or paths changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no agent tool behavior changed

## Screenshots / Logs

Verified at commit `0ca64b68e5a9174a35e8952ffeab0d899e614d34`:

- Focused Kanban Markdown tests: **3 passed**
- Full Desktop UI suite: **684 files / 6,753 tests passed**
- Desktop TypeScript checks: **passed**
- ESLint on the changed files: **passed**
- Desktop production build and packaged artifact verification: **passed**
- Synthetic merge with current `upstream/main`: focused Markdown tests (**3 passed**) and Desktop typecheck (**passed**)
- Real Desktop Kanban Playwright acceptance: **1 passed (6.7s)**
  - Verified headings, lists, bold text, inline/fenced code, tables, HTTPS-link behavior, and absence of raw bold markers in read mode.
- Security-focused DOM assertions: script/event-handler HTML was not introduced; `javascript:` and `file:` links were removed; safe HTTPS links retained `_blank` plus `noopener noreferrer`.
- Root Python suite: **40,298 passed / 349 skipped / 9 failed** in the full local run. Eight failures were caused by the local PID/user-namespace sandbox and all passed in an ordinary rerun. The one remaining failure, `TestFTS5Search::test_search_projection_skips_context_enrichment_queries`, reproduces unchanged on current `upstream/main` in this environment. This PR changes no Python, and the repository classifier reports `python=false`, so the Python CI lane is not selected for this PR.

Local JavaScript checks used Node 22/npm 10; repository CI is configured for Node 26/npm 12 and still needs to run after a maintainer approves this fork's workflows.
