### PR TITLE
fix(tui): advertise extended keys and Ctrl+J newline on alacritty, foot, kitty and VTE

### DIFF
--- a/contributors/emails/feelfree.co.nr@gmail.com
+++ b/contributors/emails/feelfree.co.nr@gmail.com
@@ -1,0 +1,2 @@
+Eakkapoom-Name
+# PR #98289 (tui: Ctrl+J newline on VTE terminals)

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { isSynchronizedOutputSupported, needsAltScreenResizeScrollbackClear, writeDiffToTerminal } from './terminal.js'
+import {
+  isSynchronizedOutputSupported,
+  needsAltScreenResizeScrollbackClear,
+  supportsExtendedKeys,
+  writeDiffToTerminal
+} from './terminal.js'
 import { BSU, ESU } from './termio/dec.js'
 
 describe('terminal resize quirks', () => {
@@ -108,4 +113,34 @@ describe('skipKittyKeyboardProtocol', () => {
       }
     }
   )
+})
+
+describe('supportsExtendedKeys', () => {
+  it.each(['iTerm.app', 'kitty', 'WezTerm', 'ghostty', 'tmux', 'windows-terminal', 'vscode'])(
+    'advertises extended keys for %s',
+    terminal => {
+      expect(supportsExtendedKeys(terminal, null)).toBe(true)
+    }
+  )
+
+  it.each(['alacritty', 'foot', 'foot-extra', 'xterm-kitty', 'xterm-ghostty'])(
+    'advertises extended keys for TERM=%s',
+    term => {
+      expect(supportsExtendedKeys(term, null)).toBe(true)
+    }
+  )
+
+  it('advertises extended keys on VTE terminals reporting TERM=xterm-256color (#51545)', () => {
+    expect(supportsExtendedKeys('xterm-256color', '7600')).toBe(true)
+  })
+
+  // A bare xterm* TERM is the generic fallback, including over SSH, and says
+  // nothing about modifyOtherKeys support. Enabling it there re-opens #75251.
+  it.each(['xterm', 'xterm-256color', 'screen-256color', 'linux'])('leaves TERM=%s alone', term => {
+    expect(supportsExtendedKeys(term, null)).toBe(false)
+  })
+
+  it('leaves an unknown terminal alone', () => {
+    expect(supportsExtendedKeys(null, null)).toBe(false)
+  })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.ts
@@ -320,10 +320,25 @@ export function parseOscColor(data: string): string | undefined {
 // terminal.
 const EXTENDED_KEYS_TERMINALS = ['iTerm.app', 'kitty', 'WezTerm', 'ghostty', 'tmux', 'windows-terminal', 'vscode']
 
+// Additional terminals known to handle modifyOtherKeys/kitty correctly on Linux
+const EXTENDED_KEYS_SUBSTRINGS = ['xterm', 'alacritty', 'foot', 'ghostty', 'kitty']
+
 /** True if this terminal correctly handles extended key reporting
  *  (Kitty keyboard protocol + xterm modifyOtherKeys). */
 export function supportsExtendedKeys(): boolean {
-  return EXTENDED_KEYS_TERMINALS.includes(env.terminal ?? '')
+  const term = env.terminal ?? ''
+  if (EXTENDED_KEYS_TERMINALS.includes(term)) {
+    return true
+  }
+  // GNOME Terminal / VTE, xterm, alacritty, foot all support modifyOtherKeys
+  if (EXTENDED_KEYS_SUBSTRINGS.some(s => term.includes(s))) {
+    return true
+  }
+  // VTE-based terminals expose VTE_VERSION even when TERM is xterm-256color
+  if (process.env.VTE_VERSION) {
+    return true
+  }
+  return false
 }
 
 /** True when the Kitty keyboard protocol push (CSI >1u) must be skipped for

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.ts
@@ -320,22 +320,32 @@ export function parseOscColor(data: string): string | undefined {
 // terminal.
 const EXTENDED_KEYS_TERMINALS = ['iTerm.app', 'kitty', 'WezTerm', 'ghostty', 'tmux', 'windows-terminal', 'vscode']
 
-// Additional terminals known to handle modifyOtherKeys/kitty correctly on Linux
-const EXTENDED_KEYS_SUBSTRINGS = ['xterm', 'alacritty', 'foot', 'ghostty', 'kitty']
+// Linux terminals that name themselves in TERM and handle
+// modifyOtherKeys/kitty correctly. Matched as substrings because these ship
+// several TERM variants (foot/foot-extra, xterm-kitty, xterm-ghostty).
+// A bare TERM=xterm* is deliberately NOT here: it is the generic default a
+// terminal falls back to, including over SSH, and says nothing about
+// modifyOtherKeys support. VTE terminals are covered by vteVersion below.
+const EXTENDED_KEYS_SUBSTRINGS = ['alacritty', 'foot', 'ghostty', 'kitty']
 
 /** True if this terminal correctly handles extended key reporting
- *  (Kitty keyboard protocol + xterm modifyOtherKeys). */
-export function supportsExtendedKeys(): boolean {
-  const term = env.terminal ?? ''
+ *  (Kitty keyboard protocol + xterm modifyOtherKeys).
+ *  Accepts an optional terminal name and VTE version for testability; both
+ *  default to the module-level values detected at startup. */
+export function supportsExtendedKeys(
+  terminal: string | null = env.terminal,
+  vteVersion: string | null = env.vteVersion
+): boolean {
+  const term = terminal ?? ''
   if (EXTENDED_KEYS_TERMINALS.includes(term)) {
     return true
   }
-  // GNOME Terminal / VTE, xterm, alacritty, foot all support modifyOtherKeys
   if (EXTENDED_KEYS_SUBSTRINGS.some(s => term.includes(s))) {
     return true
   }
-  // VTE-based terminals expose VTE_VERSION even when TERM is xterm-256color
-  if (process.env.VTE_VERSION) {
+  // GNOME Terminal and other VTE terminals report TERM=xterm-256color, so
+  // VTE_VERSION is the only thing that identifies them.
+  if (vteVersion) {
     return true
   }
   return false

--- a/ui-tui/packages/hermes-ink/src/utils/env.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/env.ts
@@ -37,7 +37,11 @@ function detectTerminal(): TerminalName {
 }
 
 export const env = {
-  terminal: detectTerminal()
+  terminal: detectTerminal(),
+  // VTE-based terminals (GNOME Terminal, Tilix, Terminator, xfce4-terminal)
+  // export VTE_VERSION even when TERM is a generic xterm-256color, so it is
+  // the only reliable fingerprint for them.
+  vteVersion: process.env.VTE_VERSION ?? null
 }
 
 // Terminals known to correctly implement OSC 52 clipboard writes

--- a/ui-tui/src/__tests__/textInputReturnAction.test.ts
+++ b/ui-tui/src/__tests__/textInputReturnAction.test.ts
@@ -56,7 +56,8 @@ describe('shouldInsertNewlineOnReturn', () => {
       'WT_SESSION',
       'GHOSTTY_RESOURCES_DIR',
       'GHOSTTY_BIN_DIR',
-      'WSL_DISTRO_NAME'
+      'WSL_DISTRO_NAME',
+      'VTE_VERSION'
     ]) {
       delete process.env[k]
     }

--- a/ui-tui/src/__tests__/textInputReturnAction.test.ts
+++ b/ui-tui/src/__tests__/textInputReturnAction.test.ts
@@ -91,37 +91,10 @@ describe('shouldInsertNewlineOnReturn', () => {
       process.env = prev
     }
   })
-
-  it('accepts a bare LF as a newline on a VTE terminal (#51545)', async () => {
-    const prev = { ...process.env }
-
-    for (const k of PLAIN_TERMINAL_ENV) {
-      delete process.env[k]
-    }
-
-    process.env.TERM = 'xterm-256color'
-    process.env.TERM_PROGRAM = ''
-    process.env.VTE_VERSION = '7600'
-
-    try {
-      const { shouldInsertNewlineOnReturn } = await importTextInput('linux')
-
-      expect(shouldInsertNewlineOnReturn(key(), '\n')).toBe(true)
-      expect(shouldInsertNewlineOnReturn(key(), '\r')).toBe(false)
-    } finally {
-      process.env = prev
-    }
-  })
 })
 
 describe('shouldPreserveCtrlJNewline', () => {
   const plainLinuxEnv = { TERM: 'xterm-256color' }
-
-  it('preserves Ctrl+J on GNOME Terminal and other VTE terminals', async () => {
-    const { shouldPreserveCtrlJNewline } = await importTextInput('linux')
-
-    expect(shouldPreserveCtrlJNewline({ ...plainLinuxEnv, VTE_VERSION: '7600' })).toBe(true)
-  })
 
   it('preserves Ctrl+J on alacritty, foot, kitty and ghostty', async () => {
     const { shouldPreserveCtrlJNewline } = await importTextInput('linux')

--- a/ui-tui/src/__tests__/textInputReturnAction.test.ts
+++ b/ui-tui/src/__tests__/textInputReturnAction.test.ts
@@ -14,6 +14,19 @@ afterEach(() => {
   vi.resetModules()
 })
 
+// Terminal fingerprints that make Hermes treat bare LF as a newline. Cleared
+// so a case can assert the no-fingerprint baseline.
+const PLAIN_TERMINAL_ENV = [
+  'SSH_CONNECTION',
+  'SSH_CLIENT',
+  'SSH_TTY',
+  'WT_SESSION',
+  'GHOSTTY_RESOURCES_DIR',
+  'GHOSTTY_BIN_DIR',
+  'WSL_DISTRO_NAME',
+  'VTE_VERSION'
+]
+
 const key = (overrides: Record<string, unknown> = {}) =>
   ({ ctrl: false, meta: false, return: true, shift: false, super: false, ...overrides }) as any
 
@@ -49,16 +62,7 @@ describe('shouldInsertNewlineOnReturn', () => {
   it('keeps plain Enter as submit on a plain non-macOS terminal', async () => {
     const prev = { ...process.env }
 
-    for (const k of [
-      'SSH_CONNECTION',
-      'SSH_CLIENT',
-      'SSH_TTY',
-      'WT_SESSION',
-      'GHOSTTY_RESOURCES_DIR',
-      'GHOSTTY_BIN_DIR',
-      'WSL_DISTRO_NAME',
-      'VTE_VERSION'
-    ]) {
+    for (const k of PLAIN_TERMINAL_ENV) {
       delete process.env[k]
     }
 
@@ -86,5 +90,50 @@ describe('shouldInsertNewlineOnReturn', () => {
     } finally {
       process.env = prev
     }
+  })
+
+  it('accepts a bare LF as a newline on a VTE terminal (#51545)', async () => {
+    const prev = { ...process.env }
+
+    for (const k of PLAIN_TERMINAL_ENV) {
+      delete process.env[k]
+    }
+
+    process.env.TERM = 'xterm-256color'
+    process.env.TERM_PROGRAM = ''
+    process.env.VTE_VERSION = '7600'
+
+    try {
+      const { shouldInsertNewlineOnReturn } = await importTextInput('linux')
+
+      expect(shouldInsertNewlineOnReturn(key(), '\n')).toBe(true)
+      expect(shouldInsertNewlineOnReturn(key(), '\r')).toBe(false)
+    } finally {
+      process.env = prev
+    }
+  })
+})
+
+describe('shouldPreserveCtrlJNewline', () => {
+  const plainLinuxEnv = { TERM: 'xterm-256color' }
+
+  it('preserves Ctrl+J on GNOME Terminal and other VTE terminals', async () => {
+    const { shouldPreserveCtrlJNewline } = await importTextInput('linux')
+
+    expect(shouldPreserveCtrlJNewline({ ...plainLinuxEnv, VTE_VERSION: '7600' })).toBe(true)
+  })
+
+  it('preserves Ctrl+J on alacritty, foot, kitty and ghostty', async () => {
+    const { shouldPreserveCtrlJNewline } = await importTextInput('linux')
+
+    for (const TERM of ['alacritty', 'foot', 'foot-extra', 'xterm-kitty', 'xterm-ghostty']) {
+      expect(shouldPreserveCtrlJNewline({ TERM })).toBe(true)
+    }
+  })
+
+  it('leaves Ctrl+J alone on a plain terminal with no fingerprint', async () => {
+    const { shouldPreserveCtrlJNewline } = await importTextInput('linux')
+
+    expect(shouldPreserveCtrlJNewline(plainLinuxEnv)).toBe(false)
   })
 })

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -275,7 +275,22 @@ export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boole
     return true
   }
 
-  return (env.WSL_DISTRO_NAME ?? '').toLowerCase().includes('microsoft')
+  if ((env.WSL_DISTRO_NAME ?? '').toLowerCase().includes('microsoft')) {
+    return true
+  }
+
+  // Linux local terminals: GNOME Terminal (VTE), xterm, alacritty, foot
+  // previously returned false for TERM=xterm-256color, breaking Ctrl+J
+  if (env.VTE_VERSION) {
+    return true
+  }
+
+  const term = (env.TERM ?? '').toLowerCase()
+  if (term.includes('alacritty') || term.startsWith('foot') || term === 'xterm-kitty' || term === 'xterm-ghostty') {
+    return true
+  }
+
+  return false
 }
 
 type ReturnDecisionKey = {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -279,8 +279,9 @@ export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boole
     return true
   }
 
-  // Linux local terminals: GNOME Terminal (VTE), xterm, alacritty, foot
-  // previously returned false for TERM=xterm-256color, breaking Ctrl+J
+  // GNOME Terminal and other VTE terminals report TERM=xterm-256color, so
+  // they previously returned false here and Ctrl+J submitted instead of
+  // inserting a newline (#51545).
   if (env.VTE_VERSION) {
     return true
   }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -279,13 +279,8 @@ export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boole
     return true
   }
 
-  // GNOME Terminal and other VTE terminals report TERM=xterm-256color, so
-  // they previously returned false here and Ctrl+J submitted instead of
-  // inserting a newline (#51545).
-  if (env.VTE_VERSION) {
-    return true
-  }
-
+  // Terminals that identify themselves only through TERM and set no
+  // dedicated env var, so they had no fingerprint here.
   const term = (env.TERM ?? '').toLowerCase()
   if (term.includes('alacritty') || term.startsWith('foot') || term === 'xterm-kitty' || term === 'xterm-ghostty') {
     return true


### PR DESCRIPTION
## What does this PR do?

Builds on #51546. That PR adds the `VTE_VERSION` fingerprint to
`shouldPreserveCtrlJNewline()` so bare LF (`Ctrl+J`) inserts a newline on GNOME
Terminal and other VTE terminals. This PR no longer carries that hunk; merge #51546
first. On its own, this PR does not resolve #51545.

What this PR adds on top:

- `shouldPreserveCtrlJNewline()` also returns true for terminals that name
  themselves in `TERM` but set no dedicated env var: `alacritty`, `foot*`,
  `xterm-kitty`, `xterm-ghostty`.
- `supportsExtendedKeys()` in `hermes-ink` matches `alacritty`, `foot`, `ghostty`,
  `kitty` as `TERM` substrings and any terminal reporting `VTE_VERSION`, so the
  Kitty / modifyOtherKeys push is advertised there too.
- `env.vteVersion` is detected once at startup next to `terminal`, so `VTE_VERSION`
  is read through the same module as every other terminal fingerprint.

## Related Issue

Related to #51545 (the fix for that issue is #51546; this PR depends on it).

### Relationship to existing PRs

- #51546: dependency. Adds the `VTE_VERSION` predicate case and its regression test.
  I wrote this fix before checking for existing PRs and found #51546 only when
  opening this one, so this PR started as a superset of it. The duplicate hunk and
  its two tests were dropped in d91b699a67 so the two PRs stack instead of competing.
- #88957: covers the normalized Kitty CSI-u / modifyOtherKeys form of `Ctrl+J`
  (`name: 'j', ctrl: true`). Note that once a terminal honors the extended-key push,
  `Ctrl+J` arrives in that form rather than as bare LF, so the `TERM` predicate cases
  above only matter while the push is off or ignored. Terminals that honor the push
  need #88957 for `Ctrl+J` to insert a newline.
- #77316: WSL detection path (#77283). Untouched here.

### Caveat on the VTE extended-key branch

As far as I can tell VTE does not yet implement the Kitty keyboard protocol
(gitlab.gnome.org/GNOME/vte issue 2601 is still open) or xterm modifyOtherKeys, so on
current VTE the `vteVersion` branch in `supportsExtendedKeys()` is inert: the push is
ignored and `Ctrl+J` keeps arriving as bare LF, handled by #51546. The branch is
forward-looking for when VTE gains that support. Happy to drop it if a maintainer
prefers to keep the allowlist strictly to terminals that honor the push today.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/textInput.tsx`: `shouldPreserveCtrlJNewline()` returns true
  for `TERM` values that name their own emulator (`alacritty`, `foot*`, `xterm-kitty`,
  `xterm-ghostty`). The `VTE_VERSION` case lives in #51546.
- `ui-tui/packages/hermes-ink/src/utils/env.ts`: `env` now carries `vteVersion`,
  detected once at startup next to `terminal`.
- `ui-tui/packages/hermes-ink/src/ink/terminal.ts`: `supportsExtendedKeys()` matches
  `alacritty`, `foot`, `ghostty`, `kitty` as `TERM` substrings and any terminal
  reporting `VTE_VERSION`. It takes optional `terminal` and `vteVersion` arguments
  defaulting to the module-level values, mirroring `supportsOsc52Clipboard()`, so it is
  testable without mutating module state.
- A bare `TERM=xterm*` is deliberately not matched. It is the generic fallback a
  terminal lands on when nothing better is set, including over SSH, and says nothing
  about modifyOtherKeys support. Enabling extended keys there would re-open #75251.
- Tests: `shouldPreserveCtrlJNewline()` across alacritty / foot / kitty / ghostty /
  bare terminals, and `supportsExtendedKeys()` including the assertion that bare
  `xterm`, `xterm-256color`, `screen-256color` and `linux` stay off. The VTE newline
  tests moved out with the predicate hunk; they are in #51546.
- `contributors/emails/`: adds the author email mapping required by the Contributor
  Attribution Check.

## How to Test

1. Check out this branch on top of #51546 (or wait for #51546 to merge). Without it,
   `Ctrl+J` on a VTE terminal still submits, by design.
2. In GNOME Terminal (or any VTE terminal), confirm `echo $VTE_VERSION` prints a
   version. Run `hermes --tui`, type a word, press `Ctrl+J`. The composer inserts a
   newline. Press `Enter`; it still submits. This result was measured on the earlier
   revision of this branch, which still carried the predicate hunk now in #51546.
3. Control: run with `VTE_VERSION` unset. `Ctrl+J` submits, exactly as on `main`,
   confirming that plain `TERM=xterm-256color` terminals are unchanged.
4. Run the suite:
   ```
   cd ui-tui
   npm run build:ink
   npm test -- --run src/__tests__/textInputReturnAction.test.ts
   npm test -- --run packages/hermes-ink/src/ink/terminal.test.ts
   npm run typecheck
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate. See "Relationship
      to existing PRs" above
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all pass. Full `ui-tui` suite: 160 files, 1742 tests passing
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, GNOME Terminal (VTE 7600), TERM=xterm-256color,
      on the earlier revision that included the #51546 predicate.

### Documentation & Housekeeping

- [x] I've updated relevant documentation: N/A, no user-facing config or docs change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact: macOS and Windows are unaffected. `VTE_VERSION`
      exists only on Linux VTE terminals; the Windows Terminal, Ghostty, SSH and WSL
      branches are untouched, and bare `xterm*` behavior is unchanged from main.
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

