### PR TITLE
fix(update): shallow --check must not report "behind" when the compare API can't resolve a local-only HEAD (#98214)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4140,11 +4140,29 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
                 # Local commits on top of the remote tip — not behind.
                 print("✓ Already up to date.")
                 return
-            if counted is not None:
-                commits_word = "commit" if counted == 1 else "commits"
-                print(f"⚕ Update available: {counted} {commits_word} behind {compare_branch}.")
-            else:
-                print(f"⚕ Update available (behind {compare_branch}).")
+            if counted is None:
+                # The compare API has no answer. That covers both a local-only
+                # HEAD SHA GitHub has never seen (the update_in_place workflow)
+                # and a failed/rate-limited API call, so ask git locally
+                # whether the target is already contained in HEAD. On a shallow
+                # clone the answer is reliable while the boundary sits at or
+                # below the target ref (the local-commits-on-top-of-tip case);
+                # across a moved boundary git may still say no — that just
+                # lands on the honest "unknown" below, never a false "behind".
+                ancestor = subprocess.run(
+                    git_cmd + ["merge-base", "--is-ancestor", compare_branch, "HEAD"],
+                    cwd=_m().PROJECT_ROOT,
+                    capture_output=True,
+                    text=True, encoding="utf-8", errors="replace",
+                )
+                if ancestor.returncode == 0:
+                    print("✓ Already up to date.")
+                    return
+                print(f"⚕ Update status unknown (could not compare against {compare_branch}).")
+                print("  Run 'hermes update' to install regardless.")
+                return
+            commits_word = "commit" if counted == 1 else "commits"
+            print(f"⚕ Update available: {counted} {commits_word} behind {compare_branch}.")
             print(f"  Run '{recommended_update_command()}' to install.")
         return
 

--- a/tests/hermes_cli/test_update_check_shallow_local_only.py
+++ b/tests/hermes_cli/test_update_check_shallow_local_only.py
@@ -1,0 +1,79 @@
+"""RED tests for #98214 — shallow `update --check` misreports `None` as behind.
+
+Simulates the exact issue scenario: shallow clone, local-only HEAD commits on
+top of origin/main, GitHub compare API cannot resolve the local SHA and returns
+None. The shallow branch must NOT assert "Update available".
+"""
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _shallow_side_effect(ancestor_rc=0):
+    """subprocess.run side effect: shallow repo, divergent SHAs, API -> None.
+
+    ancestor_rc: exit code of `git merge-base --is-ancestor <target> HEAD`
+      0  -> origin/main is contained in HEAD (ahead-or-equal, not behind)
+      1  -> genuinely not an ancestor
+      128 -> inconclusive (outside shallow boundary)
+    """
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+
+        if "rev-parse" in joined and "--is-shallow-repository" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout="true\n", stderr="")
+        if "fetch" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout="local-patches\n", stderr="")
+        if "rev-parse" in joined and "--verify" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if "rev-parse" in joined and "HEAD" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout="8" * 40 + "\n", stderr="")
+        if joined.rstrip().endswith("rev-parse origin/main"):
+            return subprocess.CompletedProcess(cmd, 0, stdout="4" * 40 + "\n", stderr="")
+        if "merge-base" in joined and "--is-ancestor" in joined:
+            return subprocess.CompletedProcess(cmd, ancestor_rc, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return side_effect
+
+
+ARGS = SimpleNamespace(check=True, branch=None)
+
+
+def _run_check():
+    from hermes_cli.main import cmd_update
+
+    with patch("hermes_cli.config.detect_install_method", return_value="git"), \
+         patch("hermes_cli.banner._github_compare_behind", return_value=None):
+        cmd_update(ARGS)
+
+
+def test_none_with_ancestor_reports_up_to_date(capsys):
+    with patch("subprocess.run", side_effect=_shallow_side_effect(ancestor_rc=0)):
+        _run_check()
+    out = capsys.readouterr().out
+    assert "Already up to date." in out, out
+    assert "Update available" not in out, out
+
+
+def test_none_without_ancestor_does_not_claim_behind(capsys):
+    with patch("subprocess.run", side_effect=_shallow_side_effect(ancestor_rc=1)):
+        _run_check()
+    out = capsys.readouterr().out
+    # Must not assert an update exists — status is unknown, not "behind".
+    assert "Update available" not in out, out
+    assert "unknown" in out, out
+
+
+def test_none_inconclusive_ancestor_does_not_claim_behind(capsys):
+    with patch("subprocess.run", side_effect=_shallow_side_effect(ancestor_rc=128)):
+        _run_check()
+    out = capsys.readouterr().out
+    assert "Update available" not in out, out
+    assert "unknown" in out, out


### PR DESCRIPTION
## What does this PR do?

Fixes the false "Update available" report from `hermes update --check` on a **shallow** checkout that carries **local-only commits** (#98214).

The shallow fast-path in `_cmd_update_check()` asks the GitHub compare API (`_github_compare_behind()`) to recover the behind-count. That API can only answer about commits GitHub has *seen* — for a local-only HEAD SHA (exactly the `updates.parked_branch_strategy: update_in_place` workflow the updater supports) it correctly returns `None` ("could not determine"), and the caller's `else` then *asserted* `⚕ Update available (behind origin/main)`. Unknown was reported as behind, forever, on a genuinely up-to-date checkout.

This PR:
1. **`None` no longer means "behind".** When the compare API has no answer, fall back to a local ancestry test: `git merge-base --is-ancestor <compare_branch> HEAD`. Exit 0 proves the target is contained in HEAD → `✓ Already up to date.` (no network needed).
2. **Honest wording for the residual case.** If git can't prove containment either (target outside the shallow boundary, or genuinely diverged), print `⚕ Update status unknown (could not compare against <ref>)` instead of claiming an update exists. The exit code and the `counted > 0` output bytes are unchanged, so script/cron gating on `update --check` keeps its current contract.

The fallback deliberately covers *both* reasons `_github_compare_behind` returns `None` — the local-only-SHA case *and* a failed/rate-limited API call — so offline shallow checks land on "unknown" or a real local answer rather than a fabricated "behind".

## Related Issue

Fixes #98214

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/update_cmd.py` — `_cmd_update_check()`, shallow fast-path only (+17/−4): handle `counted is None` with a local `merge-base --is-ancestor` containment test; "already up to date" on rc 0, honest "status unknown" otherwise. The `head_sha == target_sha` short-circuit and the `counted == 0` / `counted > 0` branches are untouched (byte-identical output).
- `tests/hermes_cli/test_update_check_shallow_local_only.py` (new, 3 tests) — simulates the exact issue scenario (shallow repo, divergent SHAs, API → `None`) for all three ancestor outcomes: contained → "Already up to date."; rc 1 and rc 128 (inconclusive git error) → "unknown" wording, never "Update available".

## How to Test

1. Reproduce on unpatched main: shallow-clone the repo (`git clone --depth 1`), `git switch -c local-patches && git commit --allow-empty -m local`, ensure the commit is unpushed, run the shallow fast-path of `_cmd_update_check` with the compare API returning `None` → prints `⚕ Update available (behind …)` even though `git merge-base --is-ancestor origin/main HEAD` exits 0. (New tests are **red on main**: 3 failed.)
2. On this branch: `pytest tests/hermes_cli/test_update_check_shallow_local_only.py -q` → **3 passed**.
3. Regression: `pytest tests/hermes_cli/test_update_check.py tests/hermes_cli/test_update_apply_shallow_count.py "tests/hermes_cli/test_cmd_update.py::TestCmdUpdateCheckBranchFlag" -q` → **15 passed** (the CheckBranchFlag suite pins the non-shallow rev-list path, untouched by this diff).
4. Mechanism verified on a *real* shallow clone (git 2.53): local-only commit atop the tip → `merge-base --is-ancestor origin/main HEAD` exit **0**; target genuinely ahead → exit **1**; ref unresolvable → exit **128**. All three feed the right branch.
5. `scripts/check-windows-footguns.py --diff <merge-base>` → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no PR references #98214 at open time)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected update/banner test modules (`tests/hermes_cli/test_update_check*.py`, `test_update_apply_shallow_count.py`, `test_cmd_update.py::TestCmdUpdateCheckBranchFlag`) — all pass; unrelated pre-existing npm-sandbox failures in `test_cmd_update.py` reproduce identically on the unpatched base (see below)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (CPython 3.11, git 2.53, Git bash)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs`, docstrings) — or N/A (no doc text asserted a "behind" guarantee; the change makes `--check` *more* truthful)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `merge-base --is-ancestor` exit-code semantics are identical across platforms; the subprocess reuses the function's existing `git_cmd` (incl. the Windows `appendAtomically` flag) and `cwd`, with the same encoding/`errors="replace"` handling as its siblings
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Red on main (base `4209d371a`):
```
FAILED ...::test_none_with_ancestor_reports_up_to_date   (prints "⚕ Update available (behind upstream/main).")
FAILED ...::test_none_without_ancestor_does_not_claim_behind
FAILED ...::test_none_inconclusive_ancestor_does_not_claim_behind
3 failed in 1.20s
```
Green on branch: `3 passed in 1.80s`; combined targeted run `18 passed`.

Note for reviewers: in this repo's `test_cmd_update.py`, a few `TestCmdUpdateMigrationPrompt` / `TestCmdUpdateBranchFallback` tests fail identically on the unpatched base in my environment (they shell out to real `npm install` against the worktree and hit an npm versions/EPERM sandbox issue here). They do not touch the shallow `--check` path and are unrelated to this diff.
