### PR TITLE
fix(qqbot): authorize approval buttons for named-profile session keys

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1105,9 +1105,15 @@ class QQAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _parse_gateway_session_key(session_key: str) -> Optional[Dict[str, str]]:
-        """Parse ``agent:main:<platform>:<chat_type>:<chat_id>[:<user_id>]``."""
+        """Parse ``agent:<namespace>:<platform>:<chat_type>:<chat_id>[:<user_id>]``.
+
+        The namespace slot carries the multiplex profile ("main" for the
+        default profile — see ``gateway.session._session_key_namespace``);
+        it takes no part in any authorization decision, so any non-empty
+        value is accepted and every later slot keeps its position.
+        """
         parts = str(session_key or "").split(":")
-        if len(parts) < 5 or parts[0] != "agent" or parts[1] != "main":
+        if len(parts) < 5 or parts[0] != "agent" or not parts[1]:
             return None
         parsed = {
             "platform": parts[2],

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -978,6 +978,132 @@ class TestDefaultInteractionDispatch:
         assert response.read_text() == "y"
 
 
+class TestProfileNamespaceApprovalAuthz:
+    """Named-profile (multiplex) session keys must authorize like ``main``.
+
+    ``build_session_key`` namespaces named-profile keys as ``agent:<profile>:...``
+    while the default profile keeps the legacy ``agent:main`` prefix
+    (``gateway/session.py::_session_key_namespace``). The interaction authz
+    parser used to require the literal ``main`` in the namespace slot, so
+    every approval button click in a named profile was rejected as
+    unauthorized and the pending approval timed out (fail-closed block).
+    """
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @staticmethod
+    def _parse(key):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter._parse_gateway_session_key(key)
+
+    def test_parse_accepts_named_profile_namespace(self):
+        parsed = self._parse("agent:coder:qqbot:dm:u-1")
+        assert parsed is not None
+        assert parsed["platform"] == "qqbot"
+        assert parsed["chat_type"] == "dm"
+        assert parsed["chat_id"] == "u-1"
+
+    def test_parse_accepts_main_namespace_with_user_id(self):
+        parsed = self._parse("agent:main:qqbot:group:g-1:owner")
+        assert parsed is not None
+        assert parsed["platform"] == "qqbot"
+        assert parsed["chat_type"] == "group"
+        assert parsed["chat_id"] == "g-1"
+        assert parsed["user_id"] == "owner"
+
+    def test_parse_still_rejects_non_agent_and_malformed_keys(self):
+        assert self._parse("session:main:qqbot:c2c:u-1") is None
+        assert self._parse("agent::qqbot:c2c:u-1") is None
+        assert self._parse("agent:main") is None
+        assert self._parse("") is None
+
+    @pytest.mark.asyncio
+    async def test_c2c_click_on_named_profile_key_resolves(self):
+        """Approval click carrying a named-profile c2c key resolves (was rejected)."""
+        adapter = self._make_adapter()
+
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-42",
+                "data": {"resolved": {"button_data": "approve:agent:coder:qqbot:c2c:u-42:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:coder:qqbot:c2c:u-42", "once", False)]
+
+    @pytest.mark.asyncio
+    async def test_group_click_on_named_profile_key_authorizes_session_owner(self):
+        """Group approval click under a named profile authorizes the session owner."""
+        adapter = self._make_adapter()
+
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 1,
+                "group_openid": "g-1",
+                "group_member_openid": "owner",
+                "data": {"resolved": {"button_data": "approve:agent:coder:qqbot:group:g-1:owner:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:coder:qqbot:group:g-1:owner", "once", False)]
+
+    @pytest.mark.asyncio
+    async def test_named_profile_key_still_rejects_wrong_operator(self):
+        """The namespace relaxation must not weaken the operator check."""
+        adapter = self._make_adapter()
+
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 1,
+                "group_openid": "g-1",
+                "group_member_openid": "attacker",
+                "data": {"resolved": {"button_data": "approve:agent:coder:qqbot:group:g-1:owner:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == []
+
+
 class TestSendExecApproval:
     """Verify the gateway contract: QQAdapter.send_exec_approval(...)."""
 


### PR DESCRIPTION
## What does this PR do?

In a **named profile** (gateway multiplexing), every QQBot approval-button click was rejected as unauthorized and the pending approval timed out fail-closed (300s → command BLOCKED).

Root cause: `_parse_gateway_session_key()` (introduced with the owner-authorization check in #30737) required the literal `main` in the namespace slot of `agent:<ns>:<platform>:<chat_type>:<chat_id>`, but `_session_key_namespace()` (`gateway/session.py`) puts the multiplex **profile name** there for named profiles — a design that is explicitly documented as position-compatible for downstream parsers. So `agent:coder:qqbot:dm:<openid>` failed to parse, `_is_authorized_interaction_for_session()` returned `False`, and the click was dropped with `Rejected unauthorized approval click`.

This is **not** the dm/c2c chat_type family (#32528 & the ~25 PRs addressing it, including the broadest #40705) — those fix a different slot of the same key. This PR fixes the namespace slot; the two changes are orthogonal and can merge independently. Telegram / Slack / Teams already have profile-aware authorization fixes in flight (#65589 / #72657 / #93516); this is the QQBot counterpart.

The fix: drop the `parts[1] != "main"` assertion, keeping a non-empty check so malformed keys (`agent::qqbot:...`) are still rejected. The namespace slot takes no part in any authorization decision — the `platform == "qqbot"`, `operator == chat_id` (c2c) and `operator == session_user` (group/guild) checks are what authorize, and they are unchanged and pinned by new negative tests.

## Related Issue

Fixes #98292

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py` — `_parse_gateway_session_key()`: accept any non-empty namespace (multiplex profile) instead of requiring the literal `main`; docstring updated to document the namespace slot
- `tests/gateway/test_qqbot.py` — new `TestProfileNamespaceApprovalAuthz` (6 tests): named-profile keys parse; default `agent:main:...` keys unchanged (no regression); malformed keys still rejected; end-to-end c2c/group approval clicks on named-profile keys resolve via `resolve_gateway_approval`; a wrong-operator click on a named-profile key is still rejected (the relaxation does not weaken the operator check)

## How to Test

1. `uv run --extra dev pytest tests/gateway/test_qqbot.py -q` → **69 passed** (63 before + 6 new)
2. Mutation check (fix reverted via `git stash push gateway/platforms/qqbot/adapter.py`):
   `uv run --extra dev pytest tests/gateway/test_qqbot.py::TestProfileNamespaceApprovalAuthz -q` → **3 failed** (the positive named-profile cases fail, reproducing the production log line `Rejected unauthorized approval click for session agent:coder:qqbot:group:g-1:owner`); restored → 6 passed
3. `uv run --extra dev pytest tests/gateway/test_qqbot_credential_isolation.py tests/gateway/test_qqbot_scope_paths.py -q` → **19 passed**
4. Minimal repro of the bug on `main`:
   ```python
   from gateway.platforms.qqbot.adapter import QQAdapter
   QQAdapter._parse_gateway_session_key("agent:coder:qqbot:dm:u-1")  # → None (bug); parses after this PR
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(targeted suites above; full-suite run pending CI)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] N/A — no config keys, no tool behavior, no architecture change (one parser assertion + tests)

## Screenshots / Logs

Mutation-check run with the fix reverted reproduces the reported failure mode:

```
WARNING  gateway.platforms.qqbot.adapter:adapter.py:1180 [QQBot:a] Rejected unauthorized approval click for session agent:coder:qqbot:group:g-1:owner (operator=owner)
```
