### PR TITLE
fix(qqbot): authorize approval clicks on dm-spelled session keys

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1131,7 +1131,14 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
+            # 1:1 C2C DMs build their session key via
+            # ``build_source(chat_type="dm")`` (see _on_c2c_message), so the
+            # key carries the literal ``"dm"`` while interaction events
+            # arrive with the QQ wire scene ``c2c``. Both name the same
+            # private chat whose chat_id IS the owner's user_openid, so a
+            # matching operator is the session owner regardless of which
+            # spelling the key used.
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -930,6 +930,74 @@ class TestDefaultInteractionDispatch:
 
 
     @pytest.mark.asyncio
+    async def test_approval_click_on_dm_key_from_c2c_operator_resolves(self):
+        """Regression: C2C DMs build session keys with ``chat_type="dm"``
+        (``build_source(chat_type="dm")`` in the adapter), but the
+        authorization check only accepted the literal ``"c2c"`` — so every
+        approval-button click on a 1:1 QQ DM was rejected as unauthorized,
+        the agent sat until its 5-minute approval timeout, and multi-turn
+        sessions stalled.
+
+        The key's ``chat_id`` segment and the clicking operator's openid are
+        the same ``user_openid`` for C2C, so a ``dm`` key with a matching
+        operator must resolve.
+        """
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,  # QQ wire scene: 2 = c2c
+                "user_openid": "u-42",
+                "data": {"resolved": {
+                    "button_data": "approve:agent:main:qqbot:dm:u-42:allow-once",
+                }},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:dm:u-42", "once", False)]
+
+    @pytest.mark.asyncio
+    async def test_approval_click_on_dm_key_rejects_other_operator(self):
+        """The ``dm`` relaxation must still reject a non-owner operator."""
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "attacker",
+                "data": {"resolved": {
+                    "button_data": "approve:agent:main:qqbot:dm:u-42:allow-once",
+                }},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == []
+
+    @pytest.mark.asyncio
     async def test_approval_click_rejects_unauthorized_operator(self):
         adapter = self._make_adapter()
         resolve_calls = []


### PR DESCRIPTION
## Problem

On a 1:1 QQ C2C DM, **every** approval-button click is rejected as unauthorized, so the agent waits until its 5-minute approval timeout and multi-turn sessions appear frozen (`response ready: time=1118.9s` with repeated `Rejected unauthorized approval click … (operator=…)` warnings where operator **is** the session owner).

## Root cause

Producer/consumer format drift on the session key:

- **Producer** — `_on_c2c_message` builds the gateway session source with `build_source(chat_type="dm", …)` (adapter.py:1327), so the key looks like `agent:main:qqbot:dm:<user_openid>`.
- **Consumer** — `_is_authorized_interaction_for_session` only matches the literal `"c2c"` (adapter.py:1134). `"dm"` falls through to `return False`.

The existing tests all hand-craft `c2c`-spelled keys (test_qqbot.py:922), so the drift is invisible to the suite.

## Fix

Treat `"dm"` as a synonym of `c2c` in the authorization check. Both name the same private chat whose `chat_id` segment IS the owner's `user_openid`, so the `operator == chat_id` match still gates authorization — the relaxation adds no attack surface: a non-owner clicking the button still fails the check.

## Tests

- `test_approval_click_on_dm_key_from_c2c_operator_resolves` — regression reproducing the field bug (fails on current main, passes with the fix).
- `test_approval_click_on_dm_key_rejects_other_operator` — asserts the cross-user rejection still holds on the `dm` spelling.
- Full existing qqbot suites green: `test_qqbot.py` (65) + `test_qqbot_credential_isolation.py` / `test_qqbot_scope_paths.py` (19).