### PR TITLE
fix(agent): cap streaming stalls to the run budget

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -538,10 +538,13 @@ def _check_stale_giveup(agent) -> None:
         )
 
 
-def _configured_stale_base(agent) -> float:
-    """Per-provider ``stale_timeout_seconds`` config, else HERMES_STREAM_STALE_TIMEOUT (180s)."""
+def _configured_stale_base(agent) -> tuple[float, bool]:
+    """Return the stream stale base and whether a user configured it explicitly."""
     cfg = get_provider_stale_timeout(agent.provider, agent.model)
-    return cfg if cfg is not None else env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+    if cfg is not None:
+        return cfg, True
+    configured_env = os.getenv("HERMES_STREAM_STALE_TIMEOUT")
+    return env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0), configured_env is not None
 
 
 def _scale_stale_timeout_for_context(base: float, est_tokens: int) -> float:
@@ -567,10 +570,27 @@ def _cloud_stale_timeout(base: float, api_kwargs: dict) -> float:
     return timeout if floor is None else max(timeout, floor)
 
 
+def _cap_implicit_stale_timeout_to_run_budget(agent, timeout: float, *, explicit: bool) -> float:
+    """Keep an implicit cloud stale timeout within the active run's remaining budget."""
+    if explicit:
+        return timeout
+    run_budget = getattr(agent, "run_budget_seconds", None)
+    started = getattr(agent, "_run_budget_started_at", None)
+    if not run_budget or not started:
+        return timeout
+    try:
+        remaining = float(run_budget) - (time.time() - float(started))
+    except (TypeError, ValueError):
+        return timeout
+    return min(timeout, max(60.0, remaining * 0.5))
+
+
 def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
     """Stale-stream patience for a provider that is never a local endpoint (Bedrock):
     the OpenAI/Anthropic stale detector's budget minus its local branch."""
-    return _cloud_stale_timeout(_configured_stale_base(agent), api_kwargs)
+    base, explicit = _configured_stale_base(agent)
+    timeout = _cloud_stale_timeout(base, api_kwargs)
+    return _cap_implicit_stale_timeout_to_run_budget(agent, timeout, explicit=explicit)
 
 
 def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
@@ -3456,7 +3476,7 @@ class _StreamingCall:
         HERMES_LOCAL_STREAM_STALE_TIMEOUT — an infinite one stalled sessions on a
         crashed endpoint forever. Cloud values scale with context size and are
         floored for known reasoning models (else BrokenPipeError from the gateway)."""
-        base = _configured_stale_base(self.agent)
+        base, explicit = _configured_stale_base(self.agent)
         if base == 180.0 and self.agent.base_url and is_local_endpoint(self.agent.base_url):
             _local_default = 900.0
             with contextlib.suppress(Exception):
@@ -3470,7 +3490,10 @@ class _StreamingCall:
             logger.debug("Local provider detected (%s) — stale stream timeout set to %.0fs",
                 self.agent.base_url, self._stream_stale_timeout)
             return
-        self._stream_stale_timeout = _cloud_stale_timeout(base, self.api_kwargs)
+        timeout = _cloud_stale_timeout(base, self.api_kwargs)
+        self._stream_stale_timeout = _cap_implicit_stale_timeout_to_run_budget(
+            self.agent, timeout, explicit=explicit
+        )
 
     def _partial_stream_stub(self):
         """Tokens already reached the platform: a finish_reason="length" stub fires the

--- a/tests/agent/test_run_budget.py
+++ b/tests/agent/test_run_budget.py
@@ -39,6 +39,8 @@ def _make_agent(tmp_path, monkeypatch, config_body: str = "", **overrides):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / ".env").write_text("", encoding="utf-8")
     monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_LOCAL_STREAM_STALE_TIMEOUT", raising=False)
     _write_config(tmp_path, config_body)
 
     from run_agent import AIAgent
@@ -195,6 +197,67 @@ def test_budget_without_started_clock_is_inert(monkeypatch, tmp_path):
     )
     agent._run_budget_started_at = None
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 600.0
+
+
+# ── streaming stale-timeout deadline scaling ────────────────────────────────
+
+
+def _resolve_cloud_stream_stale_timeout(agent, api_kwargs: dict) -> float:
+    """Resolve through the current streaming owner without starting a provider request."""
+    from agent.chat_completion_helpers import _StreamingCall
+
+    stream_call = object.__new__(_StreamingCall)
+    stream_call.agent = agent
+    stream_call.api_kwargs = api_kwargs
+    stream_call._resolve_stale_timeout()
+    return stream_call._stream_stale_timeout
+
+
+def test_active_budget_caps_implicit_cloud_stream_timeout(monkeypatch, tmp_path):
+    """The production StreamingCall owner limits the implicit DeepSeek floor."""
+    from agent import chat_completion_helpers as helpers
+
+    monkeypatch.setattr(helpers, "get_provider_stale_timeout", lambda *args: None)
+    agent = _make_agent(
+        tmp_path, monkeypatch,
+        model="deepseek/deepseek-v4-pro",
+        run_budget_seconds=900,
+    )
+    agent._run_budget_started_at = time.time() - 800
+
+    assert _resolve_cloud_stream_stale_timeout(
+        agent, {"model": agent.model, "messages": [{"role": "user", "content": "hi"}]}
+    ) == 60.0
+
+
+def test_explicit_cloud_stream_timeout_is_not_budget_capped(monkeypatch, tmp_path):
+    """An explicit provider timeout retains its current precedence over the budget cap."""
+    from agent import chat_completion_helpers as helpers
+
+    monkeypatch.setattr(helpers, "get_provider_stale_timeout", lambda *args: 1200.0)
+    agent = _make_agent(tmp_path, monkeypatch, run_budget_seconds=900)
+    agent._run_budget_started_at = time.time() - 800
+
+    assert _resolve_cloud_stream_stale_timeout(
+        agent, {"model": agent.model, "messages": [{"role": "user", "content": "hi"}]}
+    ) == 1200.0
+
+
+def test_local_stream_timeout_is_not_budget_capped(monkeypatch, tmp_path):
+    """The dedicated local-provider timeout remains outside the cloud budget rule."""
+    from agent import chat_completion_helpers as helpers
+
+    monkeypatch.setattr(helpers, "get_provider_stale_timeout", lambda *args: None)
+    agent = _make_agent(
+        tmp_path, monkeypatch,
+        base_url="http://127.0.0.1:11434/v1",
+        run_budget_seconds=900,
+    )
+    agent._run_budget_started_at = time.time() - 800
+
+    assert _resolve_cloud_stream_stale_timeout(
+        agent, {"model": agent.model, "messages": [{"role": "user", "content": "hi"}]}
+    ) == 900.0
 
 
 # ── wrap-up injection one-time-ness ────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes the documented run-budget behavior on the current streaming owner. A cloud streaming call with an implicit stale timeout could keep its reasoning-model floor even after most of the run budget had elapsed. The stream watchdog therefore waited 600 seconds when only 100 seconds remained in a 900-second run.

The change caps only implicit cloud stale timeouts at `min(timeout, max(60, remaining * 0.5))`. Explicit provider or environment stale timeouts retain their existing precedence. The dedicated local-provider branch is unchanged. This intentionally does not add the separate absolute wall-clock watchdog proposed elsewhere.

## Related Issue

Related: #97968. This PR resolves only its original implicit run-budget stale-timeout path. The later report of unbounded `ManagedLlmStream.__next__()` reads and gateway shutdown/drain behavior is outside this PR's ownership boundary and needs a separately scoped maintainer decision.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: preserve whether the stream timeout came from explicit configuration, then apply the active run-budget cap only to cloud defaults in both chat-completions/Anthropic and Bedrock derivations.
- `tests/agent/test_run_budget.py`: exercise the current `_StreamingCall._resolve_stale_timeout()` owner for the implicit DeepSeek floor, explicit provider precedence, and local-provider isolation.

## How to Test

Base: `main@006b1beb00d9d25230571d14277aca3d70e5e11f`
Head: `4dbb80b53f4b3fb3d5450dadad1268124c6ef012`
Environment: macOS local workspace with the repository Nix development virtual environment supplied through `HERMES_PYTHON`.

1. With a 900-second budget and 800 seconds elapsed, the current cloud `StreamingCall` owner resolves the implicit DeepSeek floor from 600 seconds to 60 seconds.
2. Run `HERMES_PYTHON=/private/tmp/hermes-98297-main.R5QH9f/venv/bin/python ./scripts/run_tests.sh tests/agent/test_run_budget.py tests/agent/test_reasoning_stale_timeout_floor.py tests/agent/test_local_stream_timeout.py tests/agent/test_stream_read_timeout_floor.py tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_integration.py tests/agent/test_bedrock_interrupt_post_worker.py -q` - 219 passed, 5 skipped.
3. Run Ruff lint, `compileall`, `scripts/check-windows-footguns.py`, and `git diff HEAD^ HEAD --check` on the two changed files - all passed. Changed-file TruffleHog filesystem scan reported 0 verified and 0 unverified secrets.

Scope boundary: no new configuration key, no local-provider behavior change, no explicit-timeout precedence change, no absolute stream-duration watchdog, and no changes to `agent/relay_llm.py` or gateway shutdown/drain behavior. The full repository suite was not run. Current-main Ruff-format and Ty diagnostics are unchanged from the exact base (format would rewrite both files; Ty reports 41 source and 60 test diagnostics on both base and head).

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and issues, including #99739 and #100202, and verified their adjacent ownership boundaries
- [x] My PR contains only this fix and regression coverage
- [ ] I have run `pytest tests/ -q` and all tests pass (focused and adjacent ownership suites are listed above; the full suite was not run)
- [x] I have added tests for my changes
- [x] I tested on macOS; the Windows-footgun compatibility scan passed

### Documentation & Housekeeping

- [x] Documentation is N/A; behavior follows the existing run-budget help text
- [x] `cli-config.yaml.example` is N/A; no configuration key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] I considered cross-platform impact; the change is pure Python and the Windows-footgun scan passed
- [x] Tool descriptions and schemas are N/A

## Screenshots / Logs

The focused regression observes the production owner result: implicit DeepSeek stream timeout `600.0s -> 60.0s` at the stated budget point. Explicit provider timeouts and local-provider defaults retain their prior values.
