### PR TITLE
fix(agent): detect 0-byte state.db as zeroed, not healthy (#97568)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -449,7 +449,9 @@ def is_zeroed_sqlite_file(
         size = path.stat().st_size
     except OSError:
         return False
-    if size <= 0:
+    if size == 0:
+        return True
+    if size < 0:
         return False
     from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3952,7 +3952,9 @@ def is_zeroed_state_db(
         size = path.stat().st_size
     except OSError:
         return False
-    if size <= 0:
+    if size == 0:
+        return True
+    if size < 0:
         return False
     from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
 


### PR DESCRIPTION
## Problem

`is_zeroed_state_db()` and `is_zeroed_sqlite_file()` both use `if size <= 0: return False`, which excludes the most complete form of data loss: a `state.db` truncated to exactly 0 bytes.

A 0-byte file has no SQLite header, no data, no schema. It is the definition of a zeroed database. Yet the guard returns `False`, causing the quarantine path to be skipped entirely. The result is **silent total data loss**: no ERROR log, no `.quarantine-*` rename, no signal of any kind. The empty database is indistinguishable from a fresh install.

From the issue: a deployment lost its entire message history and it was not noticed for **seven days**, because there was nothing to notice.

## Fix

Split the guard in both functions:

```python
# Before
if size <= 0:
    return False

# After
if size == 0:
    return True
if size < 0:
    return False
```

This ensures a 0-byte `state.db` triggers the quarantine path (ERROR log + rename aside + fresh DB creation), matching the behavior for files with NUL headers.

## Files Changed

- `hermes_state.py` — `is_zeroed_state_db()` (line ~3955)
- `hermes_cli/backup.py` — `is_zeroed_sqlite_file()` (line ~452)

Fixes #97568