### PR TITLE
fix(cli): fall back to plain gh auth status for gh < 2.52 (#98051)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -3200,6 +3200,17 @@ def run_doctor(args):
                 ["gh", "auth", "status", "--json", "authenticated"],
                 capture_output=True, timeout=10,
             )
+            if result.returncode == 0:
+                return True
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+        # Fallback for gh < 2.52 (no --json flag on auth status).
+        # The plain command exits 0 when authenticated, 1 otherwise.
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status"],
+                capture_output=True, timeout=10,
+            )
             return result.returncode == 0
         except (FileNotFoundError, subprocess.TimeoutExpired):
             return False


### PR DESCRIPTION
## Problem

`hermes doctor` shows "No GITHUB_TOKEN" warning even when the user is authenticated via `gh auth login`, on systems where `gh` CLI is older than v2.52.0.

The `_gh_authenticated()` fallback in `hermes_cli/doctor.py` uses `gh auth status --json authenticated`, but the `--json` flag was only introduced in gh v2.52.0 (Oct 2024). On older versions (e.g. Ubuntu 24.04 ships gh 2.45.0), this fails with `unknown flag: --json` and exit code 1, so the fallback returns `False` and the warning persists.

## Fix

Add a fallback to plain `gh auth status` (without `--json`) when the JSON variant fails. The plain command exits 0 when authenticated on all gh versions.

```python
# Try --json first (gh >= 2.52)
result = subprocess.run(["gh", "auth", "status", "--json", "authenticated"], ...)
if result.returncode == 0:
    return True
# Fallback for older gh versions
result = subprocess.run(["gh", "auth", "status"], ...)
return result.returncode == 0
```

## Files Changed

- `hermes_cli/doctor.py` — `_gh_authenticated()` function

Fixes #98051