### PR TITLE
fix(kanban): reject a review approval recorded by the implementer's profile

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2392,13 +2392,19 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 failed.append(tid)
                 continue
 
-            if not kb.complete_task(
-                conn, tid,
-                result=args.result,
-                summary=summary,
-                metadata=metadata,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                completed = kb.complete_task(
+                    conn, tid,
+                    result=args.result,
+                    summary=summary,
+                    metadata=metadata,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except kb.SelfReviewApprovalError as self_review_err:
+                failed.append(tid)
+                print(f"kanban: {self_review_err}", file=sys.stderr)
+                continue
+            if not completed:
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5360,6 +5360,71 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+class SelfReviewApprovalError(ValueError):
+    """Raised by ``complete_task`` when the profile recording a review
+    approval already has a non-review run on the same card (#98283).
+
+    Four-eyes review is meaningless if the approving profile is the same
+    one that did (or attempted) the implementation work being approved.
+    ``conflicting_run_ids`` carries the offending prior run ids for the
+    caller to surface in a diagnostic.
+    """
+
+    def __init__(self, task_id: str, profile: str, conflicting_run_ids: list[int]):
+        self.task_id = task_id
+        self.profile = profile
+        self.conflicting_run_ids = list(conflicting_run_ids)
+        super().__init__(
+            f"review approval blocked: profile {profile!r} already has "
+            f"non-review run(s) {conflicting_run_ids} on {task_id}; a "
+            f"distinct profile must record the approval"
+        )
+
+
+def _claimed_from_review(conn: sqlite3.Connection, task_id: str, run_id: int) -> bool:
+    """True if ``run_id`` was claimed via :func:`claim_review_task`.
+
+    Determined from the run's own ``claimed`` event payload, the same
+    provenance :func:`request_changes` already relies on to confirm a
+    rejection came from an active review claim.
+    """
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND run_id = ? AND kind = 'claimed' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, int(run_id)),
+    ).fetchone()
+    try:
+        payload = json.loads(row["payload"]) if row and row["payload"] else {}
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
+    return isinstance(payload, dict) and payload.get("source_status") == "review"
+
+
+def _non_review_runs_for_profile(
+    conn: sqlite3.Connection,
+    task_id: str,
+    profile: str,
+    *,
+    exclude_run_id: int,
+) -> list[int]:
+    """Prior run ids on ``task_id`` by ``profile`` that were NOT claimed
+    from review — i.e. implementation work, not review work.
+
+    Used to enforce that the profile approving a review is distinct from
+    any profile that already touched the card as an implementer.
+    """
+    rows = conn.execute(
+        "SELECT id FROM task_runs WHERE task_id = ? AND profile = ? AND id != ?",
+        (task_id, profile, int(exclude_run_id)),
+    ).fetchall()
+    return [
+        int(row["id"])
+        for row in rows
+        if not _claimed_from_review(conn, task_id, row["id"])
+    ]
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5450,6 +5515,34 @@ def complete_task(
             (task_id,),
         ).fetchone()
         prior_status = prior["status"] if prior else None
+        # Four-eyes guard (#98283): a review approval recorded by the same
+        # profile that already did non-review (implementation) work on this
+        # card is not an independent review. A review claim transitions
+        # review -> running (claim_review_task), same as a plain
+        # implementation claim, so ``prior_status`` alone can't tell the two
+        # apart here — the run's own ``claimed`` event provenance can. Only
+        # checkable when the caller proves which run is approving
+        # (expected_run_id); a human closing a card with no active run
+        # (expected_run_id=None) is an explicit override and stays out of
+        # scope, same as request_review's force=.
+        if (
+            expected_run_id is not None
+            and _claimed_from_review(conn, task_id, int(expected_run_id))
+        ):
+            approver_row = conn.execute(
+                "SELECT profile FROM task_runs WHERE id = ?",
+                (int(expected_run_id),),
+            ).fetchone()
+            approver_profile = approver_row["profile"] if approver_row else None
+            if approver_profile:
+                conflicts = _non_review_runs_for_profile(
+                    conn, task_id, approver_profile,
+                    exclude_run_id=int(expected_run_id),
+                )
+                if conflicts:
+                    raise SelfReviewApprovalError(
+                        task_id, approver_profile, conflicts,
+                    )
         if expected_run_id is None:
             cur = conn.execute(
                 """

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -149,6 +149,49 @@ def test_same_card_review_supports_changes_and_approval_without_block_loop(conn)
     assert completed.block_recurrences == 0
 
 
+def test_complete_task_rejects_self_review_approval(conn) -> None:
+    """#98283: a profile that implemented a card must not also be the one
+    whose run records the review approval. Omitting ``reviewer`` on the
+    first review leaves ``assignee`` pointed at the implementer, so the
+    same profile ends up claiming the review lane and approving its own
+    work — the exact self-approval shape the issue's board audit found.
+    """
+    task_id = kb.create_task(conn, title="self-approve me", assignee="builder")
+    implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+    assert implementation is not None
+
+    assert kb.request_review(
+        conn,
+        task_id,
+        summary="ready for review",
+        expected_run_id=implementation.current_run_id,
+    )
+    awaiting_review = kb.get_task(conn, task_id)
+    assert awaiting_review is not None
+    assert awaiting_review.assignee == "builder"
+
+    review = kb.claim_review_task(conn, task_id, claimer="builder:2")
+    assert review is not None
+    review_run = kb.latest_run(conn, task_id)
+    assert review_run is not None
+    assert review_run.profile == "builder"
+
+    with pytest.raises(kb.SelfReviewApprovalError):
+        kb.complete_task(
+            conn,
+            task_id,
+            summary="approved by myself",
+            expected_run_id=review.current_run_id,
+        )
+
+    # The rejected approval must not have mutated the card: still under
+    # the same active review claim, not flipped to done.
+    still_reviewing = kb.get_task(conn, task_id)
+    assert still_reviewing is not None
+    assert still_reviewing.status == "running"
+    assert still_reviewing.current_run_id == review.current_run_id
+
+
 @pytest.mark.parametrize("bad_payload", [None, "{not-json", "{}"])
 def test_rereview_requires_explicit_reviewer_when_provenance_is_invalid(
     conn,

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -332,6 +332,7 @@ def test_reopening_parent_retracts_review_and_blocks_approval(client):
             conn,
             child_id,
             summary="ready",
+            reviewer="approver",
             expected_run_id=implementation.current_run_id,
         )
         active_review = kb.claim_review_task(conn, child_id)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -799,6 +799,13 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"and either drop these ids from created_cards, or pass "
                     f"created_cards=[] to skip the card-claim check entirely."
                 )
+            except kb.SelfReviewApprovalError as self_review_err:
+                return tool_error(
+                    f"kanban_complete blocked: {self_review_err}. Review "
+                    f"approval must come from a profile that did not already "
+                    f"work on this card. Route the card to a distinct "
+                    f"reviewer instead of approving it yourself."
+                )
             if not ok:
                 return tool_error(
                     f"could not complete {tid} (unknown id or already terminal)"


### PR DESCRIPTION
## What does this PR do?

Closes the four-eyes gap described in #98283: `hermes kanban`'s review lane
does not require the profile that approves a review to differ from any
profile that already did non-review (implementation) work on the same card.

`request_review()` leaves `assignee` pointed at the implementer when
`reviewer` is omitted on a first review. `claim_review_task()` then records
the *new* run's `profile` from that same `assignee`, so the implementer's own
profile ends up claiming the review lane. Nothing at approval time checked
this, so `complete_task()` would happily close the card — the exact
`review_requested` → `review_approved` self-approval shape the issue's board
audit found across seven cards on a live board, two of which shipped only
because a human happened to re-check the work by hand.

This PR adds the check at the point the approval is actually recorded
(`complete_task()`), which the issue calls out as the preferred placement:
it fails at the point of the untrue claim rather than downstream.

## Related Issue

Fixes #98283

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: new `SelfReviewApprovalError`, plus
  `_claimed_from_review()` and `_non_review_runs_for_profile()` helpers.
  `complete_task()` now raises `SelfReviewApprovalError` when the run being
  completed (`expected_run_id`) was claimed via `claim_review_task` (i.e. this
  is an actual review approval, not a plain implementation close — a review
  claim transitions `review -> running`, same status as a plain
  implementation claim, so `prior_status` alone can't distinguish the two;
  the run's own `claimed` event provenance can) and that run's profile
  already has a prior run on the card that was *not* claimed from review. A
  human closing a card with no active run (`expected_run_id=None`) is an
  explicit override and stays out of scope, mirroring `request_review`'s
  existing `force=` escape hatch.
- `hermes_cli/kanban.py`: `_cmd_complete` catches the new error and prints a
  clean diagnostic instead of an uncaught traceback (a worker completing its
  own review claim via the CLI, not just the `kanban_complete` tool, can hit
  this path).
- `tools/kanban_tools.py`: `kanban_complete` catches the new error with a
  worker-facing message telling it to route the card to a distinct reviewer,
  matching the existing `HallucinatedCardsError`/`ArtifactPreservationError`
  handling pattern in the same function.
- `tests/hermes_cli/test_kanban_review_lifecycle_complete.py`: new
  `test_complete_task_rejects_self_review_approval`, reproducing the exact
  self-approval shape from the issue (reviewer omitted → same profile claims
  review → same profile calls `complete_task`) and asserting it's rejected
  without mutating the card.
- `tests/plugins/test_kanban_dashboard_plugin.py`: one existing test
  (`test_reopening_parent_retracts_review_and_blocks_approval`) happened to
  use the same profile name for the card's implementer and its review
  approval as incidental test data (unrelated to what the test actually
  verifies — parent-reopen retraction). Added an explicit distinct
  `reviewer="approver"` so it keeps testing parent-reopen behavior instead of
  incidentally re-exercising the self-review loophole this PR closes.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_kanban_review_lifecycle_complete.py -q`
2. Confirm the new test fails without the fix:
   `git checkout HEAD~1 -- hermes_cli/kanban_db.py hermes_cli/kanban.py tools/kanban_tools.py`,
   re-run the same test (`AttributeError: module 'hermes_cli.kanban_db' has no
   attribute 'SelfReviewApprovalError'` on the fully-reverted source — the
   invariant does not exist on `main` today), then restore.
3. `bash scripts/run_tests.sh tests/hermes_cli/ -q` — 743 files, 6192 passed,
   2 failed, 71 skipped. Both failures are pre-existing and reproduce
   identically on unmodified `main` (`test_kanban_review_surfaces.py::test_review_tools_are_gated_and_visible_to_kanban_workers`
   and `test_linux_desktop_entry.py::test_exec_leaves_venv_shebang_scripts_alone`,
   the latter an interpreter-path artifact of this sandbox, unrelated to
   kanban).
4. `ruff check` and `ty check` on all touched files: clean / only the same 19
   pre-existing `ty` diagnostics present on unmodified `main` (none in the
   touched line ranges).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — closest
      is #97933, which guards *reviewer assignment* at `request_review()` time
      (rejecting a first review when `reviewer` is omitted and would default
      to the implementer). It's complementary, not overlapping: it doesn't
      touch the approval path, so a reviewer assigned before that guard
      existed, an explicit-but-conflicting reviewer, or a re-review whose
      provenance recovers a profile that also did earlier implementation work
      on the card would still slip through it. This PR closes the gap at the
      point the approval itself is recorded.
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` (via `scripts/run_tests.sh`) and all tests
      pass except two pre-existing, unrelated failures (see above)
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] N/A — no config keys, no architecture/workflow changes, no tool
      schema changes (the `kanban_complete` tool's *error message* changed,
      not its schema)

## AI assistance disclosure

This PR was written with AI assistance (Claude Code / Claude Sonnet 5),
operating autonomously against the issue text and the current `main` branch,
under human-configured guardrails. The diagnosis, fix design, and test were
verified by running the real test suite, `ruff`, and `ty` against this
checkout before pushing.
