### PR TITLE
fix(todo): unversioned tool.start still merges after resume

### DIFF
--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -134,4 +134,22 @@ describe('revisioned snapshots', () => {
     restoreSessionTodosFromSnapshot('s1', snapshot, true)
     expect($todosBySession.get().s1?.[0]?.id).toBe('active')
   })
+
+  it('applies an unversioned update after a revisioned snapshot (tool.start merge)', () => {
+    setSessionTodos('s1', [todo('a', 'pending'), todo('b', 'pending')], 5)
+    setSessionTodos('s1', [todo('a', 'completed'), todo('b', 'pending')])
+
+    expect($todosBySession.get().s1?.[0]?.status).toBe('completed')
+    expect($todoRevisionsBySession.get().s1).toBe(5)
+  })
+
+  it('does not stamp a watermark from an unused empty snapshot', () => {
+    restoreSessionTodosFromSnapshot('s1', { revision: 0, todos: [] }, true)
+
+    expect($todosBySession.get().s1).toBeUndefined()
+    expect($todoRevisionsBySession.get().s1).toBeUndefined()
+
+    setSessionTodos('s1', [todo('a', 'in_progress')])
+    expect($todosBySession.get().s1?.[0]?.id).toBe('a')
+  })
 })

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -74,8 +74,10 @@ function acceptRevision(sid: string, revision?: null | number): boolean {
   const revisions = $todoRevisionsBySession.get()
   const current = revisions[sid]
 
+  // tool.start has no revision. Apply the merge locally and leave the
+  // watermark alone so a later todo.updated / tool.complete can still win.
   if (revision == null) {
-    return current == null
+    return true
   }
 
   if (current != null && revision < current) {
@@ -156,6 +158,14 @@ export function restoreSessionTodosFromSnapshot(sid: string, snapshot: unknown, 
   }
 
   const revision = parseTodoRevision(snapshot)
+
+  // An unused store serializes as {todos: [], revision: 0}. That is not a
+  // real snapshot. Applying it would stamp watermark 0 and leave an empty
+  // list in the map.
+  if (todos.length === 0 && (revision == null || revision === 0)) {
+    return
+  }
+
   const visible = running ? todos : todosForHydration(todos)
 
   if (visible !== null) {

--- a/tests/tui_gateway/test_todo_state_events.py
+++ b/tests/tui_gateway/test_todo_state_events.py
@@ -78,3 +78,23 @@ def test_live_snapshot_prefers_the_highest_revision():
     payload = server._attach_todo_state({}, session)
 
     assert payload["todo_state"]["revision"] == 5
+
+
+def test_unused_store_is_not_attached():
+    class Store:
+        @staticmethod
+        def snapshot():
+            return {"todos": [], "revision": 0}
+
+    class Agent:
+        _todo_store = Store()
+
+    payload = server._attach_todo_state({}, {"agent": Agent()})
+
+    assert "todo_state" not in payload
+
+
+def test_empty_list_at_nonzero_revision_is_a_real_clear():
+    state = server._normalize_todo_state({"todos": [], "revision": 2})
+
+    assert state == {"todos": [], "revision": 2}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7645,7 +7645,13 @@ def _normalize_todo_state(value: object) -> dict | None:
         revision = max(0, int(value.get("revision") or 0))
     except (TypeError, ValueError):
         return None
-    return {"todos": list(value["todos"]), "revision": revision}
+    todos = list(value["todos"])
+    # Unused TodoStore snapshot() is {todos: [], revision: 0}. Attaching
+    # that on resume stamps a client watermark and blocks unversioned
+    # tool.start merges. An empty list at revision >= 1 is a real clear.
+    if not todos and revision == 0:
+        return None
+    return {"todos": todos, "revision": revision}
 
 
 def _session_todo_state(session: dict) -> dict | None:


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

#97815 taught the desktop to reject todo updates that have no revision. After that work landed (via salvage #98248), a `merge: true` `tool.start` after resume never patches the list.

Resume attaches those snapshots so the Tasks panel survives reconnect. An unused store serializes as `{todos: [], revision: 0}`, and the desktop treats a missing revision as stale. `tool.start` for a `merge: true` write has no revision, so the patch from #97811 never applies after resume.

Skip unused empty snapshots. Apply unversioned updates without moving the watermark so a later `todo.updated` can still win.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #98304

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tui_gateway/server.py`: `_normalize_todo_state` returns None for `{todos: [], revision: 0}`. An empty list at revision >= 1 is still a real clear.
- `apps/desktop/src/store/todos.ts`: unversioned `setSessionTodos` applies and does not change the watermark. Restore ignores unused empty snapshots.
- `apps/desktop/src/store/todos.test.ts` and `tests/tui_gateway/test_todo_state_events.py`: start merge after a revisioned snapshot, unused snapshot is not attached.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. From `apps/desktop`: `npx vitest run src/store/todos.test.ts`
2. `python scripts/run_tests_parallel.py tests/tui_gateway/test_todo_state_events.py`
3. After `setSessionTodos(..., 5)`, an unversioned `setSessionTodos` must still update the list and leave revision at 5. `{todos: [], revision: 0}` must not stamp a watermark.

Ran on Windows 11: 13 vitest passed, 5 python tests passed. ruff clean on the python files.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
Before:
  resume attaches {todos: [], revision: 0}
  tool.start merge:true -> acceptRevision(null) fails
  panel waits for complete

After:
  unused snapshot is omitted
  tool.start merge:true updates the list, watermark stays
  todo.updated can still win later
```

```
=== Summary: 1 files, 5 tests passed, 0 failed ===
✓ ui src/store/todos.test.ts (13 tests)
```
