### PR TITLE
fix(api-server): honor native persistent goals

### DIFF
--- a/gateway/api_goal_runtime.py
+++ b/gateway/api_goal_runtime.py
@@ -1,0 +1,213 @@
+"""Persistent-goal orchestration for stateless API-server turns.
+
+Messaging adapters let :class:`gateway.run.GatewayRunner` enqueue another
+message after a goal verdict.  The API server has no persistent outbound
+channel or adapter FIFO, so its direct agent entry points need a small bridge:
+run canonical continuation prompts in the same request until GoalManager says
+done, paused, or parked.  All state, judging, quality gates, wait barriers, and
+budget accounting remain owned by :mod:`hermes_cli.goals`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Optional
+
+
+GoalStatusCallback = Callable[[dict[str, Any]], None]
+RunTurn = Callable[[str, Optional[list[dict[str, Any]]]], dict[str, Any]]
+StopPredicate = Callable[[], bool]
+
+
+def _goal_command(text: str) -> tuple[str, str] | None:
+    stripped = (text or "").strip()
+    lowered = stripped.lower()
+    if lowered in {"/goal", "/goal status"}:
+        return ("status", "")
+    for action in ("pause", "resume", "clear"):
+        if lowered == f"/goal {action}":
+            return (action, "")
+    if lowered == "/goal unwait":
+        return ("unwait", "")
+    if lowered.startswith("/goal wait "):
+        return ("wait", stripped[len("/goal wait ") :].strip())
+    if lowered.startswith("/goal "):
+        return ("set", stripped[len("/goal ") :].strip())
+    return None
+
+
+def run_goal_aware_turn(
+    *,
+    session_id: str,
+    user_message: str,
+    conversation_history: Optional[list[dict[str, Any]]],
+    run_turn: RunTurn,
+    default_max_turns: int | None = None,
+    status_callback: GoalStatusCallback | None = None,
+    should_stop: StopPredicate | None = None,
+) -> dict[str, Any]:
+    """Run one API turn plus any native persistent-goal continuations.
+
+    Control-plane commands return without calling ``run_turn``. A judge
+    ``wait`` verdict returns immediately with the persisted barrier intact.
+    A later request for the same raw session re-enters this function; when the
+    process/session/time barrier has cleared, that request is evaluated against
+    the same persisted goal.
+    """
+    from hermes_cli.goals import GoalManager, gather_background_processes
+
+    if default_max_turns is None:
+        try:
+            from hermes_cli.config import load_config
+
+            goals_config = (load_config() or {}).get("goals") or {}
+            default_max_turns = int(goals_config.get("max_turns", 20) or 20)
+        except Exception:
+            default_max_turns = 20
+
+    manager = GoalManager(
+        session_id=session_id,
+        default_max_turns=default_max_turns,
+    )
+
+    def emit(payload: dict[str, Any]) -> None:
+        if status_callback is not None:
+            status_callback(payload)
+
+    command = _goal_command(user_message)
+    current_message = user_message
+    current_history = conversation_history
+    user_initiated = True
+
+    if command is not None:
+        action, value = command
+        if action == "status":
+            return {
+                "final_response": manager.status_line(),
+                "completed": True,
+                "goal_control": True,
+            }
+        if action == "pause":
+            manager.pause()
+            return {
+                "final_response": manager.status_line(),
+                "completed": True,
+                "goal_control": True,
+            }
+        if action == "clear":
+            manager.clear()
+            return {
+                "final_response": "Goal cleared.",
+                "completed": True,
+                "goal_control": True,
+            }
+        if action == "unwait":
+            cleared = manager.stop_waiting()
+            return {
+                "final_response": (
+                    "Goal wait cleared." if cleared else "Goal has no active wait."
+                ),
+                "completed": True,
+                "goal_control": True,
+            }
+        if action == "wait":
+            pid_text, _, reason = value.partition(" ")
+            try:
+                manager.wait_on(int(pid_text), reason=reason)
+            except (RuntimeError, TypeError, ValueError) as exc:
+                return {
+                    "final_response": f"Could not park goal: {exc}",
+                    "completed": True,
+                    "goal_control": True,
+                }
+            return {
+                "final_response": manager.status_line(),
+                "completed": True,
+                "goal_control": True,
+            }
+        if action == "resume":
+            state = manager.resume(reset_budget=True)
+            if state is None:
+                return {
+                    "final_response": "No goal to resume.",
+                    "completed": True,
+                    "goal_control": True,
+                }
+            current_message = manager.next_continuation_prompt() or ""
+            current_history = None
+            user_initiated = False
+            emit({
+                "event": "goal.status",
+                "status": "active",
+                "message": manager.status_line(),
+            })
+        elif action == "set":
+            if not value:
+                return {
+                    "final_response": "Usage: /goal <objective>",
+                    "completed": True,
+                    "goal_control": True,
+                }
+            state = manager.set(value)
+            current_message = value
+            emit({
+                "event": "goal.started",
+                "status": "active",
+                "goal": state.goal,
+                "max_turns": state.max_turns,
+                "message": f"⊙ Goal set ({state.max_turns}-turn budget): {state.goal}",
+            })
+
+    goal_identity = (
+        (manager.state.created_at, manager.state.goal)
+        if manager.state is not None
+        else None
+    )
+    result = run_turn(current_message, current_history)
+
+    while manager.is_active() and not bool(result.get("failed")):
+        if should_stop is not None and should_stop():
+            break
+        # Control-plane requests may pause/clear/replace the goal while this
+        # model turn is in flight. Reload persisted state before judging so an
+        # old turn cannot resurrect a paused goal or judge a replacement goal
+        # against the old objective's response.
+        manager = GoalManager(
+            session_id=session_id,
+            default_max_turns=default_max_turns,
+        )
+        current_identity = (
+            (manager.state.created_at, manager.state.goal)
+            if manager.state is not None
+            else None
+        )
+        if not manager.is_active() or current_identity != goal_identity:
+            break
+        decision = manager.evaluate_after_turn(
+            str(result.get("final_response") or ""),
+            user_initiated=user_initiated,
+            background_processes=gather_background_processes(),
+        )
+        emit({
+            "event": "goal.status",
+            "status": decision.get("status"),
+            "verdict": decision.get("verdict"),
+            "reason": decision.get("reason"),
+            "message": decision.get("message"),
+            "turns_used": manager.state.turns_used if manager.state else None,
+            "max_turns": manager.state.max_turns if manager.state else None,
+        })
+        if not decision.get("should_continue"):
+            break
+        current_message = str(decision.get("continuation_prompt") or "")
+        if not current_message:
+            break
+        if should_stop is not None and should_stop():
+            break
+        result = run_turn(current_message, None)
+        user_initiated = False
+
+    return result
+
+
+__all__ = ["run_goal_aware_turn"]

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7330,11 +7330,30 @@ class APIServerAdapter(BasePlatformAdapter):
                     # ``agent_ref``, and only /v1/runs has a run_id, so neither
                     # is a usable hook for the rest.
                     self._shutdown_interruptible_agents[id(agent)] = agent
-                    result = agent.run_conversation(
+                    from gateway.api_goal_runtime import run_goal_aware_turn
+
+                    goal_events: List[Dict[str, Any]] = []
+
+                    def _run_turn(message, history):
+                        return agent.run_conversation(
+                            user_message=message,
+                            conversation_history=history,
+                            task_id=effective_task_id,
+                        )
+
+                    result = run_goal_aware_turn(
+                        session_id=session_id or effective_task_id,
                         user_message=user_message,
                         conversation_history=conversation_history,
-                        task_id=effective_task_id,
+                        run_turn=_run_turn,
+                        status_callback=goal_events.append,
+                        should_stop=(
+                            (lambda: active_run_id in self._stopping_run_ids)
+                            if active_run_id else None
+                        ),
                     )
+                    if goal_events:
+                        result["goal_events"] = goal_events
                     usage = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
@@ -7836,10 +7855,32 @@ class APIServerAdapter(BasePlatformAdapter):
                             # ownership so stop/cancel can reap only the
                             # background processes this run created (#76115).
                             _publish_turn_process_ownership(agent, effective_task_id)
-                            r = agent.run_conversation(
+                            from gateway.api_goal_runtime import run_goal_aware_turn
+
+                            def _goal_event(event: Dict[str, Any]) -> None:
+                                payload = dict(event)
+                                payload.update({
+                                    "run_id": run_id,
+                                    "timestamp": time.time(),
+                                })
+                                loop.call_soon_threadsafe(
+                                    _put_event_if_active, payload
+                                )
+
+                            def _run_turn(message, history):
+                                return agent.run_conversation(
+                                    user_message=message,
+                                    conversation_history=history,
+                                    task_id=effective_task_id,
+                                )
+
+                            r = run_goal_aware_turn(
+                                session_id=session_id or effective_task_id,
                                 user_message=user_message,
                                 conversation_history=conversation_history,
-                                task_id=effective_task_id,
+                                run_turn=_run_turn,
+                                status_callback=_goal_event,
+                                should_stop=lambda: run_id in self._stopping_run_ids,
                             )
                         finally:
                             # Worker finished (interrupted or complete) —

--- a/tests/gateway/test_api_server_goals.py
+++ b/tests/gateway/test_api_server_goals.py
@@ -1,0 +1,221 @@
+"""Native persistent-goal coverage for direct API-server agent turns."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.api_goal_runtime import run_goal_aware_turn
+from hermes_cli import goals
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    token = set_hermes_home_override(str(home))
+    goals._DB_CACHE.clear()
+    yield home
+    reset_hermes_home_override(token)
+    goals._DB_CACHE.clear()
+
+
+def test_api_goal_runs_canonical_continuations_until_done(hermes_home):
+    calls = []
+    events = []
+
+    def run_turn(message, history):
+        calls.append((message, history))
+        return {"final_response": f"turn {len(calls)}", "completed": True}
+
+    verdicts = [
+        ("continue", "one step remains", False, None, False),
+        ("done", "objective complete", False, None, False),
+    ]
+    with (
+        patch("hermes_cli.goals.judge_goal", side_effect=verdicts),
+        patch("hermes_cli.goals.gather_background_processes", return_value=[]),
+    ):
+        result = run_goal_aware_turn(
+            session_id="api-goal-session",
+            user_message="/goal finish the migration",
+            conversation_history=[{"role": "user", "content": "prior"}],
+            run_turn=run_turn,
+            default_max_turns=4,
+            status_callback=events.append,
+        )
+
+    assert result["final_response"] == "turn 2"
+    assert calls[0] == (
+        "finish the migration",
+        [{"role": "user", "content": "prior"}],
+    )
+    assert calls[1][0].startswith("[Continuing toward your standing goal]")
+    assert calls[1][1] is None
+    assert [event["event"] for event in events] == [
+        "goal.started",
+        "goal.status",
+        "goal.status",
+    ]
+    assert goals.GoalManager("api-goal-session").state.status == "done"
+
+
+def test_api_goal_wait_parks_without_another_turn(hermes_home):
+    calls = []
+
+    def run_turn(message, history):
+        calls.append((message, history))
+        return {"final_response": "The build watcher is still running."}
+
+    wait_verdict = (
+        "wait",
+        "waiting for the build watcher",
+        False,
+        {"seconds": 60},
+        False,
+    )
+    with (
+        patch("hermes_cli.goals.judge_goal", return_value=wait_verdict),
+        patch("hermes_cli.goals.gather_background_processes", return_value=[]),
+    ):
+        run_goal_aware_turn(
+            session_id="api-wait-session",
+            user_message="/goal monitor the build until it finishes",
+            conversation_history=None,
+            run_turn=run_turn,
+            status_callback=lambda _event: None,
+        )
+
+    assert len(calls) == 1
+    state = goals.GoalManager("api-wait-session").state
+    assert state.status == "active"
+    assert state.waiting_until > 0
+    assert state.turns_used == 1
+
+
+def test_api_goal_reentry_resumes_after_wait_barrier_clears(hermes_home):
+    calls = []
+
+    def run_turn(message, history):
+        calls.append((message, history))
+        return {"final_response": f"turn {len(calls)}"}
+
+    with (
+        patch(
+            "hermes_cli.goals.judge_goal",
+            side_effect=[
+                ("wait", "build is running", False, {"seconds": 60}, False),
+                ("done", "build completed", False, None, False),
+            ],
+        ),
+        patch("hermes_cli.goals.gather_background_processes", return_value=[]),
+    ):
+        run_goal_aware_turn(
+            session_id="api-wake-session",
+            user_message="/goal monitor the build",
+            conversation_history=None,
+            run_turn=run_turn,
+        )
+
+        manager = goals.GoalManager("api-wake-session")
+        manager.state.waiting_until = 0
+        goals.save_goal("api-wake-session", manager.state)
+
+        result = run_goal_aware_turn(
+            session_id="api-wake-session",
+            user_message="The background build completed successfully.",
+            conversation_history=None,
+            run_turn=run_turn,
+        )
+
+    assert result["final_response"] == "turn 2"
+    assert len(calls) == 2
+    assert goals.GoalManager("api-wake-session").state.status == "done"
+
+
+def test_api_goal_honors_control_plane_pause_during_model_turn(hermes_home):
+    judge_called = False
+
+    def run_turn(_message, _history):
+        goals.GoalManager("api-pause-session").pause()
+        return {"final_response": "late response from the in-flight turn"}
+
+    def forbidden_judge(*_args, **_kwargs):
+        nonlocal judge_called
+        judge_called = True
+        raise AssertionError("a paused goal must not be judged or continued")
+
+    with patch("hermes_cli.goals.judge_goal", side_effect=forbidden_judge):
+        result = run_goal_aware_turn(
+            session_id="api-pause-session",
+            user_message="/goal complete the build",
+            conversation_history=None,
+            run_turn=run_turn,
+        )
+
+    assert result["final_response"] == "late response from the in-flight turn"
+    assert judge_called is False
+    assert goals.GoalManager("api-pause-session").state.status == "paused"
+
+
+def test_api_goal_stop_predicate_prevents_next_continuation(hermes_home):
+    calls = []
+    stopping = False
+
+    def run_turn(message, history):
+        nonlocal stopping
+        calls.append((message, history))
+        stopping = True
+        return {"final_response": "first turn completed during stop"}
+
+    with patch(
+        "hermes_cli.goals.judge_goal",
+        side_effect=AssertionError("stopping run must not call the goal judge"),
+    ):
+        run_goal_aware_turn(
+            session_id="api-stop-session",
+            user_message="/goal complete a long task",
+            conversation_history=None,
+            run_turn=run_turn,
+            should_stop=lambda: stopping,
+        )
+
+    assert len(calls) == 1
+    assert goals.GoalManager("api-stop-session").state.status == "active"
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("/goal", "No active goal"),
+        ("/goal status", "No active goal"),
+        ("/goal pause", "No active goal"),
+        ("/goal clear", "Goal cleared"),
+        ("/goal resume", "No goal to resume"),
+        ("/goal unwait", "no active wait"),
+        ("/goal wait 123 build", "Could not park goal"),
+    ],
+)
+def test_api_goal_control_commands_do_not_call_model(hermes_home, command, expected):
+    def forbidden_turn(_message, _history):
+        raise AssertionError("goal control commands must not call the model")
+
+    result = run_goal_aware_turn(
+        session_id=f"control-{command}",
+        user_message=command,
+        conversation_history=None,
+        run_turn=forbidden_turn,
+    )
+
+    assert expected in result["final_response"]
+    assert result["goal_control"] is True

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -12,6 +12,7 @@ Covers:
 import asyncio
 import threading
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,6 +26,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from hermes_cli import goals
 from tools import approval as approval_mod
 
 
@@ -120,6 +122,24 @@ def adapter():
 @pytest.fixture
 def auth_adapter():
     return _make_adapter(api_key="sk-secret")
+
+
+@pytest.fixture
+def api_goal_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    token = set_hermes_home_override(str(home))
+    goals._DB_CACHE.clear()
+    yield home
+    reset_hermes_home_override(token)
+    goals._DB_CACHE.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -338,6 +358,54 @@ class TestRunEvents:
                 # Should contain run.completed
                 assert "run.completed" in body
                 assert "Hello!" in body
+
+    @pytest.mark.asyncio
+    async def test_goal_runs_continue_and_emit_native_lifecycle_events(
+        self, adapter, api_goal_home
+    ):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent") as mock_create,
+                patch(
+                    "hermes_cli.goals.judge_goal",
+                    side_effect=[
+                        ("continue", "one step remains", False, None, False),
+                        ("done", "objective complete", False, None, False),
+                    ],
+                ),
+                patch(
+                    "hermes_cli.goals.gather_background_processes",
+                    return_value=[],
+                ),
+            ):
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.side_effect = [
+                    {"final_response": "first turn"},
+                    {"final_response": "finished"},
+                ]
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "/goal finish the migration",
+                        "session_id": "api-goal-run",
+                    },
+                )
+                run_id = (await resp.json())["run_id"]
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                body = await events_resp.text()
+
+        assert mock_agent.run_conversation.call_count == 2
+        assert '"event": "goal.started"' in body
+        assert body.count('"event": "goal.status"') == 2
+        assert '"verdict": "done"' in body
+        assert '"event": "run.completed"' in body
+        assert '"output": "finished"' in body
 
 
     @pytest.mark.asyncio

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -444,6 +444,24 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 
 Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
 
+Persistent goals use the same slash-command contract as the CLI and messaging
+gateway. Send `/goal <objective>` as `input` with a stable `session_id`:
+
+```json
+{
+  "session_id": "release-check",
+  "input": "/goal Wait for CI to pass, investigate failures, and report the result"
+}
+```
+
+Hermes runs the native goal judge after each turn and performs canonical
+continuations within the run. A `wait` verdict parks the goal without another
+model call, judge call, or turn charge. Re-enter the same API session after a
+process/watch completes (or a timed wait expires) to continue the persisted
+goal. The core control commands (`/goal`, `/goal status`, `/goal pause`,
+`/goal resume`, `/goal clear`, `/goal wait <pid> [reason]`, and `/goal unwait`)
+are handled as control-plane operations and do not call the model.
+
 ### GET /v1/runs/\{run_id\}
 
 Poll the current run state. This is useful for dashboards that need status without holding an SSE connection open, or for UIs that reconnect after navigation.
@@ -465,6 +483,11 @@ Statuses are retained briefly after terminal states (`completed`, `failed`, or `
 ### GET /v1/runs/\{run_id\}/events
 
 Server-Sent Events stream of the run's tool-call progress, token deltas, and lifecycle events. Designed for dashboards and thick clients that want to attach/detach without losing state.
+
+Persistent goal runs additionally emit `goal.started` and `goal.status`.
+`goal.status` includes the native judge verdict/reason plus turn-budget state,
+allowing clients to distinguish continuation, completion, pause, and parked
+waits without parsing assistant prose.
 
 When the agent delegates work to background subagents, the stream also carries
 `subagent.start` and `subagent.complete` lifecycle events, so clients can


### PR DESCRIPTION
## Summary

- route direct API-server agent turns through a small surface bridge backed by the existing `GoalManager`
- support `/goal` lifecycle and control commands across `/v1/runs` and the shared OpenAI-compatible agent entry path
- emit native goal lifecycle events from `/v1/runs/{id}/events`
- park `wait` verdicts without extra model/judge calls or turn charges, then resume the persisted goal when the same API session is re-entered after its barrier clears
- document the API contract

This does not introduce a second goal state machine: persistence, judging, quality gates, wait barriers, continuation prompts, and budget accounting remain owned by `hermes_cli.goals.GoalManager`.

Fixes #73276.
Fixes #98299.

## Tests

- `111 passed`: full existing goal test family plus new API goal behavior tests
- `147 passed`: API server core, runs, and new goal integration tests
- `ruff check` on changed Python files
- `git diff --check`

New regression coverage includes:

- canonical `continue -> done` orchestration
- `wait` parking with no extra turn
- same-session re-entry after a cleared wait barrier
- concurrent pause during an in-flight model turn
- stop preventing judge/continuation
- control commands avoiding model calls
- `/v1/runs` SSE goal lifecycle events
