### PR TITLE
fix(gateway): re-arm active heartbeat watches on startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13691,6 +13691,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._start_loop_heartbeat_task()
 
+        # Re-arm heartbeat watches persisted as active before this restart
+        # (#98298) — must run after adapters/routing are up so the poller
+        # can deliver, and before the startup hook so restored watches are
+        # visible to it.
+        await self._restore_heartbeat_watches()
+
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
         if hook_count:
@@ -22516,8 +22522,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         The registry maps ``quick_key`` → ``(source, session_id)`` so the
         poller can rebuild a MessageEvent and enqueue via the adapter FIFO.
         In-memory by design: heartbeat STATE survives restarts in SessionDB,
-        but firing resumes when the user touches /heartbeat again in the new
-        gateway process (documented; durable schedules belong to cron).
+        and ``_restore_heartbeat_watches`` re-arms active watches from the
+        routing index on gateway startup (durable schedules belong to cron).
         """
         watch = getattr(self, "_heartbeat_watch", None)
         if watch is None:
@@ -22525,6 +22531,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._heartbeat_watch = watch
         watch[quick_key] = (source, session_id)
         self._start_heartbeat_poller()
+
+    async def _restore_heartbeat_watches(self) -> None:
+        """Re-arm watches for persisted active heartbeats on gateway startup.
+
+        Heartbeat state survives restarts in SessionDB ``state_meta``, but
+        the in-memory watch registry does not: after a restart an active
+        heartbeat was orphaned — ``/heartbeat status`` kept reporting
+        "active, next in ~Ns" while nothing could ever fire it (#98298).
+        Rebuild watches from the session routing index, whose entries carry
+        the origin source the poller needs to rebuild its delivery event.
+        Paused/cleared heartbeats are left alone; durable schedules still
+        belong to ``hermes cron``.
+        """
+        try:
+            from hermes_cli.heartbeat import load_heartbeat
+
+            entries = await self.async_session_store.list_sessions()
+        except Exception:
+            logger.debug("heartbeat restore: session list unavailable", exc_info=True)
+            return
+        restored = 0
+        for entry in entries:
+            sid = getattr(entry, "session_id", None)
+            origin = getattr(entry, "origin", None)
+            if not sid or origin is None:
+                continue
+            try:
+                state = load_heartbeat(sid)
+            except Exception:
+                state = None
+            if state is None or state.status != "active" or not state.prompt:
+                continue
+            self._register_heartbeat_watch(entry.session_key, origin, sid)
+            restored += 1
+        if restored:
+            logger.info(
+                "Heartbeat: re-armed %d active heartbeat(s) from persisted state",
+                restored,
+            )
 
     def _unregister_heartbeat_watch(self, quick_key: str) -> None:
         watch = getattr(self, "_heartbeat_watch", None)

--- a/tests/gateway/test_heartbeat_restart_restore.py
+++ b/tests/gateway/test_heartbeat_restart_restore.py
@@ -12,6 +12,7 @@ entries that still carry an origin source are re-armed, and every failure
 mode degrades to "no watches" instead of breaking startup.
 """
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -140,5 +141,101 @@ async def test_restore_survives_db_read_failure(monkeypatch):
     await r._restore_heartbeat_watches()
     try:
         assert r._heartbeat_watch == {}
+    finally:
+        await _shutdown(r)
+
+
+@pytest.mark.asyncio
+async def test_restart_end_to_end_delivers_active_without_resume(monkeypatch):
+    """Startup path: after a restart, an active heartbeat delivers via the
+    poller with no manual /heartbeat resume, while a paused one never
+    registers a watch (#98298)."""
+    active = SimpleNamespace(
+        status="active", prompt="Check CI", interval_seconds=600
+    )
+    paused = SimpleNamespace(
+        status="paused", prompt="Check mail", interval_seconds=300
+    )
+    by_sid = {"sid-active": active, "sid-paused": paused}
+    monkeypatch.setattr(
+        "hermes_cli.heartbeat.load_heartbeat", lambda sid: by_sid.get(sid)
+    )
+    # Restore starts the poller, so shorten its cadence before it closes
+    # over POLL_SECONDS.
+    monkeypatch.setattr("hermes_cli.heartbeat.POLL_SECONDS", 0.05)
+
+    delivered = []
+
+    class _DueManager:
+        def __init__(self, session_id):
+            self._sid = session_id
+
+        def has_heartbeat(self):
+            return True
+
+        def due_prompt(self):
+            # Fire once, then stay quiet: delivery cadence is the poller's
+            # contract with the real HeartbeatManager, not this test's.
+            if self._sid == "sid-active" and not delivered:
+                return "Check CI"
+            return None
+
+    monkeypatch.setattr("hermes_cli.heartbeat.HeartbeatManager", _DueManager)
+
+    r = _runner(
+        _StubStore(
+            [
+                _entry("telegram:dm:111", "sid-active", _source("111")),
+                _entry("telegram:dm:222", "sid-paused", _source("222")),
+            ]
+        )
+    )
+
+    async def _warm(_label):
+        return None
+
+    r._warm_goals_session_db = _warm
+    r._adapter_for_source = lambda source: object()
+    r._enqueue_fifo = lambda quick_key, event, adapter: delivered.append(
+        (quick_key, event)
+    )
+
+    # Simulated restart: persisted state in the store above, empty
+    # in-memory registry, restore called from the startup path.
+    await r._restore_heartbeat_watches()
+    try:
+        assert set(r._heartbeat_watch) == {"telegram:dm:111"}
+        for _ in range(200):
+            if delivered:
+                break
+            await asyncio.sleep(0.01)
+        assert [(key, event.text) for key, event in delivered] == [
+            ("telegram:dm:111", "Check CI")
+        ]
+    finally:
+        await _shutdown(r)
+
+
+@pytest.mark.asyncio
+async def test_repeated_restore_does_not_duplicate_registrations(monkeypatch):
+    """Repeated startup/recovery passes must not stack registrations for
+    the same session_key: the registry overwrites by key and the poller is
+    a gateway-wide singleton."""
+    active = SimpleNamespace(
+        status="active", prompt="Check CI", interval_seconds=600
+    )
+    monkeypatch.setattr(
+        "hermes_cli.heartbeat.load_heartbeat", lambda sid: active
+    )
+    r = _runner(_StubStore([_entry("telegram:dm:111", "sid-1", _source("111"))]))
+
+    await r._restore_heartbeat_watches()
+    try:
+        first_task = r._heartbeat_poll_task
+        assert first_task is not None and not first_task.done()
+
+        await r._restore_heartbeat_watches()
+        assert set(r._heartbeat_watch) == {"telegram:dm:111"}
+        assert r._heartbeat_poll_task is first_task
     finally:
         await _shutdown(r)

--- a/tests/gateway/test_heartbeat_restart_restore.py
+++ b/tests/gateway/test_heartbeat_restart_restore.py
@@ -1,0 +1,144 @@
+"""Gateway restart must re-arm persisted active heartbeat watches (#98298).
+
+Heartbeat state survives restarts in SessionDB ``state_meta``, but the
+in-memory ``_heartbeat_watch`` registry did not: after a restart an active
+heartbeat was orphaned — ``/heartbeat status`` kept reporting "active, next
+in ~Ns" while nothing could ever fire it. ``_restore_heartbeat_watches``
+rebuilds watches from the session routing index on startup.
+
+These tests pin the restore contract with a bare GatewayRunner (same
+pattern as test_scale_to_zero_watcher.py): only active heartbeats on
+entries that still carry an origin source are re-armed, and every failure
+mode degrades to "no watches" instead of breaking startup.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.run import GatewayRunner
+from gateway.session import Platform, SessionSource
+
+
+def _source(chat_id: str = "111") -> SessionSource:
+    return SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm")
+
+
+def _entry(session_key: str, session_id: str, origin) -> SimpleNamespace:
+    return SimpleNamespace(session_key=session_key, session_id=session_id, origin=origin)
+
+
+class _StubStore:
+    # GatewayRunner.async_session_store (a property) validates its cached
+    # facade via ``facade._store is self.session_store`` — mirror that pair
+    # so the stub survives the check instead of being replaced.
+    _store = None
+
+    def __init__(self, entries, error: Exception = None):
+        self._entries = entries
+        self._error = error
+
+    async def list_sessions(self):
+        if self._error is not None:
+            raise self._error
+        return list(self._entries)
+
+
+def _runner(store) -> GatewayRunner:
+    r = GatewayRunner.__new__(GatewayRunner)
+    r.session_store = None
+    r._heartbeat_watch = {}
+    r._heartbeat_poll_task = None
+    r._running_agents = {}
+    r._background_tasks = set()
+    r._async_session_store = store
+    return r
+
+
+async def _shutdown(r: GatewayRunner) -> None:
+    task = getattr(r, "_heartbeat_poll_task", None)
+    if task is not None and not task.done():
+        task.cancel()
+        import asyncio
+
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_restore_re_arms_active_heartbeat(monkeypatch):
+    active = SimpleNamespace(
+        status="active", prompt="Check CI", interval_seconds=600
+    )
+    paused = SimpleNamespace(
+        status="paused", prompt="Check mail", interval_seconds=300
+    )
+    by_sid = {"sid-active": active, "sid-paused": paused}
+    monkeypatch.setattr(
+        "hermes_cli.heartbeat.load_heartbeat", lambda sid: by_sid.get(sid)
+    )
+    r = _runner(
+        _StubStore(
+            [
+                _entry("telegram:dm:111", "sid-active", _source("111")),
+                _entry("telegram:dm:222", "sid-paused", _source("222")),
+            ]
+        )
+    )
+
+    await r._restore_heartbeat_watches()
+    try:
+        assert set(r._heartbeat_watch) == {"telegram:dm:111"}
+        source, sid = r._heartbeat_watch["telegram:dm:111"]
+        assert sid == "sid-active"
+        assert isinstance(source, SessionSource)
+        assert source.chat_id == "111"
+        # Registering a watch starts the gateway-wide poller.
+        assert r._heartbeat_poll_task is not None and not r._heartbeat_poll_task.done()
+    finally:
+        await _shutdown(r)
+
+
+@pytest.mark.asyncio
+async def test_restore_skips_entries_without_origin(monkeypatch):
+    active = SimpleNamespace(status="active", prompt="p", interval_seconds=60)
+    monkeypatch.setattr(
+        "hermes_cli.heartbeat.load_heartbeat", lambda sid: active if sid else None
+    )
+    r = _runner(
+        _StubStore([_entry("telegram:dm:111", "sid-1", None)])
+    )
+
+    await r._restore_heartbeat_watches()
+    try:
+        assert r._heartbeat_watch == {}
+    finally:
+        await _shutdown(r)
+
+
+@pytest.mark.asyncio
+async def test_restore_survives_store_failure(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.heartbeat.load_heartbeat", lambda sid: None
+    )
+    r = _runner(_StubStore([], error=RuntimeError("state.db unavailable")))
+
+    # A failing session store must not break gateway startup.
+    await r._restore_heartbeat_watches()
+    assert r._heartbeat_watch == {}
+
+
+@pytest.mark.asyncio
+async def test_restore_survives_db_read_failure(monkeypatch):
+    def _boom(sid):
+        raise RuntimeError("get_meta failed")
+
+    monkeypatch.setattr("hermes_cli.heartbeat.load_heartbeat", _boom)
+    r = _runner(
+        _StubStore([_entry("telegram:dm:111", "sid-1", _source("111"))])
+    )
+
+    await r._restore_heartbeat_watches()
+    try:
+        assert r._heartbeat_watch == {}
+    finally:
+        await _shutdown(r)


### PR DESCRIPTION
## What does this PR do?

Heartbeat state survives gateway restarts in SessionDB `state_meta`, but the in-memory `_heartbeat_watch` registry did not: after every gateway restart, a previously active heartbeat was orphaned — `/heartbeat status` kept reporting `active, next in ~Ns` while nothing could ever fire it, because the poller's registry starts empty on boot. Users running a 24/7 gateway had to manually run `/heartbeat resume` after each restart to re-register the watch (Bug 1 in #98298).

This PR restores watches at gateway startup: `_restore_heartbeat_watches()` walks the persisted session routing index (each entry carries the origin `SessionSource` needed to rebuild the delivery event), loads each session's heartbeat state from `state_meta`, and re-registers a watch for every `active` heartbeat. Paused/cleared heartbeats are deliberately left alone, and every failure mode (unavailable session store, unreadable heartbeat row, entry without an origin) degrades to "no watches restored" instead of breaking startup. Durable schedules still belong to `hermes cron` — a restored heartbeat only lives while the gateway process runs, exactly like one set fresh.

## Related Issue

Fixes #98298

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: new `_restore_heartbeat_watches()` — rebuilds `_heartbeat_watch` entries from the session routing index for persisted `active` heartbeats; called from `start()` right after `_start_loop_heartbeat_task()` (adapters/routing already up, before the `gateway:startup` hook).
- `gateway/run.py`: updated the `_register_heartbeat_watch` docstring — the "firing resumes when the user touches /heartbeat again" caveat is no longer accurate.
- `tests/gateway/test_heartbeat_restart_restore.py`: regression tests — active heartbeats are re-armed (paused are not), entries without an origin are skipped, and store/DB failures degrade to no watches without raising.

## How to Test

1. `python -m pytest tests/gateway/test_heartbeat_restart_restore.py -q` → Observed result: 4 passed.
2. `python -m pytest tests/gateway/test_scale_to_zero_watcher.py tests/gateway/test_goal_resume_restart.py tests/tools/test_heartbeat_stale_thresholds.py -q` → Observed result: all pass (no regression in heartbeat poller / scale-to-zero interactions).
3. Manual restart scenario: set `/heartbeat every 1m check` in a Telegram session, restart the gateway, wait ~1 minute without touching the session → the heartbeat should fire into the session; before this change it never fired until a manual `/heartbeat resume`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the restore path itself is platform-neutral (SQLite + in-memory registry)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A