### PR TITLE
fix(tui): restore DB-backed history for Desktop sessions

### DIFF
--- a/tests/tui_gateway/test_history_reconcile.py
+++ b/tests/tui_gateway/test_history_reconcile.py
@@ -1,0 +1,137 @@
+"""Regression test for the Desktop/TUI history-hollow fix.
+
+Root cause (HISTORY_PIPELINE_BUG_CONFIRMED): the Desktop/TUI gateway feeds
+``run_conversation`` an in-memory ``session["history"]`` that can be hollowed
+across turns (prior-turn content arrives empty while the session DB still holds
+the real text). The CLI surface loads history from
+``SessionDB.get_messages_as_conversation`` every turn and always carries real
+content. ``_reconcile_history_with_session_db`` makes the Desktop path do the
+same: when the in-memory copy is hollow, fall back to the DB-backed transcript.
+
+These tests exercise the REAL helper (and the exact history-handling sequence
+inside ``_run_prompt_submit``) with a fake DB/agent so they run offline and fast.
+"""
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server as S
+
+
+class FakeDB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_messages_as_conversation(self, session_id, include_ancestors=False,
+                                      repair_alternation=False, include_row_ids=False):
+        return [dict(r) for r in self._rows]
+
+
+REAL = [
+    {"role": "user", "content": "remember the code is 4271"},
+    {"role": "assistant", "content": "Got it, code 4271 noted."},
+]
+
+
+def _agent(db):
+    a = types.SimpleNamespace()
+    a._session_db = db
+    a.session_id = "sess_key"
+    return a
+
+
+def _session():
+    return {"session_key": "sess_key", "history": [], "history_lock": threading.Lock()}
+
+
+def test_intact_history_returned_unchanged():
+    agent = _agent(FakeDB(REAL))
+    sess = _session()
+    hist = [dict(r) for r in REAL]
+    assert S._reconcile_history_with_session_db(agent, sess, hist) == REAL
+
+
+def test_hollow_history_filled_from_db():
+    agent = _agent(FakeDB(REAL))
+    sess = _session()
+    hollow = [{"role": "user", "content": ""}, {"role": "assistant", "content": ""}]
+    out = S._reconcile_history_with_session_db(agent, sess, hollow)
+    assert out == REAL
+    assert out[0]["content"] == "remember the code is 4271"
+
+
+def test_hollow_with_unsaved_tail_preserved():
+    agent = _agent(FakeDB(REAL))
+    sess = _session()
+    hollow = [
+        {"role": "user", "content": ""},
+        {"role": "assistant", "content": "Got it, code 4271 noted."},
+        {"role": "user", "content": "what was the code?"},  # unsaved tail
+    ]
+    out = S._reconcile_history_with_session_db(agent, sess, hollow)
+    assert len(out) == 3
+    assert out[0]["content"] == "remember the code is 4271"
+    assert out[2]["content"] == "what was the code?"
+
+
+def test_empty_history_unchanged():
+    agent = _agent(FakeDB(REAL))
+    sess = _session()
+    assert S._reconcile_history_with_session_db(agent, sess, []) == []
+
+
+def test_tool_call_entry_not_treated_hollow():
+    agent = _agent(FakeDB(REAL))
+    sess = _session()
+    hist = [{"role": "assistant", "content": "", "tool_calls": [{"id": "x"}]}]
+    assert S._reconcile_history_with_session_db(agent, sess, hist) == hist
+
+
+def test_db_unavailable_falls_back_to_in_memory():
+    agent = _agent(None)  # no _session_db
+    sess = _session()
+    hollow = [{"role": "user", "content": ""}]
+    # No DB -> return the (hollow) in-memory history unchanged rather than crash.
+    assert S._reconcile_history_with_session_db(agent, sess, hollow) == hollow
+
+
+class StubAgent:
+    def __init__(self, db):
+        self._session_db = db
+        self.session_id = "sess_key"
+        self.recorded = []
+
+    def run_conversation(self, run_message, **kwargs):
+        ch = kwargs.get("conversation_history") or []
+        self.recorded.append([dict(m) for m in ch])
+        user_msg = {"role": "user", "content": run_message}
+        asst_msg = {"role": "assistant", "content": f"echo: {run_message}"}
+        return {
+            "final_response": asst_msg["content"],
+            "messages": [dict(m) for m in ch] + [user_msg, asst_msg],
+        }
+
+
+def _run_turn(agent, session, text):
+    # Exact history sequence from _run_prompt_submit.
+    with session["history_lock"]:
+        history = list(session["history"])
+    history = S._reconcile_history_with_session_db(agent, session, history)
+    result = agent.run_conversation(text, conversation_history=list(history))
+    with session["history_lock"]:
+        session["history"] = result["messages"]
+    return result
+
+
+def test_two_turn_hollow_history_reaches_provider():
+    agent = StubAgent(FakeDB(REAL))
+    session = _session()
+    _run_turn(agent, session, "hello")
+    assert agent.recorded[0] == []
+    # Simulate the bug: gateway in-memory history hollowed.
+    session["history"] = [{"role": "user", "content": ""}, {"role": "assistant", "content": ""}]
+    _run_turn(agent, session, "what was the code?")
+    got = agent.recorded[1]
+    assert got == REAL
+    assert session["history"][0]["content"] == "remember the code is 4271"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12539,6 +12539,93 @@ def _start_usage_ticker(
     return stop, thread
 
 
+def _reconcile_history_with_session_db(agent, session, history):
+    """Prefer DB-backed real content for the turn's conversation history.
+
+    The Desktop/TUI gateway feeds ``run_conversation`` an in-memory
+    ``session["history"]`` as ``conversation_history``. That in-memory
+    transcript aliases the agent's working messages after a turn (server.py
+    note near ``_flush_messages_to_session_db``) and, across turns, can be
+    hollowed — prior-turn content arrives as empty strings while the session
+    DB still holds the real text. The CLI surface instead loads history from
+    ``SessionDB.get_messages_as_conversation`` every turn and always carries
+    real content (history-pipeline bug HISTORY_PIPELINE_BUG_CONFIRMED).
+
+    When the in-memory copy contains hollow (empty, non-final) entries, fall
+    back to the DB-backed transcript so the provider receives the real
+    prior-turn text. An in-memory tail that extends beyond the DB (messages
+    not yet flushed) is preserved, and any hollow in-memory entry is filled
+    from the DB by position. Intact in-memory history is returned unchanged —
+    no extra DB read on the healthy path.
+    """
+    if not isinstance(history, list) or not history:
+        return history
+
+    def _is_hollow(m):
+        if not isinstance(m, dict):
+            return True
+        content = m.get("content")
+        if isinstance(content, str) and content.strip():
+            return False
+        if isinstance(content, list) and any(
+            isinstance(b, dict)
+            and (
+                b.get("type") != "text"
+                or (isinstance(b.get("text"), str) and b["text"].strip())
+            )
+            for b in content
+        ):
+            return False
+        if (
+            m.get("tool_calls")
+            or m.get("tool_call_id")
+            or m.get("reasoning")
+            or m.get("reasoning_content")
+            or m.get("reasoning_details")
+        ):
+            return False
+        return True
+
+    if not any(_is_hollow(m) for m in history):
+        return history
+
+    db = getattr(agent, "_session_db", None)
+    if db is None:
+        try:
+            db = _session_db(session)
+        except Exception:
+            db = None
+    if db is None:
+        return history
+    key = session.get("session_key") or getattr(agent, "session_id", None)
+    if not key:
+        return history
+    try:
+        db_history = db.get_messages_as_conversation(
+            key, include_ancestors=True, repair_alternation=True
+        )
+    except Exception as exc:
+        logger.debug("history reconcile: DB load failed: %s", exc)
+        return history
+    if not db_history:
+        return history
+
+    if len(db_history) >= len(history):
+        # DB is authoritative for persisted turns. Keep any in-memory tail
+        # beyond the DB (unsaved messages) so in-flight turns are never lost.
+        return list(db_history[: len(history)]) + list(history[len(db_history):])
+
+    # DB shorter than in-memory (in-memory has newer unsaved entries): fill
+    # hollow in-memory entries from the DB by position where possible.
+    filled = []
+    for i, m in enumerate(history):
+        if _is_hollow(m) and i < len(db_history):
+            filled.append(db_history[i])
+        else:
+            filled.append(m)
+    return filled
+
+
 def _run_prompt_submit(
     rid,
     sid: str,
@@ -12679,6 +12766,12 @@ def _run_prompt_submit(
             with session["history_lock"]:
                 history = list(session["history"])
                 history_version = int(session.get("history_version", 0))
+            # Reconcile the in-memory transcript with the DB-backed real content
+            # so hollowed prior-turn entries don't reach the provider (see
+            # _reconcile_history_with_session_db). The CLI path loads DB content
+            # directly every turn; Desktop must do the same or the model gets an
+            # empty context window across turns (HISTORY_PIPELINE_BUG_CONFIRMED).
+            history = _reconcile_history_with_session_db(agent, session, history)
             cwd = _session_cwd(session)
             _register_session_cwd(session)
             cols = session.get("cols", 80)


### PR DESCRIPTION
## Summary

Fix Desktop/TUI multi-turn history loss caused by hollow in-memory session history.

The persisted session DB contains the full prior user/assistant content, but the Desktop/TUI turn path feeds `run_conversation` from the gateway's in-memory `session["history"]`. In affected sessions, those entries retain the correct message count while their prior content is hollow, so provider input tokens remain flat across turns and the model behaves as if no earlier context exists.

The CLI path does not reproduce this because it loads authoritative DB-backed history via `SessionDB.get_messages_as_conversation`.

This change reconciles hollow in-memory history with the persisted DB transcript before the Desktop/TUI turn is submitted.

## Root Cause

Observed before the fix on real Desktop sessions:

- history count: `0 → 2 → 4`
- provider prompt tokens: `2050 → 2050 → 2050`
- persisted DB messages: present with real content

So the session and persistence layers were intact, but prior message content was not reaching the provider.

The Desktop/TUI submit path relied on in-memory `session["history"]`, while the authoritative DB transcript remained complete.

## Changes

- add a history reconciliation helper in `tui_gateway/server.py`
- detect hollow prior entries before Desktop/TUI prompt submission
- recover real prior content from `SessionDB.get_messages_as_conversation`
- preserve any unsaved in-memory tail
- leave healthy in-memory history unchanged
- add focused regression coverage for reconciliation behavior

## Validation

Static:
- `py_compile`: PASS
- `git diff --check`: PASS

Focused regression:
- intact history remains unchanged: PASS
- hollow history is restored from DB: PASS
- unsaved tail is preserved: PASS
- empty history handling: PASS
- DB unavailable/fallback behavior: PASS

Desktop-turn integration:
- hollow `session["history"]` simulated
- `run_conversation` receives real DB-backed prior content: PASS

Real Desktop 3-turn validation (`qwen3.5:9b`):

Before fix:
- prompt tokens: `2050 → 2050 → 2050`

After fix:
- Round 1: `history=0`, `in=16427`
- Round 2: `history=6`, `in=16835`
- Round 3: `history=8`, `in=16898`

Semantic continuity also passed:
- Round 2 correctly recalled all prior values
- Round 3 retained both newly supplied information and earlier conversation context

The larger history counts in the real test include tool-call/tool-result messages and are expected.

## Scope

This fix is limited to the Desktop/TUI gateway history handoff.

It does not change:
- CLI history loading
- Ollama configuration
- session DB schema
- model configuration
- provider routing

This PR is intentionally separate from the local Ollama `num_ctx` transport fix in PR #98229 because the two issues have different root causes.
