### PR TITLE
fix(desktop): isolate session scroll and composer focus

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { useLayoutEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { clearSessionDraft, type ComposerAttachment, mainComposerScope, stashSessionDraft } from '@/store/composer'
 import { $connection } from '@/store/session'
 
@@ -49,6 +50,38 @@ function ProbeHarness({ activeQueueSessionKey, onLayoutSnapshot, sessionId }: Pr
 
   return null
 }
+
+describe('useComposerDraft — hidden pane focus', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('does not focus a composer mounted in a hidden pane', () => {
+    const focus = vi.spyOn(HTMLDivElement.prototype, 'focus')
+
+    function HiddenComposer() {
+      const draft = useComposerDraft({
+        activeQueueSessionKey: 'session-background',
+        focusKey: 'session-background',
+        inputDisabled: false,
+        queueEditRef: { current: null as QueueEditState | null },
+        sessionId: 'session-background'
+      })
+
+      return <div ref={draft.editorRef} />
+    }
+
+    render(
+      <PaneVisibleContext.Provider value={false}>
+        <HiddenComposer />
+      </PaneVisibleContext.Provider>
+    )
+
+    expect(focus).not.toHaveBeenCalled()
+  })
+})
+
 
 describe('useComposerDraft — attachment scope stays coherent with the committed session on switch (#59305)', () => {
   afterEach(() => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -9,6 +9,7 @@ import '@/store/suggestion-providers/skill'
 import { useAui, useAuiState, useComposerRuntime } from '@assistant-ui/react'
 import { type RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import {
@@ -75,6 +76,7 @@ export function useComposerDraft({
 }: UseComposerDraftArgs) {
   const aui = useAui()
   const composerRuntime = useComposerRuntime()
+  const paneVisible = usePaneVisible()
   // Which composer this is on the focus bus + which attachment set it owns.
   const { attachments: attachmentScope, target } = useComposerScope()
 
@@ -182,10 +184,10 @@ export function useComposerDraft({
   )
 
   useEffect(() => {
-    if (!inputDisabled) {
+    if (!inputDisabled && paneVisible) {
       focusInput()
     }
-  }, [focusInput, focusKey, focusRequestId, inputDisabled])
+  }, [focusInput, focusKey, focusRequestId, inputDisabled, paneVisible])
 
   // The mirror of the `markActiveComposer` above: give the key back when this
   // composer goes away (a session tile closing, a pane unmounting). Covers both

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -682,7 +682,7 @@ const ChatViewContent = memo(function ChatViewContent({
               </ErrorState>
             </div>
           )}
-          {showChatBar && <ScrollToBottomButton />}
+          {showChatBar && <ScrollToBottomButton sessionId={activeSessionId} />}
           {/* Vibe hearts rise from the composer only when no pet is out (else
               they play on the pet). Fired by the core `reaction` event. */}
           {!petPresent && (

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
-import { onScrollToBottomRequest, resetThreadScroll, setThreadAtBottom } from '@/store/thread-scroll'
+import { onScrollToBottomRequest, requestScrollToBottom, resetThreadScroll, setThreadAtBottom } from '@/store/thread-scroll'
 
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
 
@@ -23,14 +23,14 @@ afterEach(() => {
 // control's hidden (parked-at-bottom) state.
 describe('ScrollToBottomButton', () => {
   it('stays hidden while parked at the bottom', () => {
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId={null} />)
 
     expect(screen.queryByRole('button')).toBeNull()
   })
 
   it('is a plain jump-to-bottom control when scrolled up with no approval', () => {
     setThreadAtBottom(false)
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId={null} />)
 
     expect(screen.getByRole('button', { name: 'Scroll to bottom' })).toBeTruthy()
     expect(screen.queryByText('Approval needed')).toBeNull()
@@ -39,7 +39,7 @@ describe('ScrollToBottomButton', () => {
   it('morphs into the approval pill when scrolled up with a pending approval', () => {
     pendingApproval()
     setThreadAtBottom(false)
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId={null} />)
 
     expect(screen.getByRole('button', { name: 'Approval needed' })).toBeTruthy()
     expect(screen.getByText('Approval needed')).toBeTruthy()
@@ -47,17 +47,31 @@ describe('ScrollToBottomButton', () => {
 
   it('does not morph while a pending approval is still in view (at bottom)', () => {
     pendingApproval()
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId={null} />)
 
     // Parked at bottom → control hidden, so it can't claim "approval needed".
     expect(screen.queryByRole('button')).toBeNull()
   })
 
+  it('routes a scroll request only to its session', () => {
+    const sessionA = vi.fn()
+    const sessionB = vi.fn()
+    const stopA = onScrollToBottomRequest(sessionA, 'session-a')
+    const stopB = onScrollToBottomRequest(sessionB, 'session-b')
+
+    requestScrollToBottom('session-b')
+
+    expect(sessionA).not.toHaveBeenCalled()
+    expect(sessionB).toHaveBeenCalledOnce()
+    stopA()
+    stopB()
+  })
+
   it('re-arms sticky-bottom on click', () => {
     const handler = vi.fn()
-    const stop = onScrollToBottomRequest(handler)
+    const stop = onScrollToBottomRequest(handler, 'sess-1')
     setThreadAtBottom(false)
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId="sess-1" />)
 
     fireEvent.click(screen.getByRole('button'))
 

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
@@ -28,7 +28,7 @@ import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-
  * `data-state`. `idle` (never-shown) stays silent so it can't flash on mount;
  * `in`/`out` only swap once it has actually appeared.
  */
-export function ScrollToBottomButton() {
+export function ScrollToBottomButton({ sessionId }: { sessionId: string | null }) {
   const { t } = useI18n()
   const visible = useStore($threadJumpButtonVisible)
   const request = useStore($approvalRequest)
@@ -59,7 +59,7 @@ export function ScrollToBottomButton() {
       data-state={state}
       onClick={() => {
         triggerHaptic('selection')
-        requestScrollToBottom()
+        requestScrollToBottom(sessionId)
       }}
       style={{
         bottom: 'calc(var(--composer-measured-height) + 0.625rem)'

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -53,7 +53,7 @@ describe('clarify.request stream hydration', () => {
   beforeEach(() => {
     clearClarifyRequest()
     scrollToBottom.mockClear()
-    stopScrollListener = onScrollToBottomRequest(scrollToBottom)
+    stopScrollListener = onScrollToBottomRequest(scrollToBottom, SID)
   })
 
   afterEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -94,7 +94,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         })
 
         if (sessionId === activeSessionIdRef.current) {
-          requestScrollToBottom()
+          requestScrollToBottom(sessionId)
         }
       }
 
@@ -142,7 +142,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         })
 
         if (sessionId === activeSessionIdRef.current) {
-          requestScrollToBottom()
+          requestScrollToBottom(sessionId)
         }
       }
 

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -175,6 +175,7 @@ export const Thread = memo(function Thread({
           components={messageComponents}
           emptyPlaceholder={emptyPlaceholder}
           loadingIndicator={loadingIndicator}
+          sessionId={sessionId}
           sessionKey={sessionKey}
         />
         {loading === 'session' && <CenteredThreadSpinner />}

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -186,6 +186,7 @@ interface ThreadMessageListProps {
   components: ThreadMessageComponents
   emptyPlaceholder?: ReactNode
   loadingIndicator?: ReactNode
+  sessionId?: string | null
   sessionKey?: string | null
 }
 
@@ -375,6 +376,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   components,
   emptyPlaceholder,
   loadingIndicator,
+  sessionId = null,
   sessionKey
 }) => {
   // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)
@@ -579,7 +581,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   useEffect(() => () => resetThreadScroll(), [])
 
   // Floating jump button (outside this subtree) → return to the bottom.
-  useEffect(() => onScrollToBottomRequest(() => void scrollToBottom()), [scrollToBottom])
+  useEffect(() => onScrollToBottomRequest(() => void scrollToBottom(), sessionId), [scrollToBottom, sessionId])
 
   // Waking from display: hidden (HUD mode hides the main window; OS hide does
   // the same to any window): rAF and ResizeObserver may have been frozen, so

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -31,15 +31,23 @@ export const resetThreadScroll = () => setThreadAtBottom(true)
 // Cross-component bridge: the jump button lives by the composer, the viewport's
 // `scrollToBottom` lives inside the thread. The bridge registers a handler; the
 // button fires it. Mirrors the composer focus/insert emitter pattern.
-const handlers = new Set<() => void>()
+const handlers = new Map<string | null, Set<() => void>>()
 
-export const onScrollToBottomRequest = (handler: () => void) => {
-  handlers.add(handler)
+export const onScrollToBottomRequest = (handler: () => void, sessionId: string | null = null) => {
+  const scopedHandlers = handlers.get(sessionId) ?? new Set<() => void>()
+  scopedHandlers.add(handler)
+  handlers.set(sessionId, scopedHandlers)
 
-  return () => void handlers.delete(handler)
+  return () => {
+    scopedHandlers.delete(handler)
+
+    if (scopedHandlers.size === 0) {
+      handlers.delete(sessionId)
+    }
+  }
 }
 
-export const requestScrollToBottom = () => handlers.forEach(handler => handler())
+export const requestScrollToBottom = (sessionId: string | null = null) => handlers.get(sessionId)?.forEach(handler => handler())
 
 // Inline edit grows a sticky human bubble. Fire on pointerdown so the viewport
 // escapes stick-to-bottom before focus/layout; close clears the edit flag when


### PR DESCRIPTION
## Summary
- scope jump-to-bottom requests to the originating session instead of broadcasting to every mounted transcript
- prevent hidden kept-alive panes from stealing composer focus on remount or runtime rebind
- add regressions for cross-session scroll routing and hidden-pane autofocus

## Verification
- npm run typecheck --workspace apps/desktop
- targeted Vitest: 26 tests passed