### PR TITLE
feat(browser): add browser.real_profile_headed toggle to hide the real-profile window

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -619,6 +619,13 @@ DEFAULT_CONFIG = {
         # naming a directory that doesn't exist FAILS CLOSED with a fixable
         # message rather than falling back to last-used.
         "real_profile_pin": "",
+        # Whether the real-profile browser opens a visible window. Default
+        # True preserves today's behavior (a real window, so a real login
+        # session is usable interactively). Set False to run it hidden —
+        # mirrors "headed" above, but scoped to the real-profile launch path
+        # since that one drives the user's actual logins rather than a
+        # throwaway profile.
+        "real_profile_headed": True,
         "allow_unsafe_evaluate": False,  # Legacy override: when true, browser_console(expression=...) bypasses the restrict_evaluate denylist entirely
         "restrict_evaluate": False,  # Opt-in denylist blocking sensitive JS primitives (cookies/storage/clipboard/network/form values) in browser_console(expression=...)
         # CDP supervisor — dialog + frame detection via a persistent WebSocket.

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -361,6 +361,20 @@ class TestRealProfileCdpLaunch:
         assert "--headless=new" not in captured["argv"]
         self._reset()
 
+    def test_headed_string_false_is_hidden(self):
+        """A string "false" (e.g. from a generated/migrated config) must not
+        be treated as Python's truthy non-empty string."""
+        import tools.browser_tool as bt
+        with patch("hermes_cli.config.read_raw_config",
+                   return_value={"browser": {"real_profile_headed": "false"}}):
+            assert bt._real_profile_headed() is False
+
+    def test_headed_string_true_stays_headed(self):
+        import tools.browser_tool as bt
+        with patch("hermes_cli.config.read_raw_config",
+                   return_value={"browser": {"real_profile_headed": "true"}}):
+            assert bt._real_profile_headed() is True
+
     def test_reuses_only_session_on_our_copy_dir(self, tmp_path):
         """A live session on a DIFFERENT dir (stale/throwaway) is closed, not reused."""
         import tools.browser_tool as bt

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -290,6 +290,77 @@ class TestRealProfileCdpLaunch:
         assert "--cdp" in captured["argv"]
         self._reset()
 
+    def test_hidden_mode_launches_chrome_headless(self, tmp_path):
+        """browser.real_profile_headed: false hides the real-profile window.
+
+        Unlike test_launch_never_passes_headless (which checks the
+        agent-browser ATTACH argv), this checks the argv Popen'd for the
+        real Chrome binary itself — that is where a visible window would
+        come from.
+        """
+        import tools.browser_tool as bt
+        self._reset()
+        proc = Mock(return_value=None, returncode=0, stdout="", stderr="")
+        captured = {}
+
+        class FakeChrome:
+            def poll(self):
+                return None
+
+        def fake_popen(argv, **kw):
+            captured["argv"] = argv
+            (tmp_path / "DevToolsActivePort").write_text("41000\n/devtools/browser/x\n")
+            return FakeChrome()
+
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch.object(bt, "_real_profile_headed", return_value=False), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(str(tmp_path), None)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
+             patch.object(bt, "_agent_browser_get_cdp",
+                          side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", return_value=proc), \
+             patch("sys.platform", "darwin"):
+            cdp, err = bt._real_profile_cdp()
+        assert err is None
+        assert cdp == "http://127.0.0.1:41000"
+        assert "--headless=new" in captured["argv"]
+        self._reset()
+
+    def test_headed_default_keeps_chrome_visible(self, tmp_path):
+        """Without the opt-out, the real-profile Chrome launch stays visible."""
+        import tools.browser_tool as bt
+        self._reset()
+        proc = Mock(return_value=None, returncode=0, stdout="", stderr="")
+        captured = {}
+
+        class FakeChrome:
+            def poll(self):
+                return None
+
+        def fake_popen(argv, **kw):
+            captured["argv"] = argv
+            (tmp_path / "DevToolsActivePort").write_text("41000\n/devtools/browser/x\n")
+            return FakeChrome()
+
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch.object(bt, "_real_profile_headed", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(str(tmp_path), None)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
+             patch.object(bt, "_agent_browser_get_cdp",
+                          side_effect=[None, "http://127.0.0.1:41000"]), \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", return_value=proc), \
+             patch("sys.platform", "darwin"):
+            cdp, err = bt._real_profile_cdp()
+        assert err is None
+        assert "--headless=new" not in captured["argv"]
+        self._reset()
+
     def test_reuses_only_session_on_our_copy_dir(self, tmp_path):
         """A live session on a DIFFERENT dir (stale/throwaway) is closed, not reused."""
         import tools.browser_tool as bt

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1456,14 +1456,17 @@ def _real_profile_headed() -> bool:
 
     Reads ``browser.real_profile_headed`` (default True, preserving today's
     visible-by-design behavior) on EVERY call, mirroring ``_use_real_profile``
-    so flipping it takes effect on the next launch without a restart.
+    so flipping it takes effect on the next launch without a restart. Uses
+    ``is_truthy_value`` so a string ``"false"`` (e.g. from a generated or
+    migrated config) is treated as off rather than as Python's truthy
+    non-empty string.
     """
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
         browser_cfg = cfg.get("browser", {})
         if isinstance(browser_cfg, dict):
-            return bool(browser_cfg.get("real_profile_headed", True))
+            return is_truthy_value(browser_cfg.get("real_profile_headed", True), default=True)
     except Exception as e:
         logger.debug("Could not read browser.real_profile_headed from config: %s", e)
     return True

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1451,6 +1451,24 @@ def _use_real_profile() -> bool:
 # local browsing attaches to this one agent-browser session so concurrent
 # tasks reuse the same copy-browser instead of each launching a rival Chromium
 # on the same copied user-data-dir.
+def _real_profile_headed() -> bool:
+    """Whether the real-profile browser should open a visible window.
+
+    Reads ``browser.real_profile_headed`` (default True, preserving today's
+    visible-by-design behavior) on EVERY call, mirroring ``_use_real_profile``
+    so flipping it takes effect on the next launch without a restart.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {})
+        if isinstance(browser_cfg, dict):
+            return bool(browser_cfg.get("real_profile_headed", True))
+    except Exception as e:
+        logger.debug("Could not read browser.real_profile_headed from config: %s", e)
+    return True
+
+
 _REAL_PROFILE_SESSION = "hermes-real-profile"
 _real_profile_cdp_lock = threading.Lock()
 _real_profile_cdp_cache: dict = {}
@@ -1714,12 +1732,15 @@ def _real_profile_cdp() -> tuple:
             "--disable-features=Translate",
             "--no-startup-window",
         ]
-        if sys.platform.startswith("linux") and not (
-            os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+        if not _real_profile_headed() or (
+            sys.platform.startswith("linux") and not (
+                os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")
+            )
         ):
-            # Display-less Linux (servers, CI): the real binary cannot open a
-            # window, so it exits at startup. Chrome's NEW headless mode shares
-            # the profile's normal cookie store (unlike legacy --headless with
+            # Either the user opted into a hidden window (browser.real_profile_headed:
+            # false) or this is display-less Linux (servers, CI), where the real binary
+            # cannot open a window and exits at startup either way. Chrome's NEW headless
+            # mode shares the profile's normal cookie store (unlike legacy --headless with
             # its separate store), so real-profile auth still loads.
             chrome_argv.append("--headless=new")
         try:

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -213,7 +213,8 @@ browser:
   real_profile_headed: false
 ```
 
-When you turn the toggle back off, Hermes deletes the snapshot store
+Turning `real_profile_headed` back on or off does not touch the copied
+profile — only turning `use_real_profile` back off deletes the snapshot store
 (`~/.hermes/browser-profile/`) on the next browser use, so the copied
 credentials don't linger after you revoke consent.
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -201,6 +201,18 @@ browser:
 A pin naming a profile directory that doesn't exist fails closed with a
 fixable message — it never silently falls back to the last-used profile.
 
+The real-profile browser opens a visible window by default, since it's driving
+your actual login session. To run it hidden instead — so the agent can browse
+with your real logins in the background without interrupting your screen —
+turn off `real_profile_headed`:
+
+```yaml
+# ~/.hermes/config.yaml
+browser:
+  use_real_profile: true
+  real_profile_headed: false
+```
+
 When you turn the toggle back off, Hermes deletes the snapshot store
 (`~/.hermes/browser-profile/`) on the next browser use, so the copied
 credentials don't linger after you revoke consent.


### PR DESCRIPTION
## Summary

Closes #98311.

`browser.use_real_profile` drives the user's real logged-in browser profile, but the launch always opens a **visible window that steals focus**, with no way to run it in the background. This adds a config toggle to hide it.

## Root cause

`tools/browser_tool.py::_real_profile_cdp()` launches the real Chrome/Edge/Brave/Chromium binary on a snapshot of the user's profile with `--no-startup-window`, then has agent-browser attach and run `open about:blank` over CDP. That `open` call is what actually creates the visible page/window — `--no-startup-window` only suppresses the window Chrome would otherwise open *before* that attach step. There was no equivalent of the built-in headless browser's `browser.headed` for this path, so the real-profile browser could never run hidden even though `--headless=new` was already used (and known to work, per an existing comment) for display-less Linux hosts.

## Fix

- `hermes_cli/config_defaults.py`: add `browser.real_profile_headed` (default `True`, preserving current visible-by-design behavior).
- `tools/browser_tool.py`: add `_real_profile_headed()` (mirrors the existing `_use_real_profile()` — reads the config on every call, no restart needed) and fold it into the existing headless-launch condition, so `browser.real_profile_headed: false` passes `--headless=new` to the real Chrome launch. This is the same flag already used for display-less Linux; the existing comment already establishes that Chrome's *new* headless mode (unlike legacy `--headless`) shares the profile's normal cookie store, so real-profile auth keeps loading.
- `website/docs/user-guide/features/browser.md`: document the new toggle next to the existing real-profile-browsing docs.

This is the "config toggle... mirroring the existing `browser.headed`" shape suggested in the issue. It does not add a Windows `SW_HIDE`/`STARTUPINFO` flag (the other shape mentioned) — `--headless=new` prevents a window from being created at all on every platform, which covers the reported problem without extra platform-specific code.

## Test plan

Added two tests to `tests/tools/test_browser_real_profile.py`:
- `test_hidden_mode_launches_chrome_headless` — with `browser.real_profile_headed` mocked to `False`, asserts `--headless=new` is present in the argv used to launch the real Chrome binary.
- `test_headed_default_keeps_chrome_visible` — with the toggle mocked to `True` (the default), asserts `--headless=new` is absent, so existing visible behavior is unchanged.

Verified both fail without the fix (reverted just the two source files with the tests still in place):

```
$ git stash push -- tools/browser_tool.py hermes_cli/config_defaults.py
$ scripts/run_tests.sh tests/tools/test_browser_real_profile.py -k "test_hidden_mode_launches_chrome_headless or test_headed_default_keeps_chrome_visible" -q
...
E   AttributeError: <module 'tools.browser_tool' ...> does not have the attribute '_real_profile_headed'
2 failed, 77 deselected
$ git stash pop
```

With the fix restored, the full file and related suites pass:

```
$ scripts/run_tests.sh tests/tools/test_browser_real_profile.py -q
=== Summary: 1 files, 79 tests passed, 0 failed (100% complete) in 5.1s (8 workers) ===

$ scripts/run_tests.sh tests/tools/test_browser_*.py tests/hermes_cli/test_config.py -q
=== Summary: 45 files, 722 tests passed, 0 failed, 4 skipped (100% complete) in 54.6s (8 workers) ===

$ scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k schema -q
=== Summary: 1 files, 12 tests passed, 0 failed (100% complete) in 3.0s (8 workers) ===

$ uv run ruff check tools/browser_tool.py hermes_cli/config_defaults.py tests/tools/test_browser_real_profile.py
All checks passed!
```

## Platforms tested

Linux (GitHub-hosted runner), Python 3.11 (repo venv). No platform-specific code paths added — the fix is a single extra `--headless=new` on the existing Chrome launch, gated by the new config flag instead of only by "no display detected".

## AI assistance disclosure

This PR was written with AI assistance (Claude/Claude Code), with the diff reviewed and all listed tests run and verified before pushing.
