### PR TITLE
fix(desktop): send platform-native select-all in drive_preview type

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-act.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-act.test.ts
@@ -158,11 +158,32 @@ describe('actOnActivePreview (drive_preview tool)', () => {
     // paragraph under the cursor whenever the target turns out not to be a
     // field, and the agent was leaving pages with their body text highlighted.
     expect(events.filter(event => event.type === 'mouseDown').map(event => event.clickCount)).toEqual([1])
-    expect(events.filter(event => event.type === 'keyDown' && event.keyCode === 'a')[0]).toMatchObject({
-      modifiers: ['control', 'meta']
-    })
+    const selectAll = events.filter(event => event.type === 'keyDown' && event.keyCode === 'a')[0]
+    expect(selectAll.modifiers).toHaveLength(1)
+    expect(['control', 'meta']).toContain(selectAll.modifiers[0])
     // The chord must not send a `char` phase, or select-all types a literal 'a'.
     expect(chars).toEqual(['h', 'i', 'Enter'])
+  })
+
+  it('sends Command+A on macOS and Control+A elsewhere for select-all', async () => {
+    const pin = (platform: string, userAgent: string) => {
+      Object.defineProperty(window.navigator, 'platform', { configurable: true, value: platform })
+      Object.defineProperty(window.navigator, 'userAgent', { configurable: true, value: userAgent })
+    }
+
+    pin('MacIntel', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    const mac = withDrivenPane()
+    await actOnActivePreview({ kind: 'type', ref: '@e1', text: 'x' })
+    expect(
+      mac.mock.calls.map(([event]) => event).find(event => event.type === 'keyDown' && event.keyCode === 'a')
+    ).toMatchObject({ modifiers: ['meta'] })
+
+    pin('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    const win = withDrivenPane()
+    await actOnActivePreview({ kind: 'type', ref: '@e1', text: 'x' })
+    expect(
+      win.mock.calls.map(([event]) => event).find(event => event.type === 'keyDown' && event.keyCode === 'a')
+    ).toMatchObject({ modifiers: ['control'] })
   })
 
   it('hovers by walking the pointer over and leaving it there', async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-drive.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-drive.ts
@@ -14,6 +14,8 @@
  * steps over ~280ms is what Playwright's action cursor settles on too.
  */
 
+import { isMacPlatform } from '@/lib/platform'
+
 import type { PreviewInputHandle } from './preview-input'
 
 export interface DrivePoint {
@@ -116,6 +118,16 @@ export async function pressKey(input: PreviewInputHandle, key: string): Promise<
   await wait(KEY_MS)
 }
 
+/** Native select-all modifier for Electron `sendInputEvent`.
+ *
+ *  Sending both `control` and `meta` at once is Control+Command+A on macOS
+ *  and Ctrl+Win+A on Windows — neither is the OS select-all chord, so the
+ *  field is not cleared and `drive_preview` type appends instead of replacing.
+ */
+export function selectAllModifiers(): string[] {
+  return isMacPlatform() ? ['meta'] : ['control']
+}
+
 /** Select-all inside whatever has focus, which for a focused field is that
  *  field's own text and nothing else. This replaced a triple-click: a triple
  *  click is a POINTER gesture, so it selects whatever paragraph sits under the
@@ -123,7 +135,7 @@ export async function pressKey(input: PreviewInputHandle, key: string): Promise<
  *  leaving pages with their body text highlighted. There is no `char` phase —
  *  a chord is not text entry, and sending one types a literal 'a'. */
 export async function selectAll(input: PreviewInputHandle): Promise<void> {
-  const chord = ['control', 'meta']
+  const chord = selectAllModifiers()
 
   input.send({ keyCode: 'a', modifiers: chord, type: 'keyDown' })
   input.send({ keyCode: 'a', modifiers: chord, type: 'keyUp' })


### PR DESCRIPTION
## What does this PR do?

`drive_preview` `type` clears the target field with a keyboard select-all, then types. That chord was `['control', 'meta']` on every OS.

Electron `sendInputEvent` treats that as both modifiers held at once: Control+Command+A on macOS, Ctrl+Win+A on Windows. Native select-all does not fire, the field is not cleared, and typed text appends. The tool still reports success.

This sends Command+A (`meta`) on macOS and Control+A (`control`) everywhere else, using the existing `isMacPlatform()` helper.

## Related Issue

Fixes #98324

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/right-rail/preview-drive.ts` — `selectAllModifiers()` returns one platform-correct modifier
- `apps/desktop/src/app/chat/right-rail/preview-act.test.ts` — stops pinning the broken dual-modifier chord; adds Mac vs Win assertions

## How to Test

1. `npx vitest run --project ui src/app/chat/right-rail/preview-act.test.ts` (17 passed locally)
2. On macOS Desktop: open a preview page with a prefilled input, `drive_preview type` with new text, confirm the value is replaced not appended

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (none on this chord)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 Apple Silicon

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform: macOS uses meta, Windows/Linux use control
- [x] Tool descriptions — N/A
