### PR TITLE
fix(todo): unversioned tool.start merges again after desktop resume (#98304, salvage #98306)

### DIFF
--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -134,4 +134,22 @@ describe('revisioned snapshots', () => {
     restoreSessionTodosFromSnapshot('s1', snapshot, true)
     expect($todosBySession.get().s1?.[0]?.id).toBe('active')
   })
+
+  it('applies an unversioned update after a revisioned snapshot (tool.start merge)', () => {
+    setSessionTodos('s1', [todo('a', 'pending'), todo('b', 'pending')], 5)
+    setSessionTodos('s1', [todo('a', 'completed'), todo('b', 'pending')])
+
+    expect($todosBySession.get().s1?.[0]?.status).toBe('completed')
+    expect($todoRevisionsBySession.get().s1).toBe(5)
+  })
+
+  it('does not stamp a watermark from an unused empty snapshot', () => {
+    restoreSessionTodosFromSnapshot('s1', { revision: 0, todos: [] }, true)
+
+    expect($todosBySession.get().s1).toBeUndefined()
+    expect($todoRevisionsBySession.get().s1).toBeUndefined()
+
+    setSessionTodos('s1', [todo('a', 'in_progress')])
+    expect($todosBySession.get().s1?.[0]?.id).toBe('a')
+  })
 })

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -74,8 +74,10 @@ function acceptRevision(sid: string, revision?: null | number): boolean {
   const revisions = $todoRevisionsBySession.get()
   const current = revisions[sid]
 
+  // tool.start has no revision. Apply the merge locally and leave the
+  // watermark alone so a later todo.updated / tool.complete can still win.
   if (revision == null) {
-    return current == null
+    return true
   }
 
   if (current != null && revision < current) {
@@ -156,6 +158,14 @@ export function restoreSessionTodosFromSnapshot(sid: string, snapshot: unknown, 
   }
 
   const revision = parseTodoRevision(snapshot)
+
+  // An unused store serializes as {todos: [], revision: 0}. That is not a
+  // real snapshot. Applying it would stamp watermark 0 and leave an empty
+  // list in the map.
+  if (todos.length === 0 && (revision == null || revision === 0)) {
+    return
+  }
+
   const visible = running ? todos : todosForHydration(todos)
 
   if (visible !== null) {

--- a/tests/tui_gateway/test_todo_state_events.py
+++ b/tests/tui_gateway/test_todo_state_events.py
@@ -78,3 +78,23 @@ def test_live_snapshot_prefers_the_highest_revision():
     payload = server._attach_todo_state({}, session)
 
     assert payload["todo_state"]["revision"] == 5
+
+
+def test_unused_store_is_not_attached():
+    class Store:
+        @staticmethod
+        def snapshot():
+            return {"todos": [], "revision": 0}
+
+    class Agent:
+        _todo_store = Store()
+
+    payload = server._attach_todo_state({}, {"agent": Agent()})
+
+    assert "todo_state" not in payload
+
+
+def test_empty_list_at_nonzero_revision_is_a_real_clear():
+    state = server._normalize_todo_state({"todos": [], "revision": 2})
+
+    assert state == {"todos": [], "revision": 2}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7645,7 +7645,13 @@ def _normalize_todo_state(value: object) -> dict | None:
         revision = max(0, int(value.get("revision") or 0))
     except (TypeError, ValueError):
         return None
-    return {"todos": list(value["todos"]), "revision": revision}
+    todos = list(value["todos"])
+    # Unused TodoStore snapshot() is {todos: [], revision: 0}. Attaching
+    # that on resume stamps a client watermark and blocks unversioned
+    # tool.start merges. An empty list at revision >= 1 is a real clear.
+    if not todos and revision == 0:
+        return None
+    return {"todos": todos, "revision": revision}
 
 
 def _session_todo_state(session: dict) -> dict | None:


### PR DESCRIPTION
## Summary

`merge: true` todo `tool.start` patches apply again after a desktop resume/reconnect — the regression #98248 introduced against the #97811 behavior it salvaged.

Root cause: resume/activate attaches the agent's TodoStore snapshot, and an unused store serializes as `{todos: [], revision: 0}`. The desktop treated that as a real revision and stamped a per-session watermark; unversioned updates (which is what `tool.start` merge patches are) were then rejected forever, so the panel froze until `tool.complete`.

Salvage of #98306 by @Adolanium (commit preserved with authorship). Fixes #98304.

## Changes

- `tui_gateway/server.py`: `_normalize_todo_state` returns None for the unused `{todos: [], revision: 0}` placeholder, so resume never attaches it; an empty list at revision >= 1 is still a real clear
- `apps/desktop/src/store/todos.ts`: unversioned `setSessionTodos` applies without moving the watermark (a later `todo.updated` still wins); restore ignores unused empty snapshots
- Regression tests in `todos.test.ts` + `test_todo_state_events.py`

## Validation

| Check | Result |
|---|---|
| Sabotage run (fix reverted to main's code) | 2 vitest + 1 pytest new tests FAIL as expected |
| `apps/desktop` vitest `todos.test.ts` + `todo-cleanup.test.tsx` | 17/17 pass |
| `tests/tui_gateway/test_todo_state_events.py` | 5/5 pass |
| `tsc --noEmit` | clean |
| `scripts/audit_pr_attribution.py --fix` | all emails mapped |

## Credits

- @Adolanium — #98306: full fix + regression tests (cherry-picked, authorship preserved)

## Infographic

![Unversioned tool.start merges again after resume](https://v3b.fal.media/files/b/0aa85d68/am1L-3AcGp8MmbPjnNphH_KhfrY9XU.png)
