### PR TITLE
fix(display): skip \r spinner animation when print_fn is set

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1220,6 +1220,21 @@ class KawaiiSpinner:
                 time.sleep(0.5)
             return
 
+        # When a print_fn is configured, the \r-based animation must not run:
+        #   * CLI routes output through _cprint (cli_agent_setup_mixin.py)
+        #     → prompt_toolkit print_formatted_text, which appends a newline
+        #     per call — so every frame would land on its own line and flood
+        #     the terminal, regardless of frame width.
+        #   * The CLI TUI already renders spinner state via a dedicated
+        #     widget (_spinner_text → _render_spinner_text → get_spinner_text),
+        #     so a \r animation here would also fight the widget for the same
+        #     status line (visual flicker on Windows conhost).
+        # Same rationale as the StdoutProxy branch below.
+        if self._print_fn is not None:
+            while self.running:
+                time.sleep(0.1)
+            return
+
         # When running inside prompt_toolkit's patch_stdout context the CLI
         # renders spinner state via a dedicated TUI widget (_spinner_text).
         # Driving a \r-based animation here too causes visual overdraw: the
@@ -1286,9 +1301,12 @@ class KawaiiSpinner:
             self.thread.join(timeout=0.5)
 
         is_tty = self._is_tty
-        if is_tty:
+        if is_tty and self._print_fn is None:
             # Clear the spinner line with spaces instead of \033[K to avoid
             # garbled escape codes when prompt_toolkit's patch_stdout is active.
+            # Skip when a print_fn is configured: the animation never drew a
+            # \r line to clear (see _animate), and the blanks would otherwise
+            # be emitted through print_fn as a stray line of spaces.
             blanks = ' ' * max(self.last_line_len + 5, 40)
             self._write(f"\r{blanks}\r", end='', flush=True)
         if final_message:

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -314,3 +314,60 @@ class TestBuildStatusPhrase:
             assert build_status_phrase("terminal", {"command": "ls"}) is None
         finally:
             set_friendly_tool_labels(True)
+
+
+def test_kawaii_spinner_skips_animation_when_print_fn_set(monkeypatch):
+    """When a print_fn is configured, _animate() must not run \r-based
+    animation — the CLI routes through _cprint which appends a newline per
+    frame (flood), and the TUI widget already drives spinner display. The
+    print_fn should receive only the start-of-task message (if any) and an
+    optional final completion line, not per-frame \r output."""
+    from agent.display import KawaiiSpinner
+    import time
+
+    calls = []
+
+    class FakeTty:
+        def isatty(self):
+            return True
+        def write(self, *a):
+            pass
+        def flush(self):
+            pass
+
+    spinner = KawaiiSpinner("test task", print_fn=lambda t: calls.append(t))
+    spinner._out = FakeTty()
+    spinner.start()
+    time.sleep(0.5)  # enough for several animation frames
+    spinner.stop(final_message="done")
+
+    # None of the calls should be \r-prefixed animation frames
+    for c in calls:
+        assert not c.startswith("\r"), f"print_fn received \r-animated frame: {c!r}"
+    # The final completion message should be present
+    assert any("done" in c for c in calls), "final completion message not through print_fn"
+
+
+def test_kawaii_spinner_animate_runs_when_no_print_fn(monkeypatch):
+    """Without print_fn, the \r animation runs normally on a tty."""
+    from agent.display import KawaiiSpinner
+    import time
+
+    writes = []
+
+    class FakeTty:
+        def isatty(self):
+            return True
+        def write(self, text, *a):
+            writes.append(text)
+        def flush(self):
+            pass
+
+    spinner = KawaiiSpinner("test task")
+    spinner._out = FakeTty()
+    spinner.start()
+    time.sleep(0.5)
+    spinner.stop()
+
+    # Should have seen \r-prefixed animation frames
+    assert any(w.startswith("\r") for w in writes), "no \r animation frames on tty without print_fn"


### PR DESCRIPTION
Fixes the two residual paths in #93999 that #94005 does not cover.

## Problem

`KawaiiSpinner._animate()` runs a `\r`-based animation in all cases. When a `print_fn` is configured:

1. **Flood** — `_write()` routes through `print_fn` → `_cprint` (cli_agent_setup_mixin.py:558) → prompt_toolkit `print_formatted_text`, which appends a newline per call. Every spinner frame lands on its own terminal line, flooding the scrollback — independent of frame width, so #94005's width clamp does not help.
2. **Flicker** — the CLI TUI already drives spinner display via `_render_spinner_text()` → `get_spinner_text` widget + `app.invalidate()` (cli.py:19812). A concurrent `\r` animation fights the widget for the status line → visual flicker on Windows conhost.

`stop()` is also guarded: when `print_fn` is set there is no animation line to clear, and routing `\r{blanks}\r` through `print_fn` would emit a stray line of spaces.

## Fix

`_animate()` returns early (sleep loop) when `self._print_fn is not None`, same rationale as the existing StdoutProxy branch. `stop()` skips the `\r` clear when `print_fn` is set. The completion message still flows through `print_fn`.

## Tests

- `test_kawaii_spinner_skips_animation_when_print_fn_set`: print_fn receives no `\r`-prefixed frames; completion message still delivered.
- `test_kawaii_spinner_animate_runs_when_no_print_fn`: without print_fn, `\r` animation still runs on a tty.

`pytest tests/agent/test_display.py` → 25 passed. ruff clean.

Complementary to #94005 (references the same issue, different code path).