### PR TITLE
fix(discord): restore auto-threading for threaded free-response lanes

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1251,6 +1251,7 @@ platform_toolsets:
 #   require_mention: true            # Require @mention in server channels (default: true)
 #   auto_thread: true                # Auto-create thread on @mention (default: true)
 #   free_response_channels: ""       # Channel IDs where no mention is needed
+#   threaded_free_response_channels: []  # Mention-free lanes that still auto-thread
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)

--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -693,6 +693,7 @@ driven by the managed Portal / `hermes` CLI.
 
 The relevance layer (§7.1) is the per-tenant parity for the gateway's own
 behaviour knobs (`require_mention`, `free_response_channels`,
+`threaded_free_response_channels`,
 `{PLATFORM}_ALLOW_BOTS`). So the **same** behaviour governs relay delivery, the
 gateway projects those knobs into a **platform-agnostic** policy and POSTs it to
 `POST /relay/policy` at boot (after its per-gateway secret is resolved).
@@ -703,7 +704,7 @@ Body (`gateway/relay/__init__.py` `relay_relevance_policy()` → `send_relay_pol
 | --- | --- | --- | --- |
 | `platform` | string | the fronted platform (`relay_platform_identity`) | which platform this policy applies to. |
 | `requireAddress` | bool | `require_mention` | a non-owner message must @mention / reply-to the bot to be relevant. |
-| `freeResponseScopes` | string[] | `free_response_channels` | scope (channel) ids where `requireAddress` is waived. Same scope vocabulary as §7.1's scope grants. |
+| `freeResponseScopes` | string[] | `free_response_channels` ∪ `threaded_free_response_channels` (with `{PLATFORM}_*` env compatibility fallback) | scope (channel) ids where `requireAddress` is waived. Same scope vocabulary as §7.1's scope grants. |
 | `allowOtherBots` | bool | `{PLATFORM}_ALLOW_BOTS ∈ {mentions, all}` | admit bot-authored messages (default off). |
 
 Auth is the per-gateway upgrade token (§6.1), so the connector attaches the

--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -349,6 +349,19 @@ def _policy_url(relay_dial_url: str) -> str:
     return f"{raw}/relay/policy"
 
 
+def _normalize_relay_scopes(raw: object) -> list[str]:
+    """Normalize one configured relay-scope value without losing scalars."""
+    if raw is None:
+        return []
+    values = raw if isinstance(raw, (list, tuple)) else str(raw).split(",")
+    normalized: list[str] = []
+    for value in values:
+        scope = str(value).strip()
+        if scope and scope not in normalized:
+            normalized.append(scope)
+    return normalized
+
+
 def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
     """Project a fronted platform's RELEVANCE config into the connector's generic vocabulary.
 
@@ -363,16 +376,18 @@ def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
     Mapping (the connector vocabulary ← the gateway's existing config):
       - ``requireAddress``     ← the platform's ``require_mention`` (the agent
         only engages a non-owner message that @mentions it / replies to it).
-      - ``freeResponseScopes`` ← the platform's ``free_response_channels`` (the
-        channel/scope ids where ``require_mention`` is waived — same scope
-        vocabulary the connector's δ scope grants + ε floor use).
+      - ``freeResponseScopes`` ← the union of the platform's
+        ``free_response_channels`` and ``threaded_free_response_channels``
+        (the channel/scope ids where ``require_mention`` is waived — same
+        scope vocabulary the connector's δ scope grants + ε floor use).
       - ``allowOtherBots``     ← ``{PLATFORM}_ALLOW_BOTS`` in {"mentions","all"}
         (whether bot-authored messages are admitted; default off).
 
     Read from the relay platform's config block (the platform the connector
     fronts, e.g. ``discord:``), falling back to the bridged top-level keys, then
-    the ``{PLATFORM}_*`` env. ``platform`` defaults to the PRIMARY fronted
-    platform (back-compat). Returns the generic dict, or None when relay isn't
+    the ``{PLATFORM}_*`` env when neither YAML location declares the key.
+    ``platform`` defaults to the PRIMARY fronted platform (back-compat).
+    Returns the generic dict, or None when relay isn't
     configured or the platform exposes no relevance knobs (⇒ the connector's
     default — mention-gated — applies unchallenged; an EXPLICIT
     ``require_mention: false`` IS a knob and is declared so the connector
@@ -406,13 +421,20 @@ def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
         elif cfg.get("require_mention") is not None:
             require_mention = cfg.get("require_mention")
 
-        frc = plat_cfg.get("free_response_channels")
-        if frc is None:
-            frc = cfg.get("free_response_channels")
-        if isinstance(frc, (list, tuple)):
-            free_response = [str(c).strip() for c in frc if str(c).strip()]
-        elif isinstance(frc, str) and frc.strip():
-            free_response = [c.strip() for c in frc.split(",") if c.strip()]
+        for config_key in (
+            "free_response_channels",
+            "threaded_free_response_channels",
+        ):
+            if config_key in plat_cfg:
+                configured_scopes = plat_cfg.get(config_key)
+            elif config_key in cfg:
+                configured_scopes = cfg.get(config_key)
+            else:
+                env_key = f"{platform.upper()}_{config_key.upper()}"
+                configured_scopes = os.environ.get(env_key)
+            for scope in _normalize_relay_scopes(configured_scopes):
+                if scope not in free_response:
+                    free_response.append(scope)
     except Exception:  # noqa: BLE001 - config absence/parse must never crash boot
         pass
 
@@ -431,7 +453,7 @@ def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
     if require_mention is None and not free_response and not allow_other_bots:
         return None
 
-    require_address = bool(require_mention) if require_mention is not None else False
+    require_address = bool(require_mention) if require_mention is not None else True
 
     return {
         "platform": platform,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2383,6 +2383,7 @@ DEFAULT_CONFIG = {
     "discord": {
         "require_mention": True,       # Require @mention to respond in server channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
+        "threaded_free_response_channels": [],  # Mention-free channels that still auto-thread each parent message
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
@@ -2391,7 +2392,7 @@ DEFAULT_CONFIG = {
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
         "missed_message_backfill": {
             "enabled": False,             # Replay missed Discord messages after reconnect/startup
-            "channels": "",               # Comma-separated channel IDs; empty uses free_response_channels
+            "channels": "",               # Comma-separated channel IDs; empty uses allowed/free/threaded-response channels
             "window_seconds": 21600,      # Only inspect messages from the last 6 hours
             "limit": 100,                 # Global cap on messages scanned per reconnect
             "max_dispatches": 10,         # Cap on recovered messages dispatched per reconnect

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -434,6 +434,8 @@ _GATE_ENV_KEYS = (
     "DISCORD_IGNORED_CHANNELS",
     "DISCORD_NO_THREAD_CHANNELS",
     "DISCORD_FREE_RESPONSE_CHANNELS",
+    "DISCORD_THREADED_FREE_RESPONSE_CHANNELS",
+    "DISCORD_AUTO_THREAD",
     "DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS",
     "DISCORD_ALLOW_ALL_USERS",
     "DISCORD_ALLOW_BOTS",
@@ -1623,7 +1625,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 parent_id = None
                 if hasattr(message.channel, "parent_id") and message.channel.parent_id:
                     parent_id = str(message.channel.parent_id)
-                free_channels = self._discord_free_response_channels()
+                free_channels = self._discord_mention_free_channels()
                 channel_keys = self._discord_channel_keys(message, parent_id)
                 if "*" not in free_channels and not (channel_keys & free_channels):
                     return False, False
@@ -2504,14 +2506,18 @@ class DiscordAdapter(BasePlatformAdapter):
         if isinstance(configured, dict) and "channels" in configured:
             raw = configured.get("channels")
             if isinstance(raw, list):
-                return {str(item).strip() for item in raw if str(item).strip()}
+                configured_channels = {
+                    str(item).strip() for item in raw if str(item).strip()
+                }
+                if configured_channels:
+                    return configured_channels
             raw = str(raw or "")
             if raw.strip():
                 return {item.strip() for item in raw.split(",") if item.strip()}
         raw = self._gate_env("DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS")
         if not raw.strip():
             allowed = self._get_allowed_channels()
-            return allowed | self._discord_free_response_channels()
+            return allowed | self._discord_mention_free_channels()
         return {item.strip() for item in raw.split(",") if item.strip()}
 
     def _missed_message_backfill_window_seconds(self) -> float:
@@ -2688,7 +2694,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not isinstance(message.channel, discord.DMChannel):
             parent_id = self._get_parent_channel_id(message.channel)
             channel_keys = self._discord_channel_keys(message, parent_id)
-            free_channels = self._discord_free_response_channels()
+            free_channels = self._discord_mention_free_channels()
             in_bot_thread = (
                 isinstance(message.channel, discord.Thread)
                 and str(message.channel.id) in self._threads
@@ -6737,6 +6743,39 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_threaded_free_response_channels(self) -> set:
+        """Return mention-free channels that should still auto-thread."""
+        return self._gate_csv_set(
+            self._gate_raw(
+                "threaded_free_response_channels",
+                "DISCORD_THREADED_FREE_RESPONSE_CHANNELS",
+            )
+        )
+
+    def _discord_auto_thread_enabled(self) -> bool:
+        """Resolve auto-threading from this adapter's profile configuration.
+
+        ``os.environ`` is shared by every adapter in a multiplex gateway, so
+        the profile-owned ``PlatformConfig.extra`` value must win. The
+        per-adapter gate snapshot preserves the legacy environment fallback
+        for direct/env-only construction without making it cross-profile
+        control state.
+        """
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        raw = extra.get("auto_thread") if isinstance(extra, dict) else None
+        if raw is None:
+            raw = self._gate_env("DISCORD_AUTO_THREAD", "true")
+        if isinstance(raw, bool):
+            return raw
+        return str(raw).strip().lower() in {"true", "1", "yes", "on"}
+
+    def _discord_mention_free_channels(self) -> set:
+        """Return every channel where messages do not require a bot mention."""
+        return (
+            self._discord_free_response_channels()
+            | self._discord_threaded_free_response_channels()
+        )
+
     def _raw_mentioned_user_ids(self, message: Any) -> set:
         """Extract Discord user-mention IDs directly from raw message content.
 
@@ -8088,6 +8127,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Config (all settable via discord.* in config.yaml or DISCORD_* env vars):
         #   discord.require_mention: Require @mention in server channels (default: true)
         #   discord.free_response_channels: Channel IDs where bot responds without mention
+        #   discord.threaded_free_response_channels: Mention-free channels that still auto-thread
         #   discord.ignored_channels: Channel IDs where bot NEVER responds (even when mentioned)
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
@@ -8101,6 +8141,7 @@ class DiscordAdapter(BasePlatformAdapter):
             parent_channel_id = self._get_parent_channel_id(message.channel)
 
         is_voice_linked_channel = False
+        is_threaded_free_channel = False
 
         # Save mention-stripped text before auto-threading since create_thread()
         # can clobber message.content, breaking /command detection in channels.
@@ -8143,7 +8184,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_keys)
                 return False
 
-            free_channels = self._discord_free_response_channels()
+            free_channels = self._discord_mention_free_channels()
+            threaded_free_channels = self._discord_threaded_free_response_channels()
 
             require_mention = self._discord_require_mention()
             # Voice-linked text channels act as free-response while voice is active.
@@ -8151,6 +8193,10 @@ class DiscordAdapter(BasePlatformAdapter):
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
             current_channel_id = str(message.channel.id)
             is_voice_linked_channel = current_channel_id in voice_linked_ids
+            is_threaded_free_channel = (
+                "*" in threaded_free_channels
+                or bool(channel_keys & threaded_free_channels)
+            )
             is_free_channel = (
                 "*" in free_channels
                 or bool(channel_keys & free_channels)
@@ -8178,8 +8224,12 @@ class DiscordAdapter(BasePlatformAdapter):
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels = self._get_no_thread_channels()
-            skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
+            skip_thread = (
+                bool(channel_keys & no_thread_channels)
+                or is_voice_linked_channel
+                or (is_free_channel and not is_threaded_free_channel)
+            )
+            auto_thread = self._discord_auto_thread_enabled()
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
                 thread = await self._auto_create_thread(message)
@@ -10364,30 +10414,29 @@ def interactive_setup() -> None:
 
 
 def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
-    """Translate ``config.yaml`` ``discord:`` keys into env vars.
+    """Translate ``config.yaml`` ``discord:`` keys into adapter settings.
 
     Implements the ``apply_yaml_config_fn`` contract (#24836).  Mirrors the
     legacy ``discord_cfg`` block that used to live in
     ``gateway/config.py::load_gateway_config()`` before this migration.
 
-    The DiscordAdapter reads its runtime configuration via ``os.getenv()``
-    throughout the connect / handle code paths (``DISCORD_ALLOWED_USERS``,
-    ``DISCORD_REQUIRE_MENTION``, ``DISCORD_FREE_RESPONSE_CHANNELS``,
-    ``DISCORD_AUTO_THREAD``, ``DISCORD_REACTIONS``,
+    Legacy Discord settings still have environment compatibility paths
+    (``DISCORD_ALLOWED_USERS``, ``DISCORD_REQUIRE_MENTION``,
+    ``DISCORD_FREE_RESPONSE_CHANNELS``, ``DISCORD_AUTO_THREAD``,
+    ``DISCORD_REACTIONS``,
     ``DISCORD_IGNORED_CHANNELS``, ``DISCORD_ALLOWED_CHANNELS``,
     ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_HISTORY_BACKFILL``,
     ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_MENTION_*``,
     ``DISCORD_REPLY_TO_MODE``, ``DISCORD_THREAD_REQUIRE_MENTION``,
     ``DISCORD_BOTS_REQUIRE_INLINE_MENTION``).
-    Rather than rewrite ~50 call sites inside the adapter to read from
-    ``PlatformConfig.extra`` instead, this hook keeps the existing
-    env-driven model and merely owns the YAML→env translation here, next to
-    the adapter that consumes it.
+    This hook keeps those bridges next to the adapter that consumes them while
+    seeding profile-sensitive settings into ``PlatformConfig.extra``.
 
-    ``PlatformConfig.extra`` is the per-adapter source of truth for liveness
-    settings, which keeps multiplexed profiles isolated. The legacy env bridge
-    remains only for existing callers that construct adapters without config
-    extras. Returns canonical WebSocket liveness settings to seed that extra.
+    ``PlatformConfig.extra`` is the per-adapter source of truth for
+    profile-sensitive authorization, threading, recovery, and liveness
+    settings. The legacy env bridge remains only for existing callers that
+    construct adapters without config extras. Returns the canonical settings
+    that must be seeded into that profile-owned extra mapping.
     """
     if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
         os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
@@ -10452,8 +10501,22 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         seeded_extra["free_response_channels"] = str(frc)
         if not _skip_env_bridge and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
             os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
-    if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
-        os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+    tfrc = discord_cfg.get("threaded_free_response_channels")
+    if tfrc is not None:
+        if isinstance(tfrc, list):
+            tfrc = ",".join(str(v) for v in tfrc)
+        seeded_extra["threaded_free_response_channels"] = str(tfrc)
+        if (
+            not _skip_env_bridge
+            and not os.getenv("DISCORD_THREADED_FREE_RESPONSE_CHANNELS")
+        ):
+            os.environ["DISCORD_THREADED_FREE_RESPONSE_CHANNELS"] = str(tfrc)
+    if "auto_thread" in discord_cfg:
+        seeded_extra["auto_thread"] = discord_cfg["auto_thread"]
+        if not _skip_env_bridge and not os.getenv("DISCORD_AUTO_THREAD"):
+            os.environ["DISCORD_AUTO_THREAD"] = str(
+                discord_cfg["auto_thread"]
+            ).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
     backfill_cfg = discord_cfg.get("missed_message_backfill")
@@ -10586,11 +10649,12 @@ def register(ctx) -> None:
         setup_fn=interactive_setup,
         # YAML→env config bridge — owns the translation of ``config.yaml``
         # ``discord:`` keys (require_mention, free_response_channels,
+        # threaded_free_response_channels,
         # auto_thread, reactions, ignored_channels, allowed_channels,
         # no_thread_channels, allow_mentions.*, reply_to_mode,
-        # thread_require_mention) into ``DISCORD_*`` env vars that the
-        # adapter reads via ``os.getenv()``.  Replaces the hardcoded block
-        # that used to live in ``gateway/config.py``.  Hook contract: #24836.
+        # thread_require_mention) into profile-owned adapter extras and legacy
+        # ``DISCORD_*`` compatibility env vars. Replaces the hardcoded block
+        # that used to live in ``gateway/config.py``. Hook contract: #24836.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration
         allowed_users_env="DISCORD_ALLOWED_USERS",

--- a/tests/gateway/relay/test_relay_policy_send.py
+++ b/tests/gateway/relay/test_relay_policy_send.py
@@ -26,6 +26,8 @@ def _clean_env(monkeypatch):
         "GATEWAY_RELAY_PLATFORMS",
         "GATEWAY_RELAY_BOT_IDS",
         "DISCORD_ALLOW_BOTS",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_THREADED_FREE_RESPONSE_CHANNELS",
     ):
         monkeypatch.delenv(k, raising=False)
     monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {}, raising=False)
@@ -49,6 +51,81 @@ def test_projection_maps_require_mention_and_free_response(monkeypatch):
         "freeResponseScopes": ["c-support", "c-help"],
         "allowOtherBots": False,
     }
+
+
+def test_projection_unions_threaded_free_response_scopes(monkeypatch):
+    monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "discord": {
+                "require_mention": True,
+                "free_response_channels": ["c-chat", "c-shared"],
+                "threaded_free_response_channels": ["c-intake", "c-shared"],
+            }
+        },
+        raising=False,
+    )
+
+    pol = relay.relay_relevance_policy()
+
+    assert pol is not None
+    assert pol["freeResponseScopes"] == ["c-chat", "c-shared", "c-intake"]
+
+
+def test_threaded_scopes_keep_default_mention_gate(monkeypatch):
+    monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "discord": {
+                "threaded_free_response_channels": ["c-intake"],
+            }
+        },
+        raising=False,
+    )
+
+    pol = relay.relay_relevance_policy()
+
+    assert pol is not None
+    assert pol["requireAddress"] is True
+    assert pol["freeResponseScopes"] == ["c-intake"]
+
+
+def test_projection_uses_env_only_scopes_with_normalization(monkeypatch):
+    monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
+    monkeypatch.setenv(
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        " c-chat, c-shared, c-chat ",
+    )
+    monkeypatch.setenv(
+        "DISCORD_THREADED_FREE_RESPONSE_CHANNELS",
+        "c-intake,c-shared",
+    )
+
+    pol = relay.relay_relevance_policy()
+
+    assert pol is not None
+    assert pol["requireAddress"] is True
+    assert pol["freeResponseScopes"] == ["c-chat", "c-shared", "c-intake"]
+
+
+def test_projection_preserves_scalar_channel_id(monkeypatch):
+    monkeypatch.setenv("GATEWAY_RELAY_PLATFORMS", "discord")
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "discord": {
+                "free_response_channels": 1491973769726791812,
+            }
+        },
+        raising=False,
+    )
+
+    pol = relay.relay_relevance_policy()
+
+    assert pol is not None
+    assert pol["freeResponseScopes"] == ["1491973769726791812"]
 
 
 def test_projection_declares_explicit_require_mention_false(monkeypatch):
@@ -86,7 +163,13 @@ def test_send_posts_projected_policy_with_token(monkeypatch):
     _arm(monkeypatch)
     monkeypatch.setattr(
         "gateway.run._load_gateway_config",
-        lambda: {"discord": {"require_mention": True, "free_response_channels": ["c-support"]}},
+        lambda: {
+            "discord": {
+                "require_mention": True,
+                "free_response_channels": ["c-support"],
+                "threaded_free_response_channels": ["c-intake"],
+            }
+        },
         raising=False,
     )
     captured = {}
@@ -102,7 +185,10 @@ def test_send_posts_projected_policy_with_token(monkeypatch):
     assert captured["policy_url"] == "https://connector.example/relay/policy"
     assert captured["token"]  # a real upgrade token was minted
     assert captured["policy"]["requireAddress"] is True
-    assert captured["policy"]["freeResponseScopes"] == ["c-support"]
+    assert captured["policy"]["freeResponseScopes"] == [
+        "c-support",
+        "c-intake",
+    ]
 
 
 def test_send_skips_when_no_secret(monkeypatch):
@@ -134,5 +220,3 @@ def test_send_fail_soft_on_transport_error(monkeypatch):
     monkeypatch.setattr(relay, "_post_policy", _boom)
     # Never raises; returns False so boot proceeds.
     assert relay.send_relay_policy() is False
-
-

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1,5 +1,6 @@
 """Tests for Discord free-response defaults and mention gating."""
 
+import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -7,7 +8,8 @@ import sys
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
 
 
 def _ensure_discord_mock():
@@ -109,6 +111,7 @@ def adapter(monkeypatch):
         "DISCORD_REQUIRE_MENTION",
         "DISCORD_THREAD_REQUIRE_MENTION",
         "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_THREADED_FREE_RESPONSE_CHANNELS",
         "DISCORD_AUTO_THREAD",
         "DISCORD_NO_THREAD_CHANNELS",
         "DISCORD_ALLOWED_CHANNELS",
@@ -305,6 +308,281 @@ async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypa
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "casual chat in free-response channel"
     assert event.source.chat_type == "group"
+
+
+def test_discord_threaded_free_response_channels_bare_int(adapter):
+    adapter.config.extra["threaded_free_response_channels"] = 1491973769726791812
+
+    assert adapter._discord_threaded_free_response_channels() == {
+        "1491973769726791812"
+    }
+
+
+@pytest.mark.asyncio
+async def test_discord_threaded_free_response_channel_from_config_extra(
+    adapter, monkeypatch
+):
+    """Config-driven mention-free intake lanes still create a thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    adapter.config.extra["threaded_free_response_channels"] = ["789"]
+
+    fake_thread = FakeThread(channel_id=1001, name="threaded-extra")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="config-driven thread creation",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "1001"
+    assert event.source.chat_type == "thread"
+    assert event.source.thread_id == "1001"
+    assert event.source.parent_chat_id == "789"
+
+
+@pytest.mark.asyncio
+async def test_auto_thread_setting_is_isolated_between_profile_adapters(
+    adapter, monkeypatch
+):
+    """Each profile's config must win over process-global bridge state."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setattr(
+        discord_platform,
+        "_profile_scoped_config_load",
+        lambda: True,
+    )
+
+    inline_extra = discord_platform._apply_yaml_config(
+        {}, {"auto_thread": False}
+    )
+    threaded_extra = discord_platform._apply_yaml_config(
+        {}, {"auto_thread": True}
+    )
+    assert inline_extra is not None
+    assert threaded_extra is not None
+
+    adapter.config.extra.update(inline_extra)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    adapter._snapshot_gate_env()
+    adapter._auto_create_thread = AsyncMock()
+
+    threaded_adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="second-profile-token",
+            extra=threaded_extra,
+        )
+    )
+    threaded_adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    threaded_adapter._text_batch_delay_seconds = 0
+    threaded_adapter.handle_message = AsyncMock()
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    threaded_adapter._snapshot_gate_env()
+
+    threaded_parent = FakeTextChannel(channel_id=790)
+    threaded_target = FakeThread(
+        channel_id=1002,
+        name="second-profile-thread",
+        parent=threaded_parent,
+    )
+    threaded_adapter._auto_create_thread = AsyncMock(
+        return_value=threaded_target
+    )
+
+    bot_user = adapter._client.user
+    inline_message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content=f"<@{bot_user.id}> keep this profile inline",
+        mentions=[bot_user],
+    )
+    threaded_message = make_message(
+        channel=threaded_parent,
+        content=f"<@{bot_user.id}> thread this profile",
+        mentions=[bot_user],
+    )
+
+    await adapter._handle_message(inline_message)
+    await threaded_adapter._handle_message(threaded_message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    inline_event = adapter.handle_message.await_args.args[0]
+    assert inline_event.source.chat_id == "789"
+
+    threaded_adapter._auto_create_thread.assert_awaited_once_with(
+        threaded_message
+    )
+    threaded_event = threaded_adapter.handle_message.await_args.args[0]
+    assert threaded_event.source.chat_id == "1002"
+    assert threaded_event.source.parent_chat_id == "790"
+
+
+@pytest.mark.asyncio
+async def test_no_thread_channel_overrides_threaded_free_response(
+    adapter, monkeypatch
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    adapter.config.extra["threaded_free_response_channels"] = ["789"]
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="keep this exceptional lane inline",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "789"
+    assert event.source.chat_type == "group"
+
+
+def test_discord_threaded_free_response_yaml_bridge(monkeypatch):
+    monkeypatch.delenv("DISCORD_THREADED_FREE_RESPONSE_CHANNELS", raising=False)
+
+    seeded = discord_platform._apply_yaml_config(
+        {}, {"threaded_free_response_channels": ["789", "790"]}
+    )
+
+    assert seeded is not None
+    assert seeded["threaded_free_response_channels"] == "789,790"
+    assert discord_platform.os.getenv(
+        "DISCORD_THREADED_FREE_RESPONSE_CHANNELS"
+    ) == "789,790"
+    bridged_adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    assert bridged_adapter._discord_threaded_free_response_channels() == {
+        "789",
+        "790",
+    }
+
+
+def test_empty_recovery_channel_list_uses_all_scoped_defaults(adapter):
+    adapter.config.extra.update(
+        {
+            "allowed_channels": ["111"],
+            "free_response_channels": ["222"],
+            "threaded_free_response_channels": ["333"],
+            "missed_message_backfill": {"channels": []},
+        }
+    )
+
+    assert adapter._missed_message_backfill_channels() == {
+        "111",
+        "222",
+        "333",
+    }
+
+
+@pytest.mark.asyncio
+async def test_recovered_threaded_free_response_message_passes_mention_gate(
+    adapter, monkeypatch
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    adapter.config.extra["threaded_free_response_channels"] = ["789"]
+    adapter._is_allowed_user = MagicMock(return_value=True)
+    adapter._handle_message = AsyncMock(return_value=True)
+
+    channel = FakeTextChannel(channel_id=789)
+    message = make_message(channel=channel, content="recovered intake request")
+    message.guild = channel.guild
+
+    assert await adapter._dispatch_recovered_message(message) is True
+    adapter._handle_message.assert_awaited_once_with(
+        message,
+        role_authorized=False,
+        recovered=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_threaded_free_response_ingress_binds_final_and_voice_to_thread(
+    adapter, monkeypatch
+):
+    """Parent intake state must not pull final text or voice out of the thread."""
+    from gateway.run import GatewayRunner
+
+    parent = FakeTextChannel(channel_id=789, name="intake")
+    parent.guild.id = 555
+    thread = FakeThread(channel_id=1001, name="threaded-intake", parent=parent)
+    adapter.config.typing_indicator = False
+    adapter.config.extra["threaded_free_response_channels"] = ["789"]
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.setattr(
+        "gateway.delivery_ledger.ledger_enabled", lambda: False
+    )
+    adapter._auto_create_thread = AsyncMock(return_value=thread)
+    adapter._is_allowed_user = MagicMock(return_value=True)
+    adapter._ready_event.set()
+
+    # The fixture replaces handle_message for focused ingress tests. Restore
+    # the real BasePlatformAdapter pipeline for this ingress-to-egress proof.
+    del adapter.handle_message
+
+    sent = AsyncMock(
+        return_value=SendResult(success=True, message_id="final-thread-message")
+    )
+    adapter.send = sent
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._voice_mode = {"discord:789": "all"}
+
+    handler_started = asyncio.Event()
+    release_handler = asyncio.Event()
+    captured_events = []
+    voice_decisions = []
+
+    async def _handle_threaded_turn(event):
+        captured_events.append(event)
+        voice_decisions.append(
+            runner._should_send_voice_reply(
+                event,
+                "final answer in the task thread",
+                [],
+            )
+        )
+        handler_started.set()
+        await release_handler.wait()
+        return "final answer in the task thread"
+
+    adapter.set_message_handler(_handle_threaded_turn)
+
+    other_user = SimpleNamespace(id=77, bot=False)
+    message = make_message(
+        channel=parent,
+        content="Please review this with <@77>",
+        mentions=[other_user],
+    )
+    message.guild = parent.guild
+
+    assert await adapter._dispatch_discord_message(message) is True
+    await asyncio.wait_for(handler_started.wait(), timeout=2)
+
+    event = captured_events[0]
+    assert event.source.chat_id == "1001"
+    assert event.source.thread_id == "1001"
+    assert event.source.parent_chat_id == "789"
+    assert voice_decisions == [False]
+
+    session_task = next(iter(adapter._session_tasks.values()))
+    release_handler.set()
+    await asyncio.wait_for(session_task, timeout=2)
+
+    sent.assert_awaited_once()
+    call = sent.await_args
+    assert call is not None
+    assert call.kwargs["chat_id"] == "1001"
+    assert call.kwargs["content"] == "final answer in the task thread"
+    assert call.kwargs["metadata"]["thread_id"] == "1001"
 
 
 @pytest.mark.asyncio
@@ -825,5 +1103,3 @@ async def test_discord_reply_in_free_channel_triggers_backfill(adapter, monkeypa
     assert event.channel_context == (
         "[Context around the replied-to message]\n[Hermes [bot]] earlier answer"
     )
-
-

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -118,6 +118,27 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_threaded_free_response_channels_use_public_list_config(
+        self, _isolated_hermes_home, capsys
+    ):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["discord"]["threaded_free_response_channels"] == []
+
+        set_config_value(
+            "discord.threaded_free_response_channels",
+            '["c-intake", "c-requests"]',
+        )
+
+        import yaml
+
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["discord"]["threaded_free_response_channels"] == [
+            "c-intake",
+            "c-requests",
+        ]
+        assert "not a recognized config key" not in capsys.readouterr().out
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -346,6 +346,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |
 | `DISCORD_IGNORED_CHANNELS` | Comma-separated channel IDs where the bot never responds |
 | `DISCORD_NO_THREAD_CHANNELS` | Comma-separated channel IDs where bot responds without auto-threading |
+| `DISCORD_THREADED_FREE_RESPONSE_CHANNELS` | Compatibility/manual override for `discord.threaded_free_response_channels`: comma-separated channel IDs that stay mention-free and still auto-thread each new parent-channel message. Prefer the `config.yaml` key. |
 | `DISCORD_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all` |
 | `DISCORD_ALLOW_MENTION_EVERYONE` | Allow the bot to ping `@everyone`/`@here` (default: `false`). See [Mention Control](../user-guide/messaging/discord.md#mention-control). |
 | `DISCORD_ALLOW_MENTION_ROLES` | Allow the bot to ping `@role` mentions (default: `false`). |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2434,11 +2434,13 @@ Configure Discord-specific behavior for the messaging gateway:
 discord:
   require_mention: true          # Require @mention to respond in server channels
   free_response_channels: ""     # Comma-separated channel IDs where bot responds without @mention
+  threaded_free_response_channels: []  # Mention-free channels that still auto-thread
   auto_thread: true              # Auto-create threads on @mention in channels
 ```
 
 - `require_mention` — when `true` (default), the bot only responds in server channels when mentioned with `@BotName`. DMs always work without mention.
 - `free_response_channels` — comma-separated list of channel IDs where the bot responds to every message without requiring a mention.
+- `threaded_free_response_channels` — list of channel IDs where no mention is required and each new parent-channel message still creates a dedicated thread.
 - `auto_thread` — when `true` (default), mentions in channels automatically create a thread for the conversation, keeping channels clean (similar to Slack threading).
 
 ## Security

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -16,7 +16,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 |---------|----------|
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Server channels** | By default, Hermes only responds when you `@mention` it. If you post in a channel without mentioning it, Hermes ignores the message. |
-| **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. Messages in these channels are answered inline — auto-threading is skipped so the channel stays a lightweight chat. |
+| **Free-response channels** | You can make specific channels mention-free with `discord.free_response_channels`, or disable mentions globally with `discord.require_mention: false`. Messages in these channels are answered inline by default so the channel stays a lightweight chat. If you want a mention-free intake lane that still spins each request into its own thread, use `discord.threaded_free_response_channels`. |
 | **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel for safety and clarity. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 | **Messages mentioning other users** | When `DISCORD_IGNORE_NO_MENTION` is `true` (the default), Hermes stays silent if a message @mentions other users but does **not** mention the bot. This prevents the bot from jumping into conversations directed at other people. Set to `false` if you want the bot to respond to all messages regardless of who is mentioned. This only applies in server channels, not DMs. |
@@ -335,6 +335,7 @@ discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
+  threaded_free_response_channels: []  # Mention-free lanes that still auto-thread
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
@@ -343,7 +344,7 @@ discord:
   history_backfill_limit: 50      # Max messages to scan backwards (default: 50)
   missed_message_backfill:        # Replay messages missed while disconnected (opt-in)
     enabled: false
-    channels: []                  # Empty uses free_response_channels
+    channels: []                  # Empty uses allowed/free/threaded-response channels
     window_seconds: 21600         # Look back at most 6 hours
     limit: 100                    # Global scan cap per reconnect
     max_dispatches: 10            # Recovery dispatch cap per reconnect
@@ -400,7 +401,9 @@ discord:
 
 If a thread's parent channel is in this list, the thread also becomes mention-free.
 
-Free-response channels also **skip auto-threading** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface. If you want threading behavior, don't list the channel as free-response (use normal `@mention` flow instead).
+Free-response channels also **skip auto-threading by default** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface.
+
+If you want a channel to stay mention-free **and** still spawn a dedicated thread for each new parent-channel message, use `discord.threaded_free_response_channels`. This is useful for channels that act like an intake inbox: users can talk naturally in the parent channel, but each request gets isolated scrollback immediately.
 
 #### `discord.auto_thread`
 
@@ -408,7 +411,27 @@ Free-response channels also **skip auto-threading** — the bot replies inline r
 
 When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
 
-Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
+Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead, unless they are explicitly opted back into thread spawning via `discord.threaded_free_response_channels`. `discord.no_thread_channels` takes precedence if a channel appears in both lists.
+
+#### `discord.threaded_free_response_channels`
+
+**Type:** string or list — **Default:** `[]`
+
+Channels that should remain mention-free **but** still auto-create a new Discord thread for each new parent-channel message.
+
+Use this when you want the convenience of free-response in a shared intake channel without losing the per-task thread isolation normally provided by `discord.auto_thread`.
+
+```yaml
+discord:
+  threaded_free_response_channels:
+    - 1234567890
+```
+
+The channel then behaves like:
+
+- no `@mention` required in the parent channel
+- each new top-level message opens its own Hermes-managed thread
+- follow-up replies continue inside the thread without re-mentioning the bot
 
 #### `discord.reactions`
 
@@ -534,7 +557,7 @@ discord:
     max_dispatches: 10
 ```
 
-If `channels` is empty, Hermes uses `discord.free_response_channels`. Set it to `"*"` only when the bot should inspect every reachable server text channel. The recovery ledger is stored per profile under `gateway/discord_message_recovery.db`, preventing a successfully answered message from being replayed again after a later restart.
+If `channels` is empty, Hermes uses the union of `discord.allowed_channels`, `discord.free_response_channels`, and `discord.threaded_free_response_channels`. Set it to `"*"` only when the bot should inspect every reachable server text channel. The recovery ledger is stored per profile under `gateway/discord_message_recovery.db`, preventing a successfully answered message from being replayed again after a later restart.
 
 #### `group_sessions_per_user`
 
@@ -927,5 +950,3 @@ Leave `everyone` and `roles` at `false` unless you know exactly why you need the
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
-
-


### PR DESCRIPTION
## Summary
- add profile-scoped `discord.threaded_free_response_channels` for mention-free intake lanes that still create one task thread per parent message
- preserve thread-bound final/status routing and isolate parent voice mode
- carry the scopes through relay admission, env/YAML/scalar normalization, and missed-message recovery defaults
- document the canonical config and compatibility environment surface

## Behavior contracts
- ordinary free-response channels remain inline
- `no_thread_channels` retains precedence
- multiplexed profiles do not share `auto_thread`
- relay scope-only policy keeps `requireAddress: true` outside the listed scopes
- empty recovery-channel lists fall back to allowed/free/threaded scopes
- default compaction-notice suppression is unchanged

## Verification
- rebased onto current `origin/main` (`58523f284c`); range-diff reports the reviewed patch is identical
- focused final suite: 125 passed via `scripts/run_tests.sh`
- combined Discord/relay/config suites before rebase: 836 passed, 4 Windows-only skipped
- Ruff, Windows-footgun scan, and `git diff --check`: clean
- independent Standards and Spec reviews: no hard findings

No live gateway restart, Discord message, or voice/session mutation is included in this PR.