### PR TITLE
feat(agent): add prior-work-first execution memory

### DIFF
--- a/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/active.packet.json
+++ b/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/active.packet.json
@@ -3,8 +3,8 @@
   "GOAL": "Extend Hermes with durable prior-work-first execution memory across SOUL, repository rules, protocol, guard, and focused verification without broad rediscovery.",
   "CAPABILITY_ID": "HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1",
   "PREFLIGHT_STATUS": "verified",
-  "ACCEPTED_HEAD": "7974025bbe700a1161dbada167c3c47612113ae2",
-  "ACCEPTED_TREE": "77e60859bc50296b86dc4365cf225aae6207f763",
+  "ACCEPTED_HEAD": "3a336b8ab1757f75cb796f73d35b5200c45353c5",
+  "ACCEPTED_TREE": "54ff3dbefda912a65226541c38ee7d5c2d50d89e",
   "FIRST_UNPROVEN_BOUNDARY": "LIVE_ACTIVATION",
   "KNOWN_FILES": [
     {
@@ -72,20 +72,20 @@
   "KNOWN_RECEIPTS": [
     {
       "path": ".task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/receipts/2026-08-30-focused-tests.json",
-      "digest": "fba7f68fb0d62da3179501e49c5979c5b1737e359b87c8b7aff738af309d863f"
+      "digest": "e77e7915524d549098d6c900d8bb9f1bb779c4b330dda96243f9e36228000016"
     }
   ],
   "KNOWN_WORKTREES": [
     {
       "path": "C:/Users/Vu Tuan/AppData/Local/hermes/worktrees/prior-work-first-execution-memory-v1",
       "branch": "feat/prior-work-first-execution-memory-v1",
-      "head": "7974025bbe700a1161dbada167c3c47612113ae2"
+      "head": "3a336b8ab1757f75cb796f73d35b5200c45353c5"
     }
   ],
   "KNOWN_BRANCHES": [
     {
       "branch": "feat/prior-work-first-execution-memory-v1",
-      "head": "7974025bbe700a1161dbada167c3c47612113ae2",
+      "head": "3a336b8ab1757f75cb796f73d35b5200c45353c5",
       "upstream": "fork/feat/prior-work-first-execution-memory-v1"
     }
   ],
@@ -187,7 +187,7 @@
       "subject": "tests/agent/test_prior_work_first.py"
     }
   ],
-  "LAST_MACHINE_VERIFIED_AT": "2026-08-30T11:21:15.9918202+07:00",
+  "LAST_MACHINE_VERIFIED_AT": "2026-08-30T11:44:39.9882021+07:00",
   "PRIMARY_WRITER": "codex-primary-writer",
   "PARALLEL_SCOUTS": []
 }

--- a/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/active.packet.json
+++ b/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/active.packet.json
@@ -1,0 +1,193 @@
+{
+  "PROGRAM_ID": "HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1",
+  "GOAL": "Extend Hermes with durable prior-work-first execution memory across SOUL, repository rules, protocol, guard, and focused verification without broad rediscovery.",
+  "CAPABILITY_ID": "HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1",
+  "PREFLIGHT_STATUS": "verified",
+  "ACCEPTED_HEAD": "7974025bbe700a1161dbada167c3c47612113ae2",
+  "ACCEPTED_TREE": "77e60859bc50296b86dc4365cf225aae6207f763",
+  "FIRST_UNPROVEN_BOUNDARY": "LIVE_ACTIVATION",
+  "KNOWN_FILES": [
+    {
+      "path": "agent/prior_work_first.py",
+      "digest": "c2c984d2dd1c58072baf81fb87fd66ec3fa5515a66366add7dd7b5342901d669"
+    },
+    {
+      "path": "scripts/prior_work_first.py",
+      "digest": "bd8107c97df59dec66dfb39a770f2d684330b1f19d45bc69f56ed2e38c8a3749"
+    },
+    {
+      "path": "docs/prior-work-first-execution-memory.md",
+      "digest": "b74b6938d0050f8ce5e99366c1a9ec378d6ce47c611e76e8fd805fe71a72193c"
+    },
+    {
+      "path": "skills/autonomous-ai-agents/hermes-agent/SKILL.md",
+      "digest": "3213ea1bfcd5955a593fb9ebcc3191fe16855f82cbb248545bc5528ae7ec4498"
+    },
+    {
+      "path": "skills/autonomous-ai-agents/hermes-agent/references/prior-work-first.md",
+      "digest": "05a4aaa4a4c84e0275adb08010704b59e2550c3d3de4d813a97f29afd4e1962e"
+    }
+  ],
+  "KNOWN_SYMBOLS": [
+    {
+      "path": "agent/prior_work_first.py",
+      "symbol": "normalize_packet",
+      "digest": "ad7c9a32150dd9b644f71bfe257c2e74a77dd18bfcac8e7016383b3a62dd89ab"
+    },
+    {
+      "path": "agent/prior_work_first.py",
+      "symbol": "discover_prior_work",
+      "digest": "40fd688c4ce4ea17ccea8fc2db45d2702cae4d10e199946f17d774ea70b940fb"
+    },
+    {
+      "path": "agent/prior_work_first.py",
+      "symbol": "evaluate_preflight",
+      "digest": "755128d5fcca24f48d548f736c826d030741ae640a66b8acb0f993fdaab08932"
+    },
+    {
+      "path": "agent/prior_work_first.py",
+      "symbol": "reconstruct_resume_context",
+      "digest": "6af94af6b002fb49ff5bdd7301af485ab094f8f8f66f392078e27bb4550b0f16"
+    }
+  ],
+  "KNOWN_TESTS": [
+    {
+      "path": "tests/agent/test_prior_work_first.py",
+      "digest": "6f8c3e9a7f8c8a141bd5b7d87307f868817f5a0abab827a90dfdc1037f11cc48"
+    }
+  ],
+  "KNOWN_DEPENDENCIES": [
+    {
+      "name": "pytest",
+      "path": "pyproject.toml",
+      "digest": "8fdd016886353ed18ad293c840a0422f0f750b64b30d1e19ad21649441b3f80b"
+    }
+  ],
+  "KNOWN_HANDOFFS": [
+    {
+      "path": ".task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/handoffs/2026-08-30-resume-closeout.md",
+      "digest": "1f4bde811f572b750f0cc6cbc67b3fc59aea024b386109e73930cbaa3a51c679"
+    }
+  ],
+  "KNOWN_RECEIPTS": [
+    {
+      "path": ".task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/receipts/2026-08-30-focused-tests.json",
+      "digest": "fba7f68fb0d62da3179501e49c5979c5b1737e359b87c8b7aff738af309d863f"
+    }
+  ],
+  "KNOWN_WORKTREES": [
+    {
+      "path": "C:/Users/Vu Tuan/AppData/Local/hermes/worktrees/prior-work-first-execution-memory-v1",
+      "branch": "feat/prior-work-first-execution-memory-v1",
+      "head": "7974025bbe700a1161dbada167c3c47612113ae2"
+    }
+  ],
+  "KNOWN_BRANCHES": [
+    {
+      "branch": "feat/prior-work-first-execution-memory-v1",
+      "head": "7974025bbe700a1161dbada167c3c47612113ae2",
+      "upstream": "fork/feat/prior-work-first-execution-memory-v1"
+    }
+  ],
+  "KNOWN_DRAFT_BUILDS": [],
+  "KNOWN_BASELINE_EXCEPTIONS": [
+    "Focused pytest verification uses --basetemp .pytest-tmp in this Windows worktree because the default AppData/Local/Temp root is access denied."
+  ],
+  "RELEVANT_CONTRACT_SLICES": [
+    {
+      "path": "AGENTS.md",
+      "digest": "55538dbed906f51c70a5adfaf6a1b39ad5895fe5e732b03c7728bffc085d2e3a"
+    },
+    {
+      "path": "SOUL.md",
+      "digest": "fff14e7c38e191bcd4cfd8b08eb36cc02984e6c0a667b77af3edf6a4b03cd2fc"
+    }
+  ],
+  "RELEVANT_SDD_SLICES": [
+    {
+      "path": "docs/prior-work-first-execution-memory.md",
+      "digest": "b74b6938d0050f8ce5e99366c1a9ec378d6ce47c611e76e8fd805fe71a72193c"
+    }
+  ],
+  "PROVEN_INVARIANTS": [
+    "Accepted prior work with INVALIDATOR_COUNT=0 resumes from FIRST_UNPROVEN_BOUNDARY and forbids broad rediscovery, broad preflight re-execution, and replanning.",
+    "Discovery locates active packets, handoffs, receipts, drafts, RAG artifacts, worktrees, and branches with repo-relative task artifact paths.",
+    "Old chat and RAG do not outrank current source, tests, contract, or fresh machine evidence.",
+    "Unrelated HEAD movement alone does not invalidate an accepted baseline.",
+    "Only one canonical primary writer is allowed; parallel scouts remain read-only.",
+    "A fresh agent can reconstruct resume context from repository artifacts with no chat history."
+  ],
+  "INVALIDATE_IF": [
+    {
+      "kind": "contract_change",
+      "path": "AGENTS.md",
+      "expected_digest": "55538dbed906f51c70a5adfaf6a1b39ad5895fe5e732b03c7728bffc085d2e3a"
+    },
+    {
+      "kind": "contract_change",
+      "path": "SOUL.md",
+      "expected_digest": "fff14e7c38e191bcd4cfd8b08eb36cc02984e6c0a667b77af3edf6a4b03cd2fc"
+    },
+    {
+      "kind": "sdd_change",
+      "path": "docs/prior-work-first-execution-memory.md",
+      "expected_digest": "b74b6938d0050f8ce5e99366c1a9ec378d6ce47c611e76e8fd805fe71a72193c"
+    },
+    {
+      "kind": "symbol_change",
+      "path": "agent/prior_work_first.py",
+      "symbol": "normalize_packet",
+      "expected_digest": "ad7c9a32150dd9b644f71bfe257c2e74a77dd18bfcac8e7016383b3a62dd89ab"
+    },
+    {
+      "kind": "symbol_change",
+      "path": "agent/prior_work_first.py",
+      "symbol": "discover_prior_work",
+      "expected_digest": "40fd688c4ce4ea17ccea8fc2db45d2702cae4d10e199946f17d774ea70b940fb"
+    },
+    {
+      "kind": "symbol_change",
+      "path": "agent/prior_work_first.py",
+      "symbol": "evaluate_preflight",
+      "expected_digest": "755128d5fcca24f48d548f736c826d030741ae640a66b8acb0f993fdaab08932"
+    },
+    {
+      "kind": "symbol_change",
+      "path": "agent/prior_work_first.py",
+      "symbol": "reconstruct_resume_context",
+      "expected_digest": "6af94af6b002fb49ff5bdd7301af485ab094f8f8f66f392078e27bb4550b0f16"
+    },
+    {
+      "kind": "file_change",
+      "path": "scripts/prior_work_first.py",
+      "expected_digest": "bd8107c97df59dec66dfb39a770f2d684330b1f19d45bc69f56ed2e38c8a3749"
+    },
+    {
+      "kind": "file_change",
+      "path": "skills/autonomous-ai-agents/hermes-agent/SKILL.md",
+      "expected_digest": "3213ea1bfcd5955a593fb9ebcc3191fe16855f82cbb248545bc5528ae7ec4498"
+    },
+    {
+      "kind": "file_change",
+      "path": "skills/autonomous-ai-agents/hermes-agent/references/prior-work-first.md",
+      "expected_digest": "05a4aaa4a4c84e0275adb08010704b59e2550c3d3de4d813a97f29afd4e1962e"
+    },
+    {
+      "kind": "test_semantics_change",
+      "path": "tests/agent/test_prior_work_first.py",
+      "expected_digest": "6f8c3e9a7f8c8a141bd5b7d87307f868817f5a0abab827a90dfdc1037f11cc48"
+    },
+    {
+      "kind": "dependency_change",
+      "path": "pyproject.toml",
+      "expected_digest": "8fdd016886353ed18ad293c840a0422f0f750b64b30d1e19ad21649441b3f80b"
+    },
+    {
+      "kind": "contradictory_machine_evidence",
+      "subject": "tests/agent/test_prior_work_first.py"
+    }
+  ],
+  "LAST_MACHINE_VERIFIED_AT": "2026-08-30T11:21:15.9918202+07:00",
+  "PRIMARY_WRITER": "codex-primary-writer",
+  "PARALLEL_SCOUTS": []
+}

--- a/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/handoffs/2026-08-30-resume-closeout.md
+++ b/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/handoffs/2026-08-30-resume-closeout.md
@@ -1,0 +1,15 @@
+# Prior-Work-First Resume Handoff
+
+- PROGRAM_ID: `HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1`
+- CAPABILITY_ID: `HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1`
+- PREFLIGHT_STATUS: `verified`
+- FIRST_UNPROVEN_BOUNDARY: `LIVE_ACTIVATION`
+- CURRENT_WRITER: `codex-primary-writer`
+- LAST_MACHINE_VERIFIED_AT: `2026-08-30T11:21:15.9918202+07:00`
+
+Resume rule:
+
+1. Reuse accepted boundaries unless an explicit invalidator fires.
+2. Refresh only volatile git state and fresh machine evidence first.
+3. Keep one canonical writer; any scouts remain read-only.
+4. Live activation remains pending; do not treat a process exit as completion.

--- a/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/receipts/2026-08-30-focused-tests.json
+++ b/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/receipts/2026-08-30-focused-tests.json
@@ -2,14 +2,17 @@
   "PROGRAM_ID": "HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1",
   "CAPABILITY_ID": "HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1",
   "STATUS": "PASS",
-  "VERIFIED_AT": "2026-08-30T11:21:15.9918202+07:00",
+  "VERIFIED_AT": "2026-08-30T11:44:39.9882021+07:00",
   "WORKTREE": "C:/Users/Vu Tuan/AppData/Local/hermes/worktrees/prior-work-first-execution-memory-v1",
   "BRANCH": "feat/prior-work-first-execution-memory-v1",
+  "ACCEPTED_HEAD": "3a336b8ab1757f75cb796f73d35b5200c45353c5",
+  "ACCEPTED_TREE": "54ff3dbefda912a65226541c38ee7d5c2d50d89e",
+  "ACCEPTED_PARENT": "7974025bbe700a1161dbada167c3c47612113ae2",
   "TEST_COMMANDS": [
     {
       "command": "python -m pytest tests/agent/test_prior_work_first.py --basetemp .pytest-tmp",
       "result": "PASS",
-      "details": "10 passed in 1.97s"
+      "details": "10 passed in 1.81s"
     }
   ],
   "NOTES": [

--- a/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/receipts/2026-08-30-focused-tests.json
+++ b/.task-state/prior-work-first/hermes-prior-work-first-execution-memory-v1/receipts/2026-08-30-focused-tests.json
@@ -1,0 +1,19 @@
+{
+  "PROGRAM_ID": "HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1",
+  "CAPABILITY_ID": "HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1",
+  "STATUS": "PASS",
+  "VERIFIED_AT": "2026-08-30T11:21:15.9918202+07:00",
+  "WORKTREE": "C:/Users/Vu Tuan/AppData/Local/hermes/worktrees/prior-work-first-execution-memory-v1",
+  "BRANCH": "feat/prior-work-first-execution-memory-v1",
+  "TEST_COMMANDS": [
+    {
+      "command": "python -m pytest tests/agent/test_prior_work_first.py --basetemp .pytest-tmp",
+      "result": "PASS",
+      "details": "10 passed in 1.97s"
+    }
+  ],
+  "NOTES": [
+    "The default Windows pytest temp root under AppData/Local/Temp was access denied in this environment.",
+    "Focused verification used a workspace-local basetemp and did not require Hermes runtime restart or reload."
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,41 @@ reviewing any change:
   high. Most new capability should arrive as a CLI command + skill, a
   service-gated tool, or a plugin — not as core surface.
 
+## Prior-Work-First Execution Memory
+
+Repository-authorized implementation tasks must follow the durable
+`PRIOR-WORK-FIRST` law in [SOUL.md](./SOUL.md) and the detailed protocol in
+[`docs/prior-work-first-execution-memory.md`](./docs/prior-work-first-execution-memory.md).
+
+The repo-level minimum:
+
+- Start with `GOAL -> CAPABILITY_ID -> PRIOR_WORK_LOCATE -> ACCEPTED_BASELINE
+  -> FIRST_UNPROVEN_BOUNDARY -> INVALIDATOR_CHECK`, then load only the exact
+  relevant Contract / SDD / source / test slices before implementing.
+- Prior-work locate is targeted, not exhaustive. Locate accepted packets,
+  handoffs, receipts, worktrees, branches, draft builds, focused RAG artifacts,
+  and current source/tests before creating a new plan, worktree, or replacement
+  implementation.
+- RAG and old conversation are locator-only context. Contract is semantic
+  authority; impacted SDD slices are architectural authority; current
+  source/tests are implementation truth; fresh machine evidence is PASS/FAIL
+  authority.
+- Reuse accepted boundaries when no explicit invalidator fired. If
+  `INVALIDATOR_COUNT=0`, broad rediscovery, broad preflight re-execution, and
+  replanning are forbidden; resume from `FIRST_UNPROVEN_BOUNDARY` and refresh
+  only volatile state.
+- Explicit invalidators must be narrow: relevant Contract change, relevant
+  symbol change, dependency change, accepted baseline invalidation, test
+  semantics change, contradictory fresh machine evidence, or architecture owner
+  change. Unrelated HEAD movement is not itself invalidation.
+- Preserve the one-writer invariant: one canonical primary writer per
+  capability, parallel scouts read-only only.
+- Use `python scripts/prior_work_first.py locate|check|resume|compact-packet`
+  as the checkable guard. The active packet lives at
+  `.task-state/prior-work-first/<capability-slug>/active.packet.json` and must
+  stay compact: no transcripts, only accepted state, exact slices, invalidators,
+  and fresh verification metadata.
+
 ## Contribution Rubric — What We Want / What We Don't
 
 This is the project's intent layer. Use it two ways:

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,10 @@
+# Repository Soul
+
+This repository's durable execution law for compatible agents:
+
+1. PRIOR-WORK-FIRST. Locate accepted prior work, its accepted baseline, the first unproven boundary, and explicit invalidators before planning or editing.
+2. Reuse accepted boundaries by default. Refresh only invalidated slices; unrelated HEAD motion is not itself invalidation.
+3. Treat RAG and old chat as locators, not authorities. Contract, current source/tests, and fresh machine evidence decide the next move.
+4. Keep one canonical writer. Parallel scouts, if any, stay read-only.
+
+Mechanics live in `AGENTS.md` and `docs/prior-work-first-execution-memory.md`.

--- a/agent/prior_work_first.py
+++ b/agent/prior_work_first.py
@@ -208,11 +208,11 @@ def discover_prior_work(
     packet_path = capability_root / PACKET_FILENAME
     artifacts = {
         "preflight_packets": [_relpath(packet_path, repo_root)] if packet_path.is_file() else [],
-        "handoffs": _limited_file_listing(capability_root / "handoffs", limit=limit),
-        "receipts": _limited_file_listing(capability_root / "receipts", limit=limit),
-        "draft_builds": _limited_file_listing(capability_root / "drafts", limit=limit),
-        "rag": _limited_file_listing(capability_root / "rag", limit=limit),
-        "ledgers": _limited_file_listing(capability_root / "ledgers", limit=limit),
+        "handoffs": _limited_file_listing(capability_root / "handoffs", repo_root=repo_root, limit=limit),
+        "receipts": _limited_file_listing(capability_root / "receipts", repo_root=repo_root, limit=limit),
+        "draft_builds": _limited_file_listing(capability_root / "drafts", repo_root=repo_root, limit=limit),
+        "rag": _limited_file_listing(capability_root / "rag", repo_root=repo_root, limit=limit),
+        "ledgers": _limited_file_listing(capability_root / "ledgers", repo_root=repo_root, limit=limit),
     }
     fallback_hits: list[str] = []
     if state_root.exists():
@@ -824,7 +824,11 @@ def _record_maps(state: Mapping[str, Any]) -> dict[str, dict[str, Mapping[str, A
 
 
 def _limited_file_listing(
-    directory: Path, *, suffixes: set[str] | None = None, limit: int = 64
+    directory: Path,
+    *,
+    repo_root: Path | None = None,
+    suffixes: set[str] | None = None,
+    limit: int = 64,
 ) -> list[str]:
     if not directory.exists():
         return []
@@ -836,7 +840,7 @@ def _limited_file_listing(
             continue
         if suffixes and path.suffix.lower() not in suffixes:
             continue
-        found.append(str(path))
+        found.append(_relpath(path, repo_root) if repo_root is not None else str(path))
     return found
 
 

--- a/agent/prior_work_first.py
+++ b/agent/prior_work_first.py
@@ -1,0 +1,959 @@
+"""Durable prior-work-first helpers for repository task execution.
+
+The helpers in this module let a fresh agent recover an accepted execution
+boundary from repository artifacts instead of re-running broad discovery on
+every session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+PROGRAM_ID = "HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1"
+CANONICAL_STATE_ROOT = Path(".task-state") / "prior-work-first"
+PACKET_FILENAME = "active.packet.json"
+TRANSCRIPT_KEYS = frozenset(
+    {
+        "MESSAGES",
+        "TRANSCRIPT",
+        "TRANSCRIPTS",
+        "CHAT_HISTORY",
+        "CONVERSATION",
+        "CONVERSATION_HISTORY",
+        "RAG_TRANSCRIPT",
+    }
+)
+PACKET_FIELDS = (
+    "PROGRAM_ID",
+    "GOAL",
+    "CAPABILITY_ID",
+    "PREFLIGHT_STATUS",
+    "ACCEPTED_HEAD",
+    "ACCEPTED_TREE",
+    "FIRST_UNPROVEN_BOUNDARY",
+    "KNOWN_FILES",
+    "KNOWN_SYMBOLS",
+    "KNOWN_TESTS",
+    "KNOWN_DEPENDENCIES",
+    "KNOWN_HANDOFFS",
+    "KNOWN_RECEIPTS",
+    "KNOWN_WORKTREES",
+    "KNOWN_BRANCHES",
+    "KNOWN_DRAFT_BUILDS",
+    "KNOWN_BASELINE_EXCEPTIONS",
+    "RELEVANT_CONTRACT_SLICES",
+    "RELEVANT_SDD_SLICES",
+    "PROVEN_INVARIANTS",
+    "INVALIDATE_IF",
+    "LAST_MACHINE_VERIFIED_AT",
+    "PRIMARY_WRITER",
+    "PARALLEL_SCOUTS",
+)
+LIST_FIELDS = {
+    "KNOWN_FILES",
+    "KNOWN_SYMBOLS",
+    "KNOWN_TESTS",
+    "KNOWN_DEPENDENCIES",
+    "KNOWN_HANDOFFS",
+    "KNOWN_RECEIPTS",
+    "KNOWN_WORKTREES",
+    "KNOWN_BRANCHES",
+    "KNOWN_DRAFT_BUILDS",
+    "KNOWN_BASELINE_EXCEPTIONS",
+    "RELEVANT_CONTRACT_SLICES",
+    "RELEVANT_SDD_SLICES",
+    "PROVEN_INVARIANTS",
+    "INVALIDATE_IF",
+    "PARALLEL_SCOUTS",
+}
+PATH_LIST_FIELDS = {
+    "KNOWN_FILES",
+    "KNOWN_TESTS",
+    "KNOWN_HANDOFFS",
+    "KNOWN_RECEIPTS",
+    "KNOWN_WORKTREES",
+    "KNOWN_BRANCHES",
+    "KNOWN_DRAFT_BUILDS",
+    "RELEVANT_CONTRACT_SLICES",
+    "RELEVANT_SDD_SLICES",
+}
+TARGETED_INVALIDATOR_KINDS = {
+    "contract_change": "RELEVANT_CONTRACT_SLICES",
+    "sdd_change": "RELEVANT_SDD_SLICES",
+    "symbol_change": "KNOWN_SYMBOLS",
+    "dependency_change": "KNOWN_DEPENDENCIES",
+    "test_semantics_change": "KNOWN_TESTS",
+    "file_change": "KNOWN_FILES",
+    "architecture_owner_change": "RELEVANT_SDD_SLICES",
+}
+GLOBAL_INVALIDATOR_KINDS = {
+    "accepted_baseline_invalidation",
+    "contradictory_machine_evidence",
+}
+AUTHORITY_ORDER = {
+    "locator": [
+        "preflight_packet",
+        "receipt",
+        "handoff",
+        "rag",
+        "conversation",
+    ],
+    "semantic": [
+        "contract",
+        "source",
+        "tests",
+        "sdd",
+        "machine_evidence",
+        "receipt",
+        "handoff",
+        "rag",
+        "conversation",
+    ],
+    "implementation": [
+        "source",
+        "tests",
+        "contract",
+        "sdd",
+        "machine_evidence",
+        "receipt",
+        "handoff",
+        "rag",
+        "conversation",
+    ],
+    "verification": [
+        "machine_evidence",
+        "tests",
+        "source",
+        "contract",
+        "sdd",
+        "receipt",
+        "handoff",
+        "rag",
+        "conversation",
+    ],
+}
+
+
+def capability_slug(capability_id: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", capability_id.strip().lower()).strip("-")
+    return slug or "unnamed-capability"
+
+
+def digest_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def digest_path(path: Path) -> str | None:
+    if not path.exists() or not path.is_file():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def digest_symbol(path: Path, symbol: str) -> str | None:
+    source = _read_text(path)
+    if source is None:
+        return None
+    segment = _extract_symbol_segment(source, symbol)
+    if segment is None:
+        return None
+    return digest_text(segment)
+
+
+def canonical_capability_dir(repo_root: Path, capability_id: str) -> Path:
+    return repo_root / CANONICAL_STATE_ROOT / capability_slug(capability_id)
+
+
+def canonical_packet_path(repo_root: Path, capability_id: str) -> Path:
+    return canonical_capability_dir(repo_root, capability_id) / PACKET_FILENAME
+
+
+def normalize_packet(payload: Mapping[str, Any]) -> dict[str, Any]:
+    packet: dict[str, Any] = {"PROGRAM_ID": PROGRAM_ID}
+    for key in PACKET_FIELDS:
+        if key not in payload:
+            continue
+        if key in TRANSCRIPT_KEYS:
+            continue
+        value = payload[key]
+        if key in LIST_FIELDS:
+            packet[key] = _normalize_list_field(key, value)
+        else:
+            packet[key] = value
+    for key in TRANSCRIPT_KEYS:
+        packet.pop(key, None)
+    packet.setdefault("PROGRAM_ID", PROGRAM_ID)
+    packet.setdefault("PREFLIGHT_STATUS", "unknown")
+    packet.setdefault("INVALIDATE_IF", [])
+    packet.setdefault("PROVEN_INVARIANTS", [])
+    packet.setdefault("PRIMARY_WRITER", None)
+    packet.setdefault("PARALLEL_SCOUTS", [])
+    return packet
+
+
+def discover_prior_work(
+    repo_root: Path | str, capability_id: str, *, limit: int = 64
+) -> dict[str, Any]:
+    repo_root = Path(repo_root).resolve()
+    slug = capability_slug(capability_id)
+    state_root = repo_root / ".task-state"
+    capability_root = canonical_capability_dir(repo_root, capability_id)
+    packet_path = capability_root / PACKET_FILENAME
+    artifacts = {
+        "preflight_packets": [_relpath(packet_path, repo_root)] if packet_path.is_file() else [],
+        "handoffs": _limited_file_listing(capability_root / "handoffs", limit=limit),
+        "receipts": _limited_file_listing(capability_root / "receipts", limit=limit),
+        "draft_builds": _limited_file_listing(capability_root / "drafts", limit=limit),
+        "rag": _limited_file_listing(capability_root / "rag", limit=limit),
+        "ledgers": _limited_file_listing(capability_root / "ledgers", limit=limit),
+    }
+    fallback_hits: list[str] = []
+    if state_root.exists():
+        pattern = f"*{slug}*"
+        for path in state_root.rglob(pattern):
+            if len(fallback_hits) >= limit:
+                break
+            if path.is_file():
+                fallback_hits.append(_relpath(path, repo_root))
+    git_state = collect_git_state(repo_root)
+    return {
+        "GOAL": None,
+        "CAPABILITY_ID": capability_id,
+        "SEARCH_MODE": "targeted_read_only",
+        "FULL_HISTORY_LOADED": False,
+        "SEARCHED_ROOTS": [
+            _relpath(state_root, repo_root),
+            _relpath(capability_root, repo_root),
+        ],
+        "ARTIFACTS": artifacts,
+        "FALLBACK_MATCHES": fallback_hits,
+        "KNOWN_WORKTREES": git_state["KNOWN_WORKTREES"],
+        "KNOWN_BRANCHES": git_state["KNOWN_BRANCHES"],
+        "ACCEPTED_HEAD": git_state["HEAD"],
+        "ACCEPTED_TREE": git_state["TREE"],
+        "HANDOFF_DISCOVERY_REQUIRED": True,
+        "DRAFT_BUILD_DISCOVERY_REQUIRED": True,
+        "WORKTREE_DISCOVERY_REQUIRED": True,
+        "RAG_AS_LOCATOR_REQUIRED": True,
+    }
+
+
+def collect_git_state(repo_root: Path | str) -> dict[str, Any]:
+    repo_root = Path(repo_root).resolve()
+    head = _git_output(repo_root, "rev-parse", "HEAD")
+    tree = _git_output(repo_root, "rev-parse", "HEAD^{tree}")
+    worktrees = _parse_worktree_list(_git_output(repo_root, "worktree", "list", "--porcelain"))
+    branches = _parse_branch_list(
+        _git_output(
+            repo_root,
+            "for-each-ref",
+            "--format=%(refname:short)\t%(objectname)\t%(upstream:short)",
+            "refs/heads",
+            "refs/remotes",
+        )
+    )
+    return {
+        "HEAD": head,
+        "TREE": tree,
+        "KNOWN_WORKTREES": worktrees,
+        "KNOWN_BRANCHES": branches,
+    }
+
+
+def capture_repo_state(
+    repo_root: Path | str,
+    packet: Mapping[str, Any],
+    *,
+    machine_evidence: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    repo_root = Path(repo_root).resolve()
+    packet = normalize_packet(packet)
+    git_state = collect_git_state(repo_root)
+    state: dict[str, Any] = {
+        "HEAD": git_state["HEAD"],
+        "TREE": git_state["TREE"],
+        "KNOWN_WORKTREES": git_state["KNOWN_WORKTREES"],
+        "KNOWN_BRANCHES": git_state["KNOWN_BRANCHES"],
+        "KNOWN_FILES": _capture_path_records(repo_root, packet.get("KNOWN_FILES", [])),
+        "KNOWN_TESTS": _capture_path_records(repo_root, packet.get("KNOWN_TESTS", [])),
+        "KNOWN_HANDOFFS": _capture_path_records(repo_root, packet.get("KNOWN_HANDOFFS", [])),
+        "KNOWN_RECEIPTS": _capture_path_records(repo_root, packet.get("KNOWN_RECEIPTS", [])),
+        "KNOWN_DRAFT_BUILDS": _capture_path_records(
+            repo_root, packet.get("KNOWN_DRAFT_BUILDS", [])
+        ),
+        "RELEVANT_CONTRACT_SLICES": _capture_path_records(
+            repo_root, packet.get("RELEVANT_CONTRACT_SLICES", [])
+        ),
+        "RELEVANT_SDD_SLICES": _capture_path_records(
+            repo_root, packet.get("RELEVANT_SDD_SLICES", [])
+        ),
+        "KNOWN_SYMBOLS": _capture_symbol_records(repo_root, packet.get("KNOWN_SYMBOLS", [])),
+        "KNOWN_DEPENDENCIES": _capture_dependency_records(
+            repo_root, packet.get("KNOWN_DEPENDENCIES", [])
+        ),
+        "MACHINE_EVIDENCE": [dict(item) for item in (machine_evidence or [])],
+    }
+    return state
+
+
+def evaluate_preflight(
+    packet: Mapping[str, Any],
+    state: Mapping[str, Any],
+    *,
+    attempted_full_rediscovery: bool = False,
+    attempted_full_preflight_reexecution: bool = False,
+    attempted_replan: bool = False,
+) -> dict[str, Any]:
+    packet = normalize_packet(packet)
+    writer_check = validate_writer_invariants(packet)
+    invalidations = detect_invalidations(packet, state)
+    targeted_only = invalidations and all(
+        item["kind"] not in GLOBAL_INVALIDATOR_KINDS for item in invalidations
+    )
+    resume_from_boundary = bool(packet.get("FIRST_UNPROVEN_BOUNDARY"))
+    accepted = str(packet.get("PREFLIGHT_STATUS") or "").lower() in {
+        "accepted",
+        "accepted_reuse",
+        "pass",
+        "passed",
+        "verified",
+    }
+    no_invalidators = len(invalidations) == 0
+    decision = {
+        "PROGRAM_ID": packet.get("PROGRAM_ID", PROGRAM_ID),
+        "CAPABILITY_ID": packet.get("CAPABILITY_ID"),
+        "GOAL": packet.get("GOAL"),
+        "PREFLIGHT_STATUS": (
+            "accepted_reuse"
+            if accepted and no_invalidators
+            else "targeted_refresh_required"
+            if targeted_only
+            else "global_refresh_required"
+            if invalidations
+            else packet.get("PREFLIGHT_STATUS", "unknown")
+        ),
+        "ACCEPTED_HEAD": packet.get("ACCEPTED_HEAD"),
+        "ACCEPTED_TREE": packet.get("ACCEPTED_TREE"),
+        "CURRENT_HEAD": state.get("HEAD"),
+        "CURRENT_TREE": state.get("TREE"),
+        "FIRST_UNPROVEN_BOUNDARY": packet.get("FIRST_UNPROVEN_BOUNDARY"),
+        "INVALIDATOR_COUNT": len(invalidations),
+        "INVALIDATORS_TRIGGERED": invalidations,
+        "REFRESH_SCOPE": _refresh_scope(invalidations),
+        "RESUME_FROM_FIRST_UNPROVEN_BOUNDARY": resume_from_boundary,
+        "FULL_DISCOVERY_FORBIDDEN": no_invalidators or targeted_only,
+        "FULL_PREFLIGHT_REEXECUTION_FORBIDDEN": no_invalidators or targeted_only,
+        "REPLAN_FORBIDDEN": no_invalidators or targeted_only,
+        "REDUNDANT_PREFLIGHT_ATTEMPT": no_invalidators
+        and (
+            attempted_full_rediscovery
+            or attempted_full_preflight_reexecution
+            or attempted_replan
+        ),
+        "PREFLIGHT_REUSE_REQUIRED": accepted and no_invalidators,
+        "REOPEN_REQUIRED": not (accepted and no_invalidators),
+        "HANDOFF_DISCOVERY_REQUIRED": True,
+        "DRAFT_BUILD_DISCOVERY_REQUIRED": True,
+        "WORKTREE_DISCOVERY_REQUIRED": True,
+        "RAG_AS_LOCATOR_REQUIRED": True,
+        "ONE_WRITER_INVARIANT_PRESERVED": writer_check["ok"],
+        "CANONICAL_PRIMARY_WRITER_COUNT": writer_check["primary_writer_count"],
+        "PARALLEL_SCOUT_VIOLATIONS": writer_check["violations"],
+    }
+    return decision
+
+
+def detect_invalidations(
+    packet: Mapping[str, Any], state: Mapping[str, Any]
+) -> list[dict[str, Any]]:
+    invalidations: list[dict[str, Any]] = []
+    record_maps = _record_maps(state)
+    for raw_rule in packet.get("INVALIDATE_IF", []):
+        rule = dict(raw_rule) if isinstance(raw_rule, Mapping) else {"kind": str(raw_rule)}
+        kind = str(rule.get("kind") or "").strip()
+        if kind in TARGETED_INVALIDATOR_KINDS:
+            field = TARGETED_INVALIDATOR_KINDS[kind]
+            current = _resolve_record_for_rule(field, rule, record_maps)
+            expected = _expected_digest(rule, current)
+            current_digest = None if current is None else current.get("current_digest")
+            if expected and current_digest and expected != current_digest:
+                invalidations.append(
+                    _make_invalidation(
+                        kind,
+                        rule,
+                        scope="targeted",
+                        current=current,
+                        reason=f"{kind} changed",
+                    )
+                )
+            elif expected and current is None:
+                invalidations.append(
+                    _make_invalidation(
+                        kind,
+                        rule,
+                        scope="targeted",
+                        current=None,
+                        reason=f"{kind} target missing",
+                    )
+                )
+            continue
+        if kind == "accepted_baseline_invalidation":
+            if _baseline_invalidated(rule, packet, state):
+                invalidations.append(
+                    _make_invalidation(
+                        kind,
+                        rule,
+                        scope="global",
+                        current=None,
+                        reason="accepted baseline marked invalid",
+                    )
+                )
+            continue
+        if kind == "contradictory_machine_evidence":
+            if _machine_evidence_contradicts(rule, state):
+                invalidations.append(
+                    _make_invalidation(
+                        kind,
+                        rule,
+                        scope="global",
+                        current=None,
+                        reason="fresh machine evidence contradicts accepted state",
+                    )
+                )
+            continue
+    return invalidations
+
+
+def validate_writer_invariants(packet: Mapping[str, Any]) -> dict[str, Any]:
+    violations: list[str] = []
+    primary = packet.get("PRIMARY_WRITER")
+    primary_count = 0
+    if isinstance(primary, (list, tuple, set)):
+        primary_count = len({str(item) for item in primary if str(item).strip()})
+    elif str(primary or "").strip():
+        primary_count = 1
+    if primary_count > 1:
+        violations.append("multiple canonical writers declared")
+    for scout in packet.get("PARALLEL_SCOUTS", []):
+        data = dict(scout) if isinstance(scout, Mapping) else {"name": str(scout)}
+        read_only = data.get("read_only")
+        mode = str(data.get("mode") or "").strip().lower()
+        if read_only is False or mode not in {"", "read_only", "locator"}:
+            violations.append(f"parallel scout not read-only: {data.get('name') or data}")
+    return {
+        "ok": not violations and primary_count <= 1,
+        "primary_writer_count": primary_count,
+        "violations": violations,
+    }
+
+
+def resolve_authority(
+    evidence: Sequence[Mapping[str, Any]], *, intent: str = "implementation"
+) -> Mapping[str, Any] | None:
+    order = AUTHORITY_ORDER.get(intent, AUTHORITY_ORDER["implementation"])
+    ranked = {kind: index for index, kind in enumerate(order)}
+    selected: Mapping[str, Any] | None = None
+    selected_rank = len(order) + 1
+    for item in evidence:
+        kind = str(item.get("kind") or "").strip()
+        rank = ranked.get(kind, len(order) + 1)
+        if selected is None or rank < selected_rank:
+            selected = item
+            selected_rank = rank
+    return selected
+
+
+def reconstruct_resume_context(
+    repo_root: Path | str,
+    packet: Mapping[str, Any],
+    *,
+    machine_evidence: Sequence[Mapping[str, Any]] | None = None,
+    attempted_full_rediscovery: bool = False,
+    attempted_full_preflight_reexecution: bool = False,
+    attempted_replan: bool = False,
+) -> dict[str, Any]:
+    packet = normalize_packet(packet)
+    capability_id = str(packet.get("CAPABILITY_ID") or "")
+    discovery = discover_prior_work(repo_root, capability_id)
+    state = capture_repo_state(repo_root, packet, machine_evidence=machine_evidence)
+    decision = evaluate_preflight(
+        packet,
+        state,
+        attempted_full_rediscovery=attempted_full_rediscovery,
+        attempted_full_preflight_reexecution=attempted_full_preflight_reexecution,
+        attempted_replan=attempted_replan,
+    )
+    return {
+        "GOAL": packet.get("GOAL"),
+        "CAPABILITY_ID": capability_id,
+        "PRIOR_WORK_LOCATE": discovery,
+        "ACCEPTED_BASELINE": {
+            "HEAD": packet.get("ACCEPTED_HEAD"),
+            "TREE": packet.get("ACCEPTED_TREE"),
+        },
+        "FIRST_UNPROVEN_BOUNDARY": packet.get("FIRST_UNPROVEN_BOUNDARY"),
+        "INVALIDATOR_CHECK": decision,
+        "LOAD_RELEVANT_CONTRACT_SLICES": packet.get("RELEVANT_CONTRACT_SLICES", []),
+        "LOAD_RELEVANT_SDD_SLICES": packet.get("RELEVANT_SDD_SLICES", []),
+        "LOAD_KNOWN_FILES": packet.get("KNOWN_FILES", []),
+        "LOAD_KNOWN_SYMBOLS": packet.get("KNOWN_SYMBOLS", []),
+        "LOAD_KNOWN_TESTS": packet.get("KNOWN_TESTS", []),
+        "NEXT_ACTION": (
+            "RESUME_FROM_FIRST_UNPROVEN_BOUNDARY"
+            if decision["PREFLIGHT_REUSE_REQUIRED"]
+            else "REFRESH_ONLY_AFFECTED_SLICES"
+            if decision["PREFLIGHT_STATUS"] == "targeted_refresh_required"
+            else "REBUILD_ACCEPTED_BASELINE"
+        ),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check and recover prior-work-first execution packets."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    locate = subparsers.add_parser("locate", help="Read-only targeted prior-work discovery.")
+    locate.add_argument("--repo-root", default=".")
+    locate.add_argument("--capability-id", required=True)
+
+    check = subparsers.add_parser("check", help="Evaluate a prior-work packet.")
+    check.add_argument("--repo-root", default=".")
+    check.add_argument("--packet", required=True)
+    check.add_argument("--machine-evidence")
+    check.add_argument("--attempt-full-rediscovery", action="store_true")
+    check.add_argument("--attempt-full-preflight-reexecution", action="store_true")
+    check.add_argument("--attempt-replan", action="store_true")
+
+    resume = subparsers.add_parser(
+        "resume",
+        help="Reconstruct the startup flow from packet + repository artifacts.",
+    )
+    resume.add_argument("--repo-root", default=".")
+    resume.add_argument("--packet", required=True)
+    resume.add_argument("--machine-evidence")
+    resume.add_argument("--attempt-full-rediscovery", action="store_true")
+    resume.add_argument("--attempt-full-preflight-reexecution", action="store_true")
+    resume.add_argument("--attempt-replan", action="store_true")
+
+    compact = subparsers.add_parser(
+        "compact-packet", help="Normalize a packet into the compact durable shape."
+    )
+    compact.add_argument("--packet", required=True)
+    compact.add_argument("--output")
+
+    args = parser.parse_args(argv)
+    if args.command == "locate":
+        print(
+            json.dumps(
+                discover_prior_work(Path(args.repo_root), args.capability_id),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    if args.command == "compact-packet":
+        payload = json.loads(Path(args.packet).read_text(encoding="utf-8"))
+        compact_packet = normalize_packet(payload)
+        rendered = json.dumps(compact_packet, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            Path(args.output).write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+        return 0
+    packet = json.loads(Path(args.packet).read_text(encoding="utf-8"))
+    machine_evidence = _load_machine_evidence(getattr(args, "machine_evidence", None))
+    repo_root = Path(args.repo_root)
+    if args.command == "check":
+        state = capture_repo_state(repo_root, packet, machine_evidence=machine_evidence)
+        decision = evaluate_preflight(
+            packet,
+            state,
+            attempted_full_rediscovery=args.attempt_full_rediscovery,
+            attempted_full_preflight_reexecution=args.attempt_full_preflight_reexecution,
+            attempted_replan=args.attempt_replan,
+        )
+        print(json.dumps(decision, indent=2, sort_keys=True))
+        return 0
+    context = reconstruct_resume_context(
+        repo_root,
+        packet,
+        machine_evidence=machine_evidence,
+        attempted_full_rediscovery=args.attempt_full_rediscovery,
+        attempted_full_preflight_reexecution=args.attempt_full_preflight_reexecution,
+        attempted_replan=args.attempt_replan,
+    )
+    print(json.dumps(context, indent=2, sort_keys=True))
+    return 0
+
+
+def _normalize_list_field(key: str, value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        value = [value]
+    if key in PATH_LIST_FIELDS:
+        return [_coerce_path_like(item) for item in value]
+    if key == "KNOWN_SYMBOLS":
+        return [_coerce_symbol_like(item) for item in value]
+    if key == "KNOWN_DEPENDENCIES":
+        return [_coerce_dependency_like(item) for item in value]
+    if key == "INVALIDATE_IF":
+        return [dict(item) if isinstance(item, Mapping) else {"kind": str(item)} for item in value]
+    if key == "PARALLEL_SCOUTS":
+        normalized = []
+        for item in value:
+            if isinstance(item, Mapping):
+                normalized.append(dict(item))
+            else:
+                normalized.append({"name": str(item), "mode": "read_only", "read_only": True})
+        return normalized
+    return list(value)
+
+
+def _coerce_path_like(item: Any) -> dict[str, Any]:
+    if isinstance(item, Mapping):
+        return dict(item)
+    return {"path": str(item)}
+
+
+def _coerce_symbol_like(item: Any) -> dict[str, Any]:
+    if isinstance(item, Mapping):
+        return dict(item)
+    raw = str(item)
+    if "::" in raw:
+        path, symbol = raw.split("::", 1)
+        return {"path": path, "symbol": symbol}
+    return {"symbol": raw}
+
+
+def _coerce_dependency_like(item: Any) -> dict[str, Any]:
+    if isinstance(item, Mapping):
+        return dict(item)
+    return {"name": str(item)}
+
+
+def _capture_path_records(repo_root: Path, records: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    captured = []
+    for raw in records:
+        entry = dict(raw)
+        path = entry.get("path")
+        if not path:
+            continue
+        abs_path = repo_root / str(path)
+        entry["path"] = _relpath(abs_path, repo_root)
+        entry["exists"] = abs_path.exists()
+        entry["current_digest"] = digest_path(abs_path)
+        captured.append(entry)
+    return captured
+
+
+def _capture_symbol_records(
+    repo_root: Path, records: Iterable[Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    captured = []
+    for raw in records:
+        entry = dict(raw)
+        path = entry.get("path")
+        symbol = entry.get("symbol")
+        if not path or not symbol:
+            continue
+        abs_path = repo_root / str(path)
+        entry["path"] = _relpath(abs_path, repo_root)
+        entry["exists"] = abs_path.exists()
+        entry["current_digest"] = digest_symbol(abs_path, str(symbol))
+        captured.append(entry)
+    return captured
+
+
+def _capture_dependency_records(
+    repo_root: Path, records: Iterable[Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    captured = []
+    for raw in records:
+        entry = dict(raw)
+        path = entry.get("path")
+        if path:
+            abs_path = repo_root / str(path)
+            entry["path"] = _relpath(abs_path, repo_root)
+            entry["exists"] = abs_path.exists()
+            entry["current_digest"] = digest_path(abs_path)
+        else:
+            entry["exists"] = False
+            entry["current_digest"] = None
+        captured.append(entry)
+    return captured
+
+
+def _load_machine_evidence(path: str | None) -> list[dict[str, Any]]:
+    if not path:
+        return []
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return [dict(item) for item in payload]
+    if isinstance(payload, Mapping):
+        return [dict(payload)]
+    return []
+
+
+def _resolve_record_for_rule(
+    field: str, rule: Mapping[str, Any], record_maps: Mapping[str, Mapping[str, Mapping[str, Any]]]
+) -> Mapping[str, Any] | None:
+    if field == "KNOWN_SYMBOLS":
+        key = f"{_normalize_path_key(rule.get('path'))}::{rule.get('symbol')}"
+        return record_maps.get(field, {}).get(key)
+    path = rule.get("path")
+    if path:
+        return record_maps.get(field, {}).get(_normalize_path_key(path))
+    return None
+
+
+def _expected_digest(rule: Mapping[str, Any], current: Mapping[str, Any] | None) -> str | None:
+    for key in ("expected_digest", "digest", "accepted_digest", "baseline_digest"):
+        value = rule.get(key)
+        if value:
+            return str(value)
+    if current is not None:
+        for key in ("digest", "accepted_digest", "baseline_digest"):
+            value = current.get(key)
+            if value:
+                return str(value)
+    return None
+
+
+def _baseline_invalidated(
+    rule: Mapping[str, Any], packet: Mapping[str, Any], state: Mapping[str, Any]
+) -> bool:
+    marker = rule.get("baseline_valid")
+    if marker is False:
+        return True
+    expected_tree = rule.get("expected_tree")
+    if expected_tree and expected_tree != state.get("TREE"):
+        return True
+    expected_head = rule.get("expected_head")
+    if expected_head and expected_head != state.get("HEAD"):
+        return True
+    mismatch = rule.get("mismatch_requires_invalidation")
+    if mismatch and packet.get("ACCEPTED_TREE") != state.get("TREE"):
+        return True
+    return False
+
+
+def _machine_evidence_contradicts(
+    rule: Mapping[str, Any], state: Mapping[str, Any]
+) -> bool:
+    subjects = set()
+    if rule.get("test"):
+        subjects.add(str(rule["test"]))
+    if rule.get("subject"):
+        subjects.add(str(rule["subject"]))
+    for item in state.get("MACHINE_EVIDENCE", []):
+        status = str(item.get("status") or "").upper()
+        if status not in {"FAIL", "FAILED", "ERROR"}:
+            continue
+        if not subjects:
+            return True
+        if str(item.get("test") or item.get("subject") or "") in subjects:
+            return True
+    return False
+
+
+def _make_invalidation(
+    kind: str,
+    rule: Mapping[str, Any],
+    *,
+    scope: str,
+    current: Mapping[str, Any] | None,
+    reason: str,
+) -> dict[str, Any]:
+    entry = {
+        "kind": kind,
+        "scope": scope,
+        "reason": reason,
+    }
+    for key in ("path", "symbol", "test", "subject"):
+        if rule.get(key):
+            entry[key] = rule[key]
+    if current is not None:
+        entry["current_digest"] = current.get("current_digest")
+    expected = _expected_digest(rule, current)
+    if expected:
+        entry["expected_digest"] = expected
+    return entry
+
+
+def _refresh_scope(invalidations: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    refresh = []
+    seen = set()
+    for item in invalidations:
+        target = {
+            "kind": item.get("kind"),
+            "scope": item.get("scope"),
+        }
+        for key in ("path", "symbol", "test", "subject"):
+            if item.get(key):
+                target[key] = item[key]
+        marker = tuple(sorted(target.items()))
+        if marker in seen:
+            continue
+        seen.add(marker)
+        refresh.append(target)
+    return refresh
+
+
+def _record_maps(state: Mapping[str, Any]) -> dict[str, dict[str, Mapping[str, Any]]]:
+    maps: dict[str, dict[str, Mapping[str, Any]]] = {}
+    for field in TARGETED_INVALIDATOR_KINDS.values():
+        lookup: dict[str, Mapping[str, Any]] = {}
+        for record in state.get(field, []):
+            if field == "KNOWN_SYMBOLS":
+                key = f"{_normalize_path_key(record.get('path'))}::{record.get('symbol')}"
+            else:
+                key = _normalize_path_key(record.get("path"))
+            lookup[key] = record
+        maps[field] = lookup
+    return maps
+
+
+def _limited_file_listing(
+    directory: Path, *, suffixes: set[str] | None = None, limit: int = 64
+) -> list[str]:
+    if not directory.exists():
+        return []
+    found: list[str] = []
+    for path in sorted(directory.rglob("*")):
+        if len(found) >= limit:
+            break
+        if not path.is_file():
+            continue
+        if suffixes and path.suffix.lower() not in suffixes:
+            continue
+        found.append(str(path))
+    return found
+
+
+def _relpath(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return str(path.resolve())
+
+
+def _normalize_path_key(value: Any) -> str:
+    return str(value or "").replace("\\", "/")
+
+
+def _git_output(repo_root: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip()
+
+
+def _parse_worktree_list(output: str | None) -> list[dict[str, str]]:
+    if not output:
+        return []
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in output.splitlines():
+        if not line.strip():
+            if current:
+                entries.append(current)
+                current = {}
+            continue
+        if line.startswith("worktree "):
+            current["path"] = line[len("worktree ") :].strip()
+        elif line.startswith("HEAD "):
+            current["head"] = line[len("HEAD ") :].strip()
+        elif line.startswith("branch "):
+            branch = line[len("branch ") :].strip()
+            current["branch"] = branch.removeprefix("refs/heads/")
+    if current:
+        entries.append(current)
+    return entries
+
+
+def _parse_branch_list(output: str | None) -> list[dict[str, str]]:
+    if not output:
+        return []
+    branches = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        name, _, remainder = line.partition("\t")
+        commit, _, upstream = remainder.partition("\t")
+        branches.append(
+            {
+                "branch": name.strip(),
+                "head": commit.strip(),
+                "upstream": upstream.strip(),
+            }
+        )
+    return branches
+
+
+def _read_text(path: Path) -> str | None:
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _extract_symbol_segment(source: str, symbol: str) -> str | None:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return _extract_fallback_symbol_segment(source, symbol)
+    lines = source.splitlines()
+    for qualname, node in _iter_symbol_nodes(tree):
+        if qualname != symbol:
+            continue
+        start = getattr(node, "lineno", None)
+        end = getattr(node, "end_lineno", None)
+        if not start or not end:
+            return None
+        return "\n".join(lines[start - 1 : end])
+    return _extract_fallback_symbol_segment(source, symbol)
+
+
+def _iter_symbol_nodes(tree: ast.AST) -> Iterable[tuple[str, ast.AST]]:
+    def walk(body: list[ast.stmt], prefix: str = "") -> Iterable[tuple[str, ast.AST]]:
+        for node in body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                name = f"{prefix}.{node.name}" if prefix else node.name
+                yield name, node
+                child_body = getattr(node, "body", None)
+                if isinstance(child_body, list):
+                    yield from walk(child_body, name)
+
+    return walk(getattr(tree, "body", []))
+
+
+def _extract_fallback_symbol_segment(source: str, symbol: str) -> str | None:
+    for line in source.splitlines():
+        if symbol in line:
+            return line
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/prior-work-first-execution-memory.md
+++ b/docs/prior-work-first-execution-memory.md
@@ -1,0 +1,228 @@
+# Prior-Work-First Execution Memory
+
+This document is the repository-level protocol for durable task continuity.
+It gives a fresh agent enough structure to resume accepted work from repo
+artifacts instead of repeating broad discovery.
+
+## Scope
+
+Use this protocol for repository-authorized implementation tasks where an
+agent may resume in a fresh session with no chat history.
+
+Do not use old conversation logs as implementation authority. They are
+historical locator signals only.
+
+## Canonical Owners
+
+- `SOUL.md` holds the concise law: `PRIOR-WORK-FIRST`.
+- `AGENTS.md` holds the durable repository rules future agents must follow.
+- This document holds the detailed execution protocol and packet contract.
+- `scripts/prior_work_first.py` is the machine-checkable guard and resume tool.
+- Current source and tests remain implementation truth.
+- Fresh machine evidence remains pass/fail truth.
+
+## Authority Ranking
+
+Authority depends on the question being answered.
+
+- Locator / resume / historical context:
+  `preflight packet` -> `receipt` -> `handoff` -> `RAG` -> old conversation
+- Semantic contract:
+  `Contract` -> current source -> current tests -> impacted SDD slice -> RAG
+- Implementation truth:
+  current source -> current tests -> Contract -> impacted SDD slice -> RAG
+- Verification truth:
+  fresh machine evidence -> current tests -> current source -> Contract -> RAG
+
+Old conversation and RAG never override current source, Contract, or fresh
+machine evidence.
+
+## Startup Flow
+
+Every fresh execution should follow this order:
+
+1. `GOAL`
+2. `CAPABILITY_ID`
+3. `PRIOR_WORK_LOCATE`
+4. `ACCEPTED_BASELINE`
+5. `FIRST_UNPROVEN_BOUNDARY`
+6. `INVALIDATOR_CHECK`
+7. load the exact relevant Contract / SDD / source / test slices
+8. `IMPLEMENT`
+9. `VERIFY`
+10. `DURABLE_CLOSEOUT`
+
+The first accepted boundary is the resume anchor. If prior work is accepted,
+resume from `FIRST_UNPROVEN_BOUNDARY` unless an explicit invalidator proves a
+targeted refresh is required.
+
+## Canonical Artifact Layout
+
+Store repository-task continuity artifacts under:
+
+```text
+.task-state/prior-work-first/<capability-slug>/
+  active.packet.json
+  handoffs/
+  receipts/
+  drafts/
+  rag/
+  ledgers/
+```
+
+The protocol is compact by design. Do not store transcripts in the active
+packet.
+
+## Compact Preflight Packet Contract
+
+The durable packet must retain only compact state needed to resume:
+
+```json
+{
+  "PROGRAM_ID": "HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1",
+  "GOAL": "what this task is trying to finish",
+  "CAPABILITY_ID": "stable capability identifier",
+  "PREFLIGHT_STATUS": "accepted|accepted_reuse|verified|targeted_refresh_required|global_refresh_required",
+  "ACCEPTED_HEAD": "git head accepted by prior work",
+  "ACCEPTED_TREE": "git tree accepted by prior work",
+  "FIRST_UNPROVEN_BOUNDARY": "the earliest boundary not yet proven",
+  "KNOWN_FILES": [{"path": "relative/path", "digest": "sha256"}],
+  "KNOWN_SYMBOLS": [{"path": "file.py", "symbol": "qual.name", "digest": "sha256"}],
+  "KNOWN_TESTS": [{"path": "tests/test_x.py", "digest": "sha256"}],
+  "KNOWN_DEPENDENCIES": [{"name": "pytest", "path": "pyproject.toml", "digest": "sha256"}],
+  "KNOWN_HANDOFFS": [{"path": ".task-state/.../handoffs/h1.md", "digest": "sha256"}],
+  "KNOWN_RECEIPTS": [{"path": ".task-state/.../receipts/r1.json", "digest": "sha256"}],
+  "KNOWN_WORKTREES": [{"path": "...", "branch": "feat/x", "head": "sha"}],
+  "KNOWN_BRANCHES": [{"branch": "feat/x", "head": "sha", "upstream": "origin/main"}],
+  "KNOWN_DRAFT_BUILDS": [{"path": ".task-state/.../drafts/build.txt", "digest": "sha256"}],
+  "KNOWN_BASELINE_EXCEPTIONS": ["narrow accepted exceptions only"],
+  "RELEVANT_CONTRACT_SLICES": [{"path": "AGENTS.md", "digest": "sha256"}],
+  "RELEVANT_SDD_SLICES": [{"path": "docs/design/example.md", "digest": "sha256"}],
+  "PROVEN_INVARIANTS": ["exact invariant already proven"],
+  "INVALIDATE_IF": [
+    {"kind": "contract_change", "path": "AGENTS.md", "expected_digest": "sha256"},
+    {"kind": "symbol_change", "path": "agent/example.py", "symbol": "foo", "expected_digest": "sha256"},
+    {"kind": "dependency_change", "path": "pyproject.toml", "expected_digest": "sha256"},
+    {"kind": "test_semantics_change", "path": "tests/test_x.py", "expected_digest": "sha256"},
+    {"kind": "contradictory_machine_evidence", "test": "tests/test_x.py"}
+  ],
+  "LAST_MACHINE_VERIFIED_AT": "2026-08-30T00:00:00Z",
+  "PRIMARY_WRITER": "canonical agent id",
+  "PARALLEL_SCOUTS": [{"name": "scout-a", "mode": "read_only", "read_only": true}]
+}
+```
+
+The packet is intentionally compact:
+
+- allowed: program, capability, goal, accepted baseline, first unproven
+  boundary, exact files/symbols/tests/dependencies, focused receipts/handoffs,
+  explicit invalidators, precise worktree/branch references, proven invariants
+- forbidden: full transcripts, broad conversation dumps, blind history copies,
+  speculative TODO lists detached from a proven boundary
+
+## Stale vs Refreshed Data
+
+Default to stale reuse only for data already accepted and still uninvalidated:
+
+- accepted baseline head/tree
+- exact file, symbol, contract, SDD, dependency, and test digests
+- accepted handoffs and receipts
+- the first unproven boundary
+
+Refresh volatile state first:
+
+- current HEAD and tree
+- worktree inventory
+- branch inventory
+- current digests for exact tracked files/symbols/tests
+- fresh machine evidence
+
+Do not broaden discovery when only volatile state moved and no invalidator
+fired.
+
+## Invalidator Policy
+
+Explicit invalidators should cover:
+
+- relevant Contract change
+- relevant symbol change
+- dependency change
+- accepted baseline invalidation
+- test semantics change
+- contradictory fresh machine evidence
+- architecture owner change
+
+Unrelated HEAD changes do not invalidate accepted work by themselves.
+
+## Full Rediscovery vs Targeted Refresh
+
+If `INVALIDATOR_COUNT=0`, all of these must hold:
+
+- `RESUME_FROM_FIRST_UNPROVEN_BOUNDARY=true`
+- `FULL_DISCOVERY_FORBIDDEN=true`
+- `FULL_PREFLIGHT_REEXECUTION_FORBIDDEN=true`
+- `REPLAN_FORBIDDEN=true`
+- `REDUNDANT_PREFLIGHT_ATTEMPT=true` if a broad rediscovery was attempted
+
+If a targeted invalidator fires, refresh only the affected slice. Full
+rediscovery becomes allowed only when a global invalidator proves the accepted
+baseline itself is no longer trustworthy.
+
+## Discovery Requirements Before New Work
+
+Before creating a new implementation, plan, or worktree, locate as applicable:
+
+- capability or technical-debt ledgers
+- project-context rules and handoffs
+- accepted receipts
+- active preflight packets
+- active and historical worktrees
+- active and historical branches
+- draft or partial builds
+- RAG resume / locate / impact artifacts
+- relevant Contract slices
+- impacted SDD slices
+- current source and focused tests
+- fresh machine evidence
+
+This discovery stays targeted. Do not blindly load all historical context.
+
+## One Writer Invariant
+
+There may be only one canonical primary writer for a capability at a time.
+Parallel scouts are allowed only when they are read-only. A read-only scout may
+locate or summarize evidence; it may not become a second writer.
+
+## Durable Closeout
+
+At the end of a task, refresh the compact packet and any accepted receipt with
+fresh machine evidence from the current state. A prior PASS is not reopened
+without an explicit invalidator.
+
+## Executable Guard
+
+Run the targeted locator:
+
+```bash
+python scripts/prior_work_first.py locate --capability-id <CAPABILITY_ID>
+```
+
+Check whether the accepted packet can be reused:
+
+```bash
+python scripts/prior_work_first.py check \
+  --packet .task-state/prior-work-first/<capability-slug>/active.packet.json
+```
+
+Reconstruct the startup flow in machine-readable form:
+
+```bash
+python scripts/prior_work_first.py resume \
+  --packet .task-state/prior-work-first/<capability-slug>/active.packet.json
+```
+
+Normalize a packet into the compact durable shape:
+
+```bash
+python scripts/prior_work_first.py compact-packet --packet <path>
+```

--- a/scripts/prior_work_first.py
+++ b/scripts/prior_work_first.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.prior_work_first import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -95,6 +95,7 @@ Profiles use `~/.hermes/profiles/<name>/` with the same layout. When a profile i
 | Provider setup, API keys, OAuth | `references/providers-and-models.md` |
 | config.yaml sections, toolsets, voice/STT/TTS | `references/configuration.md` |
 | AGENTS.md / .hermes.md / CLAUDE.md project rules | `references/project-context-files.md` |
+| Repository implementation task should resume prior accepted work | `references/prior-work-first.md` |
 | Secret redaction, PII, approval modes, "reset permissions" | `references/security-privacy.md` |
 | Delegation, cron, curator, kanban | `references/background-systems.md` |
 | MCP servers (add, catalog, `hermes mcp`) | `references/native-mcp.md` |

--- a/skills/autonomous-ai-agents/hermes-agent/references/prior-work-first.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/prior-work-first.md
@@ -1,0 +1,94 @@
+# Prior-Work-First
+
+Use this reference when an implementation task should resume from prior
+accepted work instead of rediscovering everything.
+
+## Core Rule
+
+Run startup in this order:
+
+1. `GOAL`
+2. `CAPABILITY_ID`
+3. `PRIOR_WORK_LOCATE`
+4. `ACCEPTED_BASELINE`
+5. `FIRST_UNPROVEN_BOUNDARY`
+6. `INVALIDATOR_CHECK`
+7. load exact relevant Contract / SDD / source / test slices
+8. `IMPLEMENT`
+9. `VERIFY`
+10. `DURABLE_CLOSEOUT`
+
+## Authority Order
+
+- RAG is locator/resume/historical context only.
+- Contract is semantic authority.
+- SDD is architectural authority only for impacted slices.
+- Current source and tests are implementation truth.
+- Fresh machine evidence is PASS/FAIL authority.
+
+Old conversation and RAG never override current source, Contract, or fresh
+machine evidence.
+
+## Reuse vs Refresh
+
+If accepted prior work exists, resume from `FIRST_UNPROVEN_BOUNDARY`.
+
+If `INVALIDATOR_COUNT=0`, all of these must hold:
+
+- `RESUME_FROM_FIRST_UNPROVEN_BOUNDARY=true`
+- `FULL_DISCOVERY_FORBIDDEN=true`
+- `FULL_PREFLIGHT_REEXECUTION_FORBIDDEN=true`
+- `REPLAN_FORBIDDEN=true`
+
+Refresh only volatile state by default:
+
+- current HEAD/tree
+- focused file, symbol, test, and dependency digests
+- worktree/branch inventory
+- fresh machine evidence
+
+## Required Discovery
+
+Before writing or replacing work, locate as applicable:
+
+- capability or technical-debt ledgers
+- project handoffs
+- accepted receipts
+- active preflight packets
+- worktrees and branches
+- draft or partial builds
+- RAG resume / locate / impact artifacts
+- relevant Contract slices
+- impacted SDD slices
+- current source and tests
+
+This discovery is targeted. Do not blindly reload all prior history.
+
+## Invalidators
+
+Explicit invalidators should cover:
+
+- relevant Contract change
+- relevant symbol change
+- dependency change
+- accepted baseline invalidation
+- test semantics change
+- contradictory fresh machine evidence
+- architecture owner change
+
+Unrelated HEAD movement does not invalidate accepted work by itself.
+
+## One Writer
+
+One canonical primary writer only. Parallel scouts may locate evidence, but
+they remain read-only.
+
+## Executable Guard
+
+Use the repository helper:
+
+```bash
+python scripts/prior_work_first.py locate --capability-id <CAPABILITY_ID>
+python scripts/prior_work_first.py check --packet <packet.json>
+python scripts/prior_work_first.py resume --packet <packet.json>
+```

--- a/tests/agent/test_prior_work_first.py
+++ b/tests/agent/test_prior_work_first.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from agent import prior_work_first as pwf
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "agent@example.com")
+    _git(repo, "config", "user.name", "Agent Test")
+    (repo / "docs").mkdir()
+    (repo / "agent").mkdir()
+    (repo / "tests").mkdir()
+    (repo / "AGENTS.md").write_text("contract v1\n", encoding="utf-8")
+    (repo / "docs" / "design.md").write_text("sdd v1\n", encoding="utf-8")
+    (repo / "agent" / "demo.py").write_text(
+        "def stable():\n"
+        "    return 1\n"
+        "\n"
+        "def helper():\n"
+        "    return 'ok'\n",
+        encoding="utf-8",
+    )
+    (repo / "tests" / "test_demo.py").write_text(
+        "def test_demo():\n"
+        "    assert True\n",
+        encoding="utf-8",
+    )
+    (repo / "pyproject.toml").write_text(
+        "[project]\n"
+        "dependencies = [\"pytest==8.4.0\"]\n",
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text("baseline\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+def _packet(repo: Path, *, status: str = "accepted") -> dict[str, object]:
+    git_state = pwf.collect_git_state(repo)
+    return pwf.normalize_packet(
+        {
+            "PROGRAM_ID": pwf.PROGRAM_ID,
+            "GOAL": "Finish the demo capability",
+            "CAPABILITY_ID": "demo-capability",
+            "PREFLIGHT_STATUS": status,
+            "ACCEPTED_HEAD": git_state["HEAD"],
+            "ACCEPTED_TREE": git_state["TREE"],
+            "FIRST_UNPROVEN_BOUNDARY": "IMPLEMENT",
+            "KNOWN_FILES": [
+                {
+                    "path": "agent/demo.py",
+                    "digest": pwf.digest_path(repo / "agent" / "demo.py"),
+                }
+            ],
+            "KNOWN_SYMBOLS": [
+                {
+                    "path": "agent/demo.py",
+                    "symbol": "stable",
+                    "digest": pwf.digest_symbol(repo / "agent" / "demo.py", "stable"),
+                }
+            ],
+            "KNOWN_TESTS": [
+                {
+                    "path": "tests/test_demo.py",
+                    "digest": pwf.digest_path(repo / "tests" / "test_demo.py"),
+                }
+            ],
+            "KNOWN_DEPENDENCIES": [
+                {
+                    "name": "pytest",
+                    "path": "pyproject.toml",
+                    "digest": pwf.digest_path(repo / "pyproject.toml"),
+                }
+            ],
+            "RELEVANT_CONTRACT_SLICES": [
+                {
+                    "path": "AGENTS.md",
+                    "digest": pwf.digest_path(repo / "AGENTS.md"),
+                }
+            ],
+            "RELEVANT_SDD_SLICES": [
+                {
+                    "path": "docs/design.md",
+                    "digest": pwf.digest_path(repo / "docs" / "design.md"),
+                }
+            ],
+            "INVALIDATE_IF": [
+                {
+                    "kind": "symbol_change",
+                    "path": "agent/demo.py",
+                    "symbol": "stable",
+                    "expected_digest": pwf.digest_symbol(
+                        repo / "agent" / "demo.py", "stable"
+                    ),
+                },
+                {
+                    "kind": "contract_change",
+                    "path": "AGENTS.md",
+                    "expected_digest": pwf.digest_path(repo / "AGENTS.md"),
+                },
+                {
+                    "kind": "dependency_change",
+                    "path": "pyproject.toml",
+                    "expected_digest": pwf.digest_path(repo / "pyproject.toml"),
+                },
+                {
+                    "kind": "test_semantics_change",
+                    "path": "tests/test_demo.py",
+                    "expected_digest": pwf.digest_path(repo / "tests" / "test_demo.py"),
+                },
+            ],
+            "PRIMARY_WRITER": "writer-1",
+            "PARALLEL_SCOUTS": [
+                {"name": "scout-1", "mode": "read_only", "read_only": True}
+            ],
+            "MESSAGES": [{"role": "user", "content": "must be stripped"}],
+        }
+    )
+
+
+def test_compact_packet_drops_transcripts():
+    packet = pwf.normalize_packet(
+        {
+            "PROGRAM_ID": pwf.PROGRAM_ID,
+            "GOAL": "Goal",
+            "CAPABILITY_ID": "cap",
+            "MESSAGES": [{"role": "user"}],
+            "TRANSCRIPT": "nope",
+            "CONVERSATION_HISTORY": ["nope"],
+        }
+    )
+
+    assert "MESSAGES" not in packet
+    assert "TRANSCRIPT" not in packet
+    assert "CONVERSATION_HISTORY" not in packet
+    assert packet["CAPABILITY_ID"] == "cap"
+
+
+def test_accepted_preflight_with_no_invalidator_skips_broad_rediscovery(tmp_path):
+    repo = _init_repo(tmp_path)
+    packet = _packet(repo)
+    state = pwf.capture_repo_state(repo, packet)
+
+    decision = pwf.evaluate_preflight(
+        packet,
+        state,
+        attempted_full_rediscovery=True,
+    )
+
+    assert decision["PREFLIGHT_STATUS"] == "accepted_reuse"
+    assert decision["INVALIDATOR_COUNT"] == 0
+    assert decision["RESUME_FROM_FIRST_UNPROVEN_BOUNDARY"] is True
+    assert decision["FULL_DISCOVERY_FORBIDDEN"] is True
+    assert decision["FULL_PREFLIGHT_REEXECUTION_FORBIDDEN"] is True
+    assert decision["REPLAN_FORBIDDEN"] is True
+    assert decision["REDUNDANT_PREFLIGHT_ATTEMPT"] is True
+    assert decision["PREFLIGHT_REUSE_REQUIRED"] is True
+
+
+def test_relevant_symbol_change_refreshes_only_affected_slice(tmp_path):
+    repo = _init_repo(tmp_path)
+    packet = _packet(repo)
+    (repo / "agent" / "demo.py").write_text(
+        "def stable():\n"
+        "    return 2\n"
+        "\n"
+        "def helper():\n"
+        "    return 'ok'\n",
+        encoding="utf-8",
+    )
+    state = pwf.capture_repo_state(repo, packet)
+
+    decision = pwf.evaluate_preflight(packet, state)
+
+    assert decision["PREFLIGHT_STATUS"] == "targeted_refresh_required"
+    assert decision["INVALIDATOR_COUNT"] == 1
+    assert decision["FULL_DISCOVERY_FORBIDDEN"] is True
+    assert decision["REFRESH_SCOPE"] == [
+        {
+            "kind": "symbol_change",
+            "scope": "targeted",
+            "path": "agent/demo.py",
+            "symbol": "stable",
+        }
+    ]
+
+
+def test_discovery_finds_handoff_worktree_draft_and_receipt_before_new_plan(tmp_path):
+    repo = _init_repo(tmp_path)
+    cap_dir = pwf.canonical_capability_dir(repo, "demo-capability")
+    (cap_dir / "handoffs").mkdir(parents=True)
+    (cap_dir / "receipts").mkdir()
+    (cap_dir / "drafts").mkdir()
+    (cap_dir / "rag").mkdir()
+    (cap_dir / "handoffs" / "accepted.md").write_text("handoff\n", encoding="utf-8")
+    (cap_dir / "receipts" / "accepted.json").write_text("{}", encoding="utf-8")
+    (cap_dir / "drafts" / "draft.txt").write_text("draft\n", encoding="utf-8")
+    (cap_dir / "rag" / "impact.json").write_text("{}", encoding="utf-8")
+    worktree_path = repo / ".worktrees" / "resume-demo"
+    worktree_path.parent.mkdir()
+    _git(repo, "worktree", "add", str(worktree_path), "-b", "feat/resume-demo", "HEAD")
+
+    discovery = pwf.discover_prior_work(repo, "demo-capability")
+
+    assert discovery["SEARCH_MODE"] == "targeted_read_only"
+    assert discovery["FULL_HISTORY_LOADED"] is False
+    assert discovery["ARTIFACTS"]["handoffs"]
+    assert discovery["ARTIFACTS"]["receipts"]
+    assert discovery["ARTIFACTS"]["draft_builds"]
+    assert discovery["ARTIFACTS"]["rag"]
+    assert any(item["branch"] == "feat/resume-demo" for item in discovery["KNOWN_WORKTREES"])
+    assert any(item["branch"] == "feat/resume-demo" for item in discovery["KNOWN_BRANCHES"])
+
+
+def test_rag_conflict_loses_to_source_and_tests():
+    selected_impl = pwf.resolve_authority(
+        [
+            {"kind": "rag", "value": "stale"},
+            {"kind": "source", "value": "live source"},
+            {"kind": "tests", "value": "live tests"},
+        ],
+        intent="implementation",
+    )
+    selected_verify = pwf.resolve_authority(
+        [
+            {"kind": "rag", "value": "stale"},
+            {"kind": "tests", "value": "live tests"},
+        ],
+        intent="verification",
+    )
+
+    assert selected_impl == {"kind": "source", "value": "live source"}
+    assert selected_verify == {"kind": "tests", "value": "live tests"}
+
+
+def test_contract_change_invalidates_only_contract_slice(tmp_path):
+    repo = _init_repo(tmp_path)
+    packet = _packet(repo)
+    (repo / "AGENTS.md").write_text("contract v2\n", encoding="utf-8")
+    state = pwf.capture_repo_state(repo, packet)
+
+    decision = pwf.evaluate_preflight(packet, state)
+
+    assert decision["PREFLIGHT_STATUS"] == "targeted_refresh_required"
+    assert decision["INVALIDATOR_COUNT"] == 1
+    assert decision["REFRESH_SCOPE"] == [
+        {
+            "kind": "contract_change",
+            "scope": "targeted",
+            "path": "AGENTS.md",
+        }
+    ]
+
+
+def test_unrelated_head_change_preserves_validity(tmp_path):
+    repo = _init_repo(tmp_path)
+    packet = _packet(repo)
+    (repo / "README.md").write_text("unrelated\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "unrelated change")
+    state = pwf.capture_repo_state(repo, packet)
+
+    decision = pwf.evaluate_preflight(packet, state)
+
+    assert state["HEAD"] != packet["ACCEPTED_HEAD"]
+    assert state["TREE"] != packet["ACCEPTED_TREE"]
+    assert decision["INVALIDATOR_COUNT"] == 0
+    assert decision["PREFLIGHT_STATUS"] == "accepted_reuse"
+
+
+def test_parallel_scouts_stay_read_only_and_one_writer_is_enforced():
+    packet = pwf.normalize_packet(
+        {
+            "PROGRAM_ID": pwf.PROGRAM_ID,
+            "GOAL": "Goal",
+            "CAPABILITY_ID": "cap",
+            "PRIMARY_WRITER": ["writer-a", "writer-b"],
+            "PARALLEL_SCOUTS": [
+                {"name": "scout-a", "mode": "write", "read_only": False}
+            ],
+        }
+    )
+
+    result = pwf.validate_writer_invariants(packet)
+
+    assert result["ok"] is False
+    assert result["primary_writer_count"] == 2
+    assert "multiple canonical writers declared" in result["violations"]
+    assert any("parallel scout not read-only" in msg for msg in result["violations"])
+
+
+def test_prior_capability_pass_is_not_reopened_without_invalidator(tmp_path):
+    repo = _init_repo(tmp_path)
+    packet = _packet(repo, status="verified")
+    state = pwf.capture_repo_state(repo, packet)
+
+    decision = pwf.evaluate_preflight(packet, state)
+
+    assert decision["PREFLIGHT_REUSE_REQUIRED"] is True
+    assert decision["REOPEN_REQUIRED"] is False
+    assert decision["INVALIDATOR_COUNT"] == 0
+
+
+def test_new_agent_without_chat_history_reconstructs_resume_from_repo_artifacts(tmp_path):
+    repo = _init_repo(tmp_path)
+    packet = _packet(repo)
+    cap_dir = pwf.canonical_capability_dir(repo, "demo-capability")
+    (cap_dir / "handoffs").mkdir(parents=True)
+    (cap_dir / "drafts").mkdir()
+    (cap_dir / "receipts").mkdir()
+    (cap_dir / "handoffs" / "accepted.md").write_text("handoff\n", encoding="utf-8")
+    (cap_dir / "drafts" / "draft.txt").write_text("draft\n", encoding="utf-8")
+    (cap_dir / "receipts" / "accepted.json").write_text("{}", encoding="utf-8")
+    packet_path = cap_dir / pwf.PACKET_FILENAME
+    packet_path.write_text(json.dumps(packet, indent=2), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/prior_work_first.py",
+            "resume",
+            "--repo-root",
+            str(repo),
+            "--packet",
+            str(packet_path),
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["GOAL"] == "Finish the demo capability"
+    assert payload["CAPABILITY_ID"] == "demo-capability"
+    assert payload["FIRST_UNPROVEN_BOUNDARY"] == "IMPLEMENT"
+    assert payload["PRIOR_WORK_LOCATE"]["ARTIFACTS"]["handoffs"]
+    assert payload["PRIOR_WORK_LOCATE"]["ARTIFACTS"]["draft_builds"]
+    assert payload["PRIOR_WORK_LOCATE"]["ARTIFACTS"]["receipts"]
+    assert payload["INVALIDATOR_CHECK"]["PREFLIGHT_STATUS"] == "accepted_reuse"
+    assert payload["NEXT_ACTION"] == "RESUME_FROM_FIRST_UNPROVEN_BOUNDARY"

--- a/tests/agent/test_prior_work_first.py
+++ b/tests/agent/test_prior_work_first.py
@@ -208,6 +208,7 @@ def test_relevant_symbol_change_refreshes_only_affected_slice(tmp_path):
 
 def test_discovery_finds_handoff_worktree_draft_and_receipt_before_new_plan(tmp_path):
     repo = _init_repo(tmp_path)
+    packet = _packet(repo)
     cap_dir = pwf.canonical_capability_dir(repo, "demo-capability")
     (cap_dir / "handoffs").mkdir(parents=True)
     (cap_dir / "receipts").mkdir()
@@ -217,6 +218,7 @@ def test_discovery_finds_handoff_worktree_draft_and_receipt_before_new_plan(tmp_
     (cap_dir / "receipts" / "accepted.json").write_text("{}", encoding="utf-8")
     (cap_dir / "drafts" / "draft.txt").write_text("draft\n", encoding="utf-8")
     (cap_dir / "rag" / "impact.json").write_text("{}", encoding="utf-8")
+    (cap_dir / pwf.PACKET_FILENAME).write_text(json.dumps(packet, indent=2), encoding="utf-8")
     worktree_path = repo / ".worktrees" / "resume-demo"
     worktree_path.parent.mkdir()
     _git(repo, "worktree", "add", str(worktree_path), "-b", "feat/resume-demo", "HEAD")
@@ -225,10 +227,21 @@ def test_discovery_finds_handoff_worktree_draft_and_receipt_before_new_plan(tmp_
 
     assert discovery["SEARCH_MODE"] == "targeted_read_only"
     assert discovery["FULL_HISTORY_LOADED"] is False
-    assert discovery["ARTIFACTS"]["handoffs"]
-    assert discovery["ARTIFACTS"]["receipts"]
-    assert discovery["ARTIFACTS"]["draft_builds"]
-    assert discovery["ARTIFACTS"]["rag"]
+    assert discovery["ARTIFACTS"]["preflight_packets"] == [
+        ".task-state/prior-work-first/demo-capability/active.packet.json"
+    ]
+    assert discovery["ARTIFACTS"]["handoffs"] == [
+        ".task-state/prior-work-first/demo-capability/handoffs/accepted.md"
+    ]
+    assert discovery["ARTIFACTS"]["receipts"] == [
+        ".task-state/prior-work-first/demo-capability/receipts/accepted.json"
+    ]
+    assert discovery["ARTIFACTS"]["draft_builds"] == [
+        ".task-state/prior-work-first/demo-capability/drafts/draft.txt"
+    ]
+    assert discovery["ARTIFACTS"]["rag"] == [
+        ".task-state/prior-work-first/demo-capability/rag/impact.json"
+    ]
     assert any(item["branch"] == "feat/resume-demo" for item in discovery["KNOWN_WORKTREES"])
     assert any(item["branch"] == "feat/resume-demo" for item in discovery["KNOWN_BRANCHES"])
 


### PR DESCRIPTION
## Summary
- add a repository-level PRIOR-WORK-FIRST law and durable execution protocol
- add a machine-checkable prior-work-first preflight/resume guard and compact packet contract
- add focused tests proving targeted invalidation, resume-from-boundary, worktree/handoff discovery, and one-writer invariants

## Verification
- python -m pytest tests/agent/test_prior_work_first.py tests/skills/test_hermes_agent_skill.py -q --basetemp .pytest-tmp-prior-work-first
- python -m compileall agent\\prior_work_first.py scripts\\prior_work_first.py
- python scripts/prior_work_first.py locate --repo-root . --capability-id HERMES-PRIOR-WORK-FIRST-EXECUTION-MEMORY-V1