### PR TITLE
perf(codex): scan for format controls with a compiled class, not a per-char loop

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -111,22 +111,78 @@ def _coerce_arguments(arguments: Any) -> str:
     return arguments.strip() or "{}"
 
 
+# Category Cf as a character class.  The obvious spelling of the guard below \u2014
+# ``any(unicodedata.category(char) == "Cf" for char in text)`` \u2014 is a
+# Python-level loop with one C call per character, and preflight runs it over
+# every string in the request.  On a long history (hundreds of KB per call,
+# dozens of calls per turn) that single line dominates preflight cost.  Cf is
+# only 21 contiguous ranges, so a compiled class does the same scan inside the
+# regex engine instead.
+#
+# Hardcoded rather than derived at import: building it from ``unicodedata``
+# costs ~80ms of startup per process, and this module is imported by every
+# short-lived agent subprocess.  ``test_cf_class_matches_unicodedata``
+# re-derives the set and fails if a future Unicode revision adds a codepoint,
+# so drift is caught in CI rather than silently narrowing the guard.
+_FORMAT_CONTROL_RE = re.compile(
+    "[\U000000ad\U00000600-\U00000605\U0000061c\U000006dd\U0000070f"
+    "\U00000890-\U00000891\U000008e2\U0000180e\U0000200b-\U0000200f"
+    "\U0000202a-\U0000202e\U00002060-\U00002064\U00002066-\U0000206f"
+    "\U0000feff\U0000fff9-\U0000fffb\U000110bd\U000110cd"
+    "\U00013430-\U00013438\U0001bca0-\U0001bca3\U0001d173-\U0001d17a"
+    "\U000e0001\U000e0020-\U000e007f]"
+)
+
+
+def _has_format_control(text: str) -> bool:
+    """True when ``text`` contains a Unicode format (Cf) codepoint.
+
+    ``str.isascii()`` short-circuits the scan: no Cf codepoint is ASCII, and
+    CPython stores the ASCII-ness of a ``str`` in its header, so the common
+    case (code, logs, command output) answers in constant time without touching
+    the buffer at all.
+    """
+    if text.isascii():
+        return False
+    return _FORMAT_CONTROL_RE.search(text) is not None
+
+
 def _neutralize_harmony_tokens(text: str) -> str:
     """Keep Harmony source readable without emitting reserved wire tokens."""
     if not text or "<" not in text or "|" not in text:
         return text
-    if not any(unicodedata.category(char) == "Cf" for char in text):
-        return _HARMONY_CONTROL_TOKEN_RE.sub(rf"<{_FULLWIDTH_PIPE}\1{_FULLWIDTH_PIPE}>", text)
-    # The backend strips Unicode format controls (e.g. U+200B) before its reserved-token
-    # check, so match on the visible text and rewrite the original spans.
-    original_positions = [i for i, char in enumerate(text) if unicodedata.category(char) != "Cf"]
-    visible_text = "".join(text[i] for i in original_positions)
-    result, cursor = [], 0
-    for match in _HARMONY_CONTROL_TOKEN_RE.finditer(visible_text):
-        start, end = original_positions[match.start()], original_positions[match.end() - 1] + 1
-        result += [text[cursor:start], f"<{_FULLWIDTH_PIPE}{match.group(1)}{_FULLWIDTH_PIPE}>"]
-        cursor = end
-    return "".join(result) + text[cursor:]
+
+    replacement = rf"<{_FULLWIDTH_PIPE}\1{_FULLWIDTH_PIPE}>"
+    if not _has_format_control(text):
+        return _HARMONY_CONTROL_TOKEN_RE.sub(replacement, text)
+
+    # U+200B is confirmed to be stripped by the Codex backend before its
+    # reserved-token check. Treat every Unicode format control equivalently so
+    # moving the character elsewhere in the token (or swapping in another Cf)
+    # cannot recreate the same visually hidden form.
+    visible_chars: List[str] = []
+    original_positions: List[int] = []
+    for index, char in enumerate(text):
+        if unicodedata.category(char) == "Cf":
+            continue
+        visible_chars.append(char)
+        original_positions.append(index)
+
+    visible_text = "".join(visible_chars)
+    matches = list(_HARMONY_CONTROL_TOKEN_RE.finditer(visible_text))
+    if not matches:
+        return text
+
+    result: List[str] = []
+    original_cursor = 0
+    for match in matches:
+        original_start = original_positions[match.start()]
+        original_end = original_positions[match.end() - 1] + 1
+        result.append(text[original_cursor:original_start])
+        result.append(f"<{_FULLWIDTH_PIPE}{match.group(1)}{_FULLWIDTH_PIPE}>")
+        original_cursor = original_end
+    result.append(text[original_cursor:])
+    return "".join(result)
 
 
 def _neutralize_harmony_structure(value: Any) -> Any:

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -111,8 +111,8 @@ def _coerce_arguments(arguments: Any) -> str:
     return arguments.strip() or "{}"
 
 
-# Category Cf as a character class.  The obvious spelling of the guard below \u2014
-# ``any(unicodedata.category(char) == "Cf" for char in text)`` \u2014 is a
+# Category Cf as a character class.  The obvious spelling of the guard below —
+# ``any(unicodedata.category(char) == "Cf" for char in text)`` — is a
 # Python-level loop with one C call per character, and preflight runs it over
 # every string in the request.  On a long history (hundreds of KB per call,
 # dozens of calls per turn) that single line dominates preflight cost.  Cf is
@@ -121,16 +121,35 @@ def _coerce_arguments(arguments: Any) -> str:
 #
 # Hardcoded rather than derived at import: building it from ``unicodedata``
 # costs ~80ms of startup per process, and this module is imported by every
-# short-lived agent subprocess.  ``test_cf_class_matches_unicodedata``
-# re-derives the set and fails if a future Unicode revision adds a codepoint,
-# so drift is caught in CI rather than silently narrowing the guard.
-_FORMAT_CONTROL_RE = re.compile(
-    "[\U000000ad\U00000600-\U00000605\U0000061c\U000006dd\U0000070f"
+# short-lived agent subprocess. CPython 3.11 uses Unicode 14 while 3.12/3.13
+# use Unicode 15.x, where the Egyptian Hieroglyph format-control range gained
+# seven codepoints. Keep one pre-generated table per supported Unicode version
+# so the optimization remains byte-for-byte equivalent on every supported
+# Python. ``test_cf_class_matches_unicodedata`` reports exact missing/extra
+# codepoints if a future Unicode revision drifts from these tables.
+_FORMAT_CONTROL_UNICODE_VERSION = unicodedata.unidata_version
+_FORMAT_CONTROL_COMMON_PREFIX = (
+    "\U000000ad\U00000600-\U00000605\U0000061c\U000006dd\U0000070f"
     "\U00000890-\U00000891\U000008e2\U0000180e\U0000200b-\U0000200f"
     "\U0000202a-\U0000202e\U00002060-\U00002064\U00002066-\U0000206f"
     "\U0000feff\U0000fff9-\U0000fffb\U000110bd\U000110cd"
-    "\U00013430-\U00013438\U0001bca0-\U0001bca3\U0001d173-\U0001d17a"
-    "\U000e0001\U000e0020-\U000e007f]"
+)
+_FORMAT_CONTROL_COMMON_SUFFIX = (
+    "\U0001bca0-\U0001bca3\U0001d173-\U0001d17a"
+    "\U000e0001\U000e0020-\U000e007f"
+)
+_FORMAT_CONTROL_PATTERNS = {
+    "14.0.0": f"[{_FORMAT_CONTROL_COMMON_PREFIX}\U00013430-\U00013438{_FORMAT_CONTROL_COMMON_SUFFIX}]",
+    "15.0.0": f"[{_FORMAT_CONTROL_COMMON_PREFIX}\U00013430-\U0001343f{_FORMAT_CONTROL_COMMON_SUFFIX}]",
+    "15.1.0": f"[{_FORMAT_CONTROL_COMMON_PREFIX}\U00013430-\U0001343f{_FORMAT_CONTROL_COMMON_SUFFIX}]",
+}
+# Unknown future runtimes use the latest known superset; the drift test then
+# fails with an actionable missing/extra list instead of an opaque mismatch.
+_FORMAT_CONTROL_RE = re.compile(
+    _FORMAT_CONTROL_PATTERNS.get(
+        _FORMAT_CONTROL_UNICODE_VERSION,
+        _FORMAT_CONTROL_PATTERNS["15.1.0"],
+    )
 )
 
 

--- a/scripts/benchmark_codex_format_control_scan.py
+++ b/scripts/benchmark_codex_format_control_scan.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Benchmark the Unicode-Cf guard used by Codex request preflight.
+
+Reports three scopes separately so numbers are not mistaken for one another:
+(1) the detector alone, (2) token neutralization, and (3) complete request
+preflight across instructions, user/assistant content, tool arguments/results,
+and a tool schema. Warm-up runs are excluded from repeated samples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import timeit
+import unicodedata
+from pathlib import Path
+from typing import Callable
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import agent.codex_responses_adapter as adapter  # noqa: E402
+
+
+def _legacy_has_format_control(text: str) -> bool:
+    return any(unicodedata.category(char) == "Cf" for char in text)
+
+
+def _legacy_neutralize_harmony_tokens(text: str) -> str:
+    original = adapter._has_format_control
+    adapter._has_format_control = _legacy_has_format_control
+    try:
+        return adapter._neutralize_harmony_tokens(text)
+    finally:
+        adapter._has_format_control = original
+
+
+def _request(text: str) -> dict:
+    return {
+        "model": "gpt-5-codex",
+        "instructions": text,
+        "input": [
+            {"role": "user", "content": text},
+            {"role": "assistant", "content": text},
+            {
+                "type": "function_call",
+                "call_id": "call_args",
+                "name": "terminal",
+                "arguments": text,
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_result",
+                "output": text,
+            },
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "name": "inspect_text",
+                "description": text,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "description": text}},
+                },
+            }
+        ],
+        "store": False,
+    }
+
+
+def _preflight_with(detector: Callable[[str], bool], request: dict) -> None:
+    original = adapter._has_format_control
+    adapter._has_format_control = detector
+    try:
+        adapter._preflight_codex_api_kwargs(request, sanitize_harmony_tokens=True)
+    finally:
+        adapter._has_format_control = original
+
+
+def _measure(
+    function: Callable[[], object], *, warmup: int, repeats: int, loops: int
+) -> tuple[float, float]:
+    for _ in range(warmup):
+        function()
+    samples = timeit.repeat(function, repeat=repeats, number=loops)
+    per_call_ms = [sample * 1000 / loops for sample in samples]
+    return statistics.median(per_call_ms), statistics.pstdev(per_call_ms)
+
+
+def _report(
+    scope: str,
+    old: Callable[[], object],
+    new: Callable[[], object],
+    args: argparse.Namespace,
+) -> None:
+    old_ms, old_stddev = _measure(
+        old, warmup=args.warmup, repeats=args.repeats, loops=args.loops
+    )
+    new_ms, new_stddev = _measure(
+        new, warmup=args.warmup, repeats=args.repeats, loops=args.loops
+    )
+    speedup = old_ms / new_ms if new_ms else float("inf")
+    print(
+        f"scope={scope} old={old_ms:.3f}ms±{old_stddev:.3f} "
+        f"new={new_ms:.3f}ms±{new_stddev:.3f} speedup={speedup:.2f}x"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--size-kib", type=int, default=480)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--loops", type=int, default=10)
+    args = parser.parse_args()
+
+    base = "code <tag|value> and non-ASCII Türkçe text " * 2048
+    text = (base * ((args.size_kib * 1024 // len(base)) + 1))[: args.size_kib * 1024]
+    request = _request(text)
+    print(
+        f"input={len(text) / 1024:.0f}KiB warmup={args.warmup} "
+        f"repeats={args.repeats} loops={args.loops} unicode={unicodedata.unidata_version}"
+    )
+    _report(
+        "guard-only",
+        lambda: _legacy_has_format_control(text),
+        lambda: adapter._has_format_control(text),
+        args,
+    )
+    _report(
+        "neutralizer-only",
+        lambda: _legacy_neutralize_harmony_tokens(text),
+        lambda: adapter._neutralize_harmony_tokens(text),
+        args,
+    )
+    _report(
+        "complete-request-preflight",
+        lambda: _preflight_with(_legacy_has_format_control, request),
+        lambda: _preflight_with(adapter._has_format_control, request),
+        args,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -6,6 +6,8 @@ import pytest
 
 from agent.codex_responses_adapter import (
     _FORMAT_CONTROL_RE,
+    _FORMAT_CONTROL_UNICODE_VERSION,
+    _HARMONY_CONTROL_TOKEN_RE,
     _chat_content_to_responses_parts,
     _chat_messages_to_responses_input,
     _sanitize_replayed_fn_name,
@@ -75,6 +77,40 @@ def _harmony_token(name: str) -> str:
     return f"<\x7c{name}\x7c>"
 
 
+def _reference_neutralize_harmony_tokens(text: str) -> str:
+    """Pre-#98340 implementation, retained for differential regression tests."""
+    if not text or "<" not in text or "|" not in text:
+        return text
+
+    replacement = r"<｜\1｜>"
+    if not any(unicodedata.category(char) == "Cf" for char in text):
+        return _HARMONY_CONTROL_TOKEN_RE.sub(replacement, text)
+
+    visible_chars = []
+    original_positions = []
+    for index, char in enumerate(text):
+        if unicodedata.category(char) == "Cf":
+            continue
+        visible_chars.append(char)
+        original_positions.append(index)
+
+    visible_text = "".join(visible_chars)
+    matches = list(_HARMONY_CONTROL_TOKEN_RE.finditer(visible_text))
+    if not matches:
+        return text
+
+    result = []
+    original_cursor = 0
+    for match in matches:
+        original_start = original_positions[match.start()]
+        original_end = original_positions[match.end() - 1] + 1
+        result.append(text[original_cursor:original_start])
+        result.append(f"<｜{match.group(1)}｜>")
+        original_cursor = original_end
+    result.append(text[original_cursor:])
+    return "".join(result)
+
+
 def test_codex_preflight_gate_off_preserves_harmony_tokens_byte_for_byte():
     raw = [{
         "type": "function_call_output",
@@ -125,6 +161,113 @@ def test_harmony_neutralizer_handles_format_controls_anywhere_in_token():
         assert _neutralize_harmony_tokens(token) == "<｜start｜>"
 
 
+_REPRESENTATIVE_FORMAT_CONTROLS = (
+    pytest.param("\u200c", id="zwnj"),
+    pytest.param("\u200d", id="zwj"),
+    pytest.param("\u2060", id="word-joiner"),
+    pytest.param("\u200e", id="bidi-mark"),
+    pytest.param("\u00ad", id="soft-hyphen"),
+    pytest.param("\ufeff", id="bom"),
+)
+
+
+def _format_control_matrix_text(control: str, placement: str) -> str:
+    token = _harmony_token("start")
+    return {
+        "outside-token": f"prefix{control} {token} suffix",
+        "inside-delimiter": f"<{control}|start|>",
+        "between-token-chars": f"<|st{control}art|>",
+        "beginning": f"{control}{token}",
+        "end": f"{token}{control}",
+    }[placement]
+
+
+@pytest.mark.parametrize("control", _REPRESENTATIVE_FORMAT_CONTROLS)
+@pytest.mark.parametrize(
+    "placement",
+    ("outside-token", "inside-delimiter", "between-token-chars", "beginning", "end"),
+)
+def test_harmony_neutralizer_matches_previous_implementation(control, placement):
+    text = _format_control_matrix_text(control, placement)
+
+    assert _neutralize_harmony_tokens(text) == _reference_neutralize_harmony_tokens(text)
+
+
+def _run_preflight_text_carrier(carrier: str, text: str) -> str:
+    kwargs = {
+        "model": "gpt-5-codex",
+        "instructions": "plain instructions",
+        "input": [{"role": "user", "content": "plain input"}],
+        "store": False,
+    }
+
+    if carrier == "instructions":
+        kwargs["instructions"] = text
+    elif carrier in ("user-content", "assistant-content"):
+        kwargs["input"] = [{"role": carrier.removesuffix("-content"), "content": text}]
+    elif carrier == "tool-arguments":
+        kwargs["input"] = [{
+            "type": "function_call",
+            "call_id": "call_args",
+            "name": "terminal",
+            "arguments": text,
+        }]
+    elif carrier == "tool-result":
+        kwargs["input"] = [{
+            "type": "function_call_output",
+            "call_id": "call_result",
+            "output": text,
+        }]
+    elif carrier == "tool-schema":
+        kwargs["tools"] = [{
+            "type": "function",
+            "name": "inspect_text",
+            "description": text,
+            "parameters": {"type": "object", "properties": {}},
+        }]
+    else:  # pragma: no cover - parametrization owns this value
+        raise AssertionError(f"unknown carrier: {carrier}")
+
+    normalized = _preflight_codex_api_kwargs(kwargs, sanitize_harmony_tokens=True)
+    if carrier == "instructions":
+        return normalized["instructions"]
+    if carrier in ("user-content", "assistant-content"):
+        return normalized["input"][0]["content"]
+    if carrier == "tool-arguments":
+        return normalized["input"][0]["arguments"]
+    if carrier == "tool-result":
+        return normalized["input"][0]["output"]
+    return normalized["tools"][0]["description"]
+
+
+@pytest.mark.parametrize("control", _REPRESENTATIVE_FORMAT_CONTROLS)
+@pytest.mark.parametrize(
+    "placement",
+    ("outside-token", "inside-delimiter", "between-token-chars", "beginning", "end"),
+)
+@pytest.mark.parametrize(
+    "carrier",
+    ("instructions", "user-content", "assistant-content", "tool-arguments", "tool-result", "tool-schema"),
+)
+def test_preflight_carriers_match_previous_neutralizer(control, placement, carrier):
+    text = _format_control_matrix_text(control, placement)
+
+    assert _run_preflight_text_carrier(carrier, text) == _reference_neutralize_harmony_tokens(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "family 👩‍👩‍👧‍👦 stays intact <not|reserved>",
+        "bidi \u200eleft-to-right \u200fright-to-left <not|reserved>",
+        "identifier kullanıcı\u200cadı remains intact <not|reserved>",
+    ),
+)
+def test_harmony_neutralizer_preserves_non_token_format_controls(text):
+    assert _has_format_control(text) is True
+    assert _neutralize_harmony_tokens(text) == text
+
+
 def test_cf_class_matches_unicodedata():
     """The hardcoded Cf character class must stay equal to the live category.
 
@@ -138,10 +281,15 @@ def test_cf_class_matches_unicodedata():
     matched = {cp for cp in range(sys.maxunicode + 1)
                if _FORMAT_CONTROL_RE.fullmatch(chr(cp))}
 
-    assert matched == derived, (
-        "hardcoded Cf class drifted from unicodedata "
-        f"(unicode {unicodedata.unidata_version}); "
-        f"missing={sorted(derived - matched)[:8]} extra={sorted(matched - derived)[:8]}"
+    missing = derived - matched
+    extra = matched - derived
+    render = lambda points: [f"U+{point:04X}" for point in sorted(points)]
+
+    assert not missing and not extra, (
+        "hardcoded Cf class drifted from unicodedata; "
+        f"generated_unicode={_FORMAT_CONTROL_UNICODE_VERSION} "
+        f"runtime_unicode={unicodedata.unidata_version}; "
+        f"missing={render(missing)} extra={render(extra)}"
     )
 
 

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -1,12 +1,16 @@
+import sys
+import unicodedata
 from types import SimpleNamespace
 
 import pytest
 
 from agent.codex_responses_adapter import (
+    _FORMAT_CONTROL_RE,
     _chat_content_to_responses_parts,
     _chat_messages_to_responses_input,
     _sanitize_replayed_fn_name,
     _format_responses_error,
+    _has_format_control,
     _normalize_codex_response,
     _neutralize_harmony_tokens,
     _preflight_codex_api_kwargs,
@@ -119,6 +123,37 @@ def test_harmony_neutralizer_handles_format_controls_anywhere_in_token():
 
     for token in disguised:
         assert _neutralize_harmony_tokens(token) == "<｜start｜>"
+
+
+def test_cf_class_matches_unicodedata():
+    """The hardcoded Cf character class must stay equal to the live category.
+
+    ``_has_format_control`` trades ``unicodedata.category`` for a compiled class
+    to keep preflight off a per-character Python loop.  If a Unicode revision
+    adds or moves a Cf codepoint the class would silently stop covering it and
+    a disguised Harmony token could slip through, so re-derive it here.
+    """
+    derived = {cp for cp in range(sys.maxunicode + 1)
+               if unicodedata.category(chr(cp)) == "Cf"}
+    matched = {cp for cp in range(sys.maxunicode + 1)
+               if _FORMAT_CONTROL_RE.fullmatch(chr(cp))}
+
+    assert matched == derived, (
+        "hardcoded Cf class drifted from unicodedata "
+        f"(unicode {unicodedata.unidata_version}); "
+        f"missing={sorted(derived - matched)[:8]} extra={sorted(matched - derived)[:8]}"
+    )
+
+
+def test_has_format_control_agrees_with_unicodedata_on_mixed_text():
+    ascii_only = "def f(x): return [y for y in x if y < 3] | s"
+    assert _has_format_control(ascii_only) is False
+
+    non_ascii_clean = "değişkenlerin çoğu güncellendi <|start|> şüpheli durum yok"
+    assert _has_format_control(non_ascii_clean) is False
+
+    for cf in ("​", "­", "﻿", "⁠", "\U000e0001"):
+        assert _has_format_control(f"prefix {cf} suffix") is True
 
 
 def test_codex_api_preflight_sanitizes_tuple_values_in_tool_schemas():


### PR DESCRIPTION
## Review follow-up (2026-09-03)

Addressed the requested regression coverage on current `main`:

- checked-in differential matrix against the exact pre-PR implementation for ZWJ/ZWNJ, word joiner, bidi mark, soft hyphen, and BOM at five token positions;
- ran that matrix through instructions, user/assistant content, tool arguments/results, and tool schemas;
- pinned non-token ZWJ emoji, bidi prose, and Unicode-identifier preservation;
- recorded Unicode 14.0/15.0/15.1 tables and made drift failures print exact missing/extra `U+XXXX` codepoints;
- added `scripts/benchmark_codex_format_control_scan.py`, with excluded warm-up and repeated samples reported separately for guard-only, neutralizer-only, and complete request preflight.

Latest 480 KiB run (CPython 3.12.3, 2 warm-ups, 5 repeats, 3 loops/sample): guard **5.35x**, neutralizer **5.16x**, complete request preflight **5.13x**. The figures below are retained as the original Windows measurement.

## What does this PR do?

`_neutralize_harmony_tokens` guards its fast path with:

```python
if not any(unicodedata.category(char) == "Cf" for char in text):
```

That is a Python-level loop with one C call per character, and preflight runs it over **every string in the request** — instructions, every input item, every tool schema. On a long history (hundreds of KB per call, dozens of calls per turn) this single line dominates preflight cost.

Category Cf is only 21 contiguous ranges, so a compiled character class does the same scan inside the regex engine. `str.isascii()` short-circuits it entirely: no Cf codepoint is ASCII, and CPython stores ASCII-ness on the `str` header, so code, logs and command output answer in constant time without touching the buffer at all.

Measured on a 480 KB request string (i9-13900K, CPython 3.11):

| input | before | after | |
|---|---|---|---|
| mixed non-ASCII prose + code | 22.2 ms | 5.9 ms | **3.8×** |
| pure ASCII | 20.3 ms | 1.8 ms | **11.3×** |

### Design note worth reviewing

The class is **hardcoded** rather than derived from `unicodedata` at import. Deriving it costs ~80 ms of startup per process, and this module is imported by every short-lived agent subprocess — that seemed the wrong trade for a table that changes once every few years.

The cost of hardcoding is drift: a future Unicode revision could add a Cf codepoint and the guard would silently stop covering it, letting a disguised Harmony token through. `test_cf_class_matches_unicodedata` re-derives the set across the whole codepoint space and fails if the two disagree, so drift surfaces in CI rather than in production.

If you would rather pay the import cost and drop the hardcoded table, say so and I will switch it — the rest of the change is unaffected.

## Related Issue

None — small self-contained performance change, no behavioral issue to fix.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_responses_adapter.py`
  - added `_FORMAT_CONTROL_RE` — category Cf as a compiled character class (21 ranges)
  - added `_has_format_control()` — `str.isascii()` short-circuit, then the compiled scan
  - `_neutralize_harmony_tokens` now calls it instead of the per-character `unicodedata` genexpr
  - the slow path (Cf present) is untouched
- `tests/agent/test_codex_responses_adapter.py`
  - `test_cf_class_matches_unicodedata` — re-derives Cf over the whole codepoint space and asserts the hardcoded class matches, so a Unicode bump fails loudly
  - `test_has_format_control_agrees_with_unicodedata_on_mixed_text` — ASCII, non-ASCII-but-clean, and Cf-bearing inputs

## How to Test

1. **Behavioural equivalence.** I ran a differential harness comparing the old and new implementations over **5,266 inputs**: every reserved token, each sampled Cf codepoint inserted at every position inside a token, fuzzed strings over an alphabet of `<`, `|`, letters and Cf characters, and idempotency cases (output fed back in). **0 mismatches** — byte-identical output.

2. **Targeted suites.** Every test file that imports or exercises this module:

   ```
   pytest tests/agent/test_codex_responses_adapter.py tests/agent/test_memory_provider.py \
     tests/agent/test_message_sanitization_policy.py tests/agent/test_native_preflight_estimate.py \
     tests/agent/transports/test_codex_transport.py tests/run_agent/test_codex_multimodal_tool_result.py \
     tests/run_agent/test_codex_xai_oauth_recovery.py tests/run_agent/test_native_compaction.py \
     tests/run_agent/test_native_compaction_summary_retention.py tests/run_agent/test_provider_parity.py \
     tests/run_agent/test_run_agent.py tests/run_agent/test_run_agent_codex_responses.py \
     tests/run_agent/test_run_agent_multimodal_prologue.py -q
   ```

   → **759 passed**

3. **Benchmark** (numbers in the table above): time `_neutralize_harmony_tokens` on a ~480 KB string containing `<` and `|` so the line-91 guard passes, once ASCII-only and once with non-ASCII text.

### On the full-suite checklist item

I could not honestly tick "ran `pytest tests/ -q` and all tests pass", so I have left it unchecked. On Windows the full suite cannot pass regardless of this change — `tests/tools/test_bot_turn_lock.py` imports `fcntl`, which is Unix-only. Five other files also fail collection in my environment for reasons unrelated to this change (`pytest_asyncio` missing locally). Excluding those six, a full run was still in progress after ~2.5 h on my box, so I stopped it and leaned on the targeted suites above plus CI. Happy to run anything specific you want to see.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`perf(codex):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see "On the full-suite checklist item" above
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, CPython 3.11.16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the rationale lives in comments next to the table
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure stdlib (`re`, `str.isascii`), no platform-specific behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
