### PR TITLE
fix(agent): mirror Claude Code OAuth rotation to the macOS Keychain

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import stat
 import subprocess
@@ -262,6 +263,9 @@ def is_rotation_consumed_uncommitted(
     return fingerprint in _read_spent_rotation_sidecar(source_path)
 
 
+_CLAUDE_CODE_KEYCHAIN_SERVICE = "Claude Code-credentials"
+
+
 def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
     """Read Claude Code OAuth credentials from the macOS Keychain.
 
@@ -281,7 +285,7 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
         # Read the "Claude Code-credentials" generic password entry
         result = subprocess.run(
             ["security", "find-generic-password",
-             "-s", "Claude Code-credentials",
+             "-s", _CLAUDE_CODE_KEYCHAIN_SERVICE,
              "-w"],
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
@@ -600,6 +604,174 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
         return None
 
 
+def _read_claude_code_keychain_entry() -> Optional[tuple]:
+    """Read the raw Claude Code Keychain entry: ``(account, claudeAiOauth)``.
+
+    Unlike ``_read_claude_code_credentials_from_keychain`` this returns the
+    stored ``claudeAiOauth`` dict as-is — metadata fields (``scopes``,
+    ``subscriptionType``, ...) included, and a non-empty ``accessToken`` NOT
+    required — because the caller needs to *update* the entry, including the
+    post-``invalid_grant`` state where Claude Code has already emptied the
+    token triple but left the metadata behind.
+
+    The account name is read from the item metadata instead of assumed to be
+    the login user name: Claude Code owns the entry, and
+    ``add-generic-password -U`` matches on ``(service, account)`` — guessing
+    the account wrong would create a second entry next to the one Claude
+    Code actually reads.
+    """
+    if platform.system() != "Darwin":
+        return None
+
+    try:
+        meta = subprocess.run(
+            ["security", "find-generic-password",
+             "-s", _CLAUDE_CODE_KEYCHAIN_SERVICE],
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        logger.debug("Keychain: security command not available or timed out")
+        return None
+
+    if meta.returncode != 0:
+        logger.debug("Keychain: no entry found for %r", _CLAUDE_CODE_KEYCHAIN_SERVICE)
+        return None
+
+    match = re.search(r'"acct"<blob>="([^"]*)"', meta.stdout)
+    if match is None or not match.group(1):
+        logger.debug("Keychain: entry has no readable account attribute")
+        return None
+    account = match.group(1)
+
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password",
+             "-a", account,
+             "-s", _CLAUDE_CODE_KEYCHAIN_SERVICE,
+             "-w"],
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        logger.debug("Keychain: security command not available or timed out")
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    raw = result.stdout.strip()
+    if not raw:
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.debug("Keychain: credentials payload is not valid JSON")
+        return None
+
+    oauth_data = data.get("claudeAiOauth")
+    if not (oauth_data and isinstance(oauth_data, dict)):
+        return None
+
+    return account, oauth_data
+
+
+def _security_i_escape(value: str) -> str:
+    """Escape *value* for a double-quoted argument of ``security -i``.
+
+    The interactive parser is not a shell: inside double quotes only
+    backslash and double-quote are special (a single quote is an ordinary
+    character — passing one through a shell-style ``'..'`` span silently
+    truncates the value at it), so this is the complete escape set.
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _sync_claude_code_keychain_credentials(oauth_data: Dict[str, Any]) -> None:
+    """Mirror a committed credential write to the macOS Keychain (#98334).
+
+    On Darwin Claude Code treats the login Keychain entry as the
+    authoritative store, and Anthropic OAuth refresh tokens are single-use
+    and rotating. A refresh that only updates ~/.claude/.credentials.json
+    strands an already-invalidated refresh token in the Keychain; Claude
+    Code's own next refresh then fails with ``invalid_grant`` and wipes the
+    entry, logging the user out of Claude Code.
+
+    Updates an existing entry only — never creates one — and merges just
+    the rotated token fields into the stored payload so the metadata Claude
+    Code gates on (``scopes`` with ``user:inference``, ``subscriptionType``,
+    ...) survives the rotation.
+
+    Best-effort by design: the JSON file write made by the caller is the
+    commit step of the refresh transaction, and every caller of
+    ``_write_claude_code_credentials`` treats an exception as a failed
+    rotation. A Keychain the user has locked (or denied ``security`` access
+    to) must not un-commit a rotation that already landed.
+    """
+    if platform.system() != "Darwin":
+        return
+
+    entry = _read_claude_code_keychain_entry()
+    if entry is None:
+        logger.debug(
+            "Keychain: no %r entry to update — leaving the store untouched",
+            _CLAUDE_CODE_KEYCHAIN_SERVICE,
+        )
+        return
+    account, stored = entry
+
+    merged = dict(stored)
+    merged.update(
+        {key: value for key, value in oauth_data.items() if value is not None}
+    )
+
+    # ``security -i`` parses its command from stdin, which keeps the payload
+    # (a secret) off argv and out of the process table; ``-w <value>`` on the
+    # command line would expose it there for the lifetime of the child.
+    payload = json.dumps({"claudeAiOauth": merged})
+    command = 'add-generic-password -U -a "%s" -s "%s" -w "%s"\n' % (
+        _security_i_escape(account),
+        _security_i_escape(_CLAUDE_CODE_KEYCHAIN_SERVICE),
+        _security_i_escape(payload),
+    )
+
+    try:
+        result = subprocess.run(
+            ["security", "-i"],
+            input=command,
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.error(
+            "Rotated Claude Code credentials were written to %s but not to "
+            "the macOS Keychain (%s). Claude Code reads the Keychain copy, "
+            "whose refresh token is now spent: re-run 'claude login' if "
+            "Claude Code reports an expired login.",
+            claude_code_credentials_path(), exc,
+        )
+        return
+
+    if result.returncode != 0:
+        logger.error(
+            "Rotated Claude Code credentials were written to %s but not to "
+            "the macOS Keychain (%s). Claude Code reads the Keychain copy, "
+            "whose refresh token is now spent: re-run 'claude login' if "
+            "Claude Code reports an expired login.",
+            claude_code_credentials_path(),
+            result.stderr.strip() or "security -i exited non-zero",
+        )
+        return
+
+    logger.debug("Keychain: mirrored rotated Claude Code credentials")
+
+
 def _write_claude_code_credentials(
     access_token: str,
     refresh_token: str,
@@ -676,6 +848,13 @@ def _write_claude_code_credentials(
         # pair never landed either.
         logger.error("Failed to write refreshed credentials to %s: %s", cred_path, e)
         raise CredentialPersistError(cred_path, e) from e
+
+    # The file write above committed the rotation. On Darwin the Keychain
+    # copy Claude Code reads must be brought in step with it or its refresh
+    # token is stranded spent (#98334). Deliberately after the commit and
+    # best-effort: a locked Keychain must not fail a rotation that already
+    # landed in the file.
+    _sync_claude_code_keychain_credentials(oauth_data)
 
 
 def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] = None) -> Optional[str]:

--- a/tests/agent/test_anthropic_keychain.py
+++ b/tests/agent/test_anthropic_keychain.py
@@ -1,6 +1,7 @@
 """Tests for Bug #12905 fixes in agent/anthropic_adapter.py — macOS Keychain support."""
 
 import json
+import re
 import threading
 import time
 from unittest.mock import patch, MagicMock
@@ -11,6 +12,10 @@ from agent.anthropic_adapter import (
     _read_claude_code_credentials_from_keychain,
     read_claude_code_credentials,
     _refresh_oauth_token,
+)
+from agent.anthropic_credentials import (
+    _security_i_escape,
+    _write_claude_code_credentials,
 )
 
 
@@ -346,4 +351,319 @@ class TestRefreshOAuthTokenAdoptsFreshCredential:
         assert not errors, errors
         assert results == {"a": "fresh-access", "b": "fresh-access"}
         assert calls == ["stale-refresh"], calls
+
+
+class TestSecurityIEscape:
+    """``_security_i_escape`` must match what ``security -i``'s parser does
+    inside double quotes — backslash and double-quote only. A single quote is
+    an ordinary character there (verified against the real CLI: a shell-style
+    ``'..'`` span silently truncates the value at the first embedded quote,
+    which would corrupt the stored payload).
+    """
+
+    def test_escapes_backslash_and_double_quote_only(self):
+        assert _security_i_escape('a"b\\c') == 'a\\"b\\\\c'
+        assert _security_i_escape("plain") == "plain"
+        # A single quote must pass through untouched...
+        assert _security_i_escape("it's") == "it's"
+        # ...and an already-produced escape must not be re-escaped wholesale:
+        # the parser collapses ``\\`` and ``\"`` and leaves everything else.
+        assert re.sub(r'\\(.)', r'\1', _security_i_escape('x\'y"z\\w')) == 'x\'y"z\\w'
+
+
+@pytest.mark.macos_only
+class TestWriteClaudeCodeCredentialsMirrorsKeychain:
+    """#98334: on Darwin a committed refresh write must also rotate the
+    Keychain copy Claude Code reads, not just ~/.claude/.credentials.json.
+
+    Anthropic refresh tokens are single-use and rotating: leaving the new
+    pair only in the file strands a spent refresh token in the Keychain, so
+    Claude Code's next refresh fails with ``invalid_grant`` and empties the
+    entry ("Login: Expired"). All ``security`` traffic is mocked — no real
+    Keychain is touched, and every token string below is a dummy fixture.
+    """
+
+    _FRESH = 9_999_999_999_999
+
+    # Dummy fixture strings (not credentials of any kind).
+    _AT = "dummy-access-token"
+    _RT = "dummy-refresh-token"
+    _OLD_AT = "dummy-stale-access"
+    _OLD_RT = "dummy-spent-refresh"
+
+    def _setup_home(self, tmp_path, monkeypatch, *, file_body=None):
+        cred_dir = tmp_path / ".claude"
+        cred_dir.mkdir(parents=True, exist_ok=True)
+        if file_body is not None:
+            (cred_dir / ".credentials.json").write_text(json.dumps(file_body))
+        monkeypatch.setattr("agent.anthropic_credentials.Path.home", lambda: tmp_path)
+
+    def _security_calls(self, stored_payload, *, add_result=None):
+        """Mock ``subprocess.run`` for the three ``security`` invocations the
+        mirror makes, recording every (argv, stdin) pair for assertions.
+        """
+        calls = []
+
+        def _run(cmd, **kwargs):
+            cmd = list(cmd)
+            calls.append((cmd, kwargs.get("input")))
+            if cmd[:2] == ["security", "find-generic-password"] and "-w" not in cmd:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        'keychain: "/Users/x/Library/Keychains/login.keychain-db"\n'
+                        '    "acct"<blob>="liuhao"\n'
+                        '    "svce"<blob>="Claude Code-credentials"\n'
+                    ),
+                    stderr="",
+                )
+            if cmd[:2] == ["security", "find-generic-password"] and "-w" in cmd:
+                return MagicMock(
+                    returncode=0,
+                    stdout=json.dumps({"claudeAiOauth": stored_payload}),
+                    stderr="",
+                )
+            if cmd == ["security", "-i"]:
+                if add_result is not None:
+                    return add_result
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected security call: {cmd}")
+
+        return _run, calls
+
+    @staticmethod
+    def _stdin_payload(command):
+        """Extract and un-escape the ``-w`` argument the way ``security -i``'s
+        parser does, so the merge can be asserted on real JSON.
+        """
+        quoted = command.split(' -w "', 1)[1].rsplit('"', 1)[0]
+        return json.loads(re.sub(r'\\(.)', r'\1', quoted))
+
+    def test_rotated_pair_mirrored_and_merged_into_existing_entry(
+        self, tmp_path, monkeypatch
+    ):
+        """After a refresh both stores must hold the same refreshToken, and
+        the Keychain metadata Claude Code gates on must survive the merge.
+        """
+        stored = {
+            "accessToken": self._OLD_AT,
+            "refreshToken": self._OLD_RT,
+            "expiresAt": 1,
+            "scopes": ["user:inference", "user:profile"],
+            "subscriptionType": "max",
+            "rateLimitTier": "tier_1",
+        }
+        self._setup_home(tmp_path, monkeypatch, file_body={"claudeAiOauth": {
+            "accessToken": self._OLD_AT,
+            "refreshToken": self._OLD_RT,
+            "expiresAt": 1,
+            "scopes": ["user:inference"],
+        }})
+        _run, calls = self._security_calls(stored)
+
+        with patch("agent.anthropic_credentials.subprocess.run", side_effect=_run):
+            _write_claude_code_credentials(self._AT, self._RT, self._FRESH)
+
+        add_calls = [c for c in calls if c[0] == ["security", "-i"]]
+        assert len(add_calls) == 1, calls
+        argv, command = add_calls[0]
+
+        # The payload is a secret: it must travel via stdin, never argv.
+        assert self._RT not in " ".join(argv)
+        assert command.startswith(
+            'add-generic-password -U -a "liuhao" '
+            '-s "Claude Code-credentials" -w "'
+        )
+
+        oauth = self._stdin_payload(command)["claudeAiOauth"]
+        assert oauth["accessToken"] == self._AT
+        assert oauth["refreshToken"] == self._RT
+        assert oauth["expiresAt"] == self._FRESH
+        # Metadata survives the rotation...
+        assert oauth["subscriptionType"] == "max"
+        assert oauth["rateLimitTier"] == "tier_1"
+        # ...while the file-side scopes (the write's own authority) win.
+        assert oauth["scopes"] == ["user:inference"]
+
+        # The file store committed the same rotation.
+        on_disk = json.loads(
+            (tmp_path / ".claude" / ".credentials.json").read_text()
+        )["claudeAiOauth"]
+        assert on_disk["refreshToken"] == self._RT
+        assert on_disk["scopes"] == ["user:inference"]
+
+    def test_merges_into_emptied_entry_after_invalid_grant(self, tmp_path, monkeypatch):
+        """Claude Code's own ``invalid_grant`` handling empties the token
+        triple but leaves the metadata; the mirror must still repopulate it.
+        """
+        stored = {
+            "accessToken": "",
+            "refreshToken": "",
+            "expiresAt": "",
+            "scopes": ["user:inference"],
+            "subscriptionType": "max",
+        }
+        self._setup_home(tmp_path, monkeypatch)
+        _run, calls = self._security_calls(stored)
+
+        with patch("agent.anthropic_credentials.subprocess.run", side_effect=_run):
+            _write_claude_code_credentials(self._AT, self._RT, self._FRESH)
+
+        add_calls = [c for c in calls if c[0] == ["security", "-i"]]
+        assert len(add_calls) == 1, calls
+        oauth = self._stdin_payload(add_calls[0][1])["claudeAiOauth"]
+        assert oauth["accessToken"] == self._AT
+        assert oauth["refreshToken"] == self._RT
+        assert oauth["expiresAt"] == self._FRESH
+        assert oauth["subscriptionType"] == "max"
+
+    def test_no_existing_entry_means_no_keychain_write(self, tmp_path, monkeypatch):
+        """A user whose Claude Code install does not use the Keychain must
+        not gain an entry from a Hermes refresh.
+        """
+        self._setup_home(tmp_path, monkeypatch)
+        calls = []
+
+        def _run(cmd, **kwargs):
+            cmd = list(cmd)
+            calls.append(cmd)
+            assert cmd[:2] == ["security", "find-generic-password"]
+            return MagicMock(returncode=44, stdout="", stderr="could not be found")
+
+        with patch("agent.anthropic_credentials.subprocess.run", side_effect=_run):
+            _write_claude_code_credentials(self._AT, self._RT, self._FRESH)
+
+        # Metadata probe only — no payload read, no add.
+        assert calls == [["security", "find-generic-password",
+                          "-s", "Claude Code-credentials"]]
+        on_disk = json.loads(
+            (tmp_path / ".claude" / ".credentials.json").read_text()
+        )["claudeAiOauth"]
+        assert on_disk["refreshToken"] == self._RT
+
+    def test_unreadable_account_attribute_skips_mirror(self, tmp_path, monkeypatch):
+        """An entry without a parsable ``acct`` cannot be matched by
+        ``add-generic-password -U``; updating blind would risk creating a
+        duplicate entry, so the mirror must stand down.
+        """
+        self._setup_home(tmp_path, monkeypatch)
+        calls = []
+
+        def _run(cmd, **kwargs):
+            cmd = list(cmd)
+            calls.append(cmd)
+            return MagicMock(
+                returncode=0,
+                stdout='    "acct"<blob>=<NULL>\n    "svce"<blob>="Claude Code-credentials"\n',
+                stderr="",
+            )
+
+        with patch("agent.anthropic_credentials.subprocess.run", side_effect=_run):
+            _write_claude_code_credentials(self._AT, self._RT, self._FRESH)
+
+        assert len(calls) == 1, calls
+        assert (tmp_path / ".claude" / ".credentials.json").exists()
+
+    def test_keychain_failure_does_not_fail_the_committed_write(
+        self, tmp_path, monkeypatch
+    ):
+        """The JSON file write is the commit step of the refresh transaction;
+        a locked/unavailable Keychain must not un-commit it. Regression guard
+        for the fail-closed contract: every caller of
+        ``_write_claude_code_credentials`` treats an exception as a failed
+        rotation and would mark a perfectly good rotated pair as spent.
+        """
+        stored = {
+            "accessToken": self._OLD_AT,
+            "refreshToken": self._OLD_RT,
+            "expiresAt": 1,
+            "scopes": ["user:inference"],
+            "subscriptionType": "max",
+        }
+        self._setup_home(tmp_path, monkeypatch, file_body={"claudeAiOauth": {
+            "accessToken": self._OLD_AT,
+            "refreshToken": self._OLD_RT,
+            "expiresAt": 1,
+        }})
+        _run, _calls = self._security_calls(
+            stored,
+            add_result=MagicMock(
+                returncode=1, stdout="",
+                stderr="security: SecKeychainItemUpdate: UNIX Operation not permitted",
+            ),
+        )
+
+        with patch("agent.anthropic_credentials.subprocess.run", side_effect=_run):
+            _write_claude_code_credentials(self._AT, self._RT, self._FRESH)
+
+        on_disk = json.loads(
+            (tmp_path / ".claude" / ".credentials.json").read_text()
+        )["claudeAiOauth"]
+        assert on_disk["refreshToken"] == self._RT
+
+    def test_security_timeout_does_not_fail_the_committed_write(
+        self, tmp_path, monkeypatch
+    ):
+        import subprocess as _subprocess
+
+        stored = {
+            "accessToken": self._OLD_AT,
+            "refreshToken": self._OLD_RT,
+            "expiresAt": 1,
+            "scopes": ["user:inference"],
+        }
+        self._setup_home(tmp_path, monkeypatch, file_body={"claudeAiOauth": {
+            "accessToken": self._OLD_AT,
+            "refreshToken": self._OLD_RT,
+            "expiresAt": 1,
+        }})
+        state = {"phase": 0}
+
+        def _run(cmd, **kwargs):
+            cmd = list(cmd)
+            if cmd == ["security", "-i"]:
+                raise _subprocess.TimeoutExpired(cmd, 5)
+            state["phase"] += 1
+            if state["phase"] == 1:
+                return MagicMock(
+                    returncode=0,
+                    stdout='    "acct"<blob>="liuhao"\n',
+                    stderr="",
+                )
+            return MagicMock(
+                returncode=0,
+                stdout=json.dumps({"claudeAiOauth": stored}),
+                stderr="",
+            )
+
+        with patch("agent.anthropic_credentials.subprocess.run", side_effect=_run):
+            _write_claude_code_credentials(self._AT, self._RT, self._FRESH)
+
+        on_disk = json.loads(
+            (tmp_path / ".claude" / ".credentials.json").read_text()
+        )["claudeAiOauth"]
+        assert on_disk["refreshToken"] == self._RT
+
+
+@pytest.mark.linux_only
+class TestWriteClaudeCodeCredentialsIgnoresKeychainOnLinux:
+    """#98334 guard: off Darwin the mirror must not shell out to ``security``
+    at all — there is no Keychain to keep in step with. Runs on the Linux
+    lane for real rather than faking the platform (see conftest OS-gating
+    rationale).
+    """
+
+    def test_non_darwin_makes_no_security_calls(self, tmp_path, monkeypatch):
+        cred_dir = tmp_path / ".claude"
+        cred_dir.mkdir(parents=True)
+        monkeypatch.setattr("agent.anthropic_credentials.Path.home", lambda: tmp_path)
+
+        with patch("agent.anthropic_credentials.subprocess.run") as mock_run:
+            _write_claude_code_credentials("dummy-access-token", "dummy-refresh-token", 12345)
+
+        assert mock_run.call_count == 0
+        on_disk = json.loads(
+            (tmp_path / ".claude" / ".credentials.json").read_text()
+        )["claudeAiOauth"]
+        assert on_disk["refreshToken"] == "dummy-refresh-token"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -646,6 +646,16 @@ def _neutralize_macos_keychain_creds(request, monkeypatch):
             lambda *_args, **_kwargs: None,
             raising=False,
         )
+        # The Keychain mirror of a committed refresh write (#98334) starts by
+        # reading the entry; neutralize it for the same reason as the reader
+        # above so an ordinary credential-file test on a macOS host cannot
+        # touch (let alone rotate) the developer's real Keychain entry.
+        monkeypatch.setattr(
+            _mod,
+            "_read_claude_code_keychain_entry",
+            lambda *_args, **_kwargs: None,
+            raising=False,
+        )
     return None
 
 


### PR DESCRIPTION
## What does this PR do?

On macOS, Claude Code's authoritative credential store is the login Keychain (generic password, service `Claude Code-credentials`). Hermes reads that entry but never wrote it: `_write_claude_code_credentials()` only updated `~/.claude/.credentials.json`. Since Anthropic OAuth refresh tokens are single-use and rotating, every Hermes-initiated refresh stranded a **spent** refresh token in the Keychain; Claude Code's next refresh then failed with `invalid_grant` and emptied the entry (`Login: Expired — log in again`), recurring until the user re-logged in.

This PR makes `_write_claude_code_credentials()` mirror the committed rotation to the Keychain on Darwin:

- **Existing entries only** — `_read_claude_code_keychain_entry()` reads the item's real `acct` attribute (rather than assuming the login user name) and the raw `claudeAiOauth` payload; if no entry exists, the store is left untouched, so a user whose Claude Code install doesn't use the Keychain never gains one. An unparsable `acct` also stands down: `add-generic-password -U` matches on `(service, account)`, and a wrong guess would create a duplicate entry next to the one Claude Code reads.
- **Merge, not replace** — only the rotated token fields are merged into the stored payload, so the metadata Claude Code gates on (`scopes` incl. `user:inference`, `subscriptionType`, `rateLimitTier`, ...) survives the rotation, including the post-`invalid_grant` state where Claude Code has already emptied the token triple.
- **Secret stays off argv** — the update goes through `security -i` (command parsed from stdin) instead of `-w <value>` on the command line. The escaping (`\` and `"` only; single quotes are ordinary characters to this parser — shell-style `'..'` spans silently truncate at an embedded quote) is verified against the real CLI and covered by `_security_i_escape()`'s unit test plus a mocked round-trip assertion.
- **Best-effort after the commit** — the JSON file write remains the commit step of the refresh transaction; every caller (the direct resolver path and both `credential_pool` paths) treats an exception from this function as a failed rotation and would mark an already-committed rotated pair as spent. A locked/unavailable Keychain therefore logs an error (naming the recovery: `claude login`) instead of un-committing the rotation.

## Related Issue

Fixes #98334

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_credentials.py`
  - Extracted the shared `_CLAUDE_CODE_KEYCHAIN_SERVICE` constant (previously the service name was inline in the reader).
  - Added `_read_claude_code_keychain_entry()`: reads `(account, raw claudeAiOauth payload)` from the existing entry, with `acct` parsed from item metadata so `add-generic-password -U` matches the entry Claude Code actually owns.
  - Added `_security_i_escape()` and `_sync_claude_code_keychain_credentials()`: the mirror itself — Darwin-gated, existing-entry-only, token-fields-only merge, `security -i` stdin transport, best-effort error handling with an actionable log message.
  - `_write_claude_code_credentials()` calls the sync after the atomic file replace succeeds.
- `tests/conftest.py` — extended the `_neutralize_macos_keychain_creds` autouse fixture to also neutralize `_read_claude_code_keychain_entry`, so ordinary credential-file tests on a macOS host cannot touch (or rotate) the developer's real Keychain entry.
- `tests/agent/test_anthropic_keychain.py` — regression tests (details under How to Test).

## How to Test

1. `python -m pytest tests/agent/test_anthropic_keychain.py -q` → **17 passed, 1 skipped** (the `linux_only` class skips on macOS; it asserts zero `security` calls off Darwin and runs for real on the Linux lane).
2. `python -m pytest tests/agent/test_anthropic_adapter.py tests/agent/test_anthropic_credential_persist_failure.py tests/agent/test_anthropic_oauth_stress.py tests/agent/test_anthropic_borrowed_row_authority.py tests/agent/test_credential_pool_anthropic_refresh_race.py tests/agent/test_auxiliary_client.py -q` → **300 passed, 1 skipped**.
3. `python -m pytest tests/agent/ -q -k "credential or anthropic or keychain or oauth"` → **658 passed, 6 skipped, 1 pre-existing failure** (`test_review_engine.py::test_delegate_task_credentials_cfg_overrides_delegation_config` fails identically on clean `upstream/main`, unrelated to this change).
4. End-to-end against the real `security` CLI (throwaway service name, never the real entry): after `_sync_claude_code_keychain_credentials()` on an entry whose payload contains quotes/backslashes, `security find-generic-password -s <svc> -w` round-trips byte-identical JSON with the token triple rotated and `subscriptionType` preserved. Observed result: `E2E roundtrip OK`.

Key regression assertions (mocked `security`, no real Keychain touched):
- after a write, both stores hold the same rotated `refreshToken` and the merge preserves `subscriptionType`/`rateLimitTier`/`scopes`;
- the payload never appears in any subprocess argv (stdin transport);
- no Keychain entry → no `security add-generic-password` call at all (file still commits);
- emptied post-`invalid_grant` entry → mirror still repopulates the token triple and keeps metadata;
- `security -i` non-zero exit or `TimeoutExpired` → the committed file write still succeeds (no `CredentialPersistError`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(targeted credential/anthropic/keychain/oauth selection: 658 passed; the single failure is pre-existing on clean main, shown above)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon, Darwin arm64), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings document the mirror contract and the `security -i` escaping rationale
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Darwin-gated; Linux lane asserts zero `security` calls; Windows unaffected (the reader already returned `None` off Darwin)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
