### PR TITLE
fix(dashboard-auth): dual-log both native-refresh failure modes

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -1079,10 +1079,30 @@ async def auth_native_refresh(request: Request, body: _NativeRefreshBody):
         }
 
     if unreachable is not None:
+        # Dual-logging (matches the provider_unreachable audits elsewhere in
+        # this module and the middleware). The per-provider WARNING above
+        # lands in agent.log, but the 503 raise pre-empted the audit_log
+        # below, so provider-unreachable refresh failures never reached the
+        # audit trail — 66% of a refresh storm was invisible in one log
+        # (#98338). Emit the audit record before raising.
+        audit_log(
+            AuditEvent.REFRESH_FAILURE,
+            provider=unreachable,
+            reason="provider_unreachable",
+            ip=_client_ip(request),
+        )
         raise HTTPException(
             status_code=503,
             detail=f"Auth provider {unreachable!r} unreachable",
         )
+    # The all-rejected path audit_logs below; also surface it in agent.log so a
+    # clean-rejection refresh storm is visible in the primary log, not only the
+    # audit trail (the mirror of the 503 gap above, #98338).
+    _log.warning(
+        "dashboard-auth: native refresh rejected by all providers "
+        "(refresh token expired/invalid) for ip=%s",
+        _client_ip(request),
+    )
     audit_log(
         AuditEvent.REFRESH_FAILURE,
         reason="all_providers_rejected_rt",

--- a/tests/hermes_cli/test_dashboard_auth_native_refresh.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_refresh.py
@@ -1,0 +1,69 @@
+"""auth_native_refresh() must dual-log both failure modes (#98338).
+
+Before the fix, provider-unreachable (503) refresh failures reached only
+agent.log (the 503 raise pre-empted the audit_log), while all-rejected (401)
+failures reached only the audit log (no agent.log WARNING). The two failure
+modes were split across two logs with zero overlap, so 66% of a refresh storm
+was invisible in the primary log. Both paths must now hit both logs.
+"""
+import unittest.mock as mock
+
+import pytest
+from fastapi import HTTPException
+
+import hermes_cli.dashboard_auth as da
+from hermes_cli.dashboard_auth import routes
+from hermes_cli.dashboard_auth.audit import AuditEvent
+from hermes_cli.dashboard_auth.base import ProviderError, RefreshExpiredError
+
+
+class _Provider:
+    def __init__(self, name, exc):
+        self.name = name
+        self.supports_session = True
+        self._exc = exc
+
+    def refresh_session(self, refresh_token=None):
+        raise self._exc
+
+
+@pytest.fixture
+def logs(monkeypatch):
+    calls = []
+    monkeypatch.setattr(routes, "audit_log", lambda event, **kw: calls.append((event, kw)))
+    log = mock.MagicMock()
+    monkeypatch.setattr(routes, "_log", log)
+    monkeypatch.setattr(routes, "_client_ip", lambda request: "1.2.3.4")
+    return calls, log
+
+
+def _reasons(calls):
+    return [(event, kw.get("reason")) for event, kw in calls]
+
+
+@pytest.mark.asyncio
+async def test_provider_unreachable_is_audit_logged_before_503(logs, monkeypatch):
+    calls, log = logs
+    monkeypatch.setattr(da, "list_session_providers", lambda: [_Provider("nous", ProviderError("idp down"))])
+
+    with pytest.raises(HTTPException) as ei:
+        await routes.auth_native_refresh(object(), routes._NativeRefreshBody(refresh_token="rt"))
+
+    assert ei.value.status_code == 503
+    # audit trail now records the unreachable failure (was invisible before)
+    assert (AuditEvent.REFRESH_FAILURE, "provider_unreachable") in _reasons(calls)
+    # agent.log still carries the per-provider WARNING
+    assert log.warning.called
+
+
+@pytest.mark.asyncio
+async def test_all_rejected_warns_in_agent_log_and_audits(logs, monkeypatch):
+    calls, log = logs
+    monkeypatch.setattr(da, "list_session_providers", lambda: [_Provider("nous", RefreshExpiredError("expired"))])
+
+    resp = await routes.auth_native_refresh(object(), routes._NativeRefreshBody(refresh_token="rt"))
+
+    assert resp.status_code == 401
+    assert (AuditEvent.REFRESH_FAILURE, "all_providers_rejected_rt") in _reasons(calls)
+    # now also surfaced in agent.log (was audit-only before)
+    assert log.warning.called


### PR DESCRIPTION
## What does this PR do?

`auth_native_refresh()` split its two failure modes across two logs with zero
overlap: the provider-unreachable path raised `HTTPException(503)` **before** the
`audit_log`, so it reached only agent.log; the all-providers-rejected path
audit_logged but emitted no agent.log WARNING, so it reached only the audit
trail. During a refresh storm ~66% of failures were invisible in the primary
log (#98338, Defect 1).

Fix: emit the `provider_unreachable` audit record before the 503 raise, and add
an agent.log WARNING on the all-rejected path — so both failure modes land in
both logs, matching the `provider_unreachable` pattern already used elsewhere in
this module and the middleware.

**Scope:** Defect 1 (dual-logging) only. Backoff, circuit breaker, `hermes
doctor` coverage, and the other observability items in the issue are separate
changes and intentionally out of scope for this focused PR.

## Related Issue

Addresses Defect 1 of #98338 (kept as `Addresses`, not `Fixes`, since the issue
tracks many other defects/requests).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_auth/routes.py` — audit the provider-unreachable refresh
  failure before the 503 raise; WARNING on the all-rejected path.
- `tests/hermes_cli/test_dashboard_auth_native_refresh.py` — both failure modes
  now hit both logs.

## How to Test

    pytest tests/hermes_cli/test_dashboard_auth_native_refresh.py -q

2 pass: a ProviderError refresh audits `provider_unreachable` before the 503 and
still WARNs; an all-rejected refresh WARNs and audits `all_providers_rejected_rt`.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs / issues
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11
