### PR TITLE
fix(compaction): retain image-only user messages across native compaction checkpoints

### DIFF
--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -389,11 +389,13 @@ def prune_pre_checkpoint_items(
 
         text = _extract_item_text(item)
         if text is None:
-            continue
-        # Image-only user messages have empty text but non-empty content —
-        # main retains them at 1-token cost (images count as zero, matching
-        # Codex's retention accounting). Don't skip them just because text
-        # is falsy.
+            # Image-only user messages have empty text but non-empty content (list of image parts) —
+            # retain them at 1-token cost (images count as zero, matching Codex's retention accounting).
+            if is_user and isinstance(item.get("content"), list) and item["content"]:
+                text = ""
+            else:
+                continue
+
         if not text and not is_user:
             continue
 
@@ -405,7 +407,7 @@ def prune_pre_checkpoint_items(
         elif is_user:
             if user_remaining <= 0:
                 continue
-            cost = _approx_tokens(text)
+            cost = max(1, _approx_tokens(text)) if not text else _approx_tokens(text)
             if cost <= user_remaining:
                 retained_reversed.append(item)
                 user_remaining -= cost

--- a/tests/run_agent/test_native_compaction.py
+++ b/tests/run_agent/test_native_compaction.py
@@ -537,6 +537,24 @@ class TestPrunePreCheckpointItems:
         users = [i["content"] for i in out if i.get("role") == "user"]
         assert users == ["next ask"]
 
+    def test_image_only_user_message_is_retained_across_checkpoint(self):
+        from agent.native_compaction import prune_pre_checkpoint_items
+
+        image_user = {
+            "role": "user",
+            "content": [{"type": "input_image", "image_url": "data:image/png;base64,AAAA"}],
+        }
+        items = [
+            image_user,
+            {"role": "assistant", "content": "I see the screenshot."},
+            {"type": "compaction", "encrypted_content": "blob_cp"},
+            {"role": "user", "content": "what was in that screenshot?"},
+        ]
+        out = prune_pre_checkpoint_items(items)
+        assert out[0] == {"type": "compaction", "encrypted_content": "blob_cp"}
+        assert out[1] == image_user
+        assert out[2] == {"role": "user", "content": "what was in that screenshot?"}
+
     def test_adapter_applies_prune_end_to_end(self):
         from agent.codex_responses_adapter import _chat_messages_to_responses_input
 


### PR DESCRIPTION
## What does this PR do?

Fixes a **(Data Loss & Vision Context Eradication)** bug in `agent/native_compaction.py` where image-only user messages (e.g. `content=[{"type": "input_image", ...}]`) were silently dropped during pre-checkpoint pruning because `_extract_item_text(item)` returned `None` for image-only lists, hitting `if text is None: continue` before the intended image retention check could execute.

In Hermes Agent:
1. When OpenAI server-side native compaction (`gpt-5.6` Responses API) compacts conversation history, `prune_pre_checkpoint_items()` retains pre-checkpoint user messages within the token budget.
2. For image-only user messages containing no text (e.g. vision attachments, screenshots from browser/computer-use tools), `_extract_item_text(item)` returns `None`.
3. In `prune_pre_checkpoint_items()`, `if text is None: continue` was evaluated prior to checking if the message was an image-only user message, causing all image-only user messages to be permanently discarded across the compaction boundary.
4. The fix ensures:
   - When `is_user` and `item.get("content")` is a non-empty list, `text` is coerced to `""`, allowing image-only user messages to be retained at 1-token cost.
   - Adds unit test in `tests/run_agent/test_native_compaction.py`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/native_compaction.py`:
  - Allowed image-only user messages with non-empty list content to be retained across compaction checkpoints in `prune_pre_checkpoint_items()`.
- `tests/run_agent/test_native_compaction.py`:
  - Added unit test verifying image-only user messages survive native compaction checkpoints.

## How to Test

Run the native compaction test suite:
```bash
uv run --with pytest python -m pytest tests/run_agent/test_native_compaction.py tests/run_agent/test_native_compaction_summary_retention.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(compaction): retain image-only user messages across native compaction checkpoints`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 77 items

tests/run_agent/test_native_compaction.py .............................. [100%]
tests/run_agent/test_native_compaction_summary_retention.py ............ [100%]

============================= 77 passed in 30.52s =============================
```
