### PR TITLE
fix(desktop): keep durable spoken replies consumed

### DIFF
--- a/apps/desktop/src/lib/spoken-reply.test.ts
+++ b/apps/desktop/src/lib/spoken-reply.test.ts
@@ -89,4 +89,55 @@ describe('resolveSpokenReply', () => {
     expect(assistantReplyOrdinal(nextTurn, 'assistant-stream-2')).toBe(1)
     expect(spoken?.ordinal).toBe(0)
   })
+
+  it('uses durable history when a stale snapshot marks an older durable reply', () => {
+    const current = [assistant('durable-1'), assistant('durable-2')]
+    markAssistantIdSpoken('s', current, 'durable-2')
+
+    const stale = [assistant('durable-1')]
+    markAssistantIdSpoken('s', stale, 'durable-1')
+
+    expect(resolveSpokenReply('s', stale)).toEqual({ id: 'durable-1', ordinal: 0 })
+    expect(resolveSpokenReply('s', current)).toEqual({ id: 'durable-2', ordinal: 1 })
+  })
+
+  it('lets a new low-ordinal live reply become consumed after compaction', () => {
+    const beforeCompaction = [
+      assistant('durable-1'),
+      assistant('durable-2'),
+      assistant('durable-3')
+    ]
+
+    markAssistantIdSpoken('s', beforeCompaction, 'durable-3')
+
+    const compacted = [assistant('assistant-stream-new')]
+    markAssistantIdSpoken('s', compacted, 'assistant-stream-new')
+
+    expect(spokenReplyOf('s')).toEqual({ id: 'assistant-stream-new', ordinal: 0 })
+    expect(resolveSpokenReply('s', compacted)).toEqual({ id: 'assistant-stream-new', ordinal: 0 })
+  })
+
+  it('keeps repeated notifications for the same durable reply consumed', () => {
+    const messages = [assistant('durable-1')]
+    markAssistantIdSpoken('s', messages, 'durable-1')
+    markAssistantIdSpoken('s', messages, 'durable-1')
+
+    expect(resolveSpokenReply('s', messages)).toEqual({ id: 'durable-1', ordinal: 0 })
+  })
+
+  it('leaves a later distinct durable reply speakable', () => {
+    const first = [assistant('durable-1')]
+    markAssistantIdSpoken('s', first, 'durable-1')
+
+    const later = [assistant('durable-1'), assistant('durable-2')]
+    expect(resolveSpokenReply('s', later)).toEqual({ id: 'durable-1', ordinal: 0 })
+    expect(later.at(-1)?.id).not.toBe(resolveSpokenReply('s', later)?.id)
+  })
+
+  it('keeps the existing live-to-durable rewrite consumed', () => {
+    markAssistantIdSpoken('s', [assistant('assistant-stream-1')], 'assistant-stream-1')
+
+    expect(resolveSpokenReply('s', [assistant('durable-1')])).toEqual({ id: 'durable-1', ordinal: 0 })
+    expect(spokenReplyOf('s')).toEqual({ id: 'durable-1', ordinal: 0 })
+  })
 })

--- a/apps/desktop/src/lib/spoken-reply.ts
+++ b/apps/desktop/src/lib/spoken-reply.ts
@@ -23,8 +23,10 @@ export interface SpokenReplyMessage {
 }
 
 const NO_SESSION = '\0'
+const MAX_SPOKEN_DURABLE_IDS_PER_SESSION = 64
 
 const lastSpokenBySession = new Map<string, SpokenReplyAnchor>()
+const spokenDurableIdsBySession = new Map<string, Set<string>>()
 
 export function isLiveTailReplyId(id: string): boolean {
   return id.startsWith('assistant-stream-') || id.startsWith('inflight-assistant-')
@@ -32,6 +34,31 @@ export function isLiveTailReplyId(id: string): boolean {
 
 function sessionKey(sessionId: string | null | undefined): string {
   return sessionId ?? NO_SESSION
+}
+
+function rememberSpokenDurableId(sessionId: string | null | undefined, id: string): void {
+  if (isLiveTailReplyId(id)) {
+    return
+  }
+
+  const key = sessionKey(sessionId)
+  const ids = spokenDurableIdsBySession.get(key) ?? new Set<string>()
+
+  // Refresh repeated notifications in the bounded insertion-ordered history.
+  ids.delete(id)
+  ids.add(id)
+
+  while (ids.size > MAX_SPOKEN_DURABLE_IDS_PER_SESSION) {
+    const oldest = ids.values().next().value
+
+    if (oldest === undefined) {
+      break
+    }
+
+    ids.delete(oldest)
+  }
+
+  spokenDurableIdsBySession.set(key, ids)
 }
 
 export function assistantReplyOrdinal(messages: readonly SpokenReplyMessage[], id: string): number {
@@ -94,6 +121,7 @@ export function spokenReplyOf(sessionId: string | null | undefined): SpokenReply
 }
 
 function markSpokenReply(sessionId: string | null | undefined, anchor: SpokenReplyAnchor): void {
+  rememberSpokenDurableId(sessionId, anchor.id)
   lastSpokenBySession.set(sessionKey(sessionId), anchor)
 }
 
@@ -123,9 +151,45 @@ export function resolveSpokenReply(
     markSpokenReply(sessionId, next)
   }
 
-  return next
+  // When this mounted composer has an older snapshot, answer from the bounded
+  // durable history without regressing the session's forward frontier.
+  const durableIds = spokenDurableIdsBySession.get(sessionKey(sessionId))
+  let latestDurable: SpokenReplyAnchor | null = null
+
+  if (durableIds) {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index]
+
+      if (message.role !== 'assistant' || message.hidden || !durableIds.has(message.id)) {
+        continue
+      }
+
+      latestDurable = { id: message.id, ordinal: assistantReplyOrdinal(messages, message.id) }
+
+      break
+    }
+  }
+
+  if (!next) {
+    return latestDurable
+  }
+
+  const nextOrdinal = assistantReplyOrdinal(messages, next.id)
+
+  if (nextOrdinal < 0) {
+    return latestDurable ?? next
+  }
+
+  // Live ids remain governed by the existing ordinal rewrite frontier. For
+  // durable rows, the newest consumed id present in this snapshot wins.
+  if (isLiveTailReplyId(next.id) || !latestDurable || nextOrdinal >= latestDurable.ordinal) {
+    return next
+  }
+
+  return latestDurable
 }
 
 export function clearSpokenRepliesForTests(): void {
   lastSpokenBySession.clear()
+  spokenDurableIdsBySession.clear()
 }


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop auto-speak from replaying a durable assistant reply after a stale mounted message snapshot moves the session's spoken anchor backward.

The existing live-to-durable rewrite logic handles a streaming reply changing IDs. A separate race remains when an older mounted snapshot later calls `markAssistantIdSpoken`: the single stored anchor can regress to an earlier durable reply. When playback returns to idle, the current snapshot can then present the already-spoken reply as pending and queue it again.

This change keeps a small, session-scoped, insertion-ordered history of durable reply IDs that have already been consumed. `resolveSpokenReply` uses that history to avoid regressing behind the newest consumed durable reply present in the caller's snapshot. Live-tail IDs remain governed by the existing rewrite/ordinal behavior, so compaction can still establish a new low-ordinal live anchor.

Related: #89896. This targets the repeat-from-the-top mode reported there; it does not claim to address the issue's separate silent or truncated playback modes.

This overlaps symptomatically with #91391, but addresses a different state transition: durable-anchor regression from stale mounted snapshots rather than filtering live/interim candidates.

## Type of Change

- [x] Bug fix (non-breaking change that fixes incorrect behavior)

## Changes Made

- Add a bounded history of recently consumed durable assistant IDs per session.
- Prefer the newest consumed durable reply visible in a stale snapshot without moving the live frontier backward.
- Preserve existing live-to-durable rewrite behavior.
- Add regression coverage for stale snapshots, repeated notifications, transcript compaction, later distinct replies, and live-to-durable rewrites.

## How to Test

From `apps/desktop`:

```bash
npx vitest run --project ui src/lib/spoken-reply.test.ts src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
npm run typecheck
npx eslint src/lib/spoken-reply.ts src/lib/spoken-reply.test.ts
npm run build
```

All commands pass on macOS (Apple Silicon). The targeted Vitest run passes 14 tests.

## Checklist

- [x] I read the contributing guide.
- [x] I searched open issues and pull requests for duplicates/adjacent fixes.
- [x] The commit uses Conventional Commits.
- [x] The PR is narrowly scoped to the Desktop spoken-reply selector.
- [x] Regression tests are included.
- [x] Desktop typecheck, focused lint, targeted tests, and production build pass.
- [x] Cross-platform impact considered: renderer-only TypeScript; no native or platform-specific APIs.
- [x] No configuration keys or documentation behavior changed.
