### PR TITLE
fix(guard): support multipart list content in continuation repetition guard

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -95,6 +95,7 @@ from agent.retry_utils import (
     jittered_backoff,
     zai_coding_overload_retry_ceiling,
 )
+from agent.message_content import flatten_message_text
 from agent.repetition_guard import is_repetition_dominated
 from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
@@ -3757,6 +3758,11 @@ def run_conversation(
                     _trunc_msg = _trunc_result
 
                     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
+                    _trunc_text = (
+                        flatten_message_text(_trunc_content)
+                        if isinstance(_trunc_content, list)
+                        else (_trunc_content if isinstance(_trunc_content, str) else "")
+                    )
                     _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
 
                     # ── Detect thinking-budget exhaustion ──────────────
@@ -3772,9 +3778,9 @@ def run_conversation(
                     # truncations that deserve continuation retries, not as
                     # thinking-budget exhaustion.
                     _has_think_tags = bool(
-                        _trunc_content and re.search(
+                        _trunc_text and re.search(
                             r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>',
-                            _trunc_content,
+                            _trunc_text,
                             re.IGNORECASE,
                         )
                     )
@@ -3782,8 +3788,8 @@ def run_conversation(
                         not _trunc_has_tool_calls
                         and _has_think_tags
                         and (
-                            (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
-                            or _trunc_content is None
+                            bool(_trunc_text and not agent._has_content_after_think_block(_trunc_text))
+                            or not _trunc_text
                         )
                     )
 
@@ -3832,9 +3838,9 @@ def run_conversation(
                     # stripped first (repeated scratchpad lines are not
                     # evidence of a degenerate visible response).
                     _visible_trunc = (
-                        agent._strip_think_blocks(_trunc_content)
-                        if isinstance(_trunc_content, str)
-                        else _trunc_content
+                        agent._strip_think_blocks(_trunc_text)
+                        if _trunc_text
+                        else ""
                     )
                     _repetition_dominated = (
                         not _trunc_has_tool_calls

--- a/agent/message_content.py
+++ b/agent/message_content.py
@@ -4,7 +4,10 @@ from collections.abc import Mapping
 from typing import Any
 
 
-_NON_TEXT_PART_TYPES = {"image", "image_url", "input_image", "audio", "input_audio"}
+_NON_TEXT_PART_TYPES = {
+    "image", "image_url", "input_image", "audio", "input_audio",
+    "tool_use", "tool_call",
+}
 _TEXT_KEYS = ("text", "content", "input_text", "output_text", "summary_text")
 
 

--- a/agent/repetition_guard.py
+++ b/agent/repetition_guard.py
@@ -21,6 +21,9 @@ repeated, code with similar-looking lines) are never blocked.
 from __future__ import annotations
 
 import math
+from typing import Any
+
+from agent.message_content import flatten_message_text
 
 # A fragment must be at least this long before the repetition check runs at
 # all.  Short truncations (a sentence cut mid-word) can trivially contain
@@ -40,7 +43,7 @@ _MIN_REPEAT_COUNT = 5
 _DOMINANCE_RATIO = 0.5
 
 
-def is_repetition_dominated(text: str) -> bool:
+def is_repetition_dominated(text: Any) -> bool:
     """True when ``text`` is dominated by verbatim repeated fragments.
 
     A truncated response is "repetition-dominated" when a single 60+ char
@@ -50,9 +53,12 @@ def is_repetition_dominated(text: str) -> bool:
     continuation nudge would just stitch more repeated text into the final
     response.
 
+    Accepts plain string or multipart list content (which is flattened).
     Returns False for non-string / empty / short inputs (fail-open: never
     blocks a continuation the guard cannot confidently judge).
     """
+    if isinstance(text, list):
+        text = flatten_message_text(text)
     if not isinstance(text, str):
         return False
     n = len(text)

--- a/tests/agent/test_repetition_guard.py
+++ b/tests/agent/test_repetition_guard.py
@@ -63,3 +63,23 @@ class TestRepetitionGuard:
             {"type": "text", "text": "Unique body part detailing verification steps."},
         ]
         assert is_repetition_dominated(parts) is False
+
+    def test_multipart_with_images_and_tool_calls_not_flagged(self):
+        """Non-text parts (images, tool_use) must not be stringified into false repetition signals."""
+        parts = [
+            {"type": "text", "text": "Here is the screenshot requested:"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            {"type": "tool_use", "id": "call_1", "name": "screenshot", "input": {}},
+        ]
+        assert is_repetition_dominated(parts) is False
+
+    def test_multipart_repeated_table_syntax_below_dominance_not_flagged(self):
+        """Legitimate repeated markdown tables or code syntax below dominance threshold must pass."""
+        table_rows = ["| col1 | col2 | col3 |", "| --- | --- | --- |"] + [
+            f"| data_{i} | value_{i} | result_{i} |" for i in range(100)
+        ]
+        parts = [
+            {"type": "text", "text": "\n".join(table_rows)},
+        ]
+        assert is_repetition_dominated(parts) is False
+

--- a/tests/agent/test_repetition_guard.py
+++ b/tests/agent/test_repetition_guard.py
@@ -48,3 +48,18 @@ class TestRepetitionGuard:
         assert is_repetition_dominated("") is False
         assert is_repetition_dominated(None) is False
         assert is_repetition_dominated(12345) is False
+
+    def test_multipart_list_content_flagged(self):
+        # Multipart list where text parts contain repeated sentences
+        parts = [
+            {"type": "text", "text": _INCIDENT_ECHO * 1000},
+            {"type": "text", "text": _INCIDENT_ECHO * 1000},
+        ]
+        assert is_repetition_dominated(parts) is True
+
+    def test_multipart_list_non_repeating_not_flagged(self):
+        parts = [
+            {"type": "text", "text": "Unique intro part describing architecture."},
+            {"type": "text", "text": "Unique body part detailing verification steps."},
+        ]
+        assert is_repetition_dominated(parts) is False

--- a/tests/run_agent/test_continuation_repetition_guard.py
+++ b/tests/run_agent/test_continuation_repetition_guard.py
@@ -97,3 +97,14 @@ class TestContinuationRepetitionGuard:
 
         assert result["partial"] is True
         assert loop_agent.client.chat.completions.create.call_count == 4
+
+    def test_multipart_list_repetition_aborts(self, loop_agent):
+        echo_list = [{"type": "text", "text": _INCIDENT_ECHO * 2000}]
+        loop_agent.client.chat.completions.create.side_effect = [_stub(echo_list)]
+
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "Repetition" in (result["final_response"] or "")
+        assert loop_agent.client.chat.completions.create.call_count == 1


### PR DESCRIPTION
## What does this PR do?

Fixes a **P0 (Severe Denial of Service / Message Flooding / Infinite Loop Continuation)** bug in `agent/repetition_guard.py` and `agent/conversation_loop.py` where truncated responses (`finish_reason=length`) containing multipart or multimodal content blocks (`[{"type": "text", "text": "..."}]`) completely bypassed the repetition guard because `is_repetition_dominated()` only accepted `str` and returned `False` on list inputs.

In Hermes Agent:
1. When a model output enters a pathological repetition loop and truncates at `finish_reason=length`, the repetition guard detects the degenerate repetition and aborts the turn cleanly instead of appending a continuation nudge that would stitch dozens of repetitive turns into channels (issue #86581).
2. For models returning structured multipart lists (standard across Anthropic, Gemini, Bedrock, and OpenAI Responses API), `_trunc_content` is a `list`.
3. `re.search` for `<think>` tags crashed with `TypeError: expected string or bytes-like object, got 'list'`, and `is_repetition_dominated()` returned `False` immediately, completely breaking repetition protection for structured responses.
4. The fix ensures:
   - `_trunc_text` is cleanly derived using `flatten_message_text()` when `_trunc_content` is a list, enabling safe think-tag search and visible text extraction.
   - `is_repetition_dominated()` flattens multipart lists before evaluating repetition dominance.
   - Unit tests added in `tests/agent/test_repetition_guard.py` and `tests/run_agent/test_continuation_repetition_guard.py`.

## Related Issue

Fixes #86581 (multipart/multimodal edge case)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/repetition_guard.py`:
  - Accepted multipart list content in `is_repetition_dominated()` by flattening with `flatten_message_text()`.
- `agent/conversation_loop.py`:
  - Safely extracted `_trunc_text` from string or list content for thinking-tag search and repetition detection.
- `tests/agent/test_repetition_guard.py`:
  - Added unit test verifying multipart lists with repeated text are flagged.
- `tests/run_agent/test_continuation_repetition_guard.py`:
  - Added E2E conversation loop test verifying continuation aborts when multipart list response is repetition-dominated.

## How to Test

Run the repetition guard test suites:
```bash
uv run --with pytest python -m pytest tests/agent/test_repetition_guard.py tests/run_agent/test_continuation_repetition_guard.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(guard): support multipart list content in continuation repetition guard`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 11 items

tests/agent/test_repetition_guard.py ........                            [ 72%]
tests/run_agent/test_continuation_repetition_guard.py ...                [100%]

============================= 11 passed in 13.81s =============================
```
