### PR TITLE
fix(delegation): keep timed-out children from crashing session owners

### DIFF
--- a/contributors/emails/ileocorp@gmail.com
+++ b/contributors/emails/ileocorp@gmail.com
@@ -1,0 +1,2 @@
+ComicBit
+# PR #98348 preserves commit 057000ed73c from #90889

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -153,6 +153,43 @@ def test_active_for_session_counts_every_live_delegation_state():
     assert ad.active_for_session("") == 0
 
 
+def test_owner_process_classification_preserves_indeterminate_live_owner():
+    """A failed start-time probe must not turn a slow live owner into an orphan."""
+    assert ad._classify_owner_process(
+        4321,
+        100,
+        pid_exists=lambda _pid: True,
+        process_start_time=lambda _pid: None,
+    ) is None
+
+
+@pytest.mark.parametrize(
+    ("pid", "started_at", "exists", "observed_start", "reason"),
+    [
+        (None, None, False, None, "owner_identity_missing"),
+        (4321, 100, False, None, "owner_process_missing"),
+        (4321, 100, True, 200, "owner_pid_reused"),
+    ],
+)
+def test_owner_process_classification_reports_only_observable_evidence(
+    pid, started_at, exists, observed_start, reason
+):
+    evidence = ad._classify_owner_process(
+        pid,
+        started_at,
+        pid_exists=lambda _pid: exists,
+        process_start_time=lambda _pid: observed_start,
+    )
+
+    assert evidence is not None
+    assert evidence["reason"] == reason
+    assert evidence["exit_code"] is None
+    assert evidence["signal"] is None
+    assert "check the process supervisor or OS crash report" in ad._owner_exit_error(
+        evidence
+    )
+
+
 def test_dispatch_returns_immediately_without_blocking():
     gate = threading.Event()
 

--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -211,6 +211,23 @@ class TestRunSingleChildTimeoutDump:
         assert "Diagnostic:" in result["error"]
         assert str(dump_path) in result["error"]
 
+    def test_timeout_defers_child_close_until_worker_exits(self, hermes_home, monkeypatch):
+        """A detached worker must keep its persistence handle until it stops."""
+        child = _StubChild(api_call_count=1, hang_seconds=10.0)
+        child.interrupt = lambda *args, **kwargs: None
+        child.close = MagicMock()
+
+        result = self._invoke_with_short_timeout(child, monkeypatch)
+
+        assert result["status"] == "timeout"
+        assert not child.close.called
+
+        child._hang.set()
+        deadline = time.monotonic() + 2.0
+        while not child.close.called and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert child.close.call_count == 1
+
 
     # ── explicit timeout metadata (#51690, salvaged from PR #60378) ────
 

--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -212,21 +212,29 @@ class TestRunSingleChildTimeoutDump:
         assert str(dump_path) in result["error"]
 
     def test_timeout_defers_child_close_until_worker_exits(self, hermes_home, monkeypatch):
-        """A detached worker must keep its persistence handle until it stops."""
+        """A detached worker retains its persistence handle and credential lease."""
         child = _StubChild(api_call_count=1, hang_seconds=10.0)
         child.interrupt = lambda *args, **kwargs: None
         child.close = MagicMock()
+        child._credential_pool = MagicMock()
+        child._credential_pool.acquire_lease.return_value = "cred-a"
+        child._credential_pool.current.return_value = MagicMock(id="cred-a")
 
         result = self._invoke_with_short_timeout(child, monkeypatch)
 
         assert result["status"] == "timeout"
         assert not child.close.called
+        assert not child._credential_pool.release_lease.called
 
         child._hang.set()
         deadline = time.monotonic() + 2.0
-        while not child.close.called and time.monotonic() < deadline:
+        while (
+            not child._credential_pool.release_lease.called
+            and time.monotonic() < deadline
+        ):
             time.sleep(0.01)
         assert child.close.call_count == 1
+        child._credential_pool.release_lease.assert_called_once_with("cred-a")
 
 
     # ── explicit timeout metadata (#51690, salvaged from PR #60378) ────

--- a/tests/tools/test_delegate_timeout_cleanup.py
+++ b/tests/tools/test_delegate_timeout_cleanup.py
@@ -1,0 +1,90 @@
+"""Regression coverage for timed-out delegation teardown."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from tools import delegate_tool
+
+
+class _SlowUnwindingChild:
+    def __init__(self) -> None:
+        self.tool_progress_callback = None
+        self._credential_pool = None
+        self._delegate_saved_tool_names = []
+        self._delegate_role = "leaf"
+        self._delegate_depth = 1
+        self._subagent_id = None
+        self.model = "test-model"
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = "unknown"
+        self.started = threading.Event()
+        self.interrupted = threading.Event()
+        self.unwinding = threading.Event()
+        self.allow_finish = threading.Event()
+        self.finished = threading.Event()
+        self.closed = threading.Event()
+        self.close_while_running = False
+
+    def run_conversation(self, **_kwargs):
+        self.started.set()
+        assert self.interrupted.wait(timeout=1)
+        # Model the real child turn's finally path: it still performs session
+        # activity/SQLite cleanup after the parent requests interruption.
+        self.unwinding.set()
+        assert self.allow_finish.wait(timeout=2)
+        self.finished.set()
+        return {
+            "final_response": "",
+            "completed": False,
+            "interrupted": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+    def hard_interrupt(self, _reason=None):
+        self.interrupted.set()
+
+    def get_activity_summary(self):
+        return {"api_call_count": 1}
+
+    def close(self):
+        if not self.finished.is_set():
+            self.close_while_running = True
+        self.closed.set()
+
+
+def test_timeout_does_not_close_child_while_worker_is_unwinding(monkeypatch):
+    child = _SlowUnwindingChild()
+    parent = SimpleNamespace(
+        session_id="parent-timeout-test",
+        _current_task_id=None,
+        _active_children=[child],
+        _active_children_lock=threading.Lock(),
+    )
+    monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 0.5)
+    monkeypatch.setattr(delegate_tool, "_get_worktree_isolation", lambda: False)
+
+    result = delegate_tool._run_single_child(
+        task_index=0,
+        goal="exercise timeout teardown",
+        child=child,
+        parent_agent=parent,
+    )
+
+    assert result["status"] == "timeout"
+    assert child.unwinding.wait(timeout=1)
+    try:
+        assert not child.closed.is_set(), (
+            "timed-out child.close() ran before its conversation thread unwound"
+        )
+    finally:
+        child.allow_finish.set()
+    assert child.finished.wait(timeout=1)
+    assert child.closed.wait(timeout=1)
+    assert not child.close_while_running, (
+        "timed-out child.close() raced its still-running conversation thread"
+    )

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -340,8 +340,71 @@ def _note_delivery_attempt(delegation_id: str) -> None:
         )
 
 
+def _classify_owner_process(
+    pid: Optional[int],
+    started_at: Optional[int],
+    *,
+    pid_exists: Callable[[int], bool],
+    process_start_time: Callable[[int], Optional[int]],
+) -> Optional[Dict[str, Any]]:
+    """Return durable owner-exit evidence, or ``None`` while owner may be live.
+
+    Recovery runs in a different process, so it cannot obtain the dead
+    process's wait status.  Report only process-table facts and leave signal /
+    exit code explicitly unknown rather than guessing that every disappearance
+    was a graceful exit.  A live PID whose start time cannot be inspected is
+    treated as indeterminate/live; recovering it would steal work from a slow
+    owner merely because the identity probe failed.
+    """
+    evidence: Dict[str, Any] = {
+        "reason": "owner_identity_missing",
+        "pid": int(pid) if pid else None,
+        "started_at": int(started_at) if started_at is not None else None,
+        "observed_started_at": None,
+        "exit_code": None,
+        "signal": None,
+        "evidence": "process_table",
+    }
+    if not pid:
+        return evidence
+
+    owner_pid = int(pid)
+    if not pid_exists(owner_pid):
+        evidence["reason"] = "owner_process_missing"
+        return evidence
+
+    if started_at is None:
+        return None
+    observed_started_at = process_start_time(owner_pid)
+    if observed_started_at is None:
+        return None
+    evidence["observed_started_at"] = int(observed_started_at)
+    if int(observed_started_at) == int(started_at):
+        return None
+    evidence["reason"] = "owner_pid_reused"
+    return evidence
+
+
+def _owner_exit_error(evidence: Dict[str, Any]) -> str:
+    reason = evidence["reason"]
+    pid = evidence.get("pid")
+    if reason == "owner_pid_reused":
+        detail = (
+            f"owner PID {pid} was reused by a different process generation"
+        )
+    elif reason == "owner_process_missing":
+        detail = f"owner process {pid} disappeared"
+    else:
+        detail = "owner process identity was not recorded"
+    return (
+        f"Delegation {detail} before recording a terminal result; outcome unknown. "
+        "Exit status and signal are unavailable to this recovery process; "
+        "check the process supervisor or OS crash report."
+    )
+
+
 def recover_abandoned_delegations() -> int:
-    """Classify records whose owning process disappeared as outcome unknown."""
+    """Recover dead-owner rows with explicit process-identity evidence."""
     try:
         from gateway.status import _pid_exists, get_process_start_time
     except Exception:
@@ -358,14 +421,16 @@ def recover_abandoned_delegations() -> int:
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
              pid, started, task_json, origin_session_id) = row
-            live = False
-            if pid:
-                live = _pid_exists(int(pid))
-                if live and started is not None:
-                    live = get_process_start_time(int(pid)) == int(started)
-            if live:
+            owner_exit = _classify_owner_process(
+                pid,
+                started,
+                pid_exists=_pid_exists,
+                process_start_time=get_process_start_time,
+            )
+            if owner_exit is None:
                 continue
             task = json.loads(task_json or "{}")
+            owner_error = _owner_exit_error(owner_exit)
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
@@ -377,7 +442,7 @@ def recover_abandoned_delegations() -> int:
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
                 "status": "unknown", "summary": None,
-                "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
+                "error": owner_error, "owner_exit": owner_exit,
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
             # Routing origin persisted at dispatch (see _capture_routing_origin):
@@ -386,7 +451,12 @@ def recover_abandoned_delegations() -> int:
             for _k in ("scope_id", "user_id", "user_name"):
                 if task.get(_k):
                     event[_k] = task[_k]
-            result = {"status": "unknown", "summary": None, "error": event["error"]}
+            result = {
+                "status": "unknown",
+                "summary": None,
+                "error": event["error"],
+                "owner_exit": owner_exit,
+            }
             conn.execute(
                 """UPDATE async_delegations SET state='unknown', completed_at=?,
                    updated_at=?, event_json=?, result_json=?, delivery_state='pending'

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2439,6 +2439,12 @@ def _run_single_child(
     Returns a structured result dict.
     """
     child_start = time.monotonic()
+    # A timed-out Future may still be unwinding on its daemon worker. Closing
+    # the child from this owner thread before that Future settles races every
+    # resource the conversation's finally path still touches (notably its
+    # owned SessionDB). The timeout branch flips this when close ownership is
+    # handed to a Future done-callback instead.
+    _child_close_deferred = False
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
@@ -2916,6 +2922,28 @@ def _run_single_child(
                     f"{_late_pending_steer}]"
                 )
             _attach_worktree(_error_entry)
+            if is_timeout and not _child_future.done():
+                # request_hard_interrupt() is cooperative: the worker still
+                # executes run_conversation's finally path before its Future
+                # becomes done. child.close() tears down that same agent's
+                # clients, messages, and owned SQLite handle, so calling it in
+                # our outer finally while the worker is alive can close SQLite
+                # underneath its final activity write. Future callbacks run
+                # only after the worker has fully returned (or raised), which
+                # is the first safe close boundary.
+                def _close_after_timed_out_worker(_done_future) -> None:
+                    try:
+                        close = getattr(child, "close", None)
+                        if callable(close):
+                            close()
+                    except Exception:
+                        logger.debug(
+                            "Failed to close timed-out child after worker exit",
+                            exc_info=True,
+                        )
+
+                _child_future.add_done_callback(_close_after_timed_out_worker)
+                _child_close_deferred = True
             return _error_entry
         finally:
             # Shut down executor without waiting — if the child thread
@@ -3339,11 +3367,13 @@ def _run_single_child(
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) so subagent subprocesses
         # don't outlive the delegation.
-        try:
-            if hasattr(child, "close"):
-                child.close()
-        except Exception:
-            logger.debug("Failed to close child agent after delegation")
+        if not _child_close_deferred:
+            try:
+                close = getattr(child, "close", None)
+                if callable(close):
+                    close()
+            except Exception:
+                logger.debug("Failed to close child agent after delegation")
 
         # The AIAgent turn boundary normally closes the child scope itself. This
         # fallback covers failures before that boundary starts, but must not pop

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2661,7 +2661,29 @@ def _run_single_child(
     # Worktree-isolation state: populated inside the try once the child's
     # task id is known; the default no-op keeps every early error path safe.
     _worktree_info: Optional[Dict[str, str]] = None
-    _defer_child_close_to_worker = False
+    _defer_child_cleanup_to_worker = False
+    _child_cleanup_lock = threading.Lock()
+    _child_cleanup_done = False
+
+    def _cleanup_child_lifetime() -> None:
+        """Release worker-owned resources exactly once after its lifetime ends."""
+        nonlocal _child_cleanup_done
+        with _child_cleanup_lock:
+            if _child_cleanup_done:
+                return
+            _child_cleanup_done = True
+
+        try:
+            if hasattr(child, "close"):
+                child.close()
+        except Exception:
+            logger.debug("Failed to close child agent after delegation", exc_info=True)
+        finally:
+            if child_pool is not None and leased_cred_id is not None:
+                try:
+                    child_pool.release_lease(leased_cred_id)
+                except Exception as exc:
+                    logger.debug("Failed to release credential lease: %s", exc)
 
     def _attach_worktree(entry_dict: Dict[str, Any]) -> None:
         """Inspect + prune the child worktree, reporting into the entry."""
@@ -2861,18 +2883,12 @@ def _run_single_child(
                 # Keep ownership with the worker until it actually exits; a
                 # future callback is race-safe even if completion happens
                 # between done() and add_done_callback().
-                _defer_child_close_to_worker = True
+                _defer_child_cleanup_to_worker = True
 
-                def _close_detached_child(_future) -> None:
-                    try:
-                        child.close()
-                    except Exception:
-                        logger.debug(
-                            "Failed to close detached child agent after worker exit",
-                            exc_info=True,
-                        )
+                def _cleanup_detached_child(_future) -> None:
+                    _cleanup_child_lifetime()
 
-                _child_future.add_done_callback(_close_detached_child)
+                _child_future.add_done_callback(_cleanup_detached_child)
             duration = round(time.monotonic() - child_start, 2)
             logger.warning(
                 "Subagent %d %s after %.1fs",
@@ -3364,12 +3380,6 @@ def _run_single_child(
         if _subagent_id:
             _unregister_subagent(_subagent_id, agent=child)
 
-        if child_pool is not None and leased_cred_id is not None:
-            try:
-                child_pool.release_lease(leased_cred_id)
-            except Exception as exc:
-                logger.debug("Failed to release credential lease: %s", exc)
-
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
         import model_tools
@@ -3392,15 +3402,10 @@ def _run_single_child(
             except (ValueError, UnboundLocalError) as e:
                 logger.debug("Could not remove child from active_children: %s", e)
 
-        # Close tool resources (terminal sandboxes, browser daemons,
-        # background processes, httpx clients) so subagent subprocesses
-        # don't outlive the delegation.
-        if not _defer_child_close_to_worker:
-            try:
-                if hasattr(child, "close"):
-                    child.close()
-            except Exception:
-                logger.debug("Failed to close child agent after delegation")
+        # Close tool resources and release the credential lease together. A
+        # timed-out worker still owns both until its Future reports completion.
+        if not _defer_child_cleanup_to_worker:
+            _cleanup_child_lifetime()
 
         # The AIAgent turn boundary normally closes the child scope itself. This
         # fallback covers failures before that boundary starts, but must not pop

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2661,6 +2661,7 @@ def _run_single_child(
     # Worktree-isolation state: populated inside the try once the child's
     # task id is known; the default no-op keeps every early error path safe.
     _worktree_info: Optional[Dict[str, str]] = None
+    _defer_child_close_to_worker = False
 
     def _attach_worktree(entry_dict: Dict[str, Any]) -> None:
         """Inspect + prune the child worktree, reporting into the entry."""
@@ -2853,6 +2854,25 @@ def _run_single_child(
                 pass
 
             is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
+            if is_timeout and not _child_future.done():
+                # The timeout owner abandons this daemon worker by design, but
+                # closing the child here also closes its dedicated SessionDB
+                # while run_conversation may still be flushing on that worker.
+                # Keep ownership with the worker until it actually exits; a
+                # future callback is race-safe even if completion happens
+                # between done() and add_done_callback().
+                _defer_child_close_to_worker = True
+
+                def _close_detached_child(_future) -> None:
+                    try:
+                        child.close()
+                    except Exception:
+                        logger.debug(
+                            "Failed to close detached child agent after worker exit",
+                            exc_info=True,
+                        )
+
+                _child_future.add_done_callback(_close_detached_child)
             duration = round(time.monotonic() - child_start, 2)
             logger.warning(
                 "Subagent %d %s after %.1fs",
@@ -3375,11 +3395,12 @@ def _run_single_child(
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) so subagent subprocesses
         # don't outlive the delegation.
-        try:
-            if hasattr(child, "close"):
-                child.close()
-        except Exception:
-            logger.debug("Failed to close child agent after delegation")
+        if not _defer_child_close_to_worker:
+            try:
+                if hasattr(child, "close"):
+                    child.close()
+            except Exception:
+                logger.debug("Failed to close child agent after delegation")
 
         # The AIAgent turn boundary normally closes the child scope itself. This
         # fallback covers failures before that boundary starts, but must not pop


### PR DESCRIPTION
## What does this PR do?

A configured subagent wall-clock timeout can currently close the child agent while its worker thread is still unwinding. That closes the child's SQLite-backed SessionDB under an active query or flush, which can lose delegation state and, on the reported managed macOS runtime, coincides with a native sqlite3 SIGSEGV that kills the session owner. This change transfers teardown to the worker completion boundary and makes abandoned-owner recovery report only process identity evidence it can actually prove.

### Symptom

With `delegation.child_timeout_seconds` configured, a child that does not stop immediately after interruption reaches the timeout path while its worker remains inside `run_conversation`. The owner then calls `child.close()` from the waiting thread. The reported environment observed two native sqlite3 SIGSEGV crashes within about one second of the 600 second timeout, followed by recovery as a generic `owner exited` outcome.

### Impact

The owner process can lose the active session and every in-flight delegation in the batch. Recovery preserves an unknown result, but the existing generic message does not distinguish a missing owner process from PID reuse or explain that signal and exit status are not observable from the recovering process.

### Bug Cause

**Trigger:** `tools/delegate_tool.py:_run_single_child` when `_child_future.result(timeout=child_timeout)` times out and interruption does not immediately stop the worker.

**Causal chain:**
1. The timeout branch requests interruption but cannot synchronously stop a daemon worker already inside a provider, tool, or SQLite-backed session operation.
2. `_run_single_child` returns through `finally` and calls `child.close()` even though `_child_future.done()` is false.
3. `AIAgent.close()` closes the child's dedicated SessionDB and other resources while the worker can still use them, creating a teardown/use race. On the reported managed runtime, the race coincides with a native sqlite3 crash and kills the owner.

**Why it is wrong:** Resource ownership crosses the worker lifetime boundary. A timeout abandons the wait, not the still-running worker, so the waiting thread cannot safely close worker-owned resources.

**Working sibling / contrast:** Normal completion and non-timeout exceptions have a completed future before final teardown, so closing on the waiting thread is safe. The fix changes only the timed-out, still-running future path.

**Ruled out:** The recovery code does not kill owners and does not classify a live owner with a matching PID/start stamp as abandoned. The regression reproduces the premature close directly without assuming the managed Python build is the sole cause of the native crash.

### Fix

- When a timeout leaves the child future running, register a done callback that retires the child exactly once after the worker exits. Until then, keep its live registry entries, parent interrupt-propagation membership, credential lease, and owned resources intact.
- Classify recovery evidence as `owner_process_missing`, `owner_pid_reused`, or `owner_identity_missing`.
- Keep live owners when the start-time probe is indeterminate instead of falsely recovering a potentially slow owner.
- Persist structured `owner_exit` evidence with explicit null `exit_code` and `signal` fields. The recovery process cannot obtain another process's wait status, so the user-facing error points operators to supervisor or OS crash evidence rather than inventing an exit cause.

## Related Issue

Addresses #98332

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py` - transfer the complete timed-out child lifetime retirement to the child future completion boundary.
- `tools/async_delegation.py` - add fail-closed owner identity classification and structured recovery evidence.
- `tests/tools/test_delegate_subagent_timeout_diagnostic.py` - reproduce the premature close and verify teardown occurs exactly once after worker exit.
- `tests/tools/test_delegate_timeout_cleanup.py` - preserve the prior delayed-unwind regression from #90889 with its original authorship.
- `tests/tools/test_async_delegation.py` - cover live, missing, reused, and untracked owner classifications.

## How to Test

1. Configure a short child timeout and run a child that ignores interruption until a test gate is released.
2. Verify the timeout result returns while `child.close()` remains uncalled, release the worker, and verify close runs exactly once.
3. Run the relevant delegation and durable-ledger suites:

```bash
scripts/run_tests.sh tests/tools/test_delegate_timeout_cleanup.py tests/tools/test_delegate_subagent_timeout_diagnostic.py tests/tools/test_delegate.py tests/tools/test_async_delegation_fd_leak.py tests/tools/test_async_delegation.py -q
```

Result: 111 passed, 1 macOS-only test skipped on Windows 11.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; recovery behavior is described by code docstrings and result fields
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] I've considered cross-platform impact; the lifetime fix is platform-independent and existing macOS-only SQLite barriers remain covered on the macOS CI lane
- [x] Tool description/schema update is N/A; no model tool schema changed

## Screenshots / Logs

The targeted test suite passed with 111 tests. The exact managed macOS runtime reproduction remains delegated to the review environment because the native crash artifact is macOS-specific, so this PR addresses rather than closes #98332.
