### PR TITLE
fix(desktop): don't dead-end the update on ledgered manual serve blockers

### DIFF
--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -100,6 +100,45 @@ describe('parseVenvBlockerScanOutput', () => {
     assert.equal(o.kind, 'blocked')
   })
 
+  // Contract fixture (#98336/#98350): the scanner reports exemption
+  // diagnostics (counts + sanitized evidence) alongside the authoritative
+  // blocked/processes fields. The consumer must tolerate those fields today
+  // and must keep enforcing blocked/processes consistency — a future parser
+  // change that either chokes on the diagnostics or silently reinterprets
+  // an exemption as a blocker breaks this fixture.
+  it('tolerates exemption diagnostics while enforcing blocked/processes consistency', () => {
+    const clear = parseVenvBlockerScanOutput(
+      ok({
+        pausable_gateways: 2,
+        ledgered_manual_serves: 1,
+        exempted_manual_serves: [{ pid: 78, purpose: 'serve', port: 9119 }]
+      })
+    )
+
+    assert.equal(clear.kind, 'clear')
+
+    const blocked = parseVenvBlockerScanOutput(
+      ok({
+        blocked: true,
+        processes: [{ pid: 79, name: 'python.exe', cmdline: 'c' }],
+        pausable_gateways: 1,
+        ledgered_manual_serves: 1,
+        exempted_manual_serves: [{ pid: 78, purpose: 'serve', port: 9119 }]
+      })
+    )
+
+    assert.equal(blocked.kind, 'blocked')
+
+    if (blocked.kind !== 'blocked') {
+      return
+    }
+
+    assert.deepEqual(
+      blocked.result.processes.map((p) => p.pid),
+      [79]
+    )
+  })
+
   it('classifies Python http.server blockers as safe local previews with a human label', () => {
     const o = parseVenvBlockerScanOutput(
       ok({

--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -234,6 +234,33 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     return looks_like_gateway_command_line(cmdline)
 
 
+def _ledgered_manual_serve_pids(matches: list[tuple[int, str, str]]) -> set[int]:
+    """Return the PIDs of venv holders the updater's serve rung owns.
+
+    Same dead-end shape as the gateway exemption above, for MANUAL
+    ``serve``/``dashboard`` backends: the CLI updater's venv guard stops a
+    self-ledgered backend whose recorded spawner is not alive and relaunches
+    it on its recorded endpoint (``_ledger_manual_serve_holders`` rung,
+    #63206).  Reporting those as blockers aborts the Desktop preflight with
+    ``venv-blocked`` before ``hermes-setup`` spawns the updater, so the rung
+    that exists precisely to handle them never runs (#98336).
+
+    Delegates to ``update_cmd._ledger_manual_serve_holders`` — the canonical
+    positive-identity matcher (spawn-ledger ``(pid, create_time)`` for THIS
+    install, spawner provably not alive) — so the preflight exemption, the
+    updater's stop rung, and the relauncher share one parser.  A
+    Desktop-owned backend (live spawner) and an unledgered ``serve`` never
+    appear here and keep blocking.  An import failure counts as no manual
+    serves, which is exactly the pre-exemption behavior.
+    """
+    try:
+        from hermes_cli.update_cmd import _ledger_manual_serve_holders  # noqa: PLC0415
+
+        return {int(entry["pid"]) for entry in _ledger_manual_serve_holders(matches)}
+    except Exception:
+        return set()
+
+
 def main() -> None:
     """Entry point.  Prints one JSON doc to stdout.  Exits 0 for valid scan."""
     try:
@@ -248,9 +275,12 @@ def main() -> None:
     except Exception as exc:
         _emit_probe_fail(f"scan aborted: {exc}")
 
+    manual_serve_pids = _ledgered_manual_serve_pids(matches)
     processes = []
     for pid, name, cmdline in matches:
         if _is_pausable_gateway(cmdline):
+            continue
+        if pid in manual_serve_pids:
             continue
         process = {
             "pid": pid,
@@ -271,6 +301,9 @@ def main() -> None:
         # Diagnostic only: gateway processes present but not counted as
         # blockers because the downstream updater pauses them itself.
         "pausable_gateways": exempted,
+        # Diagnostic only: manual serve/dashboard backends the downstream
+        # updater stops and relaunches on their recorded endpoints.
+        "ledgered_manual_serves": len(manual_serve_pids),
     }
     print(json.dumps(data))
     sys.exit(0)

--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -234,8 +234,8 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     return looks_like_gateway_command_line(cmdline)
 
 
-def _ledgered_manual_serve_pids(matches: list[tuple[int, str, str]]) -> set[int]:
-    """Return the PIDs of venv holders the updater's serve rung owns.
+def _ledgered_manual_serve_entries(matches: list[tuple[int, str, str]]) -> list[dict]:
+    """Ledger entries for venv holders the updater's serve rung owns.
 
     Same dead-end shape as the gateway exemption above, for MANUAL
     ``serve``/``dashboard`` backends: the CLI updater's venv guard stops a
@@ -256,9 +256,28 @@ def _ledgered_manual_serve_pids(matches: list[tuple[int, str, str]]) -> set[int]
     try:
         from hermes_cli.update_cmd import _ledger_manual_serve_holders  # noqa: PLC0415
 
-        return {int(entry["pid"]) for entry in _ledger_manual_serve_holders(matches)}
+        return list(_ledger_manual_serve_holders(matches))
     except Exception:
-        return set()
+        return []
+
+
+def _manual_serve_evidence(entries: list[dict]) -> list[dict]:
+    """Sanitized decision evidence for exempted manual serves.
+
+    Structured ledger fields only — pid, purpose, recorded port — never the
+    command line, which can carry tokens or private endpoints.  Lets the
+    scan result explain *why* a holder disappeared from ``processes``
+    without echoing argv.
+    """
+    evidence = []
+    for entry in entries:
+        pid = entry.get("pid")
+        if not isinstance(pid, int):
+            continue
+        evidence.append(
+            {"pid": pid, "purpose": entry.get("purpose"), "port": entry.get("port")}
+        )
+    return evidence
 
 
 def main() -> None:
@@ -275,7 +294,12 @@ def main() -> None:
     except Exception as exc:
         _emit_probe_fail(f"scan aborted: {exc}")
 
-    manual_serve_pids = _ledgered_manual_serve_pids(matches)
+    manual_serve_entries = _ledgered_manual_serve_entries(matches)
+    manual_serve_pids = {
+        entry["pid"]
+        for entry in manual_serve_entries
+        if isinstance(entry.get("pid"), int)
+    }
     processes = []
     for pid, name, cmdline in matches:
         if _is_pausable_gateway(cmdline):
@@ -304,6 +328,9 @@ def main() -> None:
         # Diagnostic only: manual serve/dashboard backends the downstream
         # updater stops and relaunches on their recorded endpoints.
         "ledgered_manual_serves": len(manual_serve_pids),
+        # Diagnostic only: sanitized evidence (structured ledger identity,
+        # never argv) explaining which holders the exemption consumed.
+        "exempted_manual_serves": _manual_serve_evidence(manual_serve_entries),
     }
     print(json.dumps(data))
     sys.exit(0)

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -404,6 +404,11 @@ def test_main_ledgered_manual_serve_is_exempt(monkeypatch, capsys):
     assert data["blocked"] is False
     assert data["processes"] == []
     assert data["ledgered_manual_serves"] == 1
+    # Sanitized decision evidence: structured ledger identity only — the
+    # exemption must explain itself without echoing the command line.
+    assert data["exempted_manual_serves"] == [
+        {"pid": 78, "purpose": "serve", "port": 9119}
+    ]
 
 
 def test_main_ledgered_serve_alongside_unledgered_holder_still_blocks(monkeypatch, capsys):
@@ -427,6 +432,10 @@ def test_main_ledgered_serve_alongside_unledgered_holder_still_blocks(monkeypatc
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [79]
     assert data["ledgered_manual_serves"] == 1
+    # Only the ledger-vouched holder shows up in the sanitized evidence.
+    assert data["exempted_manual_serves"] == [
+        {"pid": 78, "purpose": "serve", "port": 9119}
+    ]
 
 
 def test_main_ledger_matcher_failure_keeps_serve_blocking(monkeypatch, capsys):
@@ -451,3 +460,4 @@ def test_main_ledger_matcher_failure_keeps_serve_blocking(monkeypatch, capsys):
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [78]
     assert data["ledgered_manual_serves"] == 0
+    assert data["exempted_manual_serves"] == []

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -368,3 +368,86 @@ def test_main_gateway_with_long_managed_runtime_path_is_exempt(monkeypatch, caps
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [92]
     assert len(data["processes"][0]["cmdline"]) <= 120
+
+
+# ---------------------------------------------------------------------------
+# manual serve/dashboard exemption — the ledger rung mirror
+#
+# `hermes update`'s venv guard stops a self-ledgered serve/dashboard backend
+# whose recorded spawner is not alive and relaunches it on its recorded
+# endpoint (#63206). The Desktop preflight must therefore not report those
+# as blockers either, or the handoff dead-ends before the updater runs.
+# ---------------------------------------------------------------------------
+
+
+def _patch_manual_serve_ledger(monkeypatch, entries):
+    """Point the canonical matcher at *entries* (list of ledger dicts)."""
+    import hermes_cli.update_cmd as update_cmd_module
+
+    monkeypatch.setattr(update_cmd_module, "_ledger_manual_serve_holders", lambda matches: entries)
+
+
+def test_main_ledgered_manual_serve_is_exempt(monkeypatch, capsys):
+    """A serve/dashboard backend the updater's ledger rung owns (positive
+    identity, spawner not alive) must scan clear instead of dead-ending the
+    Desktop update (#98336)."""
+    serve = (
+        78,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main serve --host 10.0.0.1 --port 9119",
+    )
+    _patch_manual_serve_ledger(monkeypatch, [{"pid": 78, "purpose": "serve", "port": 9119}])
+
+    code, data = _run_main_with_detector(monkeypatch, capsys, [serve])
+    assert code == 0
+    assert data["ok"] is True
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["ledgered_manual_serves"] == 1
+
+
+def test_main_ledgered_serve_alongside_unledgered_holder_still_blocks(monkeypatch, capsys):
+    """Only the ledgered manual serve is exempt; a serve the ledger does not
+    vouch for (Desktop-owned, live spawner, foreign install) keeps blocking
+    and is the only reported PID."""
+    ledgered = (
+        78,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main serve --host 10.0.0.1 --port 9119",
+    )
+    desktop_owned = (
+        79,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main serve --host 127.0.0.1 --port 0",
+    )
+    _patch_manual_serve_ledger(monkeypatch, [{"pid": 78, "purpose": "serve", "port": 9119}])
+
+    code, data = _run_main_with_detector(monkeypatch, capsys, [ledgered, desktop_owned])
+    assert code == 0
+    assert data["blocked"] is True
+    assert [p["pid"] for p in data["processes"]] == [79]
+    assert data["ledgered_manual_serves"] == 1
+
+
+def test_main_ledger_matcher_failure_keeps_serve_blocking(monkeypatch, capsys):
+    """Fail-closed: when the canonical matcher cannot run (import/ledger
+    error), the preflight reports the serve as a blocker — the pre-exemption
+    behavior — instead of guessing."""
+
+    def _boom(_matches):
+        raise RuntimeError("ledger unreadable")
+
+    import hermes_cli.update_cmd as update_cmd_module
+
+    monkeypatch.setattr(update_cmd_module, "_ledger_manual_serve_holders", _boom)
+    serve = (
+        78,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main serve --host 10.0.0.1 --port 9119",
+    )
+
+    code, data = _run_main_with_detector(monkeypatch, capsys, [serve])
+    assert code == 0
+    assert data["blocked"] is True
+    assert [p["pid"] for p in data["processes"]] == [78]
+    assert data["ledgered_manual_serves"] == 0


### PR DESCRIPTION
## What does this PR do?

On Windows, the Desktop update preflight (`hermes_cli._scan_venv_blockers`) reports **every** `hermes serve`/`dashboard` holder as a venv blocker, so the hand-off aborts with `venv-blocked` before `hermes-setup` ever spawns the updater — even though the CLI updater's venv guard has a rung (#63206) that stops exactly the MANUAL serve/dashboard backends (spawn-ledger positive identity for this install, spawner provably not alive) and relaunches them on their recorded endpoints after the update. This is the same dead-end shape the gateway exemption (`_is_pausable_gateway`) already fixed for `gateway run`; this PR closes the gap for manual serves (#98336).

The fix mirrors the gateway exemption: holders vouched for by the canonical matcher `update_cmd._ledger_manual_serve_holders` are exempted from the blocker list (counted in a new diagnostic `ledgered_manual_serves` field). Delegating to that matcher — rather than a cmdline regex — keeps the preflight exemption, the updater's stop rung, and the relauncher on one parser, and inherits its safety properties: install-scoped ledger identity (`(pid, create_time)` for THIS install), spawner-liveness check, and structured relaunch.

Deliberately NOT exempted (fail-closed, unchanged behavior):
- Desktop-owned serves (live spawner) — the app would respawn what the update kills;
- unledgered serves (no positive identity → still a blocker, listed with PID/cmdline);
- foreign installs (ledger entries are install-id scoped);
- any matcher import failure reads as "no manual serves" → pre-exemption behavior.

## Related Issue

Fixes #98336

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/_scan_venv_blockers.py`: added `_ledgered_manual_serve_pids()`, which delegates to the canonical ledger matcher (import failure → empty set, i.e. fail-closed); `main()` now skips those PIDs after the gateway exemption and reports a `ledgered_manual_serves` diagnostic count (mirroring `pausable_gateways`).
- `tests/hermes_cli/test_scan_venv_blockers.py`: three regression tests — ledgered manual serve scans clear; a ledgered serve alongside an unledgered/Desktop-owned serve still blocks on the latter only; a matcher failure keeps the serve blocking (fail-closed).

## How to Test

1. Run the scanner suite → **34 passed** (31 pre-existing + 3 new).
2. Related ledger/guard suites (process identity, MCP helper ledger, serve runtime inventory, Windows gateway cold-start desktop lifecycle) → **50 passed**.
3. `python -m hermes_cli._scan_venv_blockers` → Observed result: `{"ok": true, "blocked": false, "processes": [], "pausable_gateways": 0, "ledgered_manual_serves": 0}`, exit 0 — new field present, import chain intact.
4. `ruff check` on both changed files → all checks passed.

The TS consumer (`apps/desktop/electron/venv-blocker-scan.ts`) needs no change: `parseVenvBlockerScanOutput` ignores unknown top-level fields, and `blocked`/`processes` consistency is produced by the Python side.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64); the Windows behavior is covered by the patched-detector unit tests, which feed real Windows cmdline shapes

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring on the new helper documents the contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
