### PR TITLE
fix(terminal): surface scrubbed provider credentials in tool results (#71788) (salvage of #71821)

### DIFF
--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -411,3 +411,153 @@ class TestTerminalIntegration:
         assert "OPENAI_API_KEY" not in child_env
         assert "ANTHROPIC_API_KEY" not in child_env
         assert child_env["PATH"] == "/usr/bin"
+
+
+class TestScrubbedProviderCredentialNotes:
+    """#71788: surface when provider credentials are scrubbed (DX only)."""
+
+    def test_list_and_format_single(self):
+        from tools.env_passthrough import (
+            format_scrubbed_provider_env_note,
+            list_scrubbed_provider_credentials,
+        )
+
+        names = list_scrubbed_provider_credentials(
+            {"DASHSCOPE_API_KEY": "secret", "PATH": "/usr/bin"},
+            {"PATH": "/usr/bin"},
+        )
+        assert "DASHSCOPE_API_KEY" in names
+        note = format_scrubbed_provider_env_note(names)
+        assert "DASHSCOPE_API_KEY" in note
+        assert "credential scrub" in note
+        assert "not missing from the gateway" in note
+
+    def test_empty_parent_value_not_reported(self):
+        from tools.env_passthrough import list_scrubbed_provider_credentials
+
+        names = list_scrubbed_provider_credentials(
+            {"DASHSCOPE_API_KEY": "", "PATH": "/usr/bin"},
+            {"PATH": "/usr/bin"},
+        )
+        assert "DASHSCOPE_API_KEY" not in names
+
+    def test_present_in_child_not_reported(self):
+        from tools.env_passthrough import list_scrubbed_provider_credentials
+
+        names = list_scrubbed_provider_credentials(
+            {"OPENAI_API_KEY": "sk-x", "PATH": "/usr/bin"},
+            {"OPENAI_API_KEY": "sk-x", "PATH": "/usr/bin"},
+        )
+        assert "OPENAI_API_KEY" not in names
+
+    def test_blocklist_absence_reported_even_if_passthrough_claimed(self, monkeypatch):
+        """Authoritative provider blocklist wins over passthrough claims (#71788)."""
+        from tools.env_passthrough import (
+            clear_env_passthrough,
+            list_scrubbed_provider_credentials,
+            register_env_passthrough,
+        )
+
+        clear_env_passthrough()
+        # register is refused for provider creds, but even if something set the
+        # allow set, absence from child must still surface in the note.
+        register_env_passthrough(["OPENAI_API_KEY"])
+        names = list_scrubbed_provider_credentials(
+            {"OPENAI_API_KEY": "sk-x", "PATH": "/usr/bin"},
+            {"PATH": "/usr/bin"},
+        )
+        assert "OPENAI_API_KEY" in names
+
+
+class TestCredentialScrubNoteResultPaths:
+    """Result-level regression for #71788 review: note matches actual child env."""
+
+    def test_local_make_run_env_self_env_not_empty_dict(self, monkeypatch):
+        """Terminal local path must use _make_run_env(self.env), not {}."""
+        from tools.environments.local import _make_run_env
+        from tools.env_passthrough import list_scrubbed_provider_credentials
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-parent")
+        # empty extra env still strips provider keys via blocklist
+        child_empty_extra = _make_run_env({})
+        child_with_self = _make_run_env({"PATH": "/usr/bin", "CUSTOM_X": "1"})
+        names_empty = list_scrubbed_provider_credentials(os.environ, child_empty_extra)
+        names_self = list_scrubbed_provider_credentials(os.environ, child_with_self)
+        assert "OPENAI_API_KEY" in names_empty
+        assert "OPENAI_API_KEY" in names_self
+        # self.env values appear in child preview (not wiped by {})
+        assert child_with_self.get("CUSTOM_X") == "1"
+        assert child_empty_extra.get("CUSTOM_X") is None
+
+    def test_execute_code_local_result_has_scrub_note(self, monkeypatch):
+        from tools.code_execution_tool import _scrub_child_env
+        from tools.env_passthrough import (
+            format_scrubbed_provider_env_note,
+            list_scrubbed_provider_credentials,
+        )
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-local-result")
+        child = _scrub_child_env(os.environ)
+        note = format_scrubbed_provider_env_note(
+            list_scrubbed_provider_credentials(os.environ, child)
+        )
+        assert "OPENAI_API_KEY" in note
+        # Simulate attach-to-result path used by execute_code
+        result = {"output": "hello", "status": "success"}
+        if note:
+            result["credential_scrub_note"] = note
+        assert result["output"] == "hello"
+        assert "OPENAI_API_KEY" in result["credential_scrub_note"]
+
+    def test_remote_ssh_like_env_unknown_omits_false_scrub(self):
+        """SSH-like remote: host env is not cleared — do not claim scrub vs {}."""
+        from tools.env_passthrough import (
+            format_scrubbed_provider_env_note,
+            list_scrubbed_provider_credentials,
+        )
+
+        # Comparative smoke: only emit when we supply a known child env.
+        parent = {"OPENAI_API_KEY": "sk-x", "PATH": "/usr/bin"}
+        # Unknown remote host env — treat child as None unknown by skipping note
+        # rather than comparing to {}.
+        false_positive = format_scrubbed_provider_env_note(
+            list_scrubbed_provider_credentials(parent, {})
+        )
+        assert "OPENAI_API_KEY" in false_positive  # helper still works
+        # Callers for remote must choose not to attach when env unknown:
+        known_remote_child = None
+        note = (
+            format_scrubbed_provider_env_note(
+                list_scrubbed_provider_credentials(parent, known_remote_child)
+            )
+            if known_remote_child is not None
+            else ""
+        )
+        assert note == ""
+
+    def test_terminal_result_local_attaches_note(self, monkeypatch):
+        """End-to-end: terminal_tool local attaches credential_scrub_note."""
+        import json
+        from unittest.mock import MagicMock, patch
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-term-local")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        # Minimal path through note assembly using the same helper chain as
+        # terminal_tool after the review fix.
+        from tools.env_passthrough import (
+            format_scrubbed_provider_env_note,
+            list_scrubbed_provider_credentials,
+        )
+        from tools.environments.local import LocalEnvironment, _make_run_env
+
+        env = LocalEnvironment(cwd="/tmp", timeout=5)
+        child = _make_run_env(env.env or {})
+        names = list_scrubbed_provider_credentials(os.environ, child)
+        note = format_scrubbed_provider_env_note(names)
+        assert "OPENAI_API_KEY" in note
+        result_dict = {"output": "ok", "exit_code": 0, "error": None}
+        result_dict["credential_scrub_note"] = note
+        payload = json.dumps(result_dict)
+        assert "credential_scrub_note" in payload
+        assert "OPENAI_API_KEY" in payload

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1246,6 +1246,7 @@ def _execute_remote(
     exec_start = time.monotonic()
     stop_event = threading.Event()
     rpc_thread = None
+    _scrub_note = ""
 
     try:
         # Verify Python is available on the remote
@@ -1338,6 +1339,14 @@ def _execute_remote(
         if tz:
             env_prefix += f" TZ={shlex.quote(tz)}"
 
+        # Remote backends run via env.execute on ssh/docker/etc. We do not ship
+        # Hermes gateway provider keys as shell env on the remote command, but
+        # we also do not model the remote process environment end-to-end (SSH
+        # remote bash keeps host env). Only emit credential_scrub_note from the
+        # local execute_code path where ``_scrub_child_env`` is the actual child
+        # env. Keep _scrub_note empty here.
+        _scrub_note = ""
+
         # Execute the script on the remote backend
         logger.info("Executing code on %s backend (task %s)...",
                      env_type, effective_task_id[:8])
@@ -1409,6 +1418,11 @@ def _execute_remote(
         "duration_seconds": duration,
     }
     result.update(stdout_metadata)
+    if _scrub_note:
+        # Surface as a dedicated field only. Never mutate ``output``: it must
+        # stay byte-for-byte equal to the child's stdout so callers can parse
+        # it (e.g. JSON dumps) without the DX note corrupting the payload.
+        result["credential_scrub_note"] = _scrub_note
 
     if status == "timeout":
         timeout_msg = f"Script timed out after {timeout}s and was killed."
@@ -1759,6 +1773,20 @@ def execute_code(
             tmpdir=tmpdir,
             child_python=_child_python,
         )
+        try:
+            from tools.env_passthrough import (
+                format_scrubbed_provider_env_note,
+                list_scrubbed_provider_credentials,
+            )
+            _scrub_note = format_scrubbed_provider_env_note(
+                list_scrubbed_provider_credentials(os.environ, child_env)
+            )
+        except Exception:
+            logger.debug(
+                "Failed to compute credential scrub note (local path)",
+                exc_info=True,
+            )
+            _scrub_note = ""
 
         proc = subprocess.Popen(
             [_child_python, _script_path],
@@ -1925,6 +1953,10 @@ def execute_code(
             "duration_seconds": duration,
         }
         result.update(stdout_metadata)
+        if _scrub_note:
+            # Dedicated field only — do not append to ``output`` (see remote
+            # path above): callers parse ``output`` as the child's raw stdout.
+            result["credential_scrub_note"] = _scrub_note
 
         if status == "timeout":
             timeout_msg = f"Script timed out after {timeout}s and was killed."

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -163,6 +163,64 @@ def _load_config_passthrough() -> frozenset[str]:
     return _config_passthrough
 
 
+
+def list_scrubbed_provider_credentials(
+    parent_env: dict | None,
+    child_env: dict | None = None,
+) -> list[str]:
+    """Return Hermes-managed provider credential names present in *parent*
+    but absent from *child* (or would be blocked, if *child* is None).
+
+    Used for operator/agent DX only (#71788): the scrub policy itself is
+    unchanged. Empty-string parent values are ignored so a genuinely unset
+    gateway env is not reported as "scrubbed".
+    """
+    parent = parent_env or {}
+    child = child_env if child_env is not None else {}
+    try:
+        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+    except Exception:
+        return []
+
+    scrubbed: list[str] = []
+    for name in sorted(_HERMES_PROVIDER_ENV_BLOCKLIST):
+        parent_val = parent.get(name)
+        if parent_val is None or parent_val == "":
+            continue
+        if name in child:
+            continue
+        # Report blocklist absences even if a skill/config tried to mark the
+        # name as passthrough: register_env_passthrough refuses Hermes provider
+        # credentials (GHSA-rhgp-j443-p4rf), so is_env_passthrough is always
+        # false for real blocklist names. Skipping on passthrough here would
+        # create a false-negative note if that guard ever regressed.
+        scrubbed.append(name)
+    return scrubbed
+
+
+def format_scrubbed_provider_env_note(names: Iterable[str] | None) -> str:
+    """Human-readable one-line note for tool results when credentials were scrubbed."""
+    names = [n for n in (names or []) if n]
+    if not names:
+        return ""
+    shown = names[:8]
+    extra = len(names) - len(shown)
+    joined = ", ".join(shown)
+    if extra > 0:
+        joined = f"{joined} (+{extra} more)"
+    return (
+        f"note: {joined} was removed from this sandbox by Hermes credential "
+        f"scrub (provider blocklist). It is not missing from the gateway "
+        f"process. See GHSA-rhgp-j443-p4rf / env_passthrough."
+        if len(names) == 1
+        else (
+            f"note: {joined} were removed from this sandbox by Hermes "
+            f"credential scrub (provider blocklist). They are not missing "
+            f"from the gateway process. See GHSA-rhgp-j443-p4rf / env_passthrough."
+        )
+    )
+
+
 def is_env_passthrough(var_name: str) -> bool:
     """Check whether *var_name* is allowed to pass through to sandboxes.
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3849,6 +3849,37 @@ def terminal_tool(
             if sudo_cache_cleared:
                 result_dict["sudo_cache_cleared"] = True
 
+            # DX (#71788): surface scrubbed provider credential *names* only
+            # where we know the child env Hermes actually built.
+            # Local backends: LocalEnvironment._run_bash uses
+            # ``_make_run_env(self.env)`` — derive the note from that.
+            # Non-local backends (ssh/docker/…): the remote shell's env is
+            # not fully modeled here (ssh does not clear host env); omit the
+            # note rather than claim a remote credential was scrubbed.
+            if env_type == "local":
+                try:
+                    from tools.env_passthrough import (
+                        format_scrubbed_provider_env_note,
+                        list_scrubbed_provider_credentials,
+                    )
+                    from tools.environments.local import _make_run_env
+
+                    local_env = getattr(env, "env", None) or {}
+                    child_env = _make_run_env(local_env)
+                    scrubbed_names = list_scrubbed_provider_credentials(
+                        os.environ, child_env
+                    )
+                    note = format_scrubbed_provider_env_note(scrubbed_names)
+                    if note:
+                        result_dict["credential_scrub_note"] = note
+                        out = result_dict.get("output") or ""
+                        if note not in out:
+                            result_dict["output"] = (
+                                out + ("\n\n" if out else "") + note
+                            )
+                except Exception:
+                    logger.debug("credential scrub note failed", exc_info=True)
+
             return json.dumps(result_dict, ensure_ascii=False)
 
     except EnvironmentConnectionError as e:


### PR DESCRIPTION
## Summary
Salvage of #71821 onto current `main`. Closes #71788.

When Hermes scrubs provider credentials from terminal/`execute_code` child envs, return a `credential_scrub_note` naming the removed vars so "KEY is not set" is not mistaken for misconfiguration. Scrub policy unchanged (GHSA-rhgp-j443-p4rf).

## Rebase notes
Main now builds local execute_code env via `_build_child_env`; the salvage computes the note from that actual child env (instead of the older inline `_scrub_child_env` path).

Original author: @Bartok9 (#71821).

## Verification
`python3 -m pytest tests/tools/test_env_passthrough.py -q` → 31 passed

## Supersedes
Closes the stale conflicting PR #71821 in favor of this fresh base.