### PR TITLE
fix(platforms): sanitize typographic Unicode from outbound messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3040,7 +3040,12 @@ _TYPOGRAPHIC_TO_ASCII = str.maketrans({
     "\u2009": " ",  # THIN SPACE
     "\u2026": "...",  # … HORIZONTAL ELLIPSIS
 })
-_TYPOGRAPHIC_DROP = frozenset("\u200b\u200c\u200d\u2060\ufeff")  # zero-width / BOM
+# Only characters that are unambiguously accidental in outbound text are
+# dropped: ZWSP, word joiner, and BOM/ZWNBSP are invisible and carry no
+# content. ZWJ (U+200D) and ZWNJ (U+200C) are deliberately NOT included —
+# they are meaningful inside emoji ZWJ sequences (family/profession emoji)
+# and in scripts such as Persian, so stripping them corrupts real content.
+_TYPOGRAPHIC_DROP = frozenset("\u200b\u2060\ufeff")  # ZWSP / word joiner / BOM
 
 
 def sanitize_outbound_typography(text: str) -> str:
@@ -3049,8 +3054,12 @@ def sanitize_outbound_typography(text: str) -> str:
     Curly quotes become straight quotes, en/em dashes become a single hyphen
     (matching ``iconv -t ASCII//TRANSLIT`` so behaviour is predictable),
     non-breaking/thin spaces become ordinary spaces, ellipsis becomes
-    ``...``, and zero-width characters are dropped entirely. Everything else
-    — CJK, emoji, real non-ASCII filenames — is left untouched.
+    ``...``, and invisible formatting — zero-width space, word joiner, and
+    BOM/ZWNBSP — is dropped entirely. ZWJ/ZWNJ (U+200C/U+200D) are preserved:
+    they are meaningful inside emoji ZWJ sequences (family, profession,
+    skin-tone) and in scripts such as Persian, so removing them would corrupt
+    real content. Everything else — CJK, emoji, real non-ASCII filenames —
+    is left untouched.
     """
     text = text.translate(_TYPOGRAPHIC_TO_ASCII)
     if _TYPOGRAPHIC_DROP.intersection(text):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3012,6 +3012,52 @@ def _strip_media_directives(text: str) -> str:
     return _strip_media_tag_directives(text)
 
 
+# Typographic Unicode that survives messaging rendering and copy-paste but
+# breaks shell parsing: curly quotes, dash lookalikes, invisible space
+# variants, and ellipsis. LLM prose (and Apple/Google smart punctuation)
+# emits these; a command copied from a phone bubble then fails in a terminal
+# with "command not found" or syntax errors even though the text "looks
+# right". Outbound text is forced to ASCII equivalents so copied commands
+# run unchanged.
+_TYPOGRAPHIC_TO_ASCII = str.maketrans({
+    "\u2018": "'",  # ‘ LEFT SINGLE QUOTATION MARK
+    "\u2019": "'",  # ’ RIGHT SINGLE QUOTATION MARK
+    "\u201a": "'",  # ‚ SINGLE LOW-9 QUOTATION MARK
+    "\u201b": "'",  # ‛ SINGLE HIGH-REVERSED-9 QUOTATION MARK
+    "\u201c": '"',  # “ LEFT DOUBLE QUOTATION MARK
+    "\u201d": '"',  # ” RIGHT DOUBLE QUOTATION MARK
+    "\u201e": '"',  # „ DOUBLE LOW-9 QUOTATION MARK
+    "\u201f": '"',  # ‟ DOUBLE HIGH-REVERSED-9 QUOTATION MARK
+    "\u2010": "-",  # ‐ HYPHEN
+    "\u2011": "-",  # ‑ NON-BREAKING HYPHEN
+    "\u2012": "-",  # ‒ FIGURE DASH
+    "\u2013": "-",  # – EN DASH
+    "\u2014": "-",  # — EM DASH
+    "\u2015": "-",  # ― HORIZONTAL BAR
+    "\u2212": "-",  # − MINUS SIGN
+    "\u00a0": " ",  # NO-BREAK SPACE
+    "\u202f": " ",  # NARROW NO-BREAK SPACE
+    "\u2009": " ",  # THIN SPACE
+    "\u2026": "...",  # … HORIZONTAL ELLIPSIS
+})
+_TYPOGRAPHIC_DROP = frozenset("\u200b\u200c\u200d\u2060\ufeff")  # zero-width / BOM
+
+
+def sanitize_outbound_typography(text: str) -> str:
+    """Replace typographic Unicode with ASCII equivalents.
+
+    Curly quotes become straight quotes, en/em dashes become a single hyphen
+    (matching ``iconv -t ASCII//TRANSLIT`` so behaviour is predictable),
+    non-breaking/thin spaces become ordinary spaces, ellipsis becomes
+    ``...``, and zero-width characters are dropped entirely. Everything else
+    — CJK, emoji, real non-ASCII filenames — is left untouched.
+    """
+    text = text.translate(_TYPOGRAPHIC_TO_ASCII)
+    if _TYPOGRAPHIC_DROP.intersection(text):
+        text = "".join(ch for ch in text if ch not in _TYPOGRAPHIC_DROP)
+    return text
+
+
 class BasePlatformAdapter(ABC):
     """
     Base class for platform adapters.

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -31,6 +31,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_document_from_bytes,
+    sanitize_outbound_typography,
 )
 from .media_cache import ext_for_mime
 from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
@@ -541,7 +542,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        text = self.format_message(content)
+        text = sanitize_outbound_typography(self.format_message(content))
         if not text:
             return SendResult(success=False, error="BlueBubbles send requires text")
         # Split on paragraph breaks first (double newlines) so each thought

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -41,6 +41,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
     cache_image_from_url,
+    sanitize_outbound_typography,
     utf16_len,
 )
 from gateway.platforms.helpers import redact_phone
@@ -1172,6 +1173,7 @@ class SignalAdapter(BasePlatformAdapter):
         await self._stop_typing_indicator(chat_id)
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+        content = sanitize_outbound_typography(content)
 
         base_params: Dict[str, Any] = {"account": self.account}
         if chat_id.startswith("group:"):

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -62,6 +62,7 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
+    sanitize_outbound_typography,
 )
 from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
 
@@ -2516,6 +2517,7 @@ class PhotonAdapter(BasePlatformAdapter):
         richlink: bool = True,
         markdown: bool = True,
     ) -> SendResult:
+        text = sanitize_outbound_typography(text)
         rich_url = _richlink_candidate(text) if richlink else None
         if rich_url:
             rich_result = await self._sidecar_send_richlink(space_id, rich_url)

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -33,6 +33,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    sanitize_outbound_typography,
 )
 from gateway.platforms.helpers import redact_phone, strip_markdown
 
@@ -189,7 +190,7 @@ class SmsAdapter(BasePlatformAdapter):
     ) -> SendResult:
         import aiohttp
 
-        formatted = self.format_message(content)
+        formatted = sanitize_outbound_typography(self.format_message(content))
         chunks = self.truncate_message(formatted)
         last_result = SendResult(success=True)
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -294,6 +294,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     cache_image_from_url,
     cache_audio_from_url,
+    sanitize_outbound_typography,
 )
 from utils import env_int
 
@@ -954,7 +955,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             import aiohttp
 
             # Format and chunk the message
-            formatted = self.format_message(content)
+            formatted = sanitize_outbound_typography(self.format_message(content))
             chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
 
             sent_message_ids: list[str] = []

--- a/tests/gateway/platforms/test_outbound_typography.py
+++ b/tests/gateway/platforms/test_outbound_typography.py
@@ -4,9 +4,13 @@ Outbound messaging text can carry typographic Unicode (curly quotes, en/em
 dashes, non-breaking and zero-width spaces) from LLM prose and phone
 keyboards' smart punctuation. When a user copies a command from a message
 bubble into a terminal, those characters break shell parsing. The sanitizer
-forces shell-safe ASCII equivalents on outbound text.
+forces shell-safe ASCII equivalents on outbound text while preserving real
+non-ASCII content — including ZWJ/ZWNJ, which are meaningful inside emoji
+ZWJ sequences (family/profession emoji) and in scripts such as Persian.
 """
 from __future__ import annotations
+
+import pytest
 
 from gateway.platforms.base import sanitize_outbound_typography
 
@@ -34,9 +38,12 @@ def test_non_breaking_and_thin_spaces_become_space() -> None:
     assert sanitize_outbound_typography("a\u2009b\u202fc") == "a b c"
 
 
-def test_zero_width_characters_removed() -> None:
-    # Invisible characters are dropped entirely.
+def test_invisible_formatting_removed() -> None:
+    # Invisible characters are dropped entirely: zero-width space, word
+    # joiner, and BOM/ZWNBSP. These are unambiguously accidental in outbound
+    # text and invisible to the reader, so removing them is safe.
     assert sanitize_outbound_typography("ssh\u200b-i") == "ssh-i"
+    assert sanitize_outbound_typography("a\u2060b") == "ab"
     assert sanitize_outbound_typography("\ufeffsystemctl status") == "systemctl status"
 
 
@@ -54,6 +61,70 @@ def test_cjk_and_emoji_left_alone() -> None:
     # shell-hostile lookalikes are.
     text = "ls \u6587\u4ef6.txt \U0001f600"
     assert sanitize_outbound_typography(text) == text
+
+
+def test_emoji_zwj_sequences_preserved() -> None:
+    # U+200D ZWJ is the glue inside multi-codepoint emoji (family, couples,
+    # professions, skin-tone). Stripping it would render them as separate
+    # glyphs, so it must survive untouched.
+    family = "\U0001f468\u200d\U0001f469\u200d\U0001f467\u200d\U0001f466"  # 👨👩👧👦
+    assert sanitize_outbound_typography(family) == family
+    profession = "\U0001f469\u200d\U0001f4bb"  # 👩💻
+    assert sanitize_outbound_typography(profession) == profession
+
+
+def test_zwnj_text_preserved() -> None:
+    # U+200C ZWNJ is a required orthographic character in Persian/Urdu and
+    # several Indic scripts; removing it changes spelling. (e.g. میخواهم)
+    persian = "\u0645\u06cc\u200c\u062e\u0648\u0627\u0647\u0645"
+    assert sanitize_outbound_typography(persian) == persian
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # plain prose
+        ("Run \u201cinstall\u201d now", 'Run "install" now'),
+        # fenced command text
+        ("```\necho \u201chi\u201d\n```", '```\necho "hi"\n```'),
+        # inline command text
+        ("run `df \u2013h`", "run `df -h`"),
+        # CJK plus emoji
+        (
+            "\u5220\u9664 \u6587\u4ef6.txt \U0001f600",
+            "\u5220\u9664 \u6587\u4ef6.txt \U0001f600",
+        ),
+        # emoji ZWJ sequence
+        (
+            "\U0001f468\u200d\U0001f469\u200d\U0001f467\u200d\U0001f466",
+            "\U0001f468\u200d\U0001f469\u200d\U0001f467\u200d\U0001f466",
+        ),
+        # ZWNJ text
+        ("\u0645\u06cc\u200c\u062e\u0648\u0627\u0647\u0645", "\u0645\u06cc\u200c\u062e\u0648\u0627\u0647\u0645"),
+        # non-ASCII filename
+        ("ls \u6587\u4ef6.txt", "ls \u6587\u4ef6.txt"),
+        # zero-width space
+        ("ssh\u200b-i", "ssh-i"),
+        # word joiner
+        ("a\u2060b", "ab"),
+        # BOM
+        ("\ufeffsystemctl status", "systemctl status"),
+    ],
+    ids=[
+        "plain-prose",
+        "fenced-command",
+        "inline-command",
+        "cjk-plus-emoji",
+        "emoji-zwj-sequence",
+        "zwnj-text",
+        "non-ascii-filename",
+        "zero-width-space",
+        "word-joiner",
+        "bom",
+    ],
+)
+def test_regression_matrix(text: str, expected: str) -> None:
+    assert sanitize_outbound_typography(text) == expected
 
 
 def test_empty_and_short_inputs() -> None:

--- a/tests/gateway/platforms/test_outbound_typography.py
+++ b/tests/gateway/platforms/test_outbound_typography.py
@@ -1,0 +1,61 @@
+"""Tests for sanitize_outbound_typography.
+
+Outbound messaging text can carry typographic Unicode (curly quotes, en/em
+dashes, non-breaking and zero-width spaces) from LLM prose and phone
+keyboards' smart punctuation. When a user copies a command from a message
+bubble into a terminal, those characters break shell parsing. The sanitizer
+forces shell-safe ASCII equivalents on outbound text.
+"""
+from __future__ import annotations
+
+from gateway.platforms.base import sanitize_outbound_typography
+
+
+def test_curly_quotes_become_straight() -> None:
+    assert (
+        sanitize_outbound_typography("\u201chello\u201d and \u2018world\u2019")
+        == '"hello" and \'world\''
+    )
+
+
+def test_dashes_become_hyphen() -> None:
+    # ASCII double-dash flags must pass through untouched.
+    assert sanitize_outbound_typography("rsync -av --delete /src/ /dst/") == (
+        "rsync -av --delete /src/ /dst/"
+    )
+    # En/em dashes and the Unicode minus map to a plain hyphen.
+    assert sanitize_outbound_typography("a \u2013 b \u2014 c \u2212 1") == "a - b - c - 1"
+
+
+def test_non_breaking_and_thin_spaces_become_space() -> None:
+    # The shell must see ordinary spaces so tokens split correctly instead of
+    # one giant argument.
+    assert sanitize_outbound_typography("ssh\u00a0user@host") == "ssh user@host"
+    assert sanitize_outbound_typography("a\u2009b\u202fc") == "a b c"
+
+
+def test_zero_width_characters_removed() -> None:
+    # Invisible characters are dropped entirely.
+    assert sanitize_outbound_typography("ssh\u200b-i") == "ssh-i"
+    assert sanitize_outbound_typography("\ufeffsystemctl status") == "systemctl status"
+
+
+def test_ellipsis_expanded() -> None:
+    assert sanitize_outbound_typography("run\u2026") == "run..."
+
+
+def test_ascii_passthrough() -> None:
+    clean = "sudo apt update && echo done"
+    assert sanitize_outbound_typography(clean) == clean
+
+
+def test_cjk_and_emoji_left_alone() -> None:
+    # Real non-ASCII content (filenames, emoji) is not touched — only the
+    # shell-hostile lookalikes are.
+    text = "ls \u6587\u4ef6.txt \U0001f600"
+    assert sanitize_outbound_typography(text) == text
+
+
+def test_empty_and_short_inputs() -> None:
+    assert sanitize_outbound_typography("") == ""
+    assert sanitize_outbound_typography("plain") == "plain"

--- a/tests/plugins/platforms/photon/test_outbound_sanitize.py
+++ b/tests/plugins/platforms/photon/test_outbound_sanitize.py
@@ -46,3 +46,17 @@ async def test_send_sanitizes_outbound_text(monkeypatch: pytest.MonkeyPatch) -> 
     assert body["text"] == 'run "df -h" - now'
     assert "\u201c" not in body["text"]
     assert "\u2014" not in body["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_preserves_emoji_zwj_sequences(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    family = "\U0001f468\u200d\U0001f469\u200d\U0001f467\u200d\U0001f466"  # 👨👩👧👦
+    await adapter.send("+155****4567", f"ok {family}")
+
+    path, body = calls[0]
+    assert path == "/send"
+    assert body["text"] == f"ok {family}"

--- a/tests/plugins/platforms/photon/test_outbound_sanitize.py
+++ b/tests/plugins/platforms/photon/test_outbound_sanitize.py
@@ -1,0 +1,48 @@
+"""Outbound text sanitization on the Photon (iMessage) send path.
+
+Every outbound text send passes through ``_sidecar_send``, which runs
+``sanitize_outbound_typography`` (see tests/gateway/platforms/
+test_outbound_typography.py) so commands copied from an iMessage bubble are
+pure ASCII and paste into a terminal unchanged.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    return PhotonAdapter(cfg)
+
+
+def _capture_sidecar(adapter: PhotonAdapter) -> List[Tuple[str, Dict[str, Any]]]:
+    calls: List[Tuple[str, Dict[str, Any]]] = []
+
+    async def _fake_call(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        calls.append((path, body))
+        return {"ok": True, "messageId": "msg-123"}
+
+    adapter._sidecar_call = _fake_call  # type: ignore[assignment]
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_send_sanitizes_outbound_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter.send("+155****4567", "run \u201cdf -h\u201d \u2014 now")
+
+    path, body = calls[0]
+    assert path == "/send"
+    assert body["text"] == 'run "df -h" - now'
+    assert "\u201c" not in body["text"]
+    assert "\u2014" not in body["text"]


### PR DESCRIPTION
## What does this PR do?

Outbound messages over phone-centric platforms can carry typographic Unicode (curly quotes, en/em dashes, non-breaking/zero-width spaces, ellipsis) from LLM prose and phone keyboards' smart punctuation. Commands copied from a message bubble then fail in a terminal with `command not found` or a syntax error, even though the text looks correct. Desktop surfaces are unaffected because code blocks are written as ASCII.

This PR adds a single shared helper, `sanitize_outbound_typography()`, in `gateway/platforms/base.py` and applies it on the outbound text path of the phone-centric adapters:

- **Photon** (iMessage via gateway) — in `_sidecar_send`, the choke point every outbound text send passes through
- **BlueBubbles** (iMessage) — in `send()`
- **SMS/Twilio** — in `send()`
- **Signal** — in `send()`
- **WhatsApp** — in `send()`

The sanitizer maps typographic characters to their ASCII equivalents (curly quotes → straight, en/em dashes → hyphen, NBSP/thin spaces → space, ellipsis → `...`, zero-width removed) and **leaves real non-ASCII content alone** (CJK, emoji, non-ASCII filenames).

## Related Issue

Fixes #98355

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` — add `sanitize_outbound_typography()` + translation table
- `plugins/platforms/photon/adapter.py` — call it in `_sidecar_send()`
- `gateway/platforms/bluebubbles.py` — call it in `send()`
- `plugins/platforms/sms/adapter.py` — call it in `send()`
- `gateway/platforms/signal.py` — call it in `send()`
- `plugins/platforms/whatsapp/adapter.py` — call it in `send()`
- `tests/gateway/platforms/test_outbound_typography.py` — unit tests for the helper
- `tests/plugins/platforms/photon/test_outbound_sanitize.py` — send-path integration test

## How to Test

1. Send a message through a phone platform containing: `echo “hello” && echo done–check`
2. Copy the command from the bubble into a terminal.
3. Before: `command not found: echo“hello”`. After: runs and prints `hello` / `done-check`.
4. Unit tests: `pytest tests/gateway/platforms/test_outbound_typography.py tests/plugins/platforms/photon/`

## Checklist

- [x] I have read the CONTRIBUTING guide.
- [x] My code follows the project's style and conventions.
- [x] I have added tests that prove my fix works.
- [x] All new and existing tests pass (photon suite 138 passed; the handful of failures in `test_whatsapp_cloud.py` / `test_whatsapp_send_message_media.py` are pre-existing on `main` — verified by stashing).
