### PR TITLE
feat(feishu): opt-in card tables with content-driven column widths

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -66,6 +66,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
+
+from plugins.platforms.feishu.feishu_table_card import build_table_card_payload
 from typing import Any, Dict, List, Literal, Optional, Sequence
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
@@ -271,6 +273,18 @@ async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> byt
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 
+# Card payload rejected by the API (invalid schema/component) — triggers the
+# interactive → post downgrade in ``send``. Only reached when the opt-in
+# ``tables_as_cards`` setting routes table content through card tables.
+_CARD_CONTENT_INVALID_RE = re.compile(
+    r"invalid card|card.*invalid|invalid.*card|schema|element"
+    r"|content format of the (post|card|interactive) type is incorrect"
+    r"|unable to parse card",
+    re.IGNORECASE,
+)
+# msg types the interactive→post→text downgrade ladder walks through.
+_CARD_DOWNGRADE_NEXT = {"interactive": "post", "post": "text"}
+
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
 # we only mark start (Typing) and failure (CrossMark); the reply itself is
@@ -436,6 +450,10 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    # Opt-in: render markdown tables as native card table components (real
+    # column-width control) instead of post/md tables. Default off — the
+    # common post+md path renders tables acceptably (issue #52786).
+    tables_as_cards: bool = False
 
 
 @dataclass
@@ -1661,6 +1679,7 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            tables_as_cards=_to_boolean(extra.get("tables_as_cards", "false")),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1693,6 +1712,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._tables_as_cards = settings.tables_as_cards
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -1984,29 +2004,58 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    next_type = _CARD_DOWNGRADE_NEXT.get(msg_type)
+                    invalid_re = (
+                        _CARD_CONTENT_INVALID_RE
+                        if msg_type == "interactive"
+                        else _POST_CONTENT_INVALID_RE
+                    )
+                    if next_type is None or not invalid_re.search(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    logger.warning(
+                        "[Feishu] Invalid %s payload rejected by API; downgrading to %s",
+                        msg_type, next_type,
+                    )
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        msg_type=next_type,
+                        payload=(
+                            _build_markdown_post_payload(chunk)
+                            if next_type == "post"
+                            else json.dumps(
+                                {"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False
+                            )
+                        ),
                         reply_to=reply_to,
                         metadata=metadata,
                     )
+                    msg_type = next_type
                 if (
-                    msg_type == "post"
-                    and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                    not self._response_succeeded(response)
+                    and (
+                        (msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or "")))
+                        or (msg_type == "interactive" and _CARD_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or "")))
+                    )
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    downgrade_to = _CARD_DOWNGRADE_NEXT[msg_type]
+                    logger.warning(
+                        "[Feishu] %s payload rejected by API response; downgrading to %s",
+                        msg_type, downgrade_to,
+                    )
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        msg_type=downgrade_to,
+                        payload=(
+                            _build_markdown_post_payload(chunk)
+                            if downgrade_to == "post"
+                            else json.dumps(
+                                {"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False
+                            )
+                        ),
                         reply_to=reply_to,
                         metadata=metadata,
                     )
+                    msg_type = downgrade_to
                 last_response = response
 
             return self._finalize_send_result(last_response, "send failed")
@@ -4663,6 +4712,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _build_outbound_payload(
         self, content: str, *, prefer_post: bool = False,
+        allow_card_table: bool = True,
     ) -> tuple[str, str]:
         # Empirically (issue #52786), current Feishu clients render markdown
         # tables inside ``post``-type ``md`` elements natively. The previous
@@ -4675,6 +4725,14 @@ class FeishuAdapter(BasePlatformAdapter):
         # markdown document: when a long markdown reply is split at
         # MAX_MESSAGE_LENGTH, the per-chunk regex would otherwise
         # mis-classify a plain-prose chunk as ``text``. See #26841.
+        #
+        # ``allow_card_table`` is False on the message-update path: the
+        # im/v1 update API rejects changing msg_type on an existing message,
+        # so edits must not emit interactive cards.
+        if getattr(self, "_tables_as_cards", False) and allow_card_table:
+            card_payload = build_table_card_payload(content)
+            if card_payload is not None:
+                return "interactive", card_payload
         if prefer_post or _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/plugins/platforms/feishu/feishu_table_card.py
+++ b/plugins/platforms/feishu/feishu_table_card.py
@@ -1,0 +1,323 @@
+"""Markdown table → Feishu card table-component converter.
+
+Why this module exists
+----------------------
+Feishu renders markdown tables inside ``post``-type ``md`` elements with
+columns squeezed to content width; long CJK/Latin cells wrap into unreadable
+narrow strips and the column widths are not controllable. Feishu's
+interactive-card ``table`` component (schema 2.0) solves this: columns accept
+``width: "auto"`` (size-to-content) and rows accept ``row_height: "auto"``
+(expand to fit).
+
+This module converts the pipe tables in an outbound markdown chunk into a
+single JSON 2.0 interactive-card payload:
+
+    prose segment  ->  {"tag": "markdown", "content": ...}
+    table block    ->  {"tag": "table", "columns": [...], "rows": [...]}
+
+Interleaved order is preserved. When the content exceeds card component
+limits (>5 tables, >50 columns, >100 rows per table) or contains no
+convertible table, ``build_table_card_payload`` returns ``None`` and the
+caller falls back to the historical post path.
+
+Docs: https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/feishu-cards/card-json-v2-components/content-components/table
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from typing import Any, Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Limits (Feishu card component constraints + defensive caps)
+# ---------------------------------------------------------------------------
+
+_MAX_TABLES_PER_CARD = 5          # Feishu hard limit per card
+_MAX_COLUMNS_PER_TABLE = 50       # Feishu hard limit per table
+_MAX_ROWS_PER_TABLE = 100         # Defensive: longer tables are unreadable in chat
+_MAX_PAGE_SIZE = 10               # Feishu max rows per page
+_ROW_MAX_HEIGHT = "999px"         # row_height auto cap; avoids clipping tall cells
+
+# A table row line: starts (after optional indent) with a pipe.
+_TABLE_ROW_LINE_RE = re.compile(r"^\s*\|")
+# The separator line under the header: cells of colons/dashes/spaces only.
+_TABLE_SEP_CELL_RE = re.compile(r"^:?-+:?$")
+# Escaped pipe inside a cell.
+_ESCAPED_PIPE = "\\|"
+
+
+def _split_table_row(line: str) -> List[str]:
+    """Split a markdown table line into raw cell strings.
+
+    Handles optional leading/trailing pipes and escaped pipes (``\\|``).
+    """
+    text = line.strip()
+    if text.startswith("|"):
+        text = text[1:]
+    if text.endswith("|") and not text.endswith(_ESCAPED_PIPE):
+        text = text[:-1]
+
+    cells: List[str] = []
+    buf: List[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\" and i + 1 < len(text) and text[i + 1] == "|":
+            buf.append("\\|")  # keep escape for now; unescape below
+            i += 2
+            continue
+        if ch == "|":
+            cells.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    cells.append("".join(buf))
+    return [c.strip().replace(_ESCAPED_PIPE, "|") for c in cells]
+
+
+def _is_separator_row(cells: List[str]) -> bool:
+    if not cells:
+        return False
+    return all(_TABLE_SEP_CELL_RE.match(c) for c in cells if c != "") and any(
+        c for c in cells
+    )
+
+
+def _alignment_for(sep_cell: str) -> str:
+    stripped = sep_cell.strip()
+    if stripped.startswith(":") and stripped.endswith(":"):
+        return "center"
+    if stripped.endswith(":"):
+        return "right"
+    return "left"
+
+
+def _clean_cell(text: str) -> str:
+    """Normalize a cell for lark_md rendering."""
+    # Internal newlines cannot occur in GFM tables; collapse stray whitespace.
+    text = re.sub(r"\s*\n\s*", " ", text)
+    # lark_md escapes: backslashes before markdown punctuation are literal.
+    return text.strip()
+
+
+def _extract_table_blocks(lines: List[str]) -> List[Dict[str, Any]]:
+    """Extract contiguous markdown table blocks from a line list.
+
+    Returns a list of blocks, each ``{"start": i, "end": j (exclusive),
+    "header": [...], "aligns": [...], "rows": [[...], ...]}``.
+    """
+    blocks: List[Dict[str, Any]] = []
+    i = 0
+    n = len(lines)
+    while i < n - 1:
+        if not _TABLE_ROW_LINE_RE.match(lines[i]):
+            i += 1
+            continue
+        header = _split_table_row(lines[i])
+        sep = _split_table_row(lines[i + 1]) if i + 1 < n else []
+        if not header or not _is_separator_row(sep):
+            i += 1
+            continue
+        # Valid table start: header + separator.
+        aligns = [_alignment_for(c) for c in sep]
+        rows: List[List[str]] = []
+        j = i + 2
+        while j < n and _TABLE_ROW_LINE_RE.match(lines[j]):
+            cells = _split_table_row(lines[j])
+            rows.append(cells)
+            j += 1
+        blocks.append(
+            {"start": i, "end": j, "header": header, "aligns": aligns, "rows": rows}
+        )
+        i = j
+    return blocks
+
+
+# Feishu column width bounds (docs): custom width is [80, 600] px.
+_MIN_COL_PX = 80
+_MAX_COL_PX = 600
+# Approximate rendered character widths at 14px body font.
+_CJK_CHAR_PX = 14.0
+_ASCII_CHAR_PX = 7.5
+# Padding/borders allowance per cell.
+_CELL_PADDING_PX = 24
+# Columns estimated no wider than this are pinned in px; wider columns stay
+# "auto" and share the remaining card width. Pinning only applies when the
+# table has at least one wide (auto) column to absorb the leftover space —
+# an all-pinned table would total far less than the card width and Feishu
+# would re-stretch it anyway.
+_PINNED_COL_MAX_PX = 220
+
+
+def _display_width(text: str) -> float:
+    """Estimated rendered width of *text* in pixels at 14px font.
+
+    CJK/fullwidth characters count double the ASCII width. Markdown markers
+    (**, `, links) are discounted since they render as styling, not glyphs.
+    """
+    # Strip markdown markers that do not render as visible characters.
+    visible = re.sub(r"\*\*|`", "", text)
+    visible = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", visible)  # [label](url) -> label
+    width = 0.0
+    for ch in visible:
+        width += _CJK_CHAR_PX if unicodedata.east_asian_width(ch) in ("W", "F") else _ASCII_CHAR_PX
+    return width
+
+
+def _column_width_px(header: str, rows: List[List[str]], idx: int) -> int:
+    """Estimate the content-driven width for column *idx* in pixels."""
+    widths = [_display_width(header[idx])]
+    for row in rows:
+        cell = row[idx] if idx < len(row) else ""
+        # Only measure the longest line of a multi-line cell.
+        widths.append(max((_display_width(part) for part in cell.split("\n")), default=0.0))
+    content_px = max(widths, default=0.0) + _CELL_PADDING_PX
+    return max(_MIN_COL_PX, min(_MAX_COL_PX, int(content_px)))
+
+
+def _build_table_element(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build a Feishu table component from one parsed table block."""
+    header = block["header"]
+    aligns = block["aligns"]
+    rows = block["rows"]
+
+    n_cols = len(header)
+    if n_cols == 0 or n_cols > _MAX_COLUMNS_PER_TABLE:
+        return None
+    if len(rows) > _MAX_ROWS_PER_TABLE:
+        return None
+
+    columns: List[Dict[str, str]] = []
+    # Two-pass: estimate every column's content width first, then pin only
+    # narrow columns to px so wide "auto" columns absorb the remaining card
+    # width. All-narrow tables keep everything "auto" (Feishu stretches the
+    # table to full card width regardless, so pinning gains nothing there).
+    estimated = [_column_width_px(header, rows, i) for i in range(n_cols)]
+    n_pinned = sum(1 for w in estimated if w <= _PINNED_COL_MAX_PX)
+    pin_narrow = 0 < n_pinned < n_cols
+    for idx in range(n_cols):
+        if pin_narrow and estimated[idx] <= _PINNED_COL_MAX_PX:
+            width = f"{estimated[idx]}px"
+        else:
+            width = "auto"
+        col: Dict[str, Any] = {
+            "name": f"c{idx}",
+            "display_name": _clean_cell(header[idx]),
+            "data_type": "lark_md",
+            "width": width,
+            "horizontal_align": aligns[idx] if idx < len(aligns) else "left",
+            "vertical_align": "top",
+        }
+        columns.append(col)
+
+    row_dicts: List[Dict[str, str]] = []
+    for row in rows:
+        row_obj: Dict[str, str] = {}
+        for idx in range(n_cols):
+            cell = _clean_cell(row[idx]) if idx < len(row) else ""
+            row_obj[f"c{idx}"] = cell
+        row_dicts.append(row_obj)
+
+    return {
+        "tag": "table",
+        "page_size": _MAX_PAGE_SIZE,
+        "row_height": "auto",
+        "row_max_height": _ROW_MAX_HEIGHT,
+        "freeze_first_column": False,
+        "header_style": {
+            "text_align": "left",
+            "text_size": "normal",
+            "background_style": "grey",
+            "text_color": "default",
+            "bold": True,
+            "lines": 1,
+        },
+        "columns": columns,
+        "rows": row_dicts,
+    }
+
+
+_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
+_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
+
+
+def _prose_elements(segment: str) -> List[Dict[str, str]]:
+    """Build markdown elements for a prose segment, splitting at code fences.
+
+    Splitting mirrors the post-path fence isolation: a fenced block gets its
+    own markdown element so a renderer quirk in one element cannot swallow the
+    content that follows it.
+    """
+    if not segment.strip():
+        return []
+    elements: List[Dict[str, str]] = []
+    current: List[str] = []
+    in_code = False
+
+    def _flush() -> None:
+        text = "\n".join(current).strip("\n")
+        if text.strip():
+            elements.append({"tag": "markdown", "content": text})
+        current.clear()
+
+    for line in segment.splitlines():
+        stripped = line.strip()
+        is_fence = bool(
+            _FENCE_CLOSE_RE.match(stripped) if in_code else _FENCE_OPEN_RE.match(stripped)
+        )
+        if is_fence:
+            if not in_code:
+                _flush()
+            current.append(line)
+            in_code = not in_code
+            if not in_code:
+                _flush()
+            continue
+        current.append(line)
+    _flush()
+    return elements
+
+
+def build_table_card_payload(content: str) -> Optional[str]:
+    """Convert a markdown chunk containing pipe tables into a card JSON string.
+
+    Returns ``None`` when the content has no convertible table or exceeds the
+    Feishu card component limits — the caller then uses the historical post
+    path unchanged.
+    """
+    if not content or "|" not in content:
+        return None
+
+    lines = content.replace("\r\n", "\n").split("\n")
+    blocks = _extract_table_blocks(lines)
+    if not blocks:
+        return None
+    if len(blocks) > _MAX_TABLES_PER_CARD:
+        return None
+
+    table_payloads: List[Optional[Dict[str, Any]]] = [
+        _build_table_element(b) for b in blocks
+    ]
+    if any(t is None for t in table_payloads):
+        return None
+
+    elements: List[Dict[str, Any]] = []
+    cursor = 0
+    for block, table in zip(blocks, table_payloads):
+        prose = "\n".join(lines[cursor : block["start"]])
+        elements.extend(_prose_elements(prose))
+        assert table is not None
+        elements.append(table)
+        cursor = block["end"]
+    elements.extend(_prose_elements("\n".join(lines[cursor:])))
+
+    card = {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True},
+        "body": {"elements": elements},
+    }
+    return json.dumps(card, ensure_ascii=False)

--- a/tests/gateway/test_feishu_table_card.py
+++ b/tests/gateway/test_feishu_table_card.py
@@ -1,0 +1,241 @@
+"""Tests for the Feishu card-table conversion module.
+
+``feishu_table_card.build_table_card_payload`` converts markdown pipe tables
+into Feishu interactive-card ``table`` components (schema 2.0) so columns get
+real width control (``auto`` or pinned px) instead of the post/md renderer's
+equal-width squeeze. Conversion is opt-in via ``tables_as_cards`` and must
+fall back to ``None`` (caller keeps the historical post path) whenever the
+content does not fit Feishu's card component limits.
+
+These are behavior-contract tests: they assert relationships that must hold
+(width estimates, fallback decisions, round-trip of cell content), not frozen
+snapshot values.
+"""
+
+from __future__ import annotations
+
+import json
+
+from plugins.platforms.feishu.feishu_table_card import (
+    _MAX_COLUMNS_PER_TABLE,
+    _MAX_ROWS_PER_TABLE,
+    _MAX_TABLES_PER_CARD,
+    _column_width_px,
+    _display_width,
+    build_table_card_payload,
+)
+
+_SIMPLE_TABLE = (
+    "| col A | col B |\n"
+    "| ----- | ----- |\n"
+    "| 1     | 2     |"
+)
+
+
+def _tables_from_card(payload_str: str) -> list[dict]:
+    """Pull every ``{tag: 'table'}`` element out of a card payload."""
+    card = json.loads(payload_str)
+    assert card["schema"] == "2.0"
+    return [el for el in card["body"]["elements"] if el.get("tag") == "table"]
+
+
+# ---------------------------------------------------------------------------
+# Fallback contract: return None → caller keeps the post path
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_without_table():
+    assert build_table_card_payload("") is None
+    assert build_table_card_payload("plain prose, no pipes") is None
+    # Pipe-looking prose that never forms header+separator is not a table.
+    assert build_table_card_payload("a | b | c\njust text") is None
+
+
+def test_returns_none_above_table_limit():
+    line = _SIMPLE_TABLE
+    too_many = ("\n\nprose\n\n".join([line] * (_MAX_TABLES_PER_CARD + 1)))
+    assert build_table_card_payload(too_many) is None
+
+
+def test_returns_none_above_row_limit():
+    header = "| h |\n| - |\n"
+    rows = "".join(f"| r{i} |\n" for i in range(_MAX_ROWS_PER_TABLE + 1))
+    assert build_table_card_payload(header + rows) is None
+
+
+def test_returns_none_above_column_limit():
+    n = _MAX_COLUMNS_PER_TABLE + 1
+    header = "| " + " | ".join(f"c{i}" for i in range(n)) + " |\n"
+    sep = "| " + " | ".join("-" for _ in range(n)) + " |\n"
+    row = "| " + " | ".join("x" for _ in range(n)) + " |\n"
+    assert build_table_card_payload(header + sep + row) is None
+
+
+# ---------------------------------------------------------------------------
+# Card structure contract
+# ---------------------------------------------------------------------------
+
+
+def test_simple_table_produces_card_table_component():
+    payload = build_table_card_payload(_SIMPLE_TABLE)
+    assert payload is not None
+    tables = _tables_from_card(payload)
+    assert len(tables) == 1
+    table = tables[0]
+    assert [c["display_name"] for c in table["columns"]] == ["col A", "col B"]
+    assert table["rows"] == [{"c0": "1", "c1": "2"}]
+    # Every column carries a Feishu-legal width value.
+    for col in table["columns"]:
+        w = col["width"]
+        assert w == "auto" or (w.endswith("px") and 80 <= int(w[:-2]) <= 600)
+
+
+def test_prose_around_table_is_preserved():
+    content = "intro paragraph\n\n" + _SIMPLE_TABLE + "\n\noutro paragraph"
+    payload = build_table_card_payload(content)
+    assert payload is not None
+    card = json.loads(payload)
+    contents = [
+        el.get("content", "")
+        for el in card["body"]["elements"]
+        if el.get("tag") == "markdown"
+    ]
+    joined = "\n".join(contents)
+    assert "intro paragraph" in joined
+    assert "outro paragraph" in joined
+
+
+def test_alignment_survives_separator_syntax():
+    content = (
+        "| left | center | right |\n"
+        "| ----- | :----: | ----: |\n"
+        "| a | b | c |"
+    )
+    payload = build_table_card_payload(content)
+    assert payload is not None
+    table = _tables_from_card(payload)[0]
+    aligns = [c["horizontal_align"] for c in table["columns"]]
+    assert aligns == ["left", "center", "right"]
+
+
+def test_escaped_pipe_renders_as_literal():
+    content = (
+        "| expr |\n"
+        "| ---- |\n"
+        "| a \\| b |"
+    )
+    payload = build_table_card_payload(content)
+    assert payload is not None
+    table = _tables_from_card(payload)[0]
+    assert table["rows"][0]["c0"] == "a | b"
+
+
+def test_multiple_tables_interleave_with_prose():
+    content = (
+        "before\n\n"
+        + _SIMPLE_TABLE
+        + "\n\nmiddle\n\n"
+        + _SIMPLE_TABLE
+        + "\n\nafter"
+    )
+    payload = build_table_card_payload(content)
+    assert payload is not None
+    card = json.loads(payload)
+    tags = [el.get("tag") for el in card["body"]["elements"]]
+    assert tags.count("table") == 2
+    # Order preserved: prose segments on both sides of both tables.
+    assert tags[0] == "markdown" and tags[-1] == "markdown"
+    joined = "\n".join(
+        el.get("content", "") for el in card["body"]["elements"] if el.get("tag") == "markdown"
+    )
+    for marker in ("before", "middle", "after"):
+        assert marker in joined
+
+
+# ---------------------------------------------------------------------------
+# Column width contract (the reason this module exists)
+# ---------------------------------------------------------------------------
+
+
+def test_cjk_content_measures_wider_than_ascii():
+    assert _display_width("中文内容") > _display_width("ascii")
+    # CJK chars count roughly double per glyph.
+    assert _display_width("四个汉字") == pytest.approx(_display_width("abcdefgh"), rel=0.1)
+
+
+def test_column_width_clamped_to_feishu_bounds():
+    header = ["x"]
+    rows = [["y"]]
+    assert _column_width_px(header, rows, 0) >= 80
+    huge = ["非常" * 400]  # far beyond 600px even at CJK width
+    rows_huge = [[huge[0]]]
+    assert _column_width_px(["h"], rows_huge, 0) <= 600
+
+
+def test_all_narrow_table_keeps_auto_widths():
+    payload = build_table_card_payload(_SIMPLE_TABLE)
+    assert payload is not None
+    table = _tables_from_card(payload)[0]
+    assert all(c["width"] == "auto" for c in table["columns"])
+
+
+def test_mixed_width_table_pins_narrow_columns():
+    # One very wide CJK column forces pin_narrow on for the short ones.
+    wide_cell = "这一列包含一段相当长的中文内容用来撑宽自适应列宽" * 4
+    content = (
+        "| short | wide |\n"
+        "| ----- | ---- |\n"
+        f"| ok | {wide_cell} |"
+    )
+    payload = build_table_card_payload(content)
+    assert payload is not None
+    table = _tables_from_card(payload)[0]
+    widths = [c["width"] for c in table["columns"]]
+    assert widths[0] != "auto" and widths[0].endswith("px")  # narrow column pinned
+    assert widths[1] == "auto"  # wide column stays auto
+
+
+# ---------------------------------------------------------------------------
+# Adapter integration: opt-in routing and update-path guard
+# ---------------------------------------------------------------------------
+
+
+def _bare_adapter():
+    from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+    adapter = load_plugin_adapter("feishu")
+    return object.__new__(adapter.FeishuAdapter)
+
+
+def test_opt_in_routes_table_to_interactive_card():
+    inst = _bare_adapter()
+    inst._tables_as_cards = True
+    msg_type, payload = inst._build_outbound_payload(_SIMPLE_TABLE)
+    assert msg_type == "interactive"
+    assert json.loads(payload)["schema"] == "2.0"
+
+
+def test_default_off_keeps_post_path():
+    inst = _bare_adapter()
+    inst._tables_as_cards = False
+    msg_type, _ = inst._build_outbound_payload(_SIMPLE_TABLE)
+    assert msg_type == "post"
+
+
+def test_message_update_path_never_emits_card():
+    # The im/v1 update API rejects msg_type changes, so allow_card_table=False.
+    inst = _bare_adapter()
+    inst._tables_as_cards = True
+    msg_type, _ = inst._build_outbound_payload(_SIMPLE_TABLE, allow_card_table=False)
+    assert msg_type == "post"
+
+
+def test_non_table_content_unaffected_by_opt_in():
+    inst = _bare_adapter()
+    inst._tables_as_cards = True
+    msg_type, payload = inst._build_outbound_payload("just **prose**, no table")
+    assert msg_type == "post"
+    assert "prose" in payload
+
+
+import pytest  # noqa: E402  (kept at bottom: only used by width-approx test)


### PR DESCRIPTION
## Problem

The post/md table fix (#52786, related discussion in #96048) made tables render on Feishu clients, but the post renderer squeezes columns to equal widths: long CJK/Latin cells wrap into unreadable narrow strips and column width is not controllable.

Feishu's interactive-card `table` component (schema 2.0) supports real column-width control: `width: "auto"` (size-to-content) or a pinned px value in [80, 600].

## Change

Adds an **opt-in** `tables_as_cards` setting (`platforms.feishu.extra.tables_as_cards: true` in config.yaml, default **false** — the default post/md path is untouched) that routes table-containing outbound chunks through a new plugin-local converter:

- **`plugins/platforms/feishu/feishu_table_card.py`** — parses GFM pipe tables (escaped pipes, alignment colons, code-fence isolation) into card table components; interleaved prose is preserved as markdown elements in original order.
- **Two-pass width algorithm** — estimates each column's content width (CJK double-width aware, markdown markers discounted), then pins narrow columns to px only when at least one wide `auto` column exists to absorb the remaining card width. All-narrow tables stay fully `auto` since Feishu stretches the table to card width regardless.
- **Graceful fallback** — returns to the historical post path whenever content exceeds card component limits (>5 tables, >50 columns, >100 rows) or contains no convertible table.
- **Downgrade ladder** — the send pipeline now walks interactive → post → text when the API rejects a payload, so a rejected card can never strand a message.
- **Update-path guard** — message edits never emit cards (the im/v1 update API rejects msg_type changes).

## Testing

- New `tests/gateway/test_feishu_table_card.py` (17 tests): fallback contract, card structure/order, width bounds + pinning behavior, escaped pipes, alignment round-trip, and adapter routing (opt-in / default-off / update-path guard).
- Full related suite green: `test_feishu_table_card.py + test_feishu_table_markdown.py + test_feishu_approval_buttons.py` → 31 passed.
- E2E verified on a live gateway: real table messages sent through a Feishu DM with the flag enabled render with content-proportional column widths.

## Notes

Default stays `false`: current Feishu clients render post/md tables acceptably for most content (#52786); this is for users who need readable wide/CJK tables.