### PR TITLE
fix(cron): honor cron.execution_retention instead of a hardcoded 1000-row cap

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -21,7 +21,11 @@ from hermes_time import now as _hermes_now
 # dashboard operations that temporarily enter another profile cannot leak that
 # profile's execution records into the import-time home.
 EXECUTIONS_FILE: Optional[Path] = None
-MAX_TERMINAL_EXECUTIONS = 1000
+_DEFAULT_MAX_TERMINAL_EXECUTIONS = 1000
+# Backward-compatible test override. Production reads
+# ``cron.execution_retention`` at prune time so a config change does not
+# require a Python reinstall.
+MAX_TERMINAL_EXECUTIONS = _DEFAULT_MAX_TERMINAL_EXECUTIONS
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
@@ -126,8 +130,25 @@ def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
     return current is not None and current == started_at
 
 
+def _terminal_execution_retention() -> int:
+    """Resolve the terminal execution-row cap from profile-local config."""
+    if MAX_TERMINAL_EXECUTIONS != _DEFAULT_MAX_TERMINAL_EXECUTIONS:
+        return max(0, int(MAX_TERMINAL_EXECUTIONS))
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+        value = cron_cfg.get(
+            "execution_retention", _DEFAULT_MAX_TERMINAL_EXECUTIONS
+        ) if isinstance(cron_cfg, dict) else _DEFAULT_MAX_TERMINAL_EXECUTIONS
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_TERMINAL_EXECUTIONS
+
+
 def _prune_unlocked(conn: sqlite3.Connection) -> None:
-    limit = max(0, int(MAX_TERMINAL_EXECUTIONS))
+    limit = _terminal_execution_retention()
     conn.execute(
         """DELETE FROM executions WHERE id IN (
              SELECT id FROM executions

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2766,6 +2766,10 @@ DEFAULT_CONFIG = {
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
+        # Maximum terminal rows kept in cron/executions.db. Claimed/running
+        # rows are always preserved. 0 removes terminal rows after each
+        # terminal write. Default 1000.
+        "execution_retention": 1000,
         # Timeout (seconds) for a no-agent cron script. Also overridable via
         # HERMES_CRON_SCRIPT_TIMEOUT. Keep this in sync with
         # cron.scheduler._DEFAULT_SCRIPT_TIMEOUT so config set recognizes the

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -415,3 +415,62 @@ def test_job_listing_exposes_latest_execution(monkeypatch, tmp_path):
     listed = jobs.list_jobs(include_disabled=True)
     assert listed[0]["latest_execution"]["id"] == record["id"]
     assert listed[0]["latest_execution"]["status"] == "running"
+
+
+def test_retention_reads_execution_retention_from_config(monkeypatch, tmp_path):
+    """cron.execution_retention must govern pruning, not a hardcoded constant.
+
+    Regression guard: the cap used to be hardcoded, so `hermes config set
+    cron.execution_retention` was cosmetic — `config get` echoed the new value
+    while pruning still trimmed to 1000. Assert the configured value actually
+    bounds the ledger.
+    """
+    executions = _point_ledger(monkeypatch, tmp_path)
+
+    home = tmp_path / "home"
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    # A distinctive cap: neither the 1000 default nor a round number, so a
+    # pass cannot be a coincidence of the old behaviour.
+    cap = 7
+    (home / "config.yaml").write_text(f"cron:\n  execution_retention: {cap}\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert executions._terminal_execution_retention() == cap
+
+    for index in range(cap + 13):
+        row = executions.create_execution(f"done-{index}", source="builtin")
+        executions.finish_execution(row["id"], success=True)
+
+    terminal = [
+        row for row in executions.list_executions(limit=1000)
+        if row["status"] in ("completed", "failed", "unknown")
+    ]
+    assert len(terminal) <= cap
+
+
+def test_module_level_override_still_wins_over_config(monkeypatch, tmp_path):
+    """An explicit MAX_TERMINAL_EXECUTIONS override must beat config.
+
+    Existing tests monkeypatch the module constant; that has to keep working
+    even though production now resolves the cap from config.
+    """
+    executions = _point_ledger(monkeypatch, tmp_path)
+
+    home = tmp_path / "home"
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("cron:\n  execution_retention: 500\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", 3)
+
+    assert executions._terminal_execution_retention() == 3
+
+
+def test_config_default_matches_module_default(monkeypatch):
+    """The documented default and the code fallback must not drift apart."""
+    import cron.executions as executions
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert (
+        DEFAULT_CONFIG["cron"]["execution_retention"]
+        == executions._DEFAULT_MAX_TERMINAL_EXECUTIONS
+    )


### PR DESCRIPTION
## Problem

`cron/executions.py` hardcodes the terminal-row cap:

```python
MAX_TERMINAL_EXECUTIONS = 1000
...
def _prune_unlocked(conn):
    limit = max(0, int(MAX_TERMINAL_EXECUTIONS))
```

Nothing reads `cron.execution_retention`. The key is accepted and echoed back, so the setting looks applied while pruning ignores it entirely:

```
$ hermes config set cron.execution_retention 2500
✓ Set cron.execution_retention = 2500
$ hermes config get cron.execution_retention
2500
```

…and the ledger then sits at exactly **1000** terminal rows. Verified on a live install: config `2500`, `select count(*) from executions where status in ('completed','failed')` → `1000`.

The practical cost is silent loss of operational history. At ~220 runs/day that caps the ledger at roughly **4.5 days** of coverage instead of the ~11 the operator configured, and the only symptom is that older executions quietly disappear — no warning, and `config get` actively suggests the larger value is in force.

## Change

`_terminal_execution_retention()` resolves the cap from profile-local config at prune time, so a change takes effect without a Python reinstall.

`MAX_TERMINAL_EXECUTIONS` is kept as an alias of `_DEFAULT_MAX_TERMINAL_EXECUTIONS` and doubles as a sentinel: if it differs from the default, an explicit override wins over config. That preserves the existing test hook — `tests/cron/test_execution_ledger.py` monkeypatches the constant to `3` — rather than breaking it.

`config_defaults.py` documents the key alongside the neighbouring `output_retention`, so the default is discoverable and can't silently drift from the code fallback.

Claimed/running rows are untouched, exactly as before.

## Tests

Three additions to `tests/cron/test_execution_ledger.py`:

- **the configured cap actually bounds the ledger** — exercises the real prune path against a temp `HERMES_HOME` with a cap of `7`, deliberately neither the `1000` default nor a round number, so a pass cannot be a coincidence of the old behaviour
- **an explicit `MAX_TERMINAL_EXECUTIONS` override still wins over config** — guards the existing monkeypatch hook
- **the documented default matches the module fallback** — an invariant, so the two cannot drift apart

## Verification

E2E against the real prune path (temp `HERMES_HOME`, cap 7):

```
config cap=7 -> resolved=7
wrote 20 terminal rows -> ledger holds 7
test override 3 -> resolved=3
```

Control on `main`: the same scenario fails (`AttributeError: no attribute '_DEFAULT_MAX_TERMINAL_EXECUTIONS'`), confirming the fix is load-bearing.

Mutation-verified: reintroducing the bug (`limit = max(0, int(MAX_TERMINAL_EXECUTIONS))`) makes `test_retention_reads_execution_retention_from_config` **fail** (1 failed, 21 passed); restoring it passes (22 passed). So the new guard is not tautological.

Full `tests/cron` suite via `scripts/run_tests_parallel.py` (per-file subprocess isolation, matching CI): **75 files, 949 passed, 0 failed, 1 skipped**. Re-run after rebasing onto current `main`.

## Provenance

This fix was recovered from a `hermes update` autostash that had been sitting in `git stash` since 2026-08-27 and was nearly dropped during stash cleanup. The recovered diff is unchanged apart from being rebased; the tests and the verification above are new.
