### PR TITLE
fix(agent): recognize Dingbats stop boundaries

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1778,7 +1778,7 @@ class AIAgent:
         if last in '.!?:)"\']}。！？：）】」』》^':
             return True
         # Emoji ranges (Misc Symbols, Dingbats, Emoticons, Supplemental, etc.)
-        if ord(last) >= 0x1F300:
+        if ord(last) >= 0x2600:
             return True
         return False
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4384,6 +4384,36 @@ class TestRunConversation:
         assert third_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in third_call_messages[-1]["content"]
 
+    def test_ollama_glm_stop_after_tools_with_dingbat_boundary_does_not_continue(self, agent):
+        """A completed Dingbats response must not receive a false continuation."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.1:cloud"
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        completed_stop = _mock_response(
+            content="The setting has been updated successfully ✅",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [tool_turn, completed_stop]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["final_response"] == "The setting has been updated successfully ✅"
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Recognizes Miscellaneous Symbols and Dingbats as terminal response boundaries in the conservative Ollama/GLM stop-to-length heuristic. A completed tool-following response ending in `✅` was previously treated as truncated, injecting an unnecessary continuation turn.

The existing bare-word branch remains unchanged: it continues to detect an actual incomplete Ollama/GLM response whose provider reports `stop`.

## Related Issue

Refs #98255. This fixes the reported Dingbats-boundary portion without changing the intentional bare-word truncation guard.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `run_agent.py`: treat Unicode U+2600 and above as terminal symbol/emoji boundaries, matching the existing comment.
- `tests/run_agent/test_run_agent.py`: exercise the production tool-call -> completed Ollama/GLM response path and assert no false continuation is requested.

## How to Test

1. Exact base `26350357d76e4508c8df9304a3374bdc5a6f6220`: a tool-following Ollama/GLM response ending in `✅` yields `_should_treat_stop_as_truncated(...) == True`; a period yields `False`.
2. Exact head `0b56a823c334108fa3f74bcc6884d075d224763b`: the same Dingbats response yields `False`, while the existing bare-word boundary remains `True`.
3. The end-to-end regression drives `AIAgent.run_conversation()` through a real tool turn then a `stop` response ending in `✅`; it completes in two API calls instead of injecting a third continuation nudge.
4. Run `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k "ollama_glm_stop_after_tools or length_finish_reason_requests_continuation"` (3 passed).
5. Run `uv run ruff check run_agent.py tests/run_agent/test_run_agent.py`, `uv run python -m compileall -q run_agent.py tests/run_agent/test_run_agent.py`, `git diff --check`, and TruffleHog over `HEAD^..HEAD` (0 findings).

## Checklist

### Code

- [x] I have read the Contributing Guide and `AGENTS.md`.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing open and closed PRs using the issue, symptom, owner symbol, and terminal-boundary terms.
- [x] This PR contains only the terminal-boundary repair and regression.
- [ ] I have run `pytest tests/ -q` and all tests pass. The focused production and adjacent regression set passed; the full repository suite was not run.
- [x] I have added regression tests.
- [x] I tested on macOS with Python 3.11.15.

### Documentation & Housekeeping

- [x] Documentation update is N/A; this aligns an existing heuristic with its documented Unicode scope.
- [x] `cli-config.yaml.example` update is N/A; no configuration key changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` update is N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered; this is Unicode classification only and preserves the existing conservative bare-word behavior.
- [x] Tool descriptions and schemas are N/A; tool behavior did not change.

## Screenshots / Logs

N/A. The exact base/head production-path result and API-call count above capture the user-visible behavior.