### PR TITLE
fix(launcher): self-relaunch under the venv interpreter when invoked directly

### DIFF
--- a/hermes
+++ b/hermes
@@ -6,6 +6,32 @@ This wrapper should behave like the installed `hermes` command, including
 subcommands such as `gateway`, `cron`, and `doctor`.
 """
 
+import os
+import sys
+from pathlib import Path
+
+# Re-exec under the venv interpreter when invoked directly (not via the
+# installer's `venv/bin/python <repo>/hermes` wrapper). `#!/usr/bin/env
+# python3` — required for this script to be portable across installs — picks
+# up whatever `python3` is first on PATH, which usually lacks Hermes' venv
+# deps. That mismatch is invisible on a normal terminal launch (the installer
+# wrapper always runs this under the venv), but a regenerated `.desktop`
+# entry can point straight at this file (see linux_desktop_entry.py's
+# `resolve_hermes_bin()` / `sys.argv[0]` preference), which then dies on the
+# first third-party import (#90292) — silently, since `Terminal=false`
+# swallows the traceback.
+#
+# Resolved at runtime relative to this file's own real location, so it works
+# for any checkout path / any user, not just the one that first hit the bug.
+_venv_python = Path(__file__).resolve().parent / "venv" / "bin" / "python"
+if _venv_python.is_file():
+    try:
+        _running_under_venv = Path(sys.executable).resolve() == _venv_python.resolve()
+    except OSError:
+        _running_under_venv = False
+    if not _running_under_venv:
+        os.execv(str(_venv_python), [str(_venv_python), str(Path(__file__).resolve())] + sys.argv[1:])
+
 if __name__ == "__main__":
     from hermes_cli.main import main
     main()


### PR DESCRIPTION
## Problem

`hermes` (the repo-root CLI launcher) has shebang `#!/usr/bin/env python3`, which resolves to whatever `python3` is first on PATH — not Hermes' venv. The installed `~/.local/bin/hermes` wrapper always execs this file via `venv/bin/python <repo>/hermes`, so the shebang mismatch is invisible on a normal terminal launch.

But `resolve_hermes_bin()` (`hermes_cli/relaunch.py`) prefers `sys.argv[0]`, and a regenerated `.desktop` entry (`linux_desktop_entry.py`) or a relaunch via `build_relaunch_argv()` can point straight at this repo-root script and exec it directly — under the system python, which lacks Hermes' deps. It dies on the first third-party import (#90292), silently, since `Terminal=false` swallows the traceback: launching Hermes from a menu/launcher does nothing, with no visible error.

## Fix

When this script isn't already running under `<repo>/venv/bin/python`, re-exec itself under that interpreter, resolved relative to the script's own real location at runtime (`Path(__file__).resolve().parent / "venv" / "bin" / "python"`) — so it's correct for any checkout path or user, not tied to one machine.

## Verified

Reproduced the failure and confirmed the fix live: running `python3 hermes --version` under the bare system interpreter (no venv deps on its import path) now correctly re-execs into the venv and prints the normal version banner, instead of `ModuleNotFoundError`.

Companion to #<!-- see fix/desktop-entry-stable-exec-path PR --> which fixes a related but distinct symptom in the same area (a stale resolved interpreter path baked into the `.desktop` entry after a venv-generation rotation).