### PR TITLE
fix(agent): keep /stop responsive while a large-session compression commit is in flight

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3320,14 +3320,41 @@ class AIAgent:
             if event is None:
                 return
             fence = vars(self).get("_active_compression_commit_fence")
+            try_cancel = getattr(
+                type(fence), "try_cancel_before_commit", None
+            )
+            if callable(try_cancel):
+                try:
+                    # Non-blocking admission (#98351). During a commit the
+                    # worker RETAINS the fence lock until finish_commit(), so
+                    # the blocking cancel_before_commit pins this thread —
+                    # and the _pending_redirect_lock it holds — behind the
+                    # whole SessionDB mutation: /stop and /new stop
+                    # answering while a large-session commit runs, and the
+                    # gateway turn-timeout watchdog hangs interrupting the
+                    # very turn it must reap. None means a commit is in
+                    # flight: publish the stop now instead of waiting. The
+                    # commit itself is still never abandoned mid-mutation,
+                    # and the conversation thread observes the stop as soon
+                    # as the compression call returns — every stop producer
+                    # only sets the flag, none consumes "commit settled".
+                    try_cancel(fence)
+                    event.set()
+                    return
+                except Exception:
+                    logger.debug(
+                        "Compression hard-cancel fence admission failed",
+                        exc_info=True,
+                    )
             cancel_before_commit = getattr(
                 type(fence), "cancel_before_commit", None
             )
             if callable(cancel_before_commit):
                 try:
-                    # This sets the Event while holding the same lock used by
-                    # begin_commit(). If commit already won, it waits for that
-                    # tracked mutation to finish before publishing the stop.
+                    # Legacy fence (no non-blocking form): set the Event
+                    # while holding the same lock used by begin_commit(). If
+                    # commit already won, it waits for that tracked mutation
+                    # to finish before publishing the stop.
                     cancel_before_commit(fence, event)
                     return
                 except Exception:

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -2019,8 +2019,17 @@ def test_hard_cancel_between_compress_return_and_commit_begin_wins_atomically(
     assert db.get_compression_lock_holder(session_id) is None
 
 
-def test_hard_stop_waits_for_commit_already_admitted(tmp_path: Path) -> None:
-    """A surfaced stop never races an untracked post-return transcript commit."""
+def test_hard_stop_returns_promptly_while_commit_in_flight(tmp_path: Path) -> None:
+    """A surfaced stop must not block behind an in-flight commit (#98351).
+
+    The commit worker retains the fence lock until finish_commit(), so a
+    blocking cancel admission pins the stop caller (and the redirect lock it
+    holds) behind the whole SessionDB mutation — /stop and /new stop
+    answering during a large-session commit. The stop is published
+    immediately instead; the already-admitted commit still runs to
+    completion (never abandoned mid-mutation) and releases its durable
+    lock, so the end state is identical to the old wait-then-publish one.
+    """
     db = SessionDB(db_path=tmp_path / "state.db")
     session_id = "HARD_CANCEL_AFTER_COMMIT_ADMISSION"
     db.create_session(session_id, source="tui")
@@ -2061,14 +2070,13 @@ def test_hard_stop_waits_for_commit_already_admitted(tmp_path: Path) -> None:
         daemon=True,
     )
     stop.start()
-    assert not stop_returned.wait(timeout=0.1)
+    assert stop_returned.wait(timeout=2)
+    assert not stop.is_alive()
     allow_commit.set()
     compression.join(timeout=5)
     stop.join(timeout=5)
 
     assert not compression.is_alive()
-    assert not stop.is_alive()
-    assert stop_returned.is_set()
     assert compression_result["value"][0][0]["content"] == (
         "[CONTEXT COMPACTION] summary"
     )


### PR DESCRIPTION
## What does this PR do?

During a context-compression commit the worker retains the `CompressionCommitFence` lock from `begin_commit()` until `finish_commit()` — by design, an admitted SessionDB mutation is never abandoned mid-commit. The problem is that `AIAgent.interrupt(hard_cancel=True)` admitted the stop through the **blocking** `cancel_before_commit(fence, event)`, which waits on that same fence lock for the whole commit to finish. On a large session (#98351, 1,500+ messages) the commit (archive/split/rotate) can run for minutes, so every explicit-stop producer was pinned behind it:

- Desktop `/stop` → `tui_gateway._interrupt_session_turn` → `request_hard_interrupt` blocked on the fence, and it blocks while holding `_pending_redirect_lock`, so `/new` (which also interrupts) stopped answering too — the UI showed a permanent "Summarizing thread" overlay with a dead input box.
- CLI Ctrl+C ran the same blocking admission inside a signal handler.
- The gateway turn-timeout watchdog (`_watch_gateway_turn_inactivity`, explicitly designed to stay runnable when gateway asyncio is starved) called the same admission and deadlocked interrupting the very turn it was supposed to reap, so `_reap_gateway_turn_processes` never ran.

The fence already exposes the non-blocking `try_cancel_before_commit()` (plus the lock-free `commit_in_flight` observer) for exactly this reason — gateway session hygiene already uses the non-blocking form; the sync `interrupt()` path was the only remaining blocking caller.

This PR switches `_admit_hard_cancel()` to `try_cancel_before_commit()`:

- `True` (cancel won before the boundary) — same as before.
- `False` (commit already finished) — same as before.
- `None` (commit in flight) — the stop event is published **immediately** instead of waiting.

Semantics are unchanged where it matters: the commit is still never abandoned mid-mutation, the conversation thread still waits for the commit inside the compression call and observes the stop as soon as it returns, and the durable lock is released exactly as before. Every `hard_interrupt` producer only sets the flag — none of them consumes "commit settled", so the wait bought nothing while costing UI responsiveness. The blocking form remains as a fallback for fence objects that predate the non-blocking API.

## Related Issue

Fixes #98351

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` — `_admit_hard_cancel()` now admits through the non-blocking `try_cancel_before_commit()` and publishes the stop event without waiting behind an in-flight commit; the blocking `cancel_before_commit` remains as the legacy-fence fallback.
- `tests/agent/test_compression_concurrent_fork.py` — `test_hard_stop_waits_for_commit_already_admitted` updated to `test_hard_stop_returns_promptly_while_commit_in_flight`: the stop must return while the commit is still blocked, and the already-admitted commit must still complete fully (compressed transcript lands, stop event set, durable compression lock released) — the end-state assertions from the old test are preserved.

## How to Test

1. `python -m pytest tests/agent/test_compression_concurrent_fork.py tests/agent/test_compression_review_76354.py tests/agent/test_compression_interrupt_protection.py tests/agent/test_compression_stall_fallback_78981.py tests/run_agent/test_interrupt_propagation.py tests/run_agent/test_steer.py tests/agent/test_interrupt_compat.py -q` — **128 passed** (Observed result: 128 passed).
2. `python -m pytest tests/run_agent/ tests/test_tui_gateway_queue_on_busy.py tests/agent/test_subagent_lifecycle.py -q` — 1952 passed; the 7 failures (`test_nous_fallback_unavailable`, `test_run_agent` Anthropic shared-client, 3× `test_streaming` Anthropic callbacks, 2× `test_switch_model_reasoning_override`) reproduce identically on a clean `upstream/main` checkout — pre-existing, unrelated to this change.
3. The updated test itself is the regression proof: it blocks `archive_and_compact` mid-commit, calls `hard_interrupt` while the commit is in flight, and asserts the stop returns promptly and the commit still completes with the durable lock released. should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: 128 passed; full `tests/run_agent/` + gateway/interrupt suites: 1952 passed, 7 pre-existing failures reproduced on clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python threading change, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A