### PR TITLE
fix(desktop-entry): use the stable venv/bin/python symlink, not a resolved generation path

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,7 +78,22 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            #
+            # LOCAL PATCH (see ~/.hermes/local-patches/): don't fully
+            # .resolve() sys.executable — that follows the venv/bin symlink
+            # all the way down into the current
+            # .hermes-runtime/python/generation-<hash>/ tree and bakes that
+            # literal, doomed path into the installed .desktop file's Exec=.
+            # `hermes update` rotates to a new generation and can prune the
+            # old one, so the next walker/wofi launch silently execs a
+            # deleted binary (Terminal=false swallows the failure) until
+            # `hermes desktop` happens to be run by hand again. venv/bin/python
+            # is the symlink `hermes update` atomically repoints — use that
+            # stable, unresolved path instead when it exists.
+            venv_python = resolved.parent / "venv" / "bin" / "python"
+            if not venv_python.is_file():
+                venv_python = Path(sys.executable).resolve()
+            argv = [str(venv_python), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:


### PR DESCRIPTION
## Problem

`resolve_exec_command()` fully resolves `sys.executable` when it needs to prefix the `.desktop` entry's `Exec=` with an interpreter. On installs that manage Python via rotating "generation" directories (`venv/bin/python` as a symlink that gets atomically repointed on update), `.resolve()` follows that symlink all the way down and bakes the literal, generation-pinned path into the installed `~/.local/share/applications/hermes.desktop`.

`hermes update` rotates to a new generation and prunes the old one, so the already-installed `.desktop` entry then points at a deleted binary. A launcher menu (Walker/wofi/etc.) selecting "Hermes" execs nothing — silently, since `Terminal=false` swallows the error. The entry only self-heals the next time `hermes desktop` happens to be run by hand (which regenerates it) — chicken-and-egg if the launcher menu is the only way Hermes gets opened.

## Fix

Prefer the stable, unresolved `<repo>/venv/bin/python` path — the one `hermes update` atomically repoints rather than deletes — over a fully resolved `sys.executable`. Falls back to the previous behavior when that venv path doesn't exist (e.g. no managed venv at all).

Companion to #98365, which fixes a related but distinct symptom in the same area (the repo-root `hermes` script itself lacking a venv-aware shebang).