### PR TITLE
fix(gateway): /compress --preview undercounts by dropping tool results, system prompt and tool schemas

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4491,14 +4491,62 @@ class GatewaySlashCommandsMixin:
                 return _agg_note
 
         if _preview:
-            # Report what WOULD be compressed — no agent, no writes.
+            # Report what WOULD be compressed — no agent, no writes. Mirror
+            # the real compression path below: keep tool-result messages
+            # (compaction rewrites them too) and fold in the system prompt
+            # + tool schemas, so this matches cli.py's preview branch and
+            # the two surfaces report the same figure for the same session
+            # state (#98360) instead of the gateway silently dropping the
+            # three biggest payload buckets.
             from agent.model_metadata import estimate_request_tokens_rough
+            from agent.skill_utils import parse_config_string_list
+            from gateway.run import _load_gateway_config, _platform_config_key
+            from model_tools import get_tool_definitions
+
             _pv_msgs = [
-                {"role": m.get("role"), "content": m.get("content")}
-                for m in history
-                if m.get("role") in {"user", "assistant"} and m.get("content")
+                m for m in history
+                if m.get("role") in {"user", "assistant", "tool"}
             ]
-            approx_tokens = estimate_request_tokens_rough(_pv_msgs)
+
+            _sys_prompt = ""
+            _get_session = getattr(self._session_db, "get_session", None)
+            if callable(_get_session):
+                try:
+                    _pv_session_row = await _get_session(session_entry.session_id)
+                except Exception:
+                    _pv_session_row = None
+                if isinstance(_pv_session_row, dict):
+                    _raw_prompt = _pv_session_row.get("system_prompt")
+                    if isinstance(_raw_prompt, str) and _raw_prompt.strip():
+                        _sys_prompt = _raw_prompt
+
+            _pv_tools = None
+            if source.platform:
+                try:
+                    _pv_cfg = _load_gateway_config()
+                    _pv_platform_key = _platform_config_key(source.platform)
+                    _pv_enabled = self._resolve_enabled_toolsets_for_source(
+                        _pv_cfg, source, _pv_platform_key
+                    )
+                    _pv_disabled = parse_config_string_list(
+                        (_pv_cfg.get("agent") or {}).get("disabled_toolsets")
+                    ) or None
+                    _pv_tools = get_tool_definitions(
+                        enabled_toolsets=_pv_enabled,
+                        disabled_toolsets=_pv_disabled,
+                        quiet_mode=True,
+                    ) or None
+                except Exception:
+                    logger.warning(
+                        "Compress preview could not resolve tool schemas for "
+                        "session %s; estimate will exclude tool schemas.",
+                        session_entry.session_id,
+                        exc_info=True,
+                    )
+
+            approx_tokens = estimate_request_tokens_rough(
+                _pv_msgs, system_prompt=_sys_prompt, tools=_pv_tools
+            )
             report = summarize_compress_preview(
                 _pv_msgs, partial, keep_last, focus_topic, approx_tokens
             )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4508,6 +4508,11 @@ class GatewaySlashCommandsMixin:
                 if m.get("role") in {"user", "assistant", "tool"}
             ]
 
+            # Track which payload buckets we couldn't resolve, so a lookup
+            # failure degrades to a labeled lower bound instead of silently
+            # posing as the full context (reviewer feedback on #98368).
+            _omitted_buckets = []
+
             _sys_prompt = ""
             _get_session = getattr(self._session_db, "get_session", None)
             if callable(_get_session):
@@ -4515,10 +4520,13 @@ class GatewaySlashCommandsMixin:
                     _pv_session_row = await _get_session(session_entry.session_id)
                 except Exception:
                     _pv_session_row = None
+                    _omitted_buckets.append("system prompt")
                 if isinstance(_pv_session_row, dict):
                     _raw_prompt = _pv_session_row.get("system_prompt")
                     if isinstance(_raw_prompt, str) and _raw_prompt.strip():
                         _sys_prompt = _raw_prompt
+            else:
+                _omitted_buckets.append("system prompt")
 
             _pv_tools = None
             if source.platform:
@@ -4543,6 +4551,9 @@ class GatewaySlashCommandsMixin:
                         session_entry.session_id,
                         exc_info=True,
                     )
+                    _omitted_buckets.append("tool schemas")
+            else:
+                _omitted_buckets.append("tool schemas")
 
             approx_tokens = estimate_request_tokens_rough(
                 _pv_msgs, system_prompt=_sys_prompt, tools=_pv_tools
@@ -4551,6 +4562,11 @@ class GatewaySlashCommandsMixin:
                 _pv_msgs, partial, keep_last, focus_topic, approx_tokens
             )
             lines = [f"🗜️ {line}" for line in report["lines"]]
+            if _omitted_buckets:
+                lines.append(
+                    "⚠️ Lower bound — could not resolve: "
+                    + ", ".join(_omitted_buckets) + "."
+                )
             if _aggressive:
                 lines.append(_agg_note)
             return "\n".join(lines)

--- a/tests/gateway/test_compress_preview.py
+++ b/tests/gateway/test_compress_preview.py
@@ -7,7 +7,7 @@ message rather than being mis-parsed as a focus topic.
 """
 
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -83,5 +83,66 @@ async def test_aggressive_dry_run_shows_preview_plus_note():
     assert "no changes made" in result.lower()
     assert "--aggressive is not supported" in result
     runner.session_store.rewrite_transcript.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_preview_feeds_tool_messages_system_prompt_and_tools_to_estimator():
+    """The preview must feed the shared estimator the same payload buckets
+    as the real compression path and the CLI's preview branch: tool-result
+    messages, the session's system prompt, and the enabled tool schemas
+    (#98360). Before the fix, the gateway preview filtered the transcript
+    to user/assistant messages only and passed neither system_prompt nor
+    tools, so it could report ~100x fewer tokens than the CLI reports for
+    the identical session state.
+    """
+    history = [
+        {"role": "user", "content": "run it"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "t1", "type": "function",
+                            "function": {"name": "x", "arguments": "{}"}}],
+        },
+        {"role": "tool", "content": "BIG RESULT " * 500, "tool_call_id": "t1"},
+        {"role": "assistant", "content": "done"},
+        {"role": "user", "content": "thanks"},
+        {"role": "assistant", "content": "np"},
+    ]
+    runner = _make_runner(history)
+    runner._session_db = MagicMock()
+    runner._session_db.get_session = AsyncMock(
+        return_value={"system_prompt": "SYSTEM PROMPT " * 100}
+    )
+    fake_tools = [{
+        "type": "function",
+        "function": {
+            "name": "t0", "description": "d",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }]
+    runner._resolve_enabled_toolsets_for_source = MagicMock(return_value=["memory"])
+
+    captured = {}
+
+    def _capture(messages, **kwargs):
+        captured["messages"] = messages
+        captured["system_prompt"] = kwargs.get("system_prompt")
+        captured["tools"] = kwargs.get("tools")
+        return 42
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={}),
+        patch("model_tools.get_tool_definitions", return_value=fake_tools),
+        patch("agent.model_metadata.estimate_request_tokens_rough", side_effect=_capture),
+    ):
+        result = await runner._handle_compress_command(
+            _make_event("/compress --preview")
+        )
+
+    assert "42" in result
+    roles = [m.get("role") for m in captured["messages"]]
+    assert "tool" in roles, f"tool-result messages dropped from the preview estimate: {roles}"
+    assert captured["system_prompt"], "system prompt dropped from the preview estimate"
+    assert captured["tools"] == fake_tools, "tool schemas dropped from the preview estimate"
 
 

--- a/tests/gateway/test_compress_preview.py
+++ b/tests/gateway/test_compress_preview.py
@@ -146,3 +146,27 @@ async def test_preview_feeds_tool_messages_system_prompt_and_tools_to_estimator(
     assert captured["tools"] == fake_tools, "tool schemas dropped from the preview estimate"
 
 
+@pytest.mark.asyncio
+async def test_preview_labels_lower_bound_when_tool_schema_lookup_fails():
+    """If tool-schema resolution raises, the preview must say the number
+    is a lower bound instead of quietly reporting a partial estimate as
+    if it were the full context (reviewer feedback on #98368).
+    """
+    runner = _make_runner(_make_history(3))
+    runner._session_db = MagicMock()
+    runner._session_db.get_session = AsyncMock(
+        return_value={"system_prompt": "SYSTEM PROMPT"}
+    )
+    runner._resolve_enabled_toolsets_for_source = MagicMock(
+        side_effect=RuntimeError("boom")
+    )
+
+    with patch("gateway.run._load_gateway_config", return_value={}):
+        result = await runner._handle_compress_command(
+            _make_event("/compress --preview")
+        )
+
+    assert "lower bound" in result.lower(), result
+    assert "tool schemas" in result
+
+


### PR DESCRIPTION
Fixes #98360.

## Problem

`summarize_compress_preview`'s own docstring (`hermes_cli/partial_compress.py:152-156`)
says it exists so the CLI's `/compress --preview` and the gateway's agree on the
reported numbers. They didn't, because the two call sites fed it different inputs:

- **CLI** (`cli.py::_manual_compress`) passes the full history plus the cached system
  prompt and the agent's tool schemas to `estimate_request_tokens_rough`.
- **Gateway** (`gateway/slash_commands.py::_handle_compress_command_inner`, preview
  branch) filtered the transcript to `user`/`assistant` messages with content and
  passed neither `system_prompt` nor `tools`.

That drops three payload buckets on the gateway path: the system prompt, the tool
schemas (which the function's own docstring warns can be 20-30K tokens with 50+ tools
enabled), and every `tool`-role message (tool results), even though the real
(non-preview) compression branch a few lines below already special-cases keeping tool
messages for exactly this reason (`#3854`). On a real session the issue reports the
preview printed `~1,890 tokens currently in context` while the actual context
(`last_prompt_tokens`) was `36,730` — an order of magnitude off, and the label calls it
"the context" while missing most of it.

## Fix

`gateway/slash_commands.py`, preview branch: mirror the real compression path a few
lines below it instead of diverging from it.

- Keep `tool`-role messages in the filtered transcript (matches the non-preview `msgs`
  filter right below, and the `#3854` rationale in its comment).
- Restore the session's persisted system prompt from `self._session_db.get_session()`
  — the same technique `gateway/run.py::_seed_hygiene_system_prompt` already uses, so
  no new agent has to be built just to read it back.
- Resolve the tool schemas a live turn for this session would actually send, via the
  same `_resolve_enabled_toolsets_for_source()` + `model_tools.get_tool_definitions()`
  pair the real gateway turn path already calls (`gateway/run.py:29319-29328`), instead
  of spinning up a full `AIAgent` (which the preview branch deliberately avoids — "no
  agent, no writes").

All three lookups are wrapped so a failure degrades to the old (partial) numbers
instead of breaking `--preview`.

## Testing

Added `tests/gateway/test_compress_preview.py::test_preview_feeds_tool_messages_system_prompt_and_tools_to_estimator`,
which asserts the shared estimator is actually called with tool-result messages, a
non-empty system prompt, and the resolved tool schemas.

Confirmed it fails without the fix:

```
$ git checkout HEAD~1 -- gateway/slash_commands.py   # pre-fix version
$ python -m pytest tests/gateway/test_compress_preview.py -q
..F
AssertionError: tool-result messages dropped from the preview estimate: ['user', 'assistant', 'user', 'assistant']
assert 'tool' in ['user', 'assistant', 'user', 'assistant']
1 failed, 2 passed in 1.47s

$ git checkout HEAD -- gateway/slash_commands.py     # fix restored
$ python -m pytest tests/gateway/test_compress_preview.py -q
...
3 passed in 2.64s
```

Full suite for the touched command, all green:

```
$ python -m pytest tests/gateway/test_compress_preview.py tests/gateway/test_compress_command.py \
    tests/gateway/test_compress_focus.py tests/gateway/test_compress_plugin_engine.py -q
13 passed in 3.64s
```

`ruff check gateway/slash_commands.py tests/gateway/test_compress_preview.py` — all
checks passed.

## Disclosure

Investigated, written, and tested with AI assistance (Claude).
