### PR TITLE
fix(gateway): count tool results in /compress --preview

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4493,10 +4493,17 @@ class GatewaySlashCommandsMixin:
         if _preview:
             # Report what WOULD be compressed — no agent, no writes.
             from agent.model_metadata import estimate_request_tokens_rough
+            # Count the same rows the real run compresses: user/assistant/tool
+            # with their full payloads (tool results and tool_call turns
+            # included), matching the non-preview branch below and the CLI.
+            # The previous user+assistant, content-only filter dropped tool
+            # results and empty-content tool_call turns, so both the token
+            # estimate and the "N of M" message count undercounted (#98360).
+            # (The system prompt + tool schemas remain out of scope here — the
+            # preview path deliberately builds no agent to obtain them.)
             _pv_msgs = [
-                {"role": m.get("role"), "content": m.get("content")}
-                for m in history
-                if m.get("role") in {"user", "assistant"} and m.get("content")
+                m for m in history
+                if m.get("role") in {"user", "assistant", "tool"}
             ]
             approx_tokens = estimate_request_tokens_rough(_pv_msgs)
             report = summarize_compress_preview(

--- a/tests/gateway/test_compress_preview.py
+++ b/tests/gateway/test_compress_preview.py
@@ -85,3 +85,30 @@ async def test_aggressive_dry_run_shows_preview_plus_note():
     runner.session_store.rewrite_transcript.assert_not_called()
 
 
+def _make_tool_history() -> list[dict]:
+    return [
+        {"role": "user", "content": "read the config"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "X" * 2000},
+        {"role": "assistant", "content": "done."},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_preview_counts_tool_results_and_tool_call_turns():
+    """#98360: the preview must count the rows the real run compresses
+    (user/assistant/tool, tool results included) — not a user+assistant,
+    content-only subset that dropped tool results and empty-content tool_call
+    turns, undercounting both tokens and the "N of M" message count."""
+    runner = _make_runner(_make_tool_history())
+    result = await runner._handle_compress_command(
+        _make_event("/compress --preview")
+    )
+    # All four compressible rows counted, not just the two user+assistant
+    # rows with non-empty content the old filter kept.
+    assert "4 of 4" in result
+    assert "2 of 2" not in result
+    runner.session_store.rewrite_transcript.assert_not_called()
+
+


### PR DESCRIPTION
## What does this PR do?

The gateway `/compress --preview` branch filtered the transcript to
user+assistant messages with non-empty content before handing it to the shared
`summarize_compress_preview` reporter — dropping tool results and empty-content
`tool_call` turns. Both the token estimate and the "Would compress N of M
message(s)" count undercounted relative to the CLI and the real compression
run, which pass the full user/assistant/tool transcript (#98360).

Fix: pass the same `{user, assistant, tool}` rows the non-preview branch and the
real run use, so tool results and tool_call turns are counted.

**Out of scope (deliberately):** the system prompt and tool schemas — the
*largest* missing slice — are still not counted in the preview, because the
preview path builds no agent to obtain them. That's a separate, larger change
(or a relabel of the shared reporter) and is left for maintainer decision; this
PR closes the clean, verifiable role-filter half.

## Related Issue

Addresses the role-filter half of #98360 (kept as `Addresses`, not `Fixes`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py` — preview branch counts `{user, assistant, tool}`
  rows (tool results + tool_call turns included), matching the non-preview
  branch and the CLI.
- `tests/gateway/test_compress_preview.py` — a tool-result transcript is counted
  in full (`4 of 4`, not `2 of 2`).

## How to Test

    pytest tests/gateway/test_compress_preview.py -q

3 pass. A transcript with a tool result + an empty-content tool_call turn now
previews all four compressible rows instead of the two user/assistant rows.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs / issues
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11