### PR TITLE
compression: emit periodic client-visible status during compaction

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1857,6 +1857,7 @@ class _CompressionActivityHeartbeat:
         # if a prior timeout/cooldown stamp is still on the agent.
         self._suppressed = False
         self._touch("context compression started", allow_terminal_overwrite=True)
+        self._emit_progress_status()
         self._thread.start()
         return self
 
@@ -1917,11 +1918,38 @@ class _CompressionActivityHeartbeat:
         except Exception:
             logger.debug("compression activity heartbeat touch failed", exc_info=True)
 
+    def _emit_progress_status(self) -> None:
+        """Publish a client-visible ``compacting`` status line.
+
+        Compression can stream for minutes with no deltas, tool events, or
+        status lines reaching remote transports. Idle-progress watchdogs on
+        those clients (e.g. the Android relay app's 180s turn watchdog)
+        treat the silence as a dead turn and fire ``session.interrupt`` —
+        killing a healthy compression mid-flight and rolling back its work,
+        which retriggers on the next prompt and loops forever on sessions
+        near the context ceiling. A periodic ``status_callback`` heartbeat
+        gives every transport a progress event to re-arm on.
+        """
+        status_callback = getattr(self._agent, "status_callback", None)
+        if not status_callback:
+            return
+        try:
+            status_callback(
+                "compacting",
+                f"🗜️ {COMPACTION_STATUS_MARKER} — still summarizing "
+                "earlier conversation so I can continue...",
+            )
+        except Exception:
+            logger.debug(
+                "status_callback error in compression heartbeat", exc_info=True
+            )
+
     def _run(self) -> None:
         while not self._stop.wait(self._interval_seconds):
             if self._should_suppress():
                 return
             self._touch("context compression in progress")
+            self._emit_progress_status()
 
 def _direct_messages_for_pre_compress_memory(messages: Any) -> list[dict[str, Any]]:
     """Return direct user/assistant evidence safe for memory checkpointing.

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -167,6 +167,48 @@ def test_compression_activity_heartbeat_touches_agent_during_long_compress(tmp_p
     assert db.get_compression_lock_holder(session_id) is None
 
 
+def test_compression_activity_heartbeat_emits_client_status_events(tmp_path: Path) -> None:
+    """The heartbeat must emit ``compacting`` status events, not just DB touches.
+
+    Remote transports (e.g. the Android relay app) run idle-progress turn
+    watchdogs that ``session.interrupt`` a turn after ~180s with no gateway
+    events. Compression is silent on the event stream, so without periodic
+    ``status_callback`` heartbeats a long compression is killed mid-flight
+    and retriggers forever on sessions near the context ceiling.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "HEARTBEAT_STATUS_TEST"
+    db.create_session(session_id, source="test")
+
+    agent = _build_agent_with_db(db, session_id)
+    agent._compression_activity_heartbeat_interval = 0.1
+    touch_calls: list[str] = []
+    agent._touch_activity = lambda desc, **_kw: touch_calls.append(desc)
+    status_events: list[tuple[str, str]] = []
+    setattr(
+        agent,
+        "status_callback",
+        lambda event, message: status_events.append((event, message)),
+    )
+
+    def _slow_compress(*_a, **_kw):
+        _wait_for_touch(touch_calls, "context compression in progress")
+        return [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "tail"},
+        ]
+
+    agent.context_compressor.compress.side_effect = _slow_compress
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    compacting = [event for event, _message in status_events if event == "compacting"]
+    # One emit at heartbeat start plus at least one periodic tick while the
+    # summary call blocks.
+    assert len(compacting) >= 2
+
+
 def test_lock_contender_preserves_terminal_compaction_lifecycle(tmp_path: Path) -> None:
     """A lock loser still closes the structured compaction lifecycle.
 


### PR DESCRIPTION
## Problem

Context compression can run for many minutes with **no deltas, tool events, or status lines** reaching remote transports. Clients that run idle-progress turn watchdogs treat that silence as a dead turn and kill it — the Android relay app fires `session.interrupt` after 180s of no events (`GatewayChatClient.kt` `TURN_TIMEOUT_MS = 180_000L`).

On a session near the context ceiling this becomes an **infinite loop**: every prompt triggers preflight compression → compression is silent → the client watchdog interrupts at exactly +180s → the work rolls back → the next prompt retriggers it. The session becomes permanently unresponsive from that client.

Observed in production tonight (gpt-5.6-sol via openai-codex, whose backend window recently dropped to 272k, making preflight compression far more common):

```
compression attempt telemetry: {"commit_status":"aborted","failure_class":"explicit_interrupt","total_duration_ms":180469}
compression attempt telemetry: {"commit_status":"aborted","failure_class":"explicit_interrupt","total_duration_ms":180233}
compression attempt telemetry: {"commit_status":"aborted","failure_class":"explicit_interrupt","total_duration_ms":180219}
Turn ended: reason=interrupted_by_user  (four times, each at prompt+~251s = visible tool work + exactly 180s of silent compression)
```

## Fix

`_CompressionActivityHeartbeat` already ticks every 60s during compression, but only refreshes the internal SessionDB activity tracker. This PR makes it also emit a client-visible `compacting` status through the existing `agent.status_callback` seam — once at compression start and on every tick. The gateway already routes `status_callback` → `status.update` events (`_status_update` even has a `compacting` re-tag path), and clients already reset their watchdogs on any received gateway event, so each heartbeat re-arms them.

No new config, no new plumbing — one method on the existing heartbeat class plus two call sites.

## Testing

- New test `test_compression_activity_heartbeat_emits_client_status_events` (mirrors the existing heartbeat test): asserts ≥2 `compacting` status events during a slow compress (start + at least one tick).
- Full file: `tests/agent/test_compression_concurrent_fork.py` — **47 passed** (all pre-existing tests unaffected; the completion-edge assertions use `.count()`/`not in`, so additive `compacting` events don't disturb them).

Companion client-side PR (defensive longer watchdog leash on `compacting` status): Codename-11/hermes-relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)