### PR TITLE
feat(web): add Search Capability Broker provider

### DIFF
--- a/plugins/web/search_broker/__init__.py
+++ b/plugins/web/search_broker/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from plugins.web.search_broker.provider import SearchBrokerWebSearchProvider
+
+
+def register(ctx) -> None:
+    ctx.register_web_search_provider(SearchBrokerWebSearchProvider())

--- a/plugins/web/search_broker/plugin.yaml
+++ b/plugins/web/search_broker/plugin.yaml
@@ -1,0 +1,9 @@
+name: web-search-broker
+version: 1.0.0
+description: "Search Capability Broker native Hermes provider"
+author: Local
+kind: backend
+provides_web_providers:
+  - search-broker
+requires_env:
+  - BROKER_CALLER_HERMES_CANARY_TOKEN

--- a/plugins/web/search_broker/provider.py
+++ b/plugins/web/search_broker/provider.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider, get_provider_env
+
+
+class SearchBrokerWebSearchProvider(WebSearchProvider):
+    @property
+    def name(self) -> str:
+        return "search-broker"
+
+    @property
+    def display_name(self) -> str:
+        return "Search Capability Broker"
+
+    def is_available(self) -> bool:
+        return bool(get_provider_env("BROKER_CALLER_HERMES_CANARY_TOKEN"))
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5, **kwargs: Any) -> Dict[str, Any]:
+        token = get_provider_env("BROKER_CALLER_HERMES_CANARY_TOKEN")
+        if not token:
+            return {"success": False, "error": "Broker caller credential is not configured"}
+        base_url = (get_provider_env("SEARCH_BROKER_URL") or "http://127.0.0.1:8766").rstrip("/")
+        try:
+            response = httpx.post(
+                f"{base_url}/v1/search",
+                headers={"Authorization": f"Bearer {token}"},
+                json={
+                    "query": query,
+                    "capability": "web.semantic",
+                    "max_results": max(1, min(int(limit), 20)),
+                },
+                timeout=20.0,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
+                return {"success": False, "error": "Broker returned an invalid response"}
+            web = []
+            for index, item in enumerate(payload["results"], start=1):
+                if not isinstance(item, dict) or not item.get("canonical_url"):
+                    continue
+                web.append(
+                    {
+                        "title": str(item.get("title") or ""),
+                        "url": str(item["canonical_url"]),
+                        "description": str(item.get("snippet") or ""),
+                        "position": int(item.get("provider_rank") or index),
+                    }
+                )
+            return {"success": True, "data": {"web": web}}
+        except (httpx.HTTPError, ValueError, TypeError):
+            return {"success": False, "error": "Search broker request failed"}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": self.display_name,
+            "badge": "local",
+            "tag": "Unified loopback search routing and budgets.",
+            "env_vars": [
+                {
+                    "key": "BROKER_CALLER_HERMES_CANARY_TOKEN",
+                    "prompt": "Broker caller token",
+                }
+            ],
+        }

--- a/plugins/web/search_broker/provider.py
+++ b/plugins/web/search_broker/provider.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-import os
 from typing import Any, Dict
+from urllib.parse import urlsplit
 
 import httpx
 
 from agent.web_search_provider import WebSearchProvider, get_provider_env
+
+
+MAX_RESPONSE_BYTES = 1_048_576
+MAX_RESULTS = 20
 
 
 class SearchBrokerWebSearchProvider(WebSearchProvider):
@@ -18,7 +22,14 @@ class SearchBrokerWebSearchProvider(WebSearchProvider):
         return "Search Capability Broker"
 
     def is_available(self) -> bool:
-        return bool(get_provider_env("BROKER_CALLER_HERMES_CANARY_TOKEN"))
+        token = get_provider_env("BROKER_CALLER_HERMES_CANARY_TOKEN")
+        base_url = get_provider_env("SEARCH_BROKER_URL") or "http://127.0.0.1:8766"
+        parsed = urlsplit(base_url)
+        return bool(token) and parsed.scheme == "http" and parsed.hostname in {
+            "127.0.0.1",
+            "localhost",
+            "::1",
+        }
 
     def supports_search(self) -> bool:
         return True
@@ -38,27 +49,44 @@ class SearchBrokerWebSearchProvider(WebSearchProvider):
                 json={
                     "query": query,
                     "capability": "web.semantic",
-                    "max_results": max(1, min(int(limit), 20)),
+                    "max_results": max(1, min(int(limit), MAX_RESULTS)),
+                    "caller": {"runtime": "hermes", "profile": "deepsearch"},
                 },
-                timeout=20.0,
+                timeout=httpx.Timeout(20.0, connect=5.0),
+                follow_redirects=False,
             )
+            if len(response.content) > MAX_RESPONSE_BYTES:
+                return {"success": False, "error": "Broker response exceeded size limit"}
+            if response.status_code in {401, 403}:
+                return {"success": False, "error": "Broker caller credential was rejected"}
+            if response.status_code == 429:
+                return {"success": False, "error": "Broker rate or budget limit reached"}
+            if response.status_code >= 500:
+                return {"success": False, "error": "Broker service is unavailable"}
             response.raise_for_status()
             payload = response.json()
             if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
                 return {"success": False, "error": "Broker returned an invalid response"}
             web = []
-            for index, item in enumerate(payload["results"], start=1):
+            seen_urls = set()
+            for index, item in enumerate(payload["results"][:MAX_RESULTS], start=1):
                 if not isinstance(item, dict) or not item.get("canonical_url"):
                     continue
+                url = str(item["canonical_url"])
+                if url in seen_urls:
+                    continue
+                seen_urls.add(url)
                 web.append(
                     {
                         "title": str(item.get("title") or ""),
-                        "url": str(item["canonical_url"]),
+                        "url": url,
                         "description": str(item.get("snippet") or ""),
                         "position": int(item.get("provider_rank") or index),
                     }
                 )
             return {"success": True, "data": {"web": web}}
+        except httpx.TimeoutException:
+            return {"success": False, "error": "Search broker request timed out"}
         except (httpx.HTTPError, ValueError, TypeError):
             return {"success": False, "error": "Search broker request failed"}
 

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -45,6 +45,8 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "BROKER_CALLER_HERMES_CANARY_TOKEN",
+        "SEARCH_BROKER_URL",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -82,6 +84,7 @@ class TestBundledPluginsRegister:
             "firecrawl",
             "keenable",
             "parallel",
+            "search-broker",
             "searxng",
             "tavily",
             "xai",
@@ -95,6 +98,7 @@ class TestBundledPluginsRegister:
             ("searxng", True, False),
             ("exa", True, True),
             ("parallel", True, True),
+            ("search-broker", True, False),
             ("tavily", True, True),
             ("firecrawl", True, True),
             # xai: search-only via Grok's agentic web_search tool.
@@ -117,7 +121,17 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        [
+            "brave-free",
+            "ddgs",
+            "searxng",
+            "exa",
+            "parallel",
+            "search-broker",
+            "tavily",
+            "firecrawl",
+            "xai",
+        ],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -175,6 +189,18 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False
         monkeypatch.setenv("EXA_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_search_broker_requires_caller_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("search-broker")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("BROKER_CALLER_HERMES_CANARY_TOKEN", "real")
         assert p.is_available() is True
 
     def test_parallel_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -82,6 +82,7 @@ def register_all_web_providers():
     from plugins.web.exa.provider import ExaWebSearchProvider
     from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
     from plugins.web.parallel.provider import ParallelWebSearchProvider
+    from plugins.web.search_broker.provider import SearchBrokerWebSearchProvider
     from plugins.web.searxng.provider import SearXNGWebSearchProvider
     from plugins.web.tavily.provider import TavilyWebSearchProvider
     from plugins.web.xai.provider import XAIWebSearchProvider
@@ -93,6 +94,7 @@ def register_all_web_providers():
         ExaWebSearchProvider,
         FirecrawlWebSearchProvider,
         ParallelWebSearchProvider,
+        SearchBrokerWebSearchProvider,
         SearXNGWebSearchProvider,
         TavilyWebSearchProvider,
         XAIWebSearchProvider,

--- a/tests/tools/test_web_providers_search_broker.py
+++ b/tests/tools/test_web_providers_search_broker.py
@@ -24,6 +24,8 @@ def test_provider_contract_and_availability(monkeypatch):
 def test_search_maps_broker_response(monkeypatch):
     monkeypatch.setenv("BROKER_CALLER_HERMES_CANARY_TOKEN", "token")
     response = Mock()
+    response.status_code = 200
+    response.content = b"{}"
     response.raise_for_status.return_value = None
     response.json.return_value = {
         "results": [
@@ -57,7 +59,45 @@ def test_search_maps_broker_response(monkeypatch):
         "query": "query",
         "capability": "web.semantic",
         "max_results": 20,
+        "caller": {"runtime": "hermes", "profile": "deepsearch"},
     }
+
+
+def test_status_and_size_errors_are_stable(monkeypatch):
+    monkeypatch.setenv("BROKER_CALLER_HERMES_CANARY_TOKEN", "token")
+    for status, message in [
+        (401, "credential was rejected"),
+        (429, "rate or budget"),
+        (503, "service is unavailable"),
+    ]:
+        response = Mock(status_code=status, content=b"{}")
+        with patch("plugins.web.search_broker.provider.httpx.post", return_value=response):
+            result = SearchBrokerWebSearchProvider().search("query")
+        assert message in result["error"]
+
+    response = Mock(status_code=200, content=b"x" * 1_048_577)
+    with patch("plugins.web.search_broker.provider.httpx.post", return_value=response):
+        result = SearchBrokerWebSearchProvider().search("query")
+    assert "size limit" in result["error"]
+
+
+def test_unicode_duplicates_and_malformed_items(monkeypatch):
+    monkeypatch.setenv("BROKER_CALLER_HERMES_CANARY_TOKEN", "token")
+    response = Mock(status_code=200, content=b"{}")
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "results": [
+            {"canonical_url": "https://example.com", "title": "中文", "snippet": "证据"},
+            {"canonical_url": "https://example.com", "title": "duplicate"},
+            {"title": "missing url"},
+        ]
+    }
+    with patch("plugins.web.search_broker.provider.httpx.post", return_value=response):
+        result = SearchBrokerWebSearchProvider().search("查询")
+    assert result["success"] is True
+    assert result["data"]["web"] == [
+        {"title": "中文", "url": "https://example.com", "description": "证据", "position": 1}
+    ]
 
 
 def test_search_failure_never_leaks_token(monkeypatch):

--- a/tests/tools/test_web_providers_search_broker.py
+++ b/tests/tools/test_web_providers_search_broker.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, patch
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+from plugins.web.search_broker.provider import SearchBrokerWebSearchProvider
+
+
+def test_provider_contract_and_availability(monkeypatch):
+    provider = SearchBrokerWebSearchProvider()
+    assert isinstance(provider, WebSearchProvider)
+    assert provider.name == "search-broker"
+    assert provider.supports_search() is True
+    assert provider.supports_extract() is False
+    monkeypatch.delenv("BROKER_CALLER_HERMES_CANARY_TOKEN", raising=False)
+    assert provider.is_available() is False
+    monkeypatch.setenv("BROKER_CALLER_HERMES_CANARY_TOKEN", "token")
+    assert provider.is_available() is True
+
+
+def test_search_maps_broker_response(monkeypatch):
+    monkeypatch.setenv("BROKER_CALLER_HERMES_CANARY_TOKEN", "token")
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "results": [
+            {
+                "canonical_url": "https://example.com",
+                "title": "Example",
+                "snippet": "Evidence",
+                "provider_rank": 1,
+            }
+        ]
+    }
+    with patch("plugins.web.search_broker.provider.httpx.post", return_value=response) as post:
+        result = SearchBrokerWebSearchProvider().search("query", limit=25)
+
+    assert result == {
+        "success": True,
+        "data": {
+            "web": [
+                {
+                    "title": "Example",
+                    "url": "https://example.com",
+                    "description": "Evidence",
+                    "position": 1,
+                }
+            ]
+        },
+    }
+    kwargs = post.call_args.kwargs
+    assert kwargs["headers"]["Authorization"] == "Bearer token"
+    assert kwargs["json"] == {
+        "query": "query",
+        "capability": "web.semantic",
+        "max_results": 20,
+    }
+
+
+def test_search_failure_never_leaks_token(monkeypatch):
+    token = "super-secret-token"
+    monkeypatch.setenv("BROKER_CALLER_HERMES_CANARY_TOKEN", token)
+    with patch(
+        "plugins.web.search_broker.provider.httpx.post",
+        side_effect=httpx.ConnectError("failed"),
+    ):
+        result = SearchBrokerWebSearchProvider().search("query")
+    assert result["success"] is False
+    assert token not in json.dumps(result)


### PR DESCRIPTION
## Summary
- add a native search-only `WebSearchProvider` for a loopback Search Capability Broker
- preserve the public `web_search` tool and existing extract providers
- keep provider credentials/routing/budgets out of Hermes
- add discovery, availability, mapping, clamp, and secret-redaction tests

## Verification
```
57 passed
```

The provider is inert unless a profile explicitly selects `web.search_backend: search-broker` and provides a caller token.