### PR TITLE
fix(backup): reject -o/--output with --quick instead of silently drop…

### DIFF
--- a/hermes_cli/subcommands/backup.py
+++ b/hermes_cli/subcommands/backup.py
@@ -21,12 +21,18 @@ def build_backup_parser(subparsers, *, cmd_backup: Callable) -> None:
         "skills, sessions, and data (excludes the hermes-agent codebase). "
         "Use --quick for a fast snapshot of just critical state files.",
     )
-    backup_parser.add_argument(
+    # -o/--output writes a full archive at that path; --quick instead stores a
+    # state snapshot into HERMES_HOME/state-snapshots/ and never writes an
+    # archive, so the two cannot combine. Passing both used to accept -o and
+    # silently never write the file (exit 0, nothing created) (#98369); make it
+    # a clear argparse error instead.
+    _backup_target = backup_parser.add_mutually_exclusive_group()
+    _backup_target.add_argument(
         "-o",
         "--output",
-        help="Output path for the zip file (default: ~/hermes-backup-<timestamp>.zip)",
+        help="Output path for the zip file (default: ~/hermes-backup-<timestamp>.zip); not used with --quick",
     )
-    backup_parser.add_argument(
+    _backup_target.add_argument(
         "-q",
         "--quick",
         action="store_true",

--- a/tests/hermes_cli/test_backup_output_quick_exclusive.py
+++ b/tests/hermes_cli/test_backup_output_quick_exclusive.py
@@ -1,0 +1,38 @@
+"""`hermes backup`: -o/--output and --quick are mutually exclusive (#98369).
+
+--quick stores a state snapshot into HERMES_HOME/state-snapshots/ and never
+writes an archive, so accepting -o with --quick silently dropped the requested
+path (exit 0, nothing created). The combination is now rejected at parse time.
+"""
+import argparse
+
+import pytest
+
+from hermes_cli.subcommands.backup import build_backup_parser
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="hermes")
+    sub = p.add_subparsers()
+    build_backup_parser(sub, cmd_backup=lambda args: None)
+    return p
+
+
+def test_quick_with_output_is_rejected():
+    with pytest.raises(SystemExit) as ei:
+        _parser().parse_args(["backup", "--quick", "-o", "/tmp/x.zip"])
+    assert ei.value.code == 2  # argparse usage error, not a silent exit 0
+
+
+@pytest.mark.parametrize(
+    "argv,expect",
+    [
+        (["backup", "-o", "/tmp/x.zip"], {"output": "/tmp/x.zip", "quick": False}),
+        (["backup", "--quick"], {"output": None, "quick": True}),
+        (["backup", "--quick", "-l", "nightly"], {"output": None, "quick": True, "label": "nightly"}),
+    ],
+)
+def test_valid_backup_arg_combos_still_parse(argv, expect):
+    ns = _parser().parse_args(argv)
+    for key, value in expect.items():
+        assert getattr(ns, key) == value


### PR DESCRIPTION
## What does this PR do?

`hermes backup --quick` accepted `-o/--output`, then never read it:
`run_quick_backup` stores a state snapshot into `HERMES_HOME/state-snapshots/`
and never writes an archive, so the requested path was silently ignored — the
command exited 0 with **no file created**, while the non-quick branch honored
the same flag (#98369).

Fix: make `-o/--output` and `-q/--quick` a mutually exclusive argparse group, so
the combination fails at parse time with a clear usage error instead of a silent
no-op. Also note in `--output`'s help that it is not used with `--quick`
(mirroring how `--label` is already documented as quick-only).

## Related Issue

Fixes #98369

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/subcommands/backup.py` — `-o/--output` and `-q/--quick` are now a
  mutually exclusive group; `--output` help notes it is not used with `--quick`.
- `tests/hermes_cli/test_backup_output_quick_exclusive.py` — the combo is
  rejected; valid combos still parse.

## How to Test

    pytest tests/hermes_cli/test_backup_output_quick_exclusive.py -q

4 pass. `backup --quick -o x` exits 2 with a usage error; `backup -o x`,
`backup --quick`, and `backup --quick -l label` still parse.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs / issues
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11