### PR TITLE
fix(feishu): preserve quoted context and native topic routing

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -151,6 +151,12 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         scope_id = getattr(source, "scope_id", None)
         if scope_id:
             metadata["slack_team_id"] = str(scope_id)
+    if (
+        _platform_name(getattr(source, "platform", None)) == "feishu"
+        and thread_id is not None
+        and reply_to_message_id is not None
+    ):
+        metadata["reply_to_message_id"] = str(reply_to_message_id)
     if not metadata:
         return None
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
@@ -207,10 +213,10 @@ def _reply_anchor_for_event(event) -> str | None:
             # the newest user message. A quoted parent remains only a recovery
             # fallback when a synthetic/resumed event has no current message ID.
             return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
-        if getattr(source, "chat_type", None) == "group":
-            # A group-channel mention is a new top-level chat message unless the
-            # inbound event carries a real Feishu thread_id.  Passing message_id
-            # here would call message.reply and render the answer as a reply/topic.
+        if getattr(source, "chat_type", None) != "dm":
+            # A non-DM mention is a new top-level chat message unless the inbound
+            # event carries a real Feishu thread_id. Passing message_id here would
+            # call message.reply and render group/forum/channel answers as topics.
             return None
     return getattr(event, "message_id", None)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -201,8 +201,11 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
+    if platform == "feishu" and thread_id:
+        # Keep the reply inside the topic via thread metadata, but anchor it to
+        # the newest user message. A quoted parent remains only a recovery
+        # fallback when a synthetic/resumed event has no current message ID.
+        return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     return getattr(event, "message_id", None)
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -201,11 +201,17 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id:
-        # Keep the reply inside the topic via thread metadata, but anchor it to
-        # the newest user message. A quoted parent remains only a recovery
-        # fallback when a synthetic/resumed event has no current message ID.
-        return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
+    if platform == "feishu":
+        if thread_id:
+            # Keep the reply inside the topic via thread metadata, but anchor it to
+            # the newest user message. A quoted parent remains only a recovery
+            # fallback when a synthetic/resumed event has no current message ID.
+            return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
+        if getattr(source, "chat_type", None) == "group":
+            # A group-channel mention is a new top-level chat message unless the
+            # inbound event carries a real Feishu thread_id.  Passing message_id
+            # here would call message.reply and render the answer as a reply/topic.
+            return None
     return getattr(event, "message_id", None)
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10526,13 +10526,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
                 content=message,
-                reply_to=(
-                    reply_anchor
-                    if event.source.platform == Platform.TELEGRAM
-                    and event.source.chat_type == "dm"
-                    and event.source.thread_id
-                    else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
-                ),
+                reply_to=reply_anchor,
                 metadata=thread_meta,
             )
             return True
@@ -10922,13 +10916,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
                 content=message,
-                reply_to=(
-                    reply_anchor
-                    if event.source.platform == Platform.TELEGRAM
-                    and event.source.chat_type == "dm"
-                    and event.source.thread_id
-                    else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
-                ),
+                reply_to=reply_anchor,
                 metadata=thread_meta,
             )
         except Exception as e:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4323,8 +4323,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client or not message_id:
             return FeishuQuotedMessageContext()
         if message_id in self._message_text_cache:
-            self._message_text_cache.move_to_end(message_id)
-            return self._message_text_cache[message_id]
+            cached_context = self._message_text_cache[message_id]
+            if all(os.path.exists(path) for path in cached_context.media_urls):
+                self._message_text_cache.move_to_end(message_id)
+                return cached_context
+            self._message_text_cache.pop(message_id, None)
         try:
             request = self._build_get_message_request(message_id)
             response = await self._run_blocking(self._client.im.v1.message.get, request)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -305,6 +305,7 @@ FALLBACK_SHARE_CHAT_TEXT = "[Shared chat]"
 FALLBACK_INTERACTIVE_TEXT = "[Interactive message]"
 FALLBACK_IMAGE_TEXT = "[Image]"
 FALLBACK_ATTACHMENT_TEXT = "[Attachment]"
+FALLBACK_QUOTED_MESSAGE_TEXT = "[Quoted message unavailable]"
 # ---------------------------------------------------------------------------
 # Post/card parsing helpers
 # ---------------------------------------------------------------------------
@@ -3366,16 +3367,6 @@ class FeishuAdapter(BasePlatformAdapter):
             if text.startswith("/"):
                 inbound_type = MessageType.COMMAND
 
-        # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped.
-        if inbound_type == MessageType.TEXT and not text and not media_urls:
-            logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
-            return
-
-        if inbound_type != MessageType.COMMAND:
-            hint = _build_mention_hint(mentions)
-            if hint:
-                text = f"{hint}\n\n{text}" if text else hint
-
         thread_id = getattr(message, "thread_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
@@ -3391,6 +3382,20 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to_text = quoted_context.text
         media_urls.extend(quoted_context.media_urls)
         media_types.extend(quoted_context.media_types)
+        if reply_to_message_id and not reply_to_text and not quoted_context.media_urls:
+            reply_to_text = FALLBACK_QUOTED_MESSAGE_TEXT
+
+        # Guard runs post-strip and post-quote lookup. A pure "@Bot" message
+        # without any semantic payload is still ignored, while a mention-only
+        # reply is admitted when the quoted parent contributes text or media.
+        if inbound_type == MessageType.TEXT and not text and not media_urls and not reply_to_text:
+            logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
+            return
+
+        if inbound_type != MessageType.COMMAND:
+            hint = _build_mention_hint(mentions)
+            if hint:
+                text = f"{hint}\n\n{text}" if text else hint
 
         sender_primary = (
             getattr(sender_id, "open_id", None)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -402,6 +402,13 @@ class FeishuNormalizedMessage:
 
 
 @dataclass(frozen=True)
+class FeishuQuotedMessageContext:
+    text: Optional[str] = None
+    media_urls: tuple[str, ...] = ()
+    media_types: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class FeishuAdapterSettings:
     app_id: str  # Canonical bot/app identifier (credential, not from event payloads)
     app_secret: str
@@ -1541,7 +1548,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
-        self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()
+        self._message_text_cache: "OrderedDict[str, FeishuQuotedMessageContext]" = OrderedDict()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -3376,7 +3383,14 @@ class FeishuAdapter(BasePlatformAdapter):
             or getattr(message, "root_id", None)
             or None
         )
-        reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+        quoted_context = (
+            await self._fetch_message_context(reply_to_message_id)
+            if reply_to_message_id
+            else FeishuQuotedMessageContext()
+        )
+        reply_to_text = quoted_context.text
+        media_urls.extend(quoted_context.media_urls)
+        media_types.extend(quoted_context.media_types)
 
         sender_primary = (
             getattr(sender_id, "open_id", None)
@@ -4300,9 +4314,9 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.debug("[Feishu] Failed to fetch bot names for %s", bot_ids, exc_info=True)
             return None
 
-    async def _fetch_message_text(self, message_id: str) -> Optional[str]:
+    async def _fetch_message_context(self, message_id: str) -> FeishuQuotedMessageContext:
         if not self._client or not message_id:
-            return None
+            return FeishuQuotedMessageContext()
         if message_id in self._message_text_cache:
             self._message_text_cache.move_to_end(message_id)
             return self._message_text_cache[message_id]
@@ -4313,25 +4327,51 @@ class FeishuAdapter(BasePlatformAdapter):
                 code = getattr(response, "code", "unknown")
                 msg = getattr(response, "msg", "message lookup failed")
                 logger.warning("[Feishu] Failed to fetch parent message %s: [%s] %s", message_id, code, msg)
-                return None
+                return FeishuQuotedMessageContext()
             items = getattr(getattr(response, "data", None), "items", None) or []
             parent = items[0] if items else None
             body = getattr(parent, "body", None)
             msg_type = getattr(parent, "msg_type", "") or ""
             raw_content = getattr(body, "content", "") or ""
             parent_mentions = getattr(parent, "mentions", None) if parent else None
-            text = self._extract_text_from_raw_content(
-                msg_type=msg_type,
+            normalized = normalize_feishu_message(
+                message_type=msg_type,
                 raw_content=raw_content,
                 mentions=parent_mentions,
+                bot=self._bot_identity(),
             )
-            self._message_text_cache[message_id] = text
+            text = self._quoted_text_from_normalized(normalized)
+            media_urls, media_types = await self._download_feishu_message_resources(
+                message_id=message_id,
+                normalized=normalized,
+            )
+            context = FeishuQuotedMessageContext(
+                text=text,
+                media_urls=tuple(media_urls),
+                media_types=tuple(media_types),
+            )
+            self._message_text_cache[message_id] = context
             while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
                 self._message_text_cache.popitem(last=False)
-            return text
+            return context
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
-            return None
+            return FeishuQuotedMessageContext()
+
+    async def _fetch_message_text(self, message_id: str) -> Optional[str]:
+        """Compatibility wrapper for callers that only need quoted text."""
+        return (await self._fetch_message_context(message_id)).text
+
+    @staticmethod
+    def _quoted_text_from_normalized(normalized: FeishuNormalizedMessage) -> Optional[str]:
+        if normalized.text_content:
+            return normalized.text_content
+        placeholder = normalized.metadata.get("placeholder_text") if isinstance(normalized.metadata, dict) else None
+        if placeholder is not None:
+            return str(placeholder).strip() or None
+        if normalized.relation_kind == "image":
+            return FALLBACK_IMAGE_TEXT
+        return None
 
     def _extract_text_from_raw_content(
         self,
@@ -4346,10 +4386,7 @@ class FeishuAdapter(BasePlatformAdapter):
             mentions=mentions,
             bot=self._bot_identity(),
         )
-        if normalized.text_content:
-            return normalized.text_content
-        placeholder = normalized.metadata.get("placeholder_text") if isinstance(normalized.metadata, dict) else None
-        return str(placeholder).strip() or None
+        return self._quoted_text_from_normalized(normalized)
 
     @staticmethod
     def _default_image_media_type(ext: str) -> str:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3369,7 +3369,7 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        thread_id = getattr(message, "thread_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3407,6 +3407,7 @@ class FeishuAdapter(BasePlatformAdapter):
             user_name=sender_profile["user_name"],
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
+            message_id=message_id,
             is_bot=is_bot,
         )
         normalized = MessageEvent(

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -190,6 +190,72 @@ class TestBusySessionAck:
 
 
     @pytest.mark.asyncio
+    async def test_feishu_top_level_busy_ack_is_not_a_reply(self):
+        """A busy ack in a Feishu group main channel must stay top-level."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter(platform_val="feishu")
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_type="group",
+            user_id="user1",
+        )
+        event = MessageEvent(
+            text="Are you working?",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="om_current",
+        )
+        sk = build_session_key(source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 1,
+            "max_iterations": 10,
+            "current_tool": "terminal",
+        }
+        runner._running_agents[sk] = agent
+        runner.adapters[source.platform] = adapter
+
+        with patch("agent.onboarding.is_seen", return_value=True):
+            await runner._handle_active_session_busy_message(event, sk)
+
+        assert adapter._send_with_retry.call_args.kwargs["reply_to"] is None
+        assert adapter._send_with_retry.call_args.kwargs["metadata"] is None
+
+    @pytest.mark.asyncio
+    async def test_feishu_top_level_drain_ack_is_not_a_reply(self):
+        """A restart/drain ack in a Feishu group main channel stays top-level."""
+        runner, _sentinel = _make_runner()
+        runner._draining = True
+        runner._restart_requested = True
+        runner._busy_input_mode = "interrupt"
+        runner._queue_during_drain_enabled = MagicMock(return_value=False)
+        adapter = _make_adapter(platform_val="feishu")
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_type="group",
+            user_id="user1",
+        )
+        event = MessageEvent(
+            text="Can you hear me?",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="om_current",
+        )
+        runner.adapters[source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(
+            event,
+            build_session_key(source),
+        )
+
+        assert adapter._send_with_retry.call_args.kwargs["reply_to"] is None
+        assert adapter._send_with_retry.call_args.kwargs["metadata"] is None
+
+    @pytest.mark.asyncio
     async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self, monkeypatch):
         """busy_input_mode='steer' injects via agent.steer() and skips queueing."""
         import gateway.run as _gr

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2209,6 +2209,23 @@ class TestFeishuExtractMessageContent(unittest.TestCase):
 
 
 class TestFeishuReplyAnchors(unittest.TestCase):
+    def test_top_level_group_message_has_no_reply_anchor(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, _reply_anchor_for_event
+        from gateway.session import SessionSource
+
+        event = MessageEvent(
+            text="Hello from the main chat",
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_chat",
+                chat_type="group",
+            ),
+            message_id="om_current",
+        )
+
+        self.assertIsNone(_reply_anchor_for_event(event))
+
     def test_threaded_reply_prefers_the_current_message(self):
         from gateway.config import Platform
         from gateway.platforms.base import MessageEvent, _reply_anchor_for_event
@@ -2265,8 +2282,37 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         return adapter
 
 
-    def test_replying_to_a_message_keeps_the_current_message_as_reply_anchor(self):
-        """A quote supplies context, but must not steal the bot's reply anchor."""
+    def test_top_level_quote_keeps_context_without_becoming_a_thread(self):
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "Can you read the quote?"}),
+            message_type="text",
+            message_id="om_current",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_quoted",
+            upper_message_id=None,
+            root_id="om_root",
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="om_current",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.message_id, "om_current")
+        self.assertEqual(event.reply_to_message_id, "om_quoted")
+        self.assertIsNone(adapter.build_source.call_args.kwargs["thread_id"])
+
+    def test_topic_reply_keeps_the_current_message_as_reply_anchor(self):
+        """A true topic stays threaded and anchors to the newest user message."""
         adapter = self._build_adapter()
         message = SimpleNamespace(
             content=json.dumps({"text": "Can you read this?"}),

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2208,6 +2208,43 @@ class TestFeishuExtractMessageContent(unittest.TestCase):
         self.assertEqual(mentions[0].open_id, "ou_alice")
 
 
+class TestFeishuReplyAnchors(unittest.TestCase):
+    def test_threaded_reply_prefers_the_current_message(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, _reply_anchor_for_event
+        from gateway.session import SessionSource
+
+        event = MessageEvent(
+            text="Can you read this?",
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_chat",
+                thread_id="omt_topic",
+            ),
+            message_id="om_current",
+            reply_to_message_id="om_quoted",
+        )
+
+        self.assertEqual(_reply_anchor_for_event(event), "om_current")
+
+    def test_threaded_reply_falls_back_to_the_quote_without_a_current_message(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, _reply_anchor_for_event
+        from gateway.session import SessionSource
+
+        event = MessageEvent(
+            text="Resumed reply",
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_chat",
+                thread_id="omt_topic",
+            ),
+            reply_to_message_id="om_quoted",
+        )
+
+        self.assertEqual(_reply_anchor_for_event(event), "om_quoted")
+
+
 class TestFeishuProcessInboundMessage(unittest.TestCase):
     def _build_adapter(self):
         from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -2226,6 +2263,40 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         adapter.build_source = Mock(return_value=SimpleNamespace(thread_id=None))
         adapter._dispatch_inbound_event = AsyncMock()
         return adapter
+
+
+    def test_replying_to_a_message_keeps_the_current_message_as_reply_anchor(self):
+        """A quote supplies context, but must not steal the bot's reply anchor."""
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "Can you read this?"}),
+            message_type="text",
+            message_id="om_current",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_quoted",
+            upper_message_id=None,
+            root_id="om_root",
+            thread_id="omt_topic",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="om_current",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.message_id, "om_current")
+        self.assertEqual(event.reply_to_message_id, "om_quoted")
+        self.assertEqual(
+            adapter.build_source.call_args.kwargs["message_id"],
+            "om_current",
+        )
 
 
     def test_non_command_message_with_mentions_injects_hint(self):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1236,8 +1236,11 @@ class TestAdapterBehavior(unittest.TestCase):
                     adapter.send_document(
                         chat_id="oc_chat",
                         file_path=file_path,
-                        reply_to="om_parent",
-                        metadata={"thread_id": "omt-thread"},
+                        reply_to=None,
+                        metadata={
+                            "thread_id": "omt-thread",
+                            "reply_to_message_id": "om_parent",
+                        },
                     )
                 )
         finally:
@@ -2226,6 +2229,43 @@ class TestFeishuReplyAnchors(unittest.TestCase):
 
         self.assertIsNone(_reply_anchor_for_event(event))
 
+    def test_top_level_forum_message_has_no_reply_anchor(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, _reply_anchor_for_event
+        from gateway.session import SessionSource
+
+        event = MessageEvent(
+            text="Hello from a forum main channel",
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_forum",
+                chat_type="forum",
+            ),
+            message_id="om_current",
+        )
+
+        self.assertIsNone(_reply_anchor_for_event(event))
+
+    def test_thread_metadata_carries_current_feishu_reply_anchor(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import _thread_metadata_for_source
+        from gateway.session import SessionSource
+
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_type="group",
+            thread_id="omt_topic",
+        )
+
+        self.assertEqual(
+            _thread_metadata_for_source(source, "om_current"),
+            {
+                "thread_id": "omt_topic",
+                "reply_to_message_id": "om_current",
+            },
+        )
+
     def test_threaded_reply_prefers_the_current_message(self):
         from gateway.config import Platform
         from gateway.platforms.base import MessageEvent, _reply_anchor_for_event
@@ -2409,6 +2449,26 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         self.assertEqual(event.media_urls, ["/tmp/quoted-image.jpg"])
         self.assertEqual(event.media_types, ["image/jpeg"])
         fetch_message_context.assert_awaited_once_with("om_quoted_image")
+
+    def test_mention_only_file_quote_dispatches_media(self):
+        from plugins.platforms.feishu.adapter import FeishuQuotedMessageContext
+
+        event, fetch_message_context, _ = self._run_mention_only(
+            parent_id="om_quoted_file",
+            quoted_context=FeishuQuotedMessageContext(
+                text="[Attachment: spec.pdf]",
+                media_urls=("/tmp/spec.pdf",),
+                media_types=("application/pdf",),
+            ),
+        )
+
+        if event is None:
+            self.fail("mention-only file quote was not dispatched")
+        self.assertEqual(event.text, "")
+        self.assertEqual(event.reply_to_text, "[Attachment: spec.pdf]")
+        self.assertEqual(event.media_urls, ["/tmp/spec.pdf"])
+        self.assertEqual(event.media_types, ["application/pdf"])
+        fetch_message_context.assert_awaited_once_with("om_quoted_file")
 
     def test_mention_only_topic_quote_preserves_native_thread(self):
         from plugins.platforms.feishu.adapter import FeishuQuotedMessageContext
@@ -2633,6 +2693,36 @@ class TestFeishuFetchMessageText(unittest.TestCase):
         # The rendered text should still have the bot name substituted.
         result = asyncio.run(adapter._fetch_message_text("m_parent"))
         self.assertEqual(result, "@Hermes hi")
+
+    def test_fetch_message_context_refetches_when_cached_media_was_deleted(self):
+        from plugins.platforms.feishu.adapter import FeishuQuotedMessageContext
+
+        adapter = self._build_adapter()
+        stale_path = "/tmp/hermes-feishu-deleted-quoted-image.jpg"
+        adapter._message_text_cache["m_parent"] = FeishuQuotedMessageContext(
+            text="[Image]",
+            media_urls=(stale_path,),
+            media_types=("image/jpeg",),
+        )
+
+        parent = SimpleNamespace(
+            body=SimpleNamespace(content=json.dumps({"image_key": "img_parent"})),
+            msg_type="image",
+            mentions=[],
+        )
+        response = Mock()
+        response.success = Mock(return_value=True)
+        response.data = SimpleNamespace(items=[parent])
+        adapter._client.im.v1.message.get = Mock(return_value=response)
+        adapter._download_feishu_message_resources = AsyncMock(
+            return_value=(["/tmp/refetched-quoted-image.jpg"], ["image/jpeg"])
+        )
+
+        result = asyncio.run(adapter._fetch_message_context("m_parent"))
+
+        self.assertEqual(result.media_urls, ("/tmp/refetched-quoted-image.jpg",))
+        adapter._client.im.v1.message.get.assert_called_once()
+        adapter._download_feishu_message_resources.assert_awaited_once()
 
 
 class TestFeishuMentionEndToEnd(unittest.TestCase):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2264,14 +2264,14 @@ class TestFeishuReplyAnchors(unittest.TestCase):
 
 class TestFeishuProcessInboundMessage(unittest.TestCase):
     def _build_adapter(self):
-        from plugins.platforms.feishu.adapter import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter, FeishuQuotedMessageContext
 
         adapter = FeishuAdapter.__new__(FeishuAdapter)
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
         adapter._download_feishu_message_resources = AsyncMock(return_value=([], []))
-        adapter._fetch_message_text = AsyncMock(return_value=None)
+        adapter._fetch_message_context = AsyncMock(return_value=FeishuQuotedMessageContext())
         adapter.get_chat_info = AsyncMock(return_value={"name": "Test Chat"})
         adapter._resolve_sender_profile = AsyncMock(
             return_value={"user_id": "u1", "user_name": "Alice", "user_id_alt": None}
@@ -2310,6 +2310,67 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         self.assertEqual(event.message_id, "om_current")
         self.assertEqual(event.reply_to_message_id, "om_quoted")
         self.assertIsNone(adapter.build_source.call_args.kwargs["thread_id"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_reply_to_image_injects_quoted_image_context(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = Mock()
+        adapter._build_get_message_request = Mock(return_value=object())
+        adapter._download_feishu_image = AsyncMock(
+            return_value=("/tmp/quoted-image.jpg", "image/jpeg")
+        )
+        parent = SimpleNamespace(
+            body=SimpleNamespace(content=json.dumps({"image_key": "img_quoted"})),
+            msg_type="image",
+            mentions=[],
+        )
+        response = Mock()
+        response.success = Mock(return_value=True)
+        response.data = SimpleNamespace(items=[parent])
+        adapter._client.im.v1.message.get = Mock(return_value=response)
+        adapter.get_chat_info = AsyncMock(return_value={"name": "Test Chat"})
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "u1", "user_name": "Alice", "user_id_alt": None}
+        )
+        adapter._resolve_source_chat_type = Mock(return_value="group")
+        adapter.build_source = Mock(return_value=SimpleNamespace(thread_id=None))
+        adapter._dispatch_inbound_event = AsyncMock()
+
+        message = SimpleNamespace(
+            content=json.dumps({"text": "What is in this?"}),
+            message_type="text",
+            message_id="om_current",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_quoted_image",
+            upper_message_id=None,
+            root_id=None,
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="om_current",
+            )
+        )
+
+        await_args = adapter._dispatch_inbound_event.await_args
+        if await_args is None:
+            self.fail("quoted reply was not dispatched")
+        event = await_args.args[0]
+        self.assertEqual(event.reply_to_text, "[Image]")
+        self.assertEqual(event.media_urls, ["/tmp/quoted-image.jpg"])
+        self.assertEqual(event.media_types, ["image/jpeg"])
+        adapter._download_feishu_image.assert_awaited_once_with(
+            message_id="om_quoted_image",
+            image_key="img_quoted",
+        )
 
     def test_topic_reply_keeps_the_current_message_as_reply_anchor(self):
         """A true topic stays threaded and anchors to the newest user message."""
@@ -2464,14 +2525,14 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
     """High-level scenarios from the design spec — verify the full pipeline."""
 
     def _build_adapter(self):
-        from plugins.platforms.feishu.adapter import FeishuAdapter
+        from plugins.platforms.feishu.adapter import FeishuAdapter, FeishuQuotedMessageContext
 
         adapter = FeishuAdapter.__new__(FeishuAdapter)
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
         adapter._download_feishu_message_resources = AsyncMock(return_value=([], []))
-        adapter._fetch_message_text = AsyncMock(return_value=None)
+        adapter._fetch_message_context = AsyncMock(return_value=FeishuQuotedMessageContext())
         adapter.get_chat_info = AsyncMock(return_value={"name": "Test Chat"})
         adapter._resolve_sender_profile = AsyncMock(
             return_value={"user_id": "u1", "user_name": "Alice", "user_id_alt": None}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2311,6 +2311,120 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         self.assertEqual(event.reply_to_message_id, "om_quoted")
         self.assertIsNone(adapter.build_source.call_args.kwargs["thread_id"])
 
+    def _run_mention_only(self, *, parent_id, quoted_context, thread_id=None):
+        adapter = self._build_adapter()
+        fetch_message_context = AsyncMock(return_value=quoted_context)
+        dispatch_inbound_event = AsyncMock()
+        build_source = Mock(return_value=SimpleNamespace(thread_id=thread_id))
+        adapter._fetch_message_context = fetch_message_context
+        adapter._dispatch_inbound_event = dispatch_inbound_event
+        adapter.build_source = build_source
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1"}),
+            message_type="text",
+            message_id="om_current",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=parent_id,
+            upper_message_id=None,
+            root_id=None,
+            thread_id=thread_id,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="om_current",
+            )
+        )
+        await_args = dispatch_inbound_event.await_args
+        event = await_args.args[0] if await_args is not None else None
+        return event, fetch_message_context, build_source
+
+    def test_mention_only_quote_dispatches_quoted_text(self):
+        from plugins.platforms.feishu.adapter import FeishuQuotedMessageContext
+
+        event, fetch_message_context, build_source = self._run_mention_only(
+            parent_id="om_quoted",
+            quoted_context=FeishuQuotedMessageContext(text="quoted parent text"),
+        )
+
+        if event is None:
+            self.fail("mention-only quoted reply was not dispatched")
+        self.assertEqual(event.text, "")
+        self.assertEqual(event.reply_to_message_id, "om_quoted")
+        self.assertEqual(event.reply_to_text, "quoted parent text")
+        fetch_message_context.assert_awaited_once_with("om_quoted")
+        self.assertIsNone(build_source.call_args.kwargs["thread_id"])
+
+    def test_mention_only_unavailable_quote_dispatches_fallback(self):
+        from plugins.platforms.feishu.adapter import FeishuQuotedMessageContext
+
+        event, fetch_message_context, _ = self._run_mention_only(
+            parent_id="om_unavailable",
+            quoted_context=FeishuQuotedMessageContext(),
+        )
+
+        if event is None:
+            self.fail("mention-only reply with unavailable quote was not dispatched")
+        self.assertEqual(event.text, "")
+        self.assertEqual(event.reply_to_message_id, "om_unavailable")
+        self.assertEqual(event.reply_to_text, "[Quoted message unavailable]")
+        fetch_message_context.assert_awaited_once_with("om_unavailable")
+
+    def test_mention_only_without_quote_is_ignored(self):
+        from plugins.platforms.feishu.adapter import FeishuQuotedMessageContext
+
+        event, fetch_message_context, _ = self._run_mention_only(
+            parent_id=None,
+            quoted_context=FeishuQuotedMessageContext(),
+        )
+
+        self.assertIsNone(event)
+        fetch_message_context.assert_not_awaited()
+
+    def test_mention_only_image_quote_dispatches_media(self):
+        from plugins.platforms.feishu.adapter import FeishuQuotedMessageContext
+
+        event, fetch_message_context, _ = self._run_mention_only(
+            parent_id="om_quoted_image",
+            quoted_context=FeishuQuotedMessageContext(
+                text="[Image]",
+                media_urls=("/tmp/quoted-image.jpg",),
+                media_types=("image/jpeg",),
+            ),
+        )
+
+        if event is None:
+            self.fail("mention-only image quote was not dispatched")
+        self.assertEqual(event.text, "")
+        self.assertEqual(event.reply_to_text, "[Image]")
+        self.assertEqual(event.media_urls, ["/tmp/quoted-image.jpg"])
+        self.assertEqual(event.media_types, ["image/jpeg"])
+        fetch_message_context.assert_awaited_once_with("om_quoted_image")
+
+    def test_mention_only_topic_quote_preserves_native_thread(self):
+        from plugins.platforms.feishu.adapter import FeishuQuotedMessageContext
+
+        event, fetch_message_context, build_source = self._run_mention_only(
+            parent_id="om_quoted",
+            quoted_context=FeishuQuotedMessageContext(text="quoted parent text"),
+            thread_id="omt_topic",
+        )
+
+        if event is None:
+            self.fail("mention-only topic quote was not dispatched")
+        self.assertEqual(event.source.thread_id, "omt_topic")
+        self.assertEqual(build_source.call_args.kwargs["thread_id"], "omt_topic")
+        fetch_message_context.assert_awaited_once_with("om_quoted")
+
     @patch.dict(os.environ, {}, clear=True)
     def test_reply_to_image_injects_quoted_image_context(self):
         from gateway.config import PlatformConfig

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -99,3 +99,23 @@ async def test_reply_prefix_still_injected_when_text_in_history():
     assert result.endswith("What's the best time to go?")
 
 
+@pytest.mark.asyncio
+async def test_reply_prefix_is_nonempty_payload_when_current_text_is_empty():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="quoted parent text",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == '[Replying to: "quoted parent text"]\n\n'
+
+


### PR DESCRIPTION
## Summary

Fix Feishu quoted-reply handling as one coherent behavior class:

- keep ordinary group messages and ordinary quoted replies in the main channel;
- keep native topic messages in their real Feishu thread and anchor replies to the current inbound message;
- inject quoted parent text and referenced image/file media into the current `MessageEvent`;
- dispatch quote-only messages whose body becomes empty after stripping the bot mention;
- retain the existing behavior that a pure bot mention with no quoted parent is ignored.

## User-visible failures

1. **A reply inside a native Feishu topic could anchor to the quoted/root message instead of the newest user message.** The bot response appeared under the wrong message in the thread.
2. **An ordinary group message or ordinary quoted reply could be misclassified as a topic.** `root_id` was used as a fallback for `thread_id`, so a main-channel response was sent into a reply thread.
3. **Quoted images/files lost their actual content.** Parent lookup returned text only; image parents could surface as `[Replying to: "None"]` or as a placeholder without the media resource, so vision-capable models could not inspect the quoted image.
4. **Quoting a message and sending only `@Bot` produced no response.** Self-mention stripping reduced the current body to an empty string, and the adapter returned before resolving the quoted parent.
5. **An unavailable/withdrawn quoted parent failed silently in the mention-only case.** There was no semantic payload left to dispatch and no explanation to the model.
6. **Native-topic media and generic error responses could lose the current-message anchor.** Text sends received `reply_to` directly, but metadata-only media/error paths had only `thread_id` and could fall back to `message.create(receive_id_type="thread_id")`.
7. **A top-level Feishu forum chat could still become a reply/topic.** The top-level guard covered `chat_type="group"` but not Feishu's `forum` source type.
8. **Frequently quoted cached media could become permanently unreadable after housekeeping.** The quoted-context LRU cached local paths indefinitely while hourly media cleanup could delete the underlying files.

## Root causes

- **Delivery scope and quote semantics were conflated.** Native `thread_id` determines topic scope; `root_id`, `parent_id`, and `upper_message_id` only describe the quoted-parent relationship.
- **Thread reply anchoring reused the quoted parent instead of the current inbound message.** A true topic response must reply to the newest user message while preserving the quoted parent separately as context.
- **Quoted-parent retrieval was text-only and stringified optional placeholders too early.** `str(None).strip()` produced the literal string `"None"`, and referenced media never entered the normal inbound media path.
- **The empty-text guard ran before quoted-context lookup.** Mention-only quoted replies were dropped before the parent could contribute text or media.
- **The shared thread metadata omitted Feishu's current reply anchor.** Non-text/error send paths therefore lacked enough information to call `message.reply(..., reply_in_thread=True)`.
- **Top-level suppression was keyed to one chat-type label instead of Feishu scope.** Non-DM forum/channel events without native `thread_id` fell through to `event.message_id`.
- **The quoted-context cache validated neither TTL nor local path existence.** A cache hit could outlive the downloaded resource it referenced.

## Fix

- Treat only a non-empty native Feishu `thread_id` as topic scope; never infer a topic from `root_id` or `parent_id`.
- Centralize reply-anchor selection so ordinary group sends remain top-level while native topics reply to the current inbound message.
- Add a structured quoted-message context carrying normalized text plus ordered media URLs/MIME types, backed by the existing bounded LRU cache.
- Download quoted image/file resources through the normal Feishu resource path and merge them into the current event.
- Preserve nulls before string conversion so missing placeholders cannot become the fake text `"None"`.
- Resolve quoted context before applying the empty-text guard. A mention-only quote dispatches when the parent contributes text/media; an unreadable parent gets `[Quoted message unavailable]`; an unquoted pure mention remains ignored.
- Keep batching compatibility strict across quoted parent and native thread identity.
- Carry `reply_to_message_id` in Feishu native-thread metadata so text, media, and error paths use the same current-message anchor.
- Treat every non-DM Feishu event without native `thread_id` as top-level, including group/forum/channel source types.
- Validate cached quoted-media paths on every hit; invalidate and refetch the parent context if housekeeping removed a file.

## Behavioral invariants

| Inbound Feishu event | Expected outbound behavior |
| --- | --- |
| Main-channel message | New top-level group message |
| Main-channel ordinary quote | Quoted parent is model context; response remains top-level |
| Native topic message | Response remains in that native `thread_id` and anchors to the current inbound message |
| Quoted image/file | Placeholder explains the relation; actual resource is attached through the normal media path |
| Quoted message + only `@Bot` | Dispatch using quoted text/media |
| Only `@Bot`, no quote | Ignore |
| Quoted parent unavailable | Dispatch with an explicit unavailable-parent marker |

## Tests

- Focused forum/thread-metadata/stale-cache/media-path checks: **9 passed**
- Reply-pointer gateway preprocessing (including empty current text): **3 passed**
- Feishu/routing regression set: **109 passed, 18 skipped**
- Extended Feishu set on the PR branch: **147 passed, 18 skipped**, with two existing approval-card failures
- The same two approval-card tests fail unchanged on current `upstream/main`, so this change introduces no new failure:
  - `test_rejects_approval_click_from_unauthorized_user`
  - `test_update_prompt_unauthorized_operator_returns_no_card`
- Ruff: passed
- `git diff --check`: passed
- Added-line security scan: no hardcoded secrets, shell injection, `eval`/`exec`, or unsafe pickle usage
- Independent read-only review: **passed after one fix/re-review cycle**; no remaining security or logic blockers

## Manual Feishu verification

Verified against a live Feishu workspace:

- main-channel text quote + mention-only body dispatched with the parent text;
- main-channel image quote + mention-only body attached one real native image and was readable by the vision model;
- native topic quote + mention-only body preserved its native `thread_id`;
- main-channel responses stayed top-level rather than creating accidental topics.
