### PR TITLE
fix(slack): keep clarification choices readable

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7350,16 +7350,19 @@ class SlackAdapter(BasePlatformAdapter):
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Render a clarify prompt as Block Kit interactive buttons.
+        """Render a clarify prompt as readable Block Kit choice rows.
 
-        Multi-choice mode (``choices`` non-empty): one button per option
-        (unique ``hermes_clarify_choice_<idx>`` action_id, ``value`` packs
+        Multi-choice mode (``choices`` non-empty): one wrapping section per
+        option with a compact ``Select <n>`` accessory button (unique
+        ``hermes_clarify_choice_<idx>`` action_id, ``value`` packs
         ``clarify_id|idx``) plus a final "✏️ Other…" button
-        (``hermes_clarify_other``).  A choice click resolves the clarify
-        primitive directly; the "Other" button flips the entry into
-        text-capture mode so the gateway's platform-agnostic text-intercept
-        (:meth:`GatewayRunner._handle_message`) picks up the next typed
-        message and resolves the clarify — no Slack-specific text machinery.
+        (``hermes_clarify_other``).  Keeping the decision text out of the
+        button label avoids Slack's aggressive button ellipsis while a choice
+        click still resolves the clarify primitive directly.  The "Other"
+        button flips the entry into text-capture mode so the gateway's
+        platform-agnostic text-intercept (:meth:`GatewayRunner._handle_message`)
+        picks up the next typed message and resolves the clarify — no
+        Slack-specific text machinery.
 
         Open-ended mode (``choices`` empty): delegates to the base
         implementation, which renders the plain question and arms the same
@@ -7397,36 +7400,61 @@ class SlackAdapter(BasePlatformAdapter):
             if len(body) > budget:
                 body = body[:budget] + "..."
 
-            # One button per choice + a free-text "Other" button.  Slack caps
-            # an actions block at 5 elements; the clarify tool caps choices at
-            # 4 (+ Other = 5) so this is normally one block, but chunk anyway
-            # so a larger choice list degrades gracefully instead of 400ing.
-            elements = []
-            for idx, choice in enumerate(choices):
-                label = str(choice).strip() or f"Option {idx + 1}"
-                elements.append({
-                    "type": "button",
-                    "text": {"type": "plain_text", "text": label[:75], "emoji": True},
-                    "action_id": f"hermes_clarify_choice_{idx}",
-                    "value": f"{clarify_id}|{idx}",
-                })
-            elements.append({
-                "type": "button",
-                "text": {"type": "plain_text", "text": "✏️ Other…", "emoji": True},
-                "action_id": "hermes_clarify_other",
-                "value": f"{clarify_id}|other",
-            })
-
+            # Slack visually truncates button labels at roughly 30 characters,
+            # so render the full option as wrapping section text and keep only
+            # the compact selection action in the button accessory.
             blocks: list = [
                 {"type": "section", "text": {"type": "mrkdwn", "text": body}},
             ]
-            for start in range(0, len(elements), 5):
-                blocks.append({"type": "actions", "elements": elements[start:start + 5]})
+            for idx, choice in enumerate(choices):
+                label = str(choice).strip() or f"Option {idx + 1}"
+                escaped_label = (
+                    label.replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;")
+                )
+                blocks.append(
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": f"*{idx + 1}.* {escaped_label}",
+                        },
+                        "accessory": {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": f"Select {idx + 1}",
+                                "emoji": True,
+                            },
+                            "accessibility_label": f"Select option {idx + 1}",
+                            "action_id": f"hermes_clarify_choice_{idx}",
+                            "value": f"{clarify_id}|{idx}",
+                        },
+                    }
+                )
+            blocks.append(
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "✏️ Other…",
+                                "emoji": True,
+                            },
+                            "action_id": "hermes_clarify_other",
+                            "value": f"{clarify_id}|other",
+                        }
+                    ],
+                }
+            )
 
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
                 "text": body,
-                "blocks": blocks,
+                "blocks": sanitize_blocks(blocks),
             }
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -94,7 +94,7 @@ class TestSlackSendClarify:
         _clear_clarify_state()
 
     @pytest.mark.asyncio
-    async def test_multi_choice_renders_buttons_and_other(self):
+    async def test_multi_choice_renders_readable_rows_and_other(self):
         adapter = _make_adapter()
         mock_client = adapter._team_clients["T1"]
         mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
@@ -116,23 +116,56 @@ class TestSlackSendClarify:
         blocks = kwargs["blocks"]
         assert blocks[0]["type"] == "section"
         assert "Which environment?" in blocks[0]["text"]["text"]
-        assert blocks[1]["type"] == "actions"
-        elements = blocks[1]["elements"]
-        # 2 choices + Other
-        assert len(elements) == 3
-        assert elements[0]["action_id"] == "hermes_clarify_choice_0"
-        assert elements[0]["value"] == "cid1|0"
-        assert elements[1]["action_id"] == "hermes_clarify_choice_1"
-        assert elements[1]["value"] == "cid1|1"
-        assert elements[0]["text"]["text"] == "staging"
-        # Final button is the free-text "Other"
-        assert elements[2]["action_id"] == "hermes_clarify_other"
-        assert elements[2]["value"] == "cid1|other"
-        for block in blocks:
-            if block["type"] == "actions":
-                action_ids = [element["action_id"] for element in block["elements"]]
-                assert len(action_ids) == len(set(action_ids))
+        assert blocks[1]["type"] == "section"
+        assert blocks[1]["text"]["text"] == "*1.* staging"
+        assert blocks[1]["accessory"]["text"]["text"] == "Select 1"
+        assert blocks[1]["accessory"]["action_id"] == "hermes_clarify_choice_0"
+        assert blocks[1]["accessory"]["value"] == "cid1|0"
+        assert blocks[2]["type"] == "section"
+        assert blocks[2]["text"]["text"] == "*2.* production"
+        assert blocks[2]["accessory"]["text"]["text"] == "Select 2"
+        assert blocks[2]["accessory"]["action_id"] == "hermes_clarify_choice_1"
+        assert blocks[2]["accessory"]["value"] == "cid1|1"
 
+        # The free-text path remains a separate final action.
+        assert blocks[3]["type"] == "actions"
+        assert len(blocks[3]["elements"]) == 1
+        assert blocks[3]["elements"][0]["action_id"] == "hermes_clarify_other"
+        assert blocks[3]["elements"][0]["value"] == "cid1|other"
+
+        action_ids = [block["accessory"]["action_id"] for block in blocks[1:3]]
+        action_ids.append(blocks[3]["elements"][0]["action_id"])
+        assert len(action_ids) == len(set(action_ids))
+
+    @pytest.mark.asyncio
+    async def test_long_choice_is_visible_in_wrapping_text_not_button_label(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "2.2"})
+        long_choice = (
+            "Keep the existing deployment branch and preserve all unpublished "
+            "changes while we inspect the <production> difference & rollback evidence."
+        )
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="Which deployment path should we use?",
+            choices=[long_choice, "Create a clean replacement branch"],
+            clarify_id="cid-long",
+            session_key="sk-long",
+        )
+
+        blocks = mock_client.chat_postMessage.call_args.kwargs["blocks"]
+        first_choice = blocks[1]
+        assert first_choice["type"] == "section"
+        assert first_choice["text"]["text"] == (
+            "*1.* Keep the existing deployment branch and preserve all unpublished "
+            "changes while we inspect the &lt;production&gt; difference "
+            "&amp; rollback evidence."
+        )
+        assert len(first_choice["text"]["text"]) > 75
+        assert first_choice["accessory"]["text"]["text"] == "Select 1"
+        assert long_choice not in first_choice["accessory"]["text"]["text"]
 
     @pytest.mark.asyncio
     async def test_mrkdwn_escapes_question(self):


### PR DESCRIPTION
## What and why

Slack visually truncates long Block Kit button labels, so clarification requests can hide most of the decision text. This change renders each choice as wrapping numbered section text with a compact Select N accessory button.

## Type

- [x] Bug fix

## Changes

- Show the full escaped choice text in a wrapping Slack section.
- Keep callback action IDs and clarify_id|index values unchanged.
- Preserve the Other free-text path.
- Add regression coverage for long choices and readable selection controls.

## How to test

- Focused Slack and clarification suite: 281 passed, 0 failed.
- Ruff, Python compilation, diff whitespace, and Windows-footgun checks: passed.
- Full repository run: 40,475 passed, 110 failed, 328 skipped. All failures were outside the two changed Slack files and included unavailable optional SDKs/backends, WSL/runtime-specific expectations, live-gateway safety-guard failures, and one unrelated browser-wiring timeout.

## Checklist

- [x] I reviewed the focused diff.
- [x] I added regression tests for the bug.
- [x] I used the repository test wrapper.
- [x] I did not change callback values or the open-ended clarification flow.
