### PR TITLE
fix(desktop): fail closed when Bot Chat lookup returns zero rows

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat-registry.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat-registry.test.ts
@@ -280,4 +280,29 @@ describe('a failed lookup fails CLOSED — never "no chat exists"', () => {
     await expect(createCanonicalChat('ops')).rejects.toThrow(/Bot Chat registry/)
     expect(calls.some(call => call.method === 'session.create')).toBe(false)
   })
+
+  // #98383: a profile backend mid-restart can answer `session.list`
+  // SUCCESSFULLY with an empty list instead of throwing. `rows.find(...) ||
+  // null` used to read that identically to "this bot never had a chat",
+  // which minted a replacement and re-fired the kickoff on every click.
+  it('refuses to mint on an empty lookup when the roster already confirmed a canonical chat', async () => {
+    const calls = respondWith(method => {
+      if (method === 'session.list') {
+        return { sessions: [] }
+      }
+
+      if (method === 'session.create') {
+        throw new Error('must not create: an empty result is not confirmed absence')
+      }
+
+      return {}
+    })
+
+    const bot = { canonical_session: { id: 'forever-chat' }, name: 'ops' } as RosterRow
+    const { openBotCanonicalChat } = await loadModule()
+
+    await expect(openBotCanonicalChat(bot)).rejects.toThrow(/Bot Chat registry/)
+    expect(calls.some(call => call.method === 'session.create')).toBe(false)
+    expect(hostMock.openSession).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-chat.ts
@@ -211,8 +211,25 @@ async function findExistingCanonicalChat(owner: RosterRow | string): Promise<Can
   }
 
   const rows = res?.sessions ?? []
+  const match = rows.find(row => isCanonicalBotChatHistory(row))
 
-  return rows.find(row => isCanonicalBotChatHistory(row)) || null
+  if (match) {
+    return match
+  }
+
+  // A zero-row result is NOT the same as a thrown error, but it is just as
+  // capable of forking the forever chat: a profile backend mid-restart can
+  // answer `session.list` successfully with an empty list rather than
+  // failing it, and `|| null` used to read that identically to "this bot
+  // never had a chat" (#98383). The roster's own `canonical_session` is the
+  // last positive confirmation this profile HAD one — when that exists,
+  // an empty lookup is unconfirmed absence, not confirmed absence, so fail
+  // closed the same way a thrown RPC error already does instead of minting.
+  if (bot?.canonical_session?.id) {
+    throw new Error(`Could not confirm ${name}'s Bot Chat registry — not starting a new chat`)
+  }
+
+  return null
 }
 
 interface CreateCanonicalChatOptions {


### PR DESCRIPTION
Fixes #98383.

## What changed and why

`findExistingCanonicalChat()` (`apps/desktop/src/plugins/hermes-bots/canonical-chat.ts`)
already fails closed on a **thrown** `session.list` error — it never mints a
replacement Bot Chat in that case. But a profile backend mid-restart can
answer `session.list` **successfully with an empty `sessions` array** instead
of throwing, and the old code:

```ts
const rows = res?.sessions ?? []
return rows.find(row => isCanonicalBotChatHistory(row)) || null
```

maps that empty result to the exact same `null` that means "this bot has
never had a chat yet." The click path (`openBotCanonicalChat` →
`createCanonicalChat`) reads `null` as "no row → create it," so it minted a
brand-new "Bot Chat" session and re-submitted the kickoff intro — even though
the real, hidden, 213-message canonical row was intact the whole time. The
issue reporter saw this happen 6 times in ~90 minutes after a desktop
restart, orphaning 39 messages of in-progress work into an unreachable
session each time.

The fix distinguishes "confirmed absent" from "unconfirmed absent": the
roster's own `canonical_session` field (already fetched server-side via
`profiles.list`, and already read elsewhere for preview/activity/the
`/new`→`/compact` guard — see AGENTS.md's Bot Mode section) is the last
positive confirmation that this profile has a Bot Chat. When that's present
but the lookup comes back with zero rows, treat it as an unconfirmed/failed
lookup and throw the same fail-closed error a thrown RPC error already
produces, instead of returning `null` and letting the caller mint. Both
existing call sites (`plugin.tsx`, `roster-actions.ts`) already catch this
error and show a "try again" toast — no new UI plumbing needed.

This does not introduce any stored session-id pointer (which AGENTS.md's Bot
Mode section explicitly forbids reintroducing) — it only reads the
already-server-resolved `canonical_session` that ships on every roster row.

## How to test

Reproduction (from the issue): click a bot row while its profile backend is
mid-restart such that `session.list` returns `{ sessions: [] }` instead of
throwing, on a profile whose roster row already carries a `canonical_session`
— previously this minted a new "Bot Chat" and fired the kickoff intro;
now it throws and the existing "try again" toast fires instead.

Added a regression test,
`apps/desktop/src/plugins/hermes-bots/canonical-chat-registry.test.ts`
→ *"refuses to mint on an empty lookup when the roster already confirmed a
canonical chat"*, which fails without the fix (falls through to
`session.create`, tripping the test's "must not create" guard) and passes
with it.

```
$ npx vitest run src/plugins/hermes-bots/canonical-chat-registry.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)

$ npx vitest run src/plugins/hermes-bots
 Test Files  58 passed (58)
      Tests  560 passed (560)

$ npx eslint src/plugins/hermes-bots/canonical-chat.ts src/plugins/hermes-bots/canonical-chat-registry.test.ts
(clean)

$ npx tsc -p . --noEmit
(clean)
```

Confirmed the new test fails on the pre-fix source (`git checkout HEAD~1 --
apps/desktop/src/plugins/hermes-bots/canonical-chat.ts`):

```
AssertionError: expected [Function] to throw error matching /Bot Chat registry/
but got 'must not create: an empty result is not confirmed absence'
```

## Platforms tested

Linux (test suite only — no Desktop UI available in this environment).

## AI assistance disclosure

This patch was prepared with AI assistance (an autonomous coding agent), with
the diff, tests, and test output verified by running them locally as shown
above.
