### PR TITLE
fix(desktop-update): fall back to .venv in the posix hand-off (#98384)

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -235,6 +235,7 @@ start_ui() {
   [ "$NO_UI" -eq 1 ] && return
   local html="$SCRIPT_DIR/ui.html" py browser port="" i
   py="${INSTALL_ROOT:+$INSTALL_ROOT/venv/bin/python3}"
+  [ -x "${py:-/nonexistent}" ] || py="${INSTALL_ROOT:+$INSTALL_ROOT/.venv/bin/python3}"
   [ -x "${py:-/nonexistent}" ] || py="$(command -v python3 2>/dev/null)"
   browser="$(find_browser)"
   if [ -n "$browser" ] && [ -n "$py" ] && ! default_browser_is_chromium "$py"; then
@@ -562,6 +563,10 @@ sleep 1
 start_ui
 
 HERMES_BIN="$INSTALL_ROOT/venv/bin/hermes"
+# uv-default and shared-venv checkouts (doctor-verified healthy) use .venv
+# instead; mirror managed_uv.py's _default_live_venv() precedence rather than
+# telling a healthy install it needs repair.
+[ -x "$HERMES_BIN" ] || HERMES_BIN="$INSTALL_ROOT/.venv/bin/hermes"
 [ -x "$HERMES_BIN" ] || { FINAL_CODE=3 FINAL_MSG="Update aborted: $HERMES_BIN is missing. The install needs repair (run the Hermes installer or hermes doctor)."; log "$FINAL_MSG"; exit 3; }
 
 # Run FROM the install root: `hermes update` resolves the tree it mutates

--- a/tests/test_desktop_update_shim_progress.py
+++ b/tests/test_desktop_update_shim_progress.py
@@ -130,11 +130,11 @@ exit "$(cat "$HERMES_TEST_EXITS.$n" 2>/dev/null || echo 0)"
 """
 
 
-def _run_handoff(tmp_path, exits: dict[int, int]) -> list[dict]:
+def _run_handoff(tmp_path, exits: dict[int, int], venv_dir: str = "venv") -> list[dict]:
     """Run the real hand-off end to end; return the stage seen at each call."""
     install_root = tmp_path / "hermes-agent"
-    (install_root / "venv" / "bin").mkdir(parents=True)
-    hermes = install_root / "venv" / "bin" / "hermes"
+    (install_root / venv_dir / "bin").mkdir(parents=True)
+    hermes = install_root / venv_dir / "bin" / "hermes"
     hermes.write_text(FAKE_HERMES)
     hermes.chmod(0o755)
 
@@ -197,3 +197,14 @@ def test_retry_gate_publishes_a_distinct_stage(tmp_path):
         "Updating code and dependencies",
         "Retrying update",
     ]
+
+
+@requires_posix_handoff
+def test_dot_venv_layout_is_not_told_it_needs_repair(tmp_path):
+    """Shared-venv checkouts (doctor-verified healthy) ship only `.venv`, no
+    `venv` directory. The hand-off must still find and run `hermes` instead
+    of aborting with "the install needs repair"."""
+    stages = _run_handoff(tmp_path, {1: 0}, venv_dir=".venv")
+
+    assert len(stages) == 1
+    assert stages[0]["message"] == "Updating code and dependencies"


### PR DESCRIPTION
## Summary

Fixes #98384.

On macOS/Linux git-installs that use the shared-venv layout (the actual venv
lives at `~/.hermes/venvs/hermes`, and the checkout only has a `.venv ->
~/.hermes/venvs/hermes` symlink — a layout `hermes doctor` itself reports as
healthy), the desktop update hand-off in `scripts/desktop-update/posix.sh`
always aborted with:

> Update aborted: <root>/venv/bin/hermes is missing. The install needs
> repair (run the Hermes installer or hermes doctor).

`posix.sh` had two gates that only ever probed `venv/bin/`, with no
`.venv/bin/` fallback:

- `HERMES_BIN="$INSTALL_ROOT/venv/bin/hermes"` (the update gate, line ~564)
- `py="${INSTALL_ROOT:+$INSTALL_ROOT/venv/bin/python3}"` (the shim-UI
  interpreter, `start_ui()`, line ~237)

This is inconsistent with the rest of the codebase: `hermes doctor` and
`hermes_cli/managed_uv.py`'s `_default_live_venv()` both already probe `venv`
first and fall back to `.venv`. This PR makes `posix.sh` follow the same
precedence at both gates instead of telling a doctor-verified-healthy install
that it needs repair.

## Changes

- `scripts/desktop-update/posix.sh`: fall back to `.venv/bin/hermes` /
  `.venv/bin/python3` when `venv/bin/...` isn't executable, mirroring
  `_default_live_venv()`.
- `tests/test_desktop_update_shim_progress.py`: parameterize the existing
  end-to-end hand-off harness (`_run_handoff`) by venv directory, and add
  `test_dot_venv_layout_is_not_told_it_needs_repair`, which runs the real
  `posix.sh` against a `.venv`-only install root and asserts the update
  actually runs (rather than being rejected before `hermes` is ever invoked).

## Test plan

New test, run directly with `pytest` (no managed venv available in this
sandbox, so `scripts/run_tests.sh` itself wasn't runnable, but the test uses
the same real-subprocess harness as the existing suite in this file):

Before the fix (`git checkout HEAD~1 -- scripts/desktop-update/posix.sh`):
```
tests/test_desktop_update_shim_progress.py::test_dot_venv_layout_is_not_told_it_needs_repair FAILED
    assert len(stages) == 1
E   assert 0 == 1
E    +  where 0 = len([])
```
(0 stages seen — the gate rejected the `.venv`-only install before `hermes`
was ever invoked, i.e. the reported bug.)

After the fix:
```
tests/test_desktop_update_shim_progress.py::test_dot_venv_layout_is_not_told_it_needs_repair PASSED
======================= 6 passed, 3 errors in 5.10s ==========================
```

The 3 errors are pre-existing and unrelated: they come from
`tests/conftest.py`'s live-system `os.kill` guard firing during the
`progress` fixture's `proc.kill()` teardown for the three tests that use
that fixture. Confirmed identical on unmodified `HEAD` (5 passed, same 3
errors) before this change touched anything.

Also ran `shellcheck --severity=error scripts/desktop-update/posix.sh`: one
pre-existing SC2071 finding at an unrelated line (539), untouched by this
diff.

## AI assistance disclosure

This PR was prepared with AI assistance (an autonomous coding agent), with
the fix, test, and verification steps described above reviewed before
submission.
