### PR TITLE
fix(desktop-update): probe .venv fallback in posix.sh entry-point gate

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -235,6 +235,7 @@ start_ui() {
   [ "$NO_UI" -eq 1 ] && return
   local html="$SCRIPT_DIR/ui.html" py browser port="" i
   py="${INSTALL_ROOT:+$INSTALL_ROOT/venv/bin/python3}"
+  [ -x "${py:-/nonexistent}" ] || py="${INSTALL_ROOT:+$INSTALL_ROOT/.venv/bin/python3}"
   [ -x "${py:-/nonexistent}" ] || py="$(command -v python3 2>/dev/null)"
   browser="$(find_browser)"
   if [ -n "$browser" ] && [ -n "$py" ] && ! default_browser_is_chromium "$py"; then
@@ -561,8 +562,13 @@ fi
 sleep 1
 start_ui
 
+# Managed installs hold <root>/venv; uv-default/git layouts hold only a
+# <root>/.venv symlink into ~/.hermes/venvs — a layout `hermes doctor`
+# reports as healthy. Probe both before declaring the install broken,
+# mirroring _default_live_venv() (hermes_cli/managed_uv.py).
 HERMES_BIN="$INSTALL_ROOT/venv/bin/hermes"
-[ -x "$HERMES_BIN" ] || { FINAL_CODE=3 FINAL_MSG="Update aborted: $HERMES_BIN is missing. The install needs repair (run the Hermes installer or hermes doctor)."; log "$FINAL_MSG"; exit 3; }
+[ -x "$HERMES_BIN" ] || HERMES_BIN="$INSTALL_ROOT/.venv/bin/hermes"
+[ -x "$HERMES_BIN" ] || { FINAL_CODE=3 FINAL_MSG="Update aborted: neither $INSTALL_ROOT/venv/bin/hermes nor $INSTALL_ROOT/.venv/bin/hermes is present. The install needs repair (run the Hermes installer or hermes doctor)."; log "$FINAL_MSG"; exit 3; }
 
 # Run FROM the install root: `hermes update` resolves the tree it mutates
 # from the working directory, and we inherit the Desktop's cwd (which can be

--- a/tests/test_desktop_update_shim_progress.py
+++ b/tests/test_desktop_update_shim_progress.py
@@ -130,11 +130,11 @@ exit "$(cat "$HERMES_TEST_EXITS.$n" 2>/dev/null || echo 0)"
 """
 
 
-def _run_handoff(tmp_path, exits: dict[int, int]) -> list[dict]:
+def _run_handoff(tmp_path, exits: dict[int, int], venv_dir: str = "venv") -> list[dict]:
     """Run the real hand-off end to end; return the stage seen at each call."""
     install_root = tmp_path / "hermes-agent"
-    (install_root / "venv" / "bin").mkdir(parents=True)
-    hermes = install_root / "venv" / "bin" / "hermes"
+    (install_root / venv_dir / "bin").mkdir(parents=True)
+    hermes = install_root / venv_dir / "bin" / "hermes"
     hermes.write_text(FAKE_HERMES)
     hermes.chmod(0o755)
 
@@ -197,3 +197,46 @@ def test_retry_gate_publishes_a_distinct_stage(tmp_path):
         "Updating code and dependencies",
         "Retrying update",
     ]
+
+
+@requires_posix_handoff
+def test_update_gate_accepts_dot_venv_layout(tmp_path):
+    """Shared-venv installs keep only a `.venv` symlink in the checkout (the
+    layout `hermes doctor` reports as healthy); the entry-point gate must
+    probe it as a fallback instead of aborting with "needs repair" (#98384)."""
+    stages = _run_handoff(tmp_path, {1: 0}, venv_dir=".venv")
+
+    assert len(stages) == 1
+    assert stages[0]["status"] == "running"
+    assert stages[0]["message"] == "Updating code and dependencies"
+
+
+@requires_posix_handoff
+def test_missing_entry_point_still_fails_closed(tmp_path):
+    """Neither venv/ nor .venv/: the gate must keep failing closed with the
+    repair exit code instead of running an update with no entry point."""
+    install_root = tmp_path / "hermes-agent"
+    install_root.mkdir()
+
+    subprocess.run(
+        [
+            "/bin/bash",
+            str(SHIM_DIR / "posix.sh"),
+            "--install-root",
+            str(install_root),
+            "--no-ui",
+        ],
+        env={**os.environ, "TMPDIR": str(tmp_path)},
+        timeout=60,
+        check=True,
+    )
+
+    result = tmp_path / ".hermes-update-result.json"
+    deadline = time.monotonic() + 45
+    while time.monotonic() < deadline and not result.exists():
+        time.sleep(0.1)
+    assert result.exists(), "hand-off never wrote its result file"
+
+    payload = json.loads(result.read_text())
+    assert payload["ok"] is False
+    assert payload["exit_code"] == 3


### PR DESCRIPTION
## What does this PR do?

On git installs using the shared-venv layout (the real venv lives at `~/.hermes/venvs/hermes` and the checkout only holds a `.venv` symlink — the layout `hermes doctor` reports as healthy), the desktop update hand-off always aborted with exit 3 at the hermes-bin gate, because `scripts/desktop-update/posix.sh` hardcoded `<root>/venv/bin/hermes` with no dot-prefixed fallback.

This PR makes the gate probe `venv/bin/hermes` first and fall back to `.venv/bin/hermes` — the same convention `hermes doctor` and `_default_live_venv()` (`hermes_cli/managed_uv.py`) already honor — before declaring the install needs repair. `start_ui()`'s venv-python probe gets the same fallback so the update window prefers the install's own interpreter. The fail-closed abort is preserved (still exit 3) and its message now names both probe paths.

## Related Issue

Fixes #98384

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/desktop-update/posix.sh` hermes-bin gate: fall back from `$INSTALL_ROOT/venv/bin/hermes` to `$INSTALL_ROOT/.venv/bin/hermes` before aborting with exit 3; fail-closed message now lists both probe paths
- `scripts/desktop-update/posix.sh` `start_ui()`: probe `$INSTALL_ROOT/.venv/bin/python3` before falling back to `command -v python3`
- `tests/test_desktop_update_shim_progress.py`: `_run_handoff()` gained a `venv_dir` param (default `"venv"`, existing tests unchanged); added two end-to-end regression tests (below)

## How to Test

1. `python -m pytest tests/test_desktop_update_shim_progress.py -q`
2. Observed result: `7 passed` — the two new tests drive the real hand-off script end to end:
   - `test_update_gate_accepts_dot_venv_layout`: an install root with only `.venv/bin/hermes` now passes the gate and reaches the `"Updating code and dependencies"` stage (previously aborted exit 3 before any update ran)
   - `test_missing_entry_point_still_fails_closed`: an install root with neither `venv/` nor `.venv/` still aborts with `exit_code == 3` in the result file
3. Manual repro on macOS (shared-venv layout, no `venv/` dir): trigger a desktop update — the hand-off now proceeds past the gate instead of reporting "needs repair".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full run of the shim-progress suite: 7 passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — posix hand-off only (macOS/Linux); the Windows hand-off uses a fixed `venv\Scripts\` layout and is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A
