### PR TITLE
fix(config): honor provider-level custom_providers context_length on /model switch

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1891,11 +1891,12 @@ def get_custom_provider_context_length(
     custom_providers: Optional[List[Dict[str, Any]]] = None,
     config: Optional[Dict[str, Any]] = None,
 ) -> Optional[int]:
-    """Look up a per-model ``context_length`` override from ``custom_providers``.
+    """Look up a ``context_length`` override from ``custom_providers``.
 
     Matches any entry whose normalized route identity equals ``base_url`` and
     returns ``custom_providers[i].models.<model>.context_length`` if present and
-    valid.  Returns ``None`` when no override applies.
+    valid; when the per-model key is absent, falls back to the matched entry's
+    provider-level ``context_length``.  Returns ``None`` when neither applies.
 
     This is the single source of truth for custom-provider context overrides,
     used by:
@@ -1933,12 +1934,19 @@ def get_custom_provider_context_length(
         if not entry_url or entry_url != target_url:
             continue
         models = entry.get("models")
-        if not isinstance(models, dict):
-            continue
-        model_cfg = models.get(model)
-        if not isinstance(model_cfg, dict):
-            continue
-        raw_ctx = model_cfg.get("context_length")
+        model_cfg = models.get(model) if isinstance(models, dict) else None
+        raw_ctx = (
+            model_cfg.get("context_length")
+            if isinstance(model_cfg, dict)
+            else None
+        )
+        if raw_ctx is None:
+            # No per-model override for this id: honor the provider-level
+            # ``context_length`` declared on the entry itself. Without this
+            # fallback the /model-switch re-derivation — which consults this
+            # helper instead of ``model.context_length`` — silently drops the
+            # user's override and lands on the hardcoded catalog (#98387).
+            raw_ctx = entry.get("context_length")
         if raw_ctx is None:
             continue
         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1896,7 +1896,11 @@ def get_custom_provider_context_length(
     Matches any entry whose normalized route identity equals ``base_url`` and
     returns ``custom_providers[i].models.<model>.context_length`` if present and
     valid; when the per-model key is absent, falls back to the matched entry's
-    provider-level ``context_length``.  Returns ``None`` when neither applies.
+    provider-level ``context_length``, provided the entry either declares no
+    ``model`` pin or its pin equals ``model`` (a pinned entry is scoped to its
+    own id, so sibling models on the same route cannot inherit it).  Values are
+    accepted only as true positive integers — ``bool`` is rejected because it
+    is an ``int`` subclass in Python.  Returns ``None`` when neither applies.
 
     This is the single source of truth for custom-provider context overrides,
     used by:
@@ -1946,8 +1950,19 @@ def get_custom_provider_context_length(
             # fallback the /model-switch re-derivation — which consults this
             # helper instead of ``model.context_length`` — silently drops the
             # user's override and lands on the hardcoded catalog (#98387).
+            # An entry that pins a specific ``model`` is scoped to that id:
+            # its entry-level value must not leak into a sibling model that
+            # merely shares the same normalized route.
+            declared = entry.get("model")
+            if isinstance(declared, str) and declared and declared != model:
+                continue
             raw_ctx = entry.get("context_length")
         if raw_ctx is None:
+            continue
+        if isinstance(raw_ctx, bool):
+            # bool is an int subclass: int(True) == 1 would silently turn a
+            # true/false typo into a 1-token (or 0) context window instead
+            # of falling through to the catalog chain.
             continue
         try:
             ctx = int(raw_ctx)

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -52,6 +52,86 @@ class TestGetCustomProviderContextLength:
         assert get_custom_provider_context_length("m", "http://x", []) is None
 
 
+class TestEntryLevelContextLengthFallback:
+    """The provider-level ``context_length`` key must be honored when the
+    per-model ``models.<id>.context_length`` lookup misses (#98387).
+
+    The ``/model`` switch re-derivation consults this helper instead of the
+    top-level ``model.context_length``, so dropping the entry-level key
+    made every switch to a relay-hosted model fall through to the hardcoded
+    catalog even though the user configured an explicit override.
+    """
+
+    def test_entry_level_used_when_model_not_in_models_dict(self):
+        """The reporter's shape: entry-level override set, but ``models:``
+        only lists *other* models — the queried id must still resolve."""
+        custom = [
+            {
+                "base_url": "https://relay.example.invalid/v1",
+                "model": "glm-5.3-flash",
+                "context_length": 1_000_000,
+                "models": {"other/model": {"context_length": 1_000_000}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "glm-5.3-flash", "https://relay.example.invalid/v1", custom
+            )
+            == 1_000_000
+        )
+
+    def test_entry_level_used_when_models_dict_absent(self):
+        """Entries without a ``models`` mapping at all used to be skipped
+        entirely, hiding their entry-level override."""
+        custom = [{"base_url": "https://x.invalid/v1", "context_length": 200_000}]
+        assert (
+            get_custom_provider_context_length(
+                "any-model", "https://x.invalid/v1", custom
+            )
+            == 200_000
+        )
+
+    def test_per_model_override_wins_over_entry_level(self):
+        custom = [
+            {
+                "base_url": "https://x.invalid/v1",
+                "context_length": 111_111,
+                "models": {"m": {"context_length": 222_222}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length("m", "https://x.invalid/v1", custom)
+            == 222_222
+        )
+
+    def test_invalid_entry_level_value_falls_through(self):
+        """Zero/negative/non-int entry-level values stay ignored instead of
+        poisoning resolution — resolver falls back to the catalog chain."""
+        for bad in (0, -5, "huge"):
+            custom = [{"base_url": "https://x.invalid/v1", "context_length": bad}]
+            assert (
+                get_custom_provider_context_length(
+                    "m", "https://x.invalid/v1", custom
+                )
+                is None
+            ), bad
+
+    def test_entry_level_is_route_isolated(self):
+        """The entry-level override must not leak across routes."""
+        custom = [
+            {
+                "base_url": "https://other.example.invalid/v1",
+                "context_length": 1_000_000,
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "m", "https://example.invalid/v1", custom
+            )
+            is None
+        )
+
+
 class TestGetCustomProviderModelCapability:
     def test_matches_exact_model_on_normalized_route(self):
         custom = [
@@ -160,6 +240,33 @@ class TestGetModelContextLengthHonorsOverride:
             for p in patches:
                 p.stop()
         assert ctx == 1_050_000
+
+    def test_entry_level_override_wins_over_default_fallback(self):
+        """Step 0b must also honor the entry-level context_length when the
+        per-model lookup misses — the /model-switch path (which passes
+        ``config_context_length=None``) depends on it (#98387)."""
+        from agent.model_metadata import get_model_context_length
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "context_length": 1_000_000,
+            }
+        ]
+        patches = self._mock_all_probes()
+        for p in patches:
+            p.start()
+        try:
+            ctx = get_model_context_length(
+                "glm-5.3-flash",
+                base_url="https://example.invalid/v1",
+                provider="custom",
+                config_context_length=None,
+                custom_providers=custom,
+            )
+        finally:
+            for p in patches:
+                p.stop()
+        assert ctx == 1_000_000
 
     def test_explicit_config_context_length_still_wins(self):
         """Top-level model.context_length (step 0) outranks custom_providers (step 0b).

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -105,9 +105,12 @@ class TestEntryLevelContextLengthFallback:
         )
 
     def test_invalid_entry_level_value_falls_through(self):
-        """Zero/negative/non-int entry-level values stay ignored instead of
-        poisoning resolution — resolver falls back to the catalog chain."""
-        for bad in (0, -5, "huge"):
+        """Zero/negative/non-int/boolean entry-level values stay ignored
+        instead of poisoning resolution — resolver falls back to the catalog
+        chain. ``True``/``False`` must be rejected explicitly: bool is an int
+        subclass in Python, so a true/false typo would otherwise parse as a
+        1-token (or 0) window instead of falling through."""
+        for bad in (0, -5, "huge", True, False):
             custom = [{"base_url": "https://x.invalid/v1", "context_length": bad}]
             assert (
                 get_custom_provider_context_length(
@@ -115,6 +118,20 @@ class TestEntryLevelContextLengthFallback:
                 )
                 is None
             ), bad
+
+    def test_boolean_per_model_value_falls_through(self):
+        """The strict non-boolean integer contract applies to per-model
+        overrides too — the two levels share one validation chain."""
+        custom = [
+            {
+                "base_url": "https://x.invalid/v1",
+                "models": {"m": {"context_length": True}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length("m", "https://x.invalid/v1", custom)
+            is None
+        )
 
     def test_entry_level_is_route_isolated(self):
         """The entry-level override must not leak across routes."""
@@ -129,6 +146,72 @@ class TestEntryLevelContextLengthFallback:
                 "m", "https://example.invalid/v1", custom
             )
             is None
+        )
+
+    def test_same_route_pinned_entries_are_model_isolated(self):
+        """Two entries sharing one normalized route, each pinning a different
+        ``model`` with its own entry-level ``context_length``: each id must
+        resolve to its own entry's value, never the sibling's — otherwise the
+        first matching entry leaks its context limit into the other model
+        during a /model switch."""
+        def resolve(entries, model):
+            return get_custom_provider_context_length(
+                model, "https://relay.example.invalid/v1", entries
+            )
+
+        forward = [
+            {
+                "base_url": "https://relay.example.invalid/v1",
+                "model": "model-a",
+                "context_length": 100_000,
+            },
+            {
+                "base_url": "https://relay.example.invalid/v1",
+                "model": "model-b",
+                "context_length": 200_000,
+            },
+        ]
+        assert resolve(forward, "model-a") == 100_000
+        assert resolve(forward, "model-b") == 200_000
+
+        reversed_order = list(reversed(forward))
+        assert resolve(reversed_order, "model-a") == 100_000
+        assert resolve(reversed_order, "model-b") == 200_000
+
+    def test_unpinned_entry_level_applies_route_wide(self):
+        """Documented counterpart of the isolation rule: an entry with no
+        ``model`` pin makes its entry-level value apply to every model on
+        that route, because the entry claims the whole route."""
+        custom = [{"base_url": "https://x.invalid/v1", "context_length": 150_000}]
+        assert (
+            get_custom_provider_context_length(
+                "model-a", "https://x.invalid/v1", custom
+            )
+            == 150_000
+        )
+        assert (
+            get_custom_provider_context_length(
+                "model-b", "https://x.invalid/v1", custom
+            )
+            == 150_000
+        )
+
+    def test_pinned_sibling_does_not_shadow_unpinned_entry(self):
+        """A pinned sibling must not consume the lookup for other models:
+        resolution continues to a later unpinned entry on the same route."""
+        custom = [
+            {
+                "base_url": "https://x.invalid/v1",
+                "model": "model-a",
+                "context_length": 100_000,
+            },
+            {"base_url": "https://x.invalid/v1", "context_length": 300_000},
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "model-b", "https://x.invalid/v1", custom
+            )
+            == 300_000
         )
 
 
@@ -267,6 +350,56 @@ class TestGetModelContextLengthHonorsOverride:
             for p in patches:
                 p.stop()
         assert ctx == 1_000_000
+
+    def test_same_route_entry_level_keeps_model_identity_through_resolver(self):
+        """End-to-end for the same-route fixture: with ``config_context_length``
+        unset (the /model-switch shape) each model's entry-level override must
+        survive the full resolver chain — with every catalog probe mocked —
+        proving the caller keeps model identity, not just the helper's local
+        return value. An explicit top-level value (cold-startup shape) still
+        wins per the documented precedence."""
+        from agent.model_metadata import get_model_context_length
+        custom = [
+            {
+                "base_url": "https://relay.example.invalid/v1",
+                "model": "model-a",
+                "context_length": 100_000,
+            },
+            {
+                "base_url": "https://relay.example.invalid/v1",
+                "model": "model-b",
+                "context_length": 200_000,
+            },
+        ]
+        patches = self._mock_all_probes()
+        for p in patches:
+            p.start()
+        try:
+            for model_id, expected in (("model-a", 100_000), ("model-b", 200_000)):
+                ctx = get_model_context_length(
+                    model_id,
+                    base_url="https://relay.example.invalid/v1",
+                    provider="custom",
+                    config_context_length=None,
+                    custom_providers=custom,
+                )
+                assert ctx == expected, model_id
+        finally:
+            for p in patches:
+                p.stop()
+
+        # Cold-startup shape: an explicit top-level model.context_length
+        # still outranks the entry-level override (documented precedence).
+        assert (
+            get_model_context_length(
+                "model-b",
+                base_url="https://relay.example.invalid/v1",
+                provider="custom",
+                config_context_length=500_000,
+                custom_providers=custom,
+            )
+            == 500_000
+        )
 
     def test_explicit_config_context_length_still_wins(self):
         """Top-level model.context_length (step 0) outranks custom_providers (step 0b).


### PR DESCRIPTION
## What does this PR do?

`get_custom_provider_context_length()` only consulted `custom_providers[i].models.<model>.context_length`. When that per-model key was absent, the entry-level `context_length` declared on the same provider entry (a documented, accepted key — it is in the normalizer's known keys and has a camelCase alias) was silently dropped. The `/model` switch re-derivation in `agent_runtime_helpers.switch_model` deliberately clears `_config_context_length` and re-derives intent through this helper, so every switch to a relay-hosted model fell through to the hardcoded catalog (e.g. `"glm": 202752`) even though the user configured an explicit 1M override — cold start with the same model resolved correctly via `model.context_length`.

This PR makes the helper fall back to the matched entry's provider-level `context_length` when the per-model lookup misses. Per-model values keep priority, and invalid entry-level values (<=0 or non-int) keep falling through to the normal resolution chain, so no new failure mode is introduced. All five call sites listed in the helper's docstring (startup, `/model` switch, `/model` display, `/info` display, `get_model_context_length` step 0b) benefit from the single-function fix.

## Related Issue

Fixes #98387

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` `get_custom_provider_context_length()`: when the per-model `models.<id>.context_length` lookup misses (no `models` dict, model not listed, or key absent), fall back to the matched entry's provider-level `context_length` instead of skipping the entry; docstring updated to describe the fallback
- `tests/hermes_cli/test_custom_provider_context_length.py`: added `TestEntryLevelContextLengthFallback` (reporter's exact config shape, no-models-dict entry, per-model priority over entry-level, invalid entry-level values still ignored, route isolation) plus a step-0b end-to-end case where the entry-level override wins over the catalog fallback with `config_context_length=None`

## How to Test

1. Offline repro of the issue's exact shape (fresh process, no live endpoint needed):
   ```python
   from hermes_cli.config import get_compatible_custom_providers, get_custom_provider_context_length
   config = {
       "model": {"default": "glm-5.3-flash", "provider": "custom", "base_url": "http://relay.local/v1", "context_length": 1000000},
       "custom_providers": [{"name": "my-relay", "base_url": "http://relay.local/v1", "model": "glm-5.3-flash", "context_length": 1000000, "models": {"other/model": {"context_length": 1000000}}}],
   }
   cps = get_compatible_custom_providers(config)
   print(get_custom_provider_context_length("glm-5.3-flash", "http://relay.local/v1", cps))
   ```
   Observed result: before this PR returns `None` (switch path then lands on 202,752); after this PR returns `1000000`.
2. `python -m pytest tests/hermes_cli/test_custom_provider_context_length.py -v` — Observed result: 15 passed (9 pre-existing + 6 new).
3. `python -m pytest tests/hermes_cli/test_custom_provider_context_length.py tests/hermes_cli/test_model_switch_context_display.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_apply_model_switch_result_context.py tests/run_agent/test_switch_model_context.py tests/hermes_cli/test_main_model_custom_provider_normalization.py tests/hermes_cli/test_custom_provider_normalize_no_mutate.py tests/agent/test_model_metadata.py -q` — Observed result: 228 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted + adjacent surfaces: 243 tests passed across 10 files)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring in `get_custom_provider_context_length` now describes the fallback; the entry-level key was already an accepted config key
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new key; existing key now honored)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python dict lookup, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Offline repro on the fix branch (issue's exact config shape):

```
cold-start path      : 1000000
switch helper        : 1000000
switch path (fixed)  : 1000000
OK — #98387 repro now resolves to 1M on the switch path
```