### PR TITLE
fix(update): wait out transient STOP_PENDING/START_PENDING in SCM gateway discovery

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1061,7 +1061,35 @@ def find_windows_gateway_services(
         if profile_processes is None:
             profile_processes = find_profile_gateway_processes(strict=True)
         service_names_by_pid: dict[int, set[str]] = {}
-        indeterminate_services_by_pid: dict[int, list[tuple[str, object]]] = {}
+        # Transient states (STOP_PENDING/START_PENDING) are re-polled instead of
+        # raising immediately — an unrelated service cycling through them must
+        # not abort the update (#98378), mirroring update_cmd's
+        # _restore_windows_gateway_service. Genuine errors still fail closed.
+        transient_services_by_pid: dict[int, list[tuple[str, object]]] = {}
+
+        def _re_poll_service_status(current_service, current_status):
+            """Return a stable status, waiting out the transient state.
+
+            Polls only this one service (never the whole SCM) at 0.2s
+            intervals until a ~10s deadline. ``None`` means the service is
+            gone or became re-inspectable as stable/unknown at the deadline;
+            the caller then re-reads it through the normal path.
+            """
+            if current_status not in ("stop_pending", "start_pending"):
+                return current_status
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                time.sleep(0.2)
+                try:
+                    polled_status = current_service.status()
+                except FileNotFoundError:
+                    return None
+                except Exception:
+                    return current_status
+                if polled_status not in ("stop_pending", "start_pending"):
+                    return polled_status
+            return None
+
         for service in psutil_module.win_service_iter():
             try:
                 if all(
@@ -1084,11 +1112,26 @@ def find_windows_gateway_services(
                 raise RuntimeError("SCM service inspection failed") from exc
             if not service_name:
                 raise RuntimeError("SCM service has an empty name")
+            settled_status = _re_poll_service_status(service, service_status)
+            if settled_status is None:
+                try:
+                    data = service.as_dict()
+                    service_status = data.get("status")
+                    service_pid = int(data.get("pid") or 0)
+                except FileNotFoundError:
+                    # The service was deleted between enumeration and
+                    # inspection; it cannot still supervise a live gateway
+                    # tree.
+                    continue
+                except Exception as exc:
+                    raise RuntimeError("SCM service inspection failed") from exc
+            else:
+                service_status = settled_status
             if service_status == "stopped":
                 continue
             if service_status != "running":
                 if service_pid > 0:
-                    indeterminate_services_by_pid.setdefault(service_pid, []).append(
+                    transient_services_by_pid.setdefault(service_pid, []).append(
                         (service_name, service_status)
                     )
                 continue
@@ -1111,9 +1154,9 @@ def find_windows_gateway_services(
                 raise RuntimeError("Gateway process identity changed during SCM discovery")
             ancestor_pids = [int(parent.pid) for parent in gateway_process.parents()]
             for pid in ancestor_pids:
-                indeterminate_services = indeterminate_services_by_pid.get(pid, [])
-                if indeterminate_services:
-                    service_name, service_status = indeterminate_services[0]
+                transient_services = transient_services_by_pid.get(pid, [])
+                if transient_services:
+                    service_name, service_status = transient_services[0]
                     raise RuntimeError(
                         f"SCM service {service_name} has indeterminate status: "
                         f"{service_status}"

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1093,11 +1093,136 @@ def test_find_windows_gateway_services_rejects_transitional_ancestor(monkeypatch
         Process=FakeProcess,
     )
 
+    # The transitional status persists past the bounded wait: fail-closed.
+    # time.sleep is called once before the first re-poll and time.monotonic()
+    # twice per loop iteration (while check + deadline), so two monotonic
+    # steps keep the loop alive for exactly one status probe before the
+    # deadline trips — the re-poll is exercised without a real 10s wait.
+    clock = iter([0.0, 0.0, 99.0, 99.0])
+    monkeypatch.setattr(gateway.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(gateway.time, "sleep", lambda *_a: None)
+
     with pytest.raises(RuntimeError, match="indeterminate status: stop_pending"):
         gateway.find_windows_gateway_services(
             psutil_module=fake_psutil,
             profile_processes=[profile],
         )
+
+
+def test_find_windows_gateway_services_waits_out_stop_pending_to_stopped(monkeypatch):
+    """A transient stop_pending ancestor that settles stopped must not abort discovery (#98378)."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, name, pid):
+            self._name = name
+            self._pid = pid
+            self._statuses = iter(["stop_pending", "stopped"])
+
+        def name(self):
+            return self._name
+
+        def pid(self):
+            return self._pid
+
+        def status(self):
+            return next(self._statuses)
+
+        def as_dict(self):
+            return {"name": self._name, "pid": self._pid, "status": "stop_pending"}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(100)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService("BcastDVRUserService_12345", 100)],
+        Process=FakeProcess,
+    )
+    monkeypatch.setattr(gateway.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(gateway.time, "sleep", lambda *_a: None)
+
+    # The settled-stopped service is ignored: discovery completes with no
+    # service ownership rather than raising and aborting the update.
+    assert gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil,
+        profile_processes=[profile],
+    ) == []
+
+
+def test_find_windows_gateway_services_stop_pending_settling_running_is_registered(
+    monkeypatch,
+):
+    """A stop_pending service that settles running registers normally, including in ancestry."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, name, pid):
+            self._name = name
+            self._pid = pid
+            self._statuses = iter(["stop_pending", "running"])
+
+        def name(self):
+            return self._name
+
+        def pid(self):
+            return self._pid
+
+        def status(self):
+            return next(self._statuses)
+
+        def as_dict(self):
+            return {"name": self._name, "pid": self._pid, "status": "running"}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(100)]
+
+        def children(self, recursive=False):
+            assert self.pid == 100
+            assert recursive is True
+            return [FakeProcess(300)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService("HermesGateway", 100)],
+        Process=FakeProcess,
+    )
+    monkeypatch.setattr(gateway.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(gateway.time, "sleep", lambda *_a: None)
+
+    # The service settles running BEFORE its descendant walk, so every
+    # identity timestamp is read live (pid 100 → 100.0, pid 300 → 300.0).
+    result = gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil,
+        profile_processes=[profile],
+    )
+
+    assert result == [
+        gateway.WindowsGatewayService(
+            name="HermesGateway",
+            profile="default",
+            service_pid=100,
+            gateway_pid=300,
+            descendant_pids=frozenset({300}),
+            descendant_identities=((300, 300.0),),
+            service_create_time=100.0,
+            gateway_create_time=300.0,
+        )
+    ]
 
 
 def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypatch):


### PR DESCRIPTION
## What

On Windows, an unrelated service sitting in `STOP_PENDING`/`START_PENDING` could abort the entire update via SCM gateway discovery. `find_windows_gateway_services()` now waits out the transient state on that one service instead of raising immediately, closing #98378.

## Root cause

`hermes_cli/gateway.py::find_windows_gateway_services()` classified every service status that is neither `running` nor `stopped` — including the *transient* `stop_pending`/`start_pending` — as indeterminate, and hard-raised if such a service's PID appeared anywhere in a validated gateway's ancestor chain. Per-user services like `BcastDVRUserService_*` cycle through `STOP_PENDING` routinely, and svchost ancestry sharing makes an unrelated pending service's PID show up in that chain by coincidence. The update then dies with `SCM service <name> has indeterminate status: stop_pending` even though the service settles on its own within moments.

The codebase already treats these states as wait-and-retry in the restore path (`update_cmd._restore_windows_gateway_service`); the discovery path just never got the same treatment.

## Fix

When the enumeration sees `stop_pending`/`start_pending` for a service with a live PID, re-poll **that one service** (0.2 s interval, ~10 s bound — nothing else in the scan grows a wait):

- settles **stopped** → skipped (a stopped service can't supervise a live gateway)
- settles **running** → registered normally, with the re-read status/pid flowing into the ownership checks
- service **deleted** mid-wait → skipped, same as the existing `FileNotFoundError` handling
- still pending / unknown at the deadline, or any genuinely-uninspectable state → raises exactly as before

Everything fail-closed stays fail-closed: empty names, running-without-PID, shared-host ambiguity, identity-change, and non-transitional indeterminate statuses are untouched (the pre-existing `test_find_windows_gateway_services_rejects_transitional_ancestor` now pins the still-pending-past-deadline case).

Contributes to #98378 (direction 1 — wait it out — from the issue's suggested directions). Not claiming `Closes`: the issue's repro is timing-dependent, so final confirmation should come from the reporter's real update attempts.

## Tests

`tests/hermes_cli/test_gateway.py`:
- `..._waits_out_stop_pending_to_stopped` — transient ancestor settles `stopped` → discovery completes, no raise
- `..._stop_pending_settling_running_is_registered` — settles `running` → registered with full service/PID/identity contract
- `..._rejects_transitional_ancestor` — updated to pin a *fake clock* (no real sleeping), so it now genuinely exercises the bounded wait and still fail-closes

```
uv run --with pytest --with python-dotenv python -m pytest \
  tests/hermes_cli/test_gateway.py tests/hermes_cli/test_update_concurrent_quarantine.py \
  tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py -q
68 passed, 5 skipped, 3 failed
```

The 3 failures (`TestReapUnsupervisedGatewayOrphans*`, `TestReaperCandidateIsSupervisorOwned`) fail identically on a pristine `origin/main` worktree at 26350357d7 on this machine — pre-existing, environment-dependent, and untouched by this diff.
