### PR TITLE
fix(desktop): stop the HUD transcript-band probe once the viewport mounts

### DIFF
--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -13,9 +13,9 @@ import { useHudClickThrough } from './click-through'
 import { useHudGameOverlay } from './game-overlay'
 import { useHudGlass } from './glass'
 import { useHudGoto, useReportHudSession } from './handoff'
-import { hudTranscriptHeight } from './layout'
 import { hudResizeDirections, useHudResizeHandle } from './resize-handle'
 import { useHudThreadFocus } from './thread-focus'
+import { useHudTranscriptBand } from './transcript-band'
 
 /** How long the transcript lingers at its glanceable opacity — after a turn
  *  lands, or after you let go of the composer — before it goes. This is the ONLY
@@ -38,11 +38,6 @@ const HUD_DIM_MS = Math.round(HUD_FADE_MS * 1.5)
  *  while the last of the text is still going — it reads as the transcript being
  *  drawn down into the bar rather than the two dissolving in lockstep. */
 const HUD_COLLAPSE_MS = Math.round(HUD_FADE_MS * 0.66)
-
-/** Breathing room the sheet keeps above the first row, so the fade has
- *  somewhere to land. Folded into the measured height rather than added in CSS,
- *  so an empty transcript measures a true zero instead of a 12px strip. */
-const HUD_SHEET_OVERHANG_PX = 12
 
 /** Composer on top, transcript always hanging below it — Spotlight's shape,
  *  rather than flipping to follow the screen edge the HUD is parked against. */
@@ -275,6 +270,8 @@ export function HudShell() {
     }
   }, [])
 
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
   // Whether bar + band actually cover the window. Gates the frost, which is
   // native vibrancy and therefore the WINDOW's content view — it fills the whole
   // rectangle and nothing in the page can clip it to the sheet. Whenever the
@@ -282,91 +279,7 @@ export function HudShell() {
   // a grey slab hanging under the bar with nothing in it. Now that the band is
   // capped it almost never covers the window, so this is almost always false —
   // which is correct, and asking anything looser paints the slab back.
-  const [filled, setFilled] = useState(false)
-  const rootRef = useRef<HTMLDivElement | null>(null)
-
-  useEffect(() => {
-    const root = rootRef.current
-
-    if (!root) {
-      return
-    }
-
-    let viewport: HTMLElement | null = null
-    const ro = new ResizeObserver(() => measure())
-
-    const measure = () => {
-      const el = viewport ?? root.querySelector<HTMLElement>('[data-slot="aui_thread-viewport"]')
-
-      if (el !== viewport) {
-        viewport = el
-
-        if (el) {
-          ro.observe(el)
-
-          if (el.firstElementChild) {
-            ro.observe(el.firstElementChild)
-          }
-        }
-      }
-
-      // How tall the band actually needs to be — the tight bbox of the message
-      // rows only. Measuring to the viewport edge counted the full-window scroll
-      // container (min-height: 100%) as transcript and painted a empty slab almost
-      // the size of the HUD.
-      const rows = el?.querySelectorAll<HTMLElement>('[data-slot="aui_thread-content"] > *:not([data-slot])')
-
-      // Zero-height rows are not a transcript. A fresh thread still renders
-      // scaffolding inside the content box (clearance, empty state), so
-      // counting rows alone paid the overhang for nothing and left a sliver of
-      // sheet hanging under the bar with no text in it.
-      const text = !rows?.length
-        ? 0
-        : Math.max(0, rows[rows.length - 1].getBoundingClientRect().bottom - rows[0].getBoundingClientRect().top)
-
-      const contentSpan = text < 1 ? 0 : text + HUD_SHEET_OVERHANG_PX
-
-      // Once the HUD has a transcript, a resize must buy readable scrollback.
-      // The old glance-band ceiling froze this at 152px and turned every extra
-      // pixel of native window height into empty transparent chrome.
-      const visible = hudTranscriptHeight({
-        barHeight: root.querySelector<HTMLElement>('[data-slot="composer-dock"]')?.getBoundingClientRect().height ?? 0,
-        contentHeight: contentSpan,
-        viewportHeight: window.innerHeight
-      })
-
-      root.style.setProperty('--hud-band-height', `${visible}px`)
-
-      // …and the bar's real height, which is what the thread has to clear.
-      // --composer-measured-height would be the obvious source, but it is a
-      // surface var that never lands here, so the clearance silently fell back
-      // to the root estimate and reserved ~20px more than the bar occupies —
-      // a visible hole under the last message.
-      const bar = root.querySelector<HTMLElement>('[data-slot="composer-dock"]')
-      const barHeight = bar?.getBoundingClientRect().height ?? 0
-
-      if (bar) {
-        ro.observe(bar)
-        root.style.setProperty('--hud-bar-height', `${Math.round(barHeight)}px`)
-      }
-
-      setFilled(barHeight + visible >= window.innerHeight - 1)
-    }
-
-    // The viewport mounts async (lazy chat surface); poll briefly until it
-    // exists, then let the ResizeObserver own it. Window resize is separate:
-    // the transcript's rows may not change size, but the available scrollback
-    // must, so observing the rows alone cannot update the band.
-    measure()
-    const probe = setInterval(measure, 500)
-    window.addEventListener('resize', measure)
-
-    return () => {
-      clearInterval(probe)
-      window.removeEventListener('resize', measure)
-      ro.disconnect()
-    }
-  }, [])
+  const filled = useHudTranscriptBand(rootRef)
 
   useHudGlass(rootRef, filled)
   useHudClickThrough(rootRef)

--- a/apps/desktop/src/app/hud/transcript-band.test.tsx
+++ b/apps/desktop/src/app/hud/transcript-band.test.tsx
@@ -1,0 +1,64 @@
+import { act, render } from '@testing-library/react'
+import { useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { stubResizeObserver } from '@/test/jsdom'
+
+import { useHudTranscriptBand } from './transcript-band'
+
+function Harness({ withViewport }: { withViewport: boolean }) {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  useHudTranscriptBand(ref)
+
+  return (
+    <div ref={ref}>
+      <div data-slot="composer-dock" />
+      {withViewport && (
+        <div data-slot="aui_thread-viewport">
+          <div data-slot="aui_thread-content">
+            <div>row</div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+beforeEach(() => {
+  stubResizeObserver()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useHudTranscriptBand', () => {
+  // The bug this replaced: the probe polled every 500ms for the lifetime of
+  // the HUD window, duplicating every measurement the ResizeObserver already
+  // owned once the viewport existed — a permanent idle timer firing re-renders
+  // forever instead of the "poll briefly, then hand off" the code documented.
+  it('stops polling once the viewport mounts', () => {
+    const measureSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+    const { rerender } = render(<Harness withViewport={false} />)
+    const beforeWaiting = measureSpy.mock.calls.length
+
+    act(() => vi.advanceTimersByTime(500))
+    act(() => vi.advanceTimersByTime(500))
+    const whileWaiting = measureSpy.mock.calls.length
+
+    expect(whileWaiting).toBeGreaterThan(beforeWaiting)
+
+    rerender(<Harness withViewport />)
+    act(() => vi.advanceTimersByTime(500))
+    const justAfterFound = measureSpy.mock.calls.length
+
+    expect(justAfterFound).toBeGreaterThan(whileWaiting)
+
+    act(() => vi.advanceTimersByTime(10_000))
+    const muchLater = measureSpy.mock.calls.length
+
+    expect(muchLater).toBe(justAfterFound)
+  })
+})

--- a/apps/desktop/src/app/hud/transcript-band.ts
+++ b/apps/desktop/src/app/hud/transcript-band.ts
@@ -1,0 +1,117 @@
+import { type RefObject, useEffect, useState } from 'react'
+
+import { hudTranscriptHeight } from './layout'
+
+/** Breathing room the sheet keeps above the first row, so the fade has
+ *  somewhere to land. Folded into the measured height rather than added in CSS,
+ *  so an empty transcript measures a true zero instead of a 12px strip. */
+const HUD_SHEET_OVERHANG_PX = 12
+
+/**
+ * Measures the HUD's transcript band and publishes it as `--hud-band-height` /
+ * `--hud-bar-height` on the root, returning whether the band + bar fill the
+ * window (which gates the frost — see `useHudGlass`).
+ *
+ * The viewport mounts async (lazy chat surface); poll briefly until it exists,
+ * then let the ResizeObserver own it. Window resize is separate: the
+ * transcript's rows may not change size, but the available scrollback must, so
+ * observing the rows alone cannot update the band.
+ */
+export function useHudTranscriptBand(rootRef: RefObject<HTMLDivElement | null>): boolean {
+  const [filled, setFilled] = useState(false)
+
+  useEffect(() => {
+    const root = rootRef.current
+
+    if (!root) {
+      return
+    }
+
+    let viewport: HTMLElement | null = null
+    const ro = new ResizeObserver(() => measure())
+
+    const measure = () => {
+      const el = viewport ?? root.querySelector<HTMLElement>('[data-slot="aui_thread-viewport"]')
+
+      if (el !== viewport) {
+        viewport = el
+
+        if (el) {
+          ro.observe(el)
+
+          if (el.firstElementChild) {
+            ro.observe(el.firstElementChild)
+          }
+        }
+      }
+
+      // How tall the band actually needs to be — the tight bbox of the message
+      // rows only. Measuring to the viewport edge counted the full-window scroll
+      // container (min-height: 100%) as transcript and painted a empty slab almost
+      // the size of the HUD.
+      const rows = el?.querySelectorAll<HTMLElement>('[data-slot="aui_thread-content"] > *:not([data-slot])')
+
+      // Zero-height rows are not a transcript. A fresh thread still renders
+      // scaffolding inside the content box (clearance, empty state), so
+      // counting rows alone paid the overhang for nothing and left a sliver of
+      // sheet hanging under the bar with no text in it.
+      const text = !rows?.length
+        ? 0
+        : Math.max(0, rows[rows.length - 1].getBoundingClientRect().bottom - rows[0].getBoundingClientRect().top)
+
+      const contentSpan = text < 1 ? 0 : text + HUD_SHEET_OVERHANG_PX
+
+      // Once the HUD has a transcript, a resize must buy readable scrollback.
+      // The old glance-band ceiling froze this at 152px and turned every extra
+      // pixel of native window height into empty transparent chrome.
+      const visible = hudTranscriptHeight({
+        barHeight: root.querySelector<HTMLElement>('[data-slot="composer-dock"]')?.getBoundingClientRect().height ?? 0,
+        contentHeight: contentSpan,
+        viewportHeight: window.innerHeight
+      })
+
+      root.style.setProperty('--hud-band-height', `${visible}px`)
+
+      // …and the bar's real height, which is what the thread has to clear.
+      // --composer-measured-height would be the obvious source, but it is a
+      // surface var that never lands here, so the clearance silently fell back
+      // to the root estimate and reserved ~20px more than the bar occupies —
+      // a visible hole under the last message.
+      const bar = root.querySelector<HTMLElement>('[data-slot="composer-dock"]')
+      const barHeight = bar?.getBoundingClientRect().height ?? 0
+
+      if (bar) {
+        ro.observe(bar)
+        root.style.setProperty('--hud-bar-height', `${Math.round(barHeight)}px`)
+      }
+
+      setFilled(barHeight + visible >= window.innerHeight - 1)
+    }
+
+    measure()
+
+    // Once the viewport has mounted, the ResizeObserver above owns every
+    // future measurement — a probe that never stops re-runs this on every
+    // tick forever, which is exactly the sustained idle CPU / re-render loop
+    // the HUD must not have.
+    const probe = window.setInterval(() => {
+      if (viewport) {
+        window.clearInterval(probe)
+
+        return
+      }
+
+      measure()
+    }, 500)
+
+    window.addEventListener('resize', measure)
+
+    return () => {
+      window.clearInterval(probe)
+      window.removeEventListener('resize', measure)
+      ro.disconnect()
+    }
+  }, [rootRef])
+
+  return filled
+}


### PR DESCRIPTION
Fixes one concrete, verifiable defect named in #98394 ("Desktop renderer permanent re-render loop — entire chat content briefly disappears and reappears").

## What's actually wrong here

The issue lists five `setInterval`-based timers as suspects for the sustained idle renderer CPU / re-render behavior. I checked each one against current `main`:

| Timer | Status on current main |
|---|---|
| `app/agents/index.tsx:200` `setNowMs` (500ms) | Already gated on `active > 0 && visible` (`usePaneVisible()`) — does not fire when idle or the panel isn't visible. Not a bug. |
| `contrib/runtime-loader.ts:590` disk plugin scan (5s) | Already gated on `document.visibilityState === 'visible'`. Not a bug. |
| `plugins/kanban/ui.tsx:101` `useTicking` force-render (5s) | Scoped to a single mounted card's own subtree, not a global re-render. Not a bug. |
| `app/hud/hud-shell.tsx:269` edge-flip poll (300ms) | Intentional continuous poll — no DOM move event exists, comment says so explicitly. Not a bug. |
| `app/hud/hud-shell.tsx:361` transcript-band "probe" (500ms) | **Actually broken** — see below. |

The transcript-band probe's own comment says: *"The viewport mounts async (lazy chat surface); poll briefly until it exists, then let the ResizeObserver own it."* The code never implemented the "poll briefly" part — the interval called `measure()` unconditionally, forever, for the entire lifetime of the HUD window, regardless of whether the ResizeObserver had already taken over. That's a real, sustained per-window timer running DOM queries + `getBoundingClientRect` + a style write every 500ms indefinitely, exactly the class of defect the issue reports (a HUD-window analog of the main-window timers it audits).

## Fix

Extracted the effect into `useHudTranscriptBand()` (matching this file's existing per-concern hook split — `useHudGlass`, `useHudClickThrough`, `useHudThreadFocus` already live this way) and made the interval check whether the viewport has been found before calling `measure()` again, clearing itself the first tick after it has — so the ResizeObserver takes over exactly as the original comment intended.

## Test

Added `apps/desktop/src/app/hud/transcript-band.test.tsx`, which mounts the hook with an inert `ResizeObserver` stub and fake timers, and asserts the probe keeps firing while the viewport hasn't mounted, fires exactly once more the tick it appears, and then stops (measured via a `getBoundingClientRect` call-count spy, since that's called unconditionally on every `measure()`).

Confirmed the test fails without the fix — reverted the interval to the old unconditional `setInterval(measure, 500)` and reran:

```
❯ |ui| src/app/hud/transcript-band.test.tsx (1 test | 1 failed) 56ms
   × stops polling once the viewport mounts
AssertionError: expected 90 to be 10 // Object.is equality
```

Restored the fix and reran — passes:

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Full `hud/` suite (6 files, includes the new test) still green:

```
 Test Files  6 passed (6)
      Tests  25 passed (25)
```

`npx eslint src/app/hud/hud-shell.tsx src/app/hud/transcript-band.ts src/app/hud/transcript-band.test.tsx` — clean.

`npx tsc -p . --noEmit` (whole project) — clean.

I did not run the entire `apps/desktop` vitest suite (684 test files) end-to-end — it exceeded the time budget of this environment. The change is scoped to one file split into two, with no behavioral change to any other module (`hud-shell.tsx`'s only change is delegating to the extracted hook), so I limited verification to the affected area plus a full-project typecheck.

## Disclosure

This PR was prepared with AI assistance (an autonomous Claude Code session), with the diff, test, and repro reviewed before submission.
