### PR TITLE
fix(agent): cap Ollama/GLM suspicious-stop continuation loop at one salvage attempt

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3611,6 +3611,14 @@ def run_conversation(
                     _finish_result = _cc_fr.normalize_response(response)
                     finish_reason = _finish_result.finish_reason
                     assistant_message = _finish_result
+                    # A clean slate for the per-API-call heuristic marker:
+                    # _should_treat_stop_as_truncated below stamps it True only
+                    # when IT rewrites stop→length, and the truncation handler
+                    # consumes it right after.  Clearing here (before the
+                    # evaluation, not after) guarantees no stale True from a
+                    # previous call can leak into this response's handler
+                    # branch (#98406).
+                    agent._suspicious_stop_rewrite = False
                     if agent._should_treat_stop_as_truncated(
                         finish_reason,
                         assistant_message,
@@ -4027,10 +4035,17 @@ def run_conversation(
                             # cap, so "still truncated" is wrong framing — the
                             # stitched partial IS the model's answer.  Complete
                             # the turn instead of reporting a truncation error
-                            # (#98406).  A genuine cap that follows later marks
-                            # itself with _suspicious_stop_rewrite=False and
-                            # runs the full 4-attempt loop as before.
-                            _converged_heuristic = not _should_request_continuation and _heuristic_truncation
+                            # (#98406).  Gated on a non-empty stitch: an empty
+                            # result is NOT a complete answer and belongs to the
+                            # empty-response recovery upstream.  A genuine cap
+                            # that follows later marks itself with
+                            # _suspicious_stop_rewrite=False and runs the full
+                            # 4-attempt loop as before.
+                            _converged_heuristic = (
+                                not _should_request_continuation
+                                and _heuristic_truncation
+                                and bool(truncated_response_parts)
+                            )
                             if partial_response and not _converged_heuristic:
                                 agent._vprint(
                                     f"{agent.log_prefix}⚠️  Response still truncated "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3933,6 +3933,30 @@ def run_conversation(
                             )
                         if assistant_message is not None and not _trunc_has_tool_calls:
                             length_continue_retries += 1
+                            # ── Heuristic-guided stop rewrite converges fast (#98406) ──
+                            # When this truncation was manufactured by the
+                            # Ollama/GLM punctuation heuristic
+                            # (_should_treat_stop_as_truncated rewrote a
+                            # provider-correct ``stop`` to ``length``), one
+                            # continuation attempt is allowed (that preserves
+                            # the salvage behavior 8011aa31ba was written for),
+                            # but a second suspicious event converges instead
+                            # of burning the full retry budget: with a reasoning
+                            # model the injected nudge itself becomes the topic
+                            # of the next reasoning pass — extra full-budget
+                            # retries just produce another unpunctuated tail
+                            # and deepen the false truncation.
+                            _heuristic_truncation = getattr(
+                                agent, "_suspicious_stop_rewrite", False
+                            )
+                            agent._suspicious_stop_rewrite = False
+                            _should_request_continuation = (
+                                length_continue_retries < 4
+                                and not (
+                                    _heuristic_truncation
+                                    and length_continue_retries >= 2
+                                )
+                            )
                             # An EMPTY partial-stream stub (stream dropped
                             # mid tool-call before any text was delivered)
                             # must not be appended as an interim assistant
@@ -3957,7 +3981,7 @@ def run_conversation(
                                 if assistant_message.content:
                                     truncated_response_parts.append(assistant_message.content)
 
-                            if length_continue_retries < 4:
+                            if _should_request_continuation:
                                 _is_partial_stream_stub = (
                                     getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
                                 )
@@ -3999,11 +4023,26 @@ def run_conversation(
                                 break
 
                             partial_response = agent._strip_think_blocks(_join_truncated_parts(truncated_response_parts)).strip()
-                            if partial_response:
+                            # Heuristic-guided rewrites never saw a real output
+                            # cap, so "still truncated" is wrong framing — the
+                            # stitched partial IS the model's answer.  Complete
+                            # the turn instead of reporting a truncation error
+                            # (#98406).  A genuine cap that follows later marks
+                            # itself with _suspicious_stop_rewrite=False and
+                            # runs the full 4-attempt loop as before.
+                            _converged_heuristic = not _should_request_continuation and _heuristic_truncation
+                            if partial_response and not _converged_heuristic:
                                 agent._vprint(
                                     f"{agent.log_prefix}⚠️  Response still truncated "
                                     f"after 4 continuation attempts — keeping the "
                                     f"partial response received so far.",
+                                    force=True,
+                                )
+                            elif _converged_heuristic:
+                                agent._vprint(
+                                    f"{agent.log_prefix}ℹ️  Ollama/GLM stop heuristic "
+                                    f"fired once — accepting stitched response as "
+                                    f"complete.",
                                     force=True,
                                 )
                             # Unanswered continue nudges made every later turn re-truncate.
@@ -4036,9 +4075,13 @@ def run_conversation(
                                 "final_response": partial_response or None,
                                 "messages": messages,
                                 "api_calls": api_call_count,
-                                "completed": False,
-                                "partial": True,
-                                "error": "Response remained truncated after 4 continuation attempts",
+                                "completed": _converged_heuristic,
+                                "partial": not _converged_heuristic,
+                                "error": (
+                                    None
+                                    if _converged_heuristic
+                                    else "Response remained truncated after 4 continuation attempts"
+                                ),
                             }
 
                     if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1795,6 +1795,19 @@ class AIAgent:
         (LiteLLM/sglang/vLLM/LM Studio proxies, Tailscale boxes), which
         report finish_reason correctly and were the source of #13971's
         false-positive truncation continuations.
+
+        Identity resolution notes:
+        - The ``glm`` substring check runs on the resolved model id, so
+          aliases that carry a GLM token (``glm-5.3-flash:cloud``,
+          ``zai/glm-5`` …) match, while a bare alias that hides the
+          model family entirely does not.
+        - The port/URL check runs on the resolved base URL: a custom
+          base URL still matches when it contains ``ollama`` or ``:11434``,
+          and a reverse proxy serving Ollama on another port matches
+          only if the provider is explicitly named ``ollama``.
+        - ``provider=="zai"`` routes are included regardless of URL
+          because Z.AI's GLM endpoints were the other half of the
+          original misreport family.
         """
         model_lower = (self.model or "").lower()
         provider_lower = (self.provider or "").lower()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1811,6 +1811,11 @@ class AIAgent:
         messages: Optional[list] = None,
     ) -> bool:
         """Detect conservative stop->length misreports for Ollama-hosted GLM models."""
+        # Cleared on every evaluation: this flag is a per-API-call diagnostic
+        # consumed by the truncation handler in conversation_loop.  A leftover
+        # True from a previous call would misclassify an unrelated genuine
+        # length truncation as heuristic-driven (see #98406).
+        self._suspicious_stop_rewrite = False
         if finish_reason != "stop" or self.api_mode != "chat_completions":
             return False
         if not self._is_ollama_glm_backend():
@@ -1833,7 +1838,17 @@ class AIAgent:
         if len(visible_text) < 20 or not re.search(r"\s", visible_text):
             return False
 
-        return not self._has_natural_response_ending(visible_text)
+        if not self._has_natural_response_ending(visible_text):
+            # The stop->length rewrite below is driven by the punctuation
+            # heuristic, not by provider-reported evidence.  conversation_loop
+            # uses this to cap heuristic-guided continuations at one attempt
+            # instead of four — with a reasoning model the injected
+            # continuation nudge itself gets deliberated over and produces yet
+            # another unpunctuated tail, so full-budget retries only
+            # manufacture the next false positive (#98406).
+            self._suspicious_stop_rewrite = True
+            return True
+        return False
 
     def _looks_like_codex_intermediate_ack(
         self,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4390,6 +4390,57 @@ class TestRunConversation:
 
 
 
+    def test_ollama_glm_suspicious_stop_converges_after_one_continuation(self, agent):
+        """A second heuristic-fired stop converges instead of burning 4 retries (#98406).
+
+        With a reasoning model, the injected continuation nudge itself becomes
+        the topic of the next reasoning pass, so full-budget retries keep
+        manufacturing unpunctuated tails.  After one salvage continuation the
+        loop must accept the stitched response as complete (no error banner).
+        """
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.3-flash:cloud"
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        # Every response ends unpunctuated — the punctuation heuristic fires
+        # on each of them, exactly as observed live in #98406.
+        first_stop = _mock_response(
+            content="Based on the search results, the best next",
+            finish_reason="stop",
+        )
+        continued = _mock_response(
+            content=" step is to update the config file now",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            tool_turn,
+            first_stop,
+            continued,
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # Converged: response delivered as complete, no truncation error.
+        assert result["completed"] is True
+        assert result.get("partial") is not True
+        assert result.get("error") is None
+        assert result["api_calls"] == 3
+        assert result["final_response"] == (
+            "Based on the search results, the best next step is to update the config file now"
+        )
+
     def test_length_thinking_exhausted_skips_continuation(self, agent):
         """When finish_reason='length' but content is only thinking, skip retries."""
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4467,6 +4467,167 @@ class TestRunConversation:
         assert "Thinking Budget Exhausted" in result["final_response"]
         assert "/thinkon" in result["final_response"]
 
+    # ------------------------------------------------------------------
+    # Regression tests for #98406 — heuristic-guided stop->length rewrite
+    # ------------------------------------------------------------------
+
+    def test_suspicious_stop_flag_lifecycle(self, agent):
+        """The _suspicious_stop_rewrite flag is stamped only on a real rewrite."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.3-flash:cloud"
+
+        def _normalized(content, tool_calls=None):
+            # Shape produced by the chat-completions transport's
+            # normalize_response — what the predicate actually receives.
+            return SimpleNamespace(content=content, tool_calls=tool_calls)
+
+        # Stale True must be cleared by any fresh evaluation.
+        agent._suspicious_stop_rewrite = True
+
+        # (1) Non-GLM model: cleared, no rewrite.
+        agent.model = "llama3:8b"
+        tool_msg = {"role": "tool", "content": "result"}
+        assert agent._should_treat_stop_as_truncated(
+            "stop", _normalized("a complete sentence."), [tool_msg]
+        ) is False
+        assert agent._suspicious_stop_rewrite is False
+
+        # (2) GLM + unpunctuated tail after tool turn: rewrite + flag set.
+        agent.model = "glm-5.3-flash:cloud"
+        suspicious = _normalized(
+            "Based on the results the best next step is to configure now"
+        )
+        assert agent._should_treat_stop_as_truncated(
+            "stop", suspicious, [tool_msg]
+        ) is True
+        assert agent._suspicious_stop_rewrite is True
+
+        # (3) Punctuated ending: no rewrite, flag stays False.
+        agent._suspicious_stop_rewrite = True
+        natural = _normalized("Based on the results, the best next step is clear.")
+        assert agent._should_treat_stop_as_truncated(
+            "stop", natural, [tool_msg]
+        ) is False
+        assert agent._suspicious_stop_rewrite is False
+
+        # (4) Genuine length truncation path: no suspicious-stop stamp.
+        agent._suspicious_stop_rewrite = True
+        genuine_length = _normalized("A long response cut off mid-sent")
+        assert agent._should_treat_stop_as_truncated(
+            "length", genuine_length, [tool_msg]
+        ) is False
+        assert agent._suspicious_stop_rewrite is False
+
+    def test_pure_genuine_length_cap_still_gets_full_continuation_loop(self, agent):
+        """A genuine finish_reason='length' (never stop) keeps the 4-attempt loop."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.3-flash:cloud"
+
+        truncated = _mock_response(
+            content="Let me explain the whole architecture step by step, the first",
+            finish_reason="length",
+        )
+        continued = _mock_response(
+            content=" component is the router. Done.",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [truncated, continued]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # Genuine cap: the loop requests a continuation with the nudge.
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["final_response"] == (
+            "Let me explain the whole architecture step by step, the first"
+            " component is the router. Done."
+        )
+        second_call_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        assert second_call_messages[-1]["role"] == "user"
+        assert "truncated by the output length limit" in second_call_messages[-1]["content"]
+
+    def test_think_only_response_never_triggers_heuristic(self, agent):
+        """Reasoning-only content cannot fire the heuristic (#98406 safety).
+
+        The predicate requires ≥20 visible chars after stripping think blocks,
+        so a think-only response can never be rewritten stop→length — the
+        structural guarantee that the convergent path can never mark an empty
+        stitch as complete.
+        """
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.3-flash:cloud"
+
+        think_only = _mock_response(
+            content=" analysing the request now",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.return_value = think_only
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # Heuristic must not have fired: visible stitch is empty → finish
+        # reason stays stop, no truncation error raised.
+        assert agent._suspicious_stop_rewrite is False
+        assert result.get("error") is None
+        # The turn completes normally (no continuation churn).
+        assert result["completed"] is True
+
+    def test_second_suspicious_event_converges_not_third_retry(self, agent):
+        """Two suspicious stops → converge; never a second full-budget retry (#98406)."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.3-flash:cloud"
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        first_stop = _mock_response(
+            content="Based on the search results, the best next",
+            finish_reason="stop",
+        )
+        second_stop = _mock_response(
+            content=" step is to restart. Also check the config file",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            tool_turn, first_stop, second_stop,
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # Converged on the 3rd API call, not a 4th retry.
+        assert result["api_calls"] == 3
+        assert result["completed"] is True
+        assert result.get("error") is None
+        assert result.get("partial") is not True
+        # The stitched response is delivered.
+        assert "restart" in (result["final_response"] or "")
+
 
     def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4614,7 +4614,7 @@ class TestRunConversation:
 
         with (
             patch("run_agent.handle_function_call", return_value="search result"),
-            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_persist_session") as persist_session,
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
@@ -4627,6 +4627,74 @@ class TestRunConversation:
         assert result.get("partial") is not True
         # The stitched response is delivered.
         assert "restart" in (result["final_response"] or "")
+
+        # Provider-spy: the second suspicious stop is provably the LAST
+        # provider interaction — no fourth API call is ever issued
+        # (review request on this PR).
+        assert agent.client.chat.completions.create.call_count == 3
+
+        # Persisted state is clean: the last message is the stitched
+        # assistant answer and no continuation nudge survives as a
+        # pending user turn for the next request.
+        persisted = persist_session.call_args[0][0]
+        assert persisted[-1]["role"] == "assistant"
+        assert "restart" in (persisted[-1].get("content") or "")
+        assert not any(
+            isinstance(m, dict) and m.get("_length_continuation_nudge")
+            for m in persisted
+        )
+
+    def test_suspicious_continuation_followed_by_empty_response(self, agent):
+        """Partial stitch + empty continuation response must not converge on empty (#98406).
+
+        The reviewer's second scenario: first suspicious stop yields a partial,
+        the salvage continuation comes back EMPTY.  The convergent path must
+        refuse to mark an empty stitch complete and hand the turn to the
+        normal empty-response recovery instead.
+        """
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.3-flash:cloud"
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        suspicious_partial = _mock_response(
+            content="Based on the search results, the best next",
+            finish_reason="stop",
+        )
+        empty_continuation = _mock_response(content="", finish_reason="stop")
+        recovered_answer = _mock_response(
+            content=" step is to update the config. Done.",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            tool_turn, suspicious_partial, empty_continuation, recovered_answer,
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session") as persist_session,
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # The empty continuation never got stitched into a "complete" turn:
+        # the loop recovered through the normal path and delivered the
+        # recovered answer joined after the partial.
+        assert result.get("error") is None
+        assert result["completed"] is True
+        assert "update the config" in (result["final_response"] or "")
+        # No leftover nudge in the persisted transcript.
+        persisted = persist_session.call_args[0][0]
+        assert not any(
+            isinstance(m, dict) and m.get("_length_continuation_nudge")
+            for m in persisted
+        )
 
 
     def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):


### PR DESCRIPTION
## Problem

On Ollama-hosted GLM models, `_should_treat_stop_as_truncated` (from #8011aa31ba) rewrites a provider-correct `finish_reason="stop"` into `"length"` whenever the visible text lacks a "natural" punctuation ending. The four-attempt continuation loop then makes things strictly worse for reasoning models: the injected `[System: ...]` continuation nudge itself becomes the topic of the next reasoning pass — the model burns its output budget deliberating over the synthetic message and produces yet another unpunctuated tail, which the heuristic flags again. Net effect on glm-5.3-flash:cloud (`reasoning_effort: high`): four full-budget generations, then the turn dies with

```
Response remained truncated after 4 continuation attempts
```

on what was a complete response. Logs from one desktop install show **391** heuristic firings; #98406 documents the full chain with live evidence, including the model's leaked thinking block reasoning about the nudge itself.

## Fix

Track the heuristic-driven rewrite with a per-API-call flag (`agent._suspicious_stop_rewrite`, consumed and cleared by the truncation handler) and let the continuation loop converge **after one salvage continuation** instead of four:

- first suspicious event → one continuation request (unchanged) — this preserves exactly the tool-tail salvage behavior `8011aa31ba` was written for, and its test still passes
- second suspicious event → accept the stitched partial as the complete turn (`completed=True`, no error banner) instead of two more full-budget retries + hard error
- a genuine `length` cap (flag clean) runs the full 4-attempt loop exactly as before

The convergent path also reframes the exit: no "still truncated after 4 attempts" warning, since the heuristic never saw real provider evidence of a cap.

## Testing

- New `test_ollama_glm_suspicious_stop_converges_after_one_continuation` reproduces the live #98406 shape (tool turn → suspicious stop → suspicious stop after continuation) and asserts convergence: `completed=True`, `error=None`, stitched response delivered
- Existing `test_ollama_glm_stop_after_tools_without_terminal_boundary_requests_continuation` still passes — the salvage-first behavior is preserved
- `tests/run_agent/test_continuation_ceiling_wedge.py` + `test_partial_stream_finish_reason.py`: 27 passed
- `tests/agent/ -k "truncat or continuation or ollama"`: 59 passed, 1 skipped
- Full `tests/run_agent/test_run_agent.py`: 281 passed; the one failure (`TestAnthropicInterruptHandler`) is pre-existing on a clean checkout (missing `anthropic` package in the dev venv, unrelated)

Closes #98406 (and substantively addresses the convergence arm of #72316).