### PR TITLE
feat: return created URI from viking_remember

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -626,7 +626,8 @@ REMEMBER_SCHEMA = {
     "description": (
         "Explicitly store a fact or memory in the OpenViking knowledge base. "
         "Use for important information the agent should remember long-term. "
-        "The system automatically categorizes and indexes the memory."
+        "The system automatically categorizes and indexes the memory. "
+        "Successful calls return the canonical URI of the created memory."
     ),
     "parameters": {
         "type": "object",
@@ -5290,6 +5291,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             written = result.get("result", {}).get("written_bytes", 0)
             return json.dumps({
                 "status": "stored",
+                "uri": uri,
                 "message": f"Memory stored ({written}b) and queued for vector indexing.",
             })
         except Exception as e:

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -962,9 +962,38 @@ class TestEnsureClientReloadsEnv:
         assert instances[1].posts[0][0] == "/api/v1/content/write"
         assert instances[1].posts[0][1]["content"] == "stable fact"
         assert instances[1].posts[0][1]["mode"] == "create"
-        assert instances[1].posts[0][1]["uri"].startswith(
+        written_uri = instances[1].posts[0][1]["uri"]
+        assert written_uri.startswith(
             "viking://user/default/peers/hermes/memories/"
         )
+        assert out["uri"] == written_uri
+
+    def test_remember_write_failure_does_not_return_uri(self, monkeypatch):
+        class _StubClient:
+            def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+                self.endpoint = endpoint
+                self.api_key = api_key
+
+            def health(self):
+                return True
+
+            def post(self, path, payload=None, **kwargs):
+                assert path == "/api/v1/content/write"
+                raise RuntimeError("write rejected")
+
+        monkeypatch.setattr("plugins.memory.openviking._VikingClient", _StubClient)
+        monkeypatch.setenv("OPENVIKING_ENDPOINT", "https://openviking.example")
+        monkeypatch.setenv("OPENVIKING_API_KEY", "sk-test")
+
+        provider = OpenVikingMemoryProvider()
+        provider.initialize("session-1")
+        out = json.loads(provider.handle_tool_call(
+            "viking_remember",
+            {"content": "stable fact"},
+        ))
+
+        assert out == {"error": "Failed to store memory: write rejected"}
+        assert "uri" not in out
 
     def test_concurrent_refresh_does_not_return_stale_client(self, monkeypatch):
         refresh_entered = threading.Event()


### PR DESCRIPTION
## Summary

- return the exact canonical URI submitted to OpenViking from successful `viking_remember` calls
- document the additive success-response field in the agent-facing tool description
- verify successful responses return the submitted URI and failed writes return no URI

## Motivation

Callers currently receive confirmation that a memory was stored but not the canonical URI that was created. Returning the URI gives callers an authoritative handle for later exact reads or URI-scoped operations without changing the existing `status` or `message` fields.

This change does not claim or test semantic-index erasure; it only exposes the canonical URI used for the successful write.

## Changes

- add `uri` to successful `viking_remember` JSON responses
- document that successful calls return the canonical created URI
- compare the returned URI with the URI independently captured from the `content/write` request
- add failure-path coverage proving rejected writes do not return a URI

## Test Plan

- [x] `scripts/run_tests.sh tests/openviking_plugin/test_openviking.py` — 43 passed
- [x] four relevant OpenViking plugin/provider suites — 117 passed
- [x] Ruff passed on both changed files
- [x] `git diff --check` passed
- [x] independent adversarial review found no security concerns or logic errors

## Notes for Reviewers

The response change is additive: existing `status` and `message` values are unchanged. The returned URI is the same value submitted to `POST /api/v1/content/write`, rather than a reconstructed or rediscovered path.
