### PR TITLE
fix(cli): decode modifyOtherKeys/Kitty escapes leaked into bare input() prompts

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -179,7 +179,9 @@ def _run_setup() -> None:
     if not sys.stdin.isatty():
         return
     try:
-        reply = input(
+        from hermes_cli.input_decode import safe_input
+
+        reply = safe_input(
             "\nInstall browser tools? Downloads agent-browser (npm) and "
             "optionally Playwright Chromium (~400 MB). [y/N] "
         ).strip().lower()

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -966,7 +966,12 @@ def _prompt_and_record(
         f"  commands you trust."
     )
     try:
-        answer = input("Allow this hook to run? [y/N]: ").strip().lower()
+        # safe_input, not bare input(): the classic CLI pushes
+        # modifyOtherKeys/Kitty extended-key mode globally, and a shifted
+        # answer would otherwise arrive as raw escape text (#97975).
+        from hermes_cli.input_decode import safe_input
+
+        answer = safe_input("Allow this hook to run? [y/N]: ").strip().lower()
     except (EOFError, KeyboardInterrupt):
         print()  # keep the terminal tidy after ^C
         return False

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from hermes_cli.cli_output import line_input
+from hermes_cli.input_decode import safe_input
 
 import math
 import sys
@@ -353,7 +354,7 @@ def auth_add_command(args) -> None:
             else:
                 print("Found existing shared Nous OAuth credentials")
             try:
-                do_import = input("Import these credentials? [Y/n]: ").strip().lower()
+                do_import = safe_input("Import these credentials? [Y/n]: ").strip().lower()
             except (EOFError, KeyboardInterrupt):
                 do_import = "y"
             if do_import in {"", "y", "yes"}:
@@ -733,7 +734,7 @@ def _interactive_auth() -> None:
         print(f"  {i}. {choice}")
 
     try:
-        raw = input("\nChoice: ").strip()
+        raw = safe_input("\nChoice: ").strip()
     except (EOFError, KeyboardInterrupt):
         return
 
@@ -779,7 +780,7 @@ def _interactive_add() -> None:
         print("  1. API key (paste a key from the provider dashboard)")
         print("  2. OAuth login (authenticate via browser)")
         try:
-            type_choice = input("Type [1/2]: ").strip()
+            type_choice = safe_input("Type [1/2]: ").strip()
         except (EOFError, KeyboardInterrupt):
             return
         if type_choice == "2":
@@ -850,7 +851,7 @@ def _interactive_strategy() -> None:
         print(f"  {i}. {s:15s} — {descriptions.get(s, '')}{marker}")
 
     try:
-        raw = input("\nStrategy [1-4]: ").strip()
+        raw = safe_input("\nStrategy [1-4]: ").strip()
     except (EOFError, KeyboardInterrupt):
         return
     if not raw:

--- a/hermes_cli/input_decode.py
+++ b/hermes_cli/input_decode.py
@@ -1,0 +1,139 @@
+"""Decode modifyOtherKeys / Kitty CSI-u escape sequences leaked into bare ``input()`` reads.
+
+The classic CLI pushes extended-key reporting globally for the process —
+xterm ``modifyOtherKeys`` level 2 (``CSI >4;2m``) and, on allowlisted
+terminals, the Kitty keyboard protocol (``CSI >1u``); see
+``cli.py::_enable_extended_enter_keys``.  While that mode is active the
+terminal re-encodes every *modified* key:
+
+* modifyOtherKeys=2: ``ESC[27;<mod>;<codepoint>~``
+* Kitty CSI-u:       ``ESC[<codepoint>;<mod>u``
+
+``prompt_toolkit`` decodes both via its ``ANSI_SEQUENCES`` table (which
+``hermes_cli.pt_input_extras`` fills in), but Python's builtin ``input()``
+does **not** — it returns the raw escape text.  Every bare ``input()`` prompt
+reached while the mode is active therefore receives garbage whenever the user
+types a shifted character (issue #97975).
+
+``decode_modified_key_sequences`` is the pure string transform that fixes
+that: it maps each sequence back to the literal character the user pressed
+when the modifier chain is Shift-only, and passes everything else through
+unchanged.  ``safe_input`` wraps builtin ``input()`` with that transform.
+"""
+
+from __future__ import annotations
+
+import builtins
+import re
+from typing import Callable
+
+__all__ = ["decode_modified_key_sequences", "safe_input"]
+
+# Shift-only modifier values per protocol.  The modifier parameter is a bitmask
+# plus one: shift=1, alt=2, ctrl=4, super=8, hyper=16, meta=32, caps=64, num=128.
+# Both protocols therefore report a plain Shift combo as 2 (0b01 + 1).  Kitty
+# additionally ORs the *event type* into the low bits only in *alternate*
+# report mode (press=+0/repeat=+1/release=+2), so there the release/repeat
+# forms of Shift+key arrive as 3 and 4.
+#
+# Under modifyOtherKeys the terminal applies CapsLock/NumLock *before*
+# encoding (shift+caps on 'T' sends codepoint 116 = 't'), so the caps/num
+# bits are not lock noise — 65/129 are genuinely un-shifted keys and must
+# pass through untouched.  Decoding only happens for the exact shift-only
+# modifiers 2 (both protocols) and 3/4 (Kitty alternate report mode).
+_SHIFT_ONLY_MODS = frozenset({2, 3, 4})
+# modifyOtherKeys never encodes event type in the modifier, so there only the
+# exact shift value (2) is safe to decode — mod 3 is genuinely Alt.
+_EXACT_SHIFT_MODS = frozenset({2})
+
+# modifyOtherKeys level-2: ESC [ 27 ; <mod> ; <codepoint> ~
+_MODIFY_OTHER_KEYS_RE = re.compile(r"\x1b\[27;(\d+);(\d+)~")
+# Kitty CSI-u: ESC [ <codepoint> ; <mod> u   (``;mod`` omitted when mod==1)
+_KITTY_CSI_U_RE = re.compile(r"\x1b\[(\d+)(?:;(\d+))?u")
+
+
+def _shift_char(
+    match: re.Match, mod_index: int, cp_index: int, allowed_mods: frozenset
+) -> str:
+    """Return the literal character for a shift-only modified-key sequence.
+
+    The codepoint parameter is *already the shifted character*: under
+    modifyOtherKeys=2 Shift+T sends ``ESC[27;2;84~`` where 84 == ``ord('T')``
+    (the terminal applies the layout before encoding).  The same holds for
+    Kitty disambiguate mode.  So decoding a shift-only event is simply
+    ``chr(codepoint)``.
+
+    Any other modifier combination (ctrl, alt, super, ...) is returned
+    verbatim: ``input()`` has no key-binding layer that could interpret a
+    decoded control character meaningfully, and silently dropping a keypress
+    is worse than letting the prompt echo it the way stock ``input()`` does.
+    Un-parsable codepoints (outside the Unicode range, surrogates) likewise
+    pass through.
+    """
+    mod_raw = match.group(mod_index)
+    if mod_raw is None or int(mod_raw) not in allowed_mods:
+        return match.group(0)
+    try:
+        codepoint = int(match.group(cp_index))
+    except (ValueError, OverflowError):
+        return match.group(0)
+    # Functional keys (Kitty private use plane 57344-63743, incl. Shift+Enter
+    # at 57427 reported by Ghostty), un-mapped control codepoints (CR, ESC,
+    # Tab, ...), surrogates and out-of-range values pass through: they stand
+    # for editor functions, not literal text, and chr(13) must never replace a
+    # byte sequence that meant "accept the prompt" under stock input().
+    if codepoint < 32 or codepoint == 127:
+        return match.group(0)
+    if 0xD800 <= codepoint <= 0xDFFF or 57344 <= codepoint <= 63743:
+        return match.group(0)
+    try:
+        char = chr(codepoint)
+    except (ValueError, OverflowError):
+        return match.group(0)
+    return char
+
+
+def decode_modified_key_sequences(text: str) -> str:
+    """Replace leaked extended-keyboard sequences with the typed characters.
+
+    * ``ESC[27;<mod>;<codepoint>~`` (modifyOtherKeys level 2) decodes to
+      ``chr(codepoint)`` when ``<mod>`` is exactly 2 — the shared encoding
+      both protocols use for a plain Shift combo.
+    * ``ESC[<codepoint>;<mod>u`` (Kitty CSI-u) additionally decodes ``<mod>``
+      3/4, the press/repeat-shifted forms Kitty's *alternate* report mode
+      produces by ORing the event type into the modifier.  Alt+T under
+      modifyOtherKeys (also mod 3) has no event bits to disambiguate from and
+      therefore passes through — never decode Alt there.
+    * Functional keys (Kitty private-use plane 57344-63743, incl. Shift+Enter
+      at 57427), control codepoints (<32/127), lock-bit combos (CapsLock is
+      applied to the codepoint before encoding), other modifiers, and all
+      plain text are left byte-for-byte untouched.
+    """
+    if not text or "\x1b[" not in text:
+        return text
+    text = _MODIFY_OTHER_KEYS_RE.sub(
+        lambda m: _shift_char(m, 1, 2, _EXACT_SHIFT_MODS), text
+    )
+    text = _KITTY_CSI_U_RE.sub(
+        lambda m: _shift_char(m, 2, 1, _SHIFT_ONLY_MODS), text
+    )
+    return text
+
+
+def safe_input(prompt: str = "", *, _reader: Callable[[str], str] | None = None) -> str:
+    """Builtin ``input()`` that decodes leaked modified-key sequences.
+
+    Drop-in replacement for ``input()`` at bare interactive prompt sites
+    (consent gates, setup wizards, credential/endpoint prompts, plugin
+    configurators).  Terminals in modifyOtherKeys / Kitty extended-key mode
+    re-encode shifted keystrokes as escape sequences that ``input()`` hands
+    back as raw text (#97975); this wrapper runs those sequences back to the
+    characters the user actually typed.
+
+    Behavior on empty input, EOF and Ctrl+C is identical to builtin
+    ``input()`` — the decode is a no-op on both.
+
+    ``_reader`` exists for tests only; it replaces the builtin read call.
+    """
+    raw = (_reader or builtins.input)(prompt)
+    return decode_modified_key_sequences(raw)

--- a/hermes_cli/input_decode.py
+++ b/hermes_cli/input_decode.py
@@ -29,22 +29,16 @@ from typing import Callable
 
 __all__ = ["decode_modified_key_sequences", "safe_input"]
 
-# Shift-only modifier values per protocol.  The modifier parameter is a bitmask
-# plus one: shift=1, alt=2, ctrl=4, super=8, hyper=16, meta=32, caps=64, num=128.
-# Both protocols therefore report a plain Shift combo as 2 (0b01 + 1).  Kitty
-# additionally ORs the *event type* into the low bits only in *alternate*
-# report mode (press=+0/repeat=+1/release=+2), so there the release/repeat
-# forms of Shift+key arrive as 3 and 4.
+# The modifier parameter is a bitmask plus one: shift=1, alt=2, ctrl=4,
+# super=8, hyper=16, meta=32, caps=64, num=128. Plain Shift is therefore
+# exactly 2. In particular, Kitty CSI-u mod 3 is Alt and mod 4 is Shift+Alt;
+# neither is safe to turn into a literal character.
 #
 # Under modifyOtherKeys the terminal applies CapsLock/NumLock *before*
 # encoding (shift+caps on 'T' sends codepoint 116 = 't'), so the caps/num
 # bits are not lock noise — 65/129 are genuinely un-shifted keys and must
-# pass through untouched.  Decoding only happens for the exact shift-only
-# modifiers 2 (both protocols) and 3/4 (Kitty alternate report mode).
-_SHIFT_ONLY_MODS = frozenset({2, 3, 4})
-# modifyOtherKeys never encodes event type in the modifier, so there only the
-# exact shift value (2) is safe to decode — mod 3 is genuinely Alt.
-_EXACT_SHIFT_MODS = frozenset({2})
+# pass through untouched.
+_SHIFT_ONLY_MODS = frozenset({2})
 
 # modifyOtherKeys level-2: ESC [ 27 ; <mod> ; <codepoint> ~
 _MODIFY_OTHER_KEYS_RE = re.compile(r"\x1b\[27;(\d+);(\d+)~")
@@ -99,11 +93,9 @@ def decode_modified_key_sequences(text: str) -> str:
     * ``ESC[27;<mod>;<codepoint>~`` (modifyOtherKeys level 2) decodes to
       ``chr(codepoint)`` when ``<mod>`` is exactly 2 — the shared encoding
       both protocols use for a plain Shift combo.
-    * ``ESC[<codepoint>;<mod>u`` (Kitty CSI-u) additionally decodes ``<mod>``
-      3/4, the press/repeat-shifted forms Kitty's *alternate* report mode
-      produces by ORing the event type into the modifier.  Alt+T under
-      modifyOtherKeys (also mod 3) has no event bits to disambiguate from and
-      therefore passes through — never decode Alt there.
+    * ``ESC[<codepoint>;<mod>u`` (Kitty CSI-u) decodes only the same exact
+      Shift modifier (2). Modifiers 3 (Alt) and 4 (Shift+Alt) pass through
+      untouched, as do all other non-Shift combinations.
     * Functional keys (Kitty private-use plane 57344-63743, incl. Shift+Enter
       at 57427), control codepoints (<32/127), lock-bit combos (CapsLock is
       applied to the codepoint before encoding), other modifiers, and all
@@ -112,7 +104,7 @@ def decode_modified_key_sequences(text: str) -> str:
     if not text or "\x1b[" not in text:
         return text
     text = _MODIFY_OTHER_KEYS_RE.sub(
-        lambda m: _shift_char(m, 1, 2, _EXACT_SHIFT_MODS), text
+        lambda m: _shift_char(m, 1, 2, _SHIFT_ONLY_MODS), text
     )
     text = _KITTY_CSI_U_RE.sub(
         lambda m: _shift_char(m, 2, 1, _SHIFT_ONLY_MODS), text

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -24,6 +24,7 @@ from hermes_cli.config import (
     get_hermes_home,  # noqa: F401 — used by test mocks
 )
 from hermes_cli.colors import Colors, color
+from hermes_cli.input_decode import safe_input
 from hermes_constants import display_hermes_home
 from hermes_cli.mcp_security import validate_mcp_server_entry
 from tools.mcp_tool import _ENV_VAR_PATTERN, _env_ref_name
@@ -59,7 +60,9 @@ def _error(text: str):
 def _confirm(question: str, default: bool = True) -> bool:
     default_str = "Y/n" if default else "y/N"
     try:
-        val = input(color(f"  {question} [{default_str}]: ", Colors.YELLOW)).strip().lower()
+        # safe_input: decode modifyOtherKeys/Kitty escapes leaked into bare
+        # input() by the CLI's global extended-key push (#97975).
+        val = safe_input(color(f"  {question} [{default_str}]: ", Colors.YELLOW)).strip().lower()
     except (KeyboardInterrupt, EOFError):
         print()
         return default
@@ -592,7 +595,7 @@ def cmd_mcp_add(args):
 
     # Ask: enable all, select, or cancel
     try:
-        choice = input(
+        choice = safe_input(
             color(f"  Enable all {len(tools)} tools? [Y/n/select]: ", Colors.YELLOW)
         ).strip().lower()
     except (KeyboardInterrupt, EOFError):

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -45,6 +45,7 @@ from hermes_constants import (
     mark_named_profile_deleted,
     named_profile_is_deleted,
 )
+from hermes_cli.input_decode import safe_input
 
 logger = logging.getLogger(__name__)
 
@@ -1740,7 +1741,7 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     if not yes:
         print()
         try:
-            confirm = input(f"Type '{canon}' to confirm: ").strip()
+            confirm = safe_input(f"Type '{canon}' to confirm: ").strip()
         except (KeyboardInterrupt, EOFError):
             print("\nCancelled.")
             return profile_dir

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -46,6 +46,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
 from agent.secret_scope import get_secret
+from hermes_cli.input_decode import safe_input
 
 from agent.memory_provider import MemoryProvider, RecallStatus
 from hermes_constants import get_hermes_home
@@ -1042,12 +1043,12 @@ class HindsightMemoryProvider(MemoryProvider):
             if api_key:
                 env_writes["HINDSIGHT_API_KEY"] = api_key
 
-            val = input(f"  API URL [{_DEFAULT_API_URL}]: ").strip()
+            val = safe_input(f"  API URL [{_DEFAULT_API_URL}]: ").strip()
             if val:
                 provider_config["api_url"] = val
 
         elif mode == "local_external":
-            val = input(f"  Hindsight API URL [{_DEFAULT_LOCAL_URL}]: ").strip()
+            val = safe_input(f"  Hindsight API URL [{_DEFAULT_LOCAL_URL}]: ").strip()
             provider_config["api_url"] = val or _DEFAULT_LOCAL_URL
 
             sys.stdout.write("  API key (optional, blank to skip): ")
@@ -1063,7 +1064,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 if existing_base_url:
                     prompt += f" [{existing_base_url}]"
                 prompt += ": "
-                val = input(prompt).strip()
+                val = safe_input(prompt).strip()
                 if val:
                     provider_config["llm_base_url"] = val
             elif llm_provider == "openrouter":
@@ -1071,7 +1072,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
             provider_default_model = _PROVIDER_DEFAULT_MODELS.get(llm_provider, "gpt-4o-mini")
             current_model = provider_config.get("llm_model") or provider_default_model
-            val = input(f"  LLM model [{current_model}]: ").strip()
+            val = safe_input(f"  LLM model [{current_model}]: ").strip()
             provider_config["llm_model"] = val or current_model
 
             sys.stdout.write("  LLM API key: ")

--- a/tests/hermes_cli/test_input_decode.py
+++ b/tests/hermes_cli/test_input_decode.py
@@ -1,0 +1,92 @@
+"""Tests for hermes_cli.input_decode (#97975) — pure string transform, no TTY."""
+
+import pytest
+
+from hermes_cli.input_decode import decode_modified_key_sequences, safe_input
+
+ESC = "\x1b"
+
+
+class TestDecodeModifiedKeySequences:
+    def test_plain_text_untouched(self):
+        for text in ("", "y", "hello world", "s3cret-key_123", "n\n"):
+            assert decode_modified_key_sequences(text) == text
+
+    def test_shift_only_modify_other_keys(self):
+        # The issue's exact repro: Shift+T arrives as ESC[27;2;84~ (84 == 'T').
+        assert decode_modified_key_sequences(f"{ESC}[27;2;84~") == "T"
+
+    def test_mixed_string_round_trip(self):
+        # Typing "Type THIS" with the shifted letters reported as sequences.
+        raw = (
+            "Type "
+            f"{ESC}[27;2;84~"   # Shift+T -> T
+            f"{ESC}[27;2;72~"   # Shift+H -> H
+            f"{ESC}[27;2;73~"   # Shift+I -> I
+            f"{ESC}[27;2;83~"   # Shift+S -> S
+        )
+        assert decode_modified_key_sequences(raw) == "Type THIS"
+
+    def test_kitty_csi_u_shift_only(self):
+        assert decode_modified_key_sequences(f"{ESC}[84;2u") == "T"
+        # Kitty press/repeat low bits: shift|press(1)+1=3, shift|release+1=4.
+        assert decode_modified_key_sequences(f"{ESC}[84;3u") == "T"
+        assert decode_modified_key_sequences(f"{ESC}[84;4u") == "T"
+
+    def test_control_and_alt_combos_pass_through(self):
+        # Ctrl+T (5), Ctrl+Shift+T (6), Super+T (12) — decoding would invent
+        # control characters or silently drop keys.  Alt+T (3) passes through
+        # under modifyOtherKeys too: unlike Kitty, that protocol never ORs
+        # event bits into the modifier, so 3 is genuinely Alt there.
+        for mod in ("5", "6", "12"):
+            seq = f"{ESC}[27;{mod};84~"
+            assert decode_modified_key_sequences(seq) == seq
+        assert decode_modified_key_sequences(f"{ESC}[27;3;84~") == f"{ESC}[27;3;84~"
+        assert decode_modified_key_sequences(f"{ESC}[84;6u") == f"{ESC}[84;6u"
+
+    def test_lock_bits_pass_through(self):
+        # CapsLock is applied by modifyOtherKeys *before* encoding: 65
+        # (shift|caps) on T sends codepoint 116 = lowercase 't'.  Decoding
+        # it would silently rewrite an un-shifted keypress, so it stays raw.
+        for seq in (f"{ESC}[27;65;116~", f"{ESC}[27;129;84~"):
+            assert decode_modified_key_sequences(seq) == seq
+
+    def test_functional_keys_pass_through(self):
+        # Shift+Enter under Kitty: codepoint 13 is a key, not a printable char.
+        seq = f"{ESC}[13;2u"
+        assert decode_modified_key_sequences(seq) == seq
+
+    def test_bare_csi_u_without_modifier_passes_through(self):
+        # CSI-u with omitted mod parameter (mod==1) is not a modified key.
+        seq = f"{ESC}[97u"
+        assert decode_modified_key_sequences(seq) == seq
+
+    def test_unparsable_codepoints_pass_through(self):
+        # Out-of-range codepoints: chr() raises, sequence stays raw.
+        assert decode_modified_key_sequences(f"{ESC}[27;2;1114112~") == f"{ESC}[27;2;1114112~"
+        assert decode_modified_key_sequences(f"{ESC}[99999999999999;2u") == f"{ESC}[99999999999999;2u"
+
+    def test_surrogate_codepoints_pass_through(self):
+        seq = f"{ESC}[27;2;55296~"  # 0xD800 — chr() raises
+        assert decode_modified_key_sequences(seq) == seq
+
+    def test_unrelated_escapes_untouched(self):
+        # Bracketed paste, colors, cursor moves are not modified-key sequences.
+        for seq in (f"{ESC}[?2004h", f"{ESC}[31m", f"{ESC}[1;2H", f"{ESC}[27;5m"):
+            assert decode_modified_key_sequences(seq) == seq
+
+
+class TestSafeInput:
+    def test_decodes_reader_output(self):
+        reader = lambda prompt: (print(prompt, end=""), f"{ESC}[27;2;89~")[1]  # Shift+Y
+        assert safe_input("Allow? [y/N]: ", _reader=reader) == "Y"
+
+    def test_passthrough_for_plain_reads(self):
+        assert safe_input("", _reader=lambda _p: "y") == "y"
+
+    def test_eof_propagates(self):
+        def boom(_p):
+            raise EOFError
+
+        with pytest.raises(EOFError):
+            safe_input("", _reader=boom)

--- a/tests/hermes_cli/test_input_decode.py
+++ b/tests/hermes_cli/test_input_decode.py
@@ -29,9 +29,6 @@ class TestDecodeModifiedKeySequences:
 
     def test_kitty_csi_u_shift_only(self):
         assert decode_modified_key_sequences(f"{ESC}[84;2u") == "T"
-        # Kitty press/repeat low bits: shift|press(1)+1=3, shift|release+1=4.
-        assert decode_modified_key_sequences(f"{ESC}[84;3u") == "T"
-        assert decode_modified_key_sequences(f"{ESC}[84;4u") == "T"
 
     def test_control_and_alt_combos_pass_through(self):
         # Ctrl+T (5), Ctrl+Shift+T (6), Super+T (12) — decoding would invent
@@ -43,6 +40,12 @@ class TestDecodeModifiedKeySequences:
             assert decode_modified_key_sequences(seq) == seq
         assert decode_modified_key_sequences(f"{ESC}[27;3;84~") == f"{ESC}[27;3;84~"
         assert decode_modified_key_sequences(f"{ESC}[84;6u") == f"{ESC}[84;6u"
+
+    def test_kitty_alt_combinations_pass_through(self):
+        # CSI-u encodes Alt as 3 and Shift+Alt as 4; neither is shift-only.
+        for mod in ("3", "4"):
+            seq = f"{ESC}[84;{mod}u"
+            assert decode_modified_key_sequences(seq) == seq
 
     def test_lock_bits_pass_through(self):
         # CapsLock is applied by modifyOtherKeys *before* encoding: 65


### PR DESCRIPTION
## What

The classic CLI enables extended-key reporting (`modifyOtherKeys` level 2, and Kitty keyboard protocol on allowlisted terminals) globally for the process so Shift+Enter works in the prompt-toolkit chat. prompt_toolkit decodes the resulting sequences — but Python's builtin `input()` does not. Every bare `input()` prompt (hook consent, credential import, MCP setup, profile destruction, the hindsight wizard, the ACP browser-tools install) receives raw escape text like `^[[27;2;84~` instead of `T` whenever the user types a shifted character (#97975).

## Root cause

`cli.py::_enable_extended_enter_keys` pushes `CSI >4;2m` / `CSI >1u` for the whole process lifetime. The chat REPL reads through prompt_toolkit (which decodes via `ANSI_SEQUENCES`, extended by `hermes_cli.pt_input_extras`), but setup/consent code paths use builtin `input()`, which has no decoder — so the escape bytes land in the answer verbatim. Free-text prompts (API keys, endpoints) silently store corrupted values.

## Fix

New `hermes_cli/input_decode.py`:

- `decode_modified_key_sequences()` — a pure string transform. Decodes `ESC[27;2;<cp>~` and Kitty `ESC[<cp>;2u` (plus Kitty alternate-report mods 3/4) to `chr(cp)`; the codepoint is already layout-applied by the terminal, so shift-only decoding is just `chr`. Everything else passes through byte-for-byte: ctrl/alt/super combos, Alt under modifyOtherKeys (mod 3 is ambiguous there, never decoded), functional keys (Kitty private-use plane incl. Shift+Enter 57427), control codepoints, lock-bit combos (CapsLock is applied to the codepoint before encoding — decoding mod 65 would rewrite an *un-shifted* keypress), and out-of-range/surrogate codepoints.
- `safe_input()` — drop-in `input()` wrapper.

Migrated all bare `input()` prompt sites named in the issue: `agent/shell_hooks.py` (consent gate), `hermes_cli/auth_commands.py` ×4, `hermes_cli/mcp_config.py` ×2, `hermes_cli/profiles.py` (destruction confirmation), `acp_adapter/entry.py`, `plugins/memory/hindsight/__init__.py` ×4. `line_input()` sites already route through prompt_toolkit and were left alone. Remaining bare `input()` calls elsewhere are non-interactive/error-path reads; the wrapper is exported for those to adopt incrementally.

## Test plan

`tests/hermes_cli/test_input_decode.py` — 15 deterministic tests, no TTY: the issue's exact repro (`ESC[27;2;84~` → `T`), mixed `"Type THIS"` round-trip, Kitty CSI-u incl. alternate-report mods, ctrl/alt/super passthrough, Alt-under-MOK passthrough, lock-bit passthrough, functional-key/control/surrogate/out-of-range passthrough, unrelated escapes (bracketed paste, SGR, cursor) untouched, `safe_input` decode + EOF propagation.

Real pytest counts:
- new tests: 15 passed
- regression (`test_input_sanitize.py`, `test_cli_output.py`): all passed
- `tests/agent/test_shell_hooks_consent.py`: 1 failure (`test_tilde_path_approval_records_resolvable_mtime`) **reproduces identically on clean origin/main** (HOME-tilde expansion in the approval store on this Windows runner) — pre-existing, unrelated to this diff.

Contributes to #97975 (not "Closes" — the ~60-site full sweep is intentionally incremental; the named high-risk sites are done).
