### PR TITLE
fix(tui_gateway): refuse disabled wake-word auto-arm before the requirements probe

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2112,6 +2112,58 @@ def test_wake_owner_is_sticky_and_routes_detection_to_first_transport(monkeypatc
         server._wake_owner_surface = ""
 
 
+def test_wake_start_auto_arm_disabled_skips_requirements_probe(monkeypatch):
+    """Auto-arm on a wake word that cannot arm must refuse BEFORE probing.
+
+    check_wake_word_requirements() → _stt_ready() can lazy-install
+    faster-whisper as a synchronous subprocess that outlives the client's RPC
+    timeout, so a disabled-config auto-arm on every gateway.ready used to
+    surface as a spurious "error: timeout: wake.start" (#98409). The refusal
+    is reason:"disabled"/"disabled_for_surface" regardless of what the probe
+    would say, so the probe (the lazy-install entry point) must not run at
+    all on this path.
+    """
+    from tools import wake_word
+
+    config = {"enabled": False, "phrase": "hey hermes", "surface": "auto",
+              "start_new_session": True}
+    monkeypatch.setattr(wake_word, "load_wake_word_config", lambda: dict(config))
+
+    def _probe_explodes(_cfg):
+        raise AssertionError(
+            "check_wake_word_requirements() ran for an auto-arm that cannot "
+            "arm — the STT lazy-install entry point must be unreachable here"
+        )
+
+    monkeypatch.setattr(wake_word, "check_wake_word_requirements", _probe_explodes)
+
+    transport = types.SimpleNamespace(_closed=False)
+    server._wake_owner_transport = None
+    server._wake_owner_surface = ""
+    try:
+        # Feature off in config.
+        disabled = _dispatch_sync({
+            "id": "wake-autoarm-disabled",
+            "method": "wake.start",
+            "params": {"surface": "gui"},
+        }, transport=transport)
+        assert disabled["result"] == {"started": False, "reason": "disabled"}
+
+        # Feature on but scoped to a different surface: same must-refuse
+        # conclusion, so the probe must not run here either.
+        config["enabled"] = True
+        config["surface"] = "tui"
+        scoped = _dispatch_sync({
+            "id": "wake-autoarm-scoped",
+            "method": "wake.start",
+            "params": {"surface": "gui"},
+        }, transport=transport)
+        assert scoped["result"] == {"started": False, "reason": "disabled_for_surface"}
+    finally:
+        server._wake_owner_transport = None
+        server._wake_owner_surface = ""
+
+
 def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch):
     """The ear toggle / /wake on|off write wake_word.enabled; auto-arm never does."""
     from tools import wake_word

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16803,6 +16803,20 @@ def _(rid, params: dict) -> dict:
     prefer_client = surface in ("gui", "desktop") or bool(params.get("client_capture"))
     capture_mode = resolve_capture_mode(cfg, prefer_client=prefer_client)
     external_audio = capture_mode == "client"
+    # Auto-arm (persist omitted) against a disabled wake word can only ever be
+    # refused, with a reason the requirements probe cannot change. Refuse
+    # BEFORE probing: check_wake_word_requirements() → _stt_ready() can
+    # lazy-install faster-whisper as a synchronous subprocess that far
+    # outlives the client's RPC timeout, so every gateway.ready auto-arm on a
+    # disabled wake word surfaced as a spurious "error: timeout: wake.start"
+    # (#98409). The persist gesture keeps requirements-first below so a
+    # gesture on an unarmed-able setup still refuses WITHOUT flipping
+    # wake_word.enabled.
+    if not persist and not wake_surface_enabled(surface, cfg):
+        reason = "disabled" if not cfg.get("enabled") else "disabled_for_surface"
+        logger.info("wake.start(%s): %s (enabled=%s, surface=%s)",
+                    surface, reason, cfg.get("enabled"), cfg.get("surface"))
+        return _ok(rid, {"started": False, "reason": reason})
     # Requirements first: a gesture on an unarmed-able setup (no STT/TTS, no
     # mic, missing key) must refuse WITHOUT flipping wake_word.enabled — else
     # config says on while nothing can ever arm, and auto-arm paths churn.


### PR DESCRIPTION
## What does this PR do?

`wake.start` ran `check_wake_word_requirements()` **before** the enabled/surface gate. On a machine with no STT provider configured (wake word disabled in config), that probe walks `check_wake_word_requirements() → _stt_ready() → _get_provider() → _try_lazy_install_stt() → lazy_deps.ensure("stt.faster_whisper")` — a synchronous `uv/pip` subprocess installing a ~200MB ctranslate2 wheel. The TUI auto-arms the "Hey Hermes" listener on every `gateway.ready` by firing a fire-and-forget `wake.start`, so on such machines the install far outlives the client RPC timeout (`REQUEST_TIMEOUT_MS`, default 120s) and every chat shows a spurious `error: timeout: wake.start`.

An auto-arm (no `persist`) against a wake word that cannot arm is refused with `reason: "disabled"` / `"disabled_for_surface"` regardless of what the probe would say — so the refusal now happens **before** the probe, which is the lazy-install entry point. The `persist: true` gesture path is unchanged and keeps requirements-first, so an explicit gesture on an unarmed-able setup (no STT/TTS, no mic, missing key) still refuses **without** flipping `wake_word.enabled`.

This is the server-side half of #98409's suggested fix (item 1). Item 2 (probes never lazy-installing at all, the #77040 intent) is being carried by open #78202 at the `tools/` layer; the two changes are orthogonal file-wise and complementary behavior-wise.

## Related Issue

Fixes #98409

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — in the `wake.start` handler, refuse non-`persist` calls with `{started: False, reason: "disabled" | "disabled_for_surface"}` before `check_wake_word_requirements()` runs. Same reasons, same log shape as the previous post-probe refusal; only the ordering changes.
- `tests/test_tui_gateway_server.py` — new regression test `test_wake_start_auto_arm_disabled_skips_requirements_probe`: monkeypatches `check_wake_word_requirements` to raise if called, then asserts both the `disabled` and the `disabled_for_surface` auto-arm paths return the refusal without ever reaching the probe.

## How to Test

1. `pytest tests/test_tui_gateway_server.py tests/tui_gateway/test_protocol.py -q` — Observed result: 686 passed (includes the new test; the pre-existing `test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture` still passes, confirming the `persist` gesture keeps requirements-first semantics).
2. `ruff check tui_gateway/server.py tests/test_tui_gateway_server.py` — Observed result: all checks passed.
3. Manual equivalent of the issue repro (fresh config, `wake_word.enabled: false`, no STT): `wake.start` auto-arm should now return `{started: False, reason: "disabled"}` immediately, with no `faster-whisper` install attempt and no `error: timeout: wake.start` in the TUI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] N/A — behavior-preserving reorder inside one handler; the handler docstring's gate description already covers both refusal reasons
- [x] N/A — no config keys changed
- [x] N/A — no architecture or workflow changes
- [x] N/A — pure server-side ordering change, no platform-specific I/O touched
- [x] N/A — no tool behavior changes
