### PR TITLE
fix(agent): exempt :cloud GLM models from stop->length truncation rewrite

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1795,10 +1795,21 @@ class AIAgent:
         (LiteLLM/sglang/vLLM/LM Studio proxies, Tailscale boxes), which
         report finish_reason correctly and were the source of #13971's
         false-positive truncation continuations.
+
+        Cloud-backed Ollama models (model name contains ":cloud") run
+        generation server-side and report finish_reason correctly — the
+        local 11434 endpoint is only a proxy.  Applying the stop→length
+        rewrite to them manufactures false truncations and causes the
+        continuation nudge to consume the model's output budget on the
+        next retry, making further false-positives more likely (#98406).
         """
         model_lower = (self.model or "").lower()
         provider_lower = (self.provider or "").lower()
         if "glm" not in model_lower and provider_lower != "zai":
+            return False
+        # Cloud-backed models: finish_reason is forwarded faithfully from the
+        # upstream server; the local proxy is transparent.  Do not rewrite.
+        if ":cloud" in model_lower:
             return False
         if "ollama" in self._base_url_lower or ":11434" in self._base_url_lower:
             return True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4340,11 +4340,11 @@ class TestRunConversation:
         assert requested_caps == [65536, 65536]
 
     def test_ollama_glm_stop_after_tools_without_terminal_boundary_requests_continuation(self, agent):
-        """Ollama-hosted GLM responses can misreport truncated output as stop."""
+        """Local Ollama-hosted GLM (no :cloud suffix) misreports truncated output as stop."""
         self._setup_agent(agent)
         agent.base_url = "http://localhost:11434/v1"
         agent._base_url_lower = agent.base_url.lower()
-        agent.model = "glm-5.1:cloud"
+        agent.model = "glm-4-9b"  # local GLM — no :cloud suffix
 
         tool_turn = _mock_response(
             content="",
@@ -4383,6 +4383,43 @@ class TestRunConversation:
         third_call_messages = agent.client.chat.completions.create.call_args_list[2].kwargs["messages"]
         assert third_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in third_call_messages[-1]["content"]
+
+    def test_ollama_glm_cloud_stop_after_tools_does_not_request_continuation(self, agent):
+        """Cloud-backed GLM (:cloud suffix) forwards finish_reason faithfully — no rewrite."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.1:cloud"  # cloud suffix — proxy is transparent
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        real_stop = _mock_response(
+            content="Based on the search results, the best next step is to update the config.",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            tool_turn,
+            real_stop,
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # Cloud GLM: stop is taken at face value — 2 API calls, no synthetic continuation
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert (
+            result["final_response"]
+            == "Based on the search results, the best next step is to update the config."
+        )
 
 
 


### PR DESCRIPTION
## Summary

`_is_ollama_glm_backend()` was returning `True` for Ollama cloud models (model names containing `:cloud`, e.g. `glm-5.3-flash:cloud`) because the local Ollama proxy on port 11434 matched the `:11434` URL check.

The local 11434 endpoint for a cloud model is a transparent HTTP proxy — generation runs on Ollama's hosted server, which reports `finish_reason` faithfully. There is no misreport to guard against on this path.

## What went wrong

`_should_treat_stop_as_truncated()` rewrote `finish_reason="stop"` to `"length"` for cloud GLM sessions, triggering the 4-attempt continuation loop. Each retry injected a synthetic `[System: ...]` user message that reasoning-capable GLM models spent their output budget deliberating over. This produced responses ending mid-thought (no terminal punctuation), which `_has_natural_response_ending()` again rejected — a self-reinforcing loop that always hit the 4-attempt limit and raised `Response remained truncated after 4 continuation attempts` on perfectly correct original responses.

From the reporter's log: 391 `Treating suspicious Ollama/GLM stop response as truncated` hits, clustered on cloud GLM sessions.

## Fix

Add an early `return False` in `_is_ollama_glm_backend` when `":cloud"` appears in the model name. Local GLM inference (no `:cloud` suffix) is still caught by the existing port/URL/provider heuristics — the original fix for local Ollama misreports (#8011aa31ba) is untouched.

```python
# Cloud-backed models: finish_reason is forwarded faithfully from the
# upstream server; the local proxy is transparent.  Do not rewrite.
if ":cloud" in model_lower:
    return False
```

## Test coverage

Logic verified against 8 cases:

| Model | Provider | base_url | Before | After |
|---|---|---|---|---|
| `glm-5.3-flash:cloud` | `ollama` | `http://127.0.0.1:11434/v1` | `True` (bug) | `False` |
| `glm-5.1:cloud` | _(none)_ | `http://localhost:11434/v1` | `True` (bug) | `False` |
| `glm-5.3-flash` | `ollama` | `http://127.0.0.1:11434/v1` | `True` | `True` |
| `glm-5.3-flash` | `ollama` | `http://mybox.ollama.local/v1` | `True` | `True` |
| `glm-5.3-flash` | `ollama` | `http://mybox/v1` | `True` | `True` |
| `gpt-5` | `openai` | `https://api.openai.com/v1` | `False` | `False` |

Fixes #98406.
