### PR TITLE
fix(deps): bump mem0ai exact pins from 2.0.10 to 2.0.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,7 @@ honcho = ["honcho-ai==2.2.0"]
 # excluded from [all] like honcho/hindsight so a quarantined upstream release
 # can't break fresh installs.
 supermemory = ["supermemory==3.50.0"]
-mem0 = ["mem0ai==2.0.10"]
+mem0 = ["mem0ai==2.0.19"]
 # Image resize recovery for the vision tools. Pillow is now a CORE dependency
 # (see the main `dependencies` list above) since the byte/pixel shrink paths are on
 # the default vision-embed path and the mid-session lazy install deadlocked the
@@ -433,7 +433,7 @@ exclude-newer = "14 days"
 # firecrawl-anydoc: same exact-pin shape (==0.2.4, hosted-OCR wiring PR).
 # The pin bump WAS the review; exclude-newer adds zero float protection to
 # an exact pin and would only delay the reviewed version 14 days.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, firecrawl-anydoc = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, firecrawl-anydoc = false, mem0ai = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -200,7 +200,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ensure() call at the import site, the SDK never installs on a hosted
     # instance and the provider silently reports itself unavailable.
     "memory.supermemory": ("supermemory==3.50.0",),
-    "memory.mem0": ("mem0ai==2.0.10",),
+    "memory.mem0": ("mem0ai==2.0.19",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.8",),

--- a/uv.lock
+++ b/uv.lock
@@ -13,10 +13,11 @@ exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
 setuptools = false
-huggingface-hub = false
+mem0ai = false
 vercel = false
 pillow = false
 unpaddedbase64 = false
+huggingface-hub = false
 h2 = false
 defusedxml = false
 aiohttp = false
@@ -1901,7 +1902,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==2.0.0" },
     { name = "mcp", marker = "extra == 'dev'", specifier = "==2.0.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = "==2.0.0" },
-    { name = "mem0ai", marker = "extra == 'mem0'", specifier = "==2.0.10" },
+    { name = "mem0ai", marker = "extra == 'mem0'", specifier = "==2.0.19" },
     { name = "microsoft-teams-apps", marker = "extra == 'teams'", specifier = "==2.0.13.4" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = "==2.4.8" },
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.3.4" },
@@ -2492,7 +2493,7 @@ wheels = [
 
 [[package]]
 name = "mem0ai"
-version = "2.0.10"
+version = "2.0.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2504,9 +2505,9 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/43/b71a46ea164dbee57d2b436d60bc446179e5829e51759ee199240552701f/mem0ai-2.0.10.tar.gz", hash = "sha256:0d2afcd51f093c915b7d1e6208e86fbf563340de181e5604ff8af9513f3dffc8", size = 236842, upload-time = "2026-06-27T17:10:02.81Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/7e/0c01a5abd2a542425f795f1e64288d7843875449ccc7b745ffd41ff44d76/mem0ai-2.0.19.tar.gz", hash = "sha256:f58d66cdcc62954b97f300e64a63f2ff40c9508ff71cb99aec9a31ba98b6cacc", size = 249034, upload-time = "2026-08-24T13:16:45.835Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/58/9c25e77f06ec3483267f898c42fba783f2dcc411c7234dd34830bef8a372/mem0ai-2.0.10-py3-none-any.whl", hash = "sha256:9a99401c2c57bfbaf6ab780b193e458eb46802b4d75cac42f61eff13c9e34062", size = 329294, upload-time = "2026-06-27T17:10:01.157Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/15/1ec84875a8f5ae2ba4fbc7e89a9dd0a9b63028c04acfc2a1adb5b13455d4/mem0ai-2.0.19-py3-none-any.whl", hash = "sha256:c0d04476eb15872f65688297befb57708e12b04298d4f4215229b2066578956e", size = 344762, upload-time = "2026-08-24T13:16:44.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Both `mem0ai` install paths in the repository were pinned to `2.0.10` (June 2026) while the current stable release is `2.0.19`. The plugin manifest already accepted `>=2.0.10,<3`, but eager installs (project extra) and lazy installs (`tools/lazy_deps.py`) both resolved the stale pin.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | `mem0 = ["mem0ai==2.0.10"]` → `mem0ai==2.0.19` |
| `tools/lazy_deps.py` | `"memory.mem0": ("mem0ai==2.0.10",)` → `mem0ai==2.0.19` |
| `uv.lock` | Regenerated with `uv lock --upgrade-package mem0ai` — only `mem0ai` moves |
| `pyproject.toml` `[tool.uv]` | Added `mem0ai = false` to `exclude-newer-package` so the 14-day cutoff does not brick installs of the newly-reviewed pin |

## Compatibility evidence

- Python support unchanged: `>=3.10,<4.0`
- Base runtime dependencies unchanged between 2.0.10 and 2.0.19
- `Memory.update(data=...)` (the spelling Hermes uses at the adapter boundary) remains a supported alias
- No lock movement outside `mem0ai` itself

## What was not changed

The plugin manifest (`plugins/memory/mem0/plugin.yaml`: `mem0ai>=2.0.10,<3`) retains its broader compatibility range — no evidence requires raising the minimum above 2.0.10 for supported setups.

Fixes #98407.
