### PR TITLE
fix(dashboard-auth): rotate the audit log via RotatingFileHandler (#98338)

### DIFF
--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -135,6 +135,13 @@ def _get_handler(path: Path) -> RotatingFileHandler:
     # Keep audit records out of the standard-library root logger graph; they
     # are written directly as raw lines to the file.
     handler.setLevel(logging.INFO)
+    # Evict handlers for a DIFFERENT resolved path (HERMES_HOME / profile
+    # moved in-process): leaving them in the cache would leak their fds.
+    # Path-change rotations are rare, so a linear sweep on rebuild is fine.
+    for old_path, old_handler in list(_handlers.items()):
+        if old_path != path:
+            old_handler.close()
+            _handlers.pop(old_path, None)
     _handlers[path] = handler
     return handler
 

--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -1,7 +1,20 @@
-"""Audit log for dashboard-auth events: ``$HERMES_HOME/logs/dashboard-auth.log``, one JSON object
-per line. Token-like fields are stripped before serialisation so refresh tokens / JWTs never
-reach disk. Minimal import surface (no ``hermes_constants`` at import time) so early-loading
-middleware can import it."""
+"""Audit log for dashboard-auth events.
+
+Profile-aware location: ``$HERMES_HOME/logs/dashboard-auth.log``.
+Format: one JSON object per line. Token-like fields are stripped before
+serialisation to avoid leaking refresh tokens or JWTs to disk.
+
+Unlike a plain append, writes go through a ``RotatingFileHandler`` so the
+log cannot grow without bound from an unauthenticated endpoint (upstream
+#98338). Rotation honours ``logging.max_size_mb`` / ``logging.backup_count``
+from ``config.yaml`` (defaults 5 MB and 3 backups).
+
+This module deliberately keeps a minimal dependency surface — no imports
+from ``hermes_constants`` or other hermes_cli modules — so it can be
+imported safely from middleware code that loads early in the startup
+sequence. Config reads use lazy imports inside the function, mirroring
+``_resolve_log_path``.
+"""
 from __future__ import annotations
 
 import datetime as _dt
@@ -9,16 +22,26 @@ import enum
 import json
 import logging
 import threading
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any
 
 _log = logging.getLogger(__name__)
 _write_lock = threading.Lock()
 
+# Default rotation policy when config.yaml is absent or unreadable.
+_DEFAULT_MAX_BYTES = 5 * 1024 * 1024
+_DEFAULT_BACKUP_COUNT = 3
+
 # Field names that must never appear in the log raw; matching kwargs are dropped.
 _REDACTED_FIELDS: frozenset = frozenset({
     "access_token", "refresh_token", "code", "code_verifier",
     "state", "ticket", "cookie", "Authorization", "authorization"})
+
+# Cache of {resolved_log_path: RotatingFileHandler}. Rebuilt lazily so a
+# HERMES_HOME / profile change in the process picks up the new path (and
+# rotation policy) on the next write.
+_handlers: dict[Path, RotatingFileHandler] = {}
 
 
 class AuditEvent(enum.Enum):
@@ -48,19 +71,102 @@ def _resolve_log_path() -> Path:
     return get_hermes_home() / "logs" / "dashboard-auth.log"
 
 
+def _rotation_policy() -> tuple[int, int]:
+    """Return ``(max_bytes, backup_count)`` from ``logging`` config.
+
+    Reads ``logging.max_size_mb`` / ``logging.backup_count`` with a lazy
+    import (load_config can raise on malformed YAML / IO), falling back to
+    the module defaults. ``max_size_mb`` is floored at 1 so a 0/negative
+    value cannot disable rotation silently.
+    """
+    max_bytes, backup_count = _DEFAULT_MAX_BYTES, _DEFAULT_BACKUP_COUNT
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception:  # noqa: BLE001 — robust to config being unavailable early
+        return (max_bytes, _DEFAULT_BACKUP_COUNT)
+
+    if not isinstance(cfg, dict):
+        return (max_bytes, _DEFAULT_BACKUP_COUNT)
+
+    logging_cfg = cfg.get("logging")
+    if not isinstance(logging_cfg, dict):
+        return (max_bytes, _DEFAULT_BACKUP_COUNT)
+
+    try:
+        size_mb = int(logging_cfg.get("max_size_mb", 5))
+        max_bytes = max(1, size_mb) * 1024 * 1024
+    except (TypeError, ValueError):
+        max_bytes = _DEFAULT_MAX_BYTES
+
+    try:
+        backup_count = int(logging_cfg.get("backup_count", 3))
+        if backup_count < 0:
+            backup_count = _DEFAULT_BACKUP_COUNT
+    except (TypeError, ValueError):
+        backup_count = _DEFAULT_BACKUP_COUNT
+
+    return (max_bytes, backup_count)
+
+
+def _get_handler(path: Path) -> RotatingFileHandler:
+    """Return a cached RotatingFileHandler for *path*, re-resolving when the
+    path or rotation policy changes (e.g. HERMES_HOME moved in-process)."""
+    handler = _handlers.get(path)
+    if handler is not None:
+        max_bytes, _ = _rotation_policy()
+        # Rebuild if the configured max size changed (backup_count changing
+        # alone is cosmetic; rebuilds are cheap and only on writes).
+        if handler.maxBytes == max_bytes:
+            return handler
+        handler.close()
+        _handlers.pop(path, None)
+
+    max_bytes, backup_count = _rotation_policy()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handler = RotatingFileHandler(
+        str(path),
+        mode="a",
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+        encoding="utf-8",
+    )
+    # Keep audit records out of the standard-library root logger graph; they
+    # are written directly as raw lines to the file.
+    handler.setLevel(logging.INFO)
+    _handlers[path] = handler
+    return handler
+
+
 def audit_log(event: AuditEvent, **fields: Any) -> None:
     """Append one event; token-like fields dropped, log dir created. Write failures are logged at
     WARNING but never raise — auth must not fail because the audit logger broke."""
+    safe_fields = {
+        k: v for k, v in fields.items()
+        if k not in _REDACTED_FIELDS
+    }
     entry = {
         "ts": _dt.datetime.now(_dt.timezone.utc).isoformat(),
         "event": event.value,
-        **{k: v for k, v in fields.items() if k not in _REDACTED_FIELDS}}
-    line = json.dumps(entry, separators=(",", ":")) + "\n"
-    path = _resolve_log_path()
+        **safe_fields,
+    }
+    line = json.dumps(entry, separators=(",", ":"))  # RotatingFileHandler appends "\n"
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with _write_lock, open(path, "a", encoding="utf-8") as f:
-            f.write(line)
+        path = _resolve_log_path()
+        with _write_lock:
+            handler = _get_handler(path)
+            handler.emit(
+                logging.LogRecord(
+                    name=__name__,
+                    level=logging.INFO,
+                    pathname=__file__,
+                    lineno=0,
+                    msg="%s",
+                    args=(line,),
+                    exc_info=None,
+                )
+            )
     except Exception as e:
         _log.warning("dashboard-auth audit log write failed: %s", e)
 

--- a/tests/hermes_cli/test_dashboard_auth_audit.py
+++ b/tests/hermes_cli/test_dashboard_auth_audit.py
@@ -55,5 +55,32 @@ def test_audit_redacts_token_like_fields(profile_home):
         assert forbidden not in raw, f"token-like value leaked into audit log: {forbidden}"
 
 
+def test_audit_honors_max_size_and_rotates(profile_home, monkeypatch):
+    """Writing past the configured max bytes rotates instead of growing
+    without bound (upstream #98338)."""
+    path = profile_home / "logs" / "dashboard-auth.log"
+
+    import hermes_cli.dashboard_auth.audit as audit_mod
+
+    # Force a tiny cap so a few records trigger the RotatingFileHandler path.
+    monkeypatch.setattr(audit_mod, "_rotation_policy", lambda: (500, 2))
+
+    for i in range(60):
+        audit_log(AuditEvent.LOGIN_SUCCESS, provider="nous", n=i)
+
+    assert path.exists()
+    # Rotation happened → a backup file exists (dashboard-auth.log.1).
+    assert path.with_name("dashboard-auth.log.1").exists(), (
+        "expected a rotated backup after exceeding maxBytes"
+    )
+    # Each line must still be one JSON object.
+    lines = path.read_text().splitlines()
+    assert lines, "no audit records written"
+    assert all(l.startswith("{") and l.endswith("}") for l in lines)
+    # The live file must not have grown without bound (60 records can't
+    # balloon past a sane bound once rotation is active).
+    assert path.stat().st_size < 50 * 1024, "live audit log grew unboundedly"
+
+
 
 

--- a/tests/hermes_cli/test_dashboard_auth_audit.py
+++ b/tests/hermes_cli/test_dashboard_auth_audit.py
@@ -82,5 +82,39 @@ def test_audit_honors_max_size_and_rotates(profile_home, monkeypatch):
     assert path.stat().st_size < 50 * 1024, "live audit log grew unboundedly"
 
 
+def test_audit_evicts_handler_when_hermes_home_moves(profile_home, monkeypatch):
+    """A HERMES_HOME / profile move in-process must not leak the old
+    handler's fd: writing to a new path closes the previous handler."""
+    import hermes_cli.dashboard_auth.audit as audit_mod
+
+    old_home = profile_home
+    new_home = old_home.parent / "moved-home"
+    new_home.mkdir()
+
+    # First write targets the fixture's home (populates _handlers).
+    audit_log(AuditEvent.LOGIN_START, provider="nous", ip="1.2.3.4")
+    old_path = old_home / "logs" / "dashboard-auth.log"
+    assert audit_mod._handlers[old_path] is not None
+
+    # Move HERMES_HOME → the audit path changes mid-process.
+    monkeypatch.setenv("HERMES_HOME", str(new_home))
+    audit_log(AuditEvent.LOGIN_SUCCESS, provider="nous", user_id="u1", ip="1.2.3.4")
+
+    new_path = new_home / "logs" / "dashboard-auth.log"
+    # New handler exists for the new path, old handler evicted + closed.
+    assert new_path.exists(), f"new home audit log not created at {new_path}"
+    assert new_path in audit_mod._handlers
+    assert old_path not in audit_mod._handlers, (
+        "old-path handler must be evicted after HERMES_HOME moves"
+    )
+    # Both records still present (old and new locations each hold their own).
+    assert json.loads(old_path.read_text().splitlines()[0])["event"] == "login_start"
+
+    # Restore: subsequent writes keep going to the new home.
+    audit_log(AuditEvent.LOGOUT, user_id="u1", ip="1.2.3.4")
+    lines = new_path.read_text().splitlines()
+    assert len(lines) == 2, lines  # login_success + logout on the new path
+
+
 
 


### PR DESCRIPTION
## What does this PR do?

Routes `dashboard-auth.log` writes through a `RotatingFileHandler`, so the audit log can no longer grow without bound from an unauthenticated endpoint.

### Problem

`hermes_cli/dashboard_auth/audit.py` appended every audit record with a plain `open(path, "a")` under a thread lock — no size cap, no rotation, no retention. The gateway's own logging uses `RotatingFileHandler(maxBytes=5*1024*1024, backupCount=3)` and the general logging subsystem exposes `logging.max_size_mb` / `logging.backup_count` (config_defaults.py), but the dashboard-auth audit log participates in neither. Because the file is written from an **unauthenticated** endpoint, a looping client or attacker can grow it until the volume fills — on a hosted instance that would take down the very audit log that is the only record of refresh failures (see the 3,338-record storm in #98338).

### Change

- `audit_log()` writes through a cached `RotatingFileHandler`, honouring `logging.max_size_mb` / `logging.backup_count` from `config.yaml` (defaults 5 MB / 3 backups).
- Preserves the module's minimal-dependency contract: config reads are **lazy imports inside the function** (mirroring the existing `_resolve_log_path`), so it stays importable early in the startup sequence.
- Handler is cached per resolved path and rebuilt if the path or cap changes, so a `HERMES_HOME` / profile move in-process picks up the new file. Handlers for a **different** resolved path are closed and evicted on rebuild, so a home move cannot leak fds.
- Behaviour preserved: one JSON object per line, `$HERMES_HOME/logs/dashboard-auth.log`, redaction of token-like fields, writes under a lock, and write failures still log WARNING and never raise (auth must not fail because the audit logger broke).

## Related Issue

**Refs #98338** (partial — satisfies the issue's **request #10: route `dashboard-auth.log` through the same `RotatingFileHandler` policy, honouring `logging.max_size_mb` / `logging.backup_count`**).

The other requests in #98338 (dual-logging of the refresh path, backoff/circuit breaker, device id on audit records, scheduler `max_parallel_jobs` logging) are NOT addressed here and are tracked in separate PRs, so #98338 should stay open for them.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/dashboard_auth/audit.py`: replaced the plain `open(path, "a")` append with a cached `RotatingFileHandler` (honouring `logging.max_size_mb` / `logging.backup_count` via lazy config read, `_rotation_policy()` helper, handler re-resolved on path/cap change). Rebuilds close and evict handlers for any different resolved path, so a `HERMES_HOME`/profile move mid-process cannot leak fds. JSON-line format, redaction, locking and fail-open-WARNING behaviour preserved.
- `tests/hermes_cli/test_dashboard_auth_audit.py`: added `test_audit_honors_max_size_and_rotates` (rotation produces a backup file and the live log stays bounded, each line still one JSON object) and `test_audit_evicts_handler_when_hermes_home_moves` (old-path handler evicted and closed after a mid-process home move; new path keeps its own records).

## How to Test

1. `pytest tests/hermes_cli/test_dashboard_auth_audit.py` → 4 passed (incl. rotation + eviction tests)
2. `pytest tests/hermes_cli/test_dashboard_auth_native_flow.py tests/plugins/dashboard_auth/` → 114 passed, no regressions

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A

---

**🛠️ Dev:** Halldrix
**🤖 Sidekick:** Hermes Agent v0.20.5 — main `26350357d7`
**🐞 Reproduction:** ✅ Confirmed (tests green)
