### PR TITLE
fix(auxiliary): continue through configured fallback chain

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5275,6 +5275,29 @@ def _fallback_provider_from_label(label: str) -> str:
     return match.group(1).strip() if match else str(label or "").strip()
 
 
+def _next_configured_fallback_index(label: str) -> int:
+    """Return the configured-chain index immediately after ``label``."""
+    match = re.match(r"fallback_chain\[(\d+)\]", label or "")
+    return int(match.group(1)) + 1 if match else 0
+
+
+def _fallback_candidate_failure_reason(exc: Exception) -> Optional[str]:
+    """Classify errors that may advance to another auxiliary fallback."""
+    if _is_auth_error(exc):
+        return "auth error"
+    if _is_payment_error(exc):
+        return "payment error"
+    if _is_rate_limit_error(exc):
+        return "rate limit"
+    if _is_model_incompatible_error(exc):
+        return "model incompatible with route"
+    if _is_invalid_aux_response_error(exc):
+        return "invalid provider response"
+    if _is_connection_error(exc):
+        return "connection error"
+    return None
+
+
 class _FallbackDestination(NamedTuple):
     provider: str
     base_url: str
@@ -5876,6 +5899,7 @@ def _try_configured_fallback_chain(
     failed_provider: str,
     reason: str = "error",
     failed_model: Optional[str] = None,
+    start_index: int = 0,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try user-configured fallback_chain for a specific auxiliary task.
 
@@ -5934,7 +5958,8 @@ def _try_configured_fallback_chain(
     tried = []
     min_ctx = _task_minimum_context_length(task)
 
-    for i, entry in enumerate(chain):
+    start_index = max(0, start_index)
+    for i, entry in enumerate(chain[start_index:], start=start_index):
         if not isinstance(entry, dict):
             continue
         fb_provider = str(entry.get("provider", "")).strip()
@@ -10509,25 +10534,68 @@ def _call_llm_impl(
             #   2. For auto: top-level main fallback_providers/fallback_model
             #   3. For auto: built-in auxiliary discovery chain
             #   4. For explicit aux providers: main agent model safety net
-            fb_client, fb_model, fb_label = (None, None, "")
-            if is_auto:
+            fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+                task, resolved_provider or "auto", reason=reason,
+                failed_model=_chain_failed_model)
+            while fb_client is not None:
+                _record_route_info(
+                    route_info, _fallback_provider_from_label(fb_label), fb_model
+                )
+                try:
+                    fb_resp = _call_fallback_candidate_sync(
+                        fb_client, fb_model, fb_label,
+                        task=task, messages=messages,
+                        temperature=temperature, max_tokens=max_tokens,
+                        tools=tools, effective_timeout=effective_timeout,
+                        effective_extra_body=effective_extra_body,
+                        reasoning_config=reasoning_config)
+                except Exception as fb_err:
+                    fb_reason = _fallback_candidate_failure_reason(fb_err)
+                    if fb_reason is None:
+                        raise
+                    failed_fb_provider = _fallback_provider_from_label(fb_label)
+                    failed_fb_model = (
+                        None
+                        if fb_reason in ("auth error", "payment error")
+                        else fb_model
+                    )
+                    if fb_reason == "payment error":
+                        _mark_provider_unhealthy(failed_fb_provider)
+                    if fb_reason == "connection error":
+                        _evict_cached_client_instance(fb_client)
+                    logger.info(
+                        "Auxiliary %s: %s on %s (%s), continuing configured fallback_chain",
+                        task or "call", fb_reason, fb_label, fb_err,
+                    )
+                else:
+                    if fb_resp is not None:
+                        return fb_resp
+                    # The candidate helper quarantines stale/unrefreshable
+                    # credentials and returns None so the chain can advance.
+                    fb_reason = "stale fallback credential"
+                    failed_fb_provider = _fallback_provider_from_label(fb_label)
+                    failed_fb_model = None
+
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
-                    failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_fallback_chain(
-                        task, resolved_provider or "auto", reason=reason)
+                    task,
+                    failed_fb_provider,
+                    reason=fb_reason,
+                    failed_model=failed_fb_model,
+                    start_index=_next_configured_fallback_index(fb_label),
+                )
+
+            # The configured chain is genuinely exhausted. Preserve the
+            # existing broader safety-net policy from this point onward.
+            if is_auto:
+                fb_client, fb_model, fb_label = _try_main_fallback_chain(
+                    task, resolved_provider or "auto", reason=reason)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
             else:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
+                fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
+                    resolved_provider, task, reason=reason,
                     failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason,
-                        failed_model=_chain_failed_model)
 
             if fb_client is not None:
                 _record_route_info(
@@ -10542,9 +10610,8 @@ def _call_llm_impl(
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
                     return fb_resp
-                # The candidate had a stale/unrefreshable credential and was
-                # quarantined — walk the discovery chain once more; unhealthy
-                # entries are skipped so the next viable candidate serves.
+                # A safety-net candidate had a stale/unrefreshable credential
+                # and was quarantined — preserve the existing discovery retry.
                 fb_client, fb_model, fb_label = _try_payment_fallback(
                     resolved_provider, task, reason="stale fallback credential")
                 if fb_client is not None:
@@ -11207,28 +11274,76 @@ async def _async_call_llm_impl(
             #   2. For auto: top-level main fallback_providers/fallback_model
             #   3. For auto: built-in auxiliary discovery chain
             #   4. For explicit aux providers: main agent model safety net
-            fb_client, fb_model, fb_label = (None, None, "")
-            if is_auto:
+            fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+                task, resolved_provider or "auto", reason=reason,
+                failed_model=_chain_failed_model)
+            while fb_client is not None:
+                # Convert sync fallback client to async
+                async_fb, async_fb_model = _to_async_client(
+                    fb_client, fb_model or "", is_vision=(task == "vision")
+                )
+                _record_route_info(
+                    route_info,
+                    _fallback_provider_from_label(fb_label),
+                    async_fb_model or fb_model,
+                )
+                try:
+                    fb_resp = await _call_fallback_candidate_async(
+                        async_fb, async_fb_model or fb_model, fb_label,
+                        task=task, messages=messages,
+                        temperature=temperature, max_tokens=max_tokens,
+                        tools=tools, effective_timeout=effective_timeout,
+                        effective_extra_body=effective_extra_body,
+                        reasoning_config=reasoning_config)
+                except Exception as fb_err:
+                    fb_reason = _fallback_candidate_failure_reason(fb_err)
+                    if fb_reason is None:
+                        raise
+                    failed_fb_provider = _fallback_provider_from_label(fb_label)
+                    failed_fb_model = (
+                        None
+                        if fb_reason in ("auth error", "payment error")
+                        else (async_fb_model or fb_model)
+                    )
+                    if fb_reason == "payment error":
+                        _mark_provider_unhealthy(failed_fb_provider)
+                    if fb_reason == "connection error":
+                        _evict_cached_client_instance(async_fb)
+                    logger.info(
+                        "Auxiliary %s (async): %s on %s (%s), continuing configured fallback_chain",
+                        task or "call", fb_reason, fb_label, fb_err,
+                    )
+                else:
+                    if fb_resp is not None:
+                        return fb_resp
+                    # The candidate helper quarantines stale/unrefreshable
+                    # credentials and returns None so the chain can advance.
+                    fb_reason = "stale fallback credential"
+                    failed_fb_provider = _fallback_provider_from_label(fb_label)
+                    failed_fb_model = None
+
                 fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
-                    failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_fallback_chain(
-                        task, resolved_provider or "auto", reason=reason)
+                    task,
+                    failed_fb_provider,
+                    reason=fb_reason,
+                    failed_model=failed_fb_model,
+                    start_index=_next_configured_fallback_index(fb_label),
+                )
+
+            # The configured chain is genuinely exhausted. Preserve the
+            # existing broader safety-net policy from this point onward.
+            if is_auto:
+                fb_client, fb_model, fb_label = _try_main_fallback_chain(
+                    task, resolved_provider or "auto", reason=reason)
                 if fb_client is None:
                     fb_client, fb_model, fb_label = _try_payment_fallback(
                         resolved_provider, task, reason=reason)
             else:
-                fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-                    task, resolved_provider or "auto", reason=reason,
+                fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
+                    resolved_provider, task, reason=reason,
                     failed_model=_chain_failed_model)
-                if fb_client is None:
-                    fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
-                        resolved_provider, task, reason=reason,
-                        failed_model=_chain_failed_model)
 
             if fb_client is not None:
-                # Convert sync fallback client to async
                 async_fb, async_fb_model = _to_async_client(
                     fb_client, fb_model or "", is_vision=(task == "vision")
                 )
@@ -11246,8 +11361,8 @@ async def _async_call_llm_impl(
                     reasoning_config=reasoning_config)
                 if fb_resp is not None:
                     return fb_resp
-                # Stale/unrefreshable candidate credential — quarantined; walk
-                # the discovery chain once more (unhealthy entries skipped).
+                # A safety-net candidate had a stale/unrefreshable credential
+                # and was quarantined — preserve the existing discovery retry.
                 fb_client, fb_model, fb_label = _try_payment_fallback(
                     resolved_provider, task, reason="stale fallback credential")
                 if fb_client is not None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5965,6 +5965,10 @@ def _try_configured_fallback_chain(
         fb_provider = str(entry.get("provider", "")).strip()
         if not fb_provider:
             continue
+        if _is_provider_unhealthy(_normalize_chain_label(fb_provider)):
+            _log_skip_unhealthy(_normalize_chain_label(fb_provider), task)
+            tried.append(f"fallback_chain[{i}]({fb_provider}) (unhealthy)")
+            continue
         fb_model_raw = str(entry.get("model", "")).strip()
         if should_skip_candidate(
             BackendIdentity.build(
@@ -9926,6 +9930,14 @@ def _call_llm_impl(
             main_runtime=main_runtime,
             task=task,
         )
+        explicit_provider = (resolved_provider or "").strip().lower()
+        if (
+            task
+            and explicit_provider not in {"", "auto"}
+            and _is_provider_unhealthy(_normalize_chain_label(explicit_provider))
+        ):
+            _log_skip_unhealthy(_normalize_chain_label(explicit_provider), task)
+            client = None
         effective_provider = _effective_provider_for_client(
             client, resolved_provider,
         )
@@ -10816,6 +10828,14 @@ async def _async_call_llm_impl(
             main_runtime=main_runtime,
             task=task,
         )
+        explicit_provider = (resolved_provider or "").strip().lower()
+        if (
+            task
+            and explicit_provider not in {"", "auto"}
+            and _is_provider_unhealthy(_normalize_chain_label(explicit_provider))
+        ):
+            _log_skip_unhealthy(_normalize_chain_label(explicit_provider), task)
+            client = None
         effective_provider = _effective_provider_for_client(
             client, resolved_provider,
         )

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -115,11 +115,13 @@ def pin_summary_route(route: Optional[Dict[str, Any]]):
     no-op passthrough so callers can wire it unconditionally. Re-entrant-safe:
     restores the previous pin on exit.
     """
-    token = _SUMMARY_ROUTE_PIN.set(route if isinstance(route, dict) else None)
+    pin_token = _SUMMARY_ROUTE_PIN.set(route if isinstance(route, dict) else None)
+    consumed_token = _SUMMARY_ROUTE_CONSUMED.set(None)
     try:
         yield
     finally:
-        _SUMMARY_ROUTE_PIN.reset(token)
+        _SUMMARY_ROUTE_CONSUMED.reset(consumed_token)
+        _SUMMARY_ROUTE_PIN.reset(pin_token)
 
 
 def take_pinned_summary_route() -> Optional[Dict[str, Any]]:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1001,21 +1001,15 @@ def resolve_context_compression_timeouts(
     return idle, ceiling
 
 
-def resolve_compression_fallback_route() -> Optional[dict]:
-    """Return the first usable ``auxiliary.compression.fallback_chain`` entry.
+def _resolve_compression_fallback_routes() -> List[dict]:
+    """Return usable ``auxiliary.compression.fallback_chain`` entries in order.
 
     The chain is the user's declared answer to "the configured compression
     route is unhealthy". The auxiliary client applies it from its exception
     handler, so a route that *stalls* — connection open, no tokens, aborted by
     the host's progress-aware timeout — never reaches it (#78981). This
     resolves the same config into explicit ``call_llm`` route arguments the
-    stall path can pin onto one retry.
-
-    Only the first structurally complete entry is returned: one extra bounded
-    attempt is the budget for a stall, and if that entry cannot build a client
-    (or errors) the auxiliary client's own exception path still walks the rest
-    of the chain from there. Returns ``None`` when no entry is usable, which
-    keeps the historical continue-without-compression behaviour.
+    stall path can pin onto bounded retries.
     """
     try:
         from agent.auxiliary_client import (
@@ -1026,10 +1020,11 @@ def resolve_compression_fallback_route() -> Optional[dict]:
         chain = _get_auxiliary_task_config("compression").get("fallback_chain")
     except Exception:
         logger.debug("compression fallback_chain lookup failed", exc_info=True)
-        return None
+        return []
     if not isinstance(chain, list):
-        return None
+        return []
 
+    routes = []
     for index, entry in enumerate(chain):
         if not isinstance(entry, dict):
             continue
@@ -1051,37 +1046,43 @@ def resolve_compression_fallback_route() -> Optional[dict]:
         from agent.auxiliary_client import _coerce_positive_timeout
 
         timeout = _coerce_positive_timeout(entry.get("timeout"))
-        return {
-            "label": f"fallback_chain[{index}]({provider})",
-            "provider": provider,
-            "model": model,
-            "base_url": str(entry.get("base_url") or "").strip() or None,
-            "api_key": api_key or None,
-            "api_mode": str(
-                entry.get("api_mode") or entry.get("transport") or ""
-            ).strip() or None,
-            "timeout": timeout,
-        }
-    return None
+        routes.append(
+            {
+                "label": f"fallback_chain[{index}]({provider})",
+                "provider": provider,
+                "model": model,
+                "base_url": str(entry.get("base_url") or "").strip() or None,
+                "api_key": api_key or None,
+                "api_mode": str(
+                    entry.get("api_mode") or entry.get("transport") or ""
+                ).strip() or None,
+                "timeout": timeout,
+            }
+        )
+    return routes
+
+
+def resolve_compression_fallback_route() -> Optional[dict]:
+    """Return the first structurally usable compression fallback route."""
+    routes = _resolve_compression_fallback_routes()
+    return routes[0] if routes else None
 
 
 def _retry_compression_on_fallback_chain(
     *,
     worker: Callable[[CompressionCommitFence], Tuple[list, str]],
     messages: list,
-    system_prompt_fallback: Any,
     idle_timeout_seconds: float,
     total_ceiling_seconds: float,
     on_commit_overrun: Optional[Callable[[float, float], None]] = None,
     telemetry_agent: Any = None,
     new_fence: Optional[Callable[[], CompressionCommitFence]] = None,
 ) -> Optional[Tuple[list, str]]:
-    """Re-run an aborted compression once with the summary route pinned.
+    """Try each configured summary fallback after an aborted compression.
 
     Returns the fallback attempt's ``(messages, system_prompt)`` when it
-    actually compressed, or ``None`` when there was nothing to fall back to,
-    the attempt raised, or it produced no compression either — the caller then
-    degrades exactly as it did before.
+    actually compressed, or ``None`` after every structurally usable entry was
+    exhausted — the caller then degrades exactly as it did before.
 
     The retry is bounded the same way the primary was: silence for one idle
     window ends it, while a fallback that is streaming keeps its ceiling. The
@@ -1096,84 +1097,89 @@ def _retry_compression_on_fallback_chain(
     worker to resume mid-pipeline would couple this path to every host's
     callback ordering — deliberately out of scope.
     """
+    hard_cancel = getattr(telemetry_agent, "_hard_interrupt_requested", None)
+    hard_cancel_is_set = getattr(hard_cancel, "is_set", None)
     # An explicit stop is not a stalled route. The retry worker would abort on
     # the same event anyway, but starting one at all makes /stop look ignored.
-    hard_cancel = getattr(telemetry_agent, "_hard_interrupt_requested", None)
-    if callable(getattr(hard_cancel, "is_set", None)) and hard_cancel.is_set():
+    if callable(hard_cancel_is_set) and hard_cancel_is_set():
         return None
 
-    route = resolve_compression_fallback_route()
-    if route is None:
-        return None
+    routes = _resolve_compression_fallback_routes()
+    for route in routes:
+        if callable(hard_cancel_is_set) and hard_cancel_is_set():
+            return None
 
-    # The aborted fence refuses every future commit, so the retry needs a
-    # fresh one. Mint it through the host's factory when it has one: hosts
-    # publish the active fence for hard-interrupt admission, and a /stop
-    # during the retry must serialize against THIS attempt's commit boundary.
-    retry_fence = None
-    if new_fence is not None:
-        try:
-            retry_fence = new_fence()
-        except Exception:
+        # Every aborted fence refuses future commits, so each retry needs a
+        # fresh one. Mint it through the host's factory when it has one: hosts
+        # publish the active fence for hard-interrupt admission, and a /stop
+        # during the retry must serialize against THIS attempt's boundary.
+        retry_fence = None
+        if new_fence is not None:
+            try:
+                retry_fence = new_fence()
+            except Exception:
+                logger.warning(
+                    "compression stall-fallback fence factory failed; the retry "
+                    "will run on an unpublished fence (a /stop mid-retry cannot "
+                    "serialize against its commit boundary)",
+                    exc_info=True,
+                )
+        if not isinstance(retry_fence, CompressionCommitFence):
             logger.warning(
-                "compression stall-fallback fence factory failed; the retry "
-                "will run on an unpublished fence (a /stop mid-retry cannot "
-                "serialize against its commit boundary)",
+                "compression stall-fallback retry running on an unpublished fence; "
+                "hard-interrupt admission will read the aborted attempt's fence "
+                "rather than the retry's commit boundary",
+            )
+            retry_fence = CompressionCommitFence()
+        idle = float(route.get("timeout") or idle_timeout_seconds)
+        ceiling = max(float(total_ceiling_seconds), idle)
+        logger.warning(
+            "Context compression stalled on the configured summary route — "
+            "retrying on %s (%s) before continuing down the fallback chain",
+            route["label"],
+            route["model"],
+        )
+        try:
+            from agent.context_compressor import pin_summary_route
+
+            with pin_summary_route(route):
+                result_msgs, result_prompt = run_compress_context_with_progress_timeout(
+                    worker=worker,
+                    messages=messages,
+                    # The outer attempt owns the one real degradation after
+                    # the whole chain is exhausted; retry no-ops discard this.
+                    system_prompt_fallback="",
+                    idle_timeout_seconds=idle,
+                    total_ceiling_seconds=ceiling,
+                    on_commit_overrun=on_commit_overrun,
+                    fence=retry_fence,
+                    telemetry_agent=telemetry_agent,
+                    stall_fallback=False,
+                )
+        except Exception:
+            # The primary already failed; a failing fallback must continue the
+            # declared chain, never turn the eventual degrade into a raised turn.
+            logger.warning(
+                "Context compression fallback attempt on %s failed",
+                route["label"],
                 exc_info=True,
             )
-    if not isinstance(retry_fence, CompressionCommitFence):
-        logger.warning(
-            "compression stall-fallback retry running on an unpublished fence; "
-            "hard-interrupt admission will read the aborted attempt's fence "
-            "rather than the retry's commit boundary",
-        )
-        retry_fence = CompressionCommitFence()
-    idle = float(route.get("timeout") or idle_timeout_seconds)
-    ceiling = max(float(total_ceiling_seconds), idle)
-    logger.warning(
-        "Context compression stalled on the configured summary route — "
-        "retrying once on %s (%s) before continuing without compression",
-        route["label"],
-        route["model"],
-    )
-    try:
-        from agent.context_compressor import pin_summary_route
-
-        with pin_summary_route(route):
-            result_msgs, result_prompt = run_compress_context_with_progress_timeout(
-                worker=worker,
-                messages=messages,
-                system_prompt_fallback=system_prompt_fallback,
-                idle_timeout_seconds=idle,
-                total_ceiling_seconds=ceiling,
-                on_commit_overrun=on_commit_overrun,
-                fence=retry_fence,
-                telemetry_agent=telemetry_agent,
-                stall_fallback=False,
+            continue
+        if result_msgs is messages:
+            # Aborted or no-op: the worker hands back the caller's own list.
+            logger.warning(
+                "Context compression fallback attempt on %s produced no "
+                "compression; trying the next configured route",
+                route["label"],
             )
-    except Exception:
-        # The primary already failed; a failing fallback must degrade, never
-        # turn "continue without compression" into a raised turn.
-        logger.warning(
-            "Context compression fallback attempt on %s failed",
-            route["label"],
-            exc_info=True,
-        )
-        return None
-    if result_msgs is messages:
-        # Aborted or no-op: the worker hands back the caller's own list.
-        logger.warning(
-            "Context compression fallback attempt on %s produced no "
-            "compression; continuing without compression",
+            continue
+        logger.info(
+            "Context compression recovered on %s after the primary summary route "
+            "stalled",
             route["label"],
         )
-        return None
-    logger.info(
-        "Context compression recovered on %s after the primary summary route "
-        "stalled",
-        route["label"],
-    )
-    return result_msgs, result_prompt
+        return result_msgs, result_prompt
+    return None
 
 
 def run_compress_context_with_progress_timeout(
@@ -1220,18 +1226,19 @@ def run_compress_context_with_progress_timeout(
     only on the timeout path, so successful compression never pays for (or
     fails on) an eager prompt rebuild.
 
-    ``stall_fallback`` (default on) makes an aborted stall attempt the
-    configured ``auxiliary.compression.fallback_chain`` once — pinned onto a
-    fresh fence — before degrading to "continue without compression". Nothing
-    raises out of a silent stall, so the auxiliary client's own fallback
-    handling (exception-path only) never sees it (#78981). ``on_timeout``
-    therefore fires only after that attempt has also failed, which keeps its
-    cooldown bookkeeping from suppressing the retry it precedes.
+    ``stall_fallback`` (default on) makes an aborted stall walk the configured
+    ``auxiliary.compression.fallback_chain`` in order — each route pinned onto
+    one fresh fence — before degrading to "continue without compression".
+    Nothing raises out of a silent stall, so the auxiliary client's own
+    fallback handling (exception-path only) never sees it (#78981).
+    ``on_timeout`` therefore fires only after every usable entry has failed,
+    which keeps its cooldown bookkeeping from suppressing the retries it
+    precedes.
 
-    ``new_fence`` mints that retry's fence. Hosts that publish the active
-    fence for hard-interrupt admission pass a factory that publishes the new
-    one too, so a ``/stop`` during the retry serializes against the retry's
-    commit boundary rather than the aborted attempt's.
+    ``new_fence`` mints each retry's fence. Hosts that publish the active fence
+    for hard-interrupt admission pass a factory that publishes each new one
+    too, so a ``/stop`` during a retry serializes against that retry's commit
+    boundary rather than the prior aborted attempt's.
     """
     if idle_timeout_seconds <= 0:
         raise ValueError(
@@ -1442,7 +1449,6 @@ def run_compress_context_with_progress_timeout(
             recovered = _retry_compression_on_fallback_chain(
                 worker=worker,
                 messages=messages,
-                system_prompt_fallback=system_prompt_fallback,
                 idle_timeout_seconds=idle,
                 total_ceiling_seconds=ceiling,
                 on_commit_overrun=on_commit_overrun,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1800,6 +1800,182 @@ class TestAuxiliaryFallbackLayering:
         exc.status_code = 402
         return exc
 
+    @staticmethod
+    def _fallback_entries():
+        return [
+            {"provider": "fallback-zero", "model": "model-zero"},
+            {"provider": "fallback-one", "model": "model-one"},
+        ]
+
+    def _patch_real_fallback_chain(
+        self, entries, primary_client, fallback_clients, *, async_clients=None,
+    ):
+        patches = [
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("primary", "primary-model", None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(primary_client, "primary-model"),
+            ),
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"fallback_chain": entries},
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                side_effect=lambda provider, model=None, **kwargs: (
+                    fallback_clients[provider], model
+                ),
+            ),
+            patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+                return_value=(None, None, ""),
+            ),
+            patch("agent.auxiliary_client._recoverable_pool_provider", return_value=None),
+        ]
+        if async_clients is not None:
+            patches.append(
+                patch(
+                    "agent.auxiliary_client._to_async_client",
+                    side_effect=lambda client, model, **kwargs: (
+                        async_clients[id(client)], model
+                    ),
+                )
+            )
+        return patches
+
+    def test_sync_configured_chain_continues_after_fallback_402(self):
+        """Primary 402 -> fallback[0] 402 -> fallback[1] success."""
+        entries = self._fallback_entries()
+        primary = MagicMock()
+        primary.chat.completions.create.side_effect = self._make_payment_err()
+        fallback_zero = MagicMock()
+        fallback_zero.chat.completions.create.side_effect = self._make_payment_err()
+        fallback_one = MagicMock()
+        fallback_one.chat.completions.create.return_value = _DummyResponse("chain-success")
+        fallback_clients = {
+            "fallback-zero": fallback_zero,
+            "fallback-one": fallback_one,
+        }
+
+        patches = self._patch_real_fallback_chain(
+            entries, primary, fallback_clients,
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result.choices[0].message.content == "chain-success"
+        assert fallback_zero.chat.completions.create.call_count == 1
+        assert fallback_one.chat.completions.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_configured_chain_continues_after_fallback_402(self):
+        """Async primary 402 -> fallback[0] 402 -> fallback[1] success."""
+        entries = self._fallback_entries()
+        primary = MagicMock()
+        primary.chat.completions.create = AsyncMock(side_effect=self._make_payment_err())
+        sync_zero, sync_one = MagicMock(), MagicMock()
+        async_zero, async_one = MagicMock(), MagicMock()
+        async_zero.chat.completions.create = AsyncMock(side_effect=self._make_payment_err())
+        async_one.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("async-chain-success")
+        )
+        fallback_clients = {
+            "fallback-zero": sync_zero,
+            "fallback-one": sync_one,
+        }
+        async_clients = {
+            id(sync_zero): async_zero,
+            id(sync_one): async_one,
+        }
+
+        patches = self._patch_real_fallback_chain(
+            entries, primary, fallback_clients, async_clients=async_clients,
+        )
+        with (
+            patches[0], patches[1], patches[2], patches[3], patches[4],
+            patches[5], patches[6],
+        ):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result.choices[0].message.content == "async-chain-success"
+        assert async_zero.chat.completions.create.await_count == 1
+        assert async_one.chat.completions.create.await_count == 1
+
+    def test_configured_chain_exhaustion_preserves_original_error_and_warning(
+        self, caplog,
+    ):
+        entries = self._fallback_entries()
+        primary_error = self._make_payment_err()
+        primary = MagicMock()
+        primary.chat.completions.create.side_effect = primary_error
+        fallback_clients = {}
+        for entry in entries:
+            client = MagicMock()
+            client.chat.completions.create.side_effect = self._make_payment_err()
+            fallback_clients[entry["provider"]] = client
+
+        patches = self._patch_real_fallback_chain(
+            entries, primary, fallback_clients,
+        )
+        with (
+            patches[0], patches[1], patches[2], patches[3], patches[4], patches[5],
+            caplog.at_level("WARNING", logger="agent.auxiliary_client"),
+        ):
+            with pytest.raises(Exception) as raised:
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "summarize"}],
+                )
+
+        assert raised.value is primary_error
+        assert all(
+            client.chat.completions.create.call_count == 1
+            for client in fallback_clients.values()
+        )
+        assert any("all fallbacks exhausted" in record.message for record in caplog.records)
+
+    def test_stale_auth_fallback_still_advances_configured_chain(self):
+        entries = self._fallback_entries()
+        primary = MagicMock()
+        primary.chat.completions.create.side_effect = self._make_payment_err()
+        stale = MagicMock()
+        stale.chat.completions.create.side_effect = _AuxAuth401("expired fallback token")
+        healthy = MagicMock()
+        healthy.chat.completions.create.return_value = _DummyResponse("auth-chain-success")
+        fallback_clients = {
+            "fallback-zero": stale,
+            "fallback-one": healthy,
+        }
+
+        patches = self._patch_real_fallback_chain(
+            entries, primary, fallback_clients,
+        )
+        with (
+            patches[0], patches[1], patches[2], patches[3], patches[4], patches[5],
+            patch(
+                "agent.auxiliary_client._refresh_provider_credentials",
+                return_value=False,
+            ) as refresh,
+        ):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result.choices[0].message.content == "auth-chain-success"
+        refresh.assert_called_once_with("fallback-zero")
+        assert stale.chat.completions.create.call_count == 1
+        assert healthy.chat.completions.create.call_count == 1
+
 
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1847,7 +1847,7 @@ class TestAuxiliaryFallbackLayering:
         return patches
 
     def test_sync_configured_chain_continues_after_fallback_402(self):
-        """Primary 402 -> fallback[0] 402 -> fallback[1] success."""
+        """Later calls skip the primary and fallback that already returned 402."""
         entries = self._fallback_entries()
         primary = MagicMock()
         primary.chat.completions.create.side_effect = self._make_payment_err()
@@ -1868,14 +1868,20 @@ class TestAuxiliaryFallbackLayering:
                 task="compression",
                 messages=[{"role": "user", "content": "summarize"}],
             )
+            repeated = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize another chunk"}],
+            )
 
         assert result.choices[0].message.content == "chain-success"
+        assert repeated.choices[0].message.content == "chain-success"
+        assert primary.chat.completions.create.call_count == 1
         assert fallback_zero.chat.completions.create.call_count == 1
-        assert fallback_one.chat.completions.create.call_count == 1
+        assert fallback_one.chat.completions.create.call_count == 2
 
     @pytest.mark.asyncio
     async def test_async_configured_chain_continues_after_fallback_402(self):
-        """Async primary 402 -> fallback[0] 402 -> fallback[1] success."""
+        """Async later calls skip routes that already returned 402."""
         entries = self._fallback_entries()
         primary = MagicMock()
         primary.chat.completions.create = AsyncMock(side_effect=self._make_payment_err())
@@ -1905,10 +1911,16 @@ class TestAuxiliaryFallbackLayering:
                 task="compression",
                 messages=[{"role": "user", "content": "summarize"}],
             )
+            repeated = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize another chunk"}],
+            )
 
         assert result.choices[0].message.content == "async-chain-success"
+        assert repeated.choices[0].message.content == "async-chain-success"
+        assert primary.chat.completions.create.await_count == 1
         assert async_zero.chat.completions.create.await_count == 1
-        assert async_one.chat.completions.create.await_count == 1
+        assert async_one.chat.completions.create.await_count == 2
 
     def test_configured_chain_exhaustion_preserves_original_error_and_warning(
         self, caplog,

--- a/tests/agent/test_compression_stall_fallback_78981.py
+++ b/tests/agent/test_compression_stall_fallback_78981.py
@@ -9,28 +9,31 @@ the one failure mode that most needs it.
 
 These tests pin the contract:
 
-* an aborted stall re-attempts compression once with the summary route pinned
-  to the configured ``auxiliary.compression.fallback_chain``;
+* an aborted stall re-attempts compression in declared fallback-chain order,
+  with each summary route pinned for one bounded attempt;
 * the pinned route reaches the summary ``call_llm`` (provider/model/base_url/
   api_key/timeout), and is single-use so the compressor's own main-model retry
   does not re-issue the same failed route;
-* the historical "continue without compression" degrade survives when no chain
-  is configured or the fallback attempt also stalls.
+* the historical "continue without compression" degrade happens once when no
+  chain is configured or every structurally usable fallback also stalls.
 """
 
 from __future__ import annotations
 
 import threading
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 from agent.context_compressor import (
     ContextCompressor,
+    attempt_summary_route_kwargs,
     pin_summary_route,
     take_pinned_summary_route,
 )
 from agent.conversation_compression import (
     CompressionCommitFence,
+    _retry_compression_on_fallback_chain,
     resolve_compression_fallback_route,
     run_compress_context_with_progress_timeout,
 )
@@ -41,6 +44,12 @@ CHAIN_ENTRY = {
     "base_url": "https://fallback.invalid/v1",
     "api_key": "sk-fallback",
     "timeout": 45,
+}
+
+SECOND_CHAIN_ENTRY = {
+    "provider": "openai-codex",
+    "model": "final-summarizer",
+    "timeout": 60,
 }
 
 
@@ -90,12 +99,21 @@ class _StalledSummaryWorker:
             fence.finish_commit()
 
 
-def _run(worker, *, chain, timeouts, messages, idle=0.05, ceiling=0.2):
+def _run(
+    worker,
+    *,
+    chain,
+    timeouts,
+    messages,
+    idle=0.05,
+    ceiling=0.2,
+    system_prompt_fallback: Any = "degraded-prompt",
+):
     with _patch_chain(chain):
         return run_compress_context_with_progress_timeout(
             worker=worker,
             messages=messages,
-            system_prompt_fallback="degraded-prompt",
+            system_prompt_fallback=system_prompt_fallback,
             idle_timeout_seconds=idle,
             total_ceiling_seconds=ceiling,
             on_timeout=lambda *args: timeouts.append(args),
@@ -107,25 +125,34 @@ def _run(worker, *, chain, timeouts, messages, idle=0.05, ceiling=0.2):
 # ---------------------------------------------------------------------------
 
 
-def test_stalled_summary_attempts_configured_fallback_chain():
+def test_stalled_summary_walks_configured_fallback_chain_until_success():
     original = [{"role": "user", "content": "keep-me"}]
     compressed = [{"role": "user", "content": "summary of earlier turns"}]
-    worker = _StalledSummaryWorker(compressed)
+    worker = _StalledSummaryWorker(compressed, stall_attempts=2)
     timeouts = []
+    chain = [
+        "not-a-mapping",
+        {"provider": "custom"},
+        dict(CHAIN_ENTRY, timeout=0.03),
+        {"model": "orphan-model"},
+        dict(SECOND_CHAIN_ENTRY, timeout=0.04),
+    ]
 
     try:
-        msgs, prompt = _run(
-            worker, chain=[CHAIN_ENTRY], timeouts=timeouts, messages=original
-        )
+        msgs, prompt = _run(worker, chain=chain, timeouts=timeouts, messages=original)
     finally:
         worker.release.set()
 
-    assert worker.attempts == 2, "the aborted stall must be retried once"
+    assert worker.attempts == 3
     assert worker.routes[0] is None, "the primary attempt is never pinned"
-    pinned = worker.routes[1]
-    assert pinned is not None, "the retry must carry the configured fallback route"
-    assert pinned["provider"] == "custom"
-    assert pinned["model"] == "backup-summarizer"
+    assert [route["label"] for route in worker.routes[1:]] == [
+        "fallback_chain[2](custom)",
+        "fallback_chain[4](openai-codex)",
+    ]
+    assert [route["model"] for route in worker.routes[1:]] == [
+        "backup-summarizer",
+        "final-summarizer",
+    ]
     assert msgs == compressed, "the fallback attempt's compression must be published"
     assert prompt == "summarized-prompt"
     assert not timeouts, "no continue-without-compression degrade after a recovery"
@@ -137,7 +164,7 @@ def test_retry_runs_on_a_host_published_fence():
     is actually running."""
     original = [{"role": "user", "content": "keep-me"}]
     compressed = [{"role": "user", "content": "summary"}]
-    worker = _StalledSummaryWorker(compressed)
+    worker = _StalledSummaryWorker(compressed, stall_attempts=2)
     minted = []
 
     def _new_fence():
@@ -146,7 +173,12 @@ def test_retry_runs_on_a_host_published_fence():
         return fence
 
     try:
-        with _patch_chain([CHAIN_ENTRY]):
+        with _patch_chain(
+            [
+                dict(CHAIN_ENTRY, timeout=0.03),
+                dict(SECOND_CHAIN_ENTRY, timeout=0.04),
+            ]
+        ):
             msgs, _prompt = run_compress_context_with_progress_timeout(
                 worker=worker,
                 messages=original,
@@ -159,10 +191,13 @@ def test_retry_runs_on_a_host_published_fence():
         worker.release.set()
 
     assert msgs == compressed
-    assert len(minted) == 1, "exactly one fence is minted for the one retry"
+    assert len(minted) == 2, "each fallback retry gets a fresh published fence"
     assert worker.fences[1] is minted[0]
+    assert worker.fences[2] is minted[1]
+    assert minted[0] is not minted[1]
     assert worker.fences[1] is not worker.fences[0]
     assert worker.fences[0].is_cancelled, "the aborted attempt stays cancelled"
+    assert worker.fences[1].is_cancelled, "the aborted fallback stays cancelled"
 
 
 def test_hard_interrupt_suppresses_the_fallback_attempt():
@@ -176,7 +211,7 @@ def test_hard_interrupt_suppresses_the_fallback_attempt():
     timeouts = []
 
     try:
-        with _patch_chain([CHAIN_ENTRY]):
+        with _patch_chain([CHAIN_ENTRY, SECOND_CHAIN_ENTRY]):
             msgs, prompt = run_compress_context_with_progress_timeout(
                 worker=worker,
                 messages=original,
@@ -190,6 +225,7 @@ def test_hard_interrupt_suppresses_the_fallback_attempt():
         worker.release.set()
 
     assert worker.attempts == 1
+    assert worker.routes == [None]
     assert msgs is original
     assert prompt == "degraded-prompt"
     assert len(timeouts) == 1
@@ -211,23 +247,194 @@ def test_no_fallback_chain_configured_degrades_without_retry():
     assert len(timeouts) == 1
 
 
-def test_fallback_that_also_stalls_degrades_after_one_attempt():
+def test_all_fallback_entries_exhausted_degrades_once():
     original = [{"role": "user", "content": "keep-me"}]
     worker = _StalledSummaryWorker(
-        [{"role": "user", "content": "unused"}], stall_attempts=2
+        [{"role": "user", "content": "unused"}], stall_attempts=3
     )
     timeouts = []
-    entry = dict(CHAIN_ENTRY, timeout=0.05)
+    chain = [
+        dict(CHAIN_ENTRY, timeout=0.03),
+        dict(SECOND_CHAIN_ENTRY, timeout=0.04),
+    ]
+    degradations = []
+
+    def _degraded_prompt():
+        degradations.append("degraded")
+        return "degraded-prompt"
 
     try:
-        msgs, prompt = _run(worker, chain=[entry], timeouts=timeouts, messages=original)
+        msgs, prompt = _run(
+            worker,
+            chain=chain,
+            timeouts=timeouts,
+            messages=original,
+            system_prompt_fallback=_degraded_prompt,
+        )
     finally:
         worker.release.set()
 
-    assert worker.attempts == 2, "the fallback is attempted once, not in a loop"
+    assert worker.attempts == 3
+    assert [route["model"] for route in worker.routes[1:]] == [
+        "backup-summarizer",
+        "final-summarizer",
+    ]
     assert msgs is original, "no messages may be dropped when both routes stall"
     assert prompt == "degraded-prompt"
+    assert degradations == ["degraded"]
     assert len(timeouts) == 1, "the degrade must be reported exactly once"
+
+
+def test_each_fallback_entry_honors_its_own_timeout():
+    original = [{"role": "user", "content": "keep-me"}]
+    compressed = [{"role": "user", "content": "summary"}]
+    attempts = []
+    chain = [
+        dict(CHAIN_ENTRY, timeout=4),
+        dict(SECOND_CHAIN_ENTRY, timeout=15),
+    ]
+
+    def _run_retry(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            return original, ""
+        return compressed, "summarized-prompt"
+
+    with _patch_chain(chain), patch(
+        "agent.conversation_compression.run_compress_context_with_progress_timeout",
+        side_effect=_run_retry,
+    ):
+        result = _retry_compression_on_fallback_chain(
+            worker=lambda _fence: (original, ""),
+            messages=original,
+            idle_timeout_seconds=2,
+            total_ceiling_seconds=10,
+        )
+
+    assert result == (compressed, "summarized-prompt")
+    assert [
+        (call["idle_timeout_seconds"], call["total_ceiling_seconds"])
+        for call in attempts
+    ] == [(4.0, 10.0), (15.0, 15.0)]
+    assert all(call["stall_fallback"] is False for call in attempts)
+
+
+def test_second_fallback_reaches_real_summary_call_with_its_route():
+    original = [{"role": "user", "content": "keep-me"}]
+    compressed = [{"role": "user", "content": "summary"}]
+    second = {
+        "provider": "openai-codex",
+        "model": "second-summarizer",
+        "base_url": "https://second.invalid/v1",
+        "api_key": "sk-second",
+        "timeout": 17,
+    }
+    compressor = _make_compressor()
+    worker_attempts = 0
+    llm_calls = []
+
+    def _worker(fence):
+        nonlocal worker_attempts
+        worker_attempts += 1
+        if worker_attempts == 1:
+            route = take_pinned_summary_route()
+            assert route is not None
+            assert route["model"] == "backup-summarizer"
+            return original, ""
+        summary = compressor._generate_summary(_msgs())
+        assert summary and "SUMMARY BODY" in summary
+        if not fence.begin_commit():
+            return original, ""
+        try:
+            return compressed, "summarized-prompt"
+        finally:
+            fence.finish_commit()
+
+    def _call_llm(**kwargs):
+        llm_calls.append(kwargs)
+        return _ok_response()
+
+    with _patch_chain([CHAIN_ENTRY, second]), patch(
+        "agent.context_compressor.call_llm", side_effect=_call_llm
+    ):
+        result = _retry_compression_on_fallback_chain(
+            worker=_worker,
+            messages=original,
+            idle_timeout_seconds=2,
+            total_ceiling_seconds=20,
+        )
+
+    assert result == (compressed, "summarized-prompt")
+    assert worker_attempts == 2
+    summary_call = next(call for call in llm_calls if call.get("task") == "compression")
+    assert {
+        key: summary_call[key]
+        for key in ("provider", "model", "base_url", "api_key", "timeout")
+    } == {
+        "provider": "openai-codex",
+        "model": "second-summarizer",
+        "base_url": "https://second.invalid/v1",
+        "api_key": "sk-second",
+        "timeout": 17,
+    }
+
+
+def test_hard_cancel_between_retries_starts_no_later_route():
+    original = [{"role": "user", "content": "keep-me"}]
+    stopped = threading.Event()
+    routes = []
+
+    def _run_retry(**_kwargs):
+        route = take_pinned_summary_route()
+        assert route is not None
+        routes.append(route["model"])
+        stopped.set()
+        return original, ""
+
+    with _patch_chain([CHAIN_ENTRY, SECOND_CHAIN_ENTRY]), patch(
+        "agent.conversation_compression.run_compress_context_with_progress_timeout",
+        side_effect=_run_retry,
+    ):
+        result = _retry_compression_on_fallback_chain(
+            worker=lambda _fence: (original, ""),
+            messages=original,
+            idle_timeout_seconds=2,
+            total_ceiling_seconds=10,
+            telemetry_agent=SimpleNamespace(_hard_interrupt_requested=stopped),
+        )
+
+    assert result is None
+    assert routes == ["backup-summarizer"]
+
+
+def test_repeated_routes_are_attempted_once_each_in_declared_order():
+    original = [{"role": "user", "content": "keep-me"}]
+    routes = []
+    chain = [CHAIN_ENTRY, dict(CHAIN_ENTRY, timeout=9), SECOND_CHAIN_ENTRY]
+
+    def _run_retry(**_kwargs):
+        route = take_pinned_summary_route()
+        assert route is not None
+        routes.append((route["label"], route["model"], route["timeout"]))
+        return original, ""
+
+    with _patch_chain(chain), patch(
+        "agent.conversation_compression.run_compress_context_with_progress_timeout",
+        side_effect=_run_retry,
+    ):
+        result = _retry_compression_on_fallback_chain(
+            worker=lambda _fence: (original, ""),
+            messages=original,
+            idle_timeout_seconds=2,
+            total_ceiling_seconds=10,
+        )
+
+    assert result is None
+    assert routes == [
+        ("fallback_chain[0](custom)", "backup-summarizer", 45.0),
+        ("fallback_chain[1](custom)", "backup-summarizer", 9.0),
+        ("fallback_chain[2](openai-codex)", "final-summarizer", 60.0),
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -310,6 +517,7 @@ def test_pinned_route_overrides_the_summary_call_route():
         with pin_summary_route(dict(CHAIN_ENTRY)):
             summary = compressor._generate_summary(_msgs())
 
+    assert attempt_summary_route_kwargs() == {}
     assert summary and "SUMMARY BODY" in summary
     assert len(calls) == 1
     call = calls[0]


### PR DESCRIPTION
## Problem

Auxiliary fallback chains can stop before later configured entries in two distinct failure modes.

### Explicit errors

If the primary auxiliary provider fails with a recoverable error and `fallback_chain[0]` also fails (for example both return HTTP 402), later entries are not attempted.

```text
primary ollama-cloud/minimax-m3 -> 402
fallback_chain[0] ollama-free/minimax-m3 -> 402
fallback_chain[1] openai-codex/gpt-5.6-luna -> never attempted
```

### Progressing stalls

Compression has a host-level progress-aware timeout because a connection can stay open without completing. The stall path previously pinned only the first usable fallback entry. If both the primary and `fallback_chain[0]` streamed until their total ceilings without producing a committed compression, Hermes degraded without attempting `fallback_chain[1]`.

Production evidence showed:

```text
ollama-cloud/nemotron-3-super -> 600s ceiling
ollama-free/nemotron-3-super  -> 600s ceiling
openai-codex/gpt-5.6-luna     -> never attempted
compression tokens            -> unchanged
```

## Root cause

- `_try_configured_fallback_chain()` returned the first constructible candidate. Sync/async fallback calls then re-raised recoverable non-auth failures, so execution never resumed at the next configured index.
- `resolve_compression_fallback_route()` returned only the first structurally usable stall fallback, and `_retry_compression_on_fallback_chain()` performed only one pinned retry before degrading.

## Fix

### Explicit-error path

- Add an explicit `start_index` when resolving configured fallback candidates.
- Continue through later configured entries after recoverable fallback-worthy failures.
- Preserve failure-scope semantics, credential refresh, per-entry timeout, cache replanning, unhealthy-provider handling, route telemetry, sync/async parity, and existing safety nets.
- Honor HTTP 402 cooldown state while walking configured fallbacks.

### Stall path

- Resolve every structurally usable compression fallback route in declared order.
- Run one bounded, pinned retry per entry, with a fresh commit fence and that entry's timeout semantics.
- Stop at the first committed compression; degrade exactly once only after all entries are exhausted.
- Re-check hard cancellation between retries and disable nested stall fallback recursion.
- Scope and restore both summary-route `ContextVar` values so consumed-route state cannot leak across attempts or tests.

## Tests

Regression coverage includes:

- sync and async primary 402 -> fallback 0 402 -> fallback 1 success;
- complete explicit-error chain exhaustion preserving the primary error;
- stale fallback authentication continuing to later entries;
- primary stall -> malformed entries skipped -> fallback 0 no-op -> fallback 1 success;
- ordered duplicate entries, fresh fences, entry-specific timeout/ceiling budgets, and one final degrade;
- hard cancellation before and between retries;
- real `ContextCompressor -> call_llm` kwargs for the second pinned route;
- `ContextVar` isolation with the ownership suite in the same pytest process.

Verified on the rebased PR head:

```text
207 passed in tests/agent/test_*compression*.py
189 passed in tests/agent/test_auxiliary_client.py
python -m py_compile (all touched Python files)
git diff --check
```

Independent review: native GPT-5.6 Luna (high) — APPROVE. Second reader disabled by user.

## Impact

Users can rely on every entry in `auxiliary.<task>.fallback_chain` being attempted in order for recoverable API failures and for compression routes that hit their progress-aware total ceiling. Later fallbacks such as Luna are no longer silently skipped after two stalled Ollama routes.
