### PR TITLE
fix(context): fail closed when preflight compression stalls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9535,6 +9535,7 @@ class _ChatStreamAccumulator:
         self._total_ceiling = total_ceiling
         self.content_parts: List[str] = []
         self.reasoning_parts: List[str] = []
+        self.reasoning_details: List[Any] = []
         self.tool_calls_acc: Dict[int, Dict[str, Any]] = {}
         self.finish_reason = None
         self.usage = None
@@ -9579,6 +9580,24 @@ class _ChatStreamAccumulator:
         if reasoning_piece and isinstance(reasoning_piece, str):
             self.reasoning_parts.append(reasoning_piece)
             made_progress = True
+        # OpenRouter-compatible reasoning models may stream their entire
+        # thinking phase through ``reasoning_details`` instead of
+        # ``reasoning`` / ``reasoning_content``.  Treat only details carrying
+        # actual text as forward progress: structural/signed envelopes must
+        # not keep an otherwise stalled compression alive indefinitely.
+        reasoning_details = getattr(delta, "reasoning_details", None)
+        if reasoning_details is None:
+            model_extra = getattr(delta, "model_extra", None)
+            if isinstance(model_extra, dict):
+                reasoning_details = model_extra.get("reasoning_details")
+        if isinstance(reasoning_details, list):
+            for detail in reasoning_details:
+                self.reasoning_details.append(detail)
+                if isinstance(detail, dict) and any(
+                    isinstance(detail.get(field), str) and detail[field]
+                    for field in ("summary", "thinking", "content", "text")
+                ):
+                    made_progress = True
         for tc in (getattr(delta, "tool_calls", None) or []):
             idx = getattr(tc, "index", 0) or 0
             acc = self.tool_calls_acc.setdefault(
@@ -9620,6 +9639,7 @@ class _ChatStreamAccumulator:
             content="".join(self.content_parts),
             tool_calls=tool_calls,
             reasoning="".join(self.reasoning_parts) or None,
+            reasoning_details=self.reasoning_details or None,
         )
         choice = SimpleNamespace(
             index=0,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -405,6 +405,21 @@ def compression_made_progress(
 _compression_made_progress = compression_made_progress
 
 
+class PreflightCompressionTimedOut(RuntimeError):
+    """Raised when an oversized turn cannot safely finish preflight."""
+
+
+def _fail_closed_after_preflight_timeout(agent, request_tokens: int) -> None:
+    """Stop an oversized turn instead of sending its unchanged provider payload."""
+    if not getattr(agent, "_last_compression_timed_out", False):
+        return
+    raise PreflightCompressionTimedOut(
+        "Context compression timed out before it could commit while the request "
+        f"was still approximately {request_tokens:,} tokens. The provider call "
+        "was not sent. Run /compress and wait for it to finish, then retry."
+    )
+
+
 def _review_fork_first_request_pending(agent: Any) -> bool:
     """Whether a detached review fork has yet to send its first provider request.
 
@@ -1169,6 +1184,7 @@ def build_turn_context(
                 if not _compression_made_progress(
                     _orig_len, len(messages), _orig_tokens, _preflight_tokens
                 ):
+                    _fail_closed_after_preflight_timeout(agent, _preflight_tokens)
                     _preflight_compression_blocked = True
                     break  # Cannot compress further: neither rows nor tokens moved
                 conversation_history = conversation_history_after_compression(

--- a/run_agent.py
+++ b/run_agent.py
@@ -8068,6 +8068,11 @@ class AIAgent:
         auto-compress abort.  Auto-compress callers use the default
         ``force=False``.
         """
+        # Per-attempt signal consumed by turn-start preflight. A stalled
+        # compression must not be mistaken for a structural no-op and followed
+        # by the oversized provider request it was meant to prevent.
+        self._last_compression_timed_out = False
+
         from agent.conversation_compression import (
             CompressionCommitFence,
             compress_context,
@@ -8194,6 +8199,7 @@ class AIAgent:
                     timeout_cause["progress_observed"] = progress_observed
 
                 def _on_timeout(idle, waited, since_progress):
+                    self._last_compression_timed_out = True
                     total_exhausted = timeout_cause["total_exhausted"]
                     progress_observed = timeout_cause["progress_observed"]
                     if total_exhausted:

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -36,12 +36,14 @@ from agent.conversation_compression import CompressionCommitFence
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _chunk(content=None, reasoning=None, finish_reason=None, usage=None,
-           tool_calls=None, model="m1", chunk_id="c1"):
+def _chunk(content=None, reasoning=None, reasoning_details=None,
+           finish_reason=None, usage=None, tool_calls=None, model="m1",
+           chunk_id="c1"):
     delta = SimpleNamespace(
         content=content,
         reasoning=reasoning,
         reasoning_content=None,
+        reasoning_details=reasoning_details,
         tool_calls=tool_calls,
     )
     choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
@@ -346,6 +348,34 @@ class TestContentBearingProgress:
             accumulator.feed(_chunk(tool_calls=[tool_call]))
 
         assert ticks == [1]
+
+    def test_openrouter_reasoning_details_keep_compression_alive(self):
+        """Reasoning-only streams must refresh the compression idle fence."""
+        ticks = []
+        accumulator = _ChatStreamAccumulator()
+        detail = {"type": "reasoning.summary", "summary": "working..."}
+
+        with aux_progress_hook(lambda: ticks.append(1)):
+            accumulator.feed(_chunk(reasoning_details=[detail]))
+
+        result = accumulator.finish()
+        assert ticks == [1]
+        assert result.choices[0].message.reasoning_details == [detail]
+
+    def test_structural_reasoning_details_are_not_progress(self):
+        ticks = []
+        accumulator = _ChatStreamAccumulator()
+
+        with aux_progress_hook(lambda: ticks.append(1)):
+            accumulator.feed(
+                _chunk(
+                    reasoning_details=[
+                        {"type": "reasoning.encrypted", "signature": "sig"}
+                    ]
+                )
+            )
+
+        assert ticks == []
 
     def test_codex_adapter_updates_fence_only_for_substantive_events(self):
         events = [

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -467,6 +467,7 @@ class TestCompressContextForwarderOwnsTimeout:
 
         assert out_msgs is original
         assert out_prompt == "sys"
+        assert agent._last_compression_timed_out is True
         assert calls["n"] == 1
         agent._emit_warning.assert_called_once()
         assert agent.context_compressor._consecutive_timeout_failures == 1
@@ -643,5 +644,6 @@ class TestCompressContextForwarderOwnsTimeout:
             commit_fence=fence,
         )
         assert seen["fence"] is fence
+        assert agent._last_compression_timed_out is False
         assert prompt == "sys"
         assert msgs[0]["content"] == "ok"

--- a/tests/agent/test_preflight_compression_timeout_fail_closed.py
+++ b/tests/agent/test_preflight_compression_timeout_fail_closed.py
@@ -1,0 +1,23 @@
+"""Regression coverage for stalled preflight compression."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.turn_context import (
+    PreflightCompressionTimedOut,
+    _fail_closed_after_preflight_timeout,
+)
+
+
+def test_preflight_timeout_blocks_unchanged_provider_payload():
+    agent = SimpleNamespace(_last_compression_timed_out=True)
+
+    with pytest.raises(PreflightCompressionTimedOut, match="provider call was not sent"):
+        _fail_closed_after_preflight_timeout(agent, 190_035)
+
+
+def test_structural_noop_keeps_existing_preflight_behavior():
+    agent = SimpleNamespace(_last_compression_timed_out=False)
+
+    _fail_closed_after_preflight_timeout(agent, 190_035)

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -15,7 +15,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.context_compressor import ContextCompressor
-from agent.turn_context import TurnContext, build_turn_context
+from agent.turn_context import (
+    PreflightCompressionTimedOut,
+    TurnContext,
+    build_turn_context,
+)
 from hermes_state import SessionDB
 
 
@@ -208,6 +212,44 @@ def test_returns_turn_context_with_user_message_appended():
     assert isinstance(ctx.messages[-1]["timestamp"], float)
     assert ctx.current_turn_user_idx == len(ctx.messages) - 1
     assert ctx.active_system_prompt == "SYSTEM"
+
+
+def test_preflight_timeout_stops_turn_before_provider_boundary():
+    """An unchanged oversized payload must not escape turn construction."""
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.max_compression_attempts = 3
+    agent.context_compressor = types.SimpleNamespace(
+        protect_first_n=2,
+        protect_last_n=2,
+        threshold_tokens=1_000,
+        context_length=4_000,
+        summary_target_ratio=0.3,
+        last_prompt_tokens=0,
+        should_compress=lambda tokens=None: True,
+        should_compress_info=lambda tokens=None: (True, None),
+        get_active_compression_failure_cooldown=lambda: None,
+    )
+
+    def stalled_compression(messages, *_args, **_kwargs):
+        agent._last_compression_timed_out = True
+        return messages, "SYSTEM"
+
+    agent._compress_context = MagicMock(side_effect=stalled_compression)
+    oversized_history = [
+        {"role": "assistant", "content": "x" * 8_000},
+    ]
+    provider_call = MagicMock()
+
+    def run_turn():
+        context = _build(agent, conversation_history=oversized_history)
+        provider_call(context.messages)
+
+    with pytest.raises(PreflightCompressionTimedOut, match="provider call was not sent"):
+        run_turn()
+
+    agent._compress_context.assert_called_once()
+    provider_call.assert_not_called()
 
 
 def test_user_message_preserves_platform_event_timestamp():


### PR DESCRIPTION
## Summary
- mark owned compression attempts that end in a progress timeout
- fail turn-start preflight closed when an oversized payload remains unchanged after that timeout
- preserve existing structural no-op and direct-fence behavior

## Root cause
A stalled preflight compressor returned the original message list, so turn setup treated it like an ordinary no-op and continued into the provider call. The detached summary later lost its commit fence while the oversized provider request failed with context overflow.

## Tests
- `uv run --with pytest pytest tests/agent/test_preflight_compression_timeout_fail_closed.py tests/agent/test_compress_context_progress_timeout.py tests/agent/test_preflight_lock_defer.py -q` (19 passed)
- `uv run python -m py_compile run_agent.py agent/turn_context.py`
- `uv run --with ruff ruff check run_agent.py agent/turn_context.py tests/agent/test_preflight_compression_timeout_fail_closed.py tests/agent/test_compress_context_progress_timeout.py`
- `git diff --check`