### PR TITLE
fix(search): prune OneDrive/iCloud sync roots from broad Windows file searches

### DIFF
--- a/tests/tools/test_windows_cloud_placeholder_search.py
+++ b/tests/tools/test_windows_cloud_placeholder_search.py
@@ -1,0 +1,166 @@
+"""Windows Cloud Files placeholder-safe broad searches (#97898).
+
+Unit tests are deterministic (fake env, fake platform). Real-rg integration
+tests skip on non-Windows: the exclusion globs are platform-correct by
+design, so forcing them cross-platform would test the OS, not the code.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+import tools.file_operations as file_operations
+from tools.file_operations import ShellFileOperations, _windows_cloud_search_exclusions
+from tools.environments.local import LocalEnvironment
+
+class RecordingEnvironment:
+    def __init__(self, cwd):
+        self.cwd = str(cwd)
+        self.commands = []
+
+    def execute(self, command, cwd=None, **kwargs):
+        self.commands.append(command)
+        if command.startswith("test -e"):
+            return {"output": "exists\n", "returncode": 0}
+        if command.startswith("command -v"):
+            return {"output": "yes\n", "returncode": 0}
+        return {"output": "", "returncode": 1}
+
+
+def _fake_env(profile: Path) -> dict:
+    return {
+        "USERPROFILE": str(profile),
+        "OneDrive": str(profile / "OneDrive"),
+        "OneDriveConsumer": str(profile / "OneDriveConsumer"),
+        "iCloudDrive": str(profile / "iCloudDrive"),
+    }
+
+
+def _patch_windows(monkeypatch, profile: Path):
+    monkeypatch.setattr(file_operations, "_HOME", str(profile))
+    monkeypatch.setattr(file_operations.sys, "platform", "win32")
+    monkeypatch.setenv("USERPROFILE", str(profile))
+    for name in ("OneDrive", "OneDriveConsumer", "OneDrivePublic",
+                 "iCloudDrive", "I_CLOUD_DRIVE_LOCATION"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("OneDrive", str(profile / "OneDrive"))
+    monkeypatch.setenv("OneDriveConsumer", str(profile / "OneDriveConsumer"))
+    monkeypatch.setenv("iCloudDrive", str(profile / "iCloudDrive"))
+
+
+def test_broad_profile_search_prunes_cloud_roots(tmp_path):
+    profile = tmp_path / "Users" / "jeff"
+    exclusions = _windows_cloud_search_exclusions(
+        str(profile), cwd=str(tmp_path), env=_fake_env(profile), platform="win32"
+    )
+    lowered = {item.lower() for item in exclusions}
+    expected = {"onedrive", "onedriveconsumer", "iclouddrive",
+                "icloud photos", "pictures/icloud photos"}
+    assert expected <= lowered
+    for item in exclusions:
+        assert "\\" not in item  # rg globs must be forward-slash
+
+
+def test_explicit_cloud_root_search_is_not_pruned(tmp_path):
+    profile = tmp_path / "Users" / "jeff"
+    got = _windows_cloud_search_exclusions(
+        str(profile / "OneDrive"), cwd=str(tmp_path),
+        env=_fake_env(profile), platform="win32")
+    assert got == []
+
+
+def test_nested_search_under_cloud_root_is_not_pruned(tmp_path):
+    profile = tmp_path / "Users" / "jeff"
+    got = _windows_cloud_search_exclusions(
+        str(profile / "OneDrive" / "work"), cwd=str(tmp_path),
+        env=_fake_env(profile), platform="win32")
+    assert got == []
+
+
+def test_non_windows_search_has_no_cloud_exclusions(tmp_path):
+    profile = tmp_path / "home" / "jeff"
+    got = _windows_cloud_search_exclusions(
+        str(profile), cwd=str(tmp_path), env=_fake_env(profile), platform="linux")
+    assert got == []
+
+
+def test_repo_root_search_outside_profile_has_no_exclusions(tmp_path):
+    repo = tmp_path / "repos" / "app"
+    got = _windows_cloud_search_exclusions(
+        str(repo), cwd=str(repo),
+        env=_fake_env(tmp_path / "Users" / "jeff"), platform="win32")
+    assert got == []
+
+
+def test_broad_file_search_passes_cloud_globs_to_ripgrep(tmp_path, monkeypatch):
+    profile = tmp_path / "Users" / "jeff"
+    profile.mkdir(parents=True)
+    env = RecordingEnvironment(profile)
+    ops = ShellFileOperations(env)
+    _patch_windows(monkeypatch, profile)
+
+    result = ops.search("*.txt", path=str(profile), target="files")
+
+    rg_command = next(c for c in env.commands if c.startswith("rg --files"))
+    lowered = rg_command.lower()
+    assert "!onedrive/**" in lowered
+    assert "!iclouddrive/**" in lowered
+    assert "!pictures/icloud photos/**" in lowered
+    assert result.warning is not None
+    assert "hydration" in result.warning
+
+
+def test_broad_content_search_passes_cloud_globs_to_ripgrep(tmp_path, monkeypatch):
+    profile = tmp_path / "Users" / "jeff"
+    profile.mkdir(parents=True)
+    env = RecordingEnvironment(profile)
+    ops = ShellFileOperations(env)
+    _patch_windows(monkeypatch, profile)
+
+    ops.search("needle", path=str(profile), target="content")
+
+    rg_command = next(c for c in env.commands if c.startswith("set -o pipefail; rg"))
+    assert "!onedrive/**" in rg_command.lower()
+
+
+def test_remote_backend_never_prunes_cloud(tmp_path, monkeypatch):
+    profile = tmp_path / "Users" / "jeff"
+    profile.mkdir(parents=True)
+    env = RecordingEnvironment(profile)
+    env.is_local = False
+    ops = ShellFileOperations(env)
+    _patch_windows(monkeypatch, profile)
+
+    result = ops.search("*.txt", path=str(profile), target="files")
+
+    rg_command = next(c for c in env.commands if c.startswith("rg --files"))
+    assert "!onedrive/**" not in rg_command.lower()
+    assert result.warning is None
+
+
+WINDOWS_ONLY = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="cloud exclusion globs are Windows-spelled; forcing them "
+           "cross-platform would test the OS, not the code",
+)
+
+
+@WINDOWS_ONLY
+def test_real_ripgrep_does_not_descend_into_cloud_folder(tmp_path, monkeypatch):
+    if shutil.which("rg") is None:
+        pytest.skip("ripgrep not installed")
+    profile = tmp_path / "Users" / "jeff"
+    (profile / "OneDrive").mkdir(parents=True)
+    (profile / "src").mkdir()
+    (profile / "OneDrive" / "big.txt").write_text("needle\n")
+    (profile / "src" / "a.txt").write_text("needle\n")
+    _patch_windows(monkeypatch, profile)
+    ops = ShellFileOperations(LocalEnvironment(cwd=str(profile)))
+
+    result = ops.search("needle", path=str(profile), target="content")
+
+    paths = [m.path.replace("\\", "/") for m in result.matches]
+    assert any("src/a.txt" in p for p in paths)
+    assert all("OneDrive" not in p for p in paths)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -65,6 +65,82 @@ _MACOS_TCC_PROTECTED_HOME_DIRS = (
 )
 
 
+# Root directories whose children Windows Cloud Files may keep as dehydrated
+# placeholders: OneDrive "Files On-Demand" and iCloud for Windows.  ANY
+# filesystem access below these roots — even a plain stat() from `rg`,
+# `find`, or `du` — triggers on-demand hydration, so a routine recursive
+# scan of a profile directory can silently download tens of GB (issue
+# #97898: a "find the repo" scan pulled iCloud Photos at ~53 MB/s).
+# Env-var names are written in their real camel-case spelling and looked up
+# case-insensitively (Windows env vars are case-insensitive; the harness
+# test fakes are not).
+_ONEDRIVE_ENV_VARS = ("OneDrive", "OneDriveConsumer", "OneDrivePublic")
+_ICLOUD_ENV_VARS = ("iCloudDrive", "I_CLOUD_DRIVE_LOCATION")
+# Default iCloud for Windows locations relative to the user profile.
+_ICLOUD_HOME_SUBDIRS = (
+    "iCloudDrive",
+    "iCloud Photos",
+    os.path.join("Pictures", "iCloud Photos"),
+)
+
+
+def _windows_cloud_search_exclusions(
+    path: str,
+    *,
+    cwd: Optional[str] = None,
+    env: Optional[dict] = None,
+    platform: Optional[str] = None,
+) -> List[str]:
+    """Return cloud-sync roots below a broad Windows search root, if any.
+
+    Absolute, forward-slash-relative-to-``path`` (a bare name when the search
+    root IS the profile home).  Verified against the real ripgrep on Windows:
+    ``-g '!<abs posix path>/**'`` prunes during traversal, while backslash
+    spellings and profile-relative names never match an absolute search root.
+    Direct searches INSIDE a cloud root stay unpruned — opening one file the
+    caller explicitly asked for may legitimately hydrate it; walking the whole
+    tree unattended is the bug.
+    """
+    if (platform or sys.platform) != "win32":
+        return []
+    environ = os.environ if env is None else env
+    profile = environ.get("USERPROFILE") or str(Path.home())
+    roots: List[Path] = []
+    for var in _ONEDRIVE_ENV_VARS + _ICLOUD_ENV_VARS:
+        # Windows env lookup is case-insensitive; envMapping fakes are not.
+        value = environ.get(var)
+        if value is None:
+            lowered = {k.lower(): v for k, v in environ.items()}
+            value = lowered.get(var.lower())
+        if value:
+            roots.append(Path(value))
+    for sub in _ICLOUD_HOME_SUBDIRS:
+        roots.append(Path(profile) / sub)
+
+    root = Path(path).expanduser()
+    if not root.is_absolute():
+        root = Path(cwd or os.getcwd()) / root
+    root = Path(os.path.normpath(str(root)))
+
+    exclusions: List[str] = []
+    seen = set()
+    for candidate in roots:
+        candidate = Path(os.path.normpath(str(candidate)))
+        try:
+            relative = candidate.relative_to(root)
+        except ValueError:
+            continue
+        if not relative.parts:
+            # Search root IS a cloud root: caller chose it explicitly.
+            continue
+        posix = relative.as_posix()
+        key = posix.lower()
+        if key not in seen:
+            seen.add(key)
+            exclusions.append(posix)
+    return exclusions
+
+
 def _macos_protected_search_exclusions(
     path: str,
     *,
@@ -2879,18 +2955,35 @@ class ShellFileOperations(FileOperations):
             result = self._search_content(pattern, path, file_glob, limit, offset,
                                           output_mode, context)
 
-        exclusions = self._macos_search_exclusions(path)
+        exclusions = self._protected_search_exclusions(path)
         if exclusions and not result.error:
-            skipped = ", ".join(item.split("/")[-1] for item in exclusions)
-            result.warning = (
-                "Skipped macOS protected folders during broad search to avoid "
-                f"an unattended privacy prompt: {skipped}. Search a protected "
-                "folder directly when access is intentional."
-            )
+            names = [item.rstrip("/").split("/")[-1] for item in exclusions]
+            env = getattr(self, "env", None)
+            local = getattr(env, "is_local", True) is not False
+            if local and sys.platform == "win32":
+                result.warning = (
+                    "Skipped cloud-sync folders during broad search to avoid "
+                    "on-demand hydration (multi-GB downloads): "
+                    f"{', '.join(names)}. Search a cloud folder directly when "
+                    "those downloads are intentional."
+                )
+            else:
+                result.warning = (
+                    "Skipped macOS protected folders during broad search to "
+                    "avoid an unattended privacy prompt: "
+                    f"{', '.join(names)}. Search a protected folder directly "
+                    "when access is intentional."
+                )
         return result
 
-    def _macos_search_exclusions(self, path: str) -> List[str]:
+    def _protected_search_exclusions(self, path: str) -> List[str]:
         """Protected descendants to prune for this search root, if any.
+
+        Unions the macOS TCC-protected home folders (unattended privacy
+        prompts) with Windows Cloud Files sync roots (on-demand hydration
+        downloads, #97898). The two are platform-exclusive in practice —
+        each helper no-ops off its platform — so one list serves every
+        engine and the search()-level warning without overlap.
 
         Gated on ``env.is_local``: ``sys.platform``/``Path.home()`` describe
         the CONTROLLER, but search commands execute on ``self.env``'s host — a
@@ -2907,7 +3000,7 @@ class ShellFileOperations(FileOperations):
         cwd = getattr(self.env, "cwd", None) or self.cwd
         return _macos_protected_search_exclusions(
             path, cwd=cwd, home=_HOME, platform=sys.platform
-        )
+        ) + _windows_cloud_search_exclusions(path, cwd=cwd)
     
     def _try_multi_path_search(self, pattern: str, path: str, target: str,
                                file_glob: Optional[str], limit: int, offset: int,
@@ -3078,7 +3171,7 @@ class ShellFileOperations(FileOperations):
         # an access attempt (filtering matched paths after descent is too late).
         protected_paths = [
             os.path.normpath(os.path.join(path, item))
-            for item in self._macos_search_exclusions(path)
+            for item in self._protected_search_exclusions(path)
         ]
         prune_expr = ""
         if protected_paths:
@@ -3152,7 +3245,7 @@ class ShellFileOperations(FileOperations):
         fetch_limit = limit + offset
         exclusion_globs = " ".join(
             f"--glob {self._escape_shell_arg(f'!{item}/**')}"
-            for item in self._macos_search_exclusions(path)
+            for item in self._protected_search_exclusions(path)
         )
         exclusion_args = f" {exclusion_globs}" if exclusion_globs else ""
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
@@ -3244,7 +3337,7 @@ class ShellFileOperations(FileOperations):
             cmd_parts.extend(["-C", str(context)])
         
         # Exclude macOS TCC-protected descendants during broad searches.
-        for item in self._macos_search_exclusions(path):
+        for item in self._protected_search_exclusions(path):
             cmd_parts.extend(["--glob", self._escape_shell_arg(f"!{item}/**")])
 
         # Add file glob filter (must be quoted to prevent shell expansion)
@@ -3391,7 +3484,7 @@ class ShellFileOperations(FileOperations):
         # instead — same traversal-prevention the find backend uses.
         protected_paths = [
             os.path.normpath(os.path.join(path, item))
-            for item in self._macos_search_exclusions(path)
+            for item in self._protected_search_exclusions(path)
         ]
         if protected_paths:
             return self._search_with_grep_pruned(


### PR DESCRIPTION
## What

Broad `search_files` walks of a Windows profile (or any directory containing one) now **prune OneDrive and iCloud sync roots before traversal**, so ripgrep/find/grep never stat the dehydrated Cloud Files placeholders below them. Contributes to #97898 — the `terminal` `
**Why:** Windows Cloud Files (OneDrive Files On-Demand, iCloud for Windows) keep directory entries that hydrate on *first access* — and a plain `stat()` counts as access. A routine agent search of `C:\Users\<user>` therefore silently downloads the user's whole cloud library (the issue reporter measured ~53 MB/s of iCloud Photos from a "find the repo" scan). Prevention must happen before descent; post-filtering matches is too late — the bytes are already spent.

**How:** mirrors the existing macOS TCC precedent in the same file. New `_windows_cloud_search_exclusions()` resolves cloud roots from `%OneDrive%` / `%OneDriveConsumer%` / `%OneDrivePublic%` / `%iCloudDrive%` / `%I_CLOUD_DRIVE_LOCATION%` plus the default iCloud-for-Windows conventions (`~\iCloudDrive`, `~\iCloud Photos`, `~\Pictures\iCloud Photos`), and returns the ones contained in the search root. `_macos_search_exclusions()` becomes `_protected_search_exclusions()` (union of the two platform helpers, each a no-op off-platform) and every engine that already consumed it inherits the pruning for free: rg `--glob '!<root>/**'` (file + content search), `find -prune`, and the grep fallback's path-scoped prune. The `env.is_local` gate carries over — a Windows controller driving a Linux backend prunes nothing.

**Glob-spelling evidence (this is the part that was easy to get wrong):** verified against real ripgrep on Windows — `-g '!C:/Users/.../OneDrive/**'` (forward slashes, absolute, anchored at the search root) prunes; backslash spellings and profile-relative names **never match an absolute search root**, so exclusion globs are emitted forward-slash. A real-rg integration test asserts the descent actually stops (`@WINDOWS_ONLY`, skips elsewhere — forcing Windows-spelled globs on Linux CI would test the OS, not the code).

**Deliberate non-goals:**
- Searching *inside* a cloud root stays unpruned — one explicitly requested file may legitimately hydrate; walking the whole tree unattended is the bug.
- `tools/terminal_tool.py` (`find`/`du` run directly by the agent) is **not** touched — the terminal half of #97898 remains open and this PR says so on the issue.

## Tests

New `tests/tools/test_windows_cloud_placeholder_search.py` — 9 tests: unit (fake env + fake platform; no dependency on the CI box's OneDrive state), engine-command tests (rg file+content globs present, remote backend never prunes, warning surfaced), and the real-rg descent test.

- `pytest tests/tools/test_windows_cloud_placeholder_search.py tests/tools/test_macos_protected_search.py -q` → **18 passed, 2 failed**
- The 2 failures are **pre-existing on clean `origin/main` on this Windows box** (verified: same 2 fail unmodified) — they compare `str(Path)` backslash spellings against MSYS-converted command strings in the `find`/grep prune paths. Not macOS regressions; the rg-glob macOS tests all pass.
- `pytest tests/tools/test_file_operations*.py tests/tools/test_file_ops_cwd_tracking.py -q` → **9 failed, 83 passed — byte-identical tally to clean `origin/main`** on this box.
- `ruff check` on both changed files: clean.