### PR TITLE
fix(tools): stop terminal guards from blocking benign commands containing '&'

### DIFF
--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -82,3 +82,72 @@ class TestBackgroundGuidanceRecipes:
 
     def test_quoted_ampersand_not_flagged(self):
         assert _foreground_background_guidance('git commit -m "a & b"') is None
+
+    def test_inspection_of_uvicorn_is_not_server_start(self):
+        """`ps aux | grep uvicorn` inspects; the server word is only a grep
+        operand, so the command must not be nudged to background mode."""
+        assert _foreground_background_guidance("ps aux | grep uvicorn | grep -v grep | head -3") is None
+        assert _foreground_background_guidance(
+            "journalctl --user -u app-server -n 5 | grep uvicorn"
+        ) is None
+        assert _foreground_background_guidance(
+            "kill 4158132 && sleep 2 && ps aux | grep uvicorn | grep -v grep | wc -l"
+        ) is None
+
+    def test_real_python_uvicorn_start_still_flagged(self):
+        assert _foreground_background_guidance(
+            "cd ~/proj && .venv/bin/python -m uvicorn src.server.main:app --port 8000"
+        ) is not None
+        # `timeout <N>` bounds the process — a smoke/restart test, not a
+        # long-lived foreground server.
+        assert _foreground_background_guidance(
+            "cd ~/proj && timeout 15 .venv/bin/python -m uvicorn src.server.main:app --port 8001"
+        ) is None
+
+    def test_timeout_bounded_server_start_not_flagged(self):
+        """A `timeout <N>` wrapper makes the command bounded, so even a server
+        start cannot occupy the foreground forever."""
+        assert _foreground_background_guidance(
+            "systemctl --user stop app-webui.service 2>/dev/null; sleep 2; cd ~/proj && timeout 15 .venv/bin/python -m uvicorn src.server.main:app --host 0.0.0.0 --port 8001"
+        ) is None
+        assert _foreground_background_guidance(
+            "cd ~/proj && MOCK=1 timeout 8 .venv/bin/python -m uvicorn src.server.main:app --host 127.0.0.1 --port 8011"
+        ) is None
+        assert _foreground_background_guidance("timeout 60s npm run dev") is None
+        # unbounded still flagged
+        assert _foreground_background_guidance("npm run dev") is not None
+
+    def test_vite_build_is_not_server_start(self):
+        """`vite build` is a one-shot build, not a long-lived dev server.
+        Bare `vite` / `vite dev` are dev servers and stay flagged."""
+        assert _foreground_background_guidance(
+            "cd ~/proj/web && npx vite build 2>&1"
+        ) is None
+        assert _foreground_background_guidance("npx vite build") is None
+        assert _foreground_background_guidance("vite") is not None
+        assert _foreground_background_guidance(
+            "cd ~/proj && npx vite dev"
+        ) is not None
+
+    def test_npm_docker_starts_still_flagged(self):
+        assert _foreground_background_guidance("cd ~/proj && npm run dev") is not None
+        assert _foreground_background_guidance("docker compose up") is not None
+
+    def test_detached_docker_compose_up_is_not_server_start(self):
+        """`docker compose up -d|--detach` returns immediately (daemon-owned),
+        so the command line itself is NOT a long-lived foreground process."""
+        assert _foreground_background_guidance("docker compose up -d") is None
+        assert _foreground_background_guidance("docker compose up --detach") is None
+        assert _foreground_background_guidance("docker compose up -d --force-recreate tei-reranker") is None
+        assert _foreground_background_guidance(
+            'cd ~/app && docker compose down 2>&1 && echo "=====UP=====" && docker compose up -d 2>&1'
+        ) is None
+        assert _foreground_background_guidance(
+            "cd ~/app && docker compose up -d 2>&1 | tail -5 && sleep 15 && docker compose ps"
+        ) is None
+        # bare `up` (no detach) still keeps the foreground attached — guard stays
+        assert _foreground_background_guidance(
+            "cd ~/app && docker compose down && docker compose up"
+        ) is not None
+        # inspection with `up` as a grep operand is not a compose start either
+        assert _foreground_background_guidance("docker ps | grep up") is None

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -802,3 +802,13 @@ def test_sudo_stdin_guard_container_bypass(clean_session):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
             assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"
+
+
+def test_grep_substitution_not_malformed():
+    """`sed -n "$(grep -n 'x' f | cut -d: -f1)"` puts a grep word inside a
+    double-quoted command substitution whose operand span cannot be located;
+    the command is well-formed and must not hardline as malformed."""
+    cmd = 'sed -n "$(grep -n "target" f.txt | cut -d: -f1)" f.txt'
+    is_hl, desc = detect_hardline_command(cmd)
+    assert not is_hl, f"expected not hardline for {cmd!r} (got: {desc})"
+    assert desc is None

--- a/tests/tools/test_terminal_heredoc_background_guard.py
+++ b/tests/tools/test_terminal_heredoc_background_guard.py
@@ -88,6 +88,111 @@ class TestInertQuotedHeredocPayloadAllowed:
         assert guidance(cmd) is None
 
 
+class TestPrologueLinkAndCompoundOpener:
+    """`cd <path> &&` / `source <path> &&` prologue links, `timeout <N>`
+    wrappers, `~`/relative interpreter paths and compound openers
+    (`|`/`&&`) keep a quoted heredoc body inert — unless a shell consumer
+    sits on the opener line (fail-closed)."""
+
+    def test_cd_link_does_not_defeat_python_heredoc(self):
+        cmd = (
+            "cd ~/proj " + AMP + AMP + " python3 - <<'EOF'" + NL
+            + "x = a " + AMP + " b" + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is None
+
+    def test_cd_abs_path_does_not_defeat_python_heredoc(self):
+        cmd = (
+            "cd /tmp/proj " + AMP + AMP + " .venv/bin/python - <<'EOF'" + NL
+            + "x = a " + AMP + " b" + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is None
+
+    def test_tilde_interpreter_path_allowed(self):
+        cmd = (
+            "cd ~/docker " + AMP + AMP + " ~/venv/bin/python3 - <<'EOF'" + NL
+            + "x = a " + AMP + " b" + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is None
+
+    def test_timeout_wrapper_does_not_defeat_heredoc(self):
+        cmd = (
+            "cd ~/proj " + AMP + AMP + " timeout 15 .venv/bin/python - <<'EOF'" + NL
+            + "x = a " + AMP + " b" + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is None
+
+    def test_source_activate_link_does_not_defeat_heredoc(self):
+        cmd = (
+            "cd ~/proj " + AMP + AMP + " source .venv/bin/activate " + AMP + AMP
+            + " python3 - <<'EOF'" + NL
+            + "x = a " + AMP + " b" + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is None
+
+    def test_cd_with_substitution_does_not_authorize_python_heredoc(self):
+        cmd = (
+            "cd $(pwd) " + AMP + AMP + " python3 - <<'EOF'" + NL
+            + "x = a " + AMP + " b" + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is not None
+
+    def test_cd_link_without_amp_does_not_authorize_heredoc(self):
+        cmd = (
+            "cd /tmp python3 - <<'EOF'" + NL
+            + "x = a " + AMP + " b" + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is not None
+
+    def test_cd_link_bash_consumer_still_scanned(self):
+        cmd = (
+            "cd /tmp " + AMP + AMP + " bash - <<'EOF'" + NL
+            + "nohup sleep 10 " + AMP + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is not None
+
+    def test_python_heredoc_into_pipeline_is_masked(self):
+        cmd = (
+            "cd ~/proj && timeout 120 python3 -u - <<'EOF' 2>&1 | grep -v 'no match'" + NL
+            + "mask = (df['a'] > 1) " + AMP + " (df['b'] < 4)" + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is None
+
+    def test_python_heredoc_after_amp_amp_link_is_masked(self):
+        cmd = (
+            "cd ~/proj && .venv/bin/python scripts/build_x.py && .venv/bin/python - <<'EOF'" + NL
+            + "bad = (df['d'] > date(2026,1,1)) " + AMP + " (df['s'] == 'active')" + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is None
+
+    def test_cat_heredoc_into_shell_pipe_stays_visible(self):
+        """`cat <<'EOF' | bash` hands the body to a shell — fail closed."""
+        cmd = (
+            "cat <<'EOF' | bash" + NL
+            + "nohup sleep 10 " + AMP + NL
+            + "EOF"
+        )
+        assert guidance(cmd) is not None
+
+    def test_cat_heredoc_redirect_single_command_still_masked(self):
+        cmd = (
+            "cat > /tmp/out.py << 'PYEOF'" + NL
+            + 'proxies = {"http": "http://127.0.0.1:7893"}' + NL
+            + "PYEOF"
+        )
+        assert guidance(cmd) is None
+
+
 class TestUnsafeHeredocPayloadRemainsVisible:
     """Bodies that can execute (or can't be proven inert) stay scanned.
 

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -628,7 +628,16 @@ def _quoted_grep_pattern_spans(command: str) -> tuple[list[tuple[int, int]], boo
                 continue
             tokens = _shell_tokens_with_spans(segment, start)
             if tokens is None:
-                return [], True
+                # The grep word sits inside a construct whose quoting is not
+                # owned by the segment at this position — most commonly a
+                # double-quoted command substitution (`"$(grep -n 'x' f)"`).
+                # The command itself is well-formed; only the operand span
+                # cannot be established. Keep the operand visible (the raw
+                # command is still scanned by every other detector) and skip
+                # this grep rather than fail-closing the WHOLE command as
+                # malformed — that produced unconditional hardline blocks for
+                # benign workflows like `sed -n "$(grep -n 'x' f | cut -d: -f1)"`.
+                continue
             args, pattern_indexes = tokens[1:], []
             pcre = explicit_patterns = False
             operand_index, i, options = None, 0, True

--- a/tools/shell_heredoc.py
+++ b/tools/shell_heredoc.py
@@ -12,11 +12,41 @@ from __future__ import annotations
 import re
 
 # Non-shell interpreters whose quoted heredoc bodies are data for THAT interpreter; optional
-# VAR=... assignments, ``env`` and a path prefix allowed. Narrow on purpose: unmatched = visible.
+# VAR=... assignments, ``env``, a ``cd <path> &&`` / ``source <path> &&`` prologue link,
+# a ``timeout <N>`` wrapper and a path prefix are allowed. Narrow on purpose: unmatched = visible.
+#
+# A prologue link (``cd``/``source``) is inert only when its path is a plain, substitution-free
+# token: quoting or ``$(...)``/backticks mean the argument is evaluated by the shell, so such a
+# link is NOT provably inert and stays visible (fail-closed). The same regex drives the scanner's
+# skip-ahead so the link's ``&&`` is not counted as a list operator.
+_INERT_PROLOGUE_LINK_RE = re.compile(
+    r"(?:cd|source)\s+(?:[^$;|&'=\"`\n()]|\\\s)+(?:\s*&&\s*)",
+    re.IGNORECASE,
+)
+
 _INERT_HEREDOC_CONSUMER_RE = re.compile(
-    r"^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:env\s+)?(?:[A-Za-z0-9_./-]+/)?"
+    r"^\s*"
+    # Env assignments may appear both before and between prologue links
+    # (e.g. `cd x && source activate && PYTHONPATH=src python`).
+    r"(?:(?:[A-Z_][A-Z0-9_]*=\S+\s+)?(?:" + _INERT_PROLOGUE_LINK_RE.pattern + r")?)*"
+    r"(?:[A-Z_][A-Z0-9_]*=\S+\s+)*"
+    r"(?:env\s+)?"
+    # ``timeout <N> python...`` defers but does not reinterpret the body;
+    # the interpreter is still the consumer, so the body stays inert.
+    r"(?:timeout\s+\d+(?:s|m|h|d)?\s+)*"
+    r"(?:~?[A-Za-z0-9_./-]+/)?"
     r"(?:python(?:3(?:\.\d+)*)?|osascript|cat)(?=\s|$)",
     re.IGNORECASE)
+
+# A shell interpreter somewhere on the opener/pipeline means body data may flow to a shell
+# (e.g. `cat <<'EOF' | bash` executes the body). When the opener is compound (`|`/`&&`/`&`),
+# presence of any such consumer keeps the whole opener fail-closed (body stays visible).
+# Python/osascript bodies are program text for that interpreter and are never handed to a
+# shell as its stdin by the interpreter, so they may be masked even in compound openers.
+_SHELL_CONSUMER_RE = re.compile(
+    r"(?<![-\w.])(?:bash|sh|zsh|dash|ksh|eval|ssh)\b",
+    re.IGNORECASE,
+)
 
 
 def _span_end(command: str, cursor: int, closer: str) -> int:
@@ -110,6 +140,19 @@ def _scan_heredoc_command_unit(command: str, start: int):
     specs = []
     unknown_operator = False
     has_list_operator = False
+    # A leading `cd <path> && ...` / `source <path> && ...` prologue only
+    # sets up the context; its `&&` is not an imperative list operator, so
+    # skip it (repeatedly) before scanning the real command. This keeps the
+    # extremely common agent spelling `cd ~/x && python - <<'EOF'` maskable
+    # by the consumer check below, while a bare `&` or `;` as a SEPARATOR
+    # still counts. Anything that is not a plain, substitution-free prologue
+    # link (quoted path, $(...)) fails closed: the link is not consumed and
+    # `&&` remains a list op.
+    while True:
+        link = _INERT_PROLOGUE_LINK_RE.match(command, cursor)
+        if link is None:
+            break
+        cursor = link.end()
     while cursor < len(command):
         char = command[cursor]
         if char == "\n" and (comment or quote is None):
@@ -187,10 +230,18 @@ def strip_inert_heredoc_bodies(command: str) -> str:
                 return command  # unterminated
             body_ranges.append((body_cursor, close_end))
             body_cursor = close_end
-        if all(quoted for _delimiter, _strip_tabs, quoted in specs) and not has_list_operator:
+        if all(quoted for _delimiter, _strip_tabs, quoted in specs):
             masked_opener = _mask_simple_quotes(command[command_start:command_end])
             if (not any(m in masked_opener for m in ("$(", "`", "<(", ">("))
-                    and _INERT_HEREDOC_CONSUMER_RE.search(masked_opener)):
+                    and _INERT_HEREDOC_CONSUMER_RE.search(masked_opener)
+                    and not (has_list_operator and _SHELL_CONSUMER_RE.search(masked_opener))):
+                # Single-command opener, or a compound opener whose consumers
+                # are program interpreters (python/osascript): the quoted body
+                # is inert data for that interpreter regardless of the pipes
+                # and links it is attached to (`python3 - <<'EOF' 2>&1 |
+                # grep -v X`, `build && python3 - <<'EOF'`). Compound openers
+                # WITH a shell consumer on the line (`cat <<'EOF' | bash`)
+                # stay fail-closed: the body data may flow to the shell.
                 ranges.extend(body_ranges)
         command_start = body_cursor
     # Single-pass rebuild (ranges are sorted and non-overlapping), bodies -> their newlines only.

--- a/tools/terminal_tool_guards.py
+++ b/tools/terminal_tool_guards.py
@@ -90,12 +90,175 @@ _LONG_LIVED_FOREGROUND_PATTERNS = tuple(re.compile(p, re.IGNORECASE) for p in (
     r"\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:dev|start|serve|watch)\b",
     r"\bdocker\s+compose\s+up\b",
     r"\bnext\s+dev\b",
-    r"\bvite(?:\s|$)",
+    r"\bvite(?:\.(?:js|ts|mjs|cjs))?(?:\s+(?!build\b)|$)",
     r"\bnodemon\b",
     r"\buvicorn\b",
     r"\bgunicorn\b",
     r"\bpython(?:3)?\s+-m\s+http\.server\b",
 ))
+
+# Commands that START one of the services above, keyed by the pattern that
+# must then match their word sequence. Scoping long-lived detection to the
+# command's own word sequence means `ps aux | grep uvicorn` (inspection) is
+# never mistaken for `python -m uvicorn` (server start).
+_LONG_LIVED_START_WORDS = {
+    "npx",
+    "npm",
+    "pnpm",
+    "yarn",
+    "bun",
+    "docker",
+    "next",
+    "vite",
+    "uvicorn",
+    "gunicorn",
+    "nodemon",
+}
+
+# A segment wrapped in `timeout <N>` is bounded: it cannot occupy the
+# foreground forever, so it is not a long-lived process even when the wrapped
+# executable is a server (`timeout 15 .venv/bin/python -m uvicorn ...`).
+# Optional `VAR=...` assignments, flags (e.g. `-s KILL`) and unit suffixes
+# (`15s`/`1m`) are accepted.
+_TIMEOUT_BOUNDED_SEGMENT_RE = re.compile(
+    r"^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*timeout\s+(?:[^\d\s][^\s]*\s+)*\d+(?:\.\d+)?(?:s|m|h|d)?\b",
+    re.IGNORECASE,
+)
+
+
+def _shell_words(command: str) -> list[str]:
+    """Tokenize a command into shell words (quotes handled by shlex)."""
+    try:
+        return shlex.split(command)
+    except ValueError:
+        # Malformed quoting; fall back to whitespace split so detection still
+        # runs on whatever is present rather than silently skipping.
+        return command.split()
+
+
+def _logical_command_segments(command: str) -> list[str]:
+    """Split a command into logical units on shell list/pipeline operators.
+
+    ``&&``/``||`` are consumed as one separator. The split is quote-naive on
+    purpose: the caller strips quoted spans first, and the only job here is
+    to find where each command starts so server detection can be scoped.
+    """
+    parts: list[str] = []
+    i = 0
+    n = len(command)
+    while i < n:
+        while i < n and command[i].isspace():
+            i += 1
+        start = i
+        while i < n and command[i] not in ";|&":
+            i += 1
+        if i > start:
+            parts.append(command[start:i])
+        if i < n and command[i] in "&|" and i + 1 < n and command[i + 1] == command[i]:
+            i += 2
+        else:
+            i += 1
+    return parts
+
+
+def _command_start_words(segment: str) -> list[str]:
+    """Return the words that actually START the command in a segment.
+
+    Walks past env assignments, `cd <path> &&` links, and the common wrappers
+    (``sudo``/``env``/``exec``/``timeout N``), so the returned list begins
+    with the program being started (e.g. ``["python", "-m", "uvicorn", ...]``
+    or ``["ps", "aux", "|", "grep", ...]``).
+    """
+    words = _shell_words(segment)
+    out: list[str] = []
+    i = 0
+    while i < len(words):
+        w = words[i]
+        # env assignment: FOO=1 (no spaces around `=`)
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", w):
+            i += 1
+            continue
+        if w in ("cd",):
+            # consume `cd <path>` and a following `&&` / `;`
+            i += 2
+            while i < len(words) and words[i] in ("&&", ";"):
+                i += 1
+            continue
+        if w in ("sudo", "env", "exec", "timeout"):
+            i += 1
+            while i < len(words):
+                tok = words[i]
+                if tok in ("&&", ";", "|"):
+                    break
+                # consume a numeric arg (`timeout 5`)
+                if re.match(r"^-?\d", tok):
+                    i += 1
+                    continue
+                # consume short-option clusters and their value (`-s TERM`,
+                # `-u root`, `-k 30`); stop at the first bare word.
+                if re.match(r"^-[a-zA-Z]", tok):
+                    i += 1
+                    # a short option with a value?
+                    if i < len(words) and not words[i].startswith("-"):
+                        i += 1
+                    continue
+                break
+            continue
+        out.extend(words[i:])
+        break
+    return out
+
+
+def _is_detached_docker_compose_up(words: list[str]) -> bool:
+    """Return True when the command is ``docker compose up -d|--detach``.
+
+    ``docker compose up -d`` (or ``--detach``) hands the containers over to the
+    Docker daemon and the command line itself returns immediately — it is NOT a
+    long-lived foreground process, so it must not be nudged to background=true
+    (and must not be hard-blocked as a server start). Only bare ``docker
+    compose up`` (no detach) keeps the foreground attached and legitimately
+    trips the long-lived guard.
+    """
+    if not words:
+        return False
+    first = words[0].rsplit("/", 1)[-1]
+    if first != "docker":
+        return False
+    try:
+        up = words.index("up")
+    except ValueError:
+        return False
+    # `compose` must precede the `up` subcommand (so `docker ps | grep up`
+    # inspection stays untouched), and the detach flag must come after it.
+    if "compose" not in words[:up]:
+        return False
+    return any(tok in ("-d", "--detach") for tok in words[up + 1:])
+
+
+def _long_lived_foreground_hit(unquoted: str) -> bool:
+    """Scoped long-lived detection: a real server/service START only.
+
+    ``ps aux | grep uvicorn`` / ``journalctl -u X | grep uvicorn`` are
+    inspections, not starts — the server word only appears as a grep operand
+    there. ``docker compose up -d`` returns immediately (daemon-owned) and
+    ``timeout <N> ...`` wrappers bound the process, so neither is long-lived.
+    """
+    for segment in _logical_command_segments(unquoted):
+        if _TIMEOUT_BOUNDED_SEGMENT_RE.match(segment):
+            continue
+        words = _command_start_words(segment)
+        if not words:
+            continue
+        first = words[0].rsplit("/", 1)[-1]
+        if first not in _LONG_LIVED_START_WORDS and not first.startswith("python"):
+            # `python -m uvicorn` / `python -m http.server` start a service;
+            # any other first word (ps, grep, curl, ...) is not a start.
+            continue
+        if _is_detached_docker_compose_up(words):
+            continue
+        if any(p.search(" ".join(words)) for p in _LONG_LIVED_FOREGROUND_PATTERNS):
+            return True
+    return False
 
 # Ordered (predicate on the unquoted command, guidance) — first hit wins.
 _FOREGROUND_GUIDANCE = (
@@ -113,7 +276,7 @@ _FOREGROUND_GUIDANCE = (
         "for bounded jobs — then run health checks and tests in follow-up terminal calls.",
     ),
     (
-        lambda s: any(p.search(s) for p in _LONG_LIVED_FOREGROUND_PATTERNS),
+        _long_lived_foreground_hit,
         "This foreground command appears to start a long-lived server/watch process. "
         "Run it with background=true, verify readiness (health endpoint/log signal), "
         "then execute tests in a separate command.",


### PR DESCRIPTION
Terminal guards scanned raw command text without respecting what actually executes, hard-blocking ordinary agent workflows (exit_code=-1, status 'error') on command text that is never run as shell syntax. This is the complete fix set for the reported false-positive families, collapsed into one commit against the current main:

1. **Heredoc bodies are inert data for their interpreter, not shell syntax.** Quoted (inert) heredoc bodies after `cd <path> &&` / `source <path> &&` prologue links, `VAR=...` assignments, `env`, `timeout <N>` wrappers and `~`/relative interpreter paths are now masked; quoted paths or command substitutions stay fail-closed, and bash/sh consumers keep their bodies scanned.

2. **Compound openers also mask inert bodies** (`python3 - <<'EOF' 2>&1 | grep -v X`, `build && python3 - <<'EOF'`) — a bitwise `&` in interpreter program text is no longer reported as shell backgrounding. An opener with a *shell* consumer on the line (`cat <<'EOF' | bash`) stays fail-closed.

3. **A grep word inside a double-quoted command substitution** made the operand span unprovable and the whole command failed the hardline check as "malformed executable payload" (not bypassable even with --yolo). Only that grep word is skipped now; the raw command still reaches every other detector.

4. **Long-lived detection is scoped to the command's own start words**, so `ps aux | grep uvicorn` / `journalctl -u X | grep uvicorn` (process inspection) are not mistaken for `python -m uvicorn` (server start). Bare `docker compose up` stays flagged, but `docker compose up -d|--detach` returns immediately (daemon-owned) and is not long-lived — this unblocks `compose down && compose up -d` restart workflows.

5. **Bounded executions are not long-lived.** A `timeout <N>` wrapper bounds the process (smoke/restart tests), so `timeout 15 .venv/bin/python -m uvicorn ...` passes; unbounded starts are still flagged.

6. **`vite build` is a one-shot build**, not a dev server — excluded from the long-lived pattern, while bare `vite` / `vite dev` stay flagged. `vite` was also missing from the long-lived start-word set, so bare dev servers actually slipped past detection; that gap is closed too.

Tests: new cases for prologue-link heredocs, compound openers (python masked / shell fail-closed), grep-substitution non-malformed, inspection-vs-start scoping, detached compose, bounded `timeout` starts and `vite build`. All existing tests pass (guards/heredoc/hardline/approval/terminal suites).