### PR TITLE
fix(tools): strip bare path:/local: pseudo-scheme in resolve_image_source

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -115,6 +115,48 @@ class TestLocalBackend:
         assert res.data == svg_bytes
 
 
+class TestPseudoSchemePrefixStripping:
+    """Issue #98428: text-routed local models (gpt-oss via Ollama) re-call
+    vision_analyze with a bare "path:"/"local:" pseudo-scheme prefixed onto the
+    injected cache path. The resolver must strip it instead of failing with
+    "media file not found" on the whole string as a relative path."""
+
+    @pytest.mark.asyncio
+    async def test_path_prefix_resolves_underlying_file(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        img = tmp_path / "img.png"
+        img.write_bytes(PNG)
+        res = await isrc.resolve_image_source(f"path:{img}", isrc.ResolveContext())
+        assert res.data == PNG
+        assert res.origin == "file"
+
+    @pytest.mark.asyncio
+    async def test_local_prefix_and_separator_variants_resolve(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        img = tmp_path / "img.png"
+        img.write_bytes(PNG)
+        for src in (f"local:{img}", f"path= {img}"):
+            res = await isrc.resolve_image_source(src, isrc.ResolveContext())
+            assert res.data == PNG
+            assert res.origin == "file"
+
+    @pytest.mark.asyncio
+    async def test_real_scheme_still_rejected_and_bare_name_untouched(
+            self, tmp_path, monkeypatch):
+        """The strip must not broaden scheme handling: a genuine scheme keeps
+        raising UnsupportedScheme, and a relative name carrying a literal colon
+        keeps the old not-found behaviour instead of being rewritten."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(isrc.UnsupportedScheme):
+            await isrc.resolve_image_source("paths://x.png", isrc.ResolveContext())
+        with pytest.raises(isrc.SourceNotFound):
+            await isrc.resolve_image_source("path:pic.png", isrc.ResolveContext())
+
+
 class TestNonLocalBackendConfinement:
     """The security model: under a sandbox backend, host reads are confined to
     the media caches; every other path is read inside the sandbox."""

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -156,6 +156,57 @@ class TestPseudoSchemePrefixStripping:
         with pytest.raises(isrc.SourceNotFound):
             await isrc.resolve_image_source("path:pic.png", isrc.ResolveContext())
 
+    @pytest.mark.parametrize(
+        "raw,stripped",
+        [
+            pytest.param("path:/abs/img.png", "/abs/img.png", id="posix-abs"),
+            pytest.param("LOCAL:~/img.png", "~/img.png", id="home-case-insensitive"),
+            pytest.param("path: ./rel.png", "./rel.png", id="equals-space-separator"),
+            pytest.param(r"path:C:\Users\me\img.png", r"C:\Users\me\img.png",
+                         id="windows-drive-backslash"),
+            pytest.param("local:C:/Users/me/img.png", "C:/Users/me/img.png",
+                         id="windows-drive-forward-slash"),
+            pytest.param(r"path:\\server\share\img.png", r"\\server\share\img.png",
+                         id="unc-root"),
+        ],
+    )
+    def test_windows_path_shapes_stripped(self, tmp_path, monkeypatch, raw, stripped):
+        """Windows drive-absolute and UNC spellings are real absolute paths and
+        must be stripped too. The strip is pure string work, so it is pinned at
+        the regex level where it stays testable on POSIX CI."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        assert isrc._PSEUDO_SCHEME_RE.sub("", raw, count=1) == stripped
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param("path://host/img.png", id="authority-form-path"),
+            pytest.param("local://host/img.png", id="authority-form-local"),
+            pytest.param("paths://x.png", id="different-scheme-name"),
+            pytest.param("path:pic.png", id="bare-relative-name"),
+            pytest.param(r"path:C:relative.png", id="drive-relative"),
+        ],
+    )
+    def test_uri_and_ambiguous_forms_left_untouched(
+            self, tmp_path, monkeypatch, raw):
+        """The "//" authority form ("path://host") is a structurally complete
+        URI, not a decorated path; drive-relative spellings are cwd-dependent
+        and ambiguous. Neither is rewritten."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        assert isrc._PSEUDO_SCHEME_RE.sub("", raw, count=1) == raw
+
+    @pytest.mark.asyncio
+    async def test_uri_authority_form_still_unsupported_scheme(
+            self, tmp_path, monkeypatch):
+        """Pins the "path://host" decision end to end: the authority form must
+        flow into the existing unsupported-scheme branch instead of being
+        rewritten to a "//host" POSIX path."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        with pytest.raises(isrc.UnsupportedScheme):
+            await isrc.resolve_image_source(
+                "path://host/img.png", isrc.ResolveContext())
+
 
 class TestNonLocalBackendConfinement:
     """The security model: under a sandbox backend, host reads are confined to

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -91,6 +91,15 @@ class ResolvedImage:
 # ("C:\x.png") don't match because they lack the "//".
 _SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
 
+# Some local models (reproducibly gpt-oss via Ollama, issue #98428) hand back a
+# filesystem path they were given as `image_url: /abs/path` with a bare
+# "path:"/"local:" pseudo-scheme prefixed ("path:/home/.../img.jpg"). That is
+# not a real URI (no "//"), so _SCHEME_RE doesn't match and the whole string
+# falls through to the path branch, failing as "media file not found". Strip
+# the pseudo-scheme only when a path character follows; real schemes
+# ("paths://x") and bare relative names ("path:foo.png") keep their old shape.
+_PSEUDO_SCHEME_RE = re.compile(r"^(?:path|local)\s*[:=]\s*(?=[/~.])", re.IGNORECASE)
+
 
 async def resolve_image_source(
     src: str,
@@ -101,6 +110,7 @@ async def resolve_image_source(
     if not isinstance(src, str) or not src.strip():
         raise SourceNotFound("image_url is required", src=str(src))
     s = src.strip()
+    s = _PSEUDO_SCHEME_RE.sub("", s, count=1)
     if s.startswith("data:"):
         data, mime = _resolve_data_url(s)
         return _finalize(data, mime, "data", s, permitted)

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -96,9 +96,16 @@ _SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
 # "path:"/"local:" pseudo-scheme prefixed ("path:/home/.../img.jpg"). That is
 # not a real URI (no "//"), so _SCHEME_RE doesn't match and the whole string
 # falls through to the path branch, failing as "media file not found". Strip
-# the pseudo-scheme only when a path character follows; real schemes
-# ("paths://x") and bare relative names ("path:foo.png") keep their old shape.
-_PSEUDO_SCHEME_RE = re.compile(r"^(?:path|local)\s*[:=]\s*(?=[/~.])", re.IGNORECASE)
+# the pseudo-scheme only when a path shape follows: POSIX absolute/home/dot
+# ("/", "~", "."), a Windows drive-absolute root ("C:\", "C:/"), or a UNC
+# root ("\\server\share"). Real schemes ("paths://x", "path://host" — the
+# "//" authority form is a genuine URI), bare relative names ("path:foo.png")
+# and drive-relative spellings ("path:C:img.png" — cwd-dependent, ambiguous)
+# keep their old shape.
+_PSEUDO_SCHEME_RE = re.compile(
+    r"^(?:path|local)\s*[:=]\s*(?=[/~.]|[A-Za-z]:[\\/]|\\\\)(?!//)",
+    re.IGNORECASE,
+)
 
 
 async def resolve_image_source(


### PR DESCRIPTION
## What does this PR do?

On the text image-routing path (non-vision main model), Hermes pre-runs `vision_analyze`, injects the description plus the cache path, and some local models — reproducibly gpt-oss:20b via Ollama — re-call `vision_analyze` with the path mangled to `image_url: "path:/home/.../img_XXXX.jpg"`. That string has no `//`, so `_SCHEME_RE` does not match and it is not rejected as an unsupported scheme either; `resolve_image_source` instead treats the whole string as a relative filesystem path and fails with `media file not found`, so the agent tells the user it cannot access an image it analyzed moments earlier.

This strips the bare `path:` / `local:` pseudo-scheme (also tolerating a `=` separator and surrounding whitespace) when it is immediately followed by a path character (`/`, `~`, `.`), before the existing scheme/path branching. The stripped remainder then flows through the unchanged path handling, including the terminal-backend confinement and credential-read guards — no new read surface is introduced.

## Related Issue

Fixes #98428

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/image_source.py` — add `_PSEUDO_SCHEME_RE` (`^(?:path|local)\s*[:=]\s*(?=[/~.])`) and strip it once at the top of `resolve_image_source`, with a comment documenting the model behavior that produces it.
- `tests/tools/test_image_source.py` — new `TestPseudoSchemePrefixStripping`: `path:` prefix resolves the underlying file; `local:` and `path= ` variants resolve; a genuine scheme (`paths://x.png`) still raises `UnsupportedScheme` and a bare relative name carrying a literal colon (`path:pic.png`) keeps its previous not-found behavior instead of being rewritten.

## How to Test

1. `pytest tests/tools/test_image_source.py -q` — Observed result: 22 passed (19 pre-existing + 3 new).
2. `pytest tests/tools/test_vision_tools.py tests/integration/test_vision_docker_resolve.py -q` — Observed result: 37 passed, 3 deselected (call sites of the resolver, no regressions).
3. Manual shape check of the regex: `path:/home/x.jpg` → `/home/x.jpg`; `local:/home/x.jpg` → `/home/x.jpg`; `paths://x.png` unchanged (rejected as a scheme); `path:pic.png` unchanged; `http(s)://`, `data:`, `file://`, and plain paths unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — change is exercised by unit tests above.