### PR TITLE
fix: skill activation no longer repeats the absolute path on every supporting-file line (-31% load cost on reference-heavy skills)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -391,9 +391,12 @@ def _build_skill_message(
             # Skill is from an external dir — use the skill name instead
             skill_view_target = skill_dir.name
         parts.append("")
-        parts.append("[This skill has supporting files:]")
+        parts.append(
+            "[This skill has supporting files (paths relative to the skill "
+            "directory above):]"
+        )
         for sf in supporting:
-            parts.append(f"- {sf}  ->  {skill_dir / sf}")
+            parts.append(f"- {sf}")
         parts.append(
             f'\nLoad any of these with skill_view(name="{skill_view_target}", '
             f'file_path="<path>"), or run scripts directly by absolute path '

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -691,7 +691,7 @@ class TestSkillDirectoryHeader:
         assert f"[Skill directory: {skill_dir}]" in msg
         assert "Resolve any relative paths" in msg
 
-    def test_supporting_files_shown_with_absolute_paths(self, tmp_path):
+    def test_supporting_files_listed_relative_only(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = _make_skill(tmp_path, "scripted-skill")
             (skill_dir / "scripts").mkdir()
@@ -700,11 +700,17 @@ class TestSkillDirectoryHeader:
             msg = build_skill_invocation_message("/scripted-skill")
 
         assert msg is not None
-        # The supporting-files block must emit both the relative form (so the
-        # agent can call skill_view on it) and the absolute form (so it can
-        # run the script directly via terminal).
-        assert "scripts/run.js" in msg
-        assert str(skill_dir / "scripts" / "run.js") in msg
+        # Each supporting file is listed ONCE, as a relative path. Repeating
+        # the absolute skill-dir prefix per line cost ~9K tokens on skills
+        # with hundreds of references; the absolute base is already stated
+        # once in the [Skill directory: ...] header and the footer example.
+        assert "- scripts/run.js" in msg
+        assert f"- scripts/run.js  ->  " not in msg
+        assert str(skill_dir / "scripts" / "run.js") not in msg.split(
+            "[This skill has supporting files"
+        )[1].split("\nLoad any of these")[0]
+        # Absolute resolution stays available via the header + footer example.
+        assert f"[Skill directory: {skill_dir}]" in msg
         assert f"node {skill_dir}/scripts/foo.js" in msg
 
 


### PR DESCRIPTION
## Summary
Skill activation messages no longer repeat the absolute skill directory on every supporting-file line — reference-heavy skills get ~31% cheaper to load, every session.

Root cause: the supporting-files block emitted `- <relative>  ->  <absolute>` per file, duplicating an identical directory prefix hundreds of times. The absolute base was already stated once in the `[Skill directory: ...]` header and the footer's worked example, so the per-line copy was pure redundancy.

## Changes
- `agent/skill_commands.py`: supporting-file lines now carry only the relative path; block header notes paths resolve against the skill directory above.
- `tests/agent/test_skill_commands.py`: repin the format contract — relative-only lines, no absolute paths inside the block, header + footer example still present (sabotage-verified: test fails against the old format).

## Validation
Live before/after on the real `build_skill_invocation_message("/hermes-agent-dev")` (462 supporting files), o200k_base:

| | Before | After |
|---|---|---|
| Activation message | 42,145 tokens | 29,042 tokens |
| Delta | | **-13,103 (-31.1%)** |

Targeted tests: `tests/agent/test_skill_commands.py` 29/29 pass.

**Live repro:** confirmed on origin/main — every one of the 462 lines carried the duplicate `/home/.../hermes-agent-dev/` prefix (~18 tokens each); after the fix the same call emits relative-only lines with the base stated once.

## Infographic

![Skill file listings de-duplicated](https://v3b.fal.media/files/b/0aa86396/X3g9a-EtYMCzndGN8TaPi_p4zrT1oi.png)
