### PR TITLE
fix(model_normalize): strip matching lmstudio/ prefix

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -104,6 +104,11 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "xiaomi",
     "arcee",
     "ollama-cloud",
+    # LM Studio's native server validates the model id against the ids it has
+    # downloaded and rejects a provider-prefixed name outright with a
+    # non-retryable HTTP 400 (``Invalid model identifier "lmstudio/<id>" ...
+    # code=model_not_found``), so every turn dies until the prefix is stripped.
+    "lmstudio",
     "nebius-token-factory",
     "custom",
     "gemini",

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -223,3 +223,30 @@ class TestLMStudioMatchingPrefixStrip:
             == "qwen3.8-flash-next"
         )
 
+    @pytest.mark.parametrize("model", [
+        "openai/gpt-4",
+        "z-ai/glm-5.2",
+        "ollama/qwen3",
+    ])
+    def test_foreign_prefix_untouched(self, model):
+        """Only the *matching* prefix is stripped.
+
+        An LM Studio endpoint can front a proxy whose route requires a
+        foreign prefix (LiteLLM-style ``ollama/…``), so a non-matching prefix
+        must survive — adding ``lmstudio`` to the strip set must not widen
+        into a general slash-stripper.
+        """
+        assert normalize_model_for_provider(model, "lmstudio") == model
+
+    @pytest.mark.parametrize("model,expected", [
+        ("lmstudio/lmstudio/qwen3-27b", "lmstudio/qwen3-27b"),
+        ("lmstudio/openai/gpt-4", "openai/gpt-4"),
+    ])
+    def test_exactly_one_prefix_level_is_stripped(self, model, expected):
+        """A stacked id loses only its own leading ``lmstudio/``.
+
+        Matches the one-level scope the other strip paths use: a leftover
+        prefix chain means the id was namespaced elsewhere, and guessing
+        further would mangle a legitimate route.
+        """
+        assert normalize_model_for_provider(model, "lmstudio") == expected

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -187,3 +187,39 @@ class TestIssue78796NvidiaPrefixRepair:
             == "anthropic/claude-sonnet-4.6"
         )
 
+
+# ── Regression: LM Studio matching-prefix strip ────────────────────────
+
+class TestLMStudioMatchingPrefixStrip:
+    """``lmstudio/<id>`` must lose its own provider prefix.
+
+    LM Studio's native server validates the model id against the ids it has
+    downloaded and rejects the prefixed form with a non-retryable HTTP 400
+    (``Invalid model identifier "lmstudio/<id>". Please specify a valid
+    downloaded model``, ``code=model_not_found``). ``lmstudio`` was absent
+    from every normalization set, so the name reached the API verbatim and
+    every turn failed. ``ollama-cloud`` — the analogous local-server
+    provider — was already covered.
+    """
+
+    @pytest.mark.parametrize("model,expected", [
+        ("lmstudio/qwen3-27b", "qwen3-27b"),
+        ("lmstudio/huihui-qwen3.8-27b-abliterated", "huihui-qwen3.8-27b-abliterated"),
+    ])
+    def test_matching_prefix_is_stripped(self, model, expected):
+        assert normalize_model_for_provider(model, "lmstudio") == expected
+
+    @pytest.mark.parametrize("model", [
+        "qwen3-27b",
+        "huihui-qwen3.8-27b-abliterated",
+    ])
+    def test_bare_id_untouched(self, model):
+        assert normalize_model_for_provider(model, "lmstudio") == model
+
+    def test_dots_preserved(self):
+        """LM Studio ids carry dots — they must not be mangled to hyphens."""
+        assert (
+            normalize_model_for_provider("lmstudio/qwen3.8-flash-next", "lmstudio")
+            == "qwen3.8-flash-next"
+        )
+


### PR DESCRIPTION
## What does this PR do?

`lmstudio` is missing from every normalization set in `hermes_cli/model_normalize.py`, so a `lmstudio/<id>` model name reaches LM Studio's native server verbatim. LM Studio validates the model id against the ids it has downloaded and rejects the prefixed form with a **non-retryable** HTTP 400, so every turn dies until the prefix is removed by hand.

Observed in production (`agent.conversation_loop`, provider `lmstudio`, `base_url=http://127.0.0.1:1234/v1`):

```
ERROR Non-retryable client error: Error code: 400 - {'error': {'message':
'Invalid model identifier "lmstudio/huihui-qwen3.8-27b-abliterated".
Please specify a valid downloaded model (e.g., huihui-qwen3.8-27b-abliterated,
qwen3.8-4b, ...)', ... 'code': 'model_not_found'}}
```

This looks like a plain omission rather than a deliberate exclusion: `ollama-cloud` — the analogous local-server provider — is already in `_MATCHING_PREFIX_STRIP_PROVIDERS`, and the set's own docstring describes this exact case ("Direct providers that accept bare native names but should repair a matching `provider/` prefix when users copy the aggregator form into config.yaml").

The prefixed form is not exotic: the repo's own test suite drives it through `switch_model` in `tests/run_agent/test_switch_model_context.py` (`assert model == "lmstudio/new-model"` with provider `lmstudio`).

Reproduced against current `main` (`2635035`):

```python
>>> from hermes_cli.model_normalize import normalize_model_for_provider as n
>>> n("lmstudio/qwen3-27b", "lmstudio")
'lmstudio/qwen3-27b'          # prefix survives -> HTTP 400 every turn
>>> n("ollama-cloud/qwen3", "ollama-cloud")
'qwen3'                       # analogous provider is handled
```

`_MATCHING_PREFIX_STRIP_PROVIDERS` is the correct bucket rather than a broader one: it strips only a prefix that *matches the provider*, so `lmstudio/x` → `x` while a non-matching prefix (e.g. a proxied `openai/x` on an endpoint fronted by LM Studio) is left untouched.

## Related Issue

No existing issue — searched open and closed issues and PRs for `lmstudio prefix`, `model_normalize`, `normalize_model_for_provider`, `_MATCHING_PREFIX_STRIP_PROVIDERS`, `Invalid model identifier`, and `model_not_found`. The nearest hits are unrelated: #54567 (merged) normalizes LM Studio *base URLs*, not model ids, and #93983 / #93989 / #71558 / #34015 touch the same file but neither add `lmstudio` nor make the strip generic (#93989 strips *foreign* vendor slugs, and only for providers already in this set).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_normalize.py` — add `"lmstudio"` to `_MATCHING_PREFIX_STRIP_PROVIDERS`, with a comment recording the API error the omission produces.
- `tests/hermes_cli/test_model_normalize.py` — add `TestLMStudioMatchingPrefixStrip`: prefix stripped, bare ids untouched, and dots preserved (LM Studio ids such as `qwen3.8-flash-next` carry dots).

## How to Test

1. Before the fix, the new tests fail:
   ```
   pytest tests/hermes_cli/test_model_normalize.py -q -k LMStudio
   3 failed, 2 passed
   ```
2. After the fix they pass, and the file's existing cases are unaffected:
   ```
   pytest tests/hermes_cli/test_model_normalize.py -q
   28 passed
   ```
3. End to end: set `model.default: lmstudio/<a-model-you-have-downloaded>` in `config.yaml` against a running LM Studio server. Before the fix every turn fails with the non-retryable 400 above; after it, the request carries the bare id and succeeds.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran `tests/hermes_cli/test_model_normalize.py` (28 passed); I did not run the full suite, which needs dev extras I don't have installed here. The change adds one string to a frozenset and touches no other module.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11, LM Studio native server

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the change is a set member with an inline comment
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, pure string normalization, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
