### PR TITLE
fix(tui): fold identical complete onto last interim

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -2084,7 +2084,7 @@ describe('createGatewayEventHandler', () => {
       expect(appended).toHaveLength(0)
     })
 
-    it('keeps identical interim and terminal replies as separate messages without response_previewed', () => {
+    it('settles identical terminal reply onto interim without response_previewed', () => {
       const appended: Msg[] = []
       const onEvent = createGatewayEventHandler(buildCtx(appended))
 
@@ -2093,7 +2093,35 @@ describe('createGatewayEventHandler', () => {
       onEvent({ payload: { text: 'same reply' }, type: 'message.complete' } as any)
 
       const assistantMsgs = appended.filter(m => m.role === 'assistant' && m.text)
-      expect(assistantMsgs).toHaveLength(2)
+      expect(assistantMsgs).toHaveLength(1)
+      expect(assistantMsgs[0]?.text).toBe('same reply')
+    })
+
+    it('settles a prefix-matched final onto the last interim without response_previewed', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { already_streamed: true, text: 'Hello' }, type: 'message.interim' } as any)
+      onEvent({ payload: { text: 'Hello world' }, type: 'message.complete' } as any)
+
+      const assistantMsgs = appended.filter(m => m.role === 'assistant' && m.text)
+      expect(assistantMsgs).toHaveLength(1)
+      expect(assistantMsgs[0]?.text).toBe('Hello world')
+    })
+
+    it('keeps already_streamed tokens when the interim payload is a truncated prefix', () => {
+      const appended: Msg[] = []
+      const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { text: 'Hello world' }, type: 'message.delta' } as any)
+      onEvent({ payload: { already_streamed: true, text: 'Hello' }, type: 'message.interim' } as any)
+      onEvent({ payload: { text: 'Hello world' }, type: 'message.complete' } as any)
+
+      const assistantMsgs = appended.filter(m => m.role === 'assistant' && m.text)
+      expect(assistantMsgs).toHaveLength(1)
+      expect(assistantMsgs[0]?.text).toBe('Hello world')
     })
 
     it('settles identical terminal reply onto interim when response_previewed', () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -16,6 +16,16 @@ vi.mock('../lib/openExternalUrl.js', () => ({
   openExternalUrl: (url: string) => openExternalUrlMock(url)
 }))
 
+vi.mock('@hermes/ink', async importOriginal => {
+  const mod = await importOriginal<Record<string, unknown>>()
+
+  return {
+    ...mod,
+    onTerminalBackground: vi.fn(),
+    onTerminalForeground: vi.fn()
+  }
+})
+
 const ref = <T>(current: T) => ({ current })
 
 const buildCtx = (appended: Msg[]) =>

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1423,7 +1423,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         const text = ev.payload?.text
 
         if (typeof text === 'string' && text.trim()) {
-          turnController.recordInterimMessage(text)
+          turnController.recordInterimMessage(text, Boolean(ev.payload?.already_streamed))
         }
 
         return

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -96,6 +96,48 @@ const finalTail = (finalText: string, segments: Msg[]) => {
   return tail
 }
 
+const lastAssistantNarrationIndex = (segments: Msg[]): number => {
+  for (let index = segments.length - 1; index >= 0; index--) {
+    const msg = segments[index]!
+
+    if (msg.role === 'assistant' && msg.kind !== 'diff' && msg.text.trim()) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+const textsContinue = (existing: string, incoming: string): boolean => {
+  const left = existing.trim()
+  const right = incoming.trim()
+
+  return Boolean(left && right && (left === right || right.startsWith(left) || left.startsWith(right)))
+}
+
+const foldContinuingInterim = (
+  segments: Msg[],
+  finalText: string
+): { foldedIndex: number; segments: Msg[] } => {
+  const index = lastAssistantNarrationIndex(segments)
+
+  if (index < 0 || !textsContinue(segments[index]!.text, finalText)) {
+    return { foldedIndex: -1, segments }
+  }
+
+  const existing = segments[index]!.text
+  const nextText = finalText.trim().length >= existing.trim().length ? finalText : existing
+
+  if (existing === nextText) {
+    return { foldedIndex: index, segments }
+  }
+
+  const next = segments.slice()
+  next[index] = { ...next[index]!, text: nextText }
+
+  return { foldedIndex: index, segments: next }
+}
+
 export interface InterruptDeps {
   appendMessage: (msg: Msg) => void
   gw: { request: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T> }
@@ -584,15 +626,30 @@ class TurnController {
     // only when the gateway elected not to send any (#16391).
     const rawText = (payload.text ?? payload.rendered ?? this.bufRef).trimStart()
     const split = splitReasoning(rawText)
+    // Seal leftover deltas before fold so the last narration is the post-tool
+    // (or post-interim) tail, not a stale pre-tool prefix of the concatenated
+    // complete payload. Skip when the buffer is empty so a tool-only complete
+    // does not mint a blank trail row.
+    if (this.bufRef.trimStart()) {
+      this.flushStreamingSegment()
+    }
+    // Fold the last sealed interim onto the terminal reply when they are the
+    // same message (exact or prefix-either-way). Desktop does this without
+    // waiting for response_previewed; TUI used to keep two identical bubbles
+    // unless that flag was set (Grok / xAI tool-heavy turns). Distinct
+    // commentary that does not continue the final still stays as its own
+    // segment.
+    const folded = foldContinuingInterim(this.segmentMessages, split.text)
+    this.segmentMessages = folded.segments
     // Only dedupe segments AFTER the interim boundary — interim-sealed
-    // segments are preserved even if the final text includes them.
-    // Exception: when response_previewed is true, the final text is the
-    // same model response that was published provisionally as an interim
-    // message. Dedupe against ALL segments (including sealed interims) so
-    // the identical text doesn't render as a duplicate message. (#65919
-    // review: duplicate-message blocker)
+    // segments are preserved even if the final text includes them, except
+    // when response_previewed (verify-on-stop) or the last interim was folded
+    // as the terminal reply.
     const dedupeStart = payload.response_previewed ? 0 : (this.interimBoundaryIndex ?? 0)
-    const finalText = finalTail(split.text, this.segmentMessages.slice(dedupeStart))
+    // A folded last interim already holds the terminal reply (the longer of
+    // the sealed text and the complete payload). Do not append it again.
+    const finalText =
+      folded.foldedIndex >= 0 ? '' : finalTail(split.text, this.segmentMessages.slice(dedupeStart))
     const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
     const savedReasoning = [existingReasoning, existingReasoning ? '' : split.reasoning].filter(Boolean).join('\n\n')
     const savedToolTokens = this.toolTokenAcc
@@ -699,7 +756,7 @@ class TurnController {
     }
   }
 
-  recordInterimMessage(text: string) {
+  recordInterimMessage(text: string, alreadyStreamed = false) {
     if (this.interrupted) {
       return
     }
@@ -710,10 +767,15 @@ class TurnController {
       return
     }
 
-    // If the streaming buffer hasn't caught up to the authoritative interim
-    // text (e.g. the backend didn't stream every token), sync it so the
-    // sealed segment matches what the user should see.
-    if (this.bufRef.trimStart() !== authoritativeText) {
+    const streamed = this.bufRef.trimStart()
+
+    // already_streamed means message.delta already painted this text. Keep the
+    // longer of the two when they continue each other so a truncated interim
+    // payload cannot erase tokens the user already saw. Unrelated text still
+    // takes the authoritative copy (the backend's sealed segment).
+    if (alreadyStreamed && streamed && textsContinue(streamed, authoritativeText)) {
+      this.bufRef = streamed.length >= authoritativeText.length ? streamed : authoritativeText
+    } else if (streamed !== authoritativeText) {
       this.bufRef = authoritativeText
     }
 


### PR DESCRIPTION
## What does this PR do?

This contribution was implemented, tested, and prepared by Hermes Agent on behalf of Enoch Lam (@eloklam). I am Hermes Agent.

Hermes TUI rendered the same assistant reply twice after a tool-heavy turn (especially Grok / xAI OAuth on the Responses path). The backend stored one `finish_reason=stop` row; the TUI still painted two bubbles because `message.complete` refused to settle onto a sealed interim unless `response_previewed` was set. Commentary turns correctly leave that flag false, so identical finals duplicated.

Desktop already folds when the last interim and the complete payload continue each other (exact or prefix-either-way). This PR brings the same settle to Ink TUI, and honours `already_streamed` so a truncated interim payload cannot erase tokens already painted by `message.delta`.

Distinct commentary that does not continue the final (for example pre-diff “Before edit.” and post-diff “After edit.”) still stays as its own bubble.

## Related Issue

Related Desktop dual-bubble reports: #81422, #81703, #71857. This PR does not claim those issues: they are Desktop settle paths. This change is the TUI counterpart (`already_streamed` + identical/prefix fold without waiting for `response_previewed`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/app/turnController.ts` — fold last sealed narration onto `message.complete` when texts continue; keep the longer copy; flush leftover deltas before fold; honour `already_streamed` on interim seal
- `ui-tui/src/app/createGatewayEventHandler.ts` — pass `already_streamed` into `recordInterimMessage`
- `ui-tui/src/__tests__/createGatewayEventHandler.test.ts` — identical and prefix settle without `response_previewed`; truncated `already_streamed` prefix keeps streamed tokens; stub Ink OSC 11 listeners so the suite can construct the handler in Vitest

## How to Test

1. `cd ui-tui && npx vitest run src/__tests__/createGatewayEventHandler.test.ts` (103 passed on this change)
2. `cd ui-tui && npm run typecheck`
3. In `hermes --tui`, run a tool-heavy Grok / xAI turn that previously showed the same final twice. Expect one assistant bubble. Mid-turn commentary that is not a prefix of the final should remain a separate segment.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
