### PR TITLE
index: add hermes-snapcompact community plugin

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,18 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "hermes-snapcompact",
+      "description": "Snapcompact context engine — archive conversation history as dense bitmap PNG frames that vision models read back at ~1/3 the input token cost. Local and deterministic, no LLM summarization call.",
+      "author": "vimona3ds",
+      "tags": ["context-engine", "compaction", "snapcompact", "vision"],
+      "repo": "vimona3ds/hermes-snapcompact",
+      "ref": "8a274ca4a501e5661f1e2762150c4c3f99e374ce",
+      "homepage": "https://github.com/vimona3ds/hermes-snapcompact",
+      "capabilities": ["commands", "context-engine"],
+      "api_version": 1,
+      "added_at": "2026-08-30"
     }
   ]
 }


### PR DESCRIPTION
Adds [hermes-snapcompact](https://github.com/vimona3ds/hermes-snapcompact) to the community plugin index.

**What it is:** A context engine plugin implementing [snapcompact](https://stencil.so/blog/snapcompact) — instead of LLM summarization, discarded conversation history is rendered into dense bitmap PNG frames (via the MIT-licensed [@oh-my-pi/snapcompact](https://www.npmjs.com/package/@oh-my-pi/snapcompact) npm package) that vision-capable models read back at roughly 1/3 the input token cost. The pass is local and deterministic — no LLM call.

**Details:**
- Registers a context engine (`context.engine: snapcompact`) and a `/compact-mode` slash command to switch between bitmap archival and classic LLM prose summary at runtime
- Default mode is `summarize` — installing changes nothing until the user opts in
- Requires Bun for the native renderer; the plugin detects and flags missing setup with exact fix commands, never installs anything itself
- `ref` pins the current release commit
- MIT licensed