### PR TITLE
fix(wake): stop forcing onnxruntime/numpy downgrades for openWakeWord

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,12 +222,15 @@ voice = [
 # first /wake; mirrored in tools/lazy_deps.py.
 wake = [
   "openwakeword==0.6.0",
-  "onnxruntime==1.27.0",
+  # Match openwakeword's own constraint (onnxruntime <2,>=1.10.0) instead of
+  # pinning 1.27.0, which forces a downgrade of the onnxruntime used by local
+  # STT and fails on Windows while the venv DLL is held by a running process.
+  "onnxruntime>=1.10.0,<2",
   "sherpa-onnx==1.13.4",
   "sentencepiece==0.2.2",
   "pvporcupine==4.0.3",
   "sounddevice==0.5.5",
-  "numpy==2.4.3",
+  "numpy>=2.4.3,<3",
   # openWakeWord's onnx embedding model scores near-zero on macOS ARM64
   # (dscripka/openWakeWord#336), so the wake word runs on tflite there.
   # Upstream declares tflite-runtime for Linux only; ai-edge-litert is the

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -167,9 +167,14 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     ),
     "wake.openwakeword": (
         "openwakeword==0.6.0",
-        "onnxruntime==1.27.0",
+        # Match openwakeword's own constraint (onnxruntime <2,>=1.10.0). The
+        # previous ==1.27.0 pin forced a downgrade of the onnxruntime already
+        # installed for local STT (faster-whisper VAD), which fails on Windows
+        # while the running process holds the DLL, leaving a half-uninstalled
+        # package behind and breaking STT.
+        "onnxruntime>=1.10.0,<2",
         "sounddevice==0.5.5",
-        "numpy==2.4.3",
+        "numpy>=2.4.3,<3",
     ),
     # Open-vocabulary keyword spotting: any typed phrase, zero training.
     # sentencepiece is required by sherpa_onnx.text2token (runtime phrase
@@ -178,12 +183,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "sherpa-onnx==1.13.4",
         "sentencepiece==0.2.2",
         "sounddevice==0.5.5",
-        "numpy==2.4.3",
+        "numpy>=2.4.3,<3",
     ),
     "wake.porcupine": (
         "pvporcupine==4.0.3",
         "sounddevice==0.5.5",
-        "numpy==2.4.3",
+        "numpy>=2.4.3,<3",
     ),
 
     # ─── Image generation backends ─────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -1907,8 +1907,8 @@ requires-dist = [
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.3.4" },
     { name = "nemo-relay", marker = "(platform_machine == 'aarch64' and 'android' not in platform_release and sys_platform == 'linux') or (platform_machine == 'x86_64' and 'android' not in platform_release and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')", specifier = ">=0.7.1,<0.8" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
-    { name = "numpy", marker = "extra == 'wake'", specifier = "==2.4.3" },
-    { name = "onnxruntime", marker = "extra == 'wake'", specifier = "==1.27.0" },
+    { name = "numpy", marker = "extra == 'wake'", specifier = ">=2.4.3,<3" },
+    { name = "onnxruntime", marker = "extra == 'wake'", specifier = ">=1.10.0,<2" },
     { name = "openai", specifier = "==2.24.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otlp'", specifier = "==1.39.1" },
     { name = "opentelemetry-sdk", marker = "extra == 'otlp'", specifier = "==1.39.1" },
@@ -4070,7 +4070,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4125,7 +4125,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4773,11 +4773,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "vercel" },
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "vercel", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [


### PR DESCRIPTION
## What does this PR do?

Fixes #98440. The `wake.openwakeword` lazy spec pinned `onnxruntime==1.27.0`
while local STT (faster-whisper VAD) uses onnxruntime 1.28.0 in the same
venv. On Windows, a runtime lazy install then tries to downgrade onnxruntime
while the running process holds the DLL, fails with
`拒绝访问 (os error 5)`, and leaves a half-uninstalled package behind —
breaking STT entirely (`module 'onnxruntime' has no attribute
'SessionOptions'`).

openwakeword 0.6.0 declares `onnxruntime <2,>=1.10.0`, so pinning 1.27.0 was
never required. Same downgrade-conflict class for `numpy==2.4.3` (the STT
stack already brings 2.4.6): relaxed to `>=2.4.3,<3` across all three wake
engines (openwakeword / sherpa / porcupine), so `ensure()` reuses installed
versions instead of forcing a downgrade.

## Test plan

- `ensure('wake.openwakeword')` performs no install on a venv with
  onnxruntime 1.28.0 + numpy 2.4.6 (previously it attempted a downgrade)
- openwakeword 0.6.0 loads and runs (VAD inference) on onnxruntime 1.28.0
- `tests/tools/test_lazy_deps*.py` + `tests/tools/test_wake_word.py`: 105
  passed, 4 platform skips; the one failure
  (`test_lazy_deps_durable_target.py::test_readonly_target_reports_error`)
  also fails on main — Windows read-only directory semantics