### PR TITLE
fix(gateway): mark shutdown/restart notifications as interim sends

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11216,7 +11216,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter=adapter,
                 )
 
-                result = await adapter.send(chat_id, msg, metadata=metadata)
+                # Fires while a turn may still be streaming — must carry the
+                # interim marker so a stream-is-the-message adapter doesn't
+                # seal the user's in-flight answer with this advisory (#98432).
+                result = await adapter.send(
+                    chat_id, msg, metadata=_interim_metadata(metadata)
+                )
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to %s:%s: %s",
@@ -11296,10 +11301,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     home.thread_id,
                     adapter=adapter,
                 )
-                if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
-                else:
-                    result = await adapter.send(str(home.chat_id), msg)
+                # Same interim-marker requirement as the per-session sends
+                # above: the broadcast races live turns on stream-is-the-
+                # message adapters (#98432).
+                result = await adapter.send(
+                    str(home.chat_id), msg, metadata=_interim_metadata(metadata)
+                )
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -388,8 +388,45 @@ async def test_shutdown_notifications_use_cached_live_thread_source_when_origin_
     adapter.send.assert_awaited_once_with(
         "parent-42",
         "⚠️ Gateway shutting down — Your current task will be interrupted.",
-        metadata={"thread_id": "topic-7"},
+        metadata={"thread_id": "topic-7", "_interim_send": True},
     )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_home_channel_broadcast_carries_interim_marker():
+    """The home-channel shutdown broadcast must be an interim send (#98432).
+
+    ``_notify_active_sessions_of_shutdown`` fires at the start of stop(),
+    while turns may still be streaming. Stream-is-the-message adapters
+    (relay Slack native streaming) intercept the first *unmarked* send to an
+    armed (chat, turn) key and seal the live stream with its content — so the
+    shutdown advisory would otherwise seal the user's in-flight answer with
+    status text. Both the per-active-session sends and the home-channel
+    broadcast must carry the ``_interim_send`` marker, including when no
+    thread routing metadata exists.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="active-42", chat_type="dm")
+    session_key = build_session_key(source)
+
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    targets = [c.args[0] for c in adapter.send.await_args_list]
+    assert targets == ["active-42", "home-42"]
+    for call in adapter.send.await_args_list:
+        assert call.kwargs["metadata"]["_interim_send"] is True, (
+            f"send to {call.args[0]} must be marked interim, got "
+            f"metadata={call.kwargs['metadata']}"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -812,8 +812,8 @@ async def test_restart_home_channel_notification_not_deduped_across_threads():
     await runner._notify_active_sessions_of_shutdown()
 
     assert len(adapter.sent) == 2
-    assert adapter.sent_calls[0][2] == {"thread_id": "topic-7"}
-    assert adapter.sent_calls[1][2] is None
+    assert adapter.sent_calls[0][2] == {"thread_id": "topic-7", "_interim_send": True}
+    assert adapter.sent_calls[1][2] == {"_interim_send": True}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`_notify_active_sessions_of_shutdown` fires at the very start of `stop()`, while turns may still be streaming — its recipient list is `_snapshot_running_agents()`. Per the contract in `_interim_metadata`'s docstring, every gateway-side send that can fire mid-turn MUST carry the interim marker, or a stream-is-the-message adapter (relay Slack native streaming) will intercept the first unmarked send to an armed `(chat, turn)` key and seal the user's live answer stream with the status text.

The three `adapter.send` sites in this function passed only thread-routing metadata, or no metadata at all — exactly the contract violation #98432 describes. This PR routes all three sends through `_interim_metadata` so the shutdown/restart advisory can never be mistaken for the turn-final. The home-channel branch collapses its `metadata`/no-`metadata` if/else into a single interim-marked call (`_interim_metadata(None)` yields `{"_interim_send": True}`).

The marker is gateway-internal and already stripped before the wire by the relay adapters (`gateway/relay/adapter.py` pops `_interim_send` in both egress doors), and four other call sites in `gateway/run.py` already use `_interim_metadata` the same way — this brings the shutdown path in line with the established pattern.

## Related Issue

Fixes #98432

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_notify_active_sessions_of_shutdown`: wrap the per-active-session send's metadata in `_interim_metadata(...)`; collapse the home-channel if/else into one send that always carries `_interim_metadata(metadata)`
- `tests/gateway/test_restart_notification.py` — updated the existing thread-metadata assertion to expect `_interim_send: True`; added `test_shutdown_home_channel_broadcast_carries_interim_marker` covering both the per-session send and the no-thread-metadata home-channel broadcast

## How to Test

1. `python -m pytest tests/gateway/test_restart_notification.py -q` — Observed result: 13 passed
2. `python -m pytest tests/gateway/test_gateway_shutdown.py tests/gateway/test_interim_send_lanes.py tests/gateway/test_cron_interrupt_notification.py tests/gateway/test_stream_final_contract.py tests/gateway/test_shutdown_cache_cleanup.py -q` — Observed result: 34 passed
3. Negative anchor: with the `gateway/run.py` change stashed (tests only), both the updated assertion and the new test fail — confirming they pin the interim marker, not incidental behavior. Observed result: 2 failed, 11 passed
4. `python -m ruff check gateway/run.py tests/gateway/test_restart_notification.py` — All checks passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A