### PR TITLE
fix(desktop): add "load more" to Command Center sessions list

### DIFF
--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -1,4 +1,3 @@
-import { useStore } from '@nanostores/react'
 import { type MouseEvent, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { LogTail } from '@/components/chat/log-tail'
@@ -30,7 +29,7 @@ import { fmtDateTime } from '@/lib/time'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
-import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
+import { $pinnedSessionIds, pinSession, SIDEBAR_SESSIONS_PAGE_SIZE, unpinSession } from '@/store/layout'
 import { $sessionProfilesTruncated, $sessions, sessionPinId } from '@/store/session'
 
 import { SidebarLoadMoreRow } from '../chat/sidebar/load-more-row'
@@ -56,6 +55,7 @@ type UsagePeriod = (typeof USAGE_PERIODS)[number]
 // component never re-renders from $sessions ticks while on System/Usage/etc.
 const EMPTY_SESSIONS: readonly never[] = []
 const EMPTY_PINNED: readonly string[] = []
+const EMPTY_TRUNCATED: Record<string, boolean> = {}
 
 interface CommandCenterViewProps {
   initialSection?: CommandCenterSection
@@ -154,9 +154,16 @@ export function CommandCenterView({
   const [section, setSection] = useRouteEnumParam('section', SECTIONS, initialSection ?? 'sessions')
   const sessions = useStoreSelector($sessions, s => (section === 'sessions' ? s : EMPTY_SESSIONS))
   const pinnedSessionIds = useStoreSelector($pinnedSessionIds, s => (section === 'sessions' ? s : EMPTY_PINNED))
+
   // Mirrors the sidebar: any profile whose backend page was capped means there
   // is more to load, so the Sessions list gets a "load more" affordance.
-  const sessionProfilesTruncated = useStore($sessionProfilesTruncated)
+  // Gate like the other selectors: only subscribe on the Sessions tab so
+  // System/Usage/Maintenance don't re-render when $sessionProfilesTruncated
+  // ticks on every session fetch.
+  const sessionProfilesTruncated = useStoreSelector(
+    $sessionProfilesTruncated,
+    s => (section === 'sessions' ? s : EMPTY_TRUNCATED)
+  )
 
   const [query, setQuery] = useState('')
   const [pendingDelete, setPendingDelete] = useState<SessionInfo | null>(null)
@@ -445,12 +452,12 @@ export function CommandCenterView({
                 </ul>
                 )}
               </div>
-              {hasMoreSessions && !debouncedQuery && (
+              {hasMoreSessions && !!onLoadMoreSessions && !debouncedQuery && (
                 <div className="flex shrink-0 items-end justify-end">
                   <SidebarLoadMoreRow
                     loading={loadMorePending}
                     onClick={() => void onLoadMore()}
-                    step={0}
+                    step={SIDEBAR_SESSIONS_PAGE_SIZE}
                   />
                 </div>
               )}

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import { type MouseEvent, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { LogTail } from '@/components/chat/log-tail'
@@ -30,8 +31,9 @@ import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionPinId } from '@/store/session'
+import { $sessionProfilesTruncated, $sessions, sessionPinId } from '@/store/session'
 
+import { SidebarLoadMoreRow } from '../chat/sidebar/load-more-row'
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
 import { OverlayMain, OverlayNav, OverlaySplitLayout } from '../overlays/overlay-split-layout'
@@ -62,6 +64,10 @@ interface CommandCenterViewProps {
   // Accepted for call-site parity; navigation lives in the global Cmd+K palette.
   onNavigateRoute?: (path: string) => void
   onOpenSession: (sessionId: string) => void
+  /** Grows the shared session window (bumpSessionsLimit + refetch), same
+   *  mechanism as the sidebar's recents "load more". Renders the Sessions
+   *  list's bottom-right button when the backend page is capped. */
+  onLoadMoreSessions?: () => Promise<void> | void
 }
 
 function formatTimestamp(value?: number | null): string {
@@ -133,7 +139,13 @@ function EmptyPanel({ action, description, title }: { action?: ReactNode; descri
   )
 }
 
-export function CommandCenterView({ initialSection, onClose, onDeleteSession, onOpenSession }: CommandCenterViewProps) {
+export function CommandCenterView({
+  initialSection,
+  onClose,
+  onDeleteSession,
+  onLoadMoreSessions,
+  onOpenSession
+}: CommandCenterViewProps) {
   const { t } = useI18n()
   const cc = t.commandCenter
   // $sessions ticks on every streaming token (title updates, new sessions),
@@ -142,9 +154,13 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   const [section, setSection] = useRouteEnumParam('section', SECTIONS, initialSection ?? 'sessions')
   const sessions = useStoreSelector($sessions, s => (section === 'sessions' ? s : EMPTY_SESSIONS))
   const pinnedSessionIds = useStoreSelector($pinnedSessionIds, s => (section === 'sessions' ? s : EMPTY_PINNED))
+  // Mirrors the sidebar: any profile whose backend page was capped means there
+  // is more to load, so the Sessions list gets a "load more" affordance.
+  const sessionProfilesTruncated = useStore($sessionProfilesTruncated)
 
   const [query, setQuery] = useState('')
   const [pendingDelete, setPendingDelete] = useState<SessionInfo | null>(null)
+  const [loadMorePending, setLoadMorePending] = useState(false)
   const [status, setStatus] = useState<StatusResponse | null>(null)
   const [logs, setLogs] = useState<string[]>([])
   const [logFile, setLogFile] = useState<(typeof LOG_FILES)[number]>('agent')
@@ -251,6 +267,25 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   })
 
   const sessionListHasResults = filteredSessions.length > 0
+
+  // Same cap semantics as the sidebar's recents ("Load more" visible when any
+  // profile's backend page was truncated). Reuses the shared $sessions window:
+  // bumping the limit on the sidebar refetches into the same store both read.
+  const hasMoreSessions = Object.values(sessionProfilesTruncated).some(Boolean)
+
+  const onLoadMore = useCallback(async () => {
+    if (!onLoadMoreSessions || loadMorePending) {
+      return
+    }
+
+    setLoadMorePending(true)
+
+    try {
+      await Promise.resolve(onLoadMoreSessions())
+    } finally {
+      setLoadMorePending(false)
+    }
+  }, [loadMorePending, onLoadMoreSessions])
 
   // Client-side substring filter over the fetched tail (matches `hermes logs --search`).
   const visibleLogs = useMemo(() => {
@@ -359,12 +394,13 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
           </header>
 
           {section === 'sessions' ? (
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              {!sessionListHasResults ? (
-                <EmptyPanel description={debouncedQuery ? cc.noResults : cc.noSessions} />
-              ) : (
-                <ul>
-                  {filteredSessions.map(session => {
+            <div className="flex min-h-0 flex-1 flex-col">
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                {!sessionListHasResults ? (
+                  <EmptyPanel description={debouncedQuery ? cc.noResults : cc.noSessions} />
+                ) : (
+                  <ul>
+                    {filteredSessions.map(session => {
                     const pinId = sessionPinId(session)
                     const pinned = pinnedSessionIds.includes(pinId)
 
@@ -407,6 +443,16 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                     )
                   })}
                 </ul>
+                )}
+              </div>
+              {hasMoreSessions && !debouncedQuery && (
+                <div className="flex shrink-0 items-end justify-end">
+                  <SidebarLoadMoreRow
+                    loading={loadMorePending}
+                    onClick={() => void onLoadMore()}
+                    step={0}
+                  />
+                </div>
               )}
             </div>
           ) : section === 'usage' ? (

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -1208,6 +1208,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
             initialSection={commandCenterInitialSection}
             onClose={closeOverlayToPreviousRoute}
             onDeleteSession={removeSession}
+            onLoadMoreSessions={loadMoreSessions}
             onNavigateRoute={path => navigateToWorkspacePage(navigate, path)}
             onOpenSession={sessionId => openSession(sessionId, navigate)}
           />


### PR DESCRIPTION
fix(desktop): add "load more" to Command Center Sessions list

## Changes

- `apps/desktop/src/app/command-center/index.tsx` (+12/-5):
  - Add `onLoadMoreSessions` prop (optional) and `loadMorePending` state
  - Gate `$sessionProfilesTruncated` subscription behind the Sessions tab
    with `useStoreSelector` + stable empty object, matching the existing
    re-render discipline for `$sessions` / `$pinnedSessionIds`
  - Show the real page size in `SidebarLoadMoreRow` so the label reads
    "load 50 more", consistent with the sidebar
  - Hide the load-more affordance when `onLoadMoreSessions` is not wired
  - Move button outside the scroll container (flex layout), fixed at the
    bottom-right extreme edge
- `apps/desktop/src/app/contrib/wiring.tsx` (+1): wire `loadMoreSessions`

## Why

The Command Center Sessions page reads the shared `$sessions` store
(paginated by the sidebar, default 50 items). The sidebar has a "load
more" button (`SidebarLoadMoreRow` + `bumpSessionsLimit()`), but the
Command Center had no equivalent — sessions beyond the first 50 were
unreachable from it. This adds the same mechanism.

Fixes #98444
