### PR TITLE
fix(browser): real-profile reuse probe no longer resurrects a browser

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -239,7 +239,7 @@ class TestRealProfileCdpLaunch:
              patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
              patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt, "_agent_browser_get_cdp",
-                          side_effect=[None, "http://127.0.0.1:41000"]), \
+                          return_value="http://127.0.0.1:41000"), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", return_value=proc), \
              patch.object(bt, "_is_headed_mode", return_value=False):
@@ -289,7 +289,7 @@ class TestRealProfileCdpLaunch:
              patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
              patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt, "_agent_browser_get_cdp",
-                          side_effect=[None, "http://127.0.0.1:41000"]), \
+                          return_value="http://127.0.0.1:41000"), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", side_effect=fake_run), \
              patch.object(bt, "_is_headed_mode", return_value=False):
@@ -302,12 +302,15 @@ class TestRealProfileCdpLaunch:
         assert "--cdp" in captured["argv"]
         self._reset()
 
-    def test_reuses_only_session_on_our_copy_dir(self, tmp_path):
-        """A live session on a DIFFERENT dir (stale/throwaway) is closed, not reused."""
+    def test_reuse_probe_never_calls_agent_browser_get_cdp(self, tmp_path):
+        """Reuse discovery must not invoke agent-browser's launching ``get
+        cdp-url`` before the signed browser has started (#98437): that
+        command launches a throwaway browser when the named session isn't
+        already running. The probe must resolve reuse purely from the copy
+        dir's own DevToolsActivePort file."""
         import tools.browser_tool as bt
         self._reset()
         proc = Mock(return_value=None, returncode=0, stdout="", stderr="")
-        closed = {"n": 0}
 
         class FakeChrome:
             def poll(self):
@@ -323,18 +326,60 @@ class TestRealProfileCdpLaunch:
              patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
              patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
              patch.object(bt, "_agent_browser_get_cdp",
-                          side_effect=["http://127.0.0.1:5000", "http://127.0.0.1:41000"]), \
-             patch.object(bt, "_cdp_http_ready", return_value=True), \
-             patch.object(bt, "_cdp_on_data_dir", return_value=False), \
+                          return_value="http://127.0.0.1:41000") as get_cdp, \
+             patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch.object(bt.subprocess, "run", return_value=proc), \
+             patch.object(bt, "_is_headed_mode", return_value=False):
+            cdp, err = bt._real_profile_cdp()
+        # The only permitted call is the post-launch attach confirmation.
+        assert get_cdp.call_count == 1
+        assert cdp == "http://127.0.0.1:41000"
+        self._reset()
+
+    def test_stale_port_file_is_closed_not_reused(self, tmp_path):
+        """A DevToolsActivePort file left by a dead process (no live browser
+        answering on it) is not reused: the stale session is closed and a
+        fresh browser is launched on the copy."""
+        import tools.browser_tool as bt
+        self._reset()
+        proc = Mock(return_value=None, returncode=0, stdout="", stderr="")
+        closed = {"n": 0}
+
+        # Stale port file from an earlier real-profile generation; nothing is
+        # actually listening on it.
+        (tmp_path / "DevToolsActivePort").write_text("5000\n/devtools/browser/x\n")
+
+        class FakeChrome:
+            def poll(self):
+                return None
+
+        def fake_popen(argv, **kw):
+            (tmp_path / "DevToolsActivePort").write_text("41000\n/devtools/browser/x\n")
+            return FakeChrome()
+
+        with patch.object(bt, "_use_real_profile", return_value=True), \
+             patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+             patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(str(tmp_path), None)), \
+             patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
+             patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
+             patch.object(bt, "_agent_browser_get_cdp",
+                          return_value="http://127.0.0.1:41000"), \
+             patch.object(bt, "_cdp_http_ready", return_value=False), \
              patch.object(bt, "_agent_browser_close_session",
                           side_effect=lambda s: closed.__setitem__("n", closed["n"] + 1)), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", return_value=proc), \
              patch.object(bt, "_is_headed_mode", return_value=False):
             cdp, err = bt._real_profile_cdp()
-        assert closed["n"] == 1  # stale wrong-dir session was closed
+        assert closed["n"] == 1  # stale session was closed before relaunch
         assert cdp == "http://127.0.0.1:41000"
         self._reset()
+
+    def test_cdp_from_data_dir_reads_devtoolsactiveport(self, tmp_path):
+        import tools.browser_tool as bt
+        assert bt._cdp_from_data_dir(str(tmp_path)) is None
+        (tmp_path / "DevToolsActivePort").write_text("41000\n/devtools/browser/x\n")
+        assert bt._cdp_from_data_dir(str(tmp_path)) == "http://127.0.0.1:41000"
 
     def test_cdp_on_data_dir_matches_devtoolsactiveport(self, tmp_path):
         import tools.browser_tool as bt
@@ -946,13 +991,12 @@ class TestReviewRound3:
         browser."""
         import tools.browser_tool as bt
         bt._real_profile_cdp_cache.clear()
+        (tmp_path / "DevToolsActivePort").write_text("9251\n/devtools/browser/x\n")
         with patch.object(bt, "_use_real_profile", return_value=True), \
              patch.object(bt, "_using_lightpanda_engine", return_value=False), \
              patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
              patch("hermes_cli.browser_connect.real_profile_copy_dir", return_value=str(tmp_path)), \
-             patch.object(bt, "_agent_browser_get_cdp", return_value="http://127.0.0.1:9251"), \
              patch.object(bt, "_cdp_http_ready", return_value=True), \
-             patch.object(bt, "_cdp_on_data_dir", return_value=True), \
              patch("hermes_cli.browser_connect.snapshot_real_profile") as snap:
             cdp, err = bt._real_profile_cdp()
         assert cdp == "http://127.0.0.1:9251" and err is None
@@ -971,7 +1015,7 @@ class TestReviewRound3:
              patch("hermes_cli.browser_connect.snapshot_real_profile",
                    return_value=(str(tmp_path), None)) as snap, \
              patch.object(bt, "_agent_browser_get_cdp",
-                          side_effect=[None, "http://127.0.0.1:9251"]), \
+                          return_value="http://127.0.0.1:9251"), \
              patch.object(bt, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch.object(bt.subprocess, "run", return_value=proc), \
              patch.object(bt, "_is_headed_mode", return_value=False):

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1523,6 +1523,27 @@ def _agent_browser_get_cdp(session_name: str) -> Optional[str]:
     return f"http://127.0.0.1:{m.group(1)}"
 
 
+def _cdp_from_data_dir(data_dir: str) -> Optional[str]:
+    """Return the HTTP CDP endpoint of a browser already running on ``data_dir``.
+
+    Reads Chrome's own ``DevToolsActivePort`` file directly instead of asking
+    agent-browser ``get cdp-url``: that command is not observational when the
+    named session isn't already an active browser process — it LAUNCHES one
+    and returns its endpoint, resurrecting the wrong browser (mock-keychain
+    Chrome for Testing) before the signed browser has even started (#98437).
+    A missing/unreadable file means no browser owns this dir; caller must not
+    infer anything else from that.
+    """
+    try:
+        with open(os.path.join(data_dir, "DevToolsActivePort"), encoding="utf-8") as fh:
+            port_line = fh.readline().strip()
+    except OSError:
+        return None
+    if not port_line.isdigit():
+        return None
+    return f"http://127.0.0.1:{port_line}"
+
+
 def _cdp_on_data_dir(http_cdp: str, data_dir: str) -> bool:
     """True when the CDP endpoint's browser is running on ``data_dir``.
 
@@ -1647,14 +1668,18 @@ def _real_profile_cdp() -> tuple:
         # snapshot/overlay happens solely on the relaunch path below, when no
         # live browser owns the dir.
         copy_dir = real_profile_copy_dir(browser)
-        existing = _agent_browser_get_cdp(_REAL_PROFILE_SESSION)
-        if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
+        # Non-launching reuse probe: read the copy dir's OWN DevToolsActivePort
+        # file rather than calling agent-browser's ``get cdp-url``, which
+        # launches a throwaway browser when the named session isn't already
+        # running (#98437). A hit here is on our data dir by construction.
+        existing = _cdp_from_data_dir(copy_dir)
+        if existing and _cdp_http_ready(existing):
             _real_profile_cdp_cache["cdp"] = existing
             return existing, None
-        if existing:
-            # Stale/wrong-dir session (throwaway-temp fallback, or an old copy):
-            # close it so nothing holds the dir open before we overlay + relaunch.
-            _agent_browser_close_session(_REAL_PROFILE_SESSION)
+        # No live browser owns the dir. Best-effort close any stale
+        # agent-browser session bound to the name (a close, never a launch)
+        # so nothing conflicts before we overlay + relaunch.
+        _agent_browser_close_session(_REAL_PROFILE_SESSION)
 
         # No live browser owns the dir now — safe to (re)snapshot + overlay.
         snap_dir, err = snapshot_real_profile(browser)


### PR DESCRIPTION
## What does this PR do?

Fixes the post-#98249 edge case in real-profile reuse discovery described in
#98437: `_real_profile_cdp()` probed for an already-running copy-browser by
calling agent-browser's `get cdp-url`. That command is **not observational**
— when the named session (`hermes-real-profile`) isn't already running,
agent-browser launches its own throwaway browser and returns that new
endpoint. With stale persisted session state from an earlier real-profile
generation, this probe resurrected Chrome for Testing on the Hermes-managed
profile copy with `--use-mock-keychain --password-store=basic` *before* the
intended signed-browser launch path ever ran. That makes every
keychain-encrypted cookie in the copy undecryptable, so the copy launches
signed out (Google Drive opening at the sign-in page, as reported).

The reuse probe now reads the copy dir's own `DevToolsActivePort` file
directly instead of asking agent-browser. Chrome writes that file itself
with its live debug port, and only while it's actually running on that exact
directory — so reading it is a pure observation with no side effects. If the
file is missing/stale (no readable HTTP endpoint on it), that now correctly
means "no live browser to reuse," not "launch one to find out." The
subsequent `_agent_browser_close_session()` best-effort cleanup call — itself
a `close`, never a launch — is now unconditional right before the
overlay+relaunch, so any stale agent-browser session-name state is cleared
either way.

`_agent_browser_get_cdp()` remains in use for the one place where a launch
*is* the correct behavior: attaching to the browser Hermes just launched
itself, after the signed-browser process already exists.

## Related Issue

Fixes #98437

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_tool.py`: added `_cdp_from_data_dir()`, a non-launching
  read of a copy dir's `DevToolsActivePort` file; `_real_profile_cdp()`'s
  reuse probe now calls it instead of `_agent_browser_get_cdp()`, and the
  stale-session `close()` call is now unconditional on a probe miss.
- `tests/tools/test_browser_real_profile.py`: added
  `test_reuse_probe_never_calls_agent_browser_get_cdp` (asserts the
  launching `get cdp-url` call happens at most once — only for the
  post-launch attach, never for reuse discovery) and
  `test_stale_port_file_is_closed_not_reused` /
  `test_cdp_from_data_dir_reads_devtoolsactiveport` for the new helper;
  updated the three existing tests that previously mocked the reuse probe
  through `_agent_browser_get_cdp`/`_cdp_on_data_dir` to reflect the new
  direct-file-read path.

## How to Test

1. `git checkout HEAD~1 -- tools/browser_tool.py` (revert only the source fix,
   keep the updated tests), then run:
   ```
   scripts/run_tests.sh tests/tools/test_browser_real_profile.py -k \
     "test_reuse_probe_never_calls_agent_browser_get_cdp or test_cdp_from_data_dir_reads_devtoolsactiveport"
   ```
   Both fail on the pre-fix code: the reuse probe calls
   `_agent_browser_get_cdp` twice (`assert get_cdp.call_count == 1` →
   `AssertionError: assert 2 == 1`), and `_cdp_from_data_dir` doesn't exist
   yet (`AttributeError`).
2. `git checkout HEAD -- tools/browser_tool.py` to restore the fix, then:
   ```
   scripts/run_tests.sh tests/tools/test_browser_real_profile.py
   ```
   → `79 tests passed, 0 failed`.
3. `ruff check tools/browser_tool.py tests/tools/test_browser_real_profile.py`
   → `All checks passed!`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the test suite for the affected file and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — this fix was verified via unit tests only
      (macOS-specific reproduction from the issue was not re-run; the bug is
      platform-independent — agent-browser's `get cdp-url` launching behavior
      is not OS-specific — and is fully exercised by the added regression
      test)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed

---

*This fix was prepared with AI assistance (Claude) and verified by running
the affected test suite locally before submission.*
