### PR TITLE
fix(update): keep the in-flight update receipt module alive across the stale purge

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -77,11 +77,19 @@ _STALE_PURGE_PREFIXES = (
 #: code currently EXECUTING the update, so evicting them buys nothing — the
 #: running frames keep their module objects alive regardless — and reloading
 #: them mid-flight is the one genuinely unsafe move.
+#: ``hermes_cli.update_receipt`` is protected for the singleton's sake: it
+#: holds the in-flight receipt's module-level ``_current`` between
+#: ``begin_update_receipt()`` and the command-boundary finalize. The
+#: fleet-restart catch-up runs mid-update, so purging it there would make
+#: the later ``from hermes_cli.update_receipt import ...`` rebuild a fresh
+#: module whose ``_current`` is None and the exactly-once finalize no-op —
+#: silently losing the receipt of the very process doing the work (#98436).
 _STALE_PURGE_PROTECTED = frozenset(
     {
         "hermes_cli",
         "hermes_cli.main",
         "hermes_cli.update_cmd",
+        "hermes_cli.update_receipt",
         "hermes_cli.hermes_logging",
     }
 )

--- a/tests/hermes_cli/test_update_stale_module_purge.py
+++ b/tests/hermes_cli/test_update_stale_module_purge.py
@@ -82,6 +82,41 @@ def test_purge_protects_executing_modules():
     assert "hermes_cli" in sys.modules
 
 
+def test_purge_preserves_inflight_update_receipt_singleton(tmp_path, monkeypatch):
+    """The in-flight receipt must survive the purge fired by the catch-up (#98436).
+
+    ``begin_update_receipt`` stores the receipt in the module-level
+    ``_current`` singleton. The fleet-restart catch-up
+    (``_run_pending_fleet_restart``) purges cached Hermes modules mid-update,
+    before the command boundary runs ``from hermes_cli.update_receipt import
+    finalize_pending_update_receipt``. If the purge evicts that module, the
+    from-import rebuilds a fresh module whose ``_current`` is None and the
+    exactly-once finalize no-ops — the Windows hand-off child that did the
+    real dependency work leaves no receipt on disk.
+    """
+    from hermes_cli import update_receipt
+
+    monkeypatch.setattr(update_receipt, "_receipt_dir", lambda: tmp_path)
+
+    update_receipt.begin_update_receipt()
+    assert update_receipt._current is not None, "precondition: receipt is open"
+
+    cli_main._purge_stale_hermes_modules()
+
+    # The purge must not evict the module holding the in-flight receipt: the
+    # later from-import binds to the SAME module object, singleton intact.
+    assert sys.modules.get("hermes_cli.update_receipt") is update_receipt
+
+    from hermes_cli.update_receipt import finalize_pending_update_receipt
+
+    path = finalize_pending_update_receipt(stop_reason="cmd boundary")
+
+    assert path is not None and path.exists(), (
+        "receipt finalized after purge must be persisted"
+    )
+    assert update_receipt._current is None
+
+
 def test_purge_leaves_prefix_lookalikes_alone():
     # `gateway_foo` starts with the string prefix "gateway" but is NOT the
     # gateway package — the root-segment check must spare it.


### PR DESCRIPTION
## What does this PR do?

On Windows, every `hermes update` that goes through the `hermes.exe` shim hand-off spawns a child that runs the pending-fleet-restart catch-up mid-update. `_run_pending_fleet_restart` begins with `_purge_stale_hermes_modules()`, which evicted `hermes_cli.update_receipt` from `sys.modules` along with every other `hermes_cli`-prefixed module — taking the module-level `_current` singleton (the receipt opened by `begin_update_receipt()`) with it. At the command boundary, `from hermes_cli.update_receipt import finalize_pending_update_receipt` then rebuilt a fresh module object whose `_current` is `None`, so the documented exactly-once finalize no-op'd: the child that performed the actual dependency sync (the riskiest part of a Windows update) left no receipt on disk, and `latest.json` kept pointing at the parent's bare `sys.exit(0)` record.

This adds `hermes_cli.update_receipt` to `_STALE_PURGE_PROTECTED`. The module holds cross-purge in-flight state — exactly the situation the protected set exists for (its docstring: modules whose eviction buys nothing because running state depends on them). The later from-import now binds to the same module object and the singleton survives to be finalized. Of the fix options suggested in the issue, this is the smallest and the only one that doesn't change any timing: re-anchoring the singleton or finalizing before the purge both reorder receipt bookkeeping around the catch-up.

## Related Issue

Fixes #98436

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` — added `hermes_cli.update_receipt` to `_STALE_PURGE_PROTECTED` with a comment explaining the singleton-preservation rationale
- `tests/hermes_cli/test_update_stale_module_purge.py` — added `test_purge_preserves_inflight_update_receipt_singleton`: begins a real receipt, runs the purge, and asserts the later from-import still binds to the same module object and the command-boundary finalize persists the receipt file

## How to Test

1. `python -m pytest tests/hermes_cli/test_update_stale_module_purge.py -q` — Observed result: 6 passed
2. Negative anchor: with only the test (protection stashed), the new test fails on `sys.modules.get("hermes_cli.update_receipt") is update_receipt` — Observed result: 1 failed, 5 passed
3. `python -m ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_update_stale_module_purge.py` — All checks passed

Note: `tests/hermes_cli/test_update_fleet_restart_pending.py::test_marker_written_after_pull_cleared_after_successful_restart` fails on this machine both with and without this change — a local environment artifact (a live gateway process and a `gateway_state.json` left by earlier pytest runs feed the real fleet probe), not a regression from this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A