### PR TITLE
fix(update): protect hermes_cli.update_receipt from the stale-module purge (#98436)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -83,6 +83,18 @@ _STALE_PURGE_PROTECTED = frozenset(
         "hermes_cli.main",
         "hermes_cli.update_cmd",
         "hermes_cli.hermes_logging",
+        # (#98436) The in-flight update receipt is a module-level singleton
+        # (_current) in hermes_cli.update_receipt — the module holds live
+        # state the executing update depends on, so its cache entry must
+        # survive. Purging it strands the receipt in an orphaned module
+        # object: the next `from hermes_cli.update_receipt import ...`
+        # (cmd_update's command-boundary safety net) rebuilds a FRESH
+        # module with ``_current is None``, the finalize hits its
+        # documented no-op, and the run that did the real work — the
+        # Windows hand-off child, whose pending fleet-restart catch-up
+        # purges here (_run_pending_fleet_restart) — silently writes NO
+        # receipt.
+        "hermes_cli.update_receipt",
     }
 )
 

--- a/tests/hermes_cli/test_update_receipt_purge_98436.py
+++ b/tests/hermes_cli/test_update_receipt_purge_98436.py
@@ -1,0 +1,89 @@
+"""Regression tests for #98436 — update receipt lost when the stale-module
+purge evicts hermes_cli.update_receipt mid-run.
+
+Windows `hermes update` hand-off child: the pending fleet-restart catch-up
+starts with _purge_stale_hermes_modules(), which evicted the cached
+hermes_cli.update_receipt module (it was not in _STALE_PURGE_PROTECTED).
+The singleton receipt lives in that module, so the later
+`from hermes_cli.update_receipt import finalize_pending_update_receipt`
+in cmd_update's command-boundary safety net re-imported a FRESH module
+with `_current is None` -> finalize hit its documented no-op -> the
+hand-off child (the process that does the real dependency sync) wrote NO
+receipt.
+
+Fix: protect hermes_cli.update_receipt from the purge. Accurate invariant
+for the protected set here: the module holds LIVE SINGLETON STATE that the
+currently-executing update depends on — evicting its cache entry strands
+that state in an orphaned module object.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from hermes_cli import main as cli_main
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    snapshot = dict(sys.modules)
+    yield
+    for name, mod in snapshot.items():
+        sys.modules[name] = mod
+    for name in list(sys.modules):
+        if name not in snapshot:
+            del sys.modules[name]
+
+
+def test_purge_protects_update_receipt_module():
+    """#98436: the receipt singleton lives in hermes_cli.update_receipt.
+
+    Evicting it mid-update silently drops the in-flight receipt: a later
+    from-import rebuilds the module with `_current is None` and finalize
+    becomes a no-op, so the run that did the real work leaves no receipt.
+    """
+    import hermes_cli.update_receipt as update_receipt
+
+    cli_main._purge_stale_hermes_modules()
+
+    assert sys.modules.get("hermes_cli.update_receipt") is update_receipt, (
+        "hermes_cli.update_receipt was purged — the in-flight receipt "
+        "singleton dies with it (#98436)"
+    )
+
+
+def test_boundary_from_import_finalizes_after_purge(tmp_path, monkeypatch):
+    """Drive the EXACT failure shape from cmd_update's boundary safety net:
+
+        begin -> purge -> `from hermes_cli.update_receipt import
+        finalize_pending_update_receipt` -> call it
+
+    asserting the receipt is actually written. On main this is RED: the
+    purge evicts the module, the from-import rebuilds it with
+    `_current is None`, and finalize returns None (documented no-op).
+    """
+    import hermes_cli.update_receipt as update_receipt
+
+    monkeypatch.setattr(
+        update_receipt, "_receipt_dir", lambda: tmp_path / "update_receipts"
+    )
+
+    update_receipt.begin_update_receipt()
+    assert update_receipt._current is not None, "precondition: receipt open"
+
+    # This is what the fleet-restart catch-up does before its work:
+    cli_main._purge_stale_hermes_modules()
+
+    # And this is cmd_update's command-boundary safety net, verbatim in
+    # import form — a from-import AFTER the purge, exactly where the real
+    # failure happened:
+    from hermes_cli.update_receipt import finalize_pending_update_receipt
+
+    path = finalize_pending_update_receipt(exit_code=0, stop_reason="test boundary")
+    assert path is not None, (
+        "#98436: receipt silently lost across the purge — the boundary "
+        "from-import rebuilt a fresh module with no open receipt"
+    )
+    assert path.exists()


### PR DESCRIPTION
## What does this PR do?

Fixes #98436: on Windows, every `hermes update` that goes through the `hermes.exe` shim hand-off loses the hand-off **child's** update receipt.

`cmd_update` begins the receipt early via `begin_update_receipt()`; the receipt lives in a module-level singleton (`_current`) inside `hermes_cli/update_receipt.py`. Later, `_run_pending_fleet_restart()` (the catch-up at `update_cmd.py:3123`) calls `_purge_stale_hermes_modules()` — and `hermes_cli.update_receipt` was **not** in `_STALE_PURGE_PROTECTED`, so the purge evicted it from `sys.modules`. The command-boundary safety net then runs `from hermes_cli.update_receipt import finalize_pending_update_receipt`, which rebuilds a **fresh module object** with `_current is None`; `finalize_pending_update_receipt` hits its documented no-op ("No-op when no receipt is open"), and the hand-off child's `os._exit(0)` path (#93581) terminates the process. Net: the process that performs the actual venv/dependency rewrite writes **no receipt**, and `latest.json` misreports the update as the parent's bare `sys.exit(0)`.

The fix adds `hermes_cli.update_receipt` to the protected set. The accurate invariant for that set — now spelled out in the comment — is "module holds live singleton state the executing update depends on": purging such a module strands its state in an orphaned module object, which is exactly this failure.

## Related Issue

Fixes #98436

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` — add `"hermes_cli.update_receipt"` to `_STALE_PURGE_PROTECTED`, with a comment stating the mechanism and the accurate protection rationale (live singleton state, not "currently executing code").
- `tests/hermes_cli/test_update_receipt_purge_98436.py` — new regression tests:
  - `test_purge_protects_update_receipt_module` — the module must survive the purge (RED on main, GREEN on branch).
  - `test_boundary_from_import_finalizes_after_purge` — drives the exact production shape: `begin_update_receipt()` → `_purge_stale_hermes_modules()` → `from hermes_cli.update_receipt import finalize_pending_update_receipt` → assert the receipt file is actually written. This is the boundary-safety-net path from `cmd_update`, not just a frozenset-membership assertion.

## How to Test

1. On `main` (before the fix), run the new tests: `pytest tests/hermes_cli/test_update_receipt_purge_98436.py -q` → both fail (purge evicts the module; boundary from-import finalize returns `None`).
2. On this branch: both pass, plus the existing purge suite `tests/hermes_cli/test_update_stale_module_purge.py` stays green (5 tests) — protection of the receipt module does not weaken the class-fix for the 2026-08-20 stale-`cli_output` field failure.
3. Blast radius: `hermes_cli.update_receipt` imports only stdlib plus fully-lazy siblings (`build_info`, `config`, `gateway.status` — the latter re-imports fresh after the purge inside fleet verification), and it is never reloaded — only exempted from eviction — so the purge's own "reloading-in-place is the unsafe operation" invariant is untouched.
4. `scripts/check-windows-footguns.py --diff origin/main` → clean.

Tested on Windows 11 (10.0.26200, x64), Python 3.11.15.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no open PR references #98436)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the update-receipt + purge + fleet-restart suites: 58 passed / 27 skipped; the one failing test in `test_update_fleet_restart_pending.py` fails identically on clean `origin/main` tip — pre-existing, unrelated)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (10.0.26200, x64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
