### PR TITLE
fix(desktop): stop status-stack remounts from re-arming a dead-runtime poll storm (#98434)

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -21,7 +21,6 @@ import {
   dismissBackgroundProcess,
   groupStatusItems,
   refreshBackgroundProcesses,
-  resetBackgroundPollingGuard,
   type StatusGroup,
   stopBackgroundProcess
 } from '@/store/composer-status'
@@ -103,13 +102,15 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   const groups = useMemo(() => groupStatusItems(items), [items])
 
   // Seed from the registry on session open; event-driven refreshes (terminal /
-  // process tool completions) live in use-message-stream.
+  // process tool completions) live in use-message-stream. This must NOT reset
+  // the gone-polling latch: a mount/remount is not proof of a fresh runtime
+  // binding (a boot-restored tile can remount repeatedly while still bound to
+  // a dead runtime id), so clearing it here re-arms an endless 4001 storm
+  // against that id. The latch is reset at the actual rebind seams instead —
+  // gateway reconnect and runtime re-mint (see resetBackgroundPollingGuard
+  // call sites in use-gateway-boot.ts and store/gateway.ts).
   useEffect(() => {
     if (sessionId) {
-      // Opening/rebinding a session is a fresh runtime binding: clear any
-      // gone-latch left by a previous runtime under this id so the poll below
-      // is allowed to run again (see resetBackgroundPollingGuard).
-      resetBackgroundPollingGuard(sessionId)
       void refreshBackgroundProcesses(sessionId)
       void refreshSessionGoal(sessionId)
     }

--- a/apps/desktop/src/app/chat/composer/status-stack/polling-guard.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/polling-guard.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { resetBackgroundPollingGuard } from '@/store/composer-status'
+import { $gateway } from '@/store/gateway'
+
+import { ComposerStatusStack } from './index'
+
+// The stack measures itself into a surface var — jsdom has no ResizeObserver.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+
+const SID = 'sess-dead-runtime'
+
+function renderStack() {
+  return render(
+    <MemoryRouter>
+      <I18nProvider configClient={null} initialLocale="en">
+        <ComposerStatusStack queue={null} sessionId={SID} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+// #98434: a boot-restored tile can stay bound to a dead runtime id and remount
+// repeatedly (no genuine rebind ever happens). The mount effect used to clear
+// the gone-polling latch on every mount, so each remount re-armed the 4001
+// storm against that id forever.
+describe('ComposerStatusStack dead-runtime remount', () => {
+  beforeEach(() => {
+    resetBackgroundPollingGuard()
+  })
+
+  afterEach(() => {
+    cleanup()
+    $gateway.set(null as never)
+    resetBackgroundPollingGuard()
+  })
+
+  it('does not re-poll process.list after a remount once the session is latched gone', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'process.list') {
+        throw new Error('session not found')
+      }
+
+      return {}
+    })
+
+    const processListCalls = () => request.mock.calls.filter(([method]) => method === 'process.list').length
+
+    $gateway.set({ request } as never)
+
+    const first = renderStack()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(processListCalls()).toBe(1)
+
+    first.unmount()
+
+    const second = renderStack()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Before the fix: the mount effect cleared the latch, so this remount
+    // re-fired process.list against the same dead id.
+    expect(processListCalls()).toBe(1)
+
+    second.unmount()
+  })
+})


### PR DESCRIPTION
Fixes the client-side half of #98434 ("Desktop: boot-restored chat stays bound to dead runtime id — status-stack polls it every 5s forever (composer flicker + focus loss)").

## What's wrong

`apps/desktop/src/store/composer-status.ts` already has a "gone-session" latch: once `process.list` comes back 4001 `session not found` for a runtime id, that id is added to `goneSessions` and every later poll against it short-circuits — this is exactly what stops the storm the issue describes. But `ComposerStatusStack`'s mount effect (`apps/desktop/src/app/chat/composer/status-stack/index.tsx`) called `resetBackgroundPollingGuard(sessionId)` on every mount, clearing that latch unconditionally:

```ts
useEffect(() => {
  if (sessionId) {
    resetBackgroundPollingGuard(sessionId)      // clears the latch
    void refreshBackgroundProcesses(sessionId)  // → process.list
    void refreshSessionGoal(sessionId)          // → slash.exec 'goal status'
  }
}, [sessionId])
```

A component mount/remount is not proof of a fresh runtime binding — the issue's own repro shows a boot-restored tile that stays bound to the same dead runtime id across repeated remounts. Each remount re-cleared the latch and re-fired both RPCs against the phantom id, so the storm never actually stopped; it just restarted itself every cycle. This is the exact failure the AI reviewer on the original PR that added this line (#94950) flagged before merge: *"The rebind-reset may not fire on runtime re-mint for the same id... consider wiring the reset into whatever store/event tracks runtime-binding changes."* That hardening landed separately, at the actual rebind seams — `resetBackgroundPollingGuard()` (no-arg, full clear) is called from the gateway reconnect path in `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts:378` and the runtime re-mint path in `apps/desktop/src/store/gateway.ts:484` — but the redundant per-mount reset in the status stack itself was never removed, so it kept defeating the latch on its own.

## Fix

Remove the `resetBackgroundPollingGuard(sessionId)` call from the mount effect. Real rebinds (gateway reconnect, runtime re-mint) already clear the latch at their own seams; the status stack no longer needs — and must not perform — its own reset on mount.

## Test

Added `apps/desktop/src/app/chat/composer/status-stack/polling-guard.test.tsx`, which renders `ComposerStatusStack` bound to a session id whose `process.list` call always rejects with "session not found", unmounts it, and remounts it — asserting `process.list` is called exactly once total (the latch must survive the remount).

Confirmed it fails without the fix (`git checkout HEAD~1 -- apps/desktop/src/app/chat/composer/status-stack/index.tsx`, i.e. the pre-fix version with the reset call restored):

```
AssertionError: expected 2 to be 1 // Object.is equality
- Expected: 1
+ Received: 2
```

Restored the fix and reran — passes:

```
 Test Files  6 passed (6)
      Tests  36 passed (36)
```
(`src/app/chat/composer/status-stack` + `src/store/composer-status.test.ts`)

Full suite:

```
npx eslint src/app/chat/composer/status-stack/index.tsx src/app/chat/composer/status-stack/polling-guard.test.tsx
# clean, 0 errors 0 warnings

npm run typecheck
# clean (tsc -p . / tsconfig.electron.json / tsconfig.e2e.json)

npm run test:ui
# full apps/desktop vitest UI suite — exit code 0
```

## Scope note

This addresses the second of the issue's two "cooperating defects" (the gone-latch being defeated by remount) — the fix that's minimal, mechanical, and provably correct from the code alone. The first defect (boot-restore re-binding the view to the runtime id instead of resolving and resuming the *stored* id) is a separate, larger client-boot-restore change and isn't attempted here.

## Disclosure

This PR was prepared with AI assistance (an autonomous Claude Code session), with the diff, test, and repro reviewed before submission.
