### PR TITLE
fix(compression): stamp _DB_PERSISTED_MARKER after in-place batch commit

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -4156,6 +4156,7 @@ def compress_context(
                     # WITHOUT destroying history, unlike a hard replace_messages).
                     # See #38763.
                     from agent.context_compressor import (
+                        _DB_PERSISTED_MARKER,
                         PROACTIVE_PRUNE_REARM_MODEL_CONFIG_KEY,
                     )
 
@@ -4169,11 +4170,24 @@ def compress_context(
                         lock_holder=_lock_holder,
                     )
                     split_status = "in_place_committed"
-                    # Reset the flush identity set so the next turn's appends are
-                    # diffed against the COMPACTED transcript: the compacted dicts
-                    # are passed as conversation_history next turn and skipped by
-                    # identity, so only genuinely new turn messages get appended
-                    # (no dup of the summary, no resurrection of dropped turns).
+                    # Stamp the persistence marker on the committed dicts —
+                    # the same post-commit contract as the micro-compaction
+                    # sync (_sync_micro_compact_to_db). compress() returns
+                    # marker-swept copies (#57491), and the compacted dicts
+                    # come back as the live ``messages`` list while the flush
+                    # still receives the pre-compaction dicts as
+                    # ``conversation_history``, so its identity skip cannot
+                    # cover them: without this stamp the next _persist_session
+                    # re-INSERTs the whole post-compaction transcript (#98450).
+                    # Stamped only after a successful archive_and_compact —
+                    # on failure the sweep stays, matching the micro path's
+                    # rollback semantics.
+                    for _compacted_msg in compressed:
+                        if isinstance(_compacted_msg, dict):
+                            _compacted_msg[_DB_PERSISTED_MARKER] = True
+                    # Reset the flush identity set: stale ids from the
+                    # pre-compaction dicts must not survive into the next
+                    # flush's one-shot seed translation.
                     agent._flushed_db_message_ids = set()
                     # Rotation-independent signal: the conversation was compacted in
                     # place (id unchanged). The gateway reads this (NOT an id-change

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -436,3 +436,65 @@ class TestCompactedTurnsStaySearchable:
                 "ZEBRAWORD", role_filter=["user", "assistant"], include_inactive=True
             )
             assert len(recovered) == 1
+
+
+class TestInPlaceCommitStampsPersistenceMarkers:
+    """The in-place batch commit must stamp ``_DB_PERSISTED_MARKER`` on the
+    compacted dicts — the same post-commit contract as the micro-compaction
+    sync. ``compress()`` returns marker-swept copies (#57491) that come back
+    as the live ``messages`` list, while the flush still receives the
+    pre-compaction dicts as ``conversation_history``; without the stamp the
+    identity skip cannot cover them and the next persist re-INSERTs the whole
+    post-compaction transcript (#98450)."""
+
+    def test_committed_dicts_carry_marker(self):
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+        from agent.context_compressor import _DB_PERSISTED_MARKER
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260830_marker"
+            _seed(db, sid, "marker")
+            agent = _make_agent(db, sid, in_place=True)
+
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+            compressed, _sp = compress_context(
+                agent, messages, approx_tokens=100_000, system_message="sys"
+            )
+
+            assert agent._last_compaction_in_place is True
+            for msg in compressed:
+                assert msg.get(_DB_PERSISTED_MARKER) is True
+
+    def test_no_duplicate_rows_after_post_commit_persist(self):
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260830_dupes"
+            _seed(db, sid, "dupes")
+            agent = _make_agent(db, sid, in_place=True)
+
+            history = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+            compressed, _sp = compress_context(
+                agent, history, approx_tokens=100_000, system_message="sys"
+            )
+
+            # Production sequence (#98450): the turn-finalize persist runs over
+            # the compacted live list while conversation_history still holds the
+            # pre-compaction dicts — identity cannot dedupe these.
+            agent._flush_messages_to_session_db(compressed, history)
+
+            active = db.get_messages_as_conversation(sid)
+            assert len(active) == 2
+            assert [m.get("content") for m in active] == [
+                "[CONTEXT COMPACTION] summary of prior turns",
+                "recent reply",
+            ]
+            all_rows = db.get_messages(sid, include_inactive=True)
+            # 8 archived originals + 2 compacted actives — nothing re-inserted.
+            assert len(all_rows) == 10
+            contents = [m["content"] for m in all_rows]
+            assert len(contents) == len(set(contents))


### PR DESCRIPTION
## What does this PR do?

The in-place batch compaction commit writes the compacted set through `SessionDB.archive_and_compact()` but never stamps `_DB_PERSISTED_MARKER` on the compacted dicts. `compress()` returns marker-swept copies (#57491 invariant) that come back as the live `messages` list, while the next `_persist_session` → `_flush_messages_to_session_db_unlocked` walk still receives the pre-compaction dicts as `conversation_history` — the flush's identity skip cannot cover the compacted dicts, so every compacted row looks unpersisted and the **entire post-compaction transcript is re-INSERTed** as duplicate active rows. Each subsequent preflight compression then runs over the doubled transcript and doubles it again (the monotonic live-set growth in #98450, until every compression hits the 600s timeout).

The fix mirrors the existing post-commit contract of the micro-compaction path (`ContextCompressor._sync_micro_compact_to_db`): after a successful `archive_and_compact()`, stamp `_DB_PERSISTED_MARKER = True` on every committed dict so the next append-only flush skips them. On failure the sweep stays, matching the micro path's rollback semantics.

## Related Issue

Fixes #98450

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py` — in the `if in_place:` commit branch, extend the existing local import with `_DB_PERSISTED_MARKER` and stamp it on every compacted dict after `archive_and_compact()` succeeds; rewrote the adjacent `_flushed_db_message_ids` comment whose identity-skip rationale was the blind spot this fix closes
- `tests/run_agent/test_in_place_compaction.py` — added `TestInPlaceCommitStampsPersistenceMarkers`: one test asserting the committed dicts carry the marker, one replaying the production sequence (in-place commit → flush over the compacted live list with the pre-compaction history) and asserting one active row per compacted message with zero duplicate contents

## How to Test

1. `pytest tests/run_agent/test_in_place_compaction.py -q` — 13 passed (11 existing + 2 new)
2. Negative anchor: with the fix stashed, both new tests fail reproducing the bug (missing marker; 4 active rows with duplicated contents instead of 2); with the fix, all pass — Observed result: 2 failed without the fix, 13 passed with it
3. Neighboring compression-persistence suites stay green: `pytest tests/run_agent/test_compression_persistence.py tests/agent/test_compressed_summary_metadata.py tests/run_agent/test_413_compression.py tests/agent/test_micro_compaction.py tests/run_agent/test_compression_closed_adoption.py -q` — 92 passed
4. `ruff check agent/conversation_compression.py tests/run_agent/test_in_place_compaction.py` — clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A