### PR TITLE
fix(kanban): make idempotent creates atomic

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3404,21 +3404,6 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
-    if idempotency_key:
-        row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
-
     now = int(time.time())
 
     # Resolve workspace_path from board-level default_workdir when the
@@ -3449,6 +3434,19 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
+                # Keep lookup and insert under the same IMMEDIATE writer
+                # transaction. Concurrent creators for one key serialize here,
+                # so the later writer observes and returns the first task.
+                if idempotency_key:
+                    row = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if row:
+                        return row["id"]
+
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
+import sys
 import threading
 from pathlib import Path
 
@@ -114,6 +116,74 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
 
     assert alpha_titles == ["alpha-task"]
     assert beta_titles == ["beta-task"]
+
+
+def test_concurrent_cli_creates_return_one_task(kanban_home, tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    start = tmp_path / "start"
+    helper = tmp_path / "concurrent_create.py"
+    helper.write_text(
+        "import os, sys, time\n"
+        "from pathlib import Path\n"
+        "start = Path(os.environ['HERMES_TEST_START'])\n"
+        "while not start.exists():\n"
+        "    time.sleep(0.005)\n"
+        "sys.argv = ['hermes', 'kanban', 'create', 'one logical CLI task', "
+        "'--idempotency-key', 'maos-todo:concurrent-cli', '--json']\n"
+        "from hermes_cli.main import main\n"
+        "raise SystemExit(main())\n",
+        encoding="utf-8",
+    )
+    env = dict(os.environ)
+    env.update({
+        "HERMES_HOME": str(kanban_home),
+        "HERMES_KANBAN_HOME": str(kanban_home),
+        "HERMES_TEST_START": str(start),
+        "PYTHONPATH": str(root) + os.pathsep + env.get("PYTHONPATH", ""),
+    })
+    for name in (
+        "HERMES_DELEGATED_CHILD_CONTEXT",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+    ):
+        env.pop(name, None)
+
+    processes = [
+        subprocess.Popen(
+            [sys.executable, str(helper)],
+            cwd=root,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for _ in range(4)
+    ]
+    start.write_text("go", encoding="utf-8")
+    try:
+        completed = [process.communicate(timeout=60) for process in processes]
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
+                process.communicate()
+
+    assert all(process.returncode == 0 for process in processes), completed
+    task_ids = [json.loads(stdout)["id"] for stdout, _stderr in completed]
+    assert len(set(task_ids)) == 1
+
+    with kb.connect_closing() as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ?",
+            ("maos-todo:concurrent-cli",),
+        ).fetchall()
+        events = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND kind = 'created'",
+            (task_ids[0],),
+        ).fetchall()
+    assert len(rows) == 1
+    assert len(events) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -56,6 +56,56 @@ def kanban_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_concurrent_idempotent_creates_return_one_task(kanban_home):
+    workers = 8
+    barrier = threading.Barrier(workers)
+    task_ids: list[str] = []
+    errors: list[BaseException] = []
+    result_lock = threading.Lock()
+
+    def create() -> None:
+        conn = kb.connect()
+        try:
+            barrier.wait()
+            task_id = kb.create_task(
+                conn,
+                title="one logical task",
+                idempotency_key="maos-todo:concurrent",
+            )
+            with result_lock:
+                task_ids.append(task_id)
+        except BaseException as exc:
+            with result_lock:
+                errors.append(exc)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=create) for _ in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    assert len(task_ids) == workers
+    assert len(set(task_ids)) == 1
+
+    conn = kb.connect()
+    try:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ?",
+            ("maos-todo:concurrent",),
+        ).fetchall()
+        events = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND kind = 'created'",
+            (task_ids[0],),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert len(events) == 1
+
 
 # ---------------------------------------------------------------------------
 # Spawn-failure circuit breaker


### PR DESCRIPTION
## Summary

- keep the idempotency lookup and task insert inside the same `BEGIN IMMEDIATE` transaction
- make concurrent callers return one task ID without duplicate `created` events
- add thread-level and real CLI subprocess concurrency regressions

## Why

The previous lookup ran before the write transaction. Two creators could both miss the key and insert duplicate active tasks. Serializing the lookup and insert under the existing writer transaction closes that race without a schema migration.

## Verification

- `python -m pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py::test_concurrent_idempotent_creates_return_one_task -q`
- 6 passed
- cross-process CLI race repeated 5 times successfully

## Compatibility

Archived keys remain reusable. Non-idempotent creates keep the existing path. No database schema change is required.