### PR TITLE
fix(gateway): dedup provider-error status and final response per turn — errors no longer delivered twice on adapters without send_or_update_status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -741,29 +741,79 @@ def _format_exec_approval_fallback(
         + ", ".join(choices[:-1]) + f", or {choices[-1]}."
     )
 
+_GATEWAY_PROVIDER_ERROR_AUTH_REPLY = (
+    "⚠️ Provider authentication failed. Check the configured credentials; "
+    "raw provider details are in the gateway logs."
+)
+_GATEWAY_PROVIDER_ERROR_POLICY_REPLY = (
+    "⚠️ The model provider rejected the request. I kept the raw provider "
+    "error out of chat; check gateway logs for details or try rephrasing."
+)
+_GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY = (
+    "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+)
+_GATEWAY_PROVIDER_ERROR_CONNECTION_REPLY = (
+    "⚠️ The model server is not responding — it looks like the configured "
+    "model endpoint is not running or is unreachable."
+)
+_GATEWAY_PROVIDER_ERROR_GENERIC_REPLY = (
+    "⚠️ The model provider failed after retries. I kept raw provider details "
+    "out of chat; check gateway logs for diagnostics."
+)
+
+# The closed set of user-safe replies _gateway_provider_error_reply can
+# produce. Membership in this set — not _looks_like_gateway_provider_error —
+# is how already-rewritten text must be recognized: the replies are written
+# for users, and e.g. the rate-limit reply ("rate-limiting requests") does
+# not match the raw-envelope shapes ("rate limited after N retries").
+_GATEWAY_PROVIDER_ERROR_REPLIES = frozenset({
+    _GATEWAY_PROVIDER_ERROR_AUTH_REPLY,
+    _GATEWAY_PROVIDER_ERROR_POLICY_REPLY,
+    _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY,
+    _GATEWAY_PROVIDER_ERROR_CONNECTION_REPLY,
+    _GATEWAY_PROVIDER_ERROR_GENERIC_REPLY,
+})
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
-        return (
-            "⚠️ Provider authentication failed. Check the configured credentials; "
-            "raw provider details are in the gateway logs."
-        )
+        return _GATEWAY_PROVIDER_ERROR_AUTH_REPLY
     if _GATEWAY_PROVIDER_POLICY_RE.search(text):
-        return (
-            "⚠️ The model provider rejected the request. I kept the raw provider "
-            "error out of chat; check gateway logs for details or try rephrasing."
-        )
+        return _GATEWAY_PROVIDER_ERROR_POLICY_REPLY
     if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+        return _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY
     if _GATEWAY_CONNECTION_ERROR_RE.search(text):
-        return (
-            "⚠️ The model server is not responding — it looks like the configured "
-            "model endpoint is not running or is unreachable."
-        )
-    return (
-        "⚠️ The model provider failed after retries. I kept raw provider details "
-        "out of chat; check gateway logs for diagnostics."
-    )
+        return _GATEWAY_PROVIDER_ERROR_CONNECTION_REPLY
+    return _GATEWAY_PROVIDER_ERROR_GENERIC_REPLY
+
+
+def _is_gateway_provider_error_reply(text: Any) -> bool:
+    """True when text is byte-identical to a canonical provider-error reply."""
+    return str(text or "").strip() in _GATEWAY_PROVIDER_ERROR_REPLIES
+
+
+def _should_suppress_provider_error_final(response: Any, delivered_statuses: Any) -> bool:
+    """#72131: the sanitized final response duplicates an already-sent status.
+
+    A provider failure is legitimately surfaced through two channels: the
+    mid-run status callback (rewritten by _prepare_gateway_status_message and,
+    on adapters without ``send_or_update_status``, delivered as a PERSISTENT
+    chat message by the plain-send fallback) and the failed turn's final
+    response, which _sanitize_gateway_final_response rewrites to the same
+    canonical text. ``delivered_statuses`` carries the reply texts whose
+    fallback send succeeded this turn (per-turn state from TurnContext), so a
+    byte-identical final response would be the second copy of the same error.
+    """
+    if not response:
+        return False
+    body = str(response).strip()
+    if body not in _GATEWAY_PROVIDER_ERROR_REPLIES:
+        return False
+    try:
+        return any(str(s or "").strip() == body for s in (delivered_statuses or ()))
+    except TypeError:
+        return False
 
 
 _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
@@ -5473,6 +5523,32 @@ class TurnRunner:
                 if getattr(res, "success", False) and mid:
                     ctx._cleanup_msg_ids.append(str(mid))
             _fut.add_done_callback(_track_status_id)
+
+        # #72131: on adapters without send_or_update_status this status just
+        # went through the plain-send fallback, where it becomes a PERSISTENT
+        # chat message. When it is a rewritten provider-error reply, record
+        # the delivered text on the turn context — only after a successful
+        # send — so the final-delivery path can suppress a byte-identical
+        # final response instead of showing the user the same error twice.
+        # Adapters WITH send_or_update_status are excluded: their bubble
+        # semantics (edited in place, ephemeral, cleaned up post-run) are
+        # adapter-defined, so the gateway cannot assume a persistent copy
+        # remains and must keep delivering the final response.
+        if (
+            not callable(getattr(ctx._status_adapter, "send_or_update_status", None))
+            and _is_gateway_provider_error_reply(prepared_message)
+        ):
+            _reply_text = prepared_message
+
+            def _record_provider_error_status(fut) -> None:
+                try:
+                    res = fut.result()
+                except Exception:
+                    return
+                if getattr(res, "success", False):
+                    ctx._provider_error_statuses_delivered.append(_reply_text)
+
+            _fut.add_done_callback(_record_provider_error_status)
 
     def run_sync(self):
         ctx = self._ctx
@@ -21463,11 +21539,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.
+            _provider_error_status_dup = False
             if not _intentional_silence:
                 response = _normalize_empty_agent_response(
                     agent_result, response, history_len=len(history),
                 )
                 response = _sanitize_gateway_final_response(source.platform, response)
+                # #72131: decide HERE, while `response` is exactly the
+                # canonical reply text (before reasoning/footer decoration),
+                # whether it duplicates a provider-error status this turn
+                # already delivered persistently. The suppression itself is
+                # applied at the delivery seam below, after transcript
+                # persistence — a delivery decision, not a transcript
+                # mutation, mirroring intentional silence. Deciding at this
+                # level (not inside run_sync) matters: this path re-derives
+                # the sanitized text from the raw result, so an inner-only
+                # suppression would be reconstructed right back.
+                _provider_error_status_dup = _should_suppress_provider_error_final(
+                    response,
+                    agent_result.get("provider_error_statuses_delivered"),
+                )
 
             # Ordering contract: the agent thread already updated the contextvar
             # in conversation_compression.py; propagate to SessionEntry + _save().
@@ -21919,6 +22010,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _intentional_silence:
                 logger.info(
                     "Suppressing intentional silence marker for session %s",
+                    session_entry.session_id,
+                )
+                response = ""
+
+            # #72131: the identical provider-error text already reached this
+            # chat as a persistent status message during the run — delivering
+            # the final response too would show the user the same error twice.
+            # Like intentional silence above, this only suppresses outbound
+            # delivery; the transcript writes above are untouched.
+            if _provider_error_status_dup and response:
+                logger.info(
+                    "Suppressing duplicate provider-error final response for "
+                    "session %s: identical status already delivered this turn "
+                    "(#72131)",
                     session_entry.session_id,
                 )
                 response = ""
@@ -31114,6 +31219,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             except Exception as _rpe:
                 logger.debug("Post-delivery cleanup registration failed: %s", _rpe)
+
+        # #72131: expose this turn's successfully delivered provider-error
+        # status texts to the outer delivery path, which decides whether the
+        # sanitized final response would be a byte-identical second copy.
+        # Attached at this single seam so every run_sync return shape carries
+        # it; only reads TurnContext state, so it is per-turn by construction.
+        if isinstance(response, dict) and turn_ctx._provider_error_statuses_delivered:
+            response.setdefault(
+                "provider_error_statuses_delivered",
+                list(turn_ctx._provider_error_statuses_delivered),
+            )
 
         return response
 

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -135,6 +135,17 @@ class TurnContext:
     _event_callback_sync: Optional[Callable] = None
     _status_callback_sync: Optional[Callable] = None
 
+    # --- provider-error duplicate-delivery dedup (#72131) ------------------
+    # Canonical provider-error reply texts already delivered to the chat as
+    # PERSISTENT status messages this turn — recorded by the status bridge
+    # only after a successful plain-``send()`` fallback (adapters without
+    # ``send_or_update_status``), consumed by the final-delivery
+    # normalization path to suppress a byte-identical final response.
+    # Per-turn by construction: concurrent turns own separate TurnContext
+    # instances. Appends happen in event-loop-thread done-callbacks and the
+    # read happens on the same loop after the worker finishes, so no lock.
+    _provider_error_statuses_delivered: List[str] = field(default_factory=list)
+
     # --- Slack-native task-card progress (opt-in; #29483) ------------------
     # True when the Slack adapter's ``native_task_cards_enabled()`` opt-in is
     # set for this turn's platform. The ID-bearing lifecycle callbacks are

--- a/tests/gateway/test_provider_error_double_delivery.py
+++ b/tests/gateway/test_provider_error_double_delivery.py
@@ -19,14 +19,13 @@ sanitizes to the byte-identical text. These tests cover the dedup:
 
 import concurrent.futures
 from datetime import datetime
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, SendResult
 from gateway.run import (
     _GATEWAY_PROVIDER_ERROR_AUTH_REPLY,
     _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY,
@@ -154,7 +153,7 @@ class TestStatusBridgeRecording:
     def test_successful_fallback_send_records_the_rewritten_reply(self, monkeypatch):
         runner, ctx = _turn_runner(_FallbackAdapter())
         sent = _stub_scheduler(
-            monkeypatch, SimpleNamespace(success=True, message_id="77"),
+            monkeypatch, SendResult(success=True, message_id="77"),
         )
 
         runner._status_callback_sync("status", RAW_RATE_LIMIT_STATUS)
@@ -166,7 +165,7 @@ class TestStatusBridgeRecording:
 
     def test_failed_send_records_nothing(self, monkeypatch):
         runner, ctx = _turn_runner(_FallbackAdapter())
-        _stub_scheduler(monkeypatch, SimpleNamespace(success=False, message_id=None))
+        _stub_scheduler(monkeypatch, SendResult(success=False, message_id=None, error="flood wait"))
 
         runner._status_callback_sync("status", RAW_RATE_LIMIT_STATUS)
 
@@ -176,7 +175,7 @@ class TestStatusBridgeRecording:
         """The gateway cannot assume an editable/ephemeral bubble persists, so
         the final response must keep flowing on these adapters."""
         runner, ctx = _turn_runner(_EditableAdapter())
-        _stub_scheduler(monkeypatch, SimpleNamespace(success=True, message_id="78"))
+        _stub_scheduler(monkeypatch, SendResult(success=True, message_id="78"))
 
         runner._status_callback_sync("status", RAW_RATE_LIMIT_STATUS)
 
@@ -185,7 +184,7 @@ class TestStatusBridgeRecording:
     def test_ordinary_status_text_records_nothing(self, monkeypatch):
         runner, ctx = _turn_runner(_FallbackAdapter())
         sent = _stub_scheduler(
-            monkeypatch, SimpleNamespace(success=True, message_id="79"),
+            monkeypatch, SendResult(success=True, message_id="79"),
         )
 
         runner._status_callback_sync("status", "reading the config file")
@@ -198,7 +197,7 @@ class TestStatusBridgeRecording:
         turn (own ctx) never inherits or consumes another turn's record."""
         runner_a, ctx_a = _turn_runner(_FallbackAdapter(), chat_id="-1001")
         runner_b, ctx_b = _turn_runner(_FallbackAdapter(), chat_id="-2002")
-        _stub_scheduler(monkeypatch, SimpleNamespace(success=True, message_id="80"))
+        _stub_scheduler(monkeypatch, SendResult(success=True, message_id="80"))
 
         runner_a._status_callback_sync("status", RAW_RATE_LIMIT_STATUS)
 

--- a/tests/gateway/test_provider_error_double_delivery.py
+++ b/tests/gateway/test_provider_error_double_delivery.py
@@ -1,0 +1,367 @@
+"""#72131: provider errors delivered twice on adapters without send_or_update_status.
+
+A provider failure is surfaced through two gateway channels — the mid-run
+status callback (rewritten to a user-safe reply and, on adapters without
+``send_or_update_status``, delivered as a PERSISTENT message by the plain-send
+fallback) and the failed turn's final response, which the delivery path
+sanitizes to the byte-identical text. These tests cover the dedup:
+
+- the canonical replies are recognized by set membership, not by re-running
+  the raw-envelope classifier (which misses e.g. the rate-limit reply);
+- the status bridge records a delivered reply on the TurnContext only after a
+  SUCCESSFUL fallback send, and never for ``send_or_update_status`` adapters;
+- recording is per-turn — interleaved turns never see each other's state;
+- the outer delivery path (`_handle_message_with_agent`), which re-derives
+  the sanitized text from the raw result, suppresses the duplicate there —
+  so inner-path reconstruction cannot resurrect it — while transcript
+  persistence is untouched.
+"""
+
+import concurrent.futures
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import (
+    _GATEWAY_PROVIDER_ERROR_AUTH_REPLY,
+    _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY,
+    _GATEWAY_PROVIDER_ERROR_REPLIES,
+    TurnRunner,
+    _gateway_provider_error_reply,
+    _is_gateway_provider_error_reply,
+    _looks_like_gateway_provider_error,
+    _should_suppress_provider_error_final,
+)
+from gateway.session import SessionEntry, SessionSource
+from gateway.turn_context import TurnContext
+
+
+# ---------------------------------------------------------------------------
+# Canonical-reply recognition
+# ---------------------------------------------------------------------------
+
+
+class TestProviderErrorReplyRecognition:
+    def test_every_canonical_reply_is_recognized(self):
+        for reply in _GATEWAY_PROVIDER_ERROR_REPLIES:
+            assert _is_gateway_provider_error_reply(reply), reply
+
+    def test_rate_limit_reply_is_recognized_without_the_envelope_classifier(self):
+        """The regression that sank the previous fix attempt: the rewritten
+        rate-limit reply says "rate-limiting requests", which the raw-envelope
+        shape matcher does not accept — recognition must not go through it."""
+        reply = _gateway_provider_error_reply("rate limited after 3 retries")
+        assert reply == _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY
+        assert not _looks_like_gateway_provider_error(reply)
+        assert _is_gateway_provider_error_reply(reply)
+
+    def test_raw_envelopes_and_prose_are_not_replies(self):
+        assert not _is_gateway_provider_error_reply("rate limited after 3 retries")
+        assert not _is_gateway_provider_error_reply("API call failed: HTTP 500")
+        assert not _is_gateway_provider_error_reply("All good, here is your answer.")
+        assert not _is_gateway_provider_error_reply("")
+        assert not _is_gateway_provider_error_reply(None)
+
+
+class TestShouldSuppressProviderErrorFinal:
+    def test_suppresses_identical_delivered_reply(self):
+        assert _should_suppress_provider_error_final(
+            _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY,
+            [_GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY],
+        )
+
+    def test_no_suppression_without_delivered_statuses(self):
+        assert not _should_suppress_provider_error_final(
+            _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY, None,
+        )
+        assert not _should_suppress_provider_error_final(
+            _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY, [],
+        )
+
+    def test_no_suppression_for_a_different_error_category(self):
+        assert not _should_suppress_provider_error_final(
+            _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY,
+            [_GATEWAY_PROVIDER_ERROR_AUTH_REPLY],
+        )
+
+    def test_never_suppresses_non_canonical_text(self):
+        """Only the closed reply set qualifies — ordinary content that merely
+        equals a delivered status must never be suppressed."""
+        assert not _should_suppress_provider_error_final(
+            "working on it", ["working on it"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Status-bridge recording (TurnRunner._status_callback_sync)
+# ---------------------------------------------------------------------------
+
+
+class _FallbackAdapter:
+    """Adapter WITHOUT send_or_update_status — statuses go through plain send."""
+
+    async def send(self, chat_id, content, metadata=None):  # pragma: no cover
+        raise AssertionError("send is not reached: scheduling is stubbed")
+
+
+class _EditableAdapter(_FallbackAdapter):
+    """Adapter WITH send_or_update_status — bubble semantics are its own."""
+
+    async def send_or_update_status(self, chat_id, status_key, content, metadata=None):
+        raise AssertionError("not reached")  # pragma: no cover
+
+
+def _source(chat_id="-1001"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="group",
+        user_id="12345",
+    )
+
+
+def _turn_runner(adapter, chat_id="-1001"):
+    ctx = TurnContext(source=_source(chat_id), _run_still_current=lambda: True)
+    ctx._status_adapter = adapter
+    ctx._status_chat_id = chat_id
+    return TurnRunner(runner=MagicMock(), ctx=ctx), ctx
+
+
+def _stub_scheduler(monkeypatch, send_result):
+    """Replace safe_schedule_threadsafe with a synchronous completed future."""
+    sent = []
+
+    def _fake_schedule(coro, loop, logger=None, log_message=None):
+        sent.append(coro)
+        coro.close()
+        fut = concurrent.futures.Future()
+        fut.set_result(send_result)
+        return fut
+
+    monkeypatch.setattr(gateway_run, "safe_schedule_threadsafe", _fake_schedule)
+    return sent
+
+
+RAW_RATE_LIMIT_STATUS = "Rate limited after 3 retries"
+
+
+class TestStatusBridgeRecording:
+    def test_successful_fallback_send_records_the_rewritten_reply(self, monkeypatch):
+        runner, ctx = _turn_runner(_FallbackAdapter())
+        sent = _stub_scheduler(
+            monkeypatch, SimpleNamespace(success=True, message_id="77"),
+        )
+
+        runner._status_callback_sync("status", RAW_RATE_LIMIT_STATUS)
+
+        assert len(sent) == 1
+        assert ctx._provider_error_statuses_delivered == [
+            _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY
+        ]
+
+    def test_failed_send_records_nothing(self, monkeypatch):
+        runner, ctx = _turn_runner(_FallbackAdapter())
+        _stub_scheduler(monkeypatch, SimpleNamespace(success=False, message_id=None))
+
+        runner._status_callback_sync("status", RAW_RATE_LIMIT_STATUS)
+
+        assert ctx._provider_error_statuses_delivered == []
+
+    def test_send_or_update_status_adapter_records_nothing(self, monkeypatch):
+        """The gateway cannot assume an editable/ephemeral bubble persists, so
+        the final response must keep flowing on these adapters."""
+        runner, ctx = _turn_runner(_EditableAdapter())
+        _stub_scheduler(monkeypatch, SimpleNamespace(success=True, message_id="78"))
+
+        runner._status_callback_sync("status", RAW_RATE_LIMIT_STATUS)
+
+        assert ctx._provider_error_statuses_delivered == []
+
+    def test_ordinary_status_text_records_nothing(self, monkeypatch):
+        runner, ctx = _turn_runner(_FallbackAdapter())
+        sent = _stub_scheduler(
+            monkeypatch, SimpleNamespace(success=True, message_id="79"),
+        )
+
+        runner._status_callback_sync("status", "reading the config file")
+
+        assert len(sent) == 1  # delivered normally
+        assert ctx._provider_error_statuses_delivered == []
+
+    def test_interleaved_turns_keep_separate_state(self, monkeypatch):
+        """Per-turn scoping: state lives on the TurnContext, so a concurrent
+        turn (own ctx) never inherits or consumes another turn's record."""
+        runner_a, ctx_a = _turn_runner(_FallbackAdapter(), chat_id="-1001")
+        runner_b, ctx_b = _turn_runner(_FallbackAdapter(), chat_id="-2002")
+        _stub_scheduler(monkeypatch, SimpleNamespace(success=True, message_id="80"))
+
+        runner_a._status_callback_sync("status", RAW_RATE_LIMIT_STATUS)
+
+        assert ctx_a._provider_error_statuses_delivered == [
+            _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY
+        ]
+        assert ctx_b._provider_error_statuses_delivered == []
+
+
+# ---------------------------------------------------------------------------
+# Delivery-level suppression (_handle_message_with_agent)
+# ---------------------------------------------------------------------------
+
+
+def _event():
+    return MessageEvent(
+        text="hello",
+        source=_source(),
+        message_id="msg-72131",
+    )
+
+
+def _gateway_runner(monkeypatch, tmp_path):
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:12345",
+        session_id="sess-72131",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner
+
+
+RAW_FAILED_FINAL = "⚠️ API call failed: rate limited after 3 retries"
+
+
+def _failed_agent_result(**extra):
+    result = {
+        "final_response": RAW_FAILED_FINAL,
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": RAW_FAILED_FINAL},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": True,
+    }
+    result.update(extra)
+    return result
+
+
+@pytest.mark.asyncio
+async def test_duplicate_provider_error_final_is_suppressed(monkeypatch, tmp_path):
+    """The outer path re-derives the sanitized reply from the raw result, so
+    the suppression must live there — and does: an identical delivered status
+    turns the final delivery into ""."""
+    runner = _gateway_runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value=_failed_agent_result(
+        provider_error_statuses_delivered=[
+            _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY
+        ],
+    ))
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response == ""
+
+
+@pytest.mark.asyncio
+async def test_transcript_persistence_is_untouched_by_the_suppression(
+    monkeypatch, tmp_path,
+):
+    """Like intentional silence, this is a delivery decision — the turn's
+    transcript rows are written exactly as without the dedup."""
+    runner = _gateway_runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value=_failed_agent_result(
+        provider_error_statuses_delivered=[
+            _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY
+        ],
+    ))
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+    suppressed_rows = [
+        c.args[1] for c in runner.session_store.append_to_transcript.call_args_list
+    ]
+
+    runner2 = _gateway_runner(monkeypatch, tmp_path)
+    runner2._run_agent = AsyncMock(return_value=_failed_agent_result())
+    await runner2._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+    plain_rows = [
+        c.args[1] for c in runner2.session_store.append_to_transcript.call_args_list
+    ]
+
+    assert [
+        (r.get("role"), r.get("content")) for r in suppressed_rows
+    ] == [(r.get("role"), r.get("content")) for r in plain_rows]
+
+
+@pytest.mark.asyncio
+async def test_without_delivered_status_the_error_reply_is_still_sent(
+    monkeypatch, tmp_path,
+):
+    runner = _gateway_runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value=_failed_agent_result())
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response == _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY
+
+
+@pytest.mark.asyncio
+async def test_mismatched_error_category_is_not_suppressed(monkeypatch, tmp_path):
+    """A delivered auth-error status must not swallow a rate-limit final."""
+    runner = _gateway_runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value=_failed_agent_result(
+        provider_error_statuses_delivered=[_GATEWAY_PROVIDER_ERROR_AUTH_REPLY],
+    ))
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert response == _GATEWAY_PROVIDER_ERROR_RATE_LIMIT_REPLY


### PR DESCRIPTION
Fixes #72131.

### Problem
On adapters without `send_or_update_status`, a provider failure reaches the chat **twice** as two identical persistent messages (e.g. `⏱️ The model provider is rate-limiting requests…` ×2 for one failed turn): the mid-run status callback rewrites the raw error via `_prepare_gateway_status_message` and delivers it through the plain-`send()` fallback, then the failed turn's final response is sanitized by `_sanitize_gateway_final_response` to the byte-identical text and sent again.

### Fix
Per-turn, delivery-level dedup, built to the checklist from the review that closed #72144:

- **Recognition by membership, not re-classification.** The canonical replies from `_gateway_provider_error_reply` become named constants with a closed set (`_GATEWAY_PROVIDER_ERROR_REPLIES`). Already-rewritten text is recognized by set membership — the raw-envelope matcher does not accept e.g. the rewritten rate-limit reply ("rate-limiting requests" vs "rate limited after N retries"), which is exactly the case #72144 failed to record.
- **Per-turn state on `TurnContext`.** The status bridge records a delivered reply on `ctx._provider_error_statuses_delivered` only after a **successful** plain-send fallback. Adapters **with** `send_or_update_status` are excluded: their bubble semantics (edited in place / ephemeral / cleaned up post-run) are adapter-defined, so the gateway cannot assume a persistent copy remains and keeps delivering the final response. Concurrent turns own separate `TurnContext` instances, so nothing is process-global and nothing can cross-deduplicate chats.
- **Suppression at the outer delivery path.** `_run_agent_inner` attaches the recorded texts to the turn result at a single seam; `_handle_message_with_agent` decides right after its own sanitization pass — the path that would otherwise reconstruct the reply from the raw result, the third finding on #72144 — and blanks only the outbound delivery after transcript persistence, mirroring the intentional-silence mechanism (a delivery decision, not a transcript mutation).

### Out of scope
The failed-turn variant on `send_or_update_status` adapters (the Telegram repro in https://github.com/NousResearch/hermes-agent/issues/72131#issuecomment-5465060605, where the cleanup path is opt-in and skips failed runs) is deliberately not covered: suppressing the final response there requires knowing whether the adapter's status bubble persists, which the gateway cannot assume, and the failed-run cleanup skip is documented intentional behavior ("breadcrumbs").

### Tests
`tests/gateway/test_provider_error_double_delivery.py` (16 tests):
- every canonical reply recognized; the rewritten rate-limit reply recognized **without** the envelope classifier (the #72144 regression);
- status bridge: successful fallback send records; failed send records nothing; `send_or_update_status` adapter records nothing; ordinary status text records nothing; interleaved turns keep separate per-turn state;
- end-to-end through `_handle_message_with_agent`: identical delivered status → final delivery suppressed; transcript rows byte-identical with and without the dedup; no delivered status → reply still sent; mismatched error category → not suppressed.

Both seams were verified red: disabling the suppression flag fails the end-to-end test, disabling the recording block fails the recording and interleaving tests. Full `tests/gateway` suite green locally; `ruff check` clean on the touched files.
