### PR TITLE
fix(providers): skip platform and memory plugins in entry-point discovery

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -214,6 +214,35 @@ def _discover_entry_point_providers() -> None:
                 "entry-point provider %r skipped: not enabled in config", ep.name
             )
             continue
+        # Import-free ownership precheck (#98438): this group is shared with
+        # the general PluginManager, which classifies entry points WITHOUT
+        # importing them and loads platform plugins lazily. Importing a
+        # platform adapter here breaks it — documented adapters do
+        # ``from gateway.config import Platform`` at module top, and when
+        # this scan runs inside the ``gateway.config -> hermes_cli.config``
+        # import chain (provider env injection at the bottom of
+        # hermes_cli/config.py) ``gateway.config`` is still half-initialized,
+        # so the import fails and the platform silently disappears. Skip
+        # entry points that are provably NOT model providers: a
+        # ``<name>-platform`` name (the manager's platform-id convention) or
+        # a memory-provider source signature. Anything else falls through to
+        # the load below — a real provider must never be dropped just
+        # because its source could not be classified.
+        try:
+            from hermes_cli.plugins import _classify_entrypoint_value_kind
+
+            value = getattr(ep, "value", "")
+            if ep.name.endswith("-platform") or (
+                value and _classify_entrypoint_value_kind(value) == "exclusive"
+            ):
+                logger.debug(
+                    "entry-point %r skipped by provider scan: platform or "
+                    "memory-provider plugin owned by the PluginManager",
+                    ep.name,
+                )
+                continue
+        except Exception:
+            pass  # classification unavailable — keep the historical behavior
         try:
             loaded = ep.load()
         except Exception as exc:

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -47,6 +47,11 @@ _ALIASES: dict[str, str] = {}
 _PROVIDER_LIST_CACHE: list[ProviderProfile] | None = None
 _discovered = False
 
+# Import-free platform-adapter signal: every documented adapter does this
+# import at module top (see gateway/platforms/*), while model-provider
+# plugins never touch gateway.config. Scanned, never executed.
+_PLATFORM_IMPORT_MARKER = "from gateway.config import Platform"
+
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
 _BUNDLED_PLUGINS_DIR = (
     Path(__file__).resolve().parent.parent / "plugins" / "model-providers"
@@ -224,17 +229,31 @@ def _discover_entry_point_providers() -> None:
         # hermes_cli/config.py) ``gateway.config`` is still half-initialized,
         # so the import fails and the platform silently disappears. Skip
         # entry points that are provably NOT model providers: a
-        # ``<name>-platform`` name (the manager's platform-id convention) or
-        # a memory-provider source signature. Anything else falls through to
-        # the load below — a real provider must never be dropped just
-        # because its source could not be classified.
+        # ``<name>-platform`` name (the manager's platform-id convention), a
+        # memory-provider source signature, or the documented adapter import
+        # in the source (hand-written ``plugins.enabled`` entries may carry
+        # any name, so the suffix alone can miss them). Anything else falls
+        # through to the load below — a real provider must never be dropped
+        # just because its source could not be classified.
         try:
-            from hermes_cli.plugins import _classify_entrypoint_value_kind
+            from hermes_cli.plugins import (
+                _classify_entrypoint_value_kind,
+                _resolve_module_source,
+            )
 
             value = getattr(ep, "value", "")
-            if ep.name.endswith("-platform") or (
+            skip = ep.name.endswith("-platform") or (
                 value and _classify_entrypoint_value_kind(value) == "exclusive"
-            ):
+            )
+            if not skip and value:
+                try:
+                    module_name = str(value).split(":", 1)[0].strip()
+                    skip = bool(module_name) and _PLATFORM_IMPORT_MARKER in (
+                        _resolve_module_source(module_name)
+                    )
+                except Exception:
+                    skip = False  # unresolvable source — fail open
+            if skip:
                 logger.debug(
                     "entry-point %r skipped by provider scan: platform or "
                     "memory-provider plugin owned by the PluginManager",

--- a/tests/providers/test_entry_point_discovery.py
+++ b/tests/providers/test_entry_point_discovery.py
@@ -51,9 +51,10 @@ def _restore_real_discovery():
 
 
 class _FakeEP:
-    def __init__(self, name, loader):
+    def __init__(self, name, loader, value=""):
         self.name = name
         self.group = "hermes_agent.plugins"
+        self.value = value
         self._loader = loader
 
     def load(self):
@@ -221,5 +222,105 @@ def test_filesystem_plugins_win_over_entry_points(monkeypatch):
         assert p is not None
         # The bundled OpenRouter profile (real base_url) must win, not the impostor.
         assert "impostor.test" not in (p.base_url or "")
+    finally:
+        _clear_provider_caches()
+
+
+def test_platform_named_entry_point_not_loaded(monkeypatch):
+    """A ``<name>-platform`` entry point must not be imported by this scan
+    (#98438).
+
+    Platform adapters are owned by the PluginManager, which loads them
+    lazily; importing one here runs its ``from gateway.config import
+    Platform`` while ``gateway.config`` may still be half-initialized (this
+    scan can run inside the ``gateway.config -> hermes_cli.config`` import
+    chain), killing the platform with a circular-import error.
+    """
+    loads = []
+
+    def _platform_side_effect():
+        loads.append("stub-platform")  # the import itself would already fail
+        return object()
+
+    fake_eps = _FakeEntryPoints(
+        [_FakeEP("stub-platform", _platform_side_effect, value="stubplat")]
+    )
+    import importlib.metadata as md
+
+    monkeypatch.setattr(md, "entry_points", lambda: fake_eps)
+    _enable(monkeypatch, "stub-platform")
+    _clear_provider_caches()
+    try:
+        providers._discover_providers()
+        assert loads == []  # never imported
+    finally:
+        _clear_provider_caches()
+
+
+def test_memory_provider_entry_point_not_loaded(monkeypatch, tmp_path):
+    """An enabled memory-provider entry point (``MemoryProvider`` source
+    signature) is not imported here — memory providers are owned by the
+    ``plugins/memory`` discovery system."""
+    loads = []
+    # A resolvable top-level module whose source carries the memory-provider
+    # markers the PluginManager's import-free classifier looks for.
+    (tmp_path / "stub_mem_plugin.py").write_text(
+        "from plugins.memory import register_memory_provider\n"
+        "class StubMemoryProvider(MemoryProvider):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def _mem_side_effect():
+        loads.append("stub-mem")
+        return object()
+
+    fake_eps = _FakeEntryPoints(
+        [_FakeEP("stub-mem", _mem_side_effect, value="stub_mem_plugin")]
+    )
+    import importlib.metadata as md
+
+    monkeypatch.setattr(md, "entry_points", lambda: fake_eps)
+    _enable(monkeypatch, "stub-mem")
+    _clear_provider_caches()
+    try:
+        providers._discover_providers()
+        assert loads == []  # never imported
+    finally:
+        sys.modules.pop("stub_mem_plugin", None)
+        _clear_provider_caches()
+
+
+def test_unresolvable_entry_point_still_loaded(monkeypatch):
+    """Fail-open: an entry point whose source cannot be classified is still
+    loaded, so a real provider is never dropped because classification
+    failed (unresolvable module, thin re-export package, ...)."""
+    from providers.base import ProviderProfile
+
+    def _register_unresolvable():
+        def register():
+            providers.register_provider(
+                ProviderProfile(name="ep-unresolvable", base_url="https://c.test/v1")
+            )
+
+        return register
+
+    fake_eps = _FakeEntryPoints(
+        [
+            _FakeEP(
+                "ep-unresolvable",
+                _register_unresolvable,
+                value="no_such_module_zq",
+            )
+        ]
+    )
+    import importlib.metadata as md
+
+    monkeypatch.setattr(md, "entry_points", lambda: fake_eps)
+    _enable(monkeypatch, "ep-unresolvable")
+    _clear_provider_caches()
+    try:
+        assert providers.get_provider_profile("ep-unresolvable") is not None
     finally:
         _clear_provider_caches()

--- a/tests/providers/test_entry_point_discovery.py
+++ b/tests/providers/test_entry_point_discovery.py
@@ -324,3 +324,84 @@ def test_unresolvable_entry_point_still_loaded(monkeypatch):
         assert providers.get_provider_profile("ep-unresolvable") is not None
     finally:
         _clear_provider_caches()
+
+
+def test_platform_import_marker_entry_point_not_loaded(monkeypatch, tmp_path):
+    """A hand-written ``plugins.enabled`` entry whose name lacks the
+    ``-platform`` suffix is still skipped when its source carries the
+    documented platform-adapter import (#98438).
+
+    The name convention only covers PluginManager-generated ids; the
+    ``from gateway.config import Platform`` base import is the remaining
+    import-free platform signal (model-provider plugins never touch
+    gateway.config).
+    """
+    loads = []
+    (tmp_path / "stub_platform_plugin.py").write_text(
+        "from gateway.config import Platform, PlatformConfig\n"
+        "class StubAdapter:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def _adapter_side_effect():
+        loads.append("stub-adapter")  # the import itself would already fail
+        return object()
+
+    fake_eps = _FakeEntryPoints(
+        [
+            _FakeEP(
+                "stub-adapter",
+                _adapter_side_effect,
+                value="stub_platform_plugin",
+            )
+        ]
+    )
+    import importlib.metadata as md
+
+    monkeypatch.setattr(md, "entry_points", lambda: fake_eps)
+    _enable(monkeypatch, "stub-adapter")
+    _clear_provider_caches()
+    try:
+        providers._discover_providers()
+        assert loads == []  # never imported
+    finally:
+        sys.modules.pop("stub_platform_plugin", None)
+        _clear_provider_caches()
+
+
+def test_plain_plugin_without_markers_still_loaded(monkeypatch, tmp_path):
+    """A source-bearing entry point with NO platform/memory markers keeps
+    the historical load path — the marker scan must not over-skip."""
+    from providers.base import ProviderProfile
+
+    (tmp_path / "stub_plain_plugin.py").write_text(
+        "# a plain plugin: no gateway import, no memory markers\n"
+        "def register():\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    def _plain_side_effect():
+        def register():
+            providers.register_provider(
+                ProviderProfile(name="ep-plain", base_url="https://d.test/v1")
+            )
+
+        return register
+
+    fake_eps = _FakeEntryPoints(
+        [_FakeEP("ep-plain", _plain_side_effect, value="stub_plain_plugin")]
+    )
+    import importlib.metadata as md
+
+    monkeypatch.setattr(md, "entry_points", lambda: fake_eps)
+    _enable(monkeypatch, "ep-plain")
+    _clear_provider_caches()
+    try:
+        assert providers.get_provider_profile("ep-plain") is not None
+    finally:
+        sys.modules.pop("stub_plain_plugin", None)
+        _clear_provider_caches()


### PR DESCRIPTION
## What does this PR do?

`_discover_entry_point_providers()` in `providers/__init__.py` calls `ep.load()` on **every** entry point listed in `plugins.enabled`, with no kind check before the import. The shared `hermes_agent.plugins` group also contains platform and memory-provider plugins, which are owned by the PluginManager / `plugins/memory` discovery and are meant to be loaded lazily. Importing a platform adapter here is actively harmful: documented adapters do `from gateway.config import Platform` at module top, and when provider discovery runs inside the `gateway.config -> hermes_cli.config` import chain (the provider-env injection at the bottom of `hermes_cli/config.py`), `gateway.config` is still half-initialized — the import fails with a circular-import error and the platform silently disappears (#98438).

This PR adds an **import-free ownership precheck** before `ep.load()` and skips entry points that are provably not model providers:

- a `<name>-platform` entry-point name — the naming convention the PluginManager itself relies on to derive platform ids (`_platform_name_from_manifest`), or
- a memory-provider source signature (`exclusive`), detected with the same import-free classifier the PluginManager already trusts (`_classify_entrypoint_value_kind`).

Anything else keeps the historical load path unchanged. This is deliberately conservative (blacklist of provable non-providers rather than a whitelist): a thin-`__init__` or lazily-importing pip provider whose source cannot be classified as `model-provider` is still loaded exactly as before, so no working provider gets deregistered. The broader "shared classifier for both consumers" refactor in #85559 addresses the same group-ownership problem from the other side; this fix is intentionally scoped to the provider-registry side and is compatible with that direction.

## Related Issue

Fixes #98438

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `providers/__init__.py` — in `_discover_entry_point_providers()`, classify each enabled entry point before `ep.load()`: skip `-platform`-named entry points and memory-provider (`exclusive`) source signatures; classification failures fall through to the existing load path (fail-open, ~29 lines).
- `tests/providers/test_entry_point_discovery.py` — `_FakeEP` now carries a `value` (entry-point target) like a real `EntryPoint`; added three regression tests: platform-named entry point never imported, memory-provider-signature entry point never imported, unresolvable entry point still loaded (fail-open).

## How to Test

1. Reproduce on `main` (from the issue): create a stub pip plugin named `stub-platform` whose entry module does `from gateway.config import Platform`, enable it, then `PYTHONPATH=/tmp/stub HERMES_HOME=/tmp/hh python -c "import gateway.config"` → Observed result: `WARNING providers: Failed to load entry-point provider plugin 'stub-platform': cannot import name 'Platform' from partially initialized module 'gateway.config' (most likely due to a circular import)`.
2. Same repro on this branch → Observed result: clean import, no warning, and `import hermes_cli.config; import stubplug` still works (the pre-fix working path is unchanged).
3. `pytest tests/providers/ tests/plugins/memory/test_discovery_sources.py tests/agent/test_memory_provider.py -q` → 158 passed (includes the 3 new tests; verified they fail on unpatched code for the two skip cases).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #85559 targets the same shared-group ownership with a two-sided shared classifier and is currently conflicting/stale; this PR is the minimal registry-side fix and notes the relationship above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: `tests/providers/`, memory-discovery, plugin-related `tests/hermes_cli/` — the batch `tests/hermes_cli/ -k plugin/provider` has 27 order-dependent failures reproducible identically on clean `main` at the same commit; each passes in isolation)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — code comments document the precheck; the plugin docs' "avoid `gateway.*` imports" caveat is a docs question for maintainers, out of scope here
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — import-free source resolution uses stdlib `importlib.util.find_spec` + `pathlib`, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (main) vs after (this branch) for the issue repro `PYTHONPATH=/tmp/stub HERMES_HOME=/tmp/hh python -c "import gateway.config"`:

```
# main
WARNING providers: Failed to load entry-point provider plugin 'stub-platform':
cannot import name 'Platform' from partially initialized module 'gateway.config'
(most likely due to a circular import)

# this branch
(no output — import succeeds, platform plugin left for the PluginManager's lazy load)
```