### PR TITLE
fix(zai): map glm-5.3-flash reasoning_effort medium to high

### DIFF
--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -127,6 +127,14 @@ GLM52_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 GLM53_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "max")
 GLM53_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 
+#: GLM-5.3-flash on the standard BigModel endpoint (open.bigmodel.cn) is
+#: narrower: it rejects ``medium`` with HTTP 400 "该模型始终思考，不支持关闭
+#: 思考；请使用 low、high 或 max" — only low/high/max are accepted (verified
+#: live 2026-08-30). ``medium`` maps to ``high`` (the positional middle and
+#: server default, same rationale as KIMI_K3_OVERRIDES); ``xhigh`` to ``max``.
+GLM53_FLASH_EFFORTS: tuple[str, ...] = ("low", "high", "max")
+GLM53_FLASH_OVERRIDES: dict[str, str] = {"medium": "high", "xhigh": "max"}
+
 #: DeepSeek V4 OpenAI-compat endpoint: low/medium/high/max; ``xhigh``
 #: requests the top tier (matches the shipped profile mapping).
 DEEPSEEK_V4_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "max")

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -78,6 +78,17 @@ def _is_glm_5_3(model: str | None) -> bool:
     return any(token in m for token in ("glm-5.3", "glm-5-3", "glm-5p3"))
 
 
+def _is_glm_5_3_flash(model: str | None) -> bool:
+    """Detect GLM-5.3-flash — narrower effort vocabulary on BigModel.
+
+    The standard endpoint (open.bigmodel.cn/api/paas/v4) rejects ``medium``
+    for glm-5.3-flash with HTTP 400 (code 1210): only ``low``/``high``/``max``
+    are accepted (verified live 2026-08-30).  The non-flash glm-5.3 accepts
+    the full graded scale, so the two need separate declared vocabularies.
+    """
+    return _is_glm_5_3(model) and "flash" in (model or "").strip().lower()
+
+
 def _glm_5_2_reasoning_effort(
     reasoning_config: dict | None, *, model: str | None = None
 ) -> str | None:
@@ -100,17 +111,23 @@ def _glm_5_2_reasoning_effort(
         return None
 
     # Per-model vocabulary declared in agent.reasoning_effort; xhigh rounds
-    # up to max on both. 5.2 cannot think less than high; 5.3 accepts a
-    # graded scale down to low (issue #91789).
+    # up to max on all GLM-5.x. 5.2 cannot think less than high; 5.3 accepts
+    # a graded scale down to low (issue #91789); 5.3-flash on the standard
+    # BigModel endpoint drops ``medium`` (HTTP 400, verified 2026-08-30) and
+    # maps it to high.
     from agent.reasoning_effort import (
         GLM52_EFFORTS,
         GLM52_OVERRIDES,
         GLM53_EFFORTS,
+        GLM53_FLASH_EFFORTS,
+        GLM53_FLASH_OVERRIDES,
         GLM53_OVERRIDES,
         clamp_effort,
     )
 
-    if _is_glm_5_3(model):
+    if _is_glm_5_3_flash(model):
+        efforts, overrides, floor = GLM53_FLASH_EFFORTS, GLM53_FLASH_OVERRIDES, "high"
+    elif _is_glm_5_3(model):
         efforts, overrides, floor = GLM53_EFFORTS, GLM53_OVERRIDES, "low"
     else:
         efforts, overrides, floor = GLM52_EFFORTS, GLM52_OVERRIDES, "high"


### PR DESCRIPTION
## Problem

`glm-5.3-flash` on the standard BigModel endpoint (`open.bigmodel.cn/api/paas/v4`) rejects `reasoning_effort=medium` with HTTP 400:

```
{"error":{"code":"1210","message":"该模型始终思考，不支持关闭思考；请使用 low、high 或 max。"}}
```

Only `low` / `high` / `max` are accepted — unlike non-flash `glm-5.3`, which accepts the graded `low`/`medium`/`high`/`max` scale verified in #91789.

Since Hermes' default `agent.reasoning_effort: medium` is translated verbatim for GLM-5.3 models, **every** `glm-5.3-flash` call failed with a non-retryable 400.

## Reproduction

Probed the live endpoint with minimal bodies (2026-08-30):

| body | result |
|---|---|
| `reasoning_effort: medium` | **HTTP 400** code 1210 (above) |
| `reasoning_effort: high` | HTTP 200 |
| `thinking: {"type":"enabled"}` + `reasoning_effort: high` | HTTP 200 (reasoning_tokens present) |
| no reasoning fields | HTTP 200 |

## Fix

Declare a separate flash vocabulary in `agent.reasoning_effort` and route `glm-5.3-flash` to it in the zai provider profile:

- `GLM53_FLASH_EFFORTS = ("low", "high", "max")` — the wire levels the endpoint actually accepts
- `GLM53_FLASH_OVERRIDES = {"medium": "high", "xhigh": "max"}` — `medium` maps to `high` (positional middle and server default, same rationale as `KIMI_K3_OVERRIDES`), `xhigh` to `max`
- New `_is_glm_5_3_flash()` detection in the zai plugin; non-flash GLM-5.2/5.3 behavior unchanged

This follows the module's declared rule: fix the declared supported set (data), never add a vendor special case at the call site.

## Verification

- `ZaiProfile.build_api_kwargs_extras(reasoning_config={"enabled": True, "effort": "medium"}, model="glm-5.3-flash")` → `{'thinking': {'type': 'enabled'}}` + `{'reasoning_effort': 'high'}`
- Same input with `model="glm-5.3"` still yields `reasoning_effort: medium` (unchanged)
- End-to-end against the live API with the provider's exact output body: HTTP 200, `completion_tokens_details.reasoning_tokens: 106` (thinking enabled at high)
