### PR TITLE
fix(bedrock): stop inserting "\n\n" between every streamed reasoning delta

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1229,6 +1229,7 @@ def stream_converse_with_callbacks(
     tool_calls: List[SimpleNamespace] = []
     current_tool: Optional[Dict] = None
     current_text_buffer: List[str] = []
+    current_reasoning_buffer: List[str] = []
     has_tool_use = False
     stop_reason = "end_turn"
     usage_data: Dict[str, int] = {}
@@ -1276,16 +1277,26 @@ def stream_converse_with_callbacks(
                 if current_tool is not None:
                     current_tool["input_json"] += delta["toolUse"].get("input", "")
             elif "reasoningContent" in delta:
-                # Claude 4.6+ on Bedrock surfaces thinking via reasoningContent
+                # Claude 4.6+ on Bedrock surfaces thinking via reasoningContent.
+                # A reasoning delta carries a fragment of a word, not a whole
+                # thought — buffer it and join on the block boundary, exactly as
+                # the text path does above. Appending straight to reasoning_parts
+                # would weld the "\n\n" block separator between every token.
                 reasoning = delta["reasoningContent"]
                 if isinstance(reasoning, dict):
                     thinking_text = reasoning.get("text", "")
                     if thinking_text:
-                        reasoning_parts.append(str(thinking_text))
+                        current_reasoning_buffer.append(str(thinking_text))
                         if on_reasoning_delta:
                             on_reasoning_delta(thinking_text)
 
         elif "contentBlockStop" in event:
+            # A reasoning block just ended (or a text/tool block did, in which
+            # case the buffer is empty). Genuinely separate thinking blocks stay
+            # separated by the "\n\n" join below.
+            if current_reasoning_buffer:
+                reasoning_parts.append("".join(current_reasoning_buffer))
+                current_reasoning_buffer = []
             if current_tool is not None:
                 try:
                     input_dict = json.loads(current_tool["input_json"]) if current_tool["input_json"] else {}
@@ -1319,6 +1330,11 @@ def stream_converse_with_callbacks(
     # Flush remaining text
     if current_text_buffer:
         text_parts.append("".join(current_text_buffer))
+
+    # Flush reasoning too — an interrupt or a truncated stream can end without
+    # the closing contentBlockStop, and partial thinking still beats none.
+    if current_reasoning_buffer:
+        reasoning_parts.append("".join(current_reasoning_buffer))
 
     msg = SimpleNamespace(
         role="assistant",

--- a/tests/agent/test_bedrock_streaming_reasoning_deltas.py
+++ b/tests/agent/test_bedrock_streaming_reasoning_deltas.py
@@ -1,0 +1,216 @@
+"""Regression tests for corrupted ``reasoning_content`` on the Bedrock streaming path.
+
+``ConverseStream`` delivers thinking as a long run of ``reasoningContent`` deltas
+that each carry a *fragment* — frequently a fragment of a single word. The
+accumulator appended every fragment to ``reasoning_parts`` as though it were a
+whole reasoning block, then joined the list with ``"\\n\\n"``, so the block
+separator was welded between every streamed token::
+
+    deltas  : 'Let'  ' me list'  ' divis'  'ors other than 1 and itself'
+    stored  : 'Let\\n\\n me list\\n\\n divis\\n\\nors other than 1 and itself'
+    correct : 'Let me list divisors other than 1 and itself'
+
+Two properties made this hard to spot:
+
+* ``on_reasoning_delta`` was always handed the correct raw chunk, so the live TUI
+  rendered the thinking perfectly. Only the *stored* value was corrupted — which
+  is what feeds conversation history, context compression, replay and token
+  accounting.
+* The inflation is exactly ``2 * (non_empty_deltas - 1)`` bytes, which merely
+  looks like verbose model output rather than a bug.
+
+The fix mirrors the text path directly above it in the same loop: buffer
+contiguous deltas, ``"".join`` them on the ``contentBlockStop`` boundary, and keep
+``"\\n\\n"`` for separating genuinely distinct reasoning blocks.
+
+The primary fixture below is a real delta sequence captured from
+``us.anthropic.claude-sonnet-4-6`` in ``us-east-2``
+(``x-amzn-RequestId: 824382e9-5ff1-4f42-8d5c-43f28914e3df``, botocore 1.42.97),
+kept verbatim — including the trailing empty delta and the model's own ``\\n\\n``
+paragraph breaks, which must survive untouched.
+"""
+
+from agent.bedrock_adapter import stream_converse_with_callbacks
+
+# Captured verbatim from a live ConverseStream call with thinking enabled.
+REAL_DELTAS = [
+    "Let", " me list", " the first 30 prime numbers step", " by step.",
+    "\n\nA prime number is a number", " greater than 1 that has no", " divis",
+    "ors other than 1 and itself", ".\n\n1", ". 2", "\n2. 3\n3. ", "5\n4. 7\n5",
+    ". 11\n6. 13", "\n7. 17\n8.", " 19\n9. 23", "\n10. 29\n11. ",
+    "31\n12. 37\n13", ". 41\n14. 43", "\n15. 47\n16.", " 53\n17. 59",
+    "\n18. 61\n19. ", "67\n20. 71\n21", ". 73\n22. 79", "\n", "23. 83\n24. ",
+    "89\n25. 97\n26", ". 101\n27. 103", "\n28. 107\n29.", " 109\n30. 113",
+    "\n\nNow", " I'm", " adding", " them", " all", " together", " to",
+    " get the sum", " of the first 30 pr", "imes.", "\n\nContinuing", " the",
+    " running", " total", "...", "",
+]
+
+# Concatenating the deltas in order IS the model's thinking text, by definition
+# of a delta stream. Everything else is measured against this.
+REAL_TRUTH = "".join(REAL_DELTAS)
+
+
+def _reasoning_delta(text, index=0):
+    return {"contentBlockDelta": {"contentBlockIndex": index,
+                                  "delta": {"reasoningContent": {"text": text}}}}
+
+
+def _text_delta(text, index=0):
+    return {"contentBlockDelta": {"contentBlockIndex": index,
+                                  "delta": {"text": text}}}
+
+
+def _stop(index=0):
+    return {"contentBlockStop": {"contentBlockIndex": index}}
+
+
+def _run(events, **callbacks):
+    return stream_converse_with_callbacks({"stream": iter(events)}, **callbacks)
+
+
+def _reasoning_of(events, **callbacks):
+    return _run(events, **callbacks).choices[0].message.reasoning_content
+
+
+def _real_stream():
+    return [_reasoning_delta(d) for d in REAL_DELTAS] + [_stop()]
+
+
+# ── the real captured stream ──────────────────────────────────────────────────
+
+def test_real_stream_reasoning_is_verbatim():
+    """The stored thinking text is byte-identical to what the model streamed."""
+    assert _reasoning_of(_real_stream()) == REAL_TRUTH
+
+
+def test_real_stream_has_no_separator_inflation():
+    """No bytes are invented. The old accumulator added 2 * (44 - 1) == 86."""
+    non_empty = len([d for d in REAL_DELTAS if d])
+    assert non_empty == 44
+    assert len(_reasoning_of(_real_stream())) == len(REAL_TRUTH) == 450
+    # What the bug produced, stated explicitly so a regression is unmistakable.
+    assert len("\n\n".join(d for d in REAL_DELTAS if d)) == 450 + 2 * (non_empty - 1)
+
+
+def test_real_stream_preserves_only_the_models_own_paragraph_breaks():
+    """The model emitted 4 blank lines; the bug reported 47."""
+    assert _reasoning_of(_real_stream()).count("\n\n") == REAL_TRUTH.count("\n\n") == 4
+
+
+def test_word_split_across_deltas_is_not_broken_apart():
+    """'divis' + 'ors' is one word. The bug turned it into 'divis\\n\\nors'."""
+    result = _reasoning_of(_real_stream())
+    assert "divisors other than 1 and itself" in result
+    assert "divis\n\nors" not in result
+
+
+def test_leading_whitespace_in_deltas_is_preserved():
+    """Deltas carry their own spacing; the accumulator must not trim or add any."""
+    result = _reasoning_of(_real_stream())
+    assert result.startswith("Let me list the first 30 prime numbers step by step.")
+    assert result.endswith("Continuing the running total...")
+
+
+# ── the live callback contract must not change ────────────────────────────────
+
+def test_reasoning_delta_callback_still_fires_once_per_raw_chunk():
+    """Buffering for storage must not batch or delay the streaming callback —
+    that is the half of this path that was already correct."""
+    chunks = []
+    _reasoning_of(_real_stream(), on_reasoning_delta=chunks.append)
+    assert chunks == [d for d in REAL_DELTAS if d]
+    assert len(chunks) == 44
+    assert "".join(chunks) == REAL_TRUTH
+
+
+# ── block separation is still meaningful ──────────────────────────────────────
+
+def test_distinct_reasoning_blocks_remain_separated():
+    """Fragments within a block are concatenated; separate blocks keep "\\n\\n"."""
+    events = [
+        _reasoning_delta("First", 0), _reasoning_delta(" thought", 0), _stop(0),
+        _reasoning_delta("Second", 1), _reasoning_delta(" thought", 1), _stop(1),
+    ]
+    assert _reasoning_of(events) == "First thought\n\nSecond thought"
+
+
+def test_single_block_is_not_prefixed_or_suffixed_with_separators():
+    events = [_reasoning_delta("only"), _reasoning_delta(" one"), _stop()]
+    assert _reasoning_of(events) == "only one"
+
+
+# ── partial and truncated streams ─────────────────────────────────────────────
+
+def test_reasoning_is_flushed_when_stream_ends_without_content_block_stop():
+    """A truncated stream still yields the thinking received so far."""
+    events = [_reasoning_delta("half a "), _reasoning_delta("thought")]
+    assert _reasoning_of(events) == "half a thought"
+
+
+def test_reasoning_is_flushed_when_interrupted_mid_block():
+    """Interrupt breaks out of the loop before contentBlockStop; partial
+    thinking is better than silently dropping all of it."""
+    events = [_reasoning_delta("keep "), _reasoning_delta("this"),
+              _reasoning_delta(" not this"), _stop()]
+    calls = {"n": 0}
+
+    def interrupted():
+        calls["n"] += 1
+        return calls["n"] > 2
+
+    assert _reasoning_of(events, on_interrupt_check=interrupted) == "keep this"
+
+
+# ── interaction with the other content types ─────────────────────────────────
+
+def test_reasoning_and_text_accumulate_independently():
+    events = [
+        _reasoning_delta("thinking", 0), _reasoning_delta(" hard", 0), _stop(0),
+        _text_delta("the ", 1), _text_delta("answer", 1), _stop(1),
+    ]
+    msg = _run(events).choices[0].message
+    assert msg.reasoning_content == "thinking hard"
+    assert msg.content == "the answer"
+
+
+def test_reasoning_survives_a_following_tool_use_block():
+    events = [
+        _reasoning_delta("I should ", 0), _reasoning_delta("call a tool", 0), _stop(0),
+        {"contentBlockStart": {"contentBlockIndex": 1,
+                               "start": {"toolUse": {"toolUseId": "tu_1", "name": "bash"}}}},
+        {"contentBlockDelta": {"contentBlockIndex": 1,
+                               "delta": {"toolUse": {"input": '{"cmd": "ls"}'}}}},
+        _stop(1),
+    ]
+    msg = _run(events).choices[0].message
+    assert msg.reasoning_content == "I should call a tool"
+    assert [tc.function.name for tc in msg.tool_calls] == ["bash"]
+
+
+# ── degenerate deltas ─────────────────────────────────────────────────────────
+
+def test_empty_deltas_do_not_create_spurious_separators():
+    events = [_reasoning_delta("a"), _reasoning_delta(""), _reasoning_delta("b"), _stop()]
+    assert _reasoning_of(events) == "ab"
+
+
+def test_signature_only_delta_produces_no_reasoning_text():
+    """The final reasoning delta often carries only a signature, no text."""
+    events = [
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {
+            "reasoningContent": {"signature": "AbCdEf=="}}}},
+        _stop(),
+    ]
+    assert _reasoning_of(events) is None
+
+
+def test_no_reasoning_at_all_yields_none():
+    events = [_text_delta("just text"), _stop()]
+    assert _reasoning_of(events) is None
+
+
+def test_non_dict_reasoning_content_is_ignored():
+    events = [{"contentBlockDelta": {"contentBlockIndex": 0,
+                                     "delta": {"reasoningContent": "unexpected"}}}, _stop()]
+    assert _reasoning_of(events) is None


### PR DESCRIPTION
Fixes #98468

## Problem

`stream_converse_with_callbacks()` treats every Bedrock `reasoningContent` **delta** as a complete reasoning **block**, appending each one to `reasoning_parts` and then joining that list with the block separator `"\n\n"`. A delta is a fragment — routinely a fragment of a single word — so the separator ends up between every streamed token:

```
model streamed : 'Let'  ' me list'  ...  ' divis'  'ors other than 1 and itself'
stored         : 'Let\n\n me list\n\n ...  divis\n\nors other than 1 and itself'
```

It has stayed invisible because `on_reasoning_delta` is handed the correct raw chunk, so the live TUI is perfect. Only the **stored** `reasoning_content` is damaged — the copy that feeds conversation history, context compression, `/resume` replay, the API server's reasoning output and token accounting.

## Fix

Mirror the text path in the same loop. `agent/bedrock_adapter.py`, +18/−2:

- add `current_reasoning_buffer` alongside `current_text_buffer`
- append deltas to the buffer instead of to `reasoning_parts`
- `"".join()` it on `contentBlockStop`, so distinct reasoning blocks still get `"\n\n"` between them and fragments within a block get nothing
- flush at the end too, so an interrupt or truncated stream still yields the partial thinking rather than dropping it

`on_reasoning_delta` still fires once per raw chunk, unchanged — that half of this path was already correct and there is a test pinning it.

Deliberately **not** touching `normalize_converse_response()`. The non-streaming path has a separate, genuinely different bug (it reads the flat `reasoning.get("text")` where the non-streaming schema nests text under `reasoningText`) which is #36260 and already has a fix in flight in #89671. Keeping this PR to the streaming accumulator so the two don't collide.

## Evidence

<details>
<summary><b>Live Bedrock run — inflation is exactly 2 × (deltas − 1)</b></summary>

`us-east-2`, `us.anthropic.claude-sonnet-4-6`, thinking enabled, botocore 1.42.97, on an EC2 instance role against live Bedrock. `x-amzn-RequestId: 824382e9-5ff1-4f42-8d5c-43f28914e3df`. Same event list replayed through both accumulators, so the only variable is the code:

```
  total events                    : 119
  reasoningContent deltas         : 45  (44 non-empty)
  distinct reasoning block indexes: [0]        <-- ONE reasoning block, not 44
  ground truth len(''.join)       : 450 chars

  ground truth   :   450 chars
  OLD (main)     :   536 chars   delta +86
  NEW (this PR)  :   450 chars   delta +0
  predicted OLD inflation = 2 * (non-empty deltas - 1) = 2 * (44 - 1) = 86
  actual   OLD inflation                               = 86   MATCH

  '\n\n' occurrences  truth=4  OLD=47  NEW=4
  NEW == ground truth : True
  OLD == ground truth : False
```

</details>

<details>
<summary><b>What the corruption looks like</b></summary>

```
--- first 140 chars, ground truth ---
'Let me list the first 30 prime numbers step by step.\n\nA prime number is a number greater than 1 that has no divisors other than 1 and itself'

--- first 140 chars, OLD (main) ---
'Let\n\n me list\n\n the first 30 prime numbers step\n\n by step.\n\n\n\nA prime number is a number\n\n greater than 1 that has no\n\n divis\n\nors other tha'

--- first 140 chars, NEW (this PR) ---
'Let me list the first 30 prime numbers step by step.\n\nA prime number is a number greater than 1 that has no divisors other than 1 and itself'
```

`divis` and `ors` arrived as two deltas and are one word. The model's own paragraph break becomes `\n\n\n\n`.

</details>

<details>
<summary><b>Why nobody noticed: the callback was never broken</b></summary>

```
  on_reasoning_delta fired      : 44 times
  ''.join(callback chunks)      : 450 chars
  callback stream == truth      : True
```

The TUI renders the correct text as it streams. The bug is only in what gets persisted.

</details>

<details>
<summary><b>Tests</b></summary>

New file `tests/agent/test_bedrock_streaming_reasoning_deltas.py`, 16 tests. The primary fixture is the real 45-delta sequence from the RequestId above, kept verbatim — including its trailing empty delta, its lone `"\n"` delta and the model's own paragraph breaks, all of which must survive untouched.

**12 of the 16 fail on `main` and pass with this change:**

```
$ git stash push -- agent/bedrock_adapter.py   # revert the fix, keep the tests
$ pytest tests/agent/test_bedrock_streaming_reasoning_deltas.py -q
12 failed, 4 passed in 0.58s

$ git stash pop
$ pytest tests/agent/test_bedrock_streaming_reasoning_deltas.py -q
16 passed in 0.52s
```

The 4 that pass either way are guards on degenerate deltas (signature-only, non-dict, no reasoning at all) — kept so a future refactor can't regress them.

Coverage: verbatim reconstruction of the real stream; the exact `2 * (n - 1)` inflation arithmetic; blank-line count preserved at 4 not 47; the `divis`/`ors` mid-word split; distinct blocks still separated by `"\n\n"`; a single block not padded; flush on a stream that ends without `contentBlockStop`; flush on interrupt mid-block; reasoning and text not contaminating each other; reasoning surviving a following `toolUse` block; empty deltas creating no spurious separators.

No existing test asserted the old behavior, so nothing had to be rewritten to accommodate this.

**Full suites, this branch:**

```
$ pytest tests/agent/test_bedrock_1m_context.py tests/agent/test_bedrock_adapter.py \
         tests/agent/test_bedrock_empty_text_blocks.py tests/agent/test_bedrock_integration.py \
         tests/agent/test_bedrock_interrupt_post_worker.py \
         tests/agent/test_bedrock_streaming_reasoning_deltas.py -q
134 passed in 3.94s

$ ruff check agent/bedrock_adapter.py tests/agent/test_bedrock_streaming_reasoning_deltas.py
All checks passed!
```

`tests/run_agent/` has 7 failures on this branch. The identical 7 fail on unpatched `main` — Anthropic SDK streaming, switch-model reasoning-override, Nous fallback activation, Anthropic interrupt handler — so none are caused by this change. Verified by running the suite in two separate checkouts, `2a598aad1c` clean and this branch, and diffing the `FAILED` sets:

```
baseline (2a598aad1c) FAILED count: 7
this branch           FAILED count: 7
diff: IDENTICAL
```

</details>

## How to Test

```bash
pytest tests/agent/test_bedrock_streaming_reasoning_deltas.py -q
```

Against live Bedrock, with credentials and a thinking-capable model — the reproduction in the issue prints ground truth vs stored and asserts equality.

## Notes for review

- The buffer is flushed on `contentBlockStop` rather than only at the end, so a model that emits multiple thinking blocks in one turn (interleaved thinking) keeps them separated by `"\n\n"` exactly as the current code intends. `"\n\n"` was always the right separator — it was just being applied at the wrong granularity.
- Happy to fold in the non-streaming `reasoningText` read as well if you'd rather see #36260 closed in one PR instead of alongside #89671; I kept them apart so this one stays reviewable and doesn't conflict.
