### PR TITLE
fix(update): persist dashboard update receipt across restart

### DIFF
--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -57,6 +57,7 @@ class UpdateReceipt:
     """Collects the observable facts of one ``hermes update`` run."""
 
     def __init__(self) -> None:
+        self.path: Optional[Path] = None
         self.data: dict[str, Any] = {
             "schema": 1,
             "started_at": _utc_now_iso(),
@@ -152,11 +153,89 @@ def _receipt_dir() -> Path:
     return get_hermes_home() / "logs" / _RECEIPT_DIR_NAME
 
 
+def _persist_receipt(receipt: UpdateReceipt) -> Optional[Path]:
+    """Write the active receipt and stable pointer without changing outcome.
+
+    The dashboard-owned updater runs in the Dashboard service cgroup. Restarting
+    that service can therefore terminate the updater before its normal command
+    boundary finalizer runs. Persist the initial ``running`` record before any
+    restart boundary, then overwrite that same timestamped receipt at finalize.
+    """
+    try:
+        directory = _receipt_dir()
+        directory.mkdir(parents=True, exist_ok=True)
+        if receipt.path is None:
+            stamp = time.strftime("%Y%m%d_%H%M%S")
+            receipt.path = directory / f"update_{stamp}_{os.getpid()}.json"
+        payload = json.dumps(receipt.data, indent=2, default=str)
+        receipt.path.write_text(payload, encoding="utf-8")
+        # Stable pointer for the dashboard/desktop.
+        try:
+            (directory / "latest.json").write_text(payload, encoding="utf-8")
+        except OSError:
+            pass
+        _prune_old_receipts(directory)
+        return receipt.path
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Could not write update receipt: %s", exc)
+        return None
+
+
+def _receipt_pid_is_live(pid: int) -> bool:
+    """Probe an updater PID with the project's cross-platform helper."""
+    try:
+        from gateway.status import _pid_exists
+
+        return pid > 0 and bool(_pid_exists(pid))
+    except Exception:
+        return False
+
+
+def _find_persisted_receipt(payload: dict[str, Any]) -> Optional[Path]:
+    """Find the timestamped file corresponding to a running latest pointer."""
+    try:
+        pid = int(payload.get("pid"))
+        started_at = payload.get("started_at")
+        for path in sorted(
+            _receipt_dir().glob(f"update_*_{pid}.json"),
+            key=lambda candidate: candidate.stat().st_mtime,
+            reverse=True,
+        ):
+            candidate = json.loads(path.read_text(encoding="utf-8"))
+            if candidate.get("started_at") == started_at:
+                return path
+    except Exception:
+        pass
+    return None
+
+
+def recover_interrupted_update_receipt() -> Optional[Path]:
+    """Finalize a dead updater's durable ``running`` receipt as interrupted."""
+    if _current is not None:
+        return None
+    payload = read_latest_receipt()
+    if not isinstance(payload, dict) or payload.get("outcome") != "running":
+        return None
+    try:
+        pid = int(payload.get("pid"))
+    except (TypeError, ValueError):
+        return None
+    if _receipt_pid_is_live(pid):
+        return None
+    receipt = UpdateReceipt.__new__(UpdateReceipt)
+    receipt.data = payload
+    receipt.path = _find_persisted_receipt(payload)
+    receipt.finalize("interrupted")
+    receipt.data["stop_reason"] = "updater exited before finalization"
+    return _persist_receipt(receipt)
+
+
 def begin_update_receipt() -> None:
     """Start recording a new update receipt. Never raises."""
     global _current
     try:
         _current = UpdateReceipt()
+        _persist_receipt(_current)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("Could not start update receipt: %s", exc)
         _current = None
@@ -210,23 +289,7 @@ def finalize_update_receipt(
             receipt.data["stop_reason"] = stop_reason
         if fleet is not None:
             receipt.data["fleet"] = fleet
-        directory = _receipt_dir()
-        directory.mkdir(parents=True, exist_ok=True)
-        stamp = time.strftime("%Y%m%d_%H%M%S")
-        path = directory / f"update_{stamp}_{os.getpid()}.json"
-        path.write_text(
-            json.dumps(receipt.data, indent=2, default=str), encoding="utf-8"
-        )
-        # Stable pointer for the dashboard/desktop: latest receipt.
-        latest = directory / "latest.json"
-        try:
-            latest.write_text(
-                json.dumps(receipt.data, indent=2, default=str), encoding="utf-8"
-            )
-        except OSError:
-            pass
-        _prune_old_receipts(directory)
-        return path
+        return _persist_receipt(receipt)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("Could not write update receipt: %s", exc)
         return None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -383,6 +383,16 @@ def _eager_reconcile_own_session_db() -> None:
         )
 
 
+def _recover_interrupted_update_receipt_at_startup() -> None:
+    """Finalize an updater killed by this Dashboard service's restart."""
+    try:
+        from hermes_cli.update_receipt import recover_interrupted_update_receipt
+
+        recover_interrupted_update_receipt()
+    except Exception as exc:
+        _log.warning("startup update-receipt recovery failed (%s)", exc)
+
+
 @asynccontextmanager
 async def _lifespan(app: "FastAPI"):
     app.state.event_channels = {}  # dict[str, set]
@@ -393,6 +403,11 @@ async def _lifespan(app: "FastAPI"):
     # On app.state (not a module global) so the Lock binds to the running
     # event loop during lifespan startup — see _get_event_state's docstring.
     app.state.chat_argv_lock = asyncio.Lock()
+
+    # A Dashboard-triggered updater is a child of this systemd unit. A service
+    # restart can kill that child before its command-boundary receipt finalizer
+    # runs, so the replacement Dashboard resolves its persisted running record.
+    _recover_interrupted_update_receipt_at_startup()
 
     # Bring this profile's state.db schema current BEFORE the first
     # session-list poll (#79531/#80037). Migrations used to run lazily on

--- a/tests/hermes_cli/test_update_receipt.py
+++ b/tests/hermes_cli/test_update_receipt.py
@@ -106,6 +106,35 @@ class TestReceiptLifecycle:
         assert latest is not None
         assert latest["outcome"] == "partial"
 
+    def test_begin_persists_running_receipt_for_crash_recovery(self, receipt_home):
+        """A dashboard-owned updater can be killed when it restarts that service.
+
+        The durable pointer must therefore exist before the restart boundary,
+        rather than only after the updater's in-memory finalizer runs.
+        """
+        ur.begin_update_receipt()
+
+        latest = ur.read_latest_receipt()
+
+        assert latest is not None
+        assert latest["outcome"] == "running"
+        assert latest["finished_at"] is None
+        assert latest["pre_update"]
+
+    def test_recover_dead_running_receipt_as_interrupted(self, receipt_home, monkeypatch):
+        ur.begin_update_receipt()
+        ur._current = None  # Simulate the updater process dying at service restart.
+        monkeypatch.setattr(ur, "_receipt_pid_is_live", lambda _pid: False)
+
+        path = ur.recover_interrupted_update_receipt()
+
+        assert path is not None and path.is_file()
+        latest = ur.read_latest_receipt()
+        assert latest is not None
+        assert latest["outcome"] == "interrupted"
+        assert latest["finished_at"] is not None
+        assert latest["stop_reason"] == "updater exited before finalization"
+
     def test_phase_error_shape(self, receipt_home):
         ur.begin_update_receipt()
         ur.record_gateway_restart(

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -541,6 +541,20 @@ class TestWebServerEndpoints:
         # Must swallow — reads fall back to the per-poll probe heal.
         web_server._eager_reconcile_own_session_db()
 
+    def test_startup_recovers_interrupted_update_receipt(self, monkeypatch):
+        from hermes_cli import update_receipt, web_server
+
+        seen = []
+        monkeypatch.setattr(
+            update_receipt,
+            "recover_interrupted_update_receipt",
+            lambda: seen.append(True),
+        )
+
+        web_server._recover_interrupted_update_receipt_at_startup()
+
+        assert seen == [True]
+
     def test_heal_gives_up_when_reconcile_cannot_fix_the_store(self, monkeypatch):
         """A probe failure reconciliation can't cure must not retry forever.
 


### PR DESCRIPTION
## Summary

- persist an initial `running` update receipt before any restart boundary
- recover a Dashboard-owned updater killed by the Dashboard systemd cgroup as an honest `interrupted` receipt on replacement Dashboard startup
- retain the same timestamped receipt rather than creating conflicting records

## Root cause

The Dashboard starts `hermes update` as a child in its systemd control group. Restarting `hermes-dashboard.service` kills that child before its in-memory command-boundary receipt finaliser can write `update_receipts/latest.json`.

## Validation

- `26 passed, 175 deselected`
- Targeted receipt lifecycle and Dashboard-startup recovery tests passed.
- Dashboard restart, listener and authenticated HTTP redirect were verified locally.
- No active Hermes Doctor security advisory.