### PR TITLE
fix(desktop): stop re-persisting an exhausted session after cleanup

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -179,6 +179,39 @@ describe('useDesktopIntegrations', () => {
     })
   })
 
+
+    it('does not re-persist an exhausted session on a session-list refresh', () => {
+      window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/exhausted-session')
+      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'exhausted-session')
+
+      const sessions = [session({ id: 'exhausted-session', profile: 'default' })]
+
+      const result = render({ profileReady: true, sessions })
+
+      // The cleanup effect drops the remembered exhausted session...
+      result.rerender({
+        activeProfile: 'default',
+        locationPathname: '/exhausted-session',
+        profileReady: true,
+        resumeExhaustedSessionId: 'exhausted-session',
+        routedSessionId: 'exhausted-session',
+        sessions
+      })
+
+      // ...and a routine session-list refresh (same sessions, ordinary re-render)
+      // must not write the dead id back into remembered navigation.
+      result.rerender({
+        activeProfile: 'default',
+        locationPathname: '/exhausted-session',
+        profileReady: true,
+        resumeExhaustedSessionId: 'exhausted-session',
+        routedSessionId: 'exhausted-session',
+        sessions: [...sessions, session({ id: 'other-session', profile: 'default' })],
+      })
+
+      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBeNull()
+      expect(window.localStorage.getItem('hermes.desktop.lastRoute.profile.default')).toBeNull()
+    })
   describe('ownership validation', () => {
     it('refuses to restore a session route owned by another profile', () => {
       window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/ai-session')

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -157,13 +157,24 @@ export function useDesktopIntegrations({
     // non-overlay route (a page like /skills, or a session route) per profile.
     // Session-shaped routes require an explicit matching owner; unresolved and
     // wrong-profile rows must not replace known-safe navigation.
-    if (routedSessionId && sessionBelongsToProfile(sessions, routedSessionId, activeProfile)) {
+    // The resume-exhausted session must not be written back into remembered
+    // navigation: the cleanup effect above drops it once, but this
+    // persistence effect re-runs on every session-list refresh while its
+    // deps are unchanged — without the barrier the dead id outlives every
+    // restart and the window boots into the resume-error screen each time.
+    const exhausted = routedSessionId !== null && routedSessionId === resumeExhaustedSessionId
+
+    if (
+      routedSessionId &&
+      !exhausted &&
+      sessionBelongsToProfile(sessions, routedSessionId, activeProfile)
+    ) {
       setRememberedSessionId(routedSessionId, activeProfile)
       setRememberedRoute(locationPathname, activeProfile)
     } else if (!routedSessionId && !isOverlayView(appViewForPath(locationPathname))) {
       setRememberedRoute(locationPathname, activeProfile)
     }
-  }, [activeProfile, locationPathname, navigate, profileReady, routedSessionId, sessions])
+  }, [activeProfile, locationPathname, navigate, profileReady, resumeExhaustedSessionId, routedSessionId, sessions])
 
   useEffect(() => {
     if (!profileReady || !resumeExhaustedSessionId) {


### PR DESCRIPTION
## Summary

The persistence effect in `useDesktopIntegrations` re-runs on every ordinary session-list refresh (its deps include `sessions` and `locationPathname`), while the cleanup effect that drops an exhausted session id only re-runs when `activeProfile` / `profileReady` / `resumeExhaustedSessionId` change. Sitting on the exhausted session's route, the persistence guard still passes (`routedSessionId` is truthy, the row still belongs to the profile) and writes the dead id straight back into `lastSessionId` / `lastRoute` — outliving the cleanup and every restart (#98467).

This adds a write barrier: while the routed session is the resume-exhausted one, the persistence effect skips both remembered-navigation writes. `resumeExhaustedSessionId` joins the effect deps so the barrier clears as soon as the id changes.

Fixes #98467