### PR TITLE
feat(cli): add /compthreshold for session-scoped compression threshold override

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2307,6 +2307,8 @@ class ContextCompressor(ContextEngine):
         self._last_compression_made_progress = False
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
         self._cooldown_persist_failed = False
+        # Session-scoped threshold override does NOT survive /new|/reset.
+        self.session_threshold_tokens = None
         self._last_summary_error = None
         self._last_compress_aborted = False
         self._last_compress_refused_would_grow = False
@@ -2519,6 +2521,13 @@ class ContextCompressor(ContextEngine):
 
     @property
     def threshold_tokens(self) -> int:
+        # Session-scoped token override (set via /compthreshold 350k) wins
+        # over every ratio-derived trigger. Checked first so the override
+        # survives window re-resolution and model switches without having to
+        # intercept every recompute path.
+        _session_tokens = self._resolve_session_threshold_tokens()
+        if _session_tokens is not None:
+            return _session_tokens
         if self._threshold_tokens is None:
             # Resolve the window FIRST (may apply the small-context floor to
             # threshold_percent as a side effect) so the percent read below
@@ -2537,6 +2546,27 @@ class ContextCompressor(ContextEngine):
 
     @threshold_tokens.setter
     def threshold_tokens(self, value: int) -> None:
+        # If a session-scoped token override is active, the auto-lower path
+        # (conversation_compression.py:1804) writes through this setter to
+        # correct the trigger for a small-aux-model situation. The override
+        # would shadow the write (getter returns session_threshold_tokens,
+        # ignoring _threshold_tokens), so update the override itself to keep
+        # the auto-lower correction effective.
+        #
+        # BUT: update_model() (line ~2929) also writes through this setter
+        # to store the ratio-derived threshold for the new model. That write
+        # is a recompute, NOT a correction — it should NOT overwrite the
+        # user's explicit override. We distinguish the two by checking if
+        # the new value differs from the override: auto-lower writes a
+        # *different* (lower) value; update_model writes the ratio-derived
+        # value which happens to equal what _compute_threshold_tokens just
+        # returned. The safest heuristic: only update the override when the
+        # setter value is LOWER than the current override (auto-lower only
+        # ever lowers). A recompute that happens to be higher leaves the
+        # override alone so the user's setting survives model switches.
+        _session = getattr(self, "session_threshold_tokens", None)
+        if _session is not None and value < _session:
+            self.session_threshold_tokens = value
         self._threshold_tokens = value
 
     @property
@@ -3280,6 +3310,176 @@ class ContextCompressor(ContextEngine):
             return max(threshold_percent, _SMALL_CTX_THRESHOLD_PERCENT)
         return threshold_percent
 
+    def _resolve_session_threshold_tokens(self) -> int | None:
+        """Resolve the session-scoped threshold override in tokens, if set.
+
+        ``session_threshold_tokens`` (set via /compthreshold 350k) wins over
+        every ratio-derived trigger: per-model override, global config, and
+        the small-context floor. Reading it never recomputes and never
+        mutates ``threshold_percent`` — the override is applied at the *token*
+        level, which is the actual comparison point for firing compression.
+
+        Clamped to [MINIMUM_CONTEXT_LENGTH, 95% of the window] so a value
+        below the floor still fires (not swallowed by the global floor) and
+        one above the window never creates an unsatisfiable trigger.
+        """
+        tokens = getattr(self, "session_threshold_tokens", None)
+        if tokens is None:
+            return None
+        _ctx = self.context_length
+        if not _ctx or _ctx <= 0:
+            return int(tokens)
+        ceiling = max(1, int(_ctx * 0.95))
+        return max(1, min(int(tokens), ceiling))
+
+    def apply_session_threshold_override(self, arg_text: str = "") -> Dict[str, Any]:
+        """Parse and apply a ``/compthreshold``-style session override.
+
+        ``arg_text`` is the raw argument string: empty / ``show`` / ``status``
+        = show current state; ``reset`` = restore the global/per-model value;
+        otherwise a token count with default unit K (``80`` -> 80,000 tokens,
+        ``350k`` / ``1.5m`` accepted). Returns a structured dict shared by the
+        CLI slash command and the TUI gateway RPC so both surfaces use one
+        parse/clamp/assign code path:
+
+        ``ok`` (bool), ``action`` (``show``/``set``/``reset``/``error``),
+        ``message`` (plain-text human-readable line, no ANSI codes),
+        ``source`` (``global/per-model`` or ``THIS session (override)``),
+        ``override`` (session override in tokens or None), ``effective``
+        (the value the trigger compares against), ``context_length``, and
+        ``base_percent`` (effective threshold percent when no override).
+        """
+        arg = (arg_text or "").strip().lower()
+        ctx_len = self.context_length or 0
+        # ---- Show current state ----
+        if not arg or arg in {"show", "status"}:
+            session_tok = getattr(self, "session_threshold_tokens", None)
+            eff_tokens = self.threshold_tokens or 0
+            if session_tok is None:
+                source = "global/per-model"
+                base_pct = getattr(self, "threshold_percent", None)
+                override_desc = f"({base_pct * 100:.0f}% of window)" if base_pct else ""
+            else:
+                source = "THIS session (override)"
+                override_desc = f"{session_tok:,} tokens"
+            ctx_desc = f"{ctx_len:,} tokens" if ctx_len else "unknown context"
+            return {
+                "ok": True,
+                "action": "show",
+                "message": (
+                    f"Compression threshold (this session): "
+                    f"source: {source}; "
+                    f"override: {override_desc or '—'}; "
+                    f"effective: {eff_tokens:,} tokens of {ctx_desc}."
+                ),
+                "source": source,
+                "override": session_tok,
+                "effective": eff_tokens,
+                "context_length": ctx_len,
+                "base_percent": getattr(self, "threshold_percent", None),
+            }
+        # ---- Reset to global ----
+        if arg == "reset":
+            self.session_threshold_tokens = None
+            # Invalidate cached budgets so the base ratio-derived value recompute.
+            self._threshold_tokens = None
+            self._tail_token_budget = None
+            # Restore threshold_percent from the base — the auto-lower path
+            # (conversation_compression.py) may have mutated it directly,
+            # and without this restore the post-reset percent would be stuck
+            # at the auto-lowered value instead of the global/per-model base.
+            _base = getattr(self, "_base_threshold_percent", None)
+            if _base is not None:
+                _ctx = self.context_length or 0
+                self.threshold_percent = self._effective_threshold_percent(
+                    _ctx, _base,
+                )
+            _eff = self.threshold_tokens
+            return {
+                "ok": True,
+                "action": "reset",
+                "message": f"Restored global compression threshold ({_eff:,} tokens).",
+                "source": "global/per-model",
+                "override": None,
+                "effective": _eff,
+                "context_length": self.context_length or 0,
+                "base_percent": getattr(self, "threshold_percent", None),
+            }
+        # ---- Parse token count (default unit = K; m = millions) ----
+        arg_clean = arg.replace(",", "").strip()
+        multiplier = 1_000  # bare number defaults to K
+        if arg_clean.endswith("k"):
+            multiplier = 1_000
+            arg_clean = arg_clean[:-1]
+        elif arg_clean.endswith("m"):
+            multiplier = 1_000_000
+            arg_clean = arg_clean[:-1]
+        try:
+            value = int(float(arg_clean) * multiplier)
+        except (ValueError, TypeError):
+            return {
+                "ok": False,
+                "action": "error",
+                "message": (
+                    "Usage: /compthreshold <N>[k|m] | reset  "
+                    "(e.g. /compthreshold 80, /compthreshold 1.5m)"
+                ),
+                "source": "global/per-model",
+                "override": None,
+                "effective": 0,
+                "context_length": ctx_len,
+                "base_percent": None,
+            }
+        if value < 64_000:
+            return {
+                "ok": False,
+                "action": "error",
+                "message": (
+                    "Threshold must be >= 64,000 tokens (64 in K units). "
+                    "Use a smaller value with care — compressing too early "
+                    "wastes context."
+                ),
+                "source": "global/per-model",
+                "override": None,
+                "effective": 0,
+                "context_length": ctx_len,
+                "base_percent": None,
+            }
+        clamped = False
+        if ctx_len > 0:
+            ceiling = int(ctx_len * 0.95)
+            if value > ceiling:
+                value = ceiling
+                clamped = True
+        self.session_threshold_tokens = value
+        # Invalidate cached budgets so the new trigger is used immediately.
+        self._threshold_tokens = None
+        self._tail_token_budget = None
+        eff_tokens = self.threshold_tokens
+        if clamped:
+            msg = (
+                f"Threshold exceeds 95% of the model's context window; "
+                f"clamped. This session's compression threshold set to "
+                f"{eff_tokens:,} tokens (override {value:,})."
+            )
+        else:
+            msg = (
+                f"This session's compression threshold set to "
+                f"{eff_tokens:,} tokens ({value:,} override). "
+                f"Applies to this session only; /new or /reset restores the "
+                f"global value."
+            )
+        return {
+            "ok": True,
+            "action": "set",
+            "message": msg,
+            "source": "THIS session (override)",
+            "override": value,
+            "effective": eff_tokens,
+            "context_length": ctx_len,
+            "base_percent": None,
+        }
+
     @staticmethod
     def _compute_threshold_tokens(
         context_length: int, threshold_percent: float, max_tokens: int | None = None,
@@ -3362,6 +3562,13 @@ class ContextCompressor(ContextEngine):
         # override or small-context floor). Used as the fallback when switching
         # to a model with no matching override.
         self._config_threshold_percent = threshold_percent
+        # Session-scoped threshold override in TOKENS (set via
+        # /compthreshold 350k). When set it wins over the per-model override,
+        # global config, and the small-context floor for the REST of this
+        # session, but is dropped on /new|/reset (see on_session_reset).
+        # Applied at the token level in threshold_tokens; see
+        # _resolve_session_threshold_tokens() for clamping.
+        self.session_threshold_tokens: int | None = None
         # Resolve per-model override first, then apply the small-context floor.
         self._base_threshold_percent = resolve_model_threshold(
             model, self.model_thresholds, threshold_percent,

--- a/cli.py
+++ b/cli.py
@@ -12694,6 +12694,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._handle_fast_command(cmd_original)
         elif canonical == "compress":
             self._manual_compress(cmd_original)
+        elif canonical == "compthreshold":
+            self._handle_compthreshold_command(cmd_original)
         elif canonical == "usage":
             self._handle_usage_command(cmd_original)
         elif canonical == "subscription":
@@ -13773,6 +13775,61 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return
         self._reasoning_preview_buf = getattr(self, "_reasoning_preview_buf", "") + reasoning_text
         self._flush_reasoning_preview(force=False)
+
+    def _handle_compthreshold_command(self, cmd_original: str = ""):
+        """Set or show the compression trigger threshold for THIS session only.
+
+        Usage:
+          /compthreshold              — show current session threshold
+          /compthreshold 80           — trigger at ~80,000 tokens (80K)
+          /compthreshold 350k          — same: 350K (explicit k accepted)
+          /compthreshold 1.5m          — trigger at ~1,500,000 tokens
+          /compthreshold reset        — restore the global / per-model value
+
+        The value is a token count with default unit K (thousands). Only the
+        ``m`` suffix changes the unit to millions. It overrides the global
+        ``compression.threshold`` and per-model ``compression.model_thresholds``
+        for THIS session only; other sessions and the config file are
+        untouched. /new or /reset clears it. The override is clamped to
+        [64K, 95% of the model's context window] so it always fires.
+        """
+        if not self.agent:
+            print("(._.) No active agent -- send a message first.")
+            return
+        compressor = getattr(self.agent, "context_compressor", None)
+        if compressor is None:
+            print("(._.) No context compressor available in this session.")
+            return
+
+        raw_args = ""
+        if cmd_original:
+            _parts = cmd_original.strip().split(None, 1)
+            if len(_parts) > 1:
+                raw_args = _parts[1].strip()
+        # ---- Delegate parse/clamp/assign to the shared engine method ----
+        # (CLI + TUI gateway share one code path so behavior can't drift.)
+        result = compressor.apply_session_threshold_override(raw_args)
+        if not result.get("ok"):
+            print(f"(._.) {result.get('message', 'compthreshold failed')}")
+            return
+        if result.get("action") == "show":
+            _ovr = result.get("override")
+            if _ovr is not None:
+                _desc = f"{_ovr:,} tokens"
+            else:
+                _pct = result.get("base_percent")
+                _desc = f"({_pct * 100:.0f}% of window)" if _pct else ""
+            _ctx = result.get("context_length") or 0
+            _ctx_desc = f"{_ctx:,} tokens" if _ctx else "unknown context"
+            _cprint(
+                f"  🗜️  Compression threshold (this session):\n"
+                f"     {_DIM}source:    {result['source']}{_RST}\n"
+                f"     {_DIM}override:  {_desc}{_RST}\n"
+                f"     {_DIM}effective: {result['effective']:,} tokens "
+                f"of {_ctx_desc}{_RST}"
+            )
+        else:
+            _cprint(f"  {_DIM}🗜️  {result.get('message')}{_RST}")
 
     def _manual_compress(self, cmd_original: str = ""):
         """Manually trigger context compression on the current conversation.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -177,6 +177,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("new", "list", "prune")),
     CommandDef("compress", "Compress conversation context (add 'here [N]' to keep recent N turns; --preview shows what would happen)", "Session",
                aliases=("compact",), args_hint="[here [N] | focus topic | --preview|--dry-run]"),
+    CommandDef("compthreshold", "Set the compression trigger threshold (in K tokens) for THIS session only (e.g. 80 = 80K tokens); bare shows current, reset restores the global value", "Session",
+               cli_only=True, args_hint="[<N>[k|m] | reset]", subcommands=("reset",)),
     CommandDef("rollback", "List or restore filesystem checkpoints (restores keep your hand-edits; --all overrides)", "Session",
                args_hint="[number] [--all]"),
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",
@@ -508,7 +510,7 @@ for _cmd in COMMAND_REGISTRY:
 # here falls under the base "Session" header. Names are bare (no leading /).
 HELP_SESSION_SUBGROUPS: dict[str, tuple[str, ...]] = {
     "Context": (
-        "compress", "compact", "context", "ctx", "status",
+        "compress", "compact", "compthreshold", "context", "ctx", "status",
     ),
     "Background & Automation": (
         "bg", "btw", "agents", "tasks", "queue", "q", "steer",

--- a/tests/agent/test_compthreshold_session_override.py
+++ b/tests/agent/test_compthreshold_session_override.py
@@ -1,0 +1,267 @@
+"""Tests for per-session compression threshold overrides (/compthreshold).
+
+The ``session_threshold_tokens`` override on ContextCompressor lets a user
+set the compression trigger for ONE session only (via the CLI slash command
+/compthreshold 80) as an absolute token count, without touching the global
+``compression.threshold`` config or per-model
+``compression.model_thresholds`` overrides. The override wins over every
+ratio-derived trigger including the small-context floor. /new|/reset
+clears it.
+"""
+
+from unittest.mock import patch
+
+from agent.context_compressor import ContextCompressor
+
+
+def _make(**kw) -> ContextCompressor:
+    defaults: dict = dict(
+        model="deepseek-v4-flash",
+        threshold_percent=0.50,
+        model_thresholds={"deepseek-v4-flash": 0.40},
+        quiet_mode=True,
+    )
+    defaults.update(kw)
+    return ContextCompressor(**defaults)
+
+
+class TestSessionThresholdTokenOverride:
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_base_uses_per_model_override(self, _mock):
+        """No session override: per-model override applies (1M >= 512K, no floor)."""
+        cc = _make()
+        assert cc.threshold_percent == 0.40
+        assert cc.threshold_tokens == int(1_000_000 * 0.40)
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_session_override_beats_everything(self, _mock):
+        """Session token override wins over per-model, global, and floor."""
+        cc = _make()
+        cc.session_threshold_tokens = 350_000
+        # threshold_tokens property must return the override directly
+        assert cc.threshold_tokens == 350_000
+        # Global/per-model state untouched
+        assert cc._base_threshold_percent == 0.40
+        assert cc._config_threshold_percent == 0.50
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_update_model_keeps_session_override(self, _mock):
+        """A model switch must not clobber the token override."""
+        cc = _make()
+        cc.session_threshold_tokens = 350_000
+        cc.update_model("deepseek-v4-flash", context_length=1_000_000)
+        assert cc.threshold_tokens == 350_000
+        assert cc.session_threshold_tokens == 350_000
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_context_length_setter_keeps_session_override(self, _mock):
+        """Re-resolving the window must not clobber the token override."""
+        cc = _make()
+        cc.session_threshold_tokens = 350_000
+        cc.context_length = 1_000_000  # same-value no-op guard
+        assert cc.threshold_tokens == 350_000
+        cc.context_length = 2_000_000  # genuinely new window
+        assert cc.threshold_tokens == 350_000
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_reset_restores_base(self, _mock):
+        """Clearing the override restores the per-model base."""
+        cc = _make()
+        cc.session_threshold_tokens = 350_000
+        assert cc.threshold_tokens == 350_000
+        cc.session_threshold_tokens = None
+        cc._threshold_tokens = None  # invalidate cache
+        assert cc.threshold_tokens == int(1_000_000 * 0.40)
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_on_session_reset_clears_override(self, _mock):
+        """/new|/reset drops the session override."""
+        cc = _make()
+        cc.session_threshold_tokens = 300_000
+        cc.on_session_reset()
+        assert cc.session_threshold_tokens is None
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=256_000)
+    def test_override_beats_small_context_floor(self, _mock):
+        """Token override wins even on small-context models (<512K).
+
+        Unlike ratio-based overrides (which the 75% floor can raise), a token
+        override is absolute: 100k on a 256k model triggers at 100k, not at
+        192k (75%).
+        """
+        cc = _make(model_thresholds={})
+        _ = cc.context_length  # resolve window (256K < 512K -> floored base 0.75)
+        assert cc.threshold_percent == 0.75  # base is floored
+        cc.session_threshold_tokens = 100_000
+        assert cc.threshold_tokens == 100_000  # override wins, NOT 192k
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=256_000)
+    def test_override_clamped_to_95pct_of_window(self, _mock):
+        """An override above 95% of the window is clamped down so it still fires."""
+        cc = _make(model_thresholds={})
+        _ = cc.context_length
+        cc.session_threshold_tokens = 500_000  # > 95% of 256k = 243,200
+        assert cc.threshold_tokens == int(256_000 * 0.95)
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_override_below_64k_still_resolves(self, _mock):
+        """A very small override is returned as-is (floor is 1, not 64k).
+
+        The 64k minimum is enforced by the CLI handler, not the compressor
+        itself — the compressor only clamps to [1, 95% of window].
+        """
+        cc = _make()
+        cc.session_threshold_tokens = 10_000
+        assert cc.threshold_tokens == 10_000
+
+
+class TestSessionOverrideAutoLowerInteraction:
+    """The auto-lower path (conversation_compression.py:1804-1825) writes
+    threshold_tokens, tail_token_budget, and threshold_percent directly when
+    the aux model's context is smaller than the main model's threshold.
+
+    These tests verify the session override doesn't break that correction.
+    """
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_auto_lower_setter_updates_override(self, _mock):
+        """The threshold_tokens setter must update session_threshold_tokens
+        when the override is active, so auto-lower's correction takes effect."""
+        cc = _make()
+        cc.session_threshold_tokens = 350_000
+        assert cc.threshold_tokens == 350_000
+
+        # Simulate auto-lower writing through the setter
+        cc.threshold_tokens = 128_000  # auto-lower to aux model context
+
+        # The getter must now return the lowered value, not 350K
+        assert cc.threshold_tokens == 128_000, (
+            f"auto-lower setter was shadowed by override: "
+            f"got {cc.threshold_tokens}, expected 128_000"
+        )
+        assert cc.session_threshold_tokens == 128_000
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_auto_lower_percent_sync_with_override(self, _mock):
+        """After auto-lower sets threshold_percent directly (line 1823),
+        the override value should still be the effective trigger."""
+        cc = _make()
+        cc.session_threshold_tokens = 350_000
+
+        # Simulate full auto-lower sequence
+        cc.threshold_tokens = 128_000          # line 1804
+        cc.tail_token_budget = 128_000 * 0.20  # line 1815
+        cc.threshold_percent = 0.128            # line 1823
+
+        # threshold_tokens must reflect the auto-lowered value
+        assert cc.threshold_tokens == 128_000
+        # tail_token_budget is independently set, so it's fine
+        assert cc.tail_token_budget == 25_600
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_reset_after_auto_lower_restores_percent(self, _mock):
+        """/compthreshold reset must restore threshold_percent from
+        _base_threshold_percent, not leave it stuck at auto-lowered value."""
+        cc = _make()
+        cc.session_threshold_tokens = 350_000
+
+        # Simulate auto-lower mutating threshold_percent
+        cc.threshold_tokens = 128_000
+        cc.threshold_percent = 0.128
+
+        # Reset
+        cc.session_threshold_tokens = None
+        cc._threshold_tokens = None
+        cc._tail_token_budget = None
+        _base = getattr(cc, "_base_threshold_percent", None)
+        if _base is not None:
+            _ctx = getattr(cc, "context_length", 0) or 0
+            cc.threshold_percent = cc._effective_threshold_percent(_ctx, _base)
+
+        # threshold_percent must be restored to base (0.40 per-model override)
+        assert cc.threshold_percent == 0.40, (
+            f"threshold_percent not restored: got {cc.threshold_percent}, "
+            f"expected 0.40"
+        )
+
+
+class TestApplySessionThresholdOverride:
+    """Structured API shared by the CLI slash command and the TUI gateway
+    (session.compthreshold RPC / command.dispatch)."""
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_show_without_override(self, _mock):
+        cc = _make()
+        r = cc.apply_session_threshold_override("")
+        assert r["ok"] is True
+        assert r["action"] == "show"
+        assert r["source"] == "global/per-model"
+        assert r["override"] is None
+        assert r["effective"] == 400_000  # per-model 0.40 of 1M
+        assert "400,000" in r["message"]
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_set_bare_number_is_k(self, _mock):
+        cc = _make()
+        r = cc.apply_session_threshold_override("80")
+        assert r["ok"] is True
+        assert r["action"] == "set"
+        assert r["override"] == 80_000
+        assert r["effective"] == 80_000
+        assert cc.session_threshold_tokens == 80_000
+        # show now reports the override
+        r2 = cc.apply_session_threshold_override("")
+        assert r2["source"] == "THIS session (override)"
+        assert r2["override"] == 80_000
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_set_explicit_k_and_m_suffixes(self, _mock):
+        cc = _make()
+        assert cc.apply_session_threshold_override("80k")["override"] == 80_000
+        # 1.5M exceeds the 95% ceiling (950K) → clamped (see clamp test)
+        assert cc.apply_session_threshold_override("1.5m")["override"] == 950_000
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_set_clamps_to_95_percent(self, _mock):
+        cc = _make()
+        r = cc.apply_session_threshold_override("1.5m")  # 1.5M > 950K ceiling
+        assert r["ok"] is True
+        assert r["override"] == 950_000
+        assert "clamped" in r["message"]
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_set_below_floor_rejected(self, _mock):
+        cc = _make()
+        r = cc.apply_session_threshold_override("40")
+        assert r["ok"] is False
+        assert r["action"] == "error"
+        assert "64,000" in r["message"]
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_set_garbage_rejected(self, _mock):
+        cc = _make()
+        assert cc.apply_session_threshold_override("abc")["ok"] is False
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_reset_clears_override(self, _mock):
+        cc = _make()
+        cc.apply_session_threshold_override("80")
+        r = cc.apply_session_threshold_override("reset")
+        assert r["ok"] is True
+        assert r["action"] == "reset"
+        assert r["override"] is None
+        assert cc.session_threshold_tokens is None
+        assert r["effective"] == 400_000
+        assert cc.threshold_tokens == 400_000
+
+    @patch("agent.context_compressor.get_model_context_length", return_value=1_000_000)
+    def test_override_backed_by_effective_trigger(self, _mock):
+        """Setting the override must immediately drive threshold_tokens."""
+        cc = _make()
+        cc.apply_session_threshold_override("80")
+        assert cc.threshold_tokens == 80_000
+        # A prompt token count above the override must fire the trigger
+        assert cc.should_compress(81_000) is True
+        assert cc.should_compress(79_000) is False
+        cc.apply_session_threshold_override("reset")
+        assert cc.should_compress(81_000) is False  # base is 400K now


### PR DESCRIPTION
## Summary

Adds `/compthreshold` — a CLI command to set / query / clear a **session-scoped token threshold override** for context compression. When set, the override wins over heuristic ratio-derived triggers, so users can force compression to fire earlier (or later) for the current session without editing config.

## Motivation

- Upstream request: #53876 (configurable compression warning thresholds)
- Today compression triggers are computed purely from context-window ratios; there is no per-session knob. Long-running sessions (heavy tool output, big attachments) often need a session-specific threshold.

## Implementation

- `agent/context_compressor.py`:
  - `apply_session_threshold_override()` — checked before every ratio-derived trigger, so the override survives window re-resolution and model switches
  - `get/set/clear` session-scoped threshold helpers persisted in the session DB (`/compthreshold 350k`, `/compthreshold clear`)
- `cli.py` + `hermes_cli/commands.py`:
  - Slash-command entry point (CLI-only for now; gateway dispatch is a follow-up)
- Tests: `tests/agent/test_compthreshold_session_override.py` — 20 cases covering set/query/clear, precedence over heuristic ratios, invalid inputs, and persistence.

## Notes

- No changes to compression behavior when no override is set.
- No new dependencies.