### PR TITLE
fix(agent): default relay completions to the progress-hook wrapper

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3555,7 +3555,14 @@ def _relay_sync_completion(
     api_mode: str | None = None,
     create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
-    callback = create or (lambda request: client.chat.completions.create(**request))
+    # The progress hook is installed per task, so every attempt for that
+    # task must go through _create_with_progress — including auxiliary
+    # retries and provider fallbacks. Defaulting at this seam covers every
+    # call site that predates the hook or forgets to thread create= through
+    # (18 of 24 today); call sites that pass their own create= keep it.
+    if create is None:
+        create = lambda request: _create_with_progress(client, request)
+    callback = create
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     # Protected compression calls isolate only the provider callback and stream
     # aggregation.  The owning thread remains free to unwind its lease/DB
@@ -3583,7 +3590,14 @@ async def _relay_async_completion(
     api_mode: str | None = None,
     create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
-    callback = create or (lambda request: client.chat.completions.create(**request))
+    # The progress hook is installed per task, so every attempt for that
+    # task must go through _create_with_progress — including auxiliary
+    # retries and provider fallbacks. Defaulting at this seam covers every
+    # call site that predates the hook or forgets to thread create= through
+    # (18 of 24 today); call sites that pass their own create= keep it.
+    if create is None:
+        create = lambda request: _create_with_progress(client, request)
+    callback = create
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
         return await callback(kwargs)


### PR DESCRIPTION
## Summary

`_create_with_progress` was applied per call site, so auxiliary retry and fallback attempts that call `_relay_sync_completion` / `_relay_async_completion` without `create=` went out through the bare `client.chat.completions.create` — non-streaming, ticking the forward-progress hook zero times. The configured `timeout` reverted to a hard wall-clock budget and the compression hygiene watchdog (`compression.hygiene_timeout_seconds`, default 30s) killed healthy, still-generating calls at the idle deadline (#98466: 18 of 24 relay call sites pass no `create=`).

This moves the wrapper to the seam: when `create` is not supplied, both relay functions default to `_create_with_progress(client, request)`. All 18 unwrapped sites are covered at once; the 6 sites that already thread their own `create=` keep their behavior unchanged. New call sites can no longer forget the wrapper.

Behavior when no progress hook is active is byte-for-byte identical (`_create_with_progress` falls straight through to the plain create in that case), so only tasks with an installed hook change at all — and for them this restores the intended invariant from #71508: every attempt for the task streams and ticks the hook.

Fixes #98466