### PR TITLE
fix(approvals): let cron_mode govern gateway-hosted cron fires

### DIFF
--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -475,3 +475,34 @@ class TestCronWithGatewayOrigin:
         finally:
             clear_session_vars(tokens)
 
+    def test_cron_deny_ignores_gateway_interactive_and_ask_env_leaks(self, monkeypatch):
+        """A gateway-hosted cron fire must use cron_mode even when the gateway
+        process exports its interactive/ask markers.
+
+        Production regression: a citation command containing quoted text
+        ``hermes update`` was smart-approved because HERMES_INTERACTIVE=1 and
+        HERMES_EXEC_ASK=1 skipped the cron-deny branch.
+        """
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "smart")
+        monkeypatch.setattr(approval_module, "_get_cron_approval_mode", lambda: "deny")
+
+        tokens = set_session_vars(
+            platform="telegram", chat_id="123", cron_session="1"
+        )
+        try:
+            from unittest.mock import patch as mock_patch
+            with mock_patch("tools.approval._smart_approve") as smart:
+                result = check_all_command_guards(
+                    "printf %s 'hermes update'", "local"
+                )
+            assert result["approved"] is False
+            assert "cron_mode" in result["message"]
+            smart.assert_not_called()
+        finally:
+            clear_session_vars(tokens)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4714,6 +4714,18 @@ def check_all_command_guards(command: str, env_type: str,
         # either here) — ignore it so single_query_mode actually takes effect.
         is_ask = False
 
+    # Cron jobs also run inside the long-lived gateway process, which may export
+    # HERMES_INTERACTIVE=1 and HERMES_EXEC_ASK=1 for attended turns. Those are
+    # process-wide host markers, not permissions for this unattended fire. If
+    # they leak through here, the cron skips its deterministic cron_mode branch
+    # and can reach smart or human approval with nobody present (#production
+    # regression: quoted ``hermes update`` evidence was smart-approved). Cron
+    # context owns the decision exactly as single-query context does above.
+    if _is_cron_approval_context():
+        is_cli = False
+        is_gateway = False
+        is_ask = False
+
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:


### PR DESCRIPTION
### The problem

Cron jobs run inside the long-lived gateway process. That process exports `HERMES_INTERACTIVE=1` and `HERMES_EXEC_ASK=1` for its attended turns, and those markers are still set when an unattended cron fires.

`check_all_command_guards` reads them, so a cron fire looks interactive. It skips the deterministic `approvals.cron_mode` branch and falls through to smart or human approval instead, with nobody present to answer. Under `approvals.cron_mode: deny` the command is neither denied nor deterministic.

### The fix

Clear `is_cli`, `is_gateway` and `is_ask` once cron context is bound, so `approvals.cron_mode` governs. This mirrors the block immediately above it, which already clears `is_ask` so `single_query_mode` takes effect.

### Test

`test_cron_deny_ignores_gateway_interactive_and_ask_env_leaks` covers the case that surfaced this: a command containing the quoted text `hermes update`, fired by cron under `cron_mode: deny`, with the gateway's interactive and ask markers set.

Verified against `main` at 2a598aad1:

- test on unpatched `main`: fails, reaching the human-approval path
- with the fix: passes
- `tests/tools/test_cron_approval_mode.py`: 31 passed
- all `tests/tools/*approval*.py`: same 7 pre-existing failures before and after, 348 → 349 passed

The 7 unrelated failures are in `test_approval.py` and `test_approval_mode_parity.py` and are present on unpatched `main` in the same environment.
