### PR TITLE
fix(projects): deleting a project must not re-promote its folder as an auto project

### DIFF
--- a/apps/desktop/electron/api-error-envelope-wiring.test.ts
+++ b/apps/desktop/electron/api-error-envelope-wiring.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Wiring contract for the `hermes:api` 404 envelope.
+ *
+ * api-error-envelope.test.ts proves the envelope's shape; this file exercises
+ * the two functions the ENDS actually call — `settleApiRequest` in
+ * `ipcMain.handle('hermes:api')` and `unwrapApiResult` in preload's
+ * `invokeHermesApi` — so the test measures shipped behaviour rather than a copy
+ * of the handler body.
+ *
+ * What the bug was: Electron logs every rejected ipcMain.handle promise with a
+ * main-process stack trace, and a REST 404 on this channel is control flow (a
+ * fresh draft probed by id, a discarded draft's id still in renderer storage).
+ * So the log filled with stack traces for a case the renderer already handles.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { isApiErrorEnvelope, settleApiRequest, unwrapApiResult } from './api-error-envelope'
+
+// The renderer's real 404 predicate (src/lib/gateway-rpc.ts::isMissingRestEndpoint)
+// lives outside this tsconfig project, and no electron test imports across that
+// boundary. Mirror only the message pattern it keys on, so this file asserts the
+// property that matters — the message still reads as a 404 after the round trip —
+// without widening the project's file list.
+const READS_AS_404 = /(?:^\s*|error:\s*)404\b/i
+
+function httpError(statusCode: number, body: string): Error & { statusCode: number } {
+  const error = new Error(`${statusCode}: ${body}`) as Error & { statusCode: number }
+  error.statusCode = statusCode
+
+  return error
+}
+
+const sessionNotFound = () => Promise.reject(httpError(404, '{"detail":"Session not found"}'))
+
+/** The full round trip: main settles, preload unwraps. */
+const roundTrip = <T>(dispatch: () => Promise<T>) => unwrapApiResult(() => settleApiRequest(dispatch))
+
+describe('settleApiRequest (main-process side)', () => {
+  it('RESOLVES a 404 so Electron has no rejected handler promise to log', async () => {
+    // The assertion that encodes the bug: a rejection here is exactly what
+    // Electron reported as "Error occurred in handler for 'hermes:api'".
+    const result = await settleApiRequest(sessionNotFound)
+
+    expect(isApiErrorEnvelope(result)).toBe(true)
+  })
+
+  it('still rejects a 500, so genuine faults stay visible in the log', async () => {
+    await expect(settleApiRequest(() => Promise.reject(httpError(500, 'boom')))).rejects.toThrow('500: boom')
+  })
+
+  it('still rejects an auth failure and a transport failure', async () => {
+    await expect(settleApiRequest(() => Promise.reject(httpError(401, 'nope')))).rejects.toThrow('401: nope')
+    await expect(settleApiRequest(() => Promise.reject(new Error('socket hang up')))).rejects.toThrow('socket hang up')
+  })
+
+  it('passes a successful payload through untouched', async () => {
+    const payload = { id: '20260830_120000_abcdef', title: 'a session' }
+
+    await expect(settleApiRequest(() => Promise.resolve(payload))).resolves.toEqual(payload)
+  })
+})
+
+describe('unwrapApiResult (preload side)', () => {
+  it('rethrows the 404 so a fail-closed caller still sees a rejection', async () => {
+    // resolveStoredSession relies on this: an envelope leaking through as a
+    // RESOLVED object would make a missing session look like a real row.
+    await expect(roundTrip(sessionNotFound)).rejects.toThrow('404: {"detail":"Session not found"}')
+  })
+
+  it('keeps message-based 404 detection working end to end', async () => {
+    const error = await roundTrip(sessionNotFound).catch((err: unknown) => err)
+
+    expect(READS_AS_404.test((error as Error).message)).toBe(true)
+    expect((error as Error & { statusCode?: number }).statusCode).toBe(404)
+  })
+
+  it('does not swallow a payload that merely looks like an error', async () => {
+    const payload = { message: '404: not really', statusCode: 404 }
+
+    await expect(roundTrip(() => Promise.resolve(payload))).resolves.toEqual(payload)
+  })
+
+  it('leaves non-enveloped rejections reaching the renderer unchanged', async () => {
+    await expect(roundTrip(() => Promise.reject(httpError(503, 'unavailable')))).rejects.toThrow('503: unavailable')
+  })
+})

--- a/apps/desktop/electron/api-error-envelope.test.ts
+++ b/apps/desktop/electron/api-error-envelope.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The 404-envelope contract for the `hermes:api` IPC channel.
+ *
+ * Guards the two renderer-visible invariants a "stop logging this" fix could
+ * silently break: the message must survive byte-identically (404 detection is
+ * message-based), and only 404 may be enveloped — everything else has to keep
+ * rejecting so real faults stay logged.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  API_ERROR_ENVELOPE,
+  apiErrorEnvelope,
+  apiErrorFromEnvelope,
+  isApiErrorEnvelope
+} from './api-error-envelope'
+
+// The renderer's real predicate lives in src/, outside this tsconfig project.
+// The end-to-end assertion against the shipped `isMissingRestEndpoint` lives in
+// the ui project (src/lib/gateway-rpc.envelope.test.ts); here we only pin the
+// message pattern it keys on.
+const READS_AS_404 = /(?:^\s*|error:\s*)404\b/i
+
+function httpError(statusCode: number, body: string): Error & { statusCode: number } {
+  const error = new Error(`${statusCode}: ${body}`) as Error & { statusCode: number }
+  error.statusCode = statusCode
+
+  return error
+}
+
+const SESSION_404 = () => httpError(404, '{"detail":"Session not found"}')
+
+describe('apiErrorEnvelope', () => {
+  it('envelopes a 404 so the handler can resolve instead of rejecting', () => {
+    const envelope = apiErrorEnvelope(SESSION_404())
+
+    expect(envelope).not.toBeNull()
+    expect(envelope?.statusCode).toBe(404)
+    expect(isApiErrorEnvelope(envelope)).toBe(true)
+  })
+
+  it('leaves every other failure rejecting, so real faults stay logged', () => {
+    for (const error of [
+      httpError(500, 'boom'),
+      httpError(401, 'nope'),
+      httpError(502, 'bad gateway'),
+      new Error('socket hang up'),
+      Object.assign(new Error('refused'), { code: 'ECONNREFUSED' })
+    ]) {
+      expect(apiErrorEnvelope(error)).toBeNull()
+    }
+  })
+
+  it('does not treat an ordinary REST payload as an envelope', () => {
+    expect(isApiErrorEnvelope({ id: 'x', title: 'a session' })).toBe(false)
+    expect(isApiErrorEnvelope(null)).toBe(false)
+    expect(isApiErrorEnvelope('404')).toBe(false)
+    expect(isApiErrorEnvelope({ [API_ERROR_ENVELOPE]: true })).toBe(false)
+  })
+})
+
+describe('apiErrorFromEnvelope', () => {
+  it('reproduces the rejection message byte-identically', () => {
+    const original = SESSION_404()
+    const envelope = apiErrorEnvelope(original)
+    const rethrown = apiErrorFromEnvelope(envelope!)
+
+    expect(rethrown).toBeInstanceOf(Error)
+    expect(rethrown.message).toBe(original.message)
+    expect((rethrown as Error & { statusCode?: number }).statusCode).toBe(404)
+  })
+
+  it('keeps message-based 404 detection working through the envelope', () => {
+    // isMissingRestEndpoint is the real consumer: a changed message shape would
+    // silently turn "route/row missing" into "unknown failure" at every caller.
+    // Asserted against the shipped predicate in the ui-project companion test.
+    const rethrown = apiErrorFromEnvelope(apiErrorEnvelope(SESSION_404())!)
+
+    expect(READS_AS_404.test(rethrown.message)).toBe(true)
+  })
+
+  it('survives the wrapped remote-method shape the renderer also parses', () => {
+    const wrapped = httpError(404, '{"detail":"No such API endpoint: /api/x"}')
+    wrapped.message = `Error invoking remote method 'hermes:api': Error: ${wrapped.message}`
+
+    const rethrown = apiErrorFromEnvelope(apiErrorEnvelope(wrapped)!)
+
+    expect(rethrown.message).toBe(wrapped.message)
+    expect(READS_AS_404.test(rethrown.message)).toBe(true)
+  })
+})

--- a/apps/desktop/electron/api-error-envelope.ts
+++ b/apps/desktop/electron/api-error-envelope.ts
@@ -1,0 +1,129 @@
+/**
+ * IPC error envelope for the `hermes:api` channel.
+ *
+ * Electron logs EVERY rejected `ipcMain.handle` promise itself, with a full
+ * main-process stack trace and no way to opt out per channel. That is right for
+ * genuine faults and wrong for the one case the renderer treats as ordinary
+ * control flow: a REST 404.
+ *
+ * `session-tile.tsx` deliberately probes a freshly created draft by id and
+ * retries across the persist lag ("404s harmlessly for an in-memory draft that
+ * hasn't persisted a turn yet"), and `resolveStoredSession` is fail-closed on a
+ * miss by design. A discarded draft — `SessionDB.delete_session_if_empty()`
+ * removes an empty one, while its id lives on in the renderer's journal /
+ * owner-hint storage — therefore produces up to seven 404s per tile, each one
+ * logged as
+ *
+ *   Error occurred in handler for 'hermes:api': Error: 404: {"detail":"Session not found"}
+ *
+ * so a normal session of work buries the log in stack traces for a case the
+ * code already handles.
+ *
+ * The fix keeps BOTH renderer-visible contracts intact and changes only what
+ * crosses the wire:
+ *
+ *  - the handler RESOLVES with an envelope instead of rejecting, so Electron
+ *    sees a settled promise and logs nothing;
+ *  - preload rethrows an `Error` whose `message` is byte-identical to the one
+ *    the rejection produced, because 404 detection is message-based
+ *    (`isMissingRestEndpoint` in `src/lib/gateway-rpc.ts` matches
+ *    `/(?:^\s*|error:\s*)404\b/`) and `inlineErrorMessage` /
+ *    `notifications.ts` unwrap the `Error invoking remote method '…': Error: …`
+ *    shape. `statusCode` is preserved on the rethrown error.
+ *
+ * Only 404 is enveloped. Every other failure keeps rejecting and keeps being
+ * logged — a 500, a timeout or a transport error is a real fault and must stay
+ * visible.
+ */
+
+/** Marker on the envelope. Unlikely to collide with any REST response body. */
+export const API_ERROR_ENVELOPE = '__hermesApiError'
+
+export interface HermesApiErrorEnvelope {
+  [API_ERROR_ENVELOPE]: true
+  message: string
+  statusCode: number
+}
+
+/** HTTP statuses the renderer handles as control flow, so they must not be
+ *  logged as main-process faults. Deliberately just 404: a missing row or route
+ *  is an answer, whereas 5xx/timeouts are faults that must stay noisy. */
+function isEnvelopedStatus(statusCode: unknown): boolean {
+  return statusCode === 404
+}
+
+/**
+ * Wrap a caught `hermes:api` error for transport when it is one the renderer
+ * treats as control flow; return null to let the caller keep rejecting.
+ */
+export function apiErrorEnvelope(error: unknown): HermesApiErrorEnvelope | null {
+  const statusCode = (error as { statusCode?: unknown } | null)?.statusCode
+
+  if (!isEnvelopedStatus(statusCode)) {
+    return null
+  }
+
+  return {
+    [API_ERROR_ENVELOPE]: true,
+    message: error instanceof Error ? error.message : String(error ?? ''),
+    statusCode: statusCode as number
+  }
+}
+
+/** True when a resolved IPC value is an enveloped error rather than a payload. */
+export function isApiErrorEnvelope(value: unknown): value is HermesApiErrorEnvelope {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      (value as Record<string, unknown>)[API_ERROR_ENVELOPE] === true &&
+      typeof (value as HermesApiErrorEnvelope).message === 'string'
+  )
+}
+
+/**
+ * The main-process side: run the real dispatch and convert a control-flow
+ * failure into a resolved envelope so Electron has no rejected handler promise
+ * to log. Every other failure is rethrown and stays logged.
+ *
+ * `ipcMain.handle('hermes:api')` wraps its dispatch in this, and the wiring test
+ * exercises THIS function — not a copy of the handler body.
+ */
+export async function settleApiRequest<T>(dispatch: () => Promise<T>): Promise<HermesApiErrorEnvelope | T> {
+  try {
+    return await dispatch()
+  } catch (error) {
+    const envelope = apiErrorEnvelope(error)
+
+    if (envelope) {
+      return envelope
+    }
+
+    throw error
+  }
+}
+
+/**
+ * The preload side: unwrap an envelope back into the exact rejection the caller
+ * would have received, and pass any real payload through untouched.
+ */
+export async function unwrapApiResult<T>(invoke: () => Promise<HermesApiErrorEnvelope | T>): Promise<T> {
+  const result = await invoke()
+
+  if (isApiErrorEnvelope(result)) {
+    throw apiErrorFromEnvelope(result)
+  }
+
+  return result as T
+}
+
+/**
+ * Rebuild the Error the renderer would have received from a rejection. The
+ * message is passed through verbatim so message-based 404 detection and the
+ * remote-method unwrappers behave exactly as before.
+ */
+export function apiErrorFromEnvelope(envelope: HermesApiErrorEnvelope): Error {
+  const error = new Error(envelope.message) as Error & { statusCode?: number }
+  error.statusCode = envelope.statusCode
+
+  return error
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,6 +31,7 @@ import {
 } from 'electron'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { settleApiRequest } from './api-error-envelope'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
@@ -16022,6 +16023,17 @@ async function handleHermesApiRequest(request) {
 }
 
 ipcMain.handle('hermes:api', async (_event, request) => {
+  // Electron logs every rejected ipcMain.handle promise with a main-process
+  // stack trace. A REST 404 is control flow here, not a fault (session-tile
+  // probes a fresh draft by id and retries across the persist lag; a discarded
+  // draft's id lives on in renderer storage), so those rejections buried the
+  // log in stack traces for a case the renderer already handles.
+  // `settleApiRequest` resolves an envelope for those and preload rethrows it
+  // byte-identically; everything else keeps rejecting and keeps being logged.
+  return settleApiRequest(() => dispatchHermesApiRequest(request))
+})
+
+async function dispatchHermesApiRequest(request) {
   // Hold the deletion gate for BOTH profile deletes and renames: a concurrent
   // renderer reconnect entering ensureBackend() mid-mutation would otherwise
   // respawn the old-name backend and recreate its HERMES_HOME (#45474).
@@ -16049,7 +16061,7 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   const releaseProfileDeletion = profileDeletionGate.acquire(mutatingProfile)
 
   return handleHermesApiRequest(request).finally(releaseProfileDeletion)
-})
+}
 
 // One deduper per cross-window cue — the choke point every window shares. Main
 // handles IPC serially, so the first window to claim a key wins with no race.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,5 +1,7 @@
 import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 
+import { unwrapApiResult } from './api-error-envelope'
+
 // Which translucency the OS can back. Asked synchronously because the renderer
 // needs it before its first paint, and answered by main because deciding it
 // needs `os.release()` — a sandboxed preload may only require electron, events,
@@ -10,6 +12,16 @@ import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 const translucencySupport = ipcRenderer.sendSync('hermes:translucency:support')
 const hudWindowing = ipcRenderer.sendSync('hermes:hud:windowing')
 const hudNativeDrag = hudWindowing?.nativeDrag === true
+
+// `hermes:api` resolves an error ENVELOPE for statuses the renderer treats as
+// control flow (a REST 404), because a rejected ipcMain.handle promise is logged
+// by Electron itself with a main-process stack trace — noise for a case the
+// renderer already handles. `unwrapApiResult` turns the envelope back into the
+// exact rejection the caller would otherwise have seen: same message (404
+// detection is message-based), same statusCode. Everything else rejects as
+// before. The helper module is import-safe in the sandboxed preload: it pulls in
+// no node builtins, only plain functions bundled into electron-preload.js.
+const invokeHermesApi = request => unwrapApiResult(() => ipcRenderer.invoke('hermes:api', request))
 
 contextBridge.exposeInMainWorld('hermesDesktop', {
   glassSupported: translucencySupport?.glass === true,
@@ -221,7 +233,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     remember: name => ipcRenderer.invoke('hermes:profile:remember', name),
     set: name => ipcRenderer.invoke('hermes:profile:set', name)
   },
-  api: request => ipcRenderer.invoke('hermes:api', request),
+  api: request => invokeHermesApi(request),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readWindowBelow: () => ipcRenderer.invoke('hermes:window:readBelow'),

--- a/apps/desktop/src/lib/gateway-rpc.envelope.test.ts
+++ b/apps/desktop/src/lib/gateway-rpc.envelope.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The renderer half of the `hermes:api` 404-envelope contract.
+ *
+ * `isMissingRestEndpoint` decides 404 from the error MESSAGE, so the envelope
+ * that stops Electron logging control-flow 404s (electron/api-error-envelope.ts)
+ * must reproduce that message byte-identically. The electron-project tests can't
+ * import from `src/`, so the assertion against the SHIPPED predicate lives here.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { apiErrorEnvelope, apiErrorFromEnvelope } from '../../electron/api-error-envelope'
+
+import { isMissingRestEndpoint } from './gateway-rpc'
+
+function httpError(statusCode: number, body: string): Error & { statusCode: number } {
+  const error = new Error(`${statusCode}: ${body}`) as Error & { statusCode: number }
+  error.statusCode = statusCode
+
+  return error
+}
+
+describe('isMissingRestEndpoint through the IPC error envelope', () => {
+  it('still recognises a bare session 404 after the round trip', () => {
+    const rethrown = apiErrorFromEnvelope(apiErrorEnvelope(httpError(404, '{"detail":"Session not found"}'))!)
+
+    expect(isMissingRestEndpoint(rethrown)).toBe(true)
+  })
+
+  it('still recognises a missing route 404 after the round trip', () => {
+    const rethrown = apiErrorFromEnvelope(
+      apiErrorEnvelope(httpError(404, '{"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}'))!
+    )
+
+    expect(isMissingRestEndpoint(rethrown)).toBe(true)
+  })
+
+  it('still recognises the wrapped remote-method shape', () => {
+    const wrapped = httpError(404, '{"detail":"Session not found"}')
+    wrapped.message = `Error invoking remote method 'hermes:api': Error: ${wrapped.message}`
+
+    const rethrown = apiErrorFromEnvelope(apiErrorEnvelope(wrapped)!)
+
+    expect(isMissingRestEndpoint(rethrown)).toBe(true)
+  })
+
+  it('does not turn a transient failure into a capability verdict', () => {
+    // 500s and transport errors are never enveloped, so they keep rejecting and
+    // must not read as "endpoint missing" either.
+    expect(apiErrorEnvelope(httpError(500, 'boom'))).toBeNull()
+    expect(isMissingRestEndpoint(httpError(500, 'boom'))).toBe(false)
+    expect(isMissingRestEndpoint(new Error('socket hang up'))).toBe(false)
+  })
+})

--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -424,6 +424,9 @@ def create_project(
                 "VALUES (?, ?, ?, ?, ?)",
                 (pid, path, None, 1 if path == primary else 0, now),
             )
+        # Re-creating a project on a previously deleted folder is newer intent
+        # than the delete, so its tombstone goes away with it.
+        _clear_tombstones_locked(conn, folder_paths)
     return pid
 
 
@@ -543,6 +546,9 @@ def add_folder(
             ).fetchone()
             if existing_primary is None:
                 _set_primary_locked(conn, project_id, norm)
+        # Attaching a previously deleted folder to a live project is the same
+        # newer intent as re-creating it, so drop its tombstone too.
+        _clear_tombstones_locked(conn, [norm])
     return norm
 
 
@@ -625,9 +631,25 @@ def restore_project(conn: sqlite3.Connection, project_id: str) -> bool:
 
 
 def delete_project(conn: sqlite3.Connection, project_id: str) -> bool:
-    """Hard-delete a project and its folders (cascade)."""
+    """Hard-delete a project and its folders (cascade).
+
+    The folders are tombstoned in the same transaction. Without that, a folder
+    that still holds sessions is re-promoted as an AUTO project on the very next
+    tree read: the row reappears in place, keeping the path and only swapping the
+    user's name for the directory leaf, so the delete looks like a no-op and the
+    row can no longer be deleted at all (an auto row only offers a local dismiss).
+    """
     with write_txn(conn):
+        folders = [
+            row["path"]
+            for row in conn.execute(
+                "SELECT path FROM project_folders WHERE project_id = ?",
+                (project_id,),
+            )
+        ]
         cur = conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
+        if cur.rowcount > 0:
+            _tombstone_folders_locked(conn, folders)
     return cur.rowcount > 0
 
 
@@ -638,6 +660,70 @@ def delete_project(conn: sqlite3.Connection, project_id: str) -> bool:
 
 _ACTIVE_META_KEY = "active_id"
 _DISCOVERY_POLICY_META_KEY = "repo_discovery_policy"
+# One meta row per deleted folder: ``tombstone:<normcase path>`` -> path. Keyed
+# per folder (not one JSON blob) so concurrent deletes of different projects
+# can't clobber each other's entry under last-writer-wins.
+_TOMBSTONE_META_PREFIX = "tombstone:"
+
+
+def _tombstone_key(path: str) -> str:
+    """The meta key for a folder's tombstone, or ``""`` for an empty path."""
+    norm = _normalize_path(path)
+    return f"{_TOMBSTONE_META_PREFIX}{os.path.normcase(norm)}" if norm else ""
+
+
+def _tombstone_folders_locked(
+    conn: sqlite3.Connection, paths: Iterable[str]
+) -> None:
+    """Record folders as deleted (caller already holds a write txn)."""
+    for path in paths:
+        key = _tombstone_key(path)
+        if key:
+            conn.execute(
+                "INSERT INTO project_meta (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (key, _normalize_path(path)),
+            )
+
+
+def _clear_tombstones_locked(
+    conn: sqlite3.Connection, paths: Iterable[str]
+) -> None:
+    """Drop folders' tombstones (caller already holds a write txn)."""
+    for path in paths:
+        key = _tombstone_key(path)
+        if key:
+            conn.execute("DELETE FROM project_meta WHERE key = ?", (key,))
+
+
+def is_folder_tombstoned(conn: sqlite3.Connection, path: str) -> bool:
+    """Whether an explicit project on ``path`` was deleted.
+
+    The tree builder consults this so a deleted project's folder is not
+    re-promoted as an AUTO project while sessions remain in it — without this
+    the row reappears in place (same path, directory-leaf label) and the delete
+    reads as a no-op.
+    """
+    key = _tombstone_key(path)
+    if not key:
+        return False
+    row = conn.execute(
+        "SELECT 1 FROM project_meta WHERE key = ?", (key,)
+    ).fetchone()
+    return row is not None
+
+
+def tombstoned_folders(conn: sqlite3.Connection) -> set[str]:
+    """Every folder whose explicit project was deleted (normalized paths).
+
+    One query per tree read; the gateway turns this into the builder's
+    ``is_tombstoned`` predicate instead of hitting the DB per candidate folder.
+    """
+    rows = conn.execute(
+        "SELECT value FROM project_meta WHERE key LIKE ?",
+        (f"{_TOMBSTONE_META_PREFIX}%",),
+    ).fetchall()
+    return {row["value"] for row in rows if row["value"]}
 
 
 def set_active(conn: sqlite3.Connection, project_id: Optional[str]) -> None:

--- a/tests/hermes_cli/test_projects_db.py
+++ b/tests/hermes_cli/test_projects_db.py
@@ -125,6 +125,85 @@ def test_find_by_primary_path(conn):
 
 
 
+def test_delete_project_tombstones_its_folders(conn):
+    # Deleting a project records its folders so the tree builder does not
+    # re-promote them as auto projects (which would make the delete a no-op).
+    pid = pdb.create_project(
+        conn, name="Quarkus", folders=["/ws/main-quarkus", "/ws/extra"]
+    )
+
+    assert pdb.is_folder_tombstoned(conn, "/ws/main-quarkus") is False
+
+    pdb.delete_project(conn, pid)
+
+    assert pdb.is_folder_tombstoned(conn, "/ws/main-quarkus") is True
+    assert pdb.is_folder_tombstoned(conn, "/ws/extra") is True
+    assert pdb.is_folder_tombstoned(conn, "/ws/unrelated") is False
+
+
+def test_tombstones_survive_a_reconnect(tmp_path):
+    # The suppression has to outlive the process: the tree is rebuilt on every
+    # app start, and an in-memory-only tombstone would let the row come back.
+    db = tmp_path / "projects.db"
+    first = pdb.connect(db_path=db)
+    try:
+        pid = pdb.create_project(first, name="Gone", folders=["/ws/gone"])
+        pdb.delete_project(first, pid)
+    finally:
+        first.close()
+
+    second = pdb.connect(db_path=db)
+    try:
+        assert pdb.is_folder_tombstoned(second, "/ws/gone") is True
+    finally:
+        second.close()
+
+
+def test_creating_a_project_clears_the_tombstone(conn):
+    # Re-creating a project on a deleted folder is newer intent than the delete.
+    pid = pdb.create_project(conn, name="Again", folders=["/ws/again"])
+    pdb.delete_project(conn, pid)
+    assert pdb.is_folder_tombstoned(conn, "/ws/again") is True
+
+    pdb.create_project(conn, name="Again 2", folders=["/ws/again"])
+
+    assert pdb.is_folder_tombstoned(conn, "/ws/again") is False
+
+
+def test_adding_a_folder_clears_its_tombstone(conn):
+    # Same intent via the other write path: attaching a previously deleted
+    # folder to a live project must un-suppress it.
+    gone = pdb.create_project(conn, name="Gone", folders=["/ws/shared"])
+    pdb.delete_project(conn, gone)
+    keeper = pdb.create_project(conn, name="Keeper", folders=["/ws/keeper"])
+
+    pdb.add_folder(conn, keeper, "/ws/shared")
+
+    assert pdb.is_folder_tombstoned(conn, "/ws/shared") is False
+
+
+def test_tombstone_lookup_normalizes_the_path(conn):
+    # The builder passes git roots as reported by git; the store's own folders
+    # are normalized, so both spellings must resolve to the same tombstone.
+    pid = pdb.create_project(conn, name="Norm", folders=["/ws/norm"])
+    pdb.delete_project(conn, pid)
+
+    assert pdb.is_folder_tombstoned(conn, "/ws/norm/") is True
+    assert pdb.is_folder_tombstoned(conn, "") is False
+
+
+def test_tombstoned_folders_lists_every_suppressed_path(conn):
+    # The gateway builds one predicate per tree read, so it needs the whole set
+    # in a single query rather than a lookup per candidate folder.
+    a = pdb.create_project(conn, name="A", folders=["/ws/a"])
+    b = pdb.create_project(conn, name="B", folders=["/ws/b1", "/ws/b2"])
+    pdb.create_project(conn, name="Live", folders=["/ws/live"])
+    pdb.delete_project(conn, a)
+    pdb.delete_project(conn, b)
+
+    assert pdb.tombstoned_folders(conn) == {"/ws/a", "/ws/b1", "/ws/b2"}
+
+
 def test_per_profile_isolation(tmp_path):
     # Two distinct DB paths stand in for two profiles' HERMES_HOME.
     a = pdb.connect(db_path=tmp_path / "a" / "projects.db")

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -547,6 +547,98 @@ def test_exists_defaults_to_keeping_everything():
     assert [p["id"] for p in tree["projects"]] == ["/remote/workspace"]
 
 
+def test_deleted_project_folder_does_not_return_as_an_auto_project():
+    # Deleting an explicit project whose folder still holds sessions must not
+    # re-promote that same folder as an AUTO project on the very next tree read.
+    # The row reappears in place, keeping the path and only swapping the user's
+    # name for the directory leaf, which reads as "delete did nothing" — and the
+    # only action left on it is a local dismiss, so the project cannot be
+    # removed at all while any session remains in its folder.
+    resolve = _resolver({"/ws/main-quarkus": ("/ws/main-quarkus", "/ws/main-quarkus")})
+    sessions = [_session("/ws/main-quarkus", branch="main")]
+
+    tree = pt.build_tree(
+        [],
+        sessions,
+        [],
+        resolve,
+        hydrate=True,
+        exists=lambda _p: True,
+        is_tombstoned=lambda path: path == "/ws/main-quarkus",
+    )
+
+    assert _real_project_ids(tree) == []
+    # The session itself survives — it falls back to Home, never disappears.
+    assert _home_session_ids(tree) == [sessions[0]["id"]]
+
+
+def test_tombstone_only_suppresses_the_deleted_folder():
+    # A tombstone is per-folder, so a sibling workspace keeps its auto project.
+    resolve = _resolver(
+        {
+            "/ws/gone": ("/ws/gone", "/ws/gone"),
+            "/ws/kept": ("/ws/kept", "/ws/kept"),
+        }
+    )
+    sessions = [_session("/ws/gone", branch="main"), _session("/ws/kept", branch="main")]
+
+    tree = pt.build_tree(
+        [],
+        sessions,
+        [],
+        resolve,
+        hydrate=True,
+        is_tombstoned=lambda path: path == "/ws/gone",
+    )
+
+    assert _real_project_ids(tree) == ["/ws/kept"]
+
+
+def test_tombstone_never_overrides_an_explicit_project():
+    # Re-creating a project on a tombstoned path must win: the explicit row is
+    # the user's newer intent, and Tier 1 must not be filtered by a stale
+    # tombstone (the store clears it on create, this is the belt-and-braces).
+    resolve = _resolver({"/ws/again": ("/ws/again", "/ws/again")})
+    sessions = [_session("/ws/again", branch="main")]
+    projects = [_project("p_1", "Again", ["/ws/again"])]
+
+    tree = pt.build_tree(
+        projects,
+        sessions,
+        [],
+        resolve,
+        hydrate=True,
+        is_tombstoned=lambda _path: True,
+    )
+
+    assert _real_project_ids(tree) == ["p_1"]
+
+
+def test_is_tombstoned_defaults_to_promoting_everything():
+    # Omitting the predicate (older callers, remote backends) keeps the previous
+    # behavior — guessing "deleted" would wrongly hide a live workspace.
+    sessions = [_session("/ws/plain")]
+
+    tree = pt.build_tree([], sessions, [], lambda _cwd: None, hydrate=True)
+
+    assert _real_project_ids(tree) == ["/ws/plain"]
+
+
+def test_tombstoned_discovered_repo_is_not_promoted():
+    # Tier 3 (disk-scan repos with no loaded sessions) promotes independently of
+    # Tier 2, so a deleted project's folder must be suppressed there too or the
+    # row simply comes back from the scan cache instead.
+    tree = pt.build_tree(
+        [],
+        [],
+        [{"root": "/ws/scanned", "label": "scanned", "sessions": 0, "last_active": 0}],
+        lambda _cwd: None,
+        is_tombstoned=lambda path: path == "/ws/scanned",
+    )
+
+    assert _real_project_ids(tree) == []
+
+
 def test_sibling_probe_is_bounded():
     # Each miss costs a git invocation, and this runs per session, so a deeply
     # nested unresolvable cwd must not fan out into an unbounded probe storm.

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -822,3 +822,63 @@ def test_projects_without_a_profile_stay_on_the_launch_home(monkeypatch, tmp_pat
     assert not (Path(os.environ["HERMES_HOME"]) / "projects.db").exists()
 
 
+
+def test_deleting_a_project_with_sessions_removes_its_row_from_the_tree(
+    monkeypatch, tmp_path
+):
+    """The reported bug, end to end through the real RPCs.
+
+    Deleting a project whose folder still holds sessions used to re-promote that
+    same folder as an AUTO project in the very next ``projects.tree`` — the row
+    reappeared in place with the same path and only the directory-leaf label, so
+    the delete read as a no-op and the row could not be removed at all (an auto
+    row only offers a local dismiss).
+    """
+    launch_home = _profile_dir(tmp_path, "launch")
+    repo = tmp_path / "repos" / "main-quarkus"
+    (repo / ".git").mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home})
+
+    with _serving_launch_profile(launch_home):
+        created = _call(
+            "projects.create",
+            {"name": "version42-adapter-ng", "folders": [str(repo)]},
+        )["project"]
+        _create_session(launch_home, "in-the-project", repo)
+
+        before = _call("projects.tree")
+        assert created["id"] in [p["id"] for p in before["projects"]]
+
+        _call("projects.delete", {"id": created["id"]})
+        after = _call("projects.tree")
+
+    ids = [p["id"] for p in after["projects"] if p["id"] != "__no_project__"]
+    # Neither the explicit row NOR an auto row on the same folder may survive.
+    assert ids == []
+    assert str(repo) not in ids
+
+
+def test_recreating_a_deleted_project_folder_works_again(monkeypatch, tmp_path):
+    """A tombstone must not lock the folder out of ever being a project again."""
+    launch_home = _profile_dir(tmp_path, "launch")
+    repo = tmp_path / "repos" / "again"
+    (repo / ".git").mkdir(parents=True)
+    _bind_profiles(monkeypatch, tmp_path, {"default": launch_home})
+
+    with _serving_launch_profile(launch_home):
+        first = _call("projects.create", {"name": "Again", "folders": [str(repo)]})[
+            "project"
+        ]
+        _create_session(launch_home, "still-here", repo)
+        _call("projects.delete", {"id": first["id"]})
+
+        second = _call("projects.create", {"name": "Again 2", "folders": [str(repo)]})[
+            "project"
+        ]
+        tree = _call("projects.tree")
+
+    rows = [p for p in tree["projects"] if p["id"] != "__no_project__"]
+    assert [p["id"] for p in rows] == [second["id"]]
+    assert rows[0]["label"] == "Again 2"
+    # The session that kept the folder alive is claimed by the new project.
+    assert rows[0]["sessionCount"] == 1

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -42,6 +42,16 @@ Resolve = Callable[[str], Optional[dict]]
 # project that lives on the other host.
 Exists = Callable[[str], bool]
 
+# A "was an explicit project on this folder deleted?" predicate, injected like
+# ``Resolve`` and ``Exists`` so the builder stays pure. Deleting a project whose
+# folder still holds sessions would otherwise re-promote that same folder as an
+# AUTO project in the very next tree read: the row reappears in place with the
+# same path, only swapping the user's name for the directory leaf, so the delete
+# reads as a no-op and the row's only remaining action is a local dismiss.
+# Defaults to "nothing was deleted", which preserves the previous behavior for
+# callers that carry no tombstone store.
+IsTombstoned = Callable[[str], bool]
+
 # Only KANBAN-TASK worktrees (`<repo>/.worktrees/t_<hex>`, the `t_…` id kanban_db
 # mints) collapse into one lane; user-named "New worktree" dirs under
 # `.worktrees/` stay as their own lanes.
@@ -567,6 +577,7 @@ def build_tree(
     is_junk_root: Optional[Callable[[str], bool]] = None,
     is_junk_cwd: Optional[Callable[[str], bool]] = None,
     exists: Optional[Exists] = None,
+    is_tombstoned: Optional[IsTombstoned] = None,
 ) -> dict:
     """Build the authoritative project tree.
 
@@ -581,7 +592,10 @@ def build_tree(
     projects are honored regardless. ``exists`` reports whether a directory is
     still on disk, so a session whose workspace was DELETED (a removed worktree,
     a scratch dir under /tmp) doesn't get promoted to a phantom AUTO project;
-    omit it (remote backends) to keep every candidate.
+    omit it (remote backends) to keep every candidate. ``is_tombstoned`` reports
+    whether an explicit project on that folder was DELETED, so the folder is not
+    re-promoted as an AUTO project on the next read (which would make the delete
+    look like a no-op); omit it to promote every candidate as before.
 
     Returns ``{"projects": [...], "scoped_session_ids": [...]}``. When
     ``hydrate`` is False (overview), lane ``sessions`` arrays are emptied but
@@ -592,6 +606,11 @@ def build_tree(
     _junk = is_junk_root or (lambda _root: False)
     _junk_cwd = is_junk_cwd or (lambda _cwd: False)
     _exists = exists or (lambda _path: True)
+    # An explicit project always wins over its own tombstone: re-creating a
+    # project on a previously deleted folder is the user's newer intent, so Tier 1
+    # is never filtered here (the store clears the tombstone on create; this keeps
+    # a stale entry from hiding a live project either way).
+    _tombstoned = is_tombstoned or (lambda _path: False)
     folder_index = _FolderIndex(active_projects)
 
     by_project: dict[str, list[dict]] = {}
@@ -660,8 +679,11 @@ def build_tree(
             # A real git root uses the stricter repo policy. Do not reinterpret a
             # filtered internal repo as a cwd-only project. A root that no longer
             # exists is a stale persisted value (the repo was deleted after the
-            # session ran) and must not resurrect as a project.
-            if not _junk(root) and _exists(root):
+            # session ran) and must not resurrect as a project. A root whose
+            # explicit project the user just DELETED must not resurrect either —
+            # otherwise the delete silently downgrades the row to an auto project
+            # in place instead of removing it.
+            if not _junk(root) and _exists(root) and not _tombstoned(root):
                 _add_auto(root, session)
             else:
                 homeless.append(session)
@@ -683,7 +705,7 @@ def build_tree(
         # with its parent, a removed /tmp scratch dir), promoting it mints a
         # phantom project that can never be opened and can only be dismissed by
         # hand. The session goes to Home instead.
-        if placement and _exists(placement["repo_key"]):
+        if placement and _exists(placement["repo_key"]) and not _tombstoned(placement["repo_key"]):
             _add_auto(placement["repo_key"], session)
         else:
             homeless.append(session)
@@ -730,7 +752,12 @@ def build_tree(
         info = resolve(raw_root) if resolve else None
         root = (info or {}).get("repo_root") or raw_root
         root_key = _path_key(root)
-        if root_key in seen or _junk(root) or _project_for_path(folder_index, root):
+        if (
+            root_key in seen
+            or _junk(root)
+            or _tombstoned(root)
+            or _project_for_path(folder_index, root)
+        ):
             continue
         seen.add(root_key)
         label = repo.get("label") or base_name(root) or root

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15110,13 +15110,16 @@ def _project_tree_row(r: dict) -> dict:
 
 def _project_tree_inputs(
     db, session_limit: int, *, include_discovered: bool
-) -> tuple[list[dict], list[dict], list[dict], str | None]:
-    """Gather (sessions, projects, discovered_repos, active_id) for build_tree.
+) -> tuple[list[dict], list[dict], list[dict], str | None, set[str]]:
+    """Gather (sessions, projects, discovered_repos, active_id, tombstones).
 
     ``include_discovered`` is the zero-session-repo overview tier; the entered
     view (drill-in) skips it entirely — it only needs the project it's showing,
     which already has sessions — avoiding the distinct-cwd scan + git probes on
     that per-turn path. One projects.db connection serves both reads.
+
+    ``tombstones`` are the folders whose explicit project was deleted, read in
+    the same connection so the builder can suppress re-promoting them.
     """
     rows = db.list_sessions_rich(
         limit=session_limit,
@@ -15150,6 +15153,7 @@ def _project_tree_inputs(
             )
         projects = [p.to_dict() for p in pdb.list_projects(conn)]
         active_id = pdb.get_active_id(conn)
+        tombstones = pdb.tombstoned_folders(conn)
         # backfill stays off the hot tree path — grouping uses the live resolver.
         discovered = (
             _discover_repos_payload(
@@ -15162,7 +15166,7 @@ def _project_tree_inputs(
             else []
         )
 
-    return sessions, projects, discovered, active_id
+    return sessions, projects, discovered, active_id, tombstones
 
 
 # Per-build memo for `_dir_exists_cached`. Cleared at the top of every
@@ -15186,6 +15190,29 @@ def _dir_exists_cached(path: str) -> bool:
     return hit
 
 
+def _tombstone_predicate(tombstones: set[str]):
+    """A ``build_tree(is_tombstoned=…)`` predicate over one build's tombstones.
+
+    The builder passes paths as git/sessions report them, while the store holds
+    normalized ones, so both sides are compared through the store's own key —
+    otherwise a trailing separator or a case difference silently misses and the
+    deleted project's row comes back.
+    """
+    if not tombstones:
+        return None
+
+    from hermes_cli.projects_db import _tombstone_key
+
+    keys = {_tombstone_key(path) for path in tombstones}
+    keys.discard("")
+
+    def is_tombstoned(path: str) -> bool:
+        key = _tombstone_key(path)
+        return bool(key) and key in keys
+
+    return is_tombstoned
+
+
 def _build_project_tree(
     db, *, preview_limit: int, hydrate: bool, session_limit: int, include_discovered: bool
 ) -> tuple[dict, str | None]:
@@ -15193,7 +15220,7 @@ def _build_project_tree(
     from tui_gateway import project_tree
 
     _DIR_EXISTS_CACHE.clear()
-    sessions, projects, discovered, active_id = _project_tree_inputs(
+    sessions, projects, discovered, active_id, tombstones = _project_tree_inputs(
         db, session_limit, include_discovered=include_discovered
     )
     # build_tree resolves every declared project folder and every discovered
@@ -15213,6 +15240,7 @@ def _build_project_tree(
         is_junk_root=_is_repo_junk,
         is_junk_cwd=_is_session_cwd_junk,
         exists=_dir_exists_cached,
+        is_tombstoned=_tombstone_predicate(tombstones),
     )
     return tree, active_id
 


### PR DESCRIPTION
## The bug

Deleting an explicit project whose folder still holds sessions is effectively impossible.

`projects.delete` does its job — `DELETE FROM projects`, `rowcount > 0`, the row is gone from `projects.list`. But the `projects.tree` refresh that `deleteProject()` fires immediately afterwards (`apps/desktop/src/store/projects.ts:1143`) re-promotes the very same folder through `_add_auto`, so the row comes straight back in place: same path, same position in the sidebar, only the user's project name swapped for the directory leaf.

To the user this reads as "delete did nothing". Worse, the row is then genuinely undeletable — an auto row's only destructive action is `Remove from sidebar`, which is a local dismiss (`dismissAutoProject`), not a delete.

Reported against a project whose folder held **63 sessions**. The reporter deleted three of them and nothing changed, which is expected once the mechanism is clear: any single remaining session in the folder is enough to re-promote it.

## Reproduction

Measured against the running install's own databases (173 real sessions, the reporter's `projects.db`), before the fix:

```
BEFORE  target row: ('p_1243f742', 'version42-adapter-ng', isAuto=False)
AFTER   delete:     ('/…/datona-version42-adapter-ng-workspace/main-quarkus', 'main-quarkus', isAuto=True)
```

Same path, new label, `isAuto` flipped. After the fix, the same run:

```
AFTER   any row for that project/path: NONE
```

## The fix

Record a per-folder tombstone in `project_meta` when a project is deleted, in the same write transaction — the folders are read *before* the cascade drops them.

`build_tree` takes an injected `is_tombstoned` predicate, the same shape as the existing `exists` / `resolve` injections, so the builder stays pure and unit-testable. It is consulted at **all three** promotion sites:

- the tier-2 git-root rung,
- the tier-2 path-only fallback,
- tier 3 (disk-scan repos).

Each promotes independently, so suppressing only one lets the row return by another route. Sessions are never lost — they fall back to Home.

**Explicit projects always win over a tombstone.** `create_project` and `add_folder` clear it, and tier 1 is never filtered, so re-creating a project on a previously deleted folder works and a stale entry can never hide a live project. Omitting the predicate preserves the previous behaviour for callers with no tombstone store (remote backends, older call sites).

Keyed one meta row per folder rather than a single JSON blob, so concurrent deletes of different projects cannot clobber each other under last-writer-wins. Lookups normalise through the store's own key, because the builder passes paths as git reports them while the store holds normalised ones — a trailing separator or case difference would otherwise miss silently and the row would come back.

## Tests

Mutation-proofed per rung, since a green test that cannot fail proves nothing:

| mutation | goes red | stays green |
|---|---|---|
| tier-2 guard reverted | exactly the 2 tier-2 tests | 36 |
| tier-3 guard reverted | exactly its own test | 37 |
| gateway wiring dropped | **only** the end-to-end delete test | 32 |
| `create`-clears-tombstone removed | only that test | 12 |

The gateway-wiring row is the one that matters: with the predicate no longer passed, the single test that encodes the reported symptom fails and nothing else moves.

New coverage:

- `tests/tui_gateway/test_project_tree.py` — the builder contract: deleted folder not re-promoted, tombstones are per-folder, explicit project beats tombstone, omitted predicate promotes everything as before, tier-3 suppression.
- `tests/hermes_cli/test_projects_db.py` — store contract: delete tombstones its folders, tombstones survive a reconnect (the tree is rebuilt on every app start, so an in-memory-only suppression would let the row return), create/add_folder clear them, path normalisation, the bulk `tombstoned_folders` read.
- `tests/tui_gateway/test_projects_rpc.py` — end to end through the real RPCs against a temp `HERMES_HOME`: delete a project whose folder holds a session and assert no row of either kind survives; then re-create on the same folder and assert it works and claims the session.

Suite: **746 passed across the 90 affected files**, no pre-existing failures in that set.

## Notes for review

- One production caller of `build_tree` (`tui_gateway/server.py::_build_project_tree`); `_project_tree_inputs` gained the tombstone set, read inside the existing `connect_closing()` so no second connection is opened.
- `tombstoned_folders()` is one query per tree build, turned into the predicate — not a DB hit per candidate folder.
- No schema migration: `project_meta` already exists and is a KV table.
