### PR TITLE
fix(desktop): stop old SSH sessions from spawning duplicate backends

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -79,6 +79,7 @@ import {
   setBusy,
   setMessages
 } from '@/store/session'
+import { sessionOwnerRouteForOpen } from '@/store/session-request-router'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
@@ -992,17 +993,13 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     // against whichever cached row is found first — the user clicks a row
     // previewing profile A and the resume dials profile B. Pin the row's own
     // (connection, profile) as the resume owner before navigating; untagged
-    // rows (single-profile installs, legacy pages) keep the id-only path.
+    // rows inherit the active registry source (or the legacy local door when
+    // no registry source is active).
     onResumeSession: (sessionId, session) => {
-      const rowProfile = session?.profile?.trim()
+      const ownerRoute = sessionOwnerRouteForOpen(session, activeConnectionId)
 
-      if (rowProfile) {
-        requestSessionResume(sessionId, {
-          connectionId: session?.connection_id?.trim() || 'local',
-          ...(session?.connection_id?.trim() ? {} : { mode: 'local' as const }),
-          profile: rowProfile,
-          targetProfile: rowProfile
-        })
+      if (ownerRoute) {
+        requestSessionResume(sessionId, ownerRoute)
       }
 
       openSession(sessionId, navigate)

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -77,7 +77,9 @@ const {
   setPrimaryGateway
 } = await import('./gateway')
 
-const { requestForSessionProfile, sessionRpcNeedsProfileRoute } = await import('./session-request-router')
+const { requestForSessionProfile, sessionOwnerRouteForOpen, sessionRpcNeedsProfileRoute } =
+  await import('./session-request-router')
+
 const { $connectionsRegistry } = await import('./connection-registry-state')
 
 function installDesktop(): void {
@@ -175,6 +177,31 @@ describe('sessionRpcNeedsProfileRoute', () => {
   it('pins a route owner with a connectionId', () => {
     expect(sessionRpcNeedsProfileRoute({ connectionId: 'local', profile: 'developer' })).toBe(true)
     expect(sessionRpcNeedsProfileRoute({ connectionId: '', profile: 'developer' })).toBe(false)
+  })
+})
+
+describe('sessionOwnerRouteForOpen', () => {
+  it('keeps a connection-tagged row on its authoritative source', () => {
+    expect(
+      sessionOwnerRouteForOpen({ connection_id: 'source-a', profile: 'worker' }, 'source-b')
+    ).toEqual({ connectionId: 'source-a', profile: 'worker', targetProfile: 'worker' })
+  })
+
+  it('routes an untagged existing row through the active registry source', () => {
+    expect(sessionOwnerRouteForOpen({ profile: 'default' }, 'forge')).toEqual({
+      connectionId: 'forge',
+      profile: 'default',
+      targetProfile: 'default'
+    })
+  })
+
+  it('preserves the legacy local fallback when no registry source is active', () => {
+    expect(sessionOwnerRouteForOpen({ profile: 'developer' }, null)).toEqual({
+      connectionId: 'local',
+      mode: 'local',
+      profile: 'developer',
+      targetProfile: 'developer'
+    })
   })
 })
 

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -43,6 +43,37 @@ export function sessionOwnerRouteFromRow(
   return { connectionId, profile: String(row?.profile ?? '').trim() || 'default' }
 }
 
+/**
+ * Resolve the exact owner captured by a sidebar open intent.
+ *
+ * Unified-list rows from another registered source carry `connection_id` and
+ * remain authoritative. Rows returned directly by the active backend can be
+ * untagged, however; those inherit the active registry connection instead of
+ * being mislabeled as local. Only a legacy window with no registry identity
+ * falls back to the local profile door.
+ */
+export function sessionOwnerRouteForOpen(
+  row: { connection_id?: null | string; profile?: null | string } | null | undefined,
+  activeConnectionId: null | string | undefined
+): SessionOwnerRoute | undefined {
+  const profile = String(row?.profile ?? '').trim()
+
+  if (!profile) {
+    return undefined
+  }
+
+  const rowConnectionId = String(row?.connection_id ?? '').trim()
+  const activeConnection = String(activeConnectionId ?? '').trim()
+  const connectionId = rowConnectionId || activeConnection || 'local'
+
+  return {
+    connectionId,
+    ...(rowConnectionId || activeConnection ? {} : { mode: 'local' as const }),
+    profile,
+    targetProfile: profile
+  }
+}
+
 // ── Session-scoped RPC routing (the #89206 class) ───────────────────────────
 // A session-scoped RPC (session.resume / session.activate / session.usage /
 // prompt.submit) only means anything on the backend that OWNS the session's


### PR DESCRIPTION
## What does this PR do?

Opening a pre-existing session from an active remote SSH connection now reuses that live connection instead of routing an untagged session row through the local backend door. This prevents each click from spawning a duplicate backend and leaving the selected session blank.

### Symptom

On Windows Desktop with a remote SSH gateway selected, clicking a session that existed before the current launch can start another `hermes serve` process on the remote host and render an empty session workspace.

### Impact

Affected users cannot reliably reopen existing sessions and accumulate duplicate remote backend processes on each attempt.

### Bug Cause

**Trigger:** `apps/desktop/src/app/contrib/wiring.tsx` / `onResumeSession` when the selected row has a profile but no `connection_id`.

**Causal chain:**
1. The active remote backend returns its own session rows without a `connection_id` tag.
2. The sidebar open handler treated every untagged row as explicitly local and captured `{ connectionId: "local", profile }` as its owner.
3. Session resume then dialed a different registry scope instead of recognizing the already-live remote primary, which spawned another backend and could not recover the selected runtime state.

**Why it is wrong:** An untagged row from the active backend is scoped to the active connection. Missing a cross-connection tag does not mean that the row belongs to the local connection.

**Working sibling / contrast:** Rows merged from another registered connection already carry `connection_id` and route correctly to that authoritative source. Sessions created during the current launch also retain an exact owner hint.

**Ruled out:** The registry primary/last-used selection was not the cause; the report confirms both values already name the SSH connection, and the failure occurs after that connection is live.

### Fix

A single owner resolver now preserves a row's explicit connection, otherwise inherits the active registry connection, and only falls back to the legacy local door when no registry identity exists. The sidebar uses that resolver before requesting resume. Focused tests cover tagged rows, untagged remote rows, and legacy local mode.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session-request-router.ts` - resolve open-time session owners against the active registry source.
- `apps/desktop/src/app/contrib/wiring.tsx` - use the shared resolver for sidebar session opens.
- `apps/desktop/src/store/session-request-router.test.ts` - cover authoritative, inherited remote, and legacy local routes.

## How to Test

1. Configure an SSH connection as primary and last-used, then launch Desktop and wait for its gateway to connect.
2. Click a session that predates the current launch and confirm it opens on the existing backend without a new backend lock or port.
3. Run the automated routing and Desktop checks:

```bash
cd apps/desktop
npx vitest run src/store/session-request-router.test.ts src/app/session/hooks/use-session-actions.test.tsx src/store/session.test.ts src/store/connections.test.ts
npm run typecheck
npx eslint --no-warn-ignored src/store/session-request-router.ts src/store/session-request-router.test.ts src/app/contrib/wiring.tsx
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop Vitest, typecheck, and ESLint checks and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the routing logic on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is covered by code comments and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - the regression is connection-routing behavior covered by the focused tests above.
