### PR TITLE
feat: surface two SSH gaps to the model — shell-out guidance + backend target host

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1269,6 +1269,27 @@ def _probe_remote_backend(env_type: str) -> str | None:
     return formatted
 
 
+def _ssh_target_summary() -> str:
+    """Return ``user@host[:port]`` for the configured SSH backend, or ``""``.
+
+    Read from the same ``TERMINAL_SSH_*`` env vars ``_get_env_config`` uses
+    (config.yaml ``terminal.ssh_*`` keys are exported to these at startup),
+    so the hint names the machine the backend actually connects to. The probe
+    reports the remote OS/user/cwd but never *which* host — without this the
+    agent is told it is on some remote Linux box with no way to name it.
+    Destination only: the key path never enters the prompt.
+    """
+    host = (os.getenv("TERMINAL_SSH_HOST") or "").strip()
+    if not host:
+        return ""
+    user = (os.getenv("TERMINAL_SSH_USER") or "").strip()
+    target = f"{user}@{host}" if user else host
+    port = (os.getenv("TERMINAL_SSH_PORT") or "").strip()
+    if port and port != "22":
+        target = f"{target}:{port}"
+    return target
+
+
 def _clear_backend_probe_cache() -> None:
     """Test helper — drop the backend probe cache so monkeypatched backends take effect."""
     _BACKEND_PROBE_CACHE.clear()
@@ -1286,7 +1307,10 @@ def build_environment_hints() -> str:
       modal, daytona, ssh, vercel_sandbox): host info is **suppressed**
       because the agent's tools can't touch the host — only the backend
       matters. A live probe inside the backend reports its OS, user, $HOME,
-      and cwd. Falls back to a static summary if the probe fails.
+      and cwd. Falls back to a static summary if the probe fails. For the
+      **ssh** backend the configured ``user@host[:port]`` is named alongside
+      the backend, since the probe reports the remote OS/user/cwd but not
+      which host they belong to.
 
     The WSL environment hint is appended unchanged when running under WSL.
     """
@@ -1333,9 +1357,11 @@ def build_environment_hints() -> str:
     else:
         # --- Remote backend block (host info suppressed) ---
         probe = _probe_remote_backend(backend)
+        ssh_target = _ssh_target_summary() if backend == "ssh" else ""
+        backend_label = f"{backend} ({ssh_target})" if ssh_target else backend
         if probe:
             hints.append(
-                f"Terminal backend: {backend}. Your `terminal`, `read_file`, "
+                f"Terminal backend: {backend_label}. Your `terminal`, `read_file`, "
                 f"`write_file`, `patch`, and `search_files` tools all operate "
                 f"inside this {backend} environment — NOT on the machine "
                 f"where Hermes itself is running. The host OS, home, and cwd "
@@ -1347,7 +1373,7 @@ def build_environment_hints() -> str:
                 backend, f"a {backend} environment (likely Linux)"
             )
             hints.append(
-                f"Terminal backend: {backend}. Your `terminal`, `read_file`, "
+                f"Terminal backend: {backend_label}. Your `terminal`, `read_file`, "
                 f"`write_file`, `patch`, and `search_files` tools all operate "
                 f"inside {description} — NOT on the machine where Hermes "
                 f"itself runs. The backend probe didn't respond at "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -850,6 +850,71 @@ class TestEnvironmentHints:
 
 
 
+    def test_ssh_backend_hint_names_the_target_host(self, monkeypatch):
+        """The probe reports the remote OS/user/cwd but never WHICH host.
+
+        Without the target the agent is told it is on "a remote host reached
+        over SSH" with no way to name the machine it is standing on — so it
+        can't reason about which box a path, service, or log belongs to.
+        """
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "build-01.example.com")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "ubuntu")
+        monkeypatch.delenv("TERMINAL_SSH_PORT", raising=False)
+        monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: None)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Terminal backend: ssh (ubuntu@build-01.example.com)" in result
+        # Host suppression still holds — the target is not a host-info leak.
+        assert "User home directory:" not in result
+
+    def test_ssh_target_named_on_the_probe_success_path_too(self, monkeypatch):
+        """The live probe is the common path — the target must land there as
+        well, not just in the fallback."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "build-01.example.com")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "ubuntu")
+        monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: "  OS: Linux 6.8.0")
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Terminal backend: ssh (ubuntu@build-01.example.com)" in result
+        assert "OS: Linux 6.8.0" in result
+
+    def test_ssh_target_includes_non_default_port_only(self, monkeypatch):
+        """Port 22 is noise; anything else is load-bearing for the agent."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "box")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "dev")
+
+        monkeypatch.setenv("TERMINAL_SSH_PORT", "22")
+        assert _pb._ssh_target_summary() == "dev@box"
+
+        monkeypatch.setenv("TERMINAL_SSH_PORT", "2222")
+        assert _pb._ssh_target_summary() == "dev@box:2222"
+
+    def test_ssh_target_omitted_when_host_unset(self, monkeypatch):
+        """No configured host → no parenthetical, and never a bare '@'."""
+        import agent.prompt_builder as _pb
+        monkeypatch.delenv("TERMINAL_SSH_HOST", raising=False)
+        monkeypatch.setenv("TERMINAL_SSH_USER", "ubuntu")
+        assert _pb._ssh_target_summary() == ""
+
+    def test_ssh_target_never_leaks_the_key_path(self, monkeypatch):
+        """Destination only — a private-key path must not reach the prompt."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "box")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "dev")
+        monkeypatch.setenv("TERMINAL_SSH_KEY", "/home/dev/.ssh/id_ed25519_prod")
+        monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: None)
+        _pb._clear_backend_probe_cache()
+        assert "id_ed25519_prod" not in _pb.build_environment_hints()
+
     def test_remote_backend_list_covers_known_sandboxes(self):
         """Regression guard: if someone adds a remote backend, they must list it here."""
         import agent.prompt_builder as _pb

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -106,3 +106,27 @@ def test_validate_workdir_still_blocks_metachars_in_unicode_paths():
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
     assert terminal_tool._count_real_sudo_invocations("grep sudo README.md") == 0
     assert terminal_tool._count_real_sudo_invocations("sudo a; sudo b") == 2
+
+
+def test_terminal_description_steers_ssh_away_from_the_devnull_traps():
+    """Reaching a host other than the configured backend means shelling out.
+
+    Two traps make that shell-out fail in ways the tool surface doesn't hint
+    at: commands run with stdin on /dev/null (`local.py`, `base.py`), so any
+    prompt dies unanswered; and the only in-tree ssh example (the
+    pinggy-tunnel skill) uses `UserKnownHostsFile=/dev/null`, which discards
+    the host key on every connection. Both must be called out.
+    """
+    desc = terminal_tool.TERMINAL_TOOL_DESCRIPTION
+    assert "ssh" in desc
+    assert "BatchMode=yes" in desc
+    assert "StrictHostKeyChecking=accept-new" in desc
+    assert "UserKnownHostsFile=/dev/null" in desc
+
+
+def test_pty_param_names_ssh_as_an_interactive_case():
+    """`pty` already supports the SSH backend but only advertised REPL-style
+    CLIs, so the model never reached for the one flag that fixes a prompting
+    ssh command."""
+    pty = terminal_tool.TERMINAL_SCHEMA["parameters"]["properties"]["pty"]
+    assert "ssh" in pty["description"]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1084,6 +1084,7 @@ Foreground (default): returns INSTANTLY when the command finishes, even with a h
 Background: set background=true (returns a session_id). Pair with notify_on_complete=true for bounded tasks; leave silent only for servers/daemons that never exit. Never use nohup/setsid/trailing '&' — use background=true so Hermes tracks the process. After starting a server, verify readiness with a health check, then act in a separate call; no blind sleep loops. Manage with process(action="poll"/"wait").
 Working directory: use 'workdir' for per-command cwd. When a command changes the session cwd (cd, pushd), the result includes a "cwd" field — trust it instead of prefixing every command with 'cd'.
 PTY: set pty=true for interactive CLIs (they hang without it). Pipe git output to cat if it might page.
+Remote hosts: ssh/scp run from here with stdin on /dev/null, so password/passphrase/host-key prompts fail instead of asking. Use key auth with `-o BatchMode=yes -o StrictHostKeyChecking=accept-new`; if a prompt is unavoidable, pty=true (local/ssh backends only). Don't pass `-o UserKnownHostsFile=/dev/null` for a real host — it discards host keys and breaks where /dev/null isn't writable.
 """
 
 # Global state for environment lifecycle management
@@ -3766,7 +3767,7 @@ TERMINAL_SCHEMA = {
             },
             "pty": {
                 "type": "boolean",
-                "description": "Run in pseudo-terminal (PTY) mode for interactive CLI tools like Codex, Claude Code, or Python REPL. Only works with local and SSH backends. Default: false.",
+                "description": "Run in pseudo-terminal (PTY) mode for interactive CLI tools like Codex, Claude Code, a Python REPL, or `ssh` to a remote host that has to prompt. Without it stdin is /dev/null and every prompt fails unanswered. Only works with local and SSH backends. Default: false.",
                 "default": False
             },
             "notify_on_complete": {

--- a/website/docs/user-guide/features/tools.md
+++ b/website/docs/user-guide/features/tools.md
@@ -222,7 +222,7 @@ process(action="kill", session_id="proc_abc123")   # Terminate
 process(action="write", session_id="proc_abc123", data="y")  # Send input
 ```
 
-PTY mode (`pty=true`) enables interactive CLI tools like Codex and Claude Code.
+PTY mode (`pty=true`) enables interactive CLI tools like Codex and Claude Code, and `ssh` to a host that has to prompt. Without it commands run with stdin on `/dev/null`, so a password, passphrase, or host-key confirmation fails unanswered rather than asking. PTY mode works on the local and SSH backends only.
 
 ## Sudo Support
 


### PR DESCRIPTION
## What does this PR do?

The SSH backend works. Two things about working with SSH are invisible to the model, and this PR surfaces both. No behavior change to the backend, no new tool, no new config — these are prompt-surface fixes.

**1. The model isn't told how to shell out to `ssh`.** The SSH backend covers "run everything on that host". It doesn't cover "reach a host other than the configured one" — a deploy target, a box named mid-conversation, `scp` to somewhere else. That is a shell-out through `terminal`, and two properties of this environment make it fail in ways nothing on the tool surface hints at:

*Commands run with stdin on `/dev/null`* — `stdin=subprocess.DEVNULL` in `environments/local.py:1540` and `environments/base.py:371`. So ssh cannot prompt; password, passphrase, and host-key confirmation all fail unanswered rather than asking:

```
$ ssh -o StrictHostKeyChecking=accept-new user@host   # via terminal
Pseudo-terminal will not be allocated because stdin is not a terminal.
```

`pty=true` fixes this and has supported the local and SSH backends all along — but its description advertised only "Codex, Claude Code, or Python REPL", so the model never reached for it.

*The only in-tree ssh example teaches `UserKnownHostsFile=/dev/null`* — `optional-skills/devops/pinggy-tunnel/SKILL.md` uses it in eight places, and it's what agents copy because it's the only example they have. Correct for a throwaway tunnel endpoint; wrong for a real host, where it discards the host key on every connection so nothing is ever pinned. Where the known-hosts target isn't writable, ssh additionally emits

```
Failed to add the host to the list of known hosts (/dev/null).
```

which reads as a failure in tool output. That one is a warning, not fatal — the connection proceeds — but it's noise the agent then has to reason about.

**2. On the ssh backend, the model isn't told which host it's on.** `build_environment_hints` correctly suppresses host info for remote backends and probes the backend for OS, `$HOME`, cwd and user. For ssh that leaves a gap the probe can't close: it reports what the remote box *looks like* but never *which box it is*. The agent sees "a remote host reached over SSH" and has no way to name the machine it's standing on — so it can't reason about which host a path, service, or log belongs to. Now:

```
Terminal backend: ssh (ubuntu@build-01.example.com). Your `terminal`, `read_file`, ...
```

### Why this approach

Both additions live in the **stable, cached** prompt tier, read once at build time and static per process — the same mechanism as the backend detection immediately above them. Nothing per-turn, nothing that mutates a cached prefix.

`_ssh_target_summary()` deliberately does **not** scan `~/.ssh/config`: that would put the user's whole host inventory into every prompt, and `~/.ssh` is already treated as strict-sensitive by `tools/approval.py` and `tools/threat_patterns.py`. It emits the destination only — the key path never enters the prompt (there's a test for that). Port 22 is elided as noise.

The `BatchMode=yes` shape of the guidance matches what `hermes_cli/doctor.py:1994` and `hermes_cli/setup.py:1629` already do when they probe an SSH host, so the model is pointed at the same idiom the CLI uses.

## Related Issue

No existing issue — found while debugging why an agent asked to reach a remote box emitted `Failed to add the host to the list of known hosts (/dev/null)` and then failed to get a session, rather than connecting cleanly. Happy to file one if you'd prefer that first.

I searched open and merged PRs/issues for overlap. Closest, neither overlapping: #38010 (profile isolation in environment hints) and #68341 (hostname in environment hints).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/terminal_tool.py` — one line added to `TERMINAL_TOOL_DESCRIPTION` pointing at `-o BatchMode=yes -o StrictHostKeyChecking=accept-new` for one-shot commands and `pty=true` (scoped to the local/ssh backends, the only ones that support it) when a prompt is unavoidable; `ssh` named in the `pty` parameter description.
- `agent/prompt_builder.py` — new `_ssh_target_summary()`; `Terminal backend: ssh (user@host[:port])` in both the probe-success and probe-fallback branches.
- `tests/agent/test_prompt_builder.py` — 5 tests: target on the probe-success and probe-fallback paths, non-default-port-only, empty when host unset, key-path non-leakage (+ host suppression still holds).
- `tests/tools/test_terminal_tool.py` — 2 tests pinning the ssh guidance and the `pty` description.
- `website/docs/user-guide/features/tools.md` — the PTY paragraph described only "Codex and Claude Code" and omitted both ssh and the reason the flag exists.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/tools/test_terminal_tool.py`
2. Configure `TERMINAL_ENV=ssh` with `TERMINAL_SSH_HOST` / `TERMINAL_SSH_USER` and start Hermes. The environment hint now names the target instead of the bare `Terminal backend: ssh.`
3. On a local backend, ask the agent to run something on a remote host. It should reach for key auth + `BatchMode`/`accept-new`, or `pty=true`, instead of a bare `ssh` that dies on the `/dev/null` stdin.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partial, see below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu on WSL2, Python 3.12

On the test checkbox: I ran `tests/agent` and `tests/tools` rather than the whole suite, in a venv built from the standard install plus `pyyaml`/`requests`/`httpx`/`openai`/`python-dotenv`/`wcwidth`. Six files under `tests/tools` (browser_cdp, clipboard, mcp_oauth_metadata, mcp_tool, skill_bundle_provenance, slack_send_message_media) couldn't be collected in my env for missing optional deps and were skipped. Everything that could run passed. CI is the authoritative check here.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `build_environment_hints` docstring, and the PTY paragraph in `website/docs/user-guide/features/tools.md`
- [x] `cli-config.yaml.example` — N/A, no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact considered — the changes are prompt strings and env-var reads, no platform-specific code paths
- [x] I've updated tool descriptions/schemas — that's the substance of the `tools/terminal_tool.py` half

## Notes for review

- The `pinggy-tunnel` skill still uses `UserKnownHostsFile=/dev/null`, which is legitimate for ephemeral tunnel endpoints, so the new wording says "for a real host" rather than forbidding the flag outright. Rewriting that skill felt like a separate PR — happy to do it if you'd rather they read consistently.
- The description line ships in every request, so it costs tokens per turn. I trimmed it once already; if you'd still rather it were shorter, or split so only the `pty` half lands, say the word and I'll cut it.
- Not attempted here: letting an agent reach a *second* host mid-session. A `host` parameter on `terminal` routing through the existing `SSHEnvironment` (ControlMaster and file-sync are already there) would do it, but it widens the approval surface considerably and should be its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6DyhPVVoTgF1ZSAcnp9F
