### PR TITLE
fix(vision): tolerate bare path:/local: pseudo-scheme in image_url

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -115,6 +115,43 @@ class TestLocalBackend:
         assert res.data == svg_bytes
 
 
+class TestPseudoScheme:
+    """Some local models (notably gpt-oss) return a filesystem path they were
+    handed as ``image_url: /abs/path`` but prefix a bare ``path:`` / ``local:``
+    pseudo-scheme onto it. It is not a real URI (no ``//``), so it fell through
+    to the path branch and failed as "media file not found"."""
+
+    @pytest.mark.asyncio
+    async def test_path_pseudo_scheme_prefix_is_stripped(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        img = tmp_path / "img_deadbeef.jpg"
+        img.write_bytes(PNG)
+        res = await isrc.resolve_image_source(
+            f"path:{img}", isrc.ResolveContext())
+        assert res.data == PNG
+        assert res.origin == "file"
+
+    @pytest.mark.asyncio
+    async def test_local_pseudo_scheme_prefix_with_space_is_stripped(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        img = tmp_path / "pic.png"
+        img.write_bytes(PNG)
+        res = await isrc.resolve_image_source(
+            f"local: {img}", isrc.ResolveContext())
+        assert res.data == PNG
+        assert res.origin == "file"
+
+    @pytest.mark.asyncio
+    async def test_real_unsupported_scheme_still_rejected(self, tmp_path, monkeypatch):
+        """The strip must not swallow a genuine URI scheme."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        with pytest.raises(isrc.UnsupportedScheme):
+            await isrc.resolve_image_source(
+                "s3://bucket/key.png", isrc.ResolveContext())
+
+
 class TestNonLocalBackendConfinement:
     """The security model: under a sandbox backend, host reads are confined to
     the media caches; every other path is read inside the sandbox."""

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -91,6 +91,13 @@ class ResolvedImage:
 # ("C:\x.png") don't match because they lack the "//".
 _SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
 
+# Some local models (notably gpt-oss) hand back a filesystem path they were
+# given as `image_url: /abs/path` but prefix a bare "path:" / "local:" pseudo-
+# scheme onto it ("path:/home/.../img.jpg"). That is not a real URI (no "//"),
+# so it falls through to the path branch and fails as "media file not found".
+# Strip the pseudo-scheme when it is immediately followed by a path character.
+_PSEUDO_SCHEME_RE = re.compile(r"^(?:path|local)\s*[:=]\s*(?=[/~.])", re.IGNORECASE)
+
 
 async def resolve_image_source(
     src: str,
@@ -101,6 +108,7 @@ async def resolve_image_source(
     if not isinstance(src, str) or not src.strip():
         raise SourceNotFound("image_url is required", src=str(src))
     s = src.strip()
+    s = _PSEUDO_SCHEME_RE.sub("", s, count=1)
     if s.startswith("data:"):
         data, mime = _resolve_data_url(s)
         return _finalize(data, mime, "data", s, permitted)


### PR DESCRIPTION
## What does this PR do?

On the text image-routing path (main agent model has no native vision),
`gateway/run.py::_enrich_message_with_image_analysis` pre-runs `vision_analyze`
and injects the description plus the cache path so the model can re-examine the
image:

    [If you need a closer look, use vision_analyze with image_url: /home/<user>/.hermes/cache/images/img_XXXX.jpg ~]

Some local models — reproducibly `gpt-oss:20b` via Ollama — then call
`vision_analyze` with the path mangled to `image_url="path:/home/.../img_XXXX.jpg"`.
`resolve_image_source` doesn't recognise the bare `path:` prefix: it has no
`//`, so `_SCHEME_RE` doesn't match and it isn't rejected as an unsupported
scheme either — it falls through to the filesystem branch and fails as
`media file not found: 'path:/home/.../img_XXXX.jpg'`. The agent then tells the
user it can't access the image, even though the pre-analysis read the same
file successfully seconds earlier.

`resolve_image_source` already special-cases `file://`, `data:`, and
`http(s)://`; this just makes it tolerate the bare `path:` / `local:` prefix
models emit. The prefix is stripped only when immediately followed by a path
character (`/`, `~`, `.`), so genuine URI schemes are untouched.

## Related Issue

Fixes #98428

Related: #91787 (different root cause — a fully hallucinated non-existent path
plus a follow-on HTTP 500 cascade — but the same entry point: a `vision_analyze`
call whose `image_url` the resolver can't turn into bytes).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/image_source.py`: add `_PSEUDO_SCHEME_RE` and strip a leading
  `path:` / `local:` pseudo-scheme in `resolve_image_source` before the
  data:/http/path dispatch.
- `tests/tools/test_image_source.py`: `TestPseudoScheme` — `path:` and
  `local:` prefixes resolve to the real file; a genuine unsupported scheme
  (`s3://`) still raises `UnsupportedScheme`.

## How to Test

1. Point `auxiliary.vision` at a working vision model but keep the **main**
   agent model non-multimodal (any text-only Ollama model), so image routing
   resolves to `text`.
2. Send a photo to the bot with a caption like "what is this?".
3. Before this change: `vision_analyze` is re-called with
   `image_url="path:/…/img.jpg"` and fails `media file not found`; the bot
   says it can't open the image.
4. After this change: the `path:` prefix is stripped, the cached file
   resolves, and the analysis returns normally.
5. `venv/bin/python -m pytest tests/tools/test_image_source.py -q` → 22 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_image_source.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux Mint 22.3 (Ubuntu 24.04 base), x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behaviour-only fix; the new module constant is commented inline)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — regex is path-separator agnostic; only strips a leading `path:`/`local:` token before a `/`, `~`, or `.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
