### PR TITLE
fix(state): audit-log end_session/reopen_session with the calling module

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7201,12 +7201,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with a different reason. Use ``reopen_session()`` first if you
         intentionally need to re-end a closed session with a new reason.
         """
+        # Audit trail (#98495): an end write on a still-live gateway session
+        # row is invisible today — the writer cannot be identified from logs,
+        # only inferred from the next routing self-heal warning. Record who
+        # ended what and why. Frame 1 is the direct caller; taken here because
+        # _execute_write runs _do synchronously but with extra frames in between.
+        _cf = sys._getframe(1)
+        _caller = f"{_cf.f_globals.get('__name__', '?')}.{_cf.f_code.co_name}"
+
         def _do(conn):
-            conn.execute(
+            updated = conn.execute(
                 "UPDATE sessions SET ended_at = ?, end_reason = ? "
                 "WHERE id = ? AND ended_at IS NULL",
                 (time.time(), end_reason, session_id),
             )
+            if updated.rowcount:
+                logger.info(
+                    "Session ended: session=%s reason=%s caller=%s",
+                    session_id, end_reason, _caller,
+                )
+            else:
+                logger.debug(
+                    "Session end no-op (already ended, first reason wins): "
+                    "session=%s reason=%s caller=%s",
+                    session_id, end_reason, _caller,
+                )
         self._execute_write(_do)
 
     def reopen_session(self, session_id: str) -> None:
@@ -7215,6 +7234,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Before clearing a reset boundary, stabilize markerless legacy reset
         children that still depend on the parent's mutable end_reason.
         """
+        _cf = sys._getframe(1)
+        _caller = f"{_cf.f_globals.get('__name__', '?')}.{_cf.f_code.co_name}"
+
         def _do(conn):
             placeholders = ",".join("?" for _ in _RESET_END_REASONS)
             # WHERE shape shared with _RESET_CHILD_SQL's fallback arm via
@@ -7230,10 +7252,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 f"AND {_legacy_reset_child_sql('child', placeholders)}",
                 (session_id, *_RESET_END_REASONS),
             )
+            _was_ended = conn.execute(
+                "SELECT ended_at FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
             conn.execute(
                 "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
                 (session_id,),
             )
+            if _was_ended and _was_ended[0] is not None:
+                # Only the ended -> open transition is interesting: that is
+                # the stale-route recovery path silently resurrecting a row
+                # (#54878 self-heal), the counterpart of the end audit above.
+                logger.info(
+                    "Session reopened: session=%s caller=%s",
+                    session_id, _caller,
+                )
         self._execute_write(_do)
 
     def promote_to_session_reset(

--- a/tests/hermes_state/test_98495_end_reopen_audit_log.py
+++ b/tests/hermes_state/test_98495_end_reopen_audit_log.py
@@ -1,0 +1,76 @@
+"""Session end/reopen writes must identify their caller (#98495).
+
+A live gateway session row was transiently marked ended (end_reason set on a
+row still serving turns) and silently reopened by the #54878 stale-route
+self-heal — four times in one day across two profiles. Because
+``end_session()`` / ``reopen_session()`` logged nothing, the writer could
+not be identified from logs at all; only the downstream routing warning was
+visible. These tests pin the audit trail: every end write records
+session/reason/caller, the first-reason-wins no-op stays at DEBUG, and only
+the ended -> open transition of a reopen is worth an INFO line.
+"""
+import logging
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def test_end_session_logs_reason_and_caller(db, caplog):
+    db.create_session("s1", source="desktop")
+    with caplog.at_level(logging.INFO, logger="hermes_state"):
+        db.end_session("s1", "agent_close")
+    matches = [r for r in caplog.records if "Session ended" in r.message]
+    assert matches, f"expected an end audit line, got {[r.message for r in caplog.records]}"
+    line = matches[0].getMessage()
+    assert "session=s1" in line
+    assert "reason=agent_close" in line
+    # The caller is what makes the trail diagnostic: it must name the module
+    # and function that performed the write, not just the row that changed.
+    assert "test_end_session_logs_reason_and_caller" in line
+    assert __name__ in line
+
+
+def test_already_ended_row_logs_noop_at_debug(db, caplog):
+    db.create_session("s1", source="desktop")
+    db.end_session("s1", "compression")
+    with caplog.at_level(logging.DEBUG, logger="hermes_state"):
+        db.end_session("s1", "agent_close")
+    matches = [
+        r for r in caplog.records
+        if "Session end no-op" in r.message and r.levelno == logging.DEBUG
+    ]
+    assert matches
+    line = matches[0].getMessage()
+    assert "session=s1" in line
+    assert "reason=agent_close" in line
+    # First reason wins: the row was not re-ended under the new reason.
+    assert db.get_session("s1")["end_reason"] == "compression"
+
+
+def test_reopen_session_logs_the_ended_to_open_transition(db, caplog):
+    db.create_session("s1", source="desktop")
+    db.end_session("s1", "agent_close")
+    with caplog.at_level(logging.INFO, logger="hermes_state"):
+        db.reopen_session("s1")
+    matches = [r for r in caplog.records if "Session reopened" in r.message]
+    assert matches, f"expected a reopen audit line, got {[r.message for r in caplog.records]}"
+    line = matches[0].getMessage()
+    assert "session=s1" in line
+    assert "test_reopen_session_logs_the_ended_to_open_transition" in line
+
+
+def test_reopen_of_a_live_session_is_not_logged(db, caplog):
+    # A live row has nothing to recover; the routing code paths that call
+    # reopen defensively must not spam INFO on every check.
+    db.create_session("s1", source="desktop")
+    with caplog.at_level(logging.INFO, logger="hermes_state"):
+        db.reopen_session("s1")
+    assert not [r for r in caplog.records if "Session reopened" in r.message]
+    row = db.get_session("s1")
+    assert row["ended_at"] is None and row["end_reason"] is None


### PR DESCRIPTION
## What does this PR do?

Implements the audit-trail mitigation requested in #98495 (its "Proposed mitigations" item 1): `SessionDB.end_session()` and `SessionDB.reopen_session()` now emit one INFO line recording the session id, the end reason, and the **calling module.function** that performed the write.

Context: #98495 documents a live gateway session row being transiently marked ended (non-NULL `end_reason` on a row still serving turns) four times in one day across two profiles, silently reopened by the #54878 stale-route self-heal. The report itself states the writer is "unconfirmed — no audit log exists": both writes are completely invisible, so the bug can only be diagnosed from the downstream routing warning, never from the writer. I statically audited every gateway cleanup path that can reach `end_session()` (the three known shared-session callers already opt out via `_end_session_on_close = False`; evictions soft-release via `release_clients()`), and the remaining suspect class is a runtime race that cannot be pinpointed without exactly this trail. With this change, the next occurrence logs one line naming the culprit — e.g. `Session ended: session=... reason=agent_close caller=gateway.run._cleanup_agent_resources`.

Design notes:

- The caller is captured with `sys._getframe(1)` at method entry, before `_execute_write` adds its own frames between the caller and the SQL.
- The first-reason-wins no-op on an already-ended row logs at DEBUG, so the many legitimate double-close paths don't chatter at INFO.
- `reopen_session()` only logs the **ended → open transition** (the recovery resurrection); defensive reopens of already-live rows stay silent, and the row state read that decides this happens inside the same write transaction.

## Related Issue

Fixes #98495

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — `end_session()`: INFO audit line (session/reason/caller) on the effective write, DEBUG no-op line when the row is already ended (first reason wins, unchanged semantics); `reopen_session()`: INFO audit line (session/caller) only when the row actually transitions from ended to open. SQL and write behavior unchanged — additive logging only.
- `tests/hermes_state/test_98495_end_reopen_audit_log.py` — new: pins the end audit line's session/reason/caller fields, the DEBUG level of the idempotent no-op (plus unchanged first-reason-wins row state), the reopen transition line, and the silence of reopens on live rows.

## How to Test

1. `python -m pytest tests/hermes_state/test_98495_end_reopen_audit_log.py -q` — should pass: 4 passed.
2. `python -m pytest tests/hermes_state/ tests/test_hermes_state.py tests/gateway/test_async_session_db.py tests/gateway/test_async_session_store.py tests/gateway/test_session_continuity_82616.py tests/gateway/test_session_store_stale_prune.py tests/gateway/test_dead_targets.py tests/cron/test_scheduler_cron_session_isolation.py tests/cron/test_scheduler.py tests/cron/test_scheduler_completion_verification.py -q` — Observed result: 594 passed, 2 skipped (all existing end/reopen consumers covered).
3. Manual smoke: in a Python shell, create a `SessionDB`, `create_session('s1', ...)` then `end_session('s1', 'agent_close')` with INFO logging enabled — observed line: `Session ended: session=s1 reason=agent_close caller=<module>.<function>`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full suites for `tests/hermes_state/`, `tests/test_hermes_state.py`, and the gateway/cron consumer subsets listed under How to Test: 594 passed, 2 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (method docstrings already describe the semantics; the new log lines are self-describing)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure logging, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
INFO hermes_state: Session ended: session=20260830_175705_abcd reason=agent_close caller=run_agent.close
INFO hermes_state: Session reopened: session=20260830_175705_abcd caller=gateway.session.get_or_create_session
```