### PR TITLE
fix(tui): give the terminal client the desktop's todo-revision parity

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -183,6 +183,32 @@ describe('createGatewayEventHandler', () => {
     expect(getTurnState().todos).toEqual(todos)
   })
 
+  it('applies a todo.updated full-snapshot event even with no prior tool.start', () => {
+    const appended: Msg[] = []
+    const todos = [{ content: 'Boil water', id: 'boil', status: 'in_progress' }]
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: { revision: 1, todos }, type: 'todo.updated' } as any)
+
+    expect(getTurnState().todos).toEqual(todos)
+  })
+
+  it('rejects a stale tool.complete revision after a newer todo.updated already landed', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({
+      payload: { revision: 2, todos: [{ content: 'x', id: 'a', status: 'completed' }] },
+      type: 'todo.updated'
+    } as any)
+    onEvent({
+      payload: { name: 'todo', revision: 1, todos: [{ content: 'x', id: 'a', status: 'pending' }], tool_id: 't1' },
+      type: 'tool.complete'
+    } as any)
+
+    expect(getTurnState().todos).toEqual([{ content: 'x', id: 'a', status: 'completed' }])
+  })
+
   it('prints compaction progress status into the transcript', () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)

--- a/ui-tui/src/__tests__/turnControllerTodos.test.ts
+++ b/ui-tui/src/__tests__/turnControllerTodos.test.ts
@@ -36,3 +36,69 @@ describe('turnController.recordTodos — preserves the parent field', () => {
     expect(getTurnState().todos).toEqual([{ content: 'x', id: 'a', status: 'pending' }])
   })
 })
+
+// A revision watermark (mirroring apps/desktop/src/store/todos.ts's
+// acceptRevision) must reject an out-of-order snapshot instead of letting a
+// late-arriving stale event undo a newer one already on screen.
+describe('turnController.recordTodos — revision watermark', () => {
+  beforeEach(() => {
+    resetTurnState()
+    turnController.fullReset()
+  })
+
+  it('applies an unrevisioned update (tool.start-shaped patch) unconditionally', () => {
+    turnController.recordTodos([{ content: 'x', id: 'a', status: 'pending' }])
+
+    expect(getTurnState().todos).toEqual([{ content: 'x', id: 'a', status: 'pending' }])
+  })
+
+  it('applies increasing revisions in order', () => {
+    turnController.recordTodos([{ content: 'x', id: 'a', status: 'pending' }], 1)
+    turnController.recordTodos([{ content: 'x', id: 'a', status: 'completed' }], 2)
+
+    expect(getTurnState().todos).toEqual([{ content: 'x', id: 'a', status: 'completed' }])
+    expect(getTurnState().todoRevision).toBe(2)
+  })
+
+  it('rejects a stale (lower) revision instead of undoing the newer state', () => {
+    turnController.recordTodos([{ content: 'x', id: 'a', status: 'completed' }], 5)
+    turnController.recordTodos([{ content: 'x', id: 'a', status: 'pending' }], 3)
+
+    expect(getTurnState().todos).toEqual([{ content: 'x', id: 'a', status: 'completed' }])
+    expect(getTurnState().todoRevision).toBe(5)
+  })
+})
+
+// applyTodoSnapshot() backs both the `todo.updated` gateway event and
+// session.resume/session.activate's `todo_state` restore.
+describe('turnController.applyTodoSnapshot', () => {
+  beforeEach(() => {
+    resetTurnState()
+    turnController.fullReset()
+  })
+
+  it('applies a live (running) snapshot even if the list is still active', () => {
+    turnController.applyTodoSnapshot([{ content: 'x', id: 'a', status: 'in_progress' }], 1, true)
+
+    expect(getTurnState().todos).toEqual([{ content: 'x', id: 'a', status: 'in_progress' }])
+  })
+
+  it('restores a finished list on resume of an idle session', () => {
+    turnController.applyTodoSnapshot([{ content: 'x', id: 'a', status: 'completed' }], 1, false)
+
+    expect(getTurnState().todos).toEqual([{ content: 'x', id: 'a', status: 'completed' }])
+  })
+
+  it('drops a still-active list on resume of an idle session instead of re-pinning a stuck panel', () => {
+    turnController.applyTodoSnapshot([{ content: 'x', id: 'a', status: 'in_progress' }], 1, false)
+
+    expect(getTurnState().todos).toEqual([])
+  })
+
+  it('ignores an unused-store snapshot (empty todos, revision 0)', () => {
+    turnController.recordTodos([{ content: 'x', id: 'a', status: 'pending' }])
+    turnController.applyTodoSnapshot([], 0, false)
+
+    expect(getTurnState().todos).toEqual([{ content: 'x', id: 'a', status: 'pending' }])
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1211,12 +1211,21 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
             ev.payload.summary,
             ev.payload.duration_s,
             ev.payload.todos,
-            resultText
+            resultText,
+            ev.payload.revision
           )
         }
 
         return
       }
+
+      // Full-snapshot event: the source of truth for task state, reconciled
+      // without interpreting provider text or partial merge arguments (mirrors
+      // apps/desktop's todo.updated handling).
+      case 'todo.updated':
+        turnController.applyTodoSnapshot(ev.payload.todos, ev.payload.revision, true)
+
+        return
 
       case 'clarify.request': {
         const batch = (ev.payload.questions ?? [])

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -79,6 +79,12 @@ const parseTodos = (value: unknown): null | TodoItem[] => {
     .filter((item): item is TodoItem => Boolean(item?.id && item.content))
 }
 
+const isTodoRevision = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+
+const todoListActive = (todos: readonly TodoItem[]) =>
+  todos.some(t => t.status === 'pending' || t.status === 'in_progress')
+
 const textSegments = (segments: Msg[]) =>
   segments.filter(msg => msg.role === 'assistant' && msg.kind !== 'diff').map(msg => msg.text)
 
@@ -452,15 +458,79 @@ class TurnController {
     }, REASONING_PULSE_MS)
   }
 
-  recordTodos(value: unknown) {
+  /** Revision watermark for the live todo list, mirroring
+   *  apps/desktop/src/store/todos.ts's acceptRevision(): a missing revision
+   *  (e.g. an old-shaped payload) always applies; an older revision than
+   *  what's already displayed is stale and rejected. */
+  private acceptTodoRevision(revision: null | undefined | number): boolean {
+    if (!isTodoRevision(revision)) {
+      return true
+    }
+
+    const current = getTurnState().todoRevision
+
+    if (current != null && revision < current) {
+      return false
+    }
+
+    if (current !== revision) {
+      patchTurnState({ todoRevision: revision })
+    }
+
+    return true
+  }
+
+  recordTodos(value: unknown, revision?: null | number) {
     if (this.interrupted) {
       return
     }
 
     const todos = parseTodos(value)
 
-    if (todos !== null) {
-      patchTurnState({ todos })
+    if (todos === null) {
+      return
+    }
+
+    if (!this.acceptTodoRevision(revision)) {
+      return
+    }
+
+    patchTurnState({ todos })
+  }
+
+  /** Full-snapshot restore: the `todo.updated` event (always live, so
+   *  `running` is true) and session.resume/session.activate's `todo_state`
+   *  (possibly idle). Mirrors apps/desktop/src/store/todos.ts's
+   *  restoreSessionTodosFromSnapshot(): an idle session's still-active list
+   *  means the prior turn ended without a final todo update, so it's stale
+   *  and dropped instead of re-pinned. */
+  applyTodoSnapshot(value: unknown, revision: null | undefined | number, running: boolean) {
+    if (this.interrupted) {
+      return
+    }
+
+    const todos = parseTodos(value)
+
+    if (todos === null) {
+      return
+    }
+
+    // An unused store serializes as revision 0 with no items — not a real
+    // snapshot worth applying.
+    if (todos.length === 0 && (revision == null || revision === 0)) {
+      return
+    }
+
+    if (running || !todoListActive(todos)) {
+      if (this.acceptTodoRevision(revision)) {
+        patchTurnState({ todos })
+      }
+
+      return
+    }
+
+    if (this.acceptTodoRevision(revision)) {
+      patchTurnState({ todos: [] })
     }
   }
 
@@ -804,13 +874,14 @@ class TurnController {
     summary?: string,
     duration?: number,
     todos?: unknown,
-    resultText?: string
+    resultText?: string,
+    todoRevision?: null | number
   ) {
     if (this.interrupted) {
       return
     }
 
-    this.recordTodos(todos)
+    this.recordTodos(todos, todoRevision)
     const line = this.completeTool(toolId, fallbackName, error, summary, duration, resultText)
 
     this.pendingSegmentTools = [...this.pendingSegmentTools, line]

--- a/ui-tui/src/app/turnStore.ts
+++ b/ui-tui/src/app/turnStore.ts
@@ -16,6 +16,7 @@ const buildTurnState = (): TurnState => ({
   streaming: '',
   subagents: [],
   todoCollapsed: false,
+  todoRevision: null,
   todos: [],
   toolTokens: 0,
   tools: [],
@@ -78,6 +79,7 @@ export interface TurnState {
   streaming: string
   subagents: SubagentProgress[]
   todoCollapsed: boolean
+  todoRevision: null | number
   todos: TodoItem[]
   toolTokens: number
   tools: ActiveTool[]

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -315,6 +315,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             usage: usageFrom(info)
           })
           hydrateLiveSessionInflight(r.inflight)
+          turnController.applyTodoSnapshot(r.todo_state?.todos, r.todo_state?.revision, running)
           cancelResumeScrollRef.current?.()
           cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
         })
@@ -369,6 +370,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               usage: usageFrom(info)
             })
             hydrateLiveSessionInflight(r.inflight)
+            turnController.applyTodoSnapshot(r.todo_state?.todos, r.todo_state?.revision, running)
             cancelResumeScrollRef.current?.()
             cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -195,6 +195,7 @@ export interface SessionResumeResponse {
   session_id: string
   started_at?: number
   status?: LiveSessionStatus
+  todo_state?: { revision?: number; todos?: unknown[] }
 }
 
 export type LiveSessionStatus = 'idle' | 'starting' | 'waiting' | 'working'
@@ -232,6 +233,7 @@ export interface SessionActivateResponse {
   session_key?: string
   started_at?: number
   status?: LiveSessionStatus
+  todo_state?: { revision?: number; todos?: unknown[] }
 }
 
 export interface SessionListItem {
@@ -703,6 +705,7 @@ export type GatewayEvent =
         inline_diff?: string
         name?: string
         result_text?: string
+        revision?: number
         summary?: string
         tool_id: string
         todos?: unknown[]
@@ -710,6 +713,7 @@ export type GatewayEvent =
       session_id?: string
       type: 'tool.complete'
     }
+  | { payload: { revision?: number; todos?: unknown[] }; session_id?: string; type: 'todo.updated' }
   | {
       payload: {
         answers?: Record<string, string>


### PR DESCRIPTION
## Summary

The revisioned-snapshot/merge treatment desktop's todo panel got across several recent commits (`cf692532cf` merge-not-replace, `393af4a310` revisioned snapshots + `todo.updated` event, `58523f284c` unversioned-patch handling) never reached the `ui-tui` terminal client. Concretely, at current main:

- `createGatewayEventHandler.ts` has no `case 'todo.updated':` — the backend's dedicated full-snapshot event (`tui_gateway/server.py`'s `_on_tool_complete`, emitted specifically so "every client can reconcile immediately without interpreting provider text or partial merge arguments") is silently dropped.
- `turnController.recordTodos()` applies any update it receives with no revision watermark, so an out-of-order/stale update could clobber a newer one.
- `session.resume`/`session.activate` responses carry a `todo_state` snapshot (`tui_gateway/methods_session.py` via `_attach_todo_state`), but `useSessionLifecycle.ts` never reads it — resuming or switching to a session silently drops its live task list until the next tool event.

## Changes

Ports the same design `apps/desktop/src/store/todos.ts` already uses:

- `turnStore.ts`: adds a `todoRevision` watermark to `TurnState`.
- `turnController.ts`: `recordTodos()` gains an optional revision param and rejects a stale (lower) revision instead of applying it over newer state; a revision-less update (the `tool.start`-shaped patch case) always applies without moving the watermark, matching desktop's `acceptRevision()`. New `applyTodoSnapshot()` backs both the live `todo.updated` event and session restore — on an idle session it drops (instead of re-pinning) a still-active list, since that means the prior turn ended without a final update and the list is stale.
- `createGatewayEventHandler.ts`: adds the `todo.updated` case, and threads `payload.revision` through `tool.complete`.
- `useSessionLifecycle.ts`: `activateLiveSession`/`resumeById` now apply `r.todo_state` via `applyTodoSnapshot(..., running)`.
- `gatewayTypes.ts`: adds `revision` to the `tool.complete` payload, a `todo.updated` event variant, and `todo_state` on `SessionResumeResponse`/`SessionActivateResponse`.

## Test plan

- [x] New unit tests for the revision watermark and `applyTodoSnapshot()` (unrevisioned patch applies, increasing revisions apply, a stale revision is rejected, a live active snapshot applies, an idle-resume active snapshot is dropped, an unused-store snapshot is ignored) in `turnControllerTodos.test.ts`.
- [x] New `createGatewayEventHandler.test.ts` cases: `todo.updated` applies a snapshot with no prior `tool.start`; a stale `tool.complete` revision arriving after a newer `todo.updated` is rejected.
- [x] Mutation-verify: reverted the production changes and confirmed all 8 new tests fail with the expected assertions, then restored them and confirmed all pass.
- [x] `npx tsc --noEmit` clean.
- [x] Full `ui-tui` vitest suite: 1733 passed, 3 skipped, 1 pre-existing unrelated failure (`execFileNoThrow.test.ts`, a timing-sensitive subprocess test that fails independently of this change on this machine's Python).

## Competitor check

Searched `gh pr list`/`gh issue list` for "ui-tui todo", "todo.updated ui-tui", "turnController todo revision", "todo revision watermark" (state=all) — no open or duplicate PR touches `ui-tui`'s todo handling. The only related recent work is `#98326` (merged as commit `58523f284c`, already on `main` at this PR's base), which fixed an analogous unversioned-revision regression on the **desktop** side — this PR brings `ui-tui` up to the same design that fix reinforced, it doesn't touch the same files.