### PR TITLE
fix(vision): negotiate native video dialects and fall back to frames

### DIFF
--- a/tests/tools/test_video_transport_negotiation.py
+++ b/tests/tools/test_video_transport_negotiation.py
@@ -1,0 +1,407 @@
+"""Regression coverage for provider video-transport negotiation."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import shutil
+import subprocess
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools import video_analysis
+from tools.video_analysis import (
+    VideoFrame,
+    VideoFrameExtractionError,
+    video_analyze_tool,
+)
+from tools.video_analysis.frames import extract_video_frames
+
+
+class ProviderError(RuntimeError):
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _response(text: str = "ok") -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = text
+    return response
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_llama_cpp_rejection_retries_documented_input_video(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video_bytes = b"native-video-bytes"
+    video.write_bytes(video_bytes)
+    calls = []
+
+    async def call_llm(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise ProviderError(
+                400,
+                "HTTP 400: unsupported content[].type: video_url",
+            )
+        return _response("native llama.cpp video")
+
+    with (
+        patch("tools.vision_tools.async_call_llm", side_effect=call_llm),
+        patch(
+            "tools.vision_tools.extract_content_or_reasoning",
+            return_value="native llama.cpp video",
+        ),
+        patch(
+            "tools.video_analysis.core._extract_video_frames_async",
+            new_callable=AsyncMock,
+        ) as extract_frames,
+    ):
+        result = _run(
+            video_analyze_tool(str(video), "Describe the timeline")
+        )
+
+    data = json.loads(result)
+    assert data["success"] is True
+    assert data["transport"] == "input_video"
+    assert len(calls) == 2
+    first_content = calls[0]["messages"][0]["content"]
+    second_content = calls[1]["messages"][0]["content"]
+    assert first_content[1]["type"] == "video_url"
+    assert second_content[1]["type"] == "input_video"
+    raw_payload = second_content[1]["input_video"]["data"]
+    assert not raw_payload.startswith("data:")
+    assert base64.b64decode(raw_payload) == video_bytes
+    extract_frames.assert_not_awaited()
+
+
+def test_bare_400_negotiates_input_video_before_frames(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"video")
+    calls = []
+
+    async def call_llm(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise ProviderError(400, "Bad Request")
+        return _response("accepted")
+
+    with (
+        patch("tools.vision_tools.async_call_llm", side_effect=call_llm),
+        patch(
+            "tools.vision_tools.extract_content_or_reasoning",
+            return_value="accepted",
+        ),
+        patch(
+            "tools.video_analysis.core._extract_video_frames_async",
+            new_callable=AsyncMock,
+        ) as extract_frames,
+    ):
+        result = _run(video_analyze_tool(str(video), "Describe this"))
+
+    data = json.loads(result)
+    assert data["success"] is True
+    assert data["transport"] == "input_video"
+    assert [
+        call["messages"][0]["content"][1]["type"] for call in calls
+    ] == ["video_url", "input_video"]
+    extract_frames.assert_not_awaited()
+
+
+def test_explicit_image_only_rejection_skips_input_video(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"video")
+    frames = [VideoFrame(0.5, "data:image/jpeg;base64,RlJBTUU=")]
+    calls = []
+
+    async def call_llm(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise ProviderError(400, "model does not support video input")
+        return _response("visible frame")
+
+    with (
+        patch("tools.vision_tools.async_call_llm", side_effect=call_llm),
+        patch(
+            "tools.vision_tools.extract_content_or_reasoning",
+            return_value="visible frame",
+        ),
+        patch(
+            "tools.video_analysis.core._extract_video_frames_async",
+            new_callable=AsyncMock,
+            return_value=frames,
+        ) as extract_frames,
+    ):
+        result = _run(video_analyze_tool(str(video), "Describe this"))
+
+    data = json.loads(result)
+    assert data["success"] is True
+    assert data["transport"] == "image_frames"
+    assert len(calls) == 2
+    assert calls[0]["messages"][0]["content"][1]["type"] == "video_url"
+    assert [
+        part["type"] for part in calls[1]["messages"][0]["content"]
+    ] == ["text", "image_url"]
+    extract_frames.assert_awaited_once_with(video)
+
+
+def test_image_fallback_sends_real_ordered_jpeg_frames(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"video")
+    calls = []
+    frames = [
+        VideoFrame(0.5, "data:image/jpeg;base64,RlJBTUUx"),
+        VideoFrame(2.5, "data:image/jpeg;base64,RlJBTUUy"),
+    ]
+
+    async def call_llm(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise ProviderError(400, "unsupported content[].type video_url")
+        if len(calls) == 2:
+            raise ProviderError(400, "unsupported content[].type input_video")
+        return _response("frame analysis")
+
+    with (
+        patch("tools.vision_tools.async_call_llm", side_effect=call_llm),
+        patch(
+            "tools.vision_tools.extract_content_or_reasoning",
+            return_value="frame analysis",
+        ),
+        patch(
+            "tools.video_analysis.core._extract_video_frames_async",
+            new_callable=AsyncMock,
+            return_value=frames,
+        ) as extract_frames,
+    ):
+        result = _run(
+            video_analyze_tool(str(video), "Describe the timeline")
+        )
+
+    data = json.loads(result)
+    assert data["success"] is True
+    assert data["transport"] == "image_frames"
+    assert data["frame_count"] == 2
+    extract_frames.assert_awaited_once_with(video)
+
+    frame_content = calls[2]["messages"][0]["content"]
+    assert [part["type"] for part in frame_content] == [
+        "text",
+        "image_url",
+        "image_url",
+    ]
+    assert [
+        part["image_url"]["url"] for part in frame_content[1:]
+    ] == [frame.data_url for frame in frames]
+    evidence_note = frame_content[0]["text"]
+    assert "0.50s, 2.50s" in evidence_note
+    assert "Do not claim audio content" in evidence_note
+
+
+def test_non_negotiable_error_does_not_retry_or_extract(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"video")
+    call_llm = AsyncMock(
+        side_effect=ProviderError(401, "HTTP 401 unauthorized")
+    )
+
+    with (
+        patch("tools.vision_tools.async_call_llm", call_llm),
+        patch(
+            "tools.video_analysis.core._extract_video_frames_async",
+            new_callable=AsyncMock,
+        ) as extract_frames,
+    ):
+        result = _run(video_analyze_tool(str(video), "Describe this"))
+
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "401" in data["error"]
+    assert call_llm.await_count == 1
+    extract_frames.assert_not_awaited()
+
+
+def test_extraction_failure_reports_each_native_attempt(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"video")
+    call_llm = AsyncMock(
+        side_effect=[
+            ProviderError(400, "unsupported content[].type video_url"),
+            ProviderError(400, "unsupported content[].type input_video"),
+        ]
+    )
+
+    with (
+        patch("tools.vision_tools.async_call_llm", call_llm),
+        patch(
+            "tools.video_analysis.core._extract_video_frames_async",
+            new_callable=AsyncMock,
+            side_effect=VideoFrameExtractionError(
+                "Frame fallback requires ffmpeg and ffprobe on PATH"
+            ),
+        ),
+    ):
+        result = _run(video_analyze_tool(str(video), "Describe this"))
+
+    data = json.loads(result)
+    assert data["success"] is False
+    assert "ffmpeg and ffprobe" in data["analysis"]
+    assert "video_url" in data["analysis"]
+    assert "input_video" in data["analysis"]
+    assert "does not support video analysis" not in data["analysis"]
+    assert call_llm.await_count == 2
+
+
+def test_frame_extraction_uses_bounded_argv_and_jpeg_payloads(
+    tmp_path,
+    monkeypatch,
+):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"video")
+    calls = []
+
+    def fake_which(name):
+        return f"/usr/bin/{name}"
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command[0].endswith("ffprobe"):
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="4.0\n",
+                stderr="",
+            )
+        Path(command[-1]).write_bytes(b"\xff\xd8\xffJPEG")
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=b"",
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(
+        "tools.video_analysis.frames.shutil.which",
+        fake_which,
+    )
+    monkeypatch.setattr(
+        "tools.video_analysis.frames.subprocess.run",
+        fake_run,
+    )
+
+    frames = extract_video_frames(video, max_frames=2, max_side=320)
+
+    assert [frame.timestamp_seconds for frame in frames] == pytest.approx(
+        [1.0, 3.0]
+    )
+    assert all(
+        frame.data_url.startswith("data:image/jpeg;base64,")
+        for frame in frames
+    )
+    assert len(calls) == 3
+    for command, kwargs in calls:
+        assert isinstance(command, list)
+        assert kwargs.get("stdin") is subprocess.DEVNULL
+        assert kwargs.get("timeout") in {30, 45}
+        assert kwargs.get("shell", False) is False
+    ffmpeg_commands = [
+        command for command, _ in calls if command[0].endswith("ffmpeg")
+    ]
+    assert all("-threads" in command for command in ffmpeg_commands)
+    assert all(
+        (
+            "scale=320:320:force_original_aspect_ratio=decrease:"
+            "force_divisible_by=2"
+        ) in command
+        for command in ffmpeg_commands
+    )
+
+
+def test_frame_extraction_requires_ffmpeg_and_ffprobe(
+    tmp_path,
+    monkeypatch,
+):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"video")
+    monkeypatch.setattr(
+        "tools.video_analysis.frames.shutil.which",
+        lambda _name: None,
+    )
+
+    with pytest.raises(VideoFrameExtractionError) as exc_info:
+        extract_video_frames(video)
+
+    assert "ffmpeg" in str(exc_info.value)
+    assert "ffprobe" in str(exc_info.value)
+
+
+def test_frame_extraction_with_real_ffmpeg(tmp_path):
+    ffmpeg = shutil.which("ffmpeg")
+    ffprobe = shutil.which("ffprobe")
+    if not ffmpeg or not ffprobe:
+        pytest.skip("ffmpeg and ffprobe are not installed")
+
+    image_module = pytest.importorskip("PIL.Image")
+    video = tmp_path / "synthetic.mp4"
+    subprocess.run(
+        [
+            ffmpeg,
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=320x240:rate=4",
+            "-t",
+            "2",
+            "-c:v",
+            "mpeg4",
+            "-q:v",
+            "5",
+            "-pix_fmt",
+            "yuv420p",
+            "-y",
+            str(video),
+        ],
+        check=True,
+        capture_output=True,
+        timeout=30,
+        stdin=subprocess.DEVNULL,
+    )
+
+    frames = extract_video_frames(video, max_frames=2, max_side=160)
+
+    assert len(frames) == 2
+    assert [frame.timestamp_seconds for frame in frames] == pytest.approx(
+        [0.5, 1.5],
+        abs=0.15,
+    )
+    for frame in frames:
+        payload = base64.b64decode(frame.data_url.split(",", 1)[1])
+        with image_module.open(BytesIO(payload)) as image:
+            assert image.format == "JPEG"
+            assert max(image.size) <= 160
+
+
+def test_discovery_bridge_settles_registry_and_legacy_api():
+    from tools import vision_tools
+    from tools import vision_video_analysis  # noqa: F401
+    from tools.registry import registry
+
+    entry = registry.get_entry("video_analyze")
+    assert entry is not None
+    assert entry.handler is video_analysis._handle_video_analyze
+    assert entry.toolset == "video"
+    assert entry.is_async is True
+    assert vision_tools.video_analyze_tool is video_analysis.video_analyze_tool
+    assert vision_tools.VIDEO_ANALYZE_SCHEMA is video_analysis.VIDEO_ANALYZE_SCHEMA

--- a/tests/tools/test_video_transport_regressions.py
+++ b/tests/tools/test_video_transport_regressions.py
@@ -1,0 +1,66 @@
+"""Regression coverage for video-analysis review repairs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.video_analysis import core
+from tools.video_analysis.frames import extract_video_frames
+
+
+def test_core_reuses_single_frame_extraction_owner():
+    assert core._extract_video_frames is extract_video_frames
+    assert not hasattr(core, "_probe_video_duration")
+    assert not hasattr(core, "_frame_timestamps")
+    assert not hasattr(core, "_jpeg_data_url")
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("HTTP 429 rate limit exceeded", 429),
+        ("429 rate limit exceeded", 429),
+        ("stream ended after 429 bytes", None),
+        ("model returned 404 tokens", None),
+        ("attempt 429: retrying", None),
+    ],
+)
+def test_status_code_string_fallback_is_leading_only(message, expected):
+    assert core._status_code(RuntimeError(message)) == expected
+
+
+def test_oversized_video_is_rejected_before_reading_file(tmp_path):
+    video = tmp_path / "oversized.mp4"
+    with video.open("wb") as handle:
+        handle.truncate(core._max_raw_video_bytes("video/mp4") + 1)
+
+    with patch.object(
+        Path,
+        "read_bytes",
+        side_effect=AssertionError("oversized input must not be buffered"),
+    ):
+        with pytest.raises(ValueError, match="Video too large for API"):
+            core._video_to_base64_data_url(video, "video/mp4")
+
+
+def test_configured_video_timeout_is_not_silently_clamped():
+    sentinel = object()
+
+    def fake_cfg_get(_cfg, *keys, default=None):
+        if keys == ("auxiliary", "video"):
+            return {"timeout": 60, "temperature": 0.2}
+        if keys == ("auxiliary", "vision"):
+            return {}
+        return default
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=sentinel),
+        patch("hermes_cli.config.cfg_get", side_effect=fake_cfg_get),
+    ):
+        timeout, temperature = core._resolve_video_call_settings()
+
+    assert timeout == 60.0
+    assert temperature == 0.2

--- a/tools/video_analysis/__init__.py
+++ b/tools/video_analysis/__init__.py
@@ -1,0 +1,69 @@
+"""Canonical video-analysis runtime and legacy vision-tools compatibility."""
+
+from __future__ import annotations
+
+from tools.video_analysis import core as core
+
+VIDEO_ANALYZE_SCHEMA = core.VIDEO_ANALYZE_SCHEMA
+VideoFrame = core.VideoFrame
+VideoFrameExtractionError = core.VideoFrameExtractionError
+VideoInputNegotiationError = core.VideoInputNegotiationError
+_MAX_VIDEO_BASE64_BYTES = core._MAX_VIDEO_BASE64_BYTES
+_VIDEO_MIME_TYPES = core._VIDEO_MIME_TYPES
+_VIDEO_SIZE_WARN_BYTES = core._VIDEO_SIZE_WARN_BYTES
+_detect_video_mime_type = core._detect_video_mime_type
+_download_video = core._download_video
+_extract_video_frames = core._extract_video_frames
+_extract_video_frames_async = core._extract_video_frames_async
+_handle_video_analyze = core._handle_video_analyze
+_is_path_like_video_source = core._is_path_like_video_source
+_materialize_video_from_terminal_backend = (
+    core._materialize_video_from_terminal_backend
+)
+_terminal_backend_is_local = core._terminal_backend_is_local
+_video_to_base64_data_url = core._video_to_base64_data_url
+video_analyze_tool = core.video_analyze_tool
+
+
+def _install_legacy_aliases() -> None:
+    """Keep tools.vision_tools imports on the canonical runtime owner."""
+    from tools import vision_tools
+
+    aliases = {
+        "VIDEO_ANALYZE_SCHEMA": VIDEO_ANALYZE_SCHEMA,
+        "VideoFrame": VideoFrame,
+        "VideoFrameExtractionError": VideoFrameExtractionError,
+        "VideoInputNegotiationError": VideoInputNegotiationError,
+        "_MAX_VIDEO_BASE64_BYTES": _MAX_VIDEO_BASE64_BYTES,
+        "_VIDEO_MIME_TYPES": _VIDEO_MIME_TYPES,
+        "_VIDEO_SIZE_WARN_BYTES": _VIDEO_SIZE_WARN_BYTES,
+        "_detect_video_mime_type": _detect_video_mime_type,
+        "_download_video": _download_video,
+        "_extract_video_frames": _extract_video_frames,
+        "_extract_video_frames_async": _extract_video_frames_async,
+        "_handle_video_analyze": _handle_video_analyze,
+        "_is_path_like_video_source": _is_path_like_video_source,
+        "_materialize_video_from_terminal_backend": (
+            _materialize_video_from_terminal_backend
+        ),
+        "_terminal_backend_is_local": _terminal_backend_is_local,
+        "_video_to_base64_data_url": _video_to_base64_data_url,
+        "video_analyze_tool": video_analyze_tool,
+    }
+    for name, value in aliases.items():
+        setattr(vision_tools, name, value)
+
+
+_install_legacy_aliases()
+
+# Registry ownership intentionally lives in tools/vision_video_analysis.py.
+# Built-in discovery imports that bridge after tools.vision_tools, so one
+# override settles the canonical handler instead of three import-order writers.
+
+__all__ = [
+    "VIDEO_ANALYZE_SCHEMA",
+    "VideoFrame",
+    "VideoFrameExtractionError",
+    "VideoInputNegotiationError",
+    "video_analyze_tool",
+]

--- a/tools/video_analysis/core.py
+++ b/tools/video_analysis/core.py
@@ -1,0 +1,862 @@
+"""Video analysis transport negotiation and frame fallback.
+
+The public video tool remains re-exported from :mod:`tools.vision_tools` for
+backward compatibility, while the implementation lives here so the image and
+video paths can evolve independently.
+
+Providers disagree on chat-content dialects for native video. Hermes keeps the
+existing OpenAI-style ``video_url`` request as the first attempt, retries the
+llama.cpp ``input_video`` shape only when the provider rejects the first wire
+format, then falls back to bounded chronological JPEG frames for image-only
+endpoints. A provider's actual response authorizes each transition; endpoint
+location or a guessed model name never substitutes for capability evidence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any, Awaitable, Dict, Optional, Sequence
+
+from hermes_constants import get_hermes_dir
+from tools.registry import tool_error
+from tools.video_analysis.frames import (
+    VideoFrame,
+    VideoFrameExtractionError,
+    extract_video_frames as _extract_video_frames,
+    extract_video_frames_async as _extract_video_frames_async,
+)
+from tools.website_policy import check_website_access
+
+logger = logging.getLogger(__name__)
+
+# Extension -> MIME. avi/mkv retain the historical mp4 fallback.
+_VIDEO_MIME_TYPES = {
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".mov": "video/mov",
+    ".avi": "video/mp4",
+    ".mkv": "video/mp4",
+    ".mpeg": "video/mpeg",
+    ".mpg": "video/mpeg",
+}
+
+_MAX_VIDEO_BASE64_BYTES = 50 * 1024 * 1024
+# Keep network and local inputs below the largest raw payload that can fit in
+# the 50 MiB data-URL budget after base64 expansion and a MIME prefix.
+_MAX_VIDEO_DATA_PREFIX_BUDGET = 64
+_MAX_VIDEO_RAW_BYTES = (
+    (_MAX_VIDEO_BASE64_BYTES - _MAX_VIDEO_DATA_PREFIX_BUDGET) // 4
+) * 3
+_VIDEO_SIZE_WARN_BYTES = 20 * 1024 * 1024
+
+
+class VideoInputNegotiationError(RuntimeError):
+    """Raised after every authorized video transport has failed."""
+
+
+def _vision_module():
+    """Return the compatibility module without importing it during bootstrap."""
+    from tools import vision_tools
+
+    return vision_tools
+
+
+def _auxiliary_callables():
+    """Reuse vision_tools' lazy auxiliary-client seam and patch targets."""
+    vision_tools = _vision_module()
+    vision_tools._load_auxiliary_client()
+    return vision_tools.async_call_llm, vision_tools.extract_content_or_reasoning
+
+
+def _debug_session():
+    """Keep video calls in the existing vision debug session."""
+    return _vision_module()._debug
+
+
+def _detect_video_mime_type(video_path: Path) -> Optional[str]:
+    """Return a video MIME type based on file extension, or None if unsupported."""
+    return _VIDEO_MIME_TYPES.get(video_path.suffix.lower())
+
+
+def _max_raw_video_bytes(mime_type: str) -> int:
+    prefix_bytes = len(f"data:{mime_type};base64,".encode("ascii"))
+    payload_budget = _MAX_VIDEO_BASE64_BYTES - prefix_bytes
+    if payload_budget <= 0:
+        return 0
+    return (payload_budget // 4) * 3
+
+
+def _video_to_base64_data_url(
+    video_path: Path, mime_type: Optional[str] = None
+) -> str:
+    """Convert a bounded video file to a base64-encoded data URL."""
+    mime = mime_type or _VIDEO_MIME_TYPES.get(
+        video_path.suffix.lower(), "video/mp4"
+    )
+    max_raw_bytes = _max_raw_video_bytes(mime)
+    raw_size = video_path.stat().st_size
+    if raw_size > max_raw_bytes:
+        raise ValueError(
+            "Video too large for API: raw payload is "
+            f"{raw_size / (1024 * 1024):.1f} MB "
+            f"(max {max_raw_bytes / (1024 * 1024):.1f} MB before base64). "
+            "Compress or trim the video and retry."
+        )
+
+    data = video_path.read_bytes()
+    encoded = base64.b64encode(data).decode("ascii")
+    data_url = f"data:{mime};base64,{encoded}"
+    if len(data_url.encode("ascii")) > _MAX_VIDEO_BASE64_BYTES:
+        raise ValueError(
+            "Video too large for API after base64 encoding: payload exceeds "
+            f"{_MAX_VIDEO_BASE64_BYTES / (1024 * 1024):.0f} MB. "
+            "Compress or trim the video and retry."
+        )
+    return data_url
+
+
+def _terminal_backend_is_local() -> bool:
+    backend = os.getenv("TERMINAL_ENV", "local").strip().lower()
+    return backend in ("", "local")
+
+
+def _is_path_like_video_source(value: str) -> bool:
+    lowered = (value or "").strip().lower()
+    if not lowered:
+        return False
+    return not lowered.startswith(("http://", "https://", "data:"))
+
+
+async def _materialize_video_from_terminal_backend(
+    video_source: str, task_id: Optional[str]
+) -> Path:
+    """Read a sandbox path through the shared media resolver into a temp file."""
+    from tools.image_source import (
+        ImageResolutionError,
+        ResolveContext,
+        resolve_image_source,
+    )
+
+    source = video_source
+    if source.startswith("file://"):
+        source = source[len("file://") :]
+    suffix = Path(source).suffix.lower()
+    if suffix not in _VIDEO_MIME_TYPES:
+        raise ValueError(
+            f"Unsupported video format: '{suffix}'. "
+            f"Supported: {', '.join(sorted(_VIDEO_MIME_TYPES.keys()))}"
+        )
+
+    try:
+        resolved = await resolve_image_source(
+            video_source,
+            ResolveContext(task_id=task_id),
+            permitted=("video",),
+        )
+    except ImageResolutionError as exc:
+        raise ValueError(
+            f"Could not read video from terminal backend: {exc}"
+        ) from exc
+
+    temp_dir = get_hermes_dir("cache/video", "temp_video_files")
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    temp_path = temp_dir / f"terminal_video_{uuid.uuid4()}{suffix}"
+    temp_path.write_bytes(resolved.data)
+    return temp_path
+
+
+async def _download_video(
+    video_url: str, destination: Path, max_retries: int = 3
+) -> Path:
+    """Download video from URL with website policy, SSRF, and byte caps."""
+    from tools.url_safety import (
+        async_is_safe_url,
+        create_ssrf_safe_async_client,
+        redirect_target_from_response,
+    )
+
+    # Shared implementation keeps the stream cap and partial-file cleanup in
+    # one place without importing vision_tools at module-import time.
+    stream_download = _vision_module()._stream_download_to_file
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    async def _ssrf_redirect_guard(response):
+        redirect_url = redirect_target_from_response(response)
+        if redirect_url and not await async_is_safe_url(redirect_url):
+            raise ValueError(
+                f"Blocked redirect to private/internal address: {redirect_url}"
+            )
+
+    last_error: Optional[Exception] = None
+    for attempt in range(max_retries):
+        try:
+            blocked = check_website_access(video_url)
+            if blocked:
+                raise PermissionError(blocked["message"])
+
+            async with create_ssrf_safe_async_client(
+                timeout=60.0,
+                follow_redirects=True,
+                event_hooks={"response": [_ssrf_redirect_guard]},
+            ) as client:
+                await stream_download(
+                    client,
+                    video_url,
+                    destination,
+                    _MAX_VIDEO_RAW_BYTES,
+                    headers={
+                        "User-Agent": (
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                            "AppleWebKit/537.36 (KHTML, like Gecko) "
+                            "Chrome/120.0.0.0 Safari/537.36"
+                        ),
+                        "Accept": "video/*,*/*;q=0.8",
+                    },
+                    media_label="Video",
+                )
+            return destination
+        except Exception as exc:  # noqa: BLE001 - retain provider diagnostics
+            last_error = exc
+            if attempt < max_retries - 1:
+                wait_time = 2 ** (attempt + 1)
+                logger.warning(
+                    "Video download failed (attempt %s/%s): %s",
+                    attempt + 1,
+                    max_retries,
+                    str(exc)[:80],
+                )
+                await asyncio.sleep(wait_time)
+            else:
+                logger.error(
+                    "Video download failed after %s attempts: %s",
+                    max_retries,
+                    str(exc)[:160],
+                    exc_info=True,
+                )
+
+    if last_error is None:
+        raise RuntimeError(
+            "_download_video exited retry loop without attempting "
+            f"(max_retries={max_retries})"
+        )
+    raise last_error
+
+
+def _raw_base64_from_data_url(video_data_url: str) -> str:
+    header, separator, payload = video_data_url.partition(",")
+    if not separator or ";base64" not in header:
+        raise ValueError("video payload is not a base64 data URL")
+    return payload
+
+
+def _video_url_messages(user_prompt: str, video_data_url: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": user_prompt},
+                {
+                    "type": "video_url",
+                    "video_url": {"url": video_data_url},
+                },
+            ],
+        }
+    ]
+
+
+def _input_video_messages(
+    user_prompt: str, video_data_url: str
+) -> list[dict[str, Any]]:
+    # llama.cpp's OpenAI-compatible server expects raw base64 here, not a data
+    # URL. This transport is attempted only after the provider rejects the
+    # generic video_url dialect, so existing providers keep their wire shape.
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": user_prompt},
+                {
+                    "type": "input_video",
+                    "input_video": {
+                        "data": _raw_base64_from_data_url(video_data_url)
+                    },
+                },
+            ],
+        }
+    ]
+
+
+def _frame_messages(
+    user_prompt: str, frames: Sequence[VideoFrame]
+) -> list[dict[str, Any]]:
+    sample_times = ", ".join(
+        f"{frame.timestamp_seconds:.2f}s" for frame in frames
+    )
+    evidence_note = (
+        f"{user_prompt}\n\n"
+        "Native video content was rejected by the provider. The following "
+        f"{len(frames)} JPEG frames were sampled in chronological order at "
+        f"{sample_times}. Use only visible evidence from these samples. Do not "
+        "claim audio content, continuous motion, or events between samples "
+        "unless the frames themselves support the inference."
+    )
+    content: list[dict[str, Any]] = [{"type": "text", "text": evidence_note}]
+    content.extend(
+        {
+            "type": "image_url",
+            "image_url": {"url": frame.data_url},
+        }
+        for frame in frames
+    )
+    return [{"role": "user", "content": content}]
+
+
+def _status_code(exc: Exception) -> Optional[int]:
+    for candidate in (
+        getattr(exc, "status_code", None),
+        getattr(getattr(exc, "response", None), "status_code", None),
+    ):
+        if isinstance(candidate, int):
+            return candidate
+    match = re.match(r"^\s*(?:http\s*)?(\d{3})\b", str(exc), re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def _error_text(exc: Exception) -> str:
+    return str(exc).strip().lower()
+
+
+def _compact_error(exc: Exception) -> str:
+    text = str(exc).strip() or exc.__class__.__name__
+    text = re.sub(
+        r"data:video/[^,\s]+,[a-zA-Z0-9+/=]+",
+        "<video data omitted>",
+        text,
+    )
+    text = re.sub(r"\s+", " ", text)
+    return text[:280]
+
+
+def _is_wire_dialect_rejection(exc: Exception) -> bool:
+    text = _error_text(exc)
+    return any(
+        hint in text
+        for hint in (
+            "video_url",
+            "input_video",
+            "unsupported content[].type",
+            "unsupported content type",
+            "unknown content type",
+            "unrecognized content type",
+            "invalid content type",
+            "content type is not supported",
+            "expected content type",
+            "unknown variant",
+        )
+    )
+
+
+def _is_video_capability_rejection(exc: Exception) -> bool:
+    text = _error_text(exc)
+    return any(
+        hint in text
+        for hint in (
+            "does not support video",
+            "doesn't support video",
+            "not support video",
+            "video input is not supported",
+            "video inputs are not supported",
+            "unsupported video input",
+            "video modality",
+            "image input only",
+            "only supports image",
+            "only support image",
+            "multimodal input",
+        )
+    )
+
+
+def _is_fatal_request_error(exc: Exception) -> bool:
+    status = _status_code(exc)
+    if status in {401, 403, 404, 408, 409, 413, 429} or (
+        status is not None and status >= 500
+    ):
+        return True
+    text = _error_text(exc)
+    return any(
+        hint in text
+        for hint in (
+            "insufficient credits",
+            "payment required",
+            "billing",
+            "authentication",
+            "unauthorized",
+            "forbidden",
+            "rate limit",
+            "too many requests",
+            "timed out",
+            "timeout",
+            "connection error",
+            "connection refused",
+            "payload too large",
+            "request too large",
+            "content_too_large",
+            "context length",
+            "model not found",
+        )
+    )
+
+
+def _is_ambiguous_bad_request(exc: Exception) -> bool:
+    if _is_fatal_request_error(exc):
+        return False
+    status = _status_code(exc)
+    if status in {400, 422}:
+        return True
+    text = _error_text(exc)
+    return "bad request" in text or "invalid_request" in text
+
+
+def _should_try_input_video(exc: Exception) -> bool:
+    if _is_fatal_request_error(exc):
+        return False
+    if _is_wire_dialect_rejection(exc):
+        return True
+    if _is_video_capability_rejection(exc):
+        return False
+    return _is_ambiguous_bad_request(exc)
+
+
+def _should_try_frames(exc: Exception) -> bool:
+    if _is_fatal_request_error(exc):
+        return False
+    return (
+        _is_wire_dialect_rejection(exc)
+        or _is_video_capability_rejection(exc)
+        or _is_ambiguous_bad_request(exc)
+    )
+
+
+def _attempt_summary(attempts: Sequence[tuple[str, Exception]]) -> str:
+    return "; ".join(
+        f"{transport}: {_compact_error(exc)}" for transport, exc in attempts
+    )
+
+
+async def _call_with_video_negotiation(
+    *,
+    async_call_llm,
+    base_call_kwargs: dict[str, Any],
+    user_prompt: str,
+    video_data_url: str,
+    video_path: Path,
+) -> tuple[Any, list[dict[str, Any]], str, int]:
+    """Call the provider through a bounded, evidence-driven transport ladder."""
+    attempts: list[tuple[str, Exception]] = []
+
+    video_url_messages = _video_url_messages(user_prompt, video_data_url)
+    try:
+        response = await async_call_llm(
+            messages=video_url_messages, **base_call_kwargs
+        )
+        return response, video_url_messages, "video_url", 0
+    except Exception as exc:  # noqa: BLE001 - provider error is classified below
+        attempts.append(("video_url", exc))
+        if not _should_try_input_video(exc) and not _should_try_frames(exc):
+            raise
+        first_error = exc
+
+    last_error = first_error
+    if _should_try_input_video(first_error):
+        input_video_messages = _input_video_messages(user_prompt, video_data_url)
+        logger.info(
+            "Provider rejected video_url; retrying llama.cpp input_video dialect"
+        )
+        try:
+            response = await async_call_llm(
+                messages=input_video_messages, **base_call_kwargs
+            )
+            return response, input_video_messages, "input_video", 0
+        except Exception as exc:  # noqa: BLE001 - classified below
+            attempts.append(("input_video", exc))
+            last_error = exc
+            if not _should_try_frames(exc):
+                raise VideoInputNegotiationError(
+                    "The provider rejected the native video_url dialect, then "
+                    "the input_video retry failed with a non-negotiable error. "
+                    + _attempt_summary(attempts)
+                ) from exc
+
+    if not _should_try_frames(last_error):
+        raise VideoInputNegotiationError(
+            "No safe video transport fallback was authorized. "
+            + _attempt_summary(attempts)
+        ) from last_error
+
+    logger.info(
+        "Native video dialects were rejected; extracting chronological JPEG frames"
+    )
+    try:
+        frames = await _extract_video_frames_async(video_path)
+    except VideoFrameExtractionError as exc:
+        raise VideoInputNegotiationError(
+            "The provider rejected native video content and frame fallback "
+            f"could not be produced: {exc}. Native attempts: "
+            + _attempt_summary(attempts)
+        ) from exc
+
+    frame_messages = _frame_messages(user_prompt, frames)
+    try:
+        response = await async_call_llm(
+            messages=frame_messages, **base_call_kwargs
+        )
+        return response, frame_messages, "image_frames", len(frames)
+    except Exception as exc:  # noqa: BLE001 - include final provider receipt
+        attempts.append(("image_frames", exc))
+        raise VideoInputNegotiationError(
+            "The provider rejected both native video dialects and the "
+            "chronological JPEG-frame fallback. " + _attempt_summary(attempts)
+        ) from exc
+
+
+def _resolve_video_call_settings() -> tuple[float, float]:
+    timeout = 180.0
+    temperature = 0.1
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        video_cfg = cfg_get(cfg, "auxiliary", "video", default={}) or {}
+        vision_cfg = cfg_get(cfg, "auxiliary", "vision", default={}) or {}
+        configured_timeout = video_cfg.get("timeout", vision_cfg.get("timeout"))
+        if configured_timeout is not None:
+            timeout = float(configured_timeout)
+        configured_temperature = video_cfg.get(
+            "temperature", vision_cfg.get("temperature")
+        )
+        if configured_temperature is not None:
+            temperature = float(configured_temperature)
+    except Exception:  # noqa: BLE001 - config fallback is intentionally soft
+        pass
+    return timeout, temperature
+
+
+async def video_analyze_tool(
+    video_url: str,
+    user_prompt: str,
+    model: str = None,
+    task_id: Optional[str] = None,
+) -> str:
+    """Analyze video with native-dialect negotiation and real-frame fallback."""
+    if not isinstance(user_prompt, str):
+        user_prompt = str(user_prompt) if user_prompt is not None else ""
+    debug_call_data: dict[str, Any] = {
+        "parameters": {
+            "video_url": video_url,
+            "user_prompt": (
+                user_prompt[:200] + "..."
+                if len(user_prompt) > 200
+                else user_prompt
+            ),
+            "model": model,
+        },
+        "error": None,
+        "success": False,
+        "analysis_length": 0,
+        "model_used": model,
+        "video_size_bytes": 0,
+        "transport": None,
+        "frame_count": 0,
+    }
+
+    temp_video_path: Optional[Path] = None
+    should_cleanup = True
+
+    try:
+        from tools.interrupt import is_interrupted
+
+        if is_interrupted():
+            return tool_error("Interrupted", success=False)
+
+        logger.info("Analyzing video: %s", video_url[:60])
+        logger.info("User prompt: %s", user_prompt[:100])
+
+        resolved_url = video_url
+        if resolved_url.startswith("file://"):
+            resolved_url = resolved_url[len("file://") :]
+        local_path = Path(os.path.expanduser(resolved_url))
+
+        if not _terminal_backend_is_local() and _is_path_like_video_source(
+            video_url
+        ):
+            logger.info("Reading video source via terminal backend: %s", video_url)
+            temp_video_path = await _materialize_video_from_terminal_backend(
+                video_url, task_id
+            )
+            should_cleanup = True
+        elif local_path.is_file():
+            from agent.file_safety import raise_if_read_blocked
+
+            raise_if_read_blocked(str(local_path))
+            logger.info("Using local video file: %s", video_url)
+            temp_video_path = local_path
+            should_cleanup = False
+        elif await _vision_module()._validate_image_url_async(video_url):
+            blocked = check_website_access(video_url)
+            if blocked:
+                raise PermissionError(blocked["message"])
+            temp_dir = get_hermes_dir("cache/video", "temp_video_files")
+            temp_video_path = temp_dir / f"temp_video_{uuid.uuid4()}.mp4"
+            await _download_video(video_url, temp_video_path)
+            should_cleanup = True
+        else:
+            raise ValueError(
+                "Invalid video source. Provide an HTTP/HTTPS URL or a valid "
+                "local file path."
+            )
+
+        video_size_bytes = temp_video_path.stat().st_size
+        video_size_mb = video_size_bytes / (1024 * 1024)
+        logger.info("Video ready (%.1f MB)", video_size_mb)
+
+        detected_mime = _detect_video_mime_type(temp_video_path)
+        if not detected_mime:
+            raise ValueError(
+                f"Unsupported video format: '{temp_video_path.suffix}'. "
+                f"Supported: {', '.join(sorted(_VIDEO_MIME_TYPES.keys()))}"
+            )
+        if video_size_bytes > _VIDEO_SIZE_WARN_BYTES:
+            logger.warning(
+                "Video is %.1f MB - may be slow or rejected", video_size_mb
+            )
+
+        video_data_url = await asyncio.to_thread(
+            _video_to_base64_data_url,
+            temp_video_path,
+            detected_mime,
+        )
+        data_size_mb = len(video_data_url) / (1024 * 1024)
+        if len(video_data_url) > _MAX_VIDEO_BASE64_BYTES:
+            raise ValueError(
+                f"Video too large for API: base64 payload is {data_size_mb:.1f} MB "
+                f"(limit {_MAX_VIDEO_BASE64_BYTES / (1024 * 1024):.0f} MB). "
+                "Compress or trim the video and retry."
+            )
+
+        debug_call_data["video_size_bytes"] = video_size_bytes
+        timeout, temperature = _resolve_video_call_settings()
+        base_call_kwargs: dict[str, Any] = {
+            "task": "vision",
+            "temperature": temperature,
+            "timeout": timeout,
+        }
+        if model:
+            base_call_kwargs["model"] = model
+
+        async_call_llm, extract_content_or_reasoning = _auxiliary_callables()
+        response, used_messages, transport, frame_count = (
+            await _call_with_video_negotiation(
+                async_call_llm=async_call_llm,
+                base_call_kwargs=base_call_kwargs,
+                user_prompt=user_prompt,
+                video_data_url=video_data_url,
+                video_path=temp_video_path,
+            )
+        )
+        analysis = extract_content_or_reasoning(response)
+
+        if not analysis:
+            logger.warning(
+                "Empty video response over %s, retrying once", transport
+            )
+            response = await async_call_llm(
+                messages=used_messages, **base_call_kwargs
+            )
+            analysis = extract_content_or_reasoning(response)
+
+        analysis_length = len(analysis) if analysis else 0
+        logger.info(
+            "Video analysis completed via %s (%s characters)",
+            transport,
+            analysis_length,
+        )
+
+        result = {
+            "success": True,
+            "analysis": analysis
+            or (
+                "There was a problem with the request and the video could not "
+                "be analyzed."
+            ),
+            "transport": transport,
+        }
+        if frame_count:
+            result["frame_count"] = frame_count
+
+        debug_call_data["success"] = True
+        debug_call_data["analysis_length"] = analysis_length
+        debug_call_data["transport"] = transport
+        debug_call_data["frame_count"] = frame_count
+        debug = _debug_session()
+        debug.log_call("video_analyze_tool", debug_call_data)
+        debug.save()
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    except Exception as exc:  # noqa: BLE001 - tool returns structured errors
+        error_msg = f"Error analyzing video: {exc}"
+        logger.error("%s", error_msg, exc_info=True)
+
+        err_str = str(exc).lower()
+        if isinstance(exc, VideoInputNegotiationError):
+            analysis = str(exc)
+        elif any(
+            hint in err_str
+            for hint in (
+                "402",
+                "insufficient",
+                "payment required",
+                "credits",
+                "billing",
+            )
+        ):
+            analysis = (
+                "Insufficient credits or payment required. Please top up your "
+                f"API provider account and try again. Error: {exc}"
+            )
+        elif any(
+            hint in err_str
+            for hint in (
+                "too large",
+                "payload",
+                "413",
+                "content_too_large",
+                "request_too_large",
+                "exceeds",
+                "size limit",
+            )
+        ):
+            analysis = (
+                "The video is too large for the API. Try compressing or "
+                f"trimming the video (raw max ~{_MAX_VIDEO_RAW_BYTES / (1024 * 1024):.1f} MB). "
+                f"Error: {exc}"
+            )
+        elif _is_video_capability_rejection(exc) or _is_wire_dialect_rejection(
+            exc
+        ):
+            analysis = (
+                "The provider rejected the video payload before a compatible "
+                "transport could settle. Error: "
+                f"{exc}"
+            )
+        else:
+            analysis = (
+                "There was a problem with the request and the video could not "
+                f"be analyzed. Error: {exc}"
+            )
+
+        result = {
+            "success": False,
+            "error": error_msg,
+            "analysis": analysis,
+        }
+        debug_call_data["error"] = error_msg
+        debug = _debug_session()
+        debug.log_call("video_analyze_tool", debug_call_data)
+        debug.save()
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+    finally:
+        if should_cleanup and temp_video_path and temp_video_path.exists():
+            try:
+                temp_video_path.unlink()
+                logger.debug("Cleaned up temporary video file")
+            except Exception as cleanup_error:  # noqa: BLE001 - best effort
+                logger.warning(
+                    "Could not delete temporary file: %s",
+                    cleanup_error,
+                    exc_info=True,
+                )
+
+
+VIDEO_ANALYZE_SCHEMA = {
+    "name": "video_analyze",
+    "description": (
+        "Analyze a video from a URL or local file path using a multimodal AI "
+        "model. Negotiates native provider video formats and falls back to "
+        "chronological image frames when the endpoint is image-only. Use this "
+        "for video files; for images, use vision_analyze instead. Supports "
+        "mp4, webm, mov, avi, mkv, and mpeg formats. Large videos (>20 MB) "
+        f"may be slow; raw input max ~{_MAX_VIDEO_RAW_BYTES / (1024 * 1024):.1f} MB "
+        "under the 50 MB encoded-payload cap."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "video_url": {
+                "type": "string",
+                "description": (
+                    "Video URL (http/https) or local file path to analyze."
+                ),
+            },
+            "question": {
+                "type": "string",
+                "description": (
+                    "Your specific question about the video. The AI will "
+                    "describe what happens and answer the question."
+                ),
+            },
+        },
+        "required": ["video_url", "question"],
+    },
+}
+
+
+def _resolve_video_model() -> Optional[str]:
+    model = None
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        configured = cfg_get(
+            cfg, "auxiliary", "video", "model"
+        ) or cfg_get(cfg, "auxiliary", "vision", "model")
+        if configured:
+            model = str(configured).strip() or None
+    except Exception:  # noqa: BLE001 - env fallback is intentional
+        pass
+    if not model:
+        model = (
+            os.getenv("AUXILIARY_VIDEO_MODEL", "").strip()
+            or os.getenv("AUXILIARY_VISION_MODEL", "").strip()
+            or None
+        )
+    return model
+
+
+def _handle_video_analyze(
+    args: Dict[str, Any], **kw: Any
+) -> Awaitable[str]:
+    video_url = args.get("video_url", "")
+    question = args.get("question", "")
+    full_prompt = (
+        "Fully describe and explain everything happening in this video, "
+        "including visual content, motion, audio cues, text overlays, and scene "
+        f"transitions. Then answer the following question:\n\n{question}"
+    )
+    # Resolve through the public module so existing callers/tests that patch
+    # tools.vision_tools.video_analyze_tool keep working after the shard.
+    public_tool = _vision_module().video_analyze_tool
+    return public_tool(
+        video_url,
+        full_prompt,
+        _resolve_video_model(),
+        task_id=kw.get("task_id"),
+    )

--- a/tools/video_analysis/frames.py
+++ b/tools/video_analysis/frames.py
@@ -1,0 +1,224 @@
+"""Bounded chronological JPEG extraction for video-analysis fallback."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import math
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_MAX_FRAME_FALLBACK_BYTES = 16 * 1024 * 1024
+_DEFAULT_FRAME_COUNT = 12
+_DEFAULT_FRAME_MAX_SIDE = 768
+
+
+class VideoFrameExtractionError(RuntimeError):
+    """Raised when a provider needs image frames but none can be produced."""
+
+
+@dataclass(frozen=True)
+class VideoFrame:
+    """One chronologically sampled JPEG frame."""
+
+    timestamp_seconds: float
+    data_url: str
+
+
+def _probe_video_duration(video_path: Path, ffprobe_path: str) -> float:
+    """Return a finite, positive video duration in seconds."""
+    completed = subprocess.run(
+        [
+            ffprobe_path,
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(video_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "unknown error").strip()
+        raise VideoFrameExtractionError(
+            f"ffprobe could not read the video duration: {detail[:240]}"
+        )
+
+    lines = (completed.stdout or "").strip().splitlines()
+    if not lines:
+        raise VideoFrameExtractionError(
+            "ffprobe returned no duration for the first video stream"
+        )
+    try:
+        duration = float(lines[0])
+    except ValueError as exc:
+        raise VideoFrameExtractionError(
+            f"ffprobe returned an invalid duration: {lines[0]!r}"
+        ) from exc
+    if not math.isfinite(duration) or duration <= 0:
+        raise VideoFrameExtractionError(
+            f"ffprobe returned a non-positive duration: {duration!r}"
+        )
+    return duration
+
+
+def _frame_timestamps(duration: float, max_frames: int) -> list[float]:
+    """Choose bounded midpoint samples that cover the complete timeline."""
+    if max_frames < 1:
+        raise ValueError("max_frames must be at least 1")
+    frame_count = min(max_frames, max(1, math.ceil(duration)))
+    return [
+        duration * (index + 0.5) / frame_count
+        for index in range(frame_count)
+    ]
+
+
+def _jpeg_data_url(frame_path: Path) -> str:
+    data = frame_path.read_bytes()
+    if not data.startswith(b"\xff\xd8\xff"):
+        raise VideoFrameExtractionError(
+            f"ffmpeg produced a non-JPEG frame at {frame_path.name}"
+        )
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:image/jpeg;base64,{encoded}"
+
+
+def extract_video_frames(
+    video_path: Path,
+    *,
+    max_frames: int = _DEFAULT_FRAME_COUNT,
+    max_side: int = _DEFAULT_FRAME_MAX_SIDE,
+) -> list[VideoFrame]:
+    """Extract bounded chronological JPEG samples with ffmpeg/ffprobe.
+
+    Subprocesses receive argv vectors, never shell commands. Their stdin is
+    disabled, execution is time-bounded, and all temporary files are closed
+    before read/delete so the fallback behaves consistently on Windows.
+    """
+    if max_side < 64:
+        raise ValueError("max_side must be at least 64 pixels")
+
+    ffmpeg_path = shutil.which("ffmpeg")
+    ffprobe_path = shutil.which("ffprobe")
+    missing = [
+        name
+        for name, resolved in (("ffmpeg", ffmpeg_path), ("ffprobe", ffprobe_path))
+        if not resolved
+    ]
+    if missing:
+        raise VideoFrameExtractionError(
+            "Frame fallback requires ffmpeg and ffprobe on PATH; missing: "
+            + ", ".join(missing)
+        )
+
+    duration = _probe_video_duration(video_path, ffprobe_path)
+    timestamps = _frame_timestamps(duration, max_frames)
+    frames: list[VideoFrame] = []
+    extraction_errors: list[str] = []
+    encoded_bytes = 0
+
+    with tempfile.TemporaryDirectory(prefix="hermes-video-frames-") as temp_dir:
+        output_dir = Path(temp_dir)
+        for index, timestamp in enumerate(timestamps):
+            output_path = output_dir / f"frame-{index:03d}.jpg"
+            completed = subprocess.run(
+                [
+                    ffmpeg_path,
+                    "-nostdin",
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-ss",
+                    f"{timestamp:.6f}",
+                    "-i",
+                    str(video_path),
+                    "-map",
+                    "0:v:0",
+                    "-an",
+                    "-sn",
+                    "-dn",
+                    "-frames:v",
+                    "1",
+                    "-threads",
+                    "1",
+                    "-vf",
+                    (
+                        f"scale={max_side}:{max_side}:"
+                        "force_original_aspect_ratio=decrease:"
+                        "force_divisible_by=2"
+                    ),
+                    "-q:v",
+                    "3",
+                    "-y",
+                    str(output_path),
+                ],
+                check=False,
+                capture_output=True,
+                timeout=45,
+                stdin=subprocess.DEVNULL,
+            )
+            if completed.returncode != 0 or not output_path.is_file():
+                detail_value = completed.stderr or completed.stdout or b"unknown error"
+                if isinstance(detail_value, bytes):
+                    detail = detail_value.decode("utf-8", errors="replace")
+                else:
+                    detail = str(detail_value)
+                extraction_errors.append(
+                    f"{timestamp:.3f}s: {detail.strip()[:160]}"
+                )
+                continue
+
+            try:
+                data_url = _jpeg_data_url(output_path)
+            except VideoFrameExtractionError as exc:
+                extraction_errors.append(f"{timestamp:.3f}s: {exc}")
+                continue
+
+            next_size = encoded_bytes + len(data_url.encode("ascii"))
+            if next_size > _MAX_FRAME_FALLBACK_BYTES:
+                logger.warning(
+                    "Stopping video frame fallback at %d frames: encoded payload "
+                    "would exceed %.0f MB",
+                    len(frames),
+                    _MAX_FRAME_FALLBACK_BYTES / (1024 * 1024),
+                )
+                break
+            frames.append(VideoFrame(timestamp_seconds=timestamp, data_url=data_url))
+            encoded_bytes = next_size
+
+    if not frames:
+        detail = extraction_errors[0] if extraction_errors else "no frames produced"
+        raise VideoFrameExtractionError(
+            "ffmpeg could not extract any decodable JPEG frames: " + detail
+        )
+    if extraction_errors:
+        logger.warning(
+            "Video frame fallback produced %d/%d frames; first failure: %s",
+            len(frames),
+            len(timestamps),
+            extraction_errors[0],
+        )
+    return frames
+
+
+async def extract_video_frames_async(video_path: Path) -> list[VideoFrame]:
+    """Keep ffmpeg work off event loops and inside the vision CPU budget."""
+    from tools import vision_tools
+
+    return await vision_tools._run_encode_on_cpu_executor(
+        extract_video_frames,
+        video_path,
+    )

--- a/tools/vision_video_analysis.py
+++ b/tools/vision_video_analysis.py
@@ -1,0 +1,20 @@
+"""Discovery bridge for the sharded video-analysis runtime.
+
+Built-in tool discovery imports self-registering top-level modules in sorted
+order. This file sorts after ``vision_tools.py`` and explicitly settles
+``video_analyze`` on the package owner after the legacy module is loaded.
+"""
+
+from tools import video_analysis
+from tools.registry import registry
+
+registry.register(
+    name="video_analyze",
+    toolset="video",
+    schema=video_analysis.VIDEO_ANALYZE_SCHEMA,
+    handler=video_analysis._handle_video_analyze,
+    check_fn=lambda: video_analysis.core._vision_module().check_vision_requirements(),
+    is_async=True,
+    emoji="🎬",
+    override=True,
+)


### PR DESCRIPTION
## What does this PR do?

Re-materializes the reviewed #97318 video transport repair as one exact current-main release object after the prior PR head was rewritten through the connected GitHub app and GitHub did not create a new hosted workflow run for that rewritten head.

`video_analyze` currently sends one hard-coded `video_url` block containing a full `data:video/...;base64,...` payload. That shape works only for a subset of providers: image-compatible OpenAI endpoints reject it, while llama.cpp accepts native video under a different typed-content dialect.

This PR replaces the false binary of “native `video_url` or generic model-capability error” with a bounded, response-driven transport ladder:

1. Preserve the existing `video_url` request as the first attempt.
2. On a content-dialect rejection, retry llama.cpp’s documented `input_video` form with raw base64 bytes.
3. When native video is rejected but image input is available, extract bounded chronological JPEG frames with `ffmpeg`/`ffprobe` and send real `image_url` parts.
4. Stop on non-negotiable failures such as auth, billing, rate limits, timeouts, payload limits, server errors, and missing models rather than disguising them as capability negotiation.

The provider response authorizes each transition. Endpoint location and guessed model names do not.

The release object also incorporates the substantive review repairs from #97318:

- one canonical frame-extraction owner in `tools/video_analysis/frames.py`;
- leading-status-only fallback parsing rather than matching arbitrary embedded numbers;
- raw-file size rejection before `Path.read_bytes()` using the exact MIME-specific data-URL budget;
- configured video timeouts are honored rather than silently clamped;
- deterministic runtime ownership through the bounded `tools/video_analysis/` package and discovery bridge.

### Exact submitted object

- Base/current main: `2a598aad1c398e95b3325a0f100f5c28efa63d12`
- Head: `1e53d8d75e7b6cb82dbf8bb1812b5e04a61c27dc`
- Tree: `f8c0d12151946387a325c81179292a19ef872845`
- Shape: exactly **1 commit / 6 files**
- Parent: exactly current main at publication
- Every submitted path is below 2,000 lines

## Related Issue

Fixes #72275.

Supersedes the release object on #97318 while preserving its discussion/review history. #97318 itself remains the historical review/provenance thread until this replacement receives exact-head hosted acceptance.

Related: #88141.

### Prior work / provenance

- #72275 by Catmittee — original reporter and reproduction.
- #72516 by JonthanaHanh — established the rejection/retry seam, but its image fallback still relabeled video bytes.
- #82996 by x7peeps — real frame-extraction direction.
- #97318 — prior implementation/review carrier; its final review repair exposed a regression-test threshold bug rather than a remaining product buffering defect.
- llama.cpp `server-common.cpp` and server documentation establish `input_video` as a real native-video request dialect.

This PR does not erase those contributions or reopen their overlapping implementations as independent landing objects.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [x] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `tools/video_analysis/core.py`
  - response-driven `video_url → input_video → image_frames` negotiation;
  - MIME-specific encoded-payload budget checked from file metadata before buffering;
  - fatal vs negotiable provider-error classification;
  - configured timeout/temperature resolution without silent timeout clamping;
  - structured settled-transport/frame-count receipts.
- `tools/video_analysis/frames.py`
  - one bounded frame extraction owner;
  - chronological midpoint sampling;
  - argv-only `ffmpeg`/`ffprobe`, disabled stdin, explicit timeouts, one ffmpeg thread;
  - bounded dimensions/encoded payload and JPEG magic validation.
- `tools/video_analysis/__init__.py`
  - canonical bounded package owner with legacy compatibility exports.
- `tools/vision_video_analysis.py`
  - deterministic registry/discovery settlement after legacy vision-tool discovery.
- `tests/tools/test_video_transport_negotiation.py`
  - native dialect retry, image-frame fallback, fatal-error refusal, extraction/runtime compatibility, real ffmpeg path, and registry settlement.
- `tests/tools/test_video_transport_regressions.py`
  - pins single extraction ownership, leading-only status fallback, pre-buffer oversize refusal at the actual `video/mp4` budget, and configured timeout preservation.

## How to Test

```bash
python -m pytest \
  tests/tools/test_video_analyze.py \
  tests/tools/test_video_transport_negotiation.py \
  tests/tools/test_video_transport_regressions.py \
  tests/tools/test_vision_tools.py \
  tests/tools/test_computer_use_vision_routing.py \
  tests/tools/test_vision_region.py \
  tests/tools/test_vision_native_fast_path.py \
  -q

python -m ruff check \
  tools/video_analysis \
  tools/vision_video_analysis.py \
  tests/tools/test_video_transport_negotiation.py \
  tests/tools/test_video_transport_regressions.py

python scripts/check-windows-footguns.py \
  tools/video_analysis \
  tools/vision_video_analysis.py \
  tests/tools/test_video_transport_negotiation.py \
  tests/tools/test_video_transport_regressions.py

git diff --check 2a598aad1c398e95b3325a0f100f5c28efa63d12..1e53d8d75e7b6cb82dbf8bb1812b5e04a61c27dc
```

### Adversarial acceptance cases

- llama.cpp-style rejection of `video_url` advances to `input_video` with raw base64.
- image-only fallback sends actual JPEG frames, never video bytes mislabeled as images.
- auth/rate-limit/server/payload failures do not get reclassified as dialect negotiation.
- a `video/mp4` exactly one byte above its MIME-specific data-URL raw-byte budget is rejected from `stat().st_size` before `read_bytes()` can execute.
- arbitrary embedded numbers such as “429 bytes” are not mistaken for HTTP status 429.
- configured timeout `60` remains `60.0` rather than being clamped.
- one canonical frame extraction implementation owns probing/timestamps/JPEG conversion.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] The single submitted commit follows Conventional Commits and includes DCO sign-off.
- [x] I searched/reconciled existing work and preserved #72275 / #72516 / #82996 / #97318 provenance.
- [x] The PR contains only the video transport/fallback repair and its regressions.
- [x] Tests are included for the original defect and review-discovered sibling classes.
- [ ] Hosted exact-head CI/Docker/Nix acceptance — publication authority is the runs created for exact head `1e53d8d…`; no predecessor receipt will be transferred.

### Documentation & Housekeeping

- [x] No public config key changed.
- [x] No contributor workflow changed.
- [x] No model-facing tool schema change requires separate documentation.
- [x] Every submitted file is below 2,000 lines.
- [x] Submitted train is one commit directly on publication-time current main.

## Screenshots / Logs

No UI surface changes.

The prior #97318 workflow results are historical evidence only. This replacement is complete only when CI, Docker, and Nix execute successfully on exact head `1e53d8d75e7b6cb82dbf8bb1812b5e04a61c27dc`.