### PR TITLE
fix(model-switch): pick /model's extra_body by target model, not just name

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2189,15 +2189,33 @@ def switch_model(
     # ``extra_body`` such as chat_template_kwargs) so a ``/model`` switch to a
     # custom provider applies it on the gateway, matching the default-provider
     # path. resolve_runtime_provider surfaces these for named custom providers.
+    #
+    # Matched by provider identity, base_url, AND model — the same rule
+    # agent_init._merge_custom_provider_extra_body and
+    # agent_runtime_helpers._apply_switched_provider_request_overrides apply
+    # via the shared _custom_provider_extra_body_for_agent matcher. Two
+    # custom_providers entries can share a name/provider_key while targeting
+    # different models with different extra_body (e.g. a local vLLM endpoint
+    # toggling chat_template_kwargs per model); _get_named_custom_provider
+    # alone always returns the FIRST name match regardless of which model
+    # this switch actually targets, so it can't be used to pick extra_body.
     request_overrides = None
     try:
-        from hermes_cli.runtime_provider import (
-            _get_named_custom_provider,
-            _custom_provider_request_overrides,
-        )
+        from hermes_cli.runtime_provider import _get_named_custom_provider
+        from hermes_cli.config import load_config, get_compatible_custom_providers
+        from agent.agent_init import _custom_provider_extra_body_for_agent
+
         _cp_for_ro = _get_named_custom_provider(target_provider)
         if _cp_for_ro:
-            request_overrides = _custom_provider_request_overrides(_cp_for_ro) or None
+            _cp_identity = str(_cp_for_ro.get("provider_key") or _cp_for_ro.get("name") or "").strip()
+            _extra_body = _custom_provider_extra_body_for_agent(
+                provider=f"custom:{_cp_identity}",
+                model=new_model,
+                base_url=base_url,
+                custom_providers=get_compatible_custom_providers(load_config()),
+            )
+            if _extra_body:
+                request_overrides = {"extra_body": dict(_extra_body)}
     except Exception:
         request_overrides = None
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -515,6 +515,65 @@ def test_picker_selection_resolves_named_custom_provider_model_id(monkeypatch):
     assert result.new_model == "deepseek-v4-flash"
 
 
+def test_switch_model_extra_body_matches_target_model_not_first_same_name_entry(monkeypatch):
+    """Two custom_providers entries can share a name/base_url while targeting
+    different models with different extra_body (e.g. a local vLLM endpoint
+    toggling chat_template_kwargs per model). A /model switch to the SECOND
+    entry's model must carry that entry's extra_body, not the first entry's
+    — the prior name-only lookup always returned the first list match
+    regardless of which model this switch actually targets."""
+    same_name_entries = [
+        {
+            "name": "vllm-local",
+            "base_url": "http://localhost:8000/v1",
+            "model": "model-a",
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": True}},
+        },
+        {
+            "name": "vllm-local",
+            "base_url": "http://localhost:8000/v1",
+            "model": "model-b",
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+        },
+    ]
+    # _get_named_custom_provider() reads config.yaml via its own late-bound
+    # load_config() delegate independent of switch_model()'s custom_providers
+    # kwarg — both must see the same two entries.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"custom_providers": same_name_entries},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key",
+            "base_url": "http://localhost:8000/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: _MOCK_VALIDATION,
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="model-b",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        explicit_provider="custom:vllm-local",
+        user_providers={},
+        custom_providers=same_name_entries,
+    )
+
+    assert result.success is True
+    assert result.new_model == "model-b"
+    assert result.request_overrides == {
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+    }
+
+
 
 
 


### PR DESCRIPTION
## Summary

`hermes_cli/model_switch.py`'s `switch_model()` — the pure function behind every `/model` surface (gateway, CLI, Telegram) — resolves the switched-to custom provider's `request_overrides` via:

```python
_cp_for_ro = _get_named_custom_provider(target_provider)
if _cp_for_ro:
    request_overrides = _custom_provider_request_overrides(_cp_for_ro) or None
```

`_get_named_custom_provider()` matches a `providers:`/`custom_providers:` entry by **name alone** and returns the **first** match. Two entries can legitimately share a name/`provider_key` while targeting different models with different `extra_body` — e.g. a local vLLM endpoint with two `custom_providers:` rows under the same name, one per model, each toggling `chat_template_kwargs.enable_thinking` differently. A `/model` switch to the second entry's model silently carried the **first** entry's `extra_body`.

This is the same bug class `agent_init._merge_custom_provider_extra_body` and `agent_runtime_helpers._apply_switched_provider_request_overrides` (added by `b10b27e6f9`) already guard against, via the shared `_custom_provider_extra_body_for_agent` matcher (provider identity + `base_url` + **model**) — its own docstring: *"Matching by name alone would let a different model selected at the same named endpoint inherit an extra_body configured for another model."* `hermes_cli/model_switch.py`'s own resolution never got the same treatment.

## Fix

`_get_named_custom_provider` is still used to resolve the entry's identity (it accepts bare aliases the strict matcher doesn't). The actual `extra_body` is now looked up via `_custom_provider_extra_body_for_agent`, scoped to that identity, the already-resolved `base_url`, and the model being switched to — reusing the established matcher instead of inventing a new one.

## Test plan

- [x] New regression test `test_switch_model_extra_body_matches_target_model_not_first_same_name_entry`: two `custom_providers` entries share a name/base_url with different `model`/`extra_body`; switching to the second entry's model must return that entry's `extra_body`, not the first's.
- [x] Mutation-verify: reverted `hermes_cli/model_switch.py` only, confirmed the new test fails (returns the first entry's `extra_body` instead of the target model's), restored and confirmed it passes.
- [x] `tests/hermes_cli/test_model_switch_custom_providers.py`, `tests/gateway/test_model_command_request_overrides.py`, `tests/hermes_cli/test_custom_provider_model_switch.py`, `tests/hermes_cli/test_user_providers_model_switch.py`, `tests/hermes_cli/test_model_switch_configured_provider_routing.py`: 99 passed.
- [x] `tests/hermes_cli/ -k "model_switch or custom_provider"`: 206 passed, 1 pre-existing unrelated skip.
- [x] `tests/gateway/ -k request_overrides` (excluding modules that fail to collect on this machine for an unrelated missing `aiohttp` dependency): 13 passed, 3 skipped.

## Competitor check

- **#98277** (merged today, ~5 hours before this branch) added `request_overrides` handling to this exact function as part of a larger salvage, but kept the name-only `_get_named_custom_provider` lookup — confirmed by reading current `main` directly and by mutation-verifying against it: the bug is present on `main` as of this PR's base commit, after `#98277` landed.
- **#86180** (open, last updated 2026-08-16 — predates `b10b27e6f9`, which added `agent_runtime_helpers._apply_switched_provider_request_overrides`) touches a different layer entirely: `list_authenticated_providers()`'s picker row-grouping (so two same-endpoint entries stay selectable as distinct rows) and `agent_init`'s build-time matcher. Its `hermes_cli/model_switch.py` hunk is exclusively the picker-grouping helpers (`_extra_body_identity`, `_group_display_prefix`) — verified via `gh pr diff` — it does not touch the `switch_model()` `request_overrides` block this PR changes.