### PR TITLE
fix(install): pass -NoAutoStart to cua-driver installer on fresh Windows installs

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1653,15 +1653,29 @@ def _run_cua_driver_installer(
     is_linux = system == "Linux"
 
     if is_windows:
-        # Mirror the one-liner printed by cua_driver_install_hint().
+        # Fresh installs use the scriptblock form with -NoAutoStart so the
+        # upstream install.ps1 skips Register-CuaDriverAutostart (the only
+        # branch that self-elevates via UAC and creates the logon-triggered
+        # scheduled task).  Unattended refreshes (installer_timeout set)
+        # already use this form; now fresh interactive installs match.
+        # The plain `irm … | iex` one-liner cannot receive parameters, which
+        # is why scriptblock invocation is required.
+        # Fixes: https://github.com/NousResearch/hermes-agent/issues/95372
+        ps_scriptblock = (
+            "$sc = irm https://raw.githubusercontent.com/trycua/cua/main/"
+            "libs/cua-driver/scripts/install.ps1; "
+            "& ([scriptblock]::Create($sc)) -NoAutoStart"
+        )
+        install_cmd = [
+            "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+            "-Command", ps_scriptblock,
+        ]
+        # Manual hint still shows the easy one-liner for users who want to
+        # run it themselves — they can add -NoAutoStart if they prefer.
         ps_oneliner = (
             "irm https://raw.githubusercontent.com/trycua/cua/main/"
             "libs/cua-driver/scripts/install.ps1 | iex"
         )
-        install_cmd = [
-            "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
-            "-Command", ps_oneliner,
-        ]
         manual_hint = (
             'powershell -NoProfile -ExecutionPolicy Bypass -Command '
             f'"{ps_oneliner}"'


### PR DESCRIPTION
## Problem

On a fresh Hermes installation on Windows (#95372), the cua-driver installer creates a \cua-driver-serve\ scheduled task with a logon trigger. This starts cua-driver and its overlay on every Windows sign-in, even when Computer Use is not active. On some systems the overlay is detected as a fullscreen application and auto-enables Do Not Disturb.

PR #95129 already fixed **update** paths by using the PowerShell scriptblock form with \-NoAutoStart\. The **fresh install** path still used the plain \irm … | iex\ one-liner, which cannot accept parameters and therefore always ran the autostart registration step.

## Fix

Switch the fresh-install Windows command to the same scriptblock form the update path already uses:

\\\powershell
\ = irm .../install.ps1; & ([scriptblock]::Create(\)) -NoAutoStart
\\\

This skips \Register-CuaDriverAutostart\ entirely on fresh installs, so:
- No \cua-driver-serve\ logon task is created.
- The overlay does not start automatically on sign-in.
- Windows DND is not activated by the overlay on startup.

cua-driver is still fully installed and functional; it just starts on demand when Hermes needs it.

## Testing

- \hermes_cli/tools_config.py\ — only the \install_cmd\ for the fresh Windows path is changed; the update path already used \-NoAutoStart\ and is unchanged.
- The manual hint shown to users still shows the simple one-liner (they can add \-NoAutoStart\ themselves if desired).

Fixes #95372