### PR TITLE
fix(memory): thread gateway user identity into OpenViking turn payloads

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -2276,6 +2276,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._account = ""
         self._user = ""
         self._agent = ""
+        # Runtime gateway user identity threaded through initialize()
+        # (#98498). Distinct from self._user, the configured OpenViking tenant:
+        # the tenant stays the shared data space (X-OpenViking-User header)
+        # while this id marks per-message ownership so the server can scope
+        # preferences to the actual speaker.
+        self._user_id = ""
         self._session_id = ""
         self._turn_count = 0
         # Server-asserted user space for explicit-uid URIs (#91995). Key the
@@ -2794,6 +2800,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._env_refresh_enabled = True
         self._session_id = session_id
         self._turn_count = 0
+        self._user_id = str(kwargs.get("user_id") or "").strip()
         hermes_home = str(kwargs.get("hermes_home") or "").strip()
         if not hermes_home:
             try:
@@ -3189,18 +3196,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return {"type": "text", "text": content}
 
     def _turn_batch_payload(self, user_content: str, assistant_content: str) -> Dict[str, Any]:
+        user_message: Dict[str, Any] = {
+            "role": "user",
+            "parts": [self._text_part(user_content)],
+        }
+        if self._user_id:
+            user_message["peer_id"] = self._user_id
         assistant_message: Dict[str, Any] = {
             "role": "assistant",
             "parts": [self._text_part(assistant_content)],
         }
         if self._agent:
             assistant_message["peer_id"] = self._agent
-        return {
-            "messages": [
-                {"role": "user", "parts": [self._text_part(user_content)]},
-                assistant_message,
-            ]
-        }
+        return {"messages": [user_message, assistant_message]}
 
     def _post_session_turn(
         self,
@@ -4489,9 +4497,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
         messages: List[Dict[str, Any]],
         *,
         assistant_peer_id: str = "",
+        user_peer_id: str = "",
     ) -> List[Dict[str, Any]]:
         """Convert Hermes canonical messages into OpenViking batch payloads."""
         assistant_peer_id = str(assistant_peer_id or "").strip()
+        user_peer_id = str(user_peer_id or "").strip()
         tool_calls_by_id: Dict[str, Dict[str, Any]] = {}
         completed_tool_ids: set[str] = set()
         skipped_tool_ids: set[str] = set()
@@ -4527,6 +4537,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
             payload: Dict[str, Any] = {"role": role, "parts": parts}
             if role == "assistant" and assistant_peer_id:
                 payload["peer_id"] = assistant_peer_id
+            elif role == "user" and user_peer_id:
+                payload["peer_id"] = user_peer_id
             return payload
 
         def flush_tool_parts() -> None:
@@ -4632,6 +4644,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         batch_messages = self._messages_to_openviking_batch(
             turn_messages,
             assistant_peer_id=getattr(self, "_agent", _DEFAULT_AGENT),
+            user_peer_id=getattr(self, "_user_id", ""),
         )
 
         if _sync_trace_enabled():

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1921,3 +1921,81 @@ class TestOpenVikingEnvWriter:
         assert env.read_text(encoding="utf-8").splitlines() == [
             "A=1", "OPENAI_API_KEY=new", "B=2",
         ]
+
+
+def test_initialize_threads_gateway_user_identity(monkeypatch):
+    """The gateway threads user_id into initialize() so memory providers can
+    scope per-user data (#98498). OpenViking used to drop it, attributing
+    every unnamed preference to the single configured tenant user."""
+    _clear_openviking_env(monkeypatch)
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "https://viking.example")
+
+    class FakeVikingClient:
+        def __init__(self, endpoint, api_key="", account="", user="", agent=""):
+            pass
+
+        def health(self):
+            return False
+
+    monkeypatch.setattr(openviking_module, "_VikingClient", FakeVikingClient)
+
+    provider = OpenVikingMemoryProvider()
+    provider.initialize("session-1", platform="cli", user_id="alice")
+
+    assert provider._user_id == "alice"
+    # The configured tenant stays the shared data space, untouched.
+    assert provider._user != "alice"
+
+    # Without a gateway identity nothing changes (single-user instances).
+    provider2 = OpenVikingMemoryProvider()
+    provider2.initialize("session-2", platform="cli")
+    assert provider2._user_id == ""
+
+
+def test_turn_batch_payload_marks_user_message_with_runtime_identity():
+    provider = _make_provider_with_session("sid", turn_count=0)
+    provider._user_id = "alice"
+    provider._agent = "hermes"
+
+    payload = provider._turn_batch_payload("u", "a")
+
+    assert payload["messages"][0]["peer_id"] == "alice"
+    assert payload["messages"][1]["peer_id"] == "hermes"
+
+
+def test_turn_batch_payload_without_user_identity_keeps_user_message_bare():
+    provider = _make_provider_with_session("sid", turn_count=0)
+    provider._user_id = ""
+    provider._agent = "hermes"
+
+    payload = provider._turn_batch_payload("u", "a")
+
+    assert "peer_id" not in payload["messages"][0]
+    assert payload["messages"][1]["peer_id"] == "hermes"
+
+
+def test_messages_to_openviking_batch_marks_user_messages_with_runtime_identity():
+    messages = [
+        {"role": "user", "content": "remember I like tea"},
+        {"role": "assistant", "content": "noted"},
+    ]
+
+    batch = OpenVikingMemoryProvider._messages_to_openviking_batch(
+        messages, assistant_peer_id="hermes", user_peer_id="alice"
+    )
+
+    user_payloads = [m for m in batch if m["role"] == "user"]
+    assistant_payloads = [m for m in batch if m["role"] == "assistant"]
+    assert user_payloads and all(m["peer_id"] == "alice" for m in user_payloads)
+    assert assistant_payloads and all(m["peer_id"] == "hermes" for m in assistant_payloads)
+
+
+def test_messages_to_openviking_batch_without_user_identity_keeps_user_messages_bare():
+    messages = [{"role": "user", "content": "remember I like tea"}]
+
+    batch = OpenVikingMemoryProvider._messages_to_openviking_batch(
+        messages, assistant_peer_id="hermes"
+    )
+
+    assert len(batch) == 1
+    assert "peer_id" not in batch[0]


### PR DESCRIPTION
## What does this PR do?

The OpenViking memory provider was the only memory plugin that discarded the gateway user identity Hermes threads into `initialize()` (`user_id`). Because the plugin only ever set `peer_id` on assistant messages, the server's ownership resolution — which keys off `role == "user"` messages — could never fire, and every preference extracted from an unnamed message was permanently attributed to the single configured tenant user on multi-user instances.

This PR threads the runtime identity through both payload construction paths:

- `initialize()` now reads `kwargs["user_id"]` (same pattern as the hindsight/mem0 providers) and stores it as `self._user_id`.
- `_messages_to_openviking_batch()` accepts a `user_peer_id` argument and attaches it to user-role messages, mirroring how `assistant_peer_id` is already attached to assistant messages.
- `_turn_batch_payload()` (the text fallback path used when the structured batch sync fails) does the same, so both paths behave identically.

The configured `X-OpenViking-User` tenant is deliberately untouched: it stays the shared data space (entities remain shared); only per-message ownership becomes runtime-derived, exactly as the issue suggests. When no gateway identity is present (single-user instances), payloads are byte-identical to before.

Note on `safe_peer_id`: the issue's suggested fix calls it, but that helper lives in the OpenViking server package, which this plugin does not import (it is a pure HTTP client). The plugin's existing convention for peer ids is `str(...).strip()` (see the `assistant_peer_id` handling), and the server re-normalizes incoming peer ids through its own `safe_peer_id` in `_message_target_id`, so stripping client-side is equivalent and dependency-free.

## Related Issue

Fixes #98498

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/openviking/__init__.py`: initialize `_user_id` in `__init__`; read `kwargs["user_id"]` in `initialize()`; accept `user_peer_id` in `_messages_to_openviking_batch()` and attach it to user-role messages in the `payload_message` closure; attach `peer_id` to the user message in `_turn_batch_payload()`; pass `user_peer_id` from `sync_turn()`.
- `tests/plugins/memory/test_openviking_provider.py`: 5 new tests — initialize threading, both payload paths with identity, and both paths without identity (backward-compat anchor).

## How to Test

1. Run `pytest tests/plugins/memory/test_openviking_provider.py -q` — Observed result: 68 passed.
2. Run `pytest tests/plugins/memory/ tests/openviking_plugin/ -q` — Observed result: 399 passed, 3 skipped; the only failures are 6 pre-existing `test_hindsight_provider.py` failures that reproduce identically on unmodified upstream/main (verified by stashing this change and re-running).
3. Negative anchor: stashing only the plugin change makes the 3 new positive tests fail while the 2 backward-compat tests keep passing, confirming the tests pin the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(memory):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full openviking + memory-plugin suites green; the 6 hindsight failures are pre-existing on main and unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comments document the tenant vs. runtime-identity distinction)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure payload construction, no OS-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A