### PR TITLE
fix(cron): accept a bare duration's natural article ('an hour', 'a minute')

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -813,13 +813,19 @@ def parse_duration(s: str) -> int:
         "2h" → 120
         "1d" → 1440
         "hour" → 60 (bare unit, no leading number)
+        "an hour" → 60 (bare unit with its natural article)
     """
     s = s.strip().lower()
-    match = re.match(r'^(\d*)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
+    # A bare unit is naturally spoken with its article ("in an hour", "in a
+    # minute") — accept and ignore it, same as the article-less bare form.
+    match = re.match(
+        r'^(?:an?\s+)?(\d*)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$',
+        s,
+    )
     if not match:
         raise ValueError(
             f"Invalid duration: '{s}'. Use format like '30m', '2h', '1d', "
-            "or a bare unit like 'hour' (defaults to 1)."
+            "or a bare unit like 'hour'/'an hour' (defaults to 1)."
         )
     
     value = int(match.group(1)) if match.group(1) else 1

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -50,6 +50,17 @@ class TestParseDuration:
         assert parse_duration("day") == 1440
         assert parse_duration("d") == 1440
 
+    def test_bare_units_accept_their_natural_article(self):
+        """'in an hour' / 'in a minute' are how these durations are actually
+        spoken — the tool schema tells the model to translate the user's own
+        phrasing verbatim (tools/cronjob_tools.py), so 'remind me in an hour'
+        plausibly becomes schedule='in an hour' and must not fail just
+        because the bare-unit form ('in hour') dropped the article."""
+        assert parse_duration("an hour") == 60
+        assert parse_duration("a hour") == 60
+        assert parse_duration("a minute") == 1
+        assert parse_duration("a day") == 1440
+
     def test_every_bare_unit_schedule(self):
         result = parse_schedule("every hour")
         assert result["kind"] == "interval"
@@ -100,6 +111,16 @@ class TestParseSchedule:
         now = datetime.now().astimezone()
         assert run_at > now
         assert run_at < now + timedelta(minutes=31)
+
+    def test_in_duration_with_article_becomes_once(self):
+        """'in an hour' is the natural way to say this and must fire once,
+        exactly like the article-less 'in hour' bare form does."""
+        result = parse_schedule("in an hour")
+        assert result["kind"] == "once"
+        run_at = datetime.fromisoformat(result["run_at"])
+        now = datetime.now().astimezone()
+        assert run_at > now + timedelta(minutes=59)
+        assert run_at < now + timedelta(minutes=61)
 
     def test_every_becomes_interval(self):
         result = parse_schedule("every 2h")


### PR DESCRIPTION
## Summary

`parse_duration()` (`cron/jobs.py`) already accepts a bare unit with no leading number — `"hour"` → 60, `"minute"` → 1, `"day"` → 1440 (added by the merged bare-duration-units fix). It does not accept the article that almost always accompanies a bare unit when it's actually spoken: `"an hour"`, `"a hour"`, `"a minute"`, `"a day"` all raise `ValueError`, while the article-less `"hour"`/`"minute"`/`"day"` succeed.

This matters because `tools/cronjob_tools.py`'s schedule field description explicitly tells the model to translate the user's own phrasing verbatim for one-shot reminders: *"use this for 'remind me in N minutes' — do NOT hand-compute an absolute timestamp"*. A user saying "remind me in an hour" plausibly becomes `schedule="in an hour"`, which currently fails.

## Fix

`parse_duration()`'s regex now accepts an optional leading `a`/`an` article before the (still-optional) numeric value and unit — ignored the same way the article-less bare-unit form already is.

## Test plan

- [x] New tests: `test_bare_units_accept_their_natural_article` (`parse_duration("an hour") == 60`, `"a hour"`, `"a minute"`, `"a day"`) and `test_in_duration_with_article_becomes_once` (`parse_schedule("in an hour")` fires once ~60 minutes out).
- [x] Verified by hand that all existing accepted forms (`"30m"`, `"2h"`, `"1d"`, `"hour"`, `"30 m"`, `"2 hours"`) are unaffected by the added optional article group.
- [x] Mutation-verify: reverted `cron/jobs.py` only, confirmed both new tests fail with the exact "Invalid duration" error, restored and confirmed they pass.
- [x] `tests/cron/test_jobs.py`: 112 passed.
- [x] `tests/cron/` + `tests/tools/test_cronjob_tools.py`: 1121 passed, 10 skipped, 2 pre-existing failures in `test_media_send_timeout.py` (`TestEmptyReasonFallback`) — confirmed unrelated: they pass in isolation and still fail with my changes fully reverted, so this is pre-existing test-order pollution, not a regression from this change.

## Competitor check

Searched `gh pr list`/`gh issue list` (state=all) for "parse_duration article", "an hour cron", "bare unit article", "in:title cron duration" — no open or duplicate PR/issue targets the article form specifically. The only related history is the already-merged/closed bare-unit fix (`#97783`) this change extends.