### PR TITLE
fix(web): don't register web_extract when backend is search-only (ddgs/searxng/brave-free)

### DIFF
--- a/tests/tools/test_web_search_only_backend.py
+++ b/tests/tools/test_web_search_only_backend.py
@@ -1,0 +1,74 @@
+"""Tests for search-only backend check_fn split (issue #89912).
+
+When web.backend is a search-only provider (ddgs, searxng, brave-free)
+and no per-capability extract_backend override is configured:
+- web_search must be available (check_fn returns True).
+- web_extract must NOT be available (check_fn returns False) so the model
+  is never shown a tool that always fails with "X is a search-only backend".
+
+When web.extract_backend is set explicitly, web_extract is available even if
+the shared backend is search-only.
+"""
+
+import pytest
+from unittest.mock import patch
+
+
+def _make_web_config(backend: str, extract_backend: str = "") -> dict:
+    return {"backend": backend, "extract_backend": extract_backend}
+
+
+@pytest.mark.parametrize("backend", ["ddgs", "searxng", "brave-free"])
+def test_search_only_backend_search_available(backend):
+    """web_search check_fn returns True for search-only backends."""
+    from tools.web_tools import check_web_search_available
+    with (
+        patch("tools.web_tools._load_web_config", return_value=_make_web_config(backend)),
+        patch("tools.web_tools._is_backend_available", return_value=True),
+    ):
+        assert check_web_search_available() is True
+
+
+@pytest.mark.parametrize("backend", ["ddgs", "searxng", "brave-free"])
+def test_search_only_backend_extract_not_available(backend):
+    """web_extract check_fn returns False when only a search-only backend is configured."""
+    from tools.web_tools import check_web_extract_available
+    with (
+        patch("tools.web_tools._load_web_config", return_value=_make_web_config(backend)),
+        patch("tools.web_tools._is_backend_available", return_value=True),
+    ):
+        assert check_web_extract_available() is False
+
+
+@pytest.mark.parametrize("backend", ["ddgs", "searxng", "brave-free"])
+def test_search_only_backend_with_extract_override_extract_available(backend):
+    """web_extract is available when extract_backend override is set even with search-only shared backend."""
+    from tools.web_tools import check_web_extract_available
+    with (
+        patch("tools.web_tools._load_web_config",
+              return_value=_make_web_config(backend, extract_backend="firecrawl")),
+        patch("tools.web_tools._is_backend_available", return_value=True),
+    ):
+        assert check_web_extract_available() is True
+
+
+def test_full_backend_extract_available():
+    """web_extract is available when a full (non-search-only) backend is configured."""
+    from tools.web_tools import check_web_extract_available
+    with (
+        patch("tools.web_tools._load_web_config", return_value=_make_web_config("firecrawl")),
+        patch("tools.web_tools._is_backend_available", return_value=True),
+    ):
+        assert check_web_extract_available() is True
+
+
+def test_search_only_constant_contents():
+    """_SEARCH_ONLY_BACKENDS contains exactly the known search-only built-in backends."""
+    from tools.web_tools import _SEARCH_ONLY_BACKENDS
+    assert "ddgs" in _SEARCH_ONLY_BACKENDS
+    assert "searxng" in _SEARCH_ONLY_BACKENDS
+    assert "brave-free" in _SEARCH_ONLY_BACKENDS
+    # Full backends must not be in the set
+    assert "firecrawl" not in _SEARCH_ONLY_BACKENDS
+    assert "exa" not in _SEARCH_ONLY_BACKENDS
+    assert "tavily" not in _SEARCH_ONLY_BACKENDS

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1525,6 +1525,25 @@ def _provider_is_ready(provider) -> bool:
         return False
 
 
+# Backends that support *search* but not *extract*.  When one of these is
+# the sole configured backend, web_extract should not be registered —
+# calling it would always fail with "X is a search-only backend".
+# Fixes: https://github.com/NousResearch/hermes-agent/issues/89912
+_SEARCH_ONLY_BACKENDS: frozenset = frozenset({"ddgs", "searxng", "brave-free"})
+
+
+def _configured_backend_is_search_only() -> bool:
+    """True when the shared backend is search-only AND no extract override exists."""
+    cfg = _load_web_config()
+    extract_override = (cfg.get("extract_backend") or "").lower().strip()
+    if extract_override:
+        # An explicit extract backend was configured — honour it regardless of
+        # the shared backend.
+        return False
+    shared = (cfg.get("backend") or "").lower().strip()
+    return shared in _SEARCH_ONLY_BACKENDS
+
+
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available.
 
@@ -1566,6 +1585,33 @@ def check_web_api_key() -> bool:
     except Exception as exc:  # noqa: BLE001 — registry optional; never fatal
         logger.debug("web provider registry availability check failed: %s", exc)
         return False
+
+
+def check_web_search_available() -> bool:
+    """check_fn for the ``web_search`` tool.
+
+    Returns True whenever any search-capable backend is available, including
+    search-only backends like ddgs/searxng/brave-free.  This is a strict
+    superset of ``check_web_api_key`` — if the general check passes, search
+    is available.
+    """
+    return check_web_api_key()
+
+
+def check_web_extract_available() -> bool:
+    """check_fn for the ``web_extract`` tool.
+
+    Returns False when the *only* configured backend is search-only (ddgs,
+    searxng, brave-free) and no per-capability ``web.extract_backend``
+    override is set.  In that case registering web_extract would produce a
+    tool the model can see but that always fails, causing it to mistakenly
+    report "web_search is not available" and fall back to worse paths.
+
+    Fixes: https://github.com/NousResearch/hermes-agent/issues/89912
+    """
+    if _configured_backend_is_search_only():
+        return False
+    return check_web_api_key()
 
 if __name__ == "__main__":
     """
@@ -1701,7 +1747,7 @@ registry.register(
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
-    check_fn=check_web_api_key,
+    check_fn=check_web_search_available,
     requires_env=_web_requires_env(),
     emoji="🔍",
     max_result_size_chars=100_000,
@@ -1715,7 +1761,7 @@ registry.register(
         "markdown",
         char_limit=args.get("char_limit"),
     ),
-    check_fn=check_web_api_key,
+    check_fn=check_web_extract_available,
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",


### PR DESCRIPTION
## Problem

When \web.backend\ is set to a search-only provider (\ddgs\, \searxng\, \rave-free\), both \web_search\ and \web_extract\ share the same \check_fn=check_web_api_key\. Since DDGS makes that check return \True\, **both tools are registered** — but every call to \web_extract\ immediately fails with:

> \DuckDuckGo (ddgs) is a search-only backend\

This leaves the model in a broken state where it concludes \web_search\ is not available and falls back to worse extraction approaches.

Reported in: #89912

## Fix

- Add \_SEARCH_ONLY_BACKENDS\ frozenset (\ddgs\, \searxng\, \rave-free\).
- Add \check_web_search_available\ — search-only backends are valid for search; returns \True\ whenever \check_web_api_key\ does.
- Add \check_web_extract_available\ — returns \False\ when the shared backend is search-only **and** no \web.extract_backend\ override is configured.
- Wire the new per-capability \check_fn\ into both registry entries.

When \web.extract_backend\ is explicitly set (e.g. \ddgs\ for search + \irecrawl\ for extract), \web_extract\ is still registered — the split-backend configuration is preserved.

## Tests

\	ests/tools/test_web_search_only_backend.py\ — 7 parametrized cases covering:
- search-only backends: search available, extract not available
- search-only backend + explicit extract override: extract available
- full backend (firecrawl): extract available
- \_SEARCH_ONLY_BACKENDS\ contents invariant

Fixes #89912