### PR TITLE
feat(cron): retain execution history fairly per job

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -24,7 +24,11 @@ from hermes_time import now as _hermes_now
 # that temporarily enter another profile cannot leak that profile's records into the import-time
 # home.
 EXECUTIONS_FILE: Optional[Path] = None
-MAX_TERMINAL_EXECUTIONS = 1000
+_DEFAULT_MAX_TERMINAL_EXECUTIONS = 1000
+# Backward-compatible test override. Production reads
+# ``cron.execution_retention`` at prune time so a config change does not
+# require a Python reinstall.
+MAX_TERMINAL_EXECUTIONS = _DEFAULT_MAX_TERMINAL_EXECUTIONS
 HANDOFF_ADOPTION_GRACE_SECONDS = 30.0
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
@@ -126,14 +130,32 @@ def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
     return current is not None and current == started_at
 
 
+def _terminal_execution_retention() -> int:
+    """Resolve the terminal execution-row cap from profile-local config."""
+    if MAX_TERMINAL_EXECUTIONS != _DEFAULT_MAX_TERMINAL_EXECUTIONS:
+        return max(0, int(MAX_TERMINAL_EXECUTIONS))
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+        value = cron_cfg.get(
+            "execution_retention", _DEFAULT_MAX_TERMINAL_EXECUTIONS
+        ) if isinstance(cron_cfg, dict) else _DEFAULT_MAX_TERMINAL_EXECUTIONS
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_TERMINAL_EXECUTIONS
+
+
 def _prune_unlocked(conn: sqlite3.Connection) -> None:
+    limit = _terminal_execution_retention()
     conn.execute(
         """DELETE FROM executions WHERE id IN (
              SELECT id FROM executions
              WHERE status IN ('completed','failed','unknown')
              ORDER BY finished_at DESC, claimed_at DESC, id DESC LIMIT -1 OFFSET ?
            )""",
-        (max(0, int(MAX_TERMINAL_EXECUTIONS)),),
+        (limit,),
     )
 
 

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -25,6 +25,7 @@ from hermes_time import now as _hermes_now
 # home.
 EXECUTIONS_FILE: Optional[Path] = None
 _DEFAULT_MAX_TERMINAL_EXECUTIONS = 1000
+_DEFAULT_MIN_TERMINAL_EXECUTIONS_PER_JOB = 5
 # Backward-compatible test override. Production reads
 # ``cron.execution_retention`` at prune time so a config change does not
 # require a Python reinstall.
@@ -135,9 +136,9 @@ def _terminal_execution_retention() -> int:
     if MAX_TERMINAL_EXECUTIONS != _DEFAULT_MAX_TERMINAL_EXECUTIONS:
         return max(0, int(MAX_TERMINAL_EXECUTIONS))
     try:
-        from hermes_cli.config import load_config
+        from hermes_cli.config import load_config_readonly
 
-        cfg = load_config() or {}
+        cfg = load_config_readonly() or {}
         cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
         value = cron_cfg.get(
             "execution_retention", _DEFAULT_MAX_TERMINAL_EXECUTIONS
@@ -147,15 +148,55 @@ def _terminal_execution_retention() -> int:
         return _DEFAULT_MAX_TERMINAL_EXECUTIONS
 
 
+def _terminal_execution_retention_per_job() -> int:
+    """Resolve the fair per-job floor within the global terminal-row cap."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
+        value = (
+            cron_cfg.get(
+                "execution_retention_per_job",
+                _DEFAULT_MIN_TERMINAL_EXECUTIONS_PER_JOB,
+            )
+            if isinstance(cron_cfg, dict)
+            else _DEFAULT_MIN_TERMINAL_EXECUTIONS_PER_JOB
+        )
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return _DEFAULT_MIN_TERMINAL_EXECUTIONS_PER_JOB
+
+
 def _prune_unlocked(conn: sqlite3.Connection) -> None:
     limit = _terminal_execution_retention()
+    per_job = _terminal_execution_retention_per_job()
     conn.execute(
-        """DELETE FROM executions WHERE id IN (
-             SELECT id FROM executions
+        """WITH ranked AS (
+             SELECT id, status, claimed_at, finished_at,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY job_id
+                      ORDER BY finished_at DESC, claimed_at DESC, id DESC
+                    ) AS job_rank
+             FROM executions
              WHERE status IN ('completed','failed','unknown')
-             ORDER BY finished_at DESC, claimed_at DESC, id DESC LIMIT -1 OFFSET ?
-           )""",
-        (limit,),
+           ), keepers AS (
+             SELECT id FROM ranked
+             ORDER BY
+               CASE
+                 WHEN job_rank = 1 THEN 0
+                 WHEN status = 'failed' THEN 1
+                 WHEN job_rank <= ? THEN 2
+                 ELSE 3
+               END,
+               CASE WHEN job_rank <= ? THEN job_rank ELSE NULL END,
+               finished_at DESC, claimed_at DESC, id DESC
+             LIMIT ?
+           )
+           DELETE FROM executions
+           WHERE status IN ('completed','failed','unknown')
+             AND id NOT IN (SELECT id FROM keepers)""",
+        (per_job, per_job, limit),
     )
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1678,6 +1678,10 @@ DEFAULT_CONFIG = {
         # save_job_output keeps the N most recent .md files per job; 0 or negative disables pruning
         # (for externally managed cleanup).
         "output_retention": 50,
+        # Maximum terminal rows kept in cron/executions.db. Claimed/running
+        # rows are always preserved. 0 removes terminal rows after each
+        # terminal write. Default 1000.
+        "execution_retention": 1000,
         # Timeout (seconds) for a no-agent cron script. Env: HERMES_CRON_SCRIPT_TIMEOUT. Keep in
         # sync with cron.scheduler._DEFAULT_SCRIPT_TIMEOUT.
         "script_timeout_seconds": 3600,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1682,6 +1682,11 @@ DEFAULT_CONFIG = {
         # rows are always preserved. 0 removes terminal rows after each
         # terminal write. Default 1000.
         "execution_retention": 1000,
+        # Fair share inside execution_retention: prioritize this many terminal
+        # rows per represented job before allocating the remaining capacity by
+        # global recency. Latest-per-job and failed rows have higher priority;
+        # the global cap remains hard when protected tiers exceed it.
+        "execution_retention_per_job": 5,
         # Timeout (seconds) for a no-agent cron script. Env: HERMES_CRON_SCRIPT_TIMEOUT. Keep in
         # sync with cron.scheduler._DEFAULT_SCRIPT_TIMEOUT.
         "script_timeout_seconds": 3600,

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -532,3 +532,62 @@ def test_job_listing_exposes_latest_execution(monkeypatch, tmp_path):
     listed = jobs.list_jobs(include_disabled=True)
     assert listed[0]["latest_execution"]["id"] == record["id"]
     assert listed[0]["latest_execution"]["status"] == "running"
+
+
+def test_retention_reads_execution_retention_from_config(monkeypatch, tmp_path):
+    """cron.execution_retention must govern pruning, not a hardcoded constant.
+
+    Regression guard: the cap used to be hardcoded, so `hermes config set
+    cron.execution_retention` was cosmetic — `config get` echoed the new value
+    while pruning still trimmed to 1000. Assert the configured value actually
+    bounds the ledger.
+    """
+    executions = _point_ledger(monkeypatch, tmp_path)
+
+    home = tmp_path / "home"
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    # A distinctive cap: neither the 1000 default nor a round number, so a
+    # pass cannot be a coincidence of the old behaviour.
+    cap = 7
+    (home / "config.yaml").write_text(f"cron:\n  execution_retention: {cap}\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert executions._terminal_execution_retention() == cap
+
+    for index in range(cap + 13):
+        row = executions.create_execution(f"done-{index}", source="builtin")
+        executions.finish_execution(row["id"], success=True)
+
+    terminal = [
+        row for row in executions.list_executions(limit=1000)
+        if row["status"] in ("completed", "failed", "unknown")
+    ]
+    assert len(terminal) <= cap
+
+
+def test_module_level_override_still_wins_over_config(monkeypatch, tmp_path):
+    """An explicit MAX_TERMINAL_EXECUTIONS override must beat config.
+
+    Existing tests monkeypatch the module constant; that has to keep working
+    even though production now resolves the cap from config.
+    """
+    executions = _point_ledger(monkeypatch, tmp_path)
+
+    home = tmp_path / "home"
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("cron:\n  execution_retention: 500\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", 3)
+
+    assert executions._terminal_execution_retention() == 3
+
+
+def test_config_default_matches_module_default(monkeypatch):
+    """The documented default and the code fallback must not drift apart."""
+    import cron.executions as executions
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    assert (
+        DEFAULT_CONFIG["cron"]["execution_retention"]
+        == executions._DEFAULT_MAX_TERMINAL_EXECUTIONS
+    )

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 def _point_ledger(monkeypatch, tmp_path):
     import cron.executions as executions
@@ -176,7 +178,129 @@ def test_retention_bounds_terminal_history_but_preserves_inflight(monkeypatch, t
 
     records = executions.list_executions(limit=100)
     assert len([row for row in records if row["status"] == "completed"]) == 3
-    assert executions.latest_execution("live")["status"] == "running"
+    latest_live = executions.latest_execution("live")
+    assert latest_live is not None
+    assert latest_live["status"] == "running"
+
+
+def _set_retention_config(monkeypatch, executions, *, total, per_job):
+    monkeypatch.setattr(
+        executions,
+        "MAX_TERMINAL_EXECUTIONS",
+        executions._DEFAULT_MAX_TERMINAL_EXECUTIONS,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "cron": {
+                "execution_retention": total,
+                "execution_retention_per_job": per_job,
+            }
+        },
+    )
+
+
+def _finish_many(executions, job_id, count, *, success=True):
+    records = []
+    for _ in range(count):
+        row = executions.create_execution(job_id, source="synthetic")
+        records.append(
+            executions.finish_execution(
+                row["id"], success=success, error=None if success else "synthetic failure"
+            )
+        )
+    return records
+
+
+def test_retention_keeps_a_fair_floor_for_each_job(monkeypatch, tmp_path):
+    """A frequent job cannot evict all history for slower represented jobs."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _set_retention_config(monkeypatch, executions, total=8, per_job=2)
+
+    _finish_many(executions, "slow-a", 2)
+    _finish_many(executions, "slow-b", 2)
+    _finish_many(executions, "fast", 20)
+
+    rows = executions.list_executions(limit=100)
+    counts = {
+        job_id: sum(row["job_id"] == job_id for row in rows)
+        for job_id in ("slow-a", "slow-b", "fast")
+    }
+    assert len(rows) == 8
+    assert counts["slow-a"] == 2
+    assert counts["slow-b"] == 2
+    assert counts["fast"] == 4
+
+
+def test_retention_prioritizes_latest_per_job_and_failures(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _set_retention_config(monkeypatch, executions, total=6, per_job=1)
+
+    old_failure = _finish_many(executions, "fast", 1, success=False)[0]
+    _finish_many(executions, "slow", 1)
+    _finish_many(executions, "fast", 8)
+
+    rows = executions.list_executions(limit=100)
+    retained_ids = {row["id"] for row in rows}
+    assert len(rows) == 6
+    assert old_failure["id"] in retained_ids
+    assert executions.latest_execution("slow") is not None
+    assert executions.latest_execution("fast") is not None
+
+
+def test_retention_config_controls_total_and_fair_floor(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _set_retention_config(monkeypatch, executions, total=5, per_job=2)
+
+    _finish_many(executions, "job-a", 6)
+    _finish_many(executions, "job-b", 6)
+
+    rows = executions.list_executions(limit=100)
+    assert len(rows) == 5
+    assert sum(row["job_id"] == "job-a" for row in rows) >= 2
+    assert sum(row["job_id"] == "job-b" for row in rows) >= 2
+
+
+def test_retention_remains_bounded_when_protected_rows_exceed_cap(monkeypatch, tmp_path):
+    """Protection tiers are priorities, never exemptions from the hard cap."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _set_retention_config(monkeypatch, executions, total=3, per_job=5)
+
+    for index in range(7):
+        _finish_many(executions, f"job-{index}", 1, success=index % 2 == 0)
+
+    rows = executions.list_executions(limit=100)
+    assert len(rows) == 3
+    assert len({row["job_id"] for row in rows}) == 3
+
+
+@pytest.mark.parametrize(
+    ("total", "per_job", "job_count", "rows_per_job"),
+    [(0, 1, 3, 4), (1, 5, 5, 2), (7, 2, 3, 9), (11, 20, 4, 6)],
+)
+def test_terminal_retention_cap_is_a_hard_invariant(
+    monkeypatch, tmp_path, total, per_job, job_count, rows_per_job
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _set_retention_config(monkeypatch, executions, total=total, per_job=per_job)
+    live = executions.create_execution("live", source="synthetic")
+    executions.mark_execution_running(live["id"])
+
+    for job_index in range(job_count):
+        for row_index in range(rows_per_job):
+            _finish_many(
+                executions,
+                f"job-{job_index}",
+                1,
+                success=(job_index + row_index) % 3 != 0,
+            )
+
+    rows = executions.list_executions(limit=1000)
+    terminal = [row for row in rows if row["status"] in executions._TERMINAL_STATES]
+    assert len(terminal) <= total
+    latest_live = executions.latest_execution("live")
+    assert latest_live is not None
+    assert latest_live["status"] == "running"
 
 
 def test_recently_finished_long_running_execution_survives_retention(
@@ -590,4 +714,8 @@ def test_config_default_matches_module_default(monkeypatch):
     assert (
         DEFAULT_CONFIG["cron"]["execution_retention"]
         == executions._DEFAULT_MAX_TERMINAL_EXECUTIONS
+    )
+    assert (
+        DEFAULT_CONFIG["cron"]["execution_retention_per_job"]
+        == executions._DEFAULT_MIN_TERMINAL_EXECUTIONS_PER_JOB
     )

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -673,7 +673,9 @@ def test_retention_reads_execution_retention_from_config(monkeypatch, tmp_path):
     # A distinctive cap: neither the 1000 default nor a round number, so a
     # pass cannot be a coincidence of the old behaviour.
     cap = 7
-    (home / "config.yaml").write_text(f"cron:\n  execution_retention: {cap}\n")
+    (home / "config.yaml").write_text(
+        f"cron:\n  execution_retention: {cap}\n", encoding="utf-8"
+    )
     monkeypatch.setenv("HERMES_HOME", str(home))
 
     assert executions._terminal_execution_retention() == cap
@@ -699,7 +701,9 @@ def test_module_level_override_still_wins_over_config(monkeypatch, tmp_path):
 
     home = tmp_path / "home"
     (home / "cron").mkdir(parents=True, exist_ok=True)
-    (home / "config.yaml").write_text("cron:\n  execution_retention: 500\n")
+    (home / "config.yaml").write_text(
+        "cron:\n  execution_retention: 500\n", encoding="utf-8"
+    )
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", 3)
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -356,6 +356,20 @@ prove completion. Restoring the ledger itself to an older backup also removes
 that evidence. External fire callbacks identify the currently accepted store
 claim, not an upstream scheduled slot absent from the callback.
 
+Configure the terminal-row budget and its fair per-job share in `config.yaml`:
+
+```yaml
+cron:
+  execution_retention: 1000          # hard cap for terminal rows
+  execution_retention_per_job: 5     # fair-share target inside that cap
+```
+
+Hermes keeps each represented job's latest terminal attempt first, then failed
+attempts, then up to the per-job target in rounds before filling remaining
+capacity by recency. These are priorities rather than exemptions: when the
+protected sets exceed `execution_retention`, the hard cap still wins. Claimed
+and running attempts are outside the terminal-row cap and are never pruned.
+
 ### Repeated-failure review nudge
 
 Each job tracks a `failure_streak` — consecutive failed runs (delivery


### PR DESCRIPTION
## Summary

- make terminal execution retention configurable with `cron.execution_retention` while preserving the default hard cap of 1000 rows
- add `cron.execution_retention_per_job` as a fair-share target within that cap
- retain terminal rows by priority: latest attempt per represented job, failed attempts, fair-share rounds, then global recency
- keep claimed and running attempts outside terminal pruning
- preserve `MAX_TERMINAL_EXECUTIONS` as a test and embedding override
- document both settings and use explicit UTF-8 in configuration fixtures

Fixes #93616.

## Behavior

The cap remains strict even when represented jobs, failures, or fair-share targets exceed it. Protection tiers are priorities, not unbounded exemptions. A retention value of zero removes terminal rows while leaving active attempts untouched.

## Verification

- execution-ledger tests — 30 passed
- configuration tests — 112 passed, 4 platform-specific skips
- Ruff — passed
- Ty for `cron/executions.py` — passed
- Windows-footgun scan — passed
- `git diff --check` — passed

## Compatibility

No schema migration or new environment variable. Existing default capacity and the module-level override remain supported.