### PR TITLE
fix(desktop): prevent settings search bar seam under glass translucency with tint (#98484)

### DIFF
--- a/apps/desktop/src/app/overlays/overlay-view.test.tsx
+++ b/apps/desktop/src/app/overlays/overlay-view.test.tsx
@@ -1,0 +1,31 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { OverlayView } from './overlay-view'
+
+describe('OverlayView', () => {
+  afterEach(cleanup)
+
+  it('renders card with data-glass-raised and edgeBadge with data-glass-opaque (#98484)', () => {
+    const onClose = vi.fn()
+    const { container } = render(
+      <OverlayView
+        closeLabel="Close"
+        edgeBadge={<span data-testid="search-pill">Search Settings</span>}
+        onClose={onClose}
+      >
+        <div data-testid="content">Settings Content</div>
+      </OverlayView>
+    )
+
+    // The card has data-glass-raised
+    const raisedCard = container.querySelector('[data-glass-raised]')
+    expect(raisedCard).not.toBeNull()
+    expect(screen.getByTestId('content')).toBeDefined()
+
+    // The edgeBadge wrapper has data-glass-opaque
+    const opaqueBadgeWrapper = container.querySelector('[data-glass-opaque]')
+    expect(opaqueBadgeWrapper).not.toBeNull()
+    expect(opaqueBadgeWrapper?.contains(screen.getByTestId('search-pill'))).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/overlays/overlay-view.tsx
+++ b/apps/desktop/src/app/overlays/overlay-view.tsx
@@ -143,8 +143,17 @@ export function OverlayView({
 
         {/* Sibling of the card, not a child: the card clips its own overflow
             (rounded corners), and the badge deliberately straddles the top
-            border — half above, half below. */}
-        {edgeBadge && <div className="absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-1/2">{edgeBadge}</div>}
+            border — half above, half below. Must stay opaque under Glass so the
+            card's top border does not bleed through the straddling badge.
+            Contract: `[data-glass-opaque]` in styles.css. */}
+        {edgeBadge && (
+          <div
+            className="absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-1/2"
+            data-glass-opaque=""
+          >
+            {edgeBadge}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -326,6 +326,7 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
         'flex h-(--titlebar-control-height) items-center gap-1.5 rounded-full border border-(--ui-stroke-secondary) bg-(--ui-chat-surface-background) px-2.5 text-(--ui-text-tertiary) shadow-sm transition-all duration-200 ease-out hover:text-foreground motion-reduce:transition-none',
         paletteOpen && 'pointer-events-none scale-110 opacity-0'
       )}
+      data-glass-opaque=""
       onClick={() => {
         triggerHaptic('open')
         openCommandPalettePage('settings')


### PR DESCRIPTION
## Problem

When Window Translucency is set to `Glass` with a non-zero `Tint`, the Settings search bar shows a visible horizontal background seam running across its center.

### Cause
- `searchPill` is rendered inside `edgeBadge` in `OverlayView`, straddling the top border of the raised card (`top-0`, `-translate-y-1/2`).
- The card is marked with `data-glass-raised=""`, which keeps its background near-opaque under Glass.
- However, `edgeBadge` is rendered as a sibling outside `data-glass-raised`, inheriting the translucent field `--ui-chat-surface-background`.
- The translucent search pill reveals the horizontal edge and background transition of the card underneath, visually splitting the search bar in two.

## Solution

1. In `apps/desktop/src/app/overlays/overlay-view.tsx`, add `data-glass-opaque=""` to the `edgeBadge` wrapper div so that edge badges straddling card borders maintain an opaque fill under `:root[data-hermes-glass] [data-glass-opaque]`.
2. In `apps/desktop/src/app/settings/index.tsx`, mark `searchPill` with `data-glass-opaque=""`.
3. Added unit test in `apps/desktop/src/app/overlays/overlay-view.test.tsx` asserting `edgeBadge` carries `data-glass-opaque` and the card carries `data-glass-raised`.

## Verification

- Ran `vitest run src/app/overlays/overlay-view.test.tsx`: 1/1 test passed.
- Verified under Glass translucency with non-zero Tint: search bar background remains solid and seamless.

Closes #98484
