### PR TITLE
fix(gateway): rescue session events from dead transports via live viewers

### DIFF
--- a/tests/tui_gateway/test_session_event_rescue.py
+++ b/tests/tui_gateway/test_session_event_rescue.py
@@ -1,0 +1,152 @@
+"""Session-event rescue in ``write_json``: a dead bound transport must not
+silently swallow a session's events (#98503).
+
+``clarify.request`` (and the other blocking bridges) is emitted from the agent
+worker thread via ``_emit`` → ``write_json``, which routed strictly through
+``_sessions[sid]["transport"]``. When that transport is the post-disconnect
+drop sentinel — or a socket that went ``_closed`` before a rebind — the frame
+was lost with no error, and the clarify tool blocked until timeout with no
+client ever seeing the card. These tests pin the viewer-fallback rescue.
+"""
+
+import importlib
+import json
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_original_stdout = sys.stdout
+
+
+@pytest.fixture(autouse=True)
+def _restore_stdout():
+    yield
+    sys.stdout = _original_stdout
+
+
+class _RecordingTransport:
+    """Minimal Transport stand-in that records frames written to it."""
+
+    def __init__(self) -> None:
+        self.frames: list[dict] = []
+        self._closed = False
+
+    def write(self, obj: dict) -> bool:
+        if self._closed:
+            return False
+        self.frames.append(obj)
+        return True
+
+    def close(self) -> None:
+        self._closed = True
+
+
+@pytest.fixture()
+def server():
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(return_value="/tmp/hermes_test")
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+    yield mod
+    for sid in list(mod._sessions):
+        mod._sessions.pop(sid, None)
+    mod._live_transports.clear()
+
+
+def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
+    params: dict = {"type": event, "session_id": sid}
+    if payload is not None:
+        params["payload"] = payload
+    return {"jsonrpc": "2.0", "method": "event", "params": params}
+
+
+def _install_session(server, sid: str, transport, viewers: dict | None = None):
+    server._sessions[sid] = {
+        "session_key": sid,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "transport": transport,
+        "viewers": dict(viewers or {}),
+    }
+
+
+def test_dead_bound_transport_falls_back_to_newest_live_viewer(server):
+    """The disconnect path parks the session on the drop sentinel; a live
+    pop-out viewer of the same session must still receive the frame."""
+    sid = "rescue-live-viewer"
+    dead = _RecordingTransport()
+    dead._closed = True
+    older_viewer = _RecordingTransport()
+    newest_viewer = _RecordingTransport()
+    _install_session(
+        server,
+        sid,
+        server._detached_ws_transport,
+        viewers={dead: 1.0, older_viewer: 2.0, newest_viewer: 3.0},
+    )
+
+    frame = _event_frame("clarify.request", sid, {"question": "ship it?"})
+    assert server.write_json(frame) is True
+
+    assert newest_viewer.frames == [frame]
+    assert older_viewer.frames == []
+    assert dead.frames == []
+    # The rescued frame keeps the single seq stamp from the original write.
+    assert newest_viewer.frames[0]["params"]["seq"] == frame["params"]["seq"]
+
+
+def test_drop_of_blocking_request_warns_when_no_viewer_takes_it(server, caplog):
+    """With no live viewer the frame is still lost — but a blocking
+    ``*.request`` drop must be visible in the logs instead of silent."""
+    sid = "rescue-no-viewer"
+    closed = _RecordingTransport()
+    closed._closed = True
+    _install_session(server, sid, closed, viewers={closed: 1.0})
+
+    with caplog.at_level("WARNING", logger="tui_gateway.server"):
+        ok = server.write_json(_event_frame("clarify.request", sid))
+
+    assert ok is False
+    assert any(
+        "clarify.request" in rec.message and "dropped" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_non_request_drop_stays_quiet(server, caplog):
+    """High-frequency progress frames must not spam warnings when a detached
+    session has no viewer; the replay ring still carries them for a
+    reconnecting client."""
+    sid = "rescue-quiet"
+    _install_session(server, sid, server._detached_ws_transport)
+
+    with caplog.at_level("WARNING", logger="tui_gateway.server"):
+        ok = server.write_json(_event_frame("tool.progress", sid))
+
+    assert ok is False
+    assert not [rec for rec in caplog.records if rec.levelname == "WARNING"]
+
+
+def test_live_bound_transport_skips_viewer_fallback(server):
+    """A healthy bound transport stays the single delivery path — viewers of
+    the same session must not receive a duplicate frame."""
+    sid = "rescue-healthy"
+    bound = _RecordingTransport()
+    viewer = _RecordingTransport()
+    _install_session(server, sid, bound, viewers={viewer: 1.0})
+
+    frame = _event_frame("tool.complete", sid)
+    assert server.write_json(frame) is True
+
+    assert bound.frames == [frame]
+    assert viewer.frames == []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2475,6 +2475,47 @@ def _default_session_cwd() -> str:
     return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
 
 
+def _rescue_session_event(sid: str, obj: dict, params: dict) -> bool:
+    """Second-chance delivery when the session's bound transport is gone.
+
+    ``write_json`` routes session events to ``_sessions[sid]["transport"]``.
+    When that transport is the post-disconnect drop sentinel, or a socket
+    that went ``_closed`` before any rebind, its write returns False and the
+    frame used to be dropped silently — a blocking bridge (clarify/sudo/
+    secret/terminal.read) then parked its agent thread until timeout while
+    no client ever saw the request (#98503; the approval twin is #82976).
+    The disconnect path re-binds the session to the newest surviving
+    viewer, but emitters on agent worker threads race that rebind, so try
+    the session's other live viewers first, newest first. The frame is
+    already stamped and replay-recorded by the caller; this only re-routes
+    the live write.
+    """
+    with _sessions_lock:
+        viewers = dict((_sessions.get(sid) or {}).get("viewers") or {})
+    for transport, _ts in sorted(viewers.items(), key=lambda kv: kv[1], reverse=True):
+        if _transport_is_dead(transport):
+            continue
+        try:
+            if transport.write(obj):
+                return True
+        except Exception:
+            logger.debug(
+                "viewer fallback write failed for sid=%s", sid, exc_info=True
+            )
+    event_type = params.get("type") if isinstance(params, dict) else None
+    log = (
+        logger.warning
+        if isinstance(event_type, str) and event_type.endswith(".request")
+        else logger.debug
+    )
+    log(
+        "session event type=%s sid=%s dropped: bound transport is gone and no live viewer took it",
+        event_type,
+        sid,
+    )
+    return False
+
+
 def write_json(obj: dict) -> bool:
     """Emit one JSON frame. Routes via the most-specific transport available.
 
@@ -2500,7 +2541,9 @@ def write_json(obj: dict) -> bool:
             from tui_gateway.event_replay import _stamp_event
 
             _stamp_event(obj)
-            return t.write(obj)
+            if t.write(obj):
+                return True
+            return _rescue_session_event(sid, obj, params)
 
     from tui_gateway.event_replay import _stamp_event
 


### PR DESCRIPTION
## What does this PR do?

`write_json` routed session events strictly through `_sessions[sid]["transport"]`. When that transport is the post-disconnect drop sentinel (`_detached_ws_transport`) or a socket that went `_closed` before any rebind, `t.write()` returned `False` and the frame was silently dropped — no error, no fallback, no log line. For the blocking bridges (`clarify`/`sudo`/`secret`/`terminal.read`) this means the `*.request` never reaches any client, the agent worker thread parks on `ev.wait(timeout)` until it times out, and the user sees nothing at all: no card, no spinner, just a tool that eventually returns a timeout (#98503; the approval twin of this mechanism is #82976).

The disconnect path already re-binds a session to its newest surviving viewer, but emitters on agent worker threads race that rebind. This PR adds the missing second chance inside `write_json`: on a dead bound transport, retry the same (already-stamped, already replay-recorded) frame on the session's other live viewers, newest first, skipping dead ones. If no viewer takes it, a dropped `*.request` is now logged at WARNING so silent loss becomes a diagnosable line — the issue's own evidence section shows the debugging pain of zero clarify entries in desktop/gui logs. High-frequency frames (progress etc.) stay at DEBUG to avoid log spam; their lossless recovery path is unchanged via the replay ring.

## Related Issue

Fixes #98503

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: `_rescue_session_event()` — viewer-fallback write (newest-first, `_transport_is_dead` filtered, single-viewer failure tolerated) plus WARN-on-dropped-`*.request` / DEBUG for other frames; `write_json()`'s session branch now calls it when the bound transport's write returns `False` instead of returning the failure silently.
- `tests/tui_gateway/test_session_event_rescue.py`: 4 regression tests — dead bound transport falls back to newest live viewer (seq unchanged, no duplicate stamps); no-viewer drop of `clarify.request` warns; non-`*.request` drop stays quiet; healthy bound transport never duplicates to viewers.

## How to Test

1. `python -m pytest tests/tui_gateway/test_session_event_rescue.py -v` — Observed result: `4 passed in 0.77s`.
2. `python -m pytest tests/tui_gateway/test_protocol.py tests/tui_gateway/test_94895_backend_heartbeat.py tests/tui_gateway/test_startup_orphan_sweep.py tests/tui_gateway/test_entry_picker_prewarm.py` — Observed result: `86 passed` (write_json routing/stdio fallback/reap behavior unchanged).
3. Full suite slice: `python -m pytest tests/tui_gateway/` — Observed result: `720 passed, 2 failed` where both failures (`test_gui_surface_toolsets.py::TestDesktopUiToolset::test_holds_exactly_the_gui_affordances`, `test_stale_provider_resume_live.py::TestStaleProviderResumeLive::test_renamed_provider_heals_to_new_identity`) reproduce on a clean `upstream/main` checkout with this PR stashed, and each passes when run individually — pre-existing order-dependent flakes, unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full `tests/tui_gateway/` slice: 720 passed; the 2 failures are pre-existing flakes reproduced on clean main — see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior documented in the new helper's docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (no platform-specific code; the dead-transport race reported on Windows Desktop applies to every WS surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (transport-layer fix; behavior demonstrated by the new tests).