### PR TITLE
fix(desktop): avoid Windows SSH probe command-line limit

### DIFF
--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
-import crypto from 'node:crypto'
 import { spawn } from 'node:child_process'
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -74,7 +74,11 @@ type SshExecOptions = { stdinData?: string | Buffer }
 function scriptFromInvocation(command: string, options: SshExecOptions = {}) {
   const encoded = command.match(/-EncodedCommand\s+([^\s]+)$/)?.[1]
 
-  return encoded ? Buffer.from(encoded, 'base64').toString('utf16le') : String(options.stdinData || '')
+  if (encoded) {
+    return Buffer.from(encoded, 'base64').toString('utf16le')
+  }
+
+  return Buffer.from(String(options.stdinData || '').trim(), 'base64').toString('utf16le')
 }
 
 test('PowerShell transport uses UTF-16LE encoded commands and literal escaping', () => {
@@ -205,8 +209,33 @@ test('Windows platform probe streams long PowerShell scripts over stdin', async 
   assert.match(command, /-Command \[ScriptBlock\]::Create/)
   assert.doesNotMatch(command, /-EncodedCommand/)
   assert.ok(command.length < 1024)
-  assert.ok(stdinData.length > 0)
-  assert.match(stdinData, /Assert-NoReparse/)
+  assert.match(stdinData, /^[A-Za-z0-9+/=\r\n]+$/)
+  const decodedScript = Buffer.from(stdinData.trim(), 'base64').toString('utf16le')
+  assert.match(decodedScript, /Assert-NoReparse/)
+})
+
+test('Windows platform probe preserves Unicode paths in its UTF-16LE stdin payload', async () => {
+  let stdinData = ''
+
+  await probeWindowsRemote(
+    {
+      async exec(_command: string, options: SshExecOptions = {}) {
+        stdinData = String(options.stdinData || '')
+
+        return JSON.stringify({
+          os: 'Windows',
+          arch: 'AMD64',
+          hermesHome: 'C:\\\\h',
+          hermesPath: 'C:\\\\h\\\\hermes.exe',
+          python: 'C:\\\\h\\\\python.exe'
+        })
+      }
+    },
+    'C:\\Users\\한글\\hermes.exe'
+  )
+
+  const decodedScript = Buffer.from(stdinData.trim(), 'base64').toString('utf16le')
+  assert.ok(decodedScript.includes('C:\\Users\\한글\\hermes.exe'))
 })
 
 function runLocalWindowsCommand(command, stdinData) {
@@ -223,6 +252,7 @@ function runLocalWindowsCommand(command, stdinData) {
 
       if (code === 0) {
         resolve(out)
+
         return
       }
 

--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict'
 import crypto from 'node:crypto'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
 import { test } from 'vitest'
 
@@ -65,6 +69,14 @@ function sshWith(exec) {
   return { exec }
 }
 
+type SshExecOptions = { stdinData?: string | Buffer }
+
+function scriptFromInvocation(command: string, options: SshExecOptions = {}) {
+  const encoded = command.match(/-EncodedCommand\s+([^\s]+)$/)?.[1]
+
+  return encoded ? Buffer.from(encoded, 'base64').toString('utf16le') : String(options.stdinData || '')
+}
+
 test('PowerShell transport uses UTF-16LE encoded commands and literal escaping', () => {
   assert.equal(Buffer.from(encodedPowerShell("'ok'"), 'base64').toString('utf16le'), "'ok'")
   assert.equal(psLiteral("a'b"), "'a''b'")
@@ -75,8 +87,8 @@ test('Windows relaunch gate refuses live and uncertain markers before executing 
   for (const observation of ['LIVE:4242', 'UNCERTAIN']) {
     const scripts: string[] = []
 
-    const ssh = sshWith(async command => {
-      const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+    const ssh = sshWith(async (command, options) => {
+      const script = scriptFromInvocation(command, options)
       scripts.push(script)
 
       if (script.includes('Get-Command hermes.exe')) {
@@ -119,8 +131,8 @@ test('Windows relaunch gate refuses live and uncertain markers before executing 
 test('Windows relaunch gate uses strict install-wide marker parsing and fail-closed PID probing', async () => {
   let script = ''
 
-  const ssh = sshWith(async command => {
-    script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+  const ssh = sshWith(async (command, options) => {
+    script = scriptFromInvocation(command, options)
 
     return 'CLEAR'
   })
@@ -137,8 +149,8 @@ test('Windows relaunch gate uses strict install-wide marker parsing and fail-clo
 test('Windows probe validates Hermes and Python topology before selection', async () => {
   let script = ''
   await probeWindowsRemote(
-    sshWith(async command => {
-      script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+    sshWith(async (command, options) => {
+      script = scriptFromInvocation(command, options)
 
       return JSON.stringify({
         os: 'Windows',
@@ -170,6 +182,80 @@ test('Windows probe validates Hermes and Python topology before selection', asyn
   assert.ok(pythonCheck < output)
 })
 
+test('Windows platform probe streams long PowerShell scripts over stdin', async () => {
+  let command = ''
+  let stdinData = ''
+
+  const result = await probeWindowsRemote({
+    async exec(nextCommand: string, options: SshExecOptions = {}) {
+      command = nextCommand
+      stdinData = String(options.stdinData || '')
+
+      return JSON.stringify({
+        os: 'Windows',
+        arch: 'AMD64',
+        hermesHome: 'C:\\\\h',
+        hermesPath: 'C:\\\\h\\\\hermes.exe',
+        python: 'C:\\\\h\\\\python.exe'
+      })
+    }
+  })
+
+  assert.equal(result.os, 'Windows')
+  assert.match(command, /-Command \[ScriptBlock\]::Create/)
+  assert.doesNotMatch(command, /-EncodedCommand/)
+  assert.ok(command.length < 1024)
+  assert.ok(stdinData.length > 0)
+  assert.match(stdinData, /Assert-NoReparse/)
+})
+
+function runLocalWindowsCommand(command, stdinData) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('cmd.exe', ['/d', '/s', '/c', command], { windowsHide: true })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+
+    child.stdout.on('data', chunk => stdout.push(chunk))
+    child.stderr.on('data', chunk => stderr.push(chunk))
+    child.once('error', reject)
+    child.once('close', code => {
+      const out = Buffer.concat(stdout).toString('utf8')
+
+      if (code === 0) {
+        resolve(out)
+        return
+      }
+
+      reject(new Error(Buffer.concat(stderr).toString('utf8') || `command exited with ${code}`))
+    })
+
+    child.stdin.end(stdinData || '')
+  })
+}
+
+test.skipIf(process.platform !== 'win32')('Windows platform probe executes in real PowerShell', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-probe-'))
+  const hermesPath = path.join(tempDir, 'hermes.exe')
+
+  try {
+    fs.writeFileSync(hermesPath, '')
+    fs.writeFileSync(path.join(tempDir, 'python.exe'), '')
+
+    const result = await probeWindowsRemote(
+      {
+        exec: (command: string, options: SshExecOptions = {}) => runLocalWindowsCommand(command, options.stdinData)
+      },
+      hermesPath
+    )
+
+    assert.equal(result.os, 'Windows')
+    assert.equal(result.hermesPath, hermesPath)
+    assert.equal(result.python, path.join(tempDir, 'python.exe'))
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+})
+
 test('platform detection preserves POSIX and falls back to Windows PowerShell', async () => {
   assert.deepEqual(await detectRemotePlatform(sshWith(async () => 'Linux\nx86_64\n')), { os: 'Linux', arch: 'x86_64' })
   const calls: string[] = []
@@ -193,7 +279,7 @@ test('platform detection preserves POSIX and falls back to Windows PowerShell', 
   )
 
   assert.equal(result.os, 'Windows')
-  assert.match(calls[1], /EncodedCommand/)
+  assert.match(calls[1], /-Command \[ScriptBlock\]::Create/)
 })
 
 test('platform detection surfaces transport failures as themselves, not unsupported-platform', async () => {

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -19,6 +19,13 @@ function powerShellCommand(script) {
   return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedPowerShell(script)}`
 }
 
+// Keep long probes out of the remote command line. Windows' default OpenSSH
+// command shell is commonly cmd.exe, whose command-line limit is 8191 chars.
+// SshConnection.exec already supports streaming stdin to the remote command.
+function powerShellStdinCommand() {
+  return 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command [ScriptBlock]::Create([Console]::In.ReadToEnd()).Invoke()'
+}
+
 async function probeWindowsRemote(ssh, explicitHermesPath = '') {
   const explicit = psLiteral(explicitHermesPath)
 
@@ -63,9 +70,11 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     '$python=[IO.Path]::Combine([IO.Path]::GetDirectoryName($hermes), "python.exe")',
     'Assert-NoReparse $python $false',
     '[ordered]@{os="Windows";arch=$env:PROCESSOR_ARCHITECTURE;hermesHome=$hermesHome;hermesPath=$hermes;python=$python}|ConvertTo-Json -Compress'
-  ].join(';')
+  ].join('\r\n')
 
-  return JSON.parse((await ssh.exec(powerShellCommand(script))).trim())
+  const output = await ssh.exec(powerShellStdinCommand(), { stdinData: `${script}\r\n` })
+
+  return JSON.parse(String(output || '').trim())
 }
 
 function windowsUpdateMarkerProbeCommand(hermesHome) {

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -23,7 +23,7 @@ function powerShellCommand(script) {
 // command shell is commonly cmd.exe, whose command-line limit is 8191 chars.
 // SshConnection.exec already supports streaming stdin to the remote command.
 function powerShellStdinCommand() {
-  return 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command [ScriptBlock]::Create([Console]::In.ReadToEnd()).Invoke()'
+  return 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command [ScriptBlock]::Create([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String([Console]::In.ReadToEnd()))).Invoke()'
 }
 
 async function probeWindowsRemote(ssh, explicitHermesPath = '') {
@@ -72,7 +72,7 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     '[ordered]@{os="Windows";arch=$env:PROCESSOR_ARCHITECTURE;hermesHome=$hermesHome;hermesPath=$hermes;python=$python}|ConvertTo-Json -Compress'
   ].join('\r\n')
 
-  const output = await ssh.exec(powerShellStdinCommand(), { stdinData: `${script}\r\n` })
+  const output = await ssh.exec(powerShellStdinCommand(), { stdinData: `${encodedPowerShell(script)}\r\n` })
 
   return JSON.parse(String(output || '').trim())
 }


### PR DESCRIPTION
## Summary

- Stream the Windows Desktop SSH platform probe over SSH stdin instead of embedding a long PowerShell payload in the remote command line.
- Encode the streamed payload as UTF-16LE Base64 so Unicode paths survive the stdin transport.
- Keep probe statements CRLF-separated so PowerShell `try`/`catch` blocks parse correctly.
- Add transport, Unicode payload, and real-Windows-PowerShell regression coverage.

## Root cause

Windows OpenSSH commonly invokes `cmd.exe`, whose command-line limit rejects the UTF-16LE Base64 `-EncodedCommand` used by the probe. The actual error was `The command line is too long`, but Desktop surfaced it as `Unsupported remote platform`.

The probe now invokes a short PowerShell command and reads a Base64-encoded UTF-16LE script from stdin, keeping the payload out of the command line while preserving path characters.

## Related issues and PRs

- Related to #91479
- Complements #91540 (Windows runtime-pair and CLIXML handling)

## Test plan

- `windows-remote-lifecycle.test.ts`: 17/17 passed on Windows.
- Real PowerShell execution test runs through local `cmd.exe` and verifies the returned Windows probe JSON.
- Direct `cmd.exe`/PowerShell smoke test verifies a Unicode path payload returns `unicode-ok`.
- ESLint on both changed files: 0 errors, 0 warnings.
- `git diff --check`: passed.

The repository checkout is missing several UI/Electron dependencies, so the full repository `typecheck` is not currently runnable; unrelated baseline errors include missing Electron declarations and Windows-vs-POSIX assumptions in `ssh-connection.test.ts`.

## Scope

Only these files are changed:

- `apps/desktop/electron/windows-remote-lifecycle.ts`
- `apps/desktop/electron/windows-remote-lifecycle.test.ts`
