### PR TITLE
test(kanban): preserve canonical plugin graph across fixtures

### DIFF
--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
-import tempfile
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -18,14 +16,16 @@ import pytest
 
 
 @pytest.fixture()
-def isolated_kanban_home(monkeypatch):
+def isolated_kanban_home(tmp_path, monkeypatch):
     """Spin up a fresh HERMES_HOME with a clean kanban DB."""
-    test_home = tempfile.mkdtemp(prefix="kanban_cli_passthrough_")
+    test_home = tmp_path / ".hermes"
     os.makedirs(os.path.join(test_home, "profiles", "default"), exist_ok=True)
-    monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
+    monkeypatch.setenv("HERMES_HOME", str(test_home))
+
+    # Runtime path resolution follows HERMES_HOME dynamically.  Purging the
+    # whole package tree here creates two hermes_cli.plugins singletons in a
+    # combined test process and disconnects lifecycle-hook subscribers from
+    # the dispatcher emitter.
     yield test_home
 
 
@@ -92,5 +92,4 @@ def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypat
     assert captured.get("max_spawn") == 2, (
         f"CLI --max=2 must override config kanban.max_spawn=10; got {captured.get('max_spawn')!r}"
     )
-
 

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -7,27 +7,25 @@ the task is skipped (existing behavior preserved).
 from __future__ import annotations
 
 import json
-import os
-import sys
-import tempfile
 
 import pytest
 
 
 @pytest.fixture()
-def isolated_kanban_home(monkeypatch):
+def isolated_kanban_home(tmp_path, monkeypatch):
     """Spin up a fresh HERMES_HOME with a clean kanban DB."""
-    test_home = tempfile.mkdtemp(prefix="kanban_default_assignee_test_")
-    monkeypatch.setenv("HERMES_HOME", test_home)
-    # Force-reimport so the fresh HERMES_HOME is picked up.
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
+    test_home = tmp_path / ".hermes"
+    test_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(test_home))
+
+    # Kanban paths resolve HERMES_HOME at call time.  Reusing the canonical
+    # module object is load-bearing: deleting the entire hermes_cli package
+    # tree from sys.modules leaves already-collected test modules holding
+    # stale plugin-manager functions, so later lifecycle hooks register on a
+    # different singleton from the dispatcher that emits them.
     from hermes_cli import kanban_db
+
     yield kanban_db, test_home
-    # Cleanup is best-effort; tempfile dir survives but pytest isolation
-    # gives each test its own monkeypatched HERMES_HOME so no cross-test
-    # contamination.
 
 
 def _fake_spawn(*args, **kwargs):
@@ -91,5 +89,4 @@ def test_explicitly_assigned_task_untouched_by_default_assignee(isolated_kanban_
         )
     assert task_id not in res.auto_assigned_default
     assert any(s[0] == task_id and s[1] == "default" for s in res.spawned)
-
 

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -8,23 +8,24 @@ model / API quota / browser pool from being overwhelmed by a fan-out.
 from __future__ import annotations
 
 import os
-import sys
-import tempfile
 
 import pytest
 
 
 @pytest.fixture()
-def isolated_kanban_home_with_profiles(monkeypatch):
+def isolated_kanban_home_with_profiles(tmp_path, monkeypatch):
     """Spin up a fresh HERMES_HOME with kanban DB + alpha/beta profiles."""
-    test_home = tempfile.mkdtemp(prefix="kanban_per_profile_cap_test_")
+    test_home = tmp_path / ".hermes"
     for prof in ("alpha", "beta", "default"):
         os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
-    monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
+    monkeypatch.setenv("HERMES_HOME", str(test_home))
+
+    # get_default_hermes_root() memoizes by the current HERMES_HOME value, so
+    # no re-import is needed.  Keep one canonical hermes_cli module graph so
+    # hook registration and hook emission cannot split across stale singleton
+    # instances when test files are collected in one process.
     from hermes_cli import kanban_db
+
     yield kanban_db
 
 
@@ -96,5 +97,4 @@ def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_pr
     assert len(res2.spawned) == 1
     assert len(res2.skipped_per_profile_capped) == 1
     assert res2.spawned[0][0] != spawned_id  # different task this time
-
 


### PR DESCRIPTION
Fixes combined-order hook test failures caused by three legacy Kanban fixtures deleting all loaded `hermes_cli` modules after pytest collection. Those purges created two live `hermes_cli.plugins` singleton graphs, so hooks registered on one manager were invisible to lifecycle events emitted through the other.

This replaces only the three broad module-purge fixtures with `tmp_path` + canonical module imports. Production webhook code and assertions are unchanged.

Evidence:
- exact combined order: 74 passed, 1 skipped (previously 69 passed, 1 skipped, 5 failed)
- reverse order: 15/15 passed
- affected files: 15/15 passed
- webhook security suite: 145/145 passed
- `git diff --check`: passed

An independent source-static cold review found no P0/P1/P2 issues.