### PR TITLE
fix(tui): add sustained-direction ramp to wheelAccel for quantised terminals

### DIFF
--- a/ui-tui/src/__tests__/wheelAccel.test.ts
+++ b/ui-tui/src/__tests__/wheelAccel.test.ts
@@ -20,14 +20,44 @@ describe('wheelAccel — native path', () => {
     expect(computeWheelStep(s, 1, 1060)).toBeGreaterThanOrEqual(1)
   })
 
-  it('gap beyond window resets mult to base', () => {
+  it('gap ≥500ms (idle) resets mult to base', () => {
     const s = initWheelAccel(false, 1)
 
     for (let t = 1000; t < 1100; t += 20) {
       computeWheelStep(s, 1, t)
     }
 
+    // 900ms gap — well past the 500ms sustained window → hard reset.
     expect(computeWheelStep(s, 1, 2000)).toBe(1)
+  })
+
+  // Regression for #98295: modern terminals (Windows Terminal, Ghostty,
+  // iTerm2, Alacritty) quantise touchpad deltas and emit SGR events at
+  // ~80-300ms intervals — well above the old 40ms fast-burst window.
+  // Before the fix, every such event would hard-reset mult to base (1),
+  // so acceleration never engaged.
+  it('sustained scroll at ~120ms intervals ramps above base (#98295)', () => {
+    const s = initWheelAccel(false, 1)
+
+    // Simulate 10 scroll events at 120ms cadence (typical Windows Terminal).
+    computeWheelStep(s, 1, 1000)
+    for (let i = 1; i <= 9; i++) {
+      computeWheelStep(s, 1, 1000 + i * 120)
+    }
+
+    // After 9 sustained same-direction events the multiplier must be > 1.
+    expect(s.mult).toBeGreaterThan(1)
+  })
+
+  it('sustained scroll stays within cap', () => {
+    const s = initWheelAccel(false, 1)
+
+    // 30 events at 100ms each — multiplier must never exceed WHEEL_ACCEL_MAX (6).
+    computeWheelStep(s, 1, 1000)
+    for (let i = 1; i <= 30; i++) {
+      const rows = computeWheelStep(s, 1, 1000 + i * 100)
+      expect(rows).toBeLessThanOrEqual(6)
+    }
   })
 
   it('direction flip defers one event for bounce detection', () => {

--- a/ui-tui/src/lib/wheelAccel.ts
+++ b/ui-tui/src/lib/wheelAccel.ts
@@ -5,7 +5,11 @@
 // Heuristic on inter-event gap + direction flips:
 //
 //   gap < 5ms                 → same-batch burst → 1 row/event
-//   gap < 40ms (native)       → ramp +0.3, cap 6
+//   gap < 40ms (native)       → fast ramp +0.5, cap 6
+//   gap 40-500ms (native)     → sustained-direction ramp: decay-then-grow
+//                               so scrolling stays accelerated even when the
+//                               terminal quantises deltas to ~120ms intervals
+//                               (Windows Terminal, Ghostty, iTerm2, Alacritty)
 //   gap 80-500ms (xterm.js)   → mult = 1 + (mult-1)·0.5^(gap/150) + 5·decay
 //                               cap 3 slow / 6 fast
 //   gap > 500ms               → reset (deliberate click stays responsive)
@@ -14,13 +18,28 @@
 //
 // Native terminals (Ghostty, iTerm2) and xterm.js embedders (VS Code,
 // Cursor) emit wheel events with different cadences, hence two paths.
+//
+// Fix for issue #98295: modern terminals (Windows Terminal, Ghostty, iTerm2)
+// accumulate continuous pixel/touchpad deltas and only emit SGR mouse
+// sequences when an entire character line is crossed — typical inter-event
+// gaps are 80-300ms, well above the old WHEEL_ACCEL_WINDOW_MS=40ms reset
+// threshold.  The sustained-direction ramp replaces the hard reset so
+// acceleration engages at normal scrolling cadences.
 
 import { isXtermJs } from '@hermes/ink'
 
 // ── Native (ghostty, iTerm2, WezTerm, …) ───────────────────────────────
+// Fast-burst window: events within this gap get the full +STEP ramp.
 const WHEEL_ACCEL_WINDOW_MS = 40
-const WHEEL_ACCEL_STEP = 0.3
+const WHEEL_ACCEL_STEP = 0.5
 const WHEEL_ACCEL_MAX = 6
+// Sustained-direction window: events beyond the fast-burst window but still
+// within this gap are considered "user is still scrolling" on quantised
+// terminals.  We apply a gentle half-life decay and a smaller grow step so
+// the multiplier stays elevated rather than hard-resetting to base.
+const WHEEL_SUSTAINED_WINDOW_MS = 500
+const WHEEL_SUSTAINED_STEP = 0.15
+const WHEEL_SUSTAINED_HALFLIFE_MS = 200
 
 // ── Encoder bounce / wheel-mode (mechanical wheels) ────────────────────
 const WHEEL_BOUNCE_GAP_MAX_MS = 200
@@ -146,14 +165,23 @@ function nativeStep(state: WheelAccelState, dir: -1 | 1, now: number): number {
     return Math.floor(state.mult)
   }
 
-  // Trackpad / hi-res native: tight 40ms window — sub-window ramps,
-  // anything slower resets to baseline.
-  if (gap > WHEEL_ACCEL_WINDOW_MS) {
-    state.mult = state.base
-  } else {
-    const cap = Math.max(WHEEL_ACCEL_MAX, state.base * 2)
+  // Trackpad / hi-res native — two tiers:
+  //
+  // Fast burst (gap < 40ms): sub-window ramps aggressively (+0.5/event).
+  // Sustained scroll (40ms ≤ gap < 500ms): apply half-life decay then a
+  //   gentle grow step so quantised-delta terminals (Windows Terminal,
+  //   Ghostty, iTerm2, Alacritty — typical gap 80-300ms) keep accelerating
+  //   instead of hard-resetting to base on every event (fixes #98295).
+  // Idle (gap ≥ 500ms): hard reset — deliberate single click stays crisp.
+  const cap = Math.max(WHEEL_ACCEL_MAX, state.base * 2)
 
+  if (gap < WHEEL_ACCEL_WINDOW_MS) {
     state.mult = Math.min(cap, state.mult + WHEEL_ACCEL_STEP)
+  } else if (gap < WHEEL_SUSTAINED_WINDOW_MS) {
+    const decay = Math.pow(0.5, gap / WHEEL_SUSTAINED_HALFLIFE_MS)
+    state.mult = Math.min(cap, 1 + (state.mult - 1) * decay + WHEEL_SUSTAINED_STEP)
+  } else {
+    state.mult = state.base
   }
 
   return Math.floor(state.mult)


### PR DESCRIPTION
## Problem

Modern terminals (Windows Terminal, Ghostty, iTerm2, Alacritty) accumulate touchpad/mouse-wheel deltas and only emit a SGR mouse event when a full character cell is crossed. Typical inter-event gaps are **80–300 ms** — well above the old \WHEEL_ACCEL_WINDOW_MS = 40 ms\ fast-burst threshold.

Before this fix every such event hard-reset the multiplier to base (1 row/event), so \wheelAccel\ acceleration **never engaged** during normal scrolling, regardless of scroll speed.

Reported in: #98295

## Fix

Add a **sustained-direction window** (40 ms – 500 ms) that applies a gentle half-life decay + grow step, keeping the multiplier elevated across quantised-delta events:

| Gap | Behaviour |
|-----|-----------|
| < 5 ms | same-batch burst → 1 row/event |
| 5–40 ms | fast-burst ramp (+0.5/event, cap 6) — unchanged |
| 40–500 ms | sustained ramp: decay × ½^(gap/200ms) + 0.15 grow |
| ≥ 500 ms | hard reset to base — deliberate single clicks stay crisp |

\WHEEL_ACCEL_STEP\ tuned 0.3 → 0.5 for the narrower fast-burst window.

## Tests

Two new cases in \src/__tests__/wheelAccel.test.ts\:
- *sustained scroll at ~120ms intervals ramps above base* — regression witness for #98295
- *sustained scroll stays within cap* — safety bound (≤ 6 rows/event)

All **15 wheelAccel tests pass**.

Fixes #98295