### PR TITLE
fix(desktop): resume profile chats after reconnect

### DIFF
--- a/apps/desktop/e2e/profile-session-reconnect.spec.ts
+++ b/apps/desktop/e2e/profile-session-reconnect.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Full-chain regression for #97764.
+ *
+ * A named local profile is served by its own routed WebSocket. Dropping that
+ * socket after prompt.submit has acknowledged, but while inference is still
+ * running, must reconnect and resume the durable session before the backend's
+ * orphan reaper interrupts the turn. The prompt must not be replayed.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig
+} from './fixtures'
+import { MOCK_REPLY, startMockServer } from './mock-server'
+import { RealSessionBuilder } from './real-session-builder'
+import { expect, test } from './test'
+
+const PROFILE = 'youtube'
+const SEED_PROMPT = 'E2E durable YouTube session before reconnect'
+const LIVE_PROMPT = 'E2E hold this YouTube turn across a dropped profile socket'
+const ORPHAN_REAP_GRACE_MS = 3_000
+
+interface TrackedSocketWindow extends Window {
+  __e2eGatewaySockets?: WebSocket[]
+}
+
+async function installWebSocketTracker(fixture: MockBackendFixture): Promise<void> {
+  await fixture.page.addInitScript(() => {
+    const NativeWebSocket = window.WebSocket
+
+    class TrackedWebSocket extends NativeWebSocket {
+      constructor(url: string | URL, protocols?: string | string[]) {
+        if (protocols === undefined) {
+          super(url)
+        } else {
+          super(url, protocols)
+        }
+
+        const trackedWindow = window as TrackedSocketWindow
+        trackedWindow.__e2eGatewaySockets ??= []
+        trackedWindow.__e2eGatewaySockets.push(this)
+      }
+    }
+
+    window.WebSocket = TrackedWebSocket
+    ;(window as TrackedSocketWindow).__e2eGatewaySockets = []
+  })
+
+  // addInitScript applies on the next document. A cold renderer also mirrors
+  // the reporter's reconnect path more closely than instrumenting app code.
+  await fixture.page.reload()
+  await waitForAppReady(fixture, 120_000)
+}
+
+async function trackedSocketCount(fixture: MockBackendFixture): Promise<number> {
+  return fixture.page.evaluate(() => (window as TrackedSocketWindow).__e2eGatewaySockets?.length ?? 0)
+}
+
+async function waitForNewOpenSocket(fixture: MockBackendFixture, afterIndex: number): Promise<number> {
+  await fixture.page.waitForFunction(
+    index =>
+      ((window as TrackedSocketWindow).__e2eGatewaySockets ?? []).some(
+        (socket, socketIndex) => socketIndex > index && socket.readyState === WebSocket.OPEN
+      ),
+    afterIndex,
+    { timeout: 60_000 }
+  )
+
+  return fixture.page.evaluate(index => {
+    const sockets = (window as TrackedSocketWindow).__e2eGatewaySockets ?? []
+
+    return sockets.findIndex((socket, socketIndex) => socketIndex > index && socket.readyState === WebSocket.OPEN)
+  }, afterIndex)
+}
+
+async function textNodeOccurrences(fixture: MockBackendFixture, expected: string): Promise<number> {
+  return fixture.page.evaluate(text => {
+    const viewport = document.querySelector('[data-slot="aui_thread-viewport"]')
+
+    if (!viewport) return 0
+
+    const walker = document.createTreeWalker(viewport, NodeFilter.SHOW_TEXT)
+    let count = 0
+
+    while (walker.nextNode()) {
+      if (walker.currentNode.textContent?.includes(text)) count += 1
+    }
+
+    return count
+  }, expected)
+}
+
+test('a named-profile turn resumes after its WebSocket drops mid-stream', async () => {
+  test.setTimeout(180_000)
+
+  const mock = await startMockServer({ holdFirstStreamForPrompt: LIVE_PROMPT })
+  const sandbox = createSandbox('profile-session-reconnect')
+  let fixture: MockBackendFixture | null = null
+
+  try {
+    writeMockProviderConfig(sandbox.hermesHome, mock.url)
+    writeEnvFile(sandbox.hermesHome)
+
+    const profileHome = path.join(sandbox.hermesHome, 'profiles', PROFILE)
+    fs.mkdirSync(profileHome, { recursive: true })
+    writeMockProviderConfig(
+      profileHome,
+      mock.url,
+      undefined,
+      `dashboard:\n  ws_orphan_reap_grace_s: ${ORPHAN_REAP_GRACE_MS / 1_000}`
+    )
+    writeEnvFile(profileHome)
+
+    const builder = await RealSessionBuilder.start(profileHome)
+
+    try {
+      await builder.createSession({ title: SEED_PROMPT, turns: [SEED_PROMPT] })
+    } finally {
+      await builder.close()
+    }
+
+    const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+    fixture = {
+      app,
+      page,
+      mock,
+      mockUrl: mock.url,
+      sandbox,
+      cleanup: async () => undefined
+    }
+
+    await waitForAppReady(fixture, 120_000)
+    await installWebSocketTracker(fixture)
+
+    const beforeProfileSocket = (await trackedSocketCount(fixture)) - 1
+    const profileButton = page
+      .getByRole('group', { name: 'Profiles' })
+      .getByRole('button', { name: PROFILE, exact: true })
+    await expect(profileButton).toBeVisible({ timeout: 60_000 })
+    await profileButton.click()
+    await expect(profileButton).toHaveAttribute('aria-pressed', 'true', { timeout: 60_000 })
+
+    const sessionRow = page.locator('[data-slot="sidebar"] button').filter({ hasText: SEED_PROMPT }).first()
+    await expect(sessionRow).toBeVisible({ timeout: 60_000 })
+    await sessionRow.click()
+    await expect(page.getByText(SEED_PROMPT, { exact: true }).filter({ visible: true }).first()).toBeVisible({
+      timeout: 60_000
+    })
+
+    const initialReplyCount = await textNodeOccurrences(fixture, MOCK_REPLY)
+
+    const composer = page
+      .locator('[data-slot="composer-root"] [contenteditable="true"]')
+      .filter({ visible: true })
+      .first()
+    await composer.click()
+    await composer.fill(LIVE_PROMPT)
+    await page.keyboard.press('Enter')
+    await mock.waitForHeldStream()
+
+    // prompt.submit already returned here. The routed turn lease must keep the
+    // profile socket alive until a terminal turn event, not just until the ACK.
+    const profileSocketIndex = await waitForNewOpenSocket(fixture, beforeProfileSocket)
+    expect(await textNodeOccurrences(fixture, LIVE_PROMPT), 'prompt duplicated before the forced drop').toBe(1)
+    expect(
+      await page.evaluate(
+        index => ((window as TrackedSocketWindow).__e2eGatewaySockets ?? [])[index]?.readyState,
+        profileSocketIndex
+      )
+    ).toBe(1)
+
+    await page.evaluate(index => {
+      const socket = ((window as TrackedSocketWindow).__e2eGatewaySockets ?? [])[index]
+      socket?.close(4000, 'E2E mid-turn transport drop')
+    }, profileSocketIndex)
+
+    await waitForNewOpenSocket(fixture, profileSocketIndex)
+
+    // Stay disconnected long enough that a stale runtime would be interrupted
+    // by ws_orphan_reap. A reconnect that resumes the durable id cancels it.
+    await page.waitForTimeout(ORPHAN_REAP_GRACE_MS + 1_500)
+    expect(await textNodeOccurrences(fixture, LIVE_PROMPT), 'prompt duplicated during reconnect resume').toBe(1)
+    mock.releaseHeldStream()
+
+    await expect.poll(() => textNodeOccurrences(fixture!, MOCK_REPLY), { timeout: 60_000 }).toBe(initialReplyCount + 1)
+    expect(await textNodeOccurrences(fixture, LIVE_PROMPT)).toBe(1)
+    expect(mock.receivedPrompts.filter(prompt => prompt.includes(LIVE_PROMPT))).toHaveLength(1)
+  } finally {
+    await fixture?.app.close().catch(() => undefined)
+    await mock.close()
+    sandbox.cleanup()
+  }
+})

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -447,6 +447,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     queryClient,
     refreshHermesConfig,
     refreshSessions,
+    runtimeIdByStoredSessionIdRef,
     sessionStateByRuntimeIdRef,
     updateSessionState
   })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
@@ -265,6 +265,7 @@ describe('useMessageStream composed with the real useSessionStateCache', () => {
       queryClient: queryClientRef.current,
       refreshHermesConfig: vi.fn(async () => undefined),
       refreshSessions: vi.fn(async () => undefined),
+      runtimeIdByStoredSessionIdRef: sessionCache.runtimeIdByStoredSessionIdRef,
       sessionStateByRuntimeIdRef: sessionCache.sessionStateByRuntimeIdRef,
       updateSessionState: sessionCache.updateSessionState
     })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -94,6 +94,7 @@ const HANDLERS: GatewayEventHandler[] = [
 export function useGatewayEventHandler(deps: GatewayEventDeps) {
   const { activeSessionIdRef, compactedTurnRef, refreshHermesConfig, sessionStateByRuntimeIdRef } = deps
 
+  const reclaimedRuntimeIdsRef = useRef(new Set<string>())
   const unscopedStreamSessionIdRef = useRef<string | null>(null)
 
   // session.info arrives in bursts (agent build ready + turn end + title /
@@ -152,6 +153,21 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           : Date.now() / 1000
 
       const explicitSid = event.session_id || ''
+
+      if (
+        explicitSid &&
+        event.type !== 'session.reclaimed' &&
+        reclaimedRuntimeIdsRef.current.has(explicitSid) &&
+        (sessionStateByRuntimeIdRef.current.has(explicitSid) ||
+          [...deps.runtimeIdByStoredSessionIdRef.current.values()].includes(explicitSid))
+      ) {
+        // Runtime ids can be recycled after a backend restart. Any fresh
+        // session-scoped event proves this generation is live and may claim a
+        // future reclaim independently of an older generation with the same
+        // id. Require a fresh cache/binding too, so a queued late event from the
+        // dead generation cannot re-arm duplicate global broadcasts.
+        reclaimedRuntimeIdsRef.current.delete(explicitSid)
+      }
 
       const route = resolveGatewayEventSessionId({
         activeSessionId: activeSessionIdRef.current,
@@ -218,6 +234,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       }
 
       const ctx: GatewayEventContext = {
+        claimReclaimedRuntime: runtimeId => {
+          if (reclaimedRuntimeIdsRef.current.has(runtimeId)) {
+            return false
+          }
+
+          reclaimedRuntimeIdsRef.current.add(runtimeId)
+
+          return true
+        },
         deps,
         event,
         payload,
@@ -253,6 +278,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       deps.lastCwdInfoSessionRef,
       deps.nativeSubagentSessionsRef,
       deps.queryClient,
+      deps.runtimeIdByStoredSessionIdRef,
       scheduleConfigRefresh,
       deps.scheduleSessionsRefresh,
       deps.sessionInterrupted,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
@@ -1,3 +1,4 @@
+import { registryBackendScopeKey } from '@hermes/shared'
 import type { HermesSkin } from '@hermes/shared/skin'
 
 import {
@@ -9,12 +10,89 @@ import {
   type PetChangeMeta,
   setChangeEventsAvailable
 } from '@/store/live-sync'
-import { dropSessionState, unbindTileRuntime } from '@/store/session-states'
+import { normalizeProfileKey } from '@/store/profile'
+import {
+  $selectedStoredSessionId,
+  getSessionOwnerHints,
+  idsShareLineage,
+  ownerLookupSessionRows,
+  requestSessionResume,
+  sessionMatchesStoredId
+} from '@/store/session'
+import type { SessionOwnerRoute } from '@/store/session-request-router'
+import {
+  dropSessionState,
+  holdSessionOwnerUntilForeground,
+  runtimeSessionScope,
+  unbindTileRuntime
+} from '@/store/session-states'
 // Leaf import (not the `@/themes` barrel) to avoid pulling the ThemeProvider
 // module graph into the gateway event hot path.
 import { ingestBackendSkin } from '@/themes/backend-sync'
 
 import type { GatewayEventContext } from './types'
+
+/** Resolve a durable owner without trusting the event's arrival socket.
+ *  session.reclaimed is broadcast to every client, so that socket is only a
+ *  bystander. A unique persisted route is safe; same-id twins fail closed. */
+function reclaimOwnerRoute(durableIds: string[], runtimeScope: string | undefined): SessionOwnerRoute | null | undefined {
+  const hintsByScope = new Map<string, SessionOwnerRoute>()
+
+  for (const durableId of durableIds) {
+    for (const hint of getSessionOwnerHints(durableId)) {
+      hintsByScope.set(registryBackendScopeKey(hint.connectionId, normalizeProfileKey(hint.profile)), hint)
+    }
+  }
+
+  if (runtimeScope) {
+    // The existing live-work scope ledger is stronger than durable metadata
+    // for same-id twins. Use it only to select a COMPLETE hint (preserving
+    // targetProfile/mode); never turn the broadcast's bystander socket into an
+    // owner or introduce a second structured runtime-owner registry.
+    return hintsByScope.get(runtimeScope) ?? null
+  }
+
+  const hintScopes = new Set(hintsByScope.keys())
+  const bareProfiles = new Set<string>()
+
+  for (const row of ownerLookupSessionRows().filter(candidate =>
+    durableIds.some(durableId => sessionMatchesStoredId(candidate, durableId))
+  )) {
+    const connectionId = row.connection_id?.trim()
+    const profile = normalizeProfileKey(row.profile)
+
+    if (connectionId) {
+      const scope = registryBackendScopeKey(connectionId, profile)
+
+      hintsByScope.set(scope, hintsByScope.get(scope) ?? { connectionId, profile })
+    } else {
+      bareProfiles.add(profile)
+    }
+  }
+
+  const hints = [...hintsByScope.values()]
+
+  if (hints.length !== 1) {
+    return hints.length > 1 || bareProfiles.size > 1 ? null : undefined
+  }
+
+  const owner = hints[0]
+  const ownerScope = registryBackendScopeKey(owner.connectionId, owner.profile)
+
+  const compatibleProfiles = new Set([
+    normalizeProfileKey(owner.profile),
+    normalizeProfileKey(owner.targetProfile || owner.profile)
+  ])
+
+  if (![...bareProfiles].every(profile => compatibleProfiles.has(profile))) {
+    return null
+  }
+
+  // A row-only exact route proves uniqueness but may omit targetProfile/mode.
+  // Let the established resume resolver consume that row instead of persisting
+  // an incomplete hint here.
+  return hintScopes.has(ownerScope) ? owner : undefined
+}
 
 /** gateway.ready / skin.changed / change-watcher broadcasts / session.reclaimed. */
 export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
@@ -77,7 +155,27 @@ export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
     // session vanishing rather than being reclaimed. Drop the cached state
     // now — the stored row is untouched, so the sidebar keeps the
     // conversation and reopening it resumes from the DB.
-    const reclaimedRuntimeId = String((payload as { session_id?: string } | undefined)?.session_id ?? '')
+    const reclaimed = payload as
+      | { reason?: string; session_id?: string; stored_session_id?: string }
+      | undefined
+
+    const reclaimedRuntimeId = String(reclaimed?.session_id ?? '').trim()
+    const reclaimedStoredId = String(reclaimed?.stored_session_id ?? '').trim()
+    const selectedStoredId = $selectedStoredSessionId.get()?.trim() || ''
+    const reclaimedRuntimeScope = reclaimedRuntimeId ? runtimeSessionScope(reclaimedRuntimeId) : undefined
+
+    const rebindActiveMain = Boolean(
+      reclaimed?.reason === 'ws_orphan_reap' &&
+        reclaimedRuntimeId &&
+        reclaimedRuntimeId === deps.activeSessionIdRef.current &&
+        selectedStoredId &&
+        reclaimedStoredId &&
+        idsShareLineage(selectedStoredId, reclaimedStoredId, ownerLookupSessionRows())
+    )
+
+    const ownerRoute = rebindActiveMain
+      ? reclaimOwnerRoute([...new Set([selectedStoredId, reclaimedStoredId])], reclaimedRuntimeScope)
+      : undefined
 
     if (reclaimedRuntimeId) {
       dropSessionState(reclaimedRuntimeId)
@@ -90,6 +188,27 @@ export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
       // runtime straight back instead of cold-resuming a live one.
       unbindTileRuntime(reclaimedRuntimeId)
       deps.sessionStateByRuntimeIdRef.current.delete(reclaimedRuntimeId)
+
+      // Delete every durable alias that still points at this dead runtime. A
+      // raw SessionStateCache.delete does not run its onEvict callback, and one
+      // stale reverse entry would make the explicit resume's warm path hand the
+      // reclaimed id straight back instead of minting/reusing a live runtime.
+      for (const [storedSessionId, runtimeId] of deps.runtimeIdByStoredSessionIdRef.current) {
+        if (runtimeId === reclaimedRuntimeId) {
+          deps.runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+        }
+      }
+    }
+
+    if (rebindActiveMain && ownerRoute !== null && ctx.claimReclaimedRuntime(reclaimedRuntimeId)) {
+      // Reuse the route-resume door: it already owns exact routing,
+      // single-flight resume, transcript preservation and navigation-drift
+      // guards. Do not replay prompt.submit here.
+      if (ownerRoute) {
+        holdSessionOwnerUntilForeground(selectedStoredId, ownerRoute)
+      }
+
+      requestSessionResume(selectedStoredId, ownerRoute)
     }
 
     // The row's ended_at moved, so refresh the lists that render it.

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -31,6 +31,7 @@ export interface GatewayEventDeps {
   ) => Promise<void>
   queryClient: QueryClient
   refreshHermesConfig: () => Promise<void>
+  runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   scheduleSessionsRefresh: () => void
   sessionInterrupted: (sessionId: string) => boolean
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
@@ -51,6 +52,9 @@ export interface GatewayEventDeps {
 /** Everything a per-family handler needs about the event being dispatched —
  *  the routing preamble in index.ts computes it once per event. */
 export interface GatewayEventContext {
+  /** Claim one backend-reclaimed runtime for rebind. Global broadcasts arrive
+   *  once per socket; only the first copy may schedule recovery. */
+  claimReclaimedRuntime: (runtimeId: string) => boolean
   deps: GatewayEventDeps
   event: RpcEvent
   payload: GatewayEventPayload | undefined

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -46,6 +46,7 @@ interface MessageStreamOptions {
   queryClient: QueryClient
   refreshHermesConfig: () => Promise<void>
   refreshSessions: () => Promise<void>
+  runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
   updateSessionState: (
     sessionId: string,
@@ -74,6 +75,7 @@ export function useMessageStream({
   queryClient,
   refreshHermesConfig,
   refreshSessions,
+  runtimeIdByStoredSessionIdRef,
   sessionStateByRuntimeIdRef,
   updateSessionState
 }: MessageStreamOptions) {
@@ -867,6 +869,7 @@ export function useMessageStream({
     hydrateFromStoredSession,
     queryClient,
     refreshHermesConfig,
+    runtimeIdByStoredSessionIdRef,
     scheduleSessionsRefresh,
     sessionInterrupted,
     sessionStateByRuntimeIdRef,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
@@ -4,7 +4,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { $sessionStates, $sessionTiles, publishSessionState } from '@/store/session-states'
+import {
+  $activeSessionId,
+  $selectedStoredSessionId,
+  $sessionResumeRequest,
+  _resetSessionOwnerHintsForTests,
+  setSessionOwnerHint,
+  setSessions
+} from '@/store/session'
+import {
+  $sessionStates,
+  $sessionTiles,
+  _resetSessionOwnerHoldsForTests,
+  publishSessionState,
+  recordSessionEventScope
+} from '@/store/session-states'
 import type { RpcEvent } from '@/types/hermes'
 
 import { type MessageStreamHarness, renderMessageStream } from './test-harness'
@@ -16,6 +30,7 @@ import { type MessageStreamHarness, renderMessageStream } from './test-harness'
 
 const ACTIVE_SID = 'session-active'
 const ACTIVE_PROFILE = 'compass'
+const STORED_SID = 'stored-1'
 let stream: MessageStreamHarness
 let queryClient: QueryClient
 let wiringCache: Map<string, ClientSessionState>
@@ -38,12 +53,24 @@ beforeEach(() => {
   queryClient = new QueryClient()
   $sessionStates.set({})
   $sessionTiles.set([])
+  $activeSessionId.set(null)
+  $selectedStoredSessionId.set(null)
+  $sessionResumeRequest.set(null)
+  setSessions([])
+  _resetSessionOwnerHintsForTests({ storage: true })
+  _resetSessionOwnerHoldsForTests()
 })
 
 afterEach(() => {
   cleanup()
   $sessionStates.set({})
   $sessionTiles.set([])
+  $activeSessionId.set(null)
+  $selectedStoredSessionId.set(null)
+  $sessionResumeRequest.set(null)
+  setSessions([])
+  _resetSessionOwnerHintsForTests({ storage: true })
+  _resetSessionOwnerHoldsForTests()
   vi.restoreAllMocks()
 })
 
@@ -128,5 +155,200 @@ describe('session.reclaimed', () => {
 
     expect(wiringCache.has('live-gone')).toBe(false)
     expect(wiringCache.has('live-kept')).toBe(true)
+  })
+
+  it('re-arms the active main chat from its durable id and exact owner after a WS orphan reap', () => {
+    const runtimeBindings = new Map([[STORED_SID, ACTIVE_SID]])
+    stream = renderMessageStream(ACTIVE_SID, {
+      activeGatewayProfile: 'youtube',
+      queryClient,
+      runtimeBindings
+    })
+    wiringCache = stream.states
+    wiringCache.set(ACTIVE_SID, createClientSessionState(STORED_SID))
+    publishSessionState(ACTIVE_SID, createClientSessionState(STORED_SID))
+    $activeSessionId.set(ACTIVE_SID)
+    $selectedStoredSessionId.set(STORED_SID)
+
+    // The same stored id can exist on two sources. The old runtime's recorded
+    // source is authoritative; the global reclaim broadcast's arrival socket
+    // must not make recovery pick the cloud twin or a bare ambient profile.
+    setSessionOwnerHint(STORED_SID, {
+      connectionId: 'local',
+      mode: 'local',
+      profile: 'youtube',
+      targetProfile: 'youtube'
+    })
+    setSessionOwnerHint(STORED_SID, {
+      connectionId: 'cloud-a',
+      mode: 'remote',
+      profile: 'youtube',
+      targetProfile: 'yt-remote'
+    })
+    recordSessionEventScope({ connectionId: 'local', profile: 'youtube', session_id: ACTIVE_SID })
+    const previousSequence = $sessionResumeRequest.get()?.sequence ?? 0
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: 'local',
+        payload: {
+          reason: 'ws_orphan_reap',
+          session_id: ACTIVE_SID,
+          stored_session_id: STORED_SID
+        },
+        profile: 'bystander-profile',
+        session_id: '',
+        type: 'session.reclaimed'
+      } as RpcEvent)
+    )
+
+    expect($sessionStates.get()[ACTIVE_SID]).toBeUndefined()
+    expect(wiringCache.has(ACTIVE_SID)).toBe(false)
+    expect(runtimeBindings.has(STORED_SID)).toBe(false)
+    expect($sessionResumeRequest.get()).toEqual({
+      ownerRoute: {
+        connectionId: 'local',
+        mode: 'local',
+        profile: 'youtube',
+        targetProfile: 'youtube'
+      },
+      sequence: expect.any(Number),
+      sessionId: STORED_SID
+    })
+    expect($sessionResumeRequest.get()!.sequence).toBeGreaterThan(previousSequence)
+
+    const firstRecoverySequence = $sessionResumeRequest.get()!.sequence
+
+    // The backend global-broadcasts once per socket. A duplicate delivered by
+    // the bystander after the first handler dropped the runtime scope must not
+    // replace the local recovery with the cloud twin or restart the resume.
+    act(() =>
+      stream.handleEvent({
+        connectionId: 'local',
+        payload: {
+          reason: 'ws_orphan_reap',
+          session_id: ACTIVE_SID,
+          stored_session_id: STORED_SID
+        },
+        profile: 'bystander-profile',
+        session_id: '',
+        type: 'session.reclaimed'
+      } as RpcEvent)
+    )
+
+    expect($sessionResumeRequest.get()!.sequence).toBe(firstRecoverySequence)
+    expect($sessionResumeRequest.get()!.ownerRoute?.connectionId).toBe('local')
+  })
+
+  it.each(['idle_timeout', 'lru_evict'])(
+    'does not auto-resume an intentionally reclaimed active chat (%s)',
+    reason => {
+      mountStream()
+      wiringCache.set(ACTIVE_SID, createClientSessionState(STORED_SID))
+      $activeSessionId.set(ACTIVE_SID)
+      $selectedStoredSessionId.set(STORED_SID)
+
+      reclaim(ACTIVE_SID, reason)
+
+      // Cache cleanup still happens, but resuming an idle/LRU reclaim would
+      // immediately recreate the resource the backend deliberately evicted.
+      expect(wiringCache.has(ACTIVE_SID)).toBe(false)
+      expect($sessionResumeRequest.get()).toBeNull()
+    }
+  )
+
+  it('resumes the currently routed lineage root when reclaim reports a rotated compression tip', () => {
+    mountStream()
+    setSessions([{ _lineage_root_id: 'lineage-root', id: 'lineage-tip', profile: ACTIVE_PROFILE } as never])
+    wiringCache.set(ACTIVE_SID, createClientSessionState('lineage-root'))
+    stream.runtimeBindings.set('lineage-root', ACTIVE_SID)
+    $activeSessionId.set(ACTIVE_SID)
+    $selectedStoredSessionId.set('lineage-root')
+    setSessionOwnerHint('lineage-root', {
+      connectionId: 'local',
+      profile: ACTIVE_PROFILE
+    })
+    recordSessionEventScope({ connectionId: 'local', profile: ACTIVE_PROFILE, session_id: ACTIVE_SID })
+
+    act(() =>
+      stream.handleEvent({
+        payload: {
+          reason: 'ws_orphan_reap',
+          session_id: ACTIVE_SID,
+          stored_session_id: 'lineage-tip'
+        },
+        session_id: '',
+        type: 'session.reclaimed'
+      } as RpcEvent)
+    )
+
+    expect($sessionResumeRequest.get()).toMatchObject({
+      ownerRoute: { connectionId: 'local', profile: ACTIVE_PROFILE },
+      sessionId: 'lineage-root'
+    })
+    expect(stream.runtimeBindings.has('lineage-root')).toBe(false)
+  })
+
+  it('fails closed when an untagged reclaim has two possible exact owners', () => {
+    mountStream()
+    wiringCache.set(ACTIVE_SID, createClientSessionState(STORED_SID))
+    $activeSessionId.set(ACTIVE_SID)
+    $selectedStoredSessionId.set(STORED_SID)
+    setSessionOwnerHint(STORED_SID, { connectionId: 'local', profile: ACTIVE_PROFILE })
+    setSessionOwnerHint(STORED_SID, { connectionId: 'cloud-a', profile: ACTIVE_PROFILE })
+
+    reclaim(ACTIVE_SID)
+
+    expect($sessionResumeRequest.get()).toBeNull()
+  })
+
+  it('fails closed when a stale unique hint conflicts with the current tagged row owner', () => {
+    mountStream()
+    setSessions([{ connection_id: 'local', id: STORED_SID, profile: ACTIVE_PROFILE } as never])
+    wiringCache.set(ACTIVE_SID, createClientSessionState(STORED_SID))
+    $activeSessionId.set(ACTIVE_SID)
+    $selectedStoredSessionId.set(STORED_SID)
+    setSessionOwnerHint(STORED_SID, { connectionId: 'cloud-a', profile: ACTIVE_PROFILE })
+
+    reclaim(ACTIVE_SID)
+
+    expect($sessionResumeRequest.get()).toBeNull()
+  })
+
+  it('fails closed when two untagged profile rows share the reclaimed durable id', () => {
+    mountStream()
+    setSessions([
+      { id: STORED_SID, profile: 'youtube' } as never,
+      { id: STORED_SID, profile: 'research' } as never
+    ])
+    wiringCache.set(ACTIVE_SID, createClientSessionState(STORED_SID))
+    $activeSessionId.set(ACTIVE_SID)
+    $selectedStoredSessionId.set(STORED_SID)
+
+    reclaim(ACTIVE_SID)
+
+    expect($sessionResumeRequest.get()).toBeNull()
+  })
+
+  it('does not collapse a known scoped runtime to ambient when its complete owner hint is missing', () => {
+    mountStream()
+    wiringCache.set(ACTIVE_SID, createClientSessionState(STORED_SID))
+    $activeSessionId.set(ACTIVE_SID)
+    $selectedStoredSessionId.set(STORED_SID)
+    recordSessionEventScope({ connectionId: 'cloud-a', profile: ACTIVE_PROFILE, session_id: ACTIVE_SID })
+
+    reclaim(ACTIVE_SID)
+
+    expect($sessionResumeRequest.get()).toBeNull()
+  })
+
+  it('does not let a late background reclaim rebind the active main chat', () => {
+    mountStream()
+    $activeSessionId.set(ACTIVE_SID)
+    $selectedStoredSessionId.set(STORED_SID)
+
+    reclaim('runtime-from-previous-chat')
+
+    expect($sessionResumeRequest.get()).toBeNull()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/steer-arrival-order.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/steer-arrival-order.test.tsx
@@ -68,6 +68,7 @@ function Harness() {
     queryClient: queryClientRef.current,
     refreshHermesConfig: vi.fn(async () => undefined),
     refreshSessions: vi.fn(async () => undefined),
+    runtimeIdByStoredSessionIdRef,
     sessionStateByRuntimeIdRef,
     updateSessionState
   })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/test-harness.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/test-harness.tsx
@@ -10,6 +10,10 @@ import type { RpcEvent } from '@/types/hermes'
 import { useMessageStream } from './index'
 
 export interface MessageStreamHarnessOptions extends Partial<Parameters<typeof useMessageStream>[0]> {
+  /** Stored→runtime bindings owned by the wiring cache. Reclaim tests seed the
+   *  reverse half explicitly so a stale runtime cannot be handed back on the
+   *  next resume. */
+  runtimeBindings?: Map<string, string>
   /** Session-state map to mount with, for tests that seed state up front. */
   states?: Map<string, ClientSessionState>
 }
@@ -22,6 +26,8 @@ export interface MessageStreamHarness {
   appendDelta: (sessionId: string, delta: string) => void
   /** The hook's session-state map, so callers can seed or inspect it directly. */
   states: Map<string, ClientSessionState>
+  /** The hook's stored→runtime reverse bindings. */
+  runtimeBindings: Map<string, string>
   /** State for a session, blank before the hook has written any. */
   state: (sessionId?: string) => ClientSessionState
   /** Last state written for any session — for assertions about the write itself. */
@@ -45,7 +51,11 @@ export interface MessageStreamHarness {
  *  own `cleanup()`. */
 export function renderMessageStream(
   sessionId: string | null,
-  { states = new Map<string, ClientSessionState>(), ...overrides }: MessageStreamHarnessOptions = {}
+  {
+    runtimeBindings = new Map<string, string>(),
+    states = new Map<string, ClientSessionState>(),
+    ...overrides
+  }: MessageStreamHarnessOptions = {}
 ): MessageStreamHarness {
   let dispatch: ((event: RpcEvent) => void) | null = null
   let appendDelta: ((sessionId: string, delta: string) => void) | null = null
@@ -53,6 +63,7 @@ export function renderMessageStream(
 
   function Harness() {
     const activeSessionIdRef = useRef<string | null>(sessionId)
+    const runtimeIdByStoredSessionIdRef = useRef(runtimeBindings)
     const sessionStateByRuntimeIdRef = useRef(states)
     const queryClientRef = useRef(new QueryClient())
 
@@ -62,6 +73,7 @@ export function renderMessageStream(
       queryClient: queryClientRef.current,
       refreshHermesConfig: vi.fn(async () => undefined),
       refreshSessions: vi.fn(async () => undefined),
+      runtimeIdByStoredSessionIdRef,
       sessionStateByRuntimeIdRef,
       updateSessionState: (id, updater) => {
         const next = updater(states.get(id) ?? createClientSessionState())
@@ -100,6 +112,7 @@ export function renderMessageStream(
 
       appendDelta(id, delta)
     },
+    runtimeBindings,
     states,
     state,
     latest: () => latest,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -9,7 +9,6 @@ import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
-import { requestGatewayForAgent } from '@/store/gateway'
 import { $goalsBySession, setSessionGoal } from '@/store/goals'
 import { $hudMode } from '@/store/hud'
 import { $notifications, clearNotifications } from '@/store/notifications'
@@ -48,11 +47,6 @@ vi.mock('@/hermes', () => ({
   PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_800_000,
   setApiRequestProfile: vi.fn(),
   transcribeAudio: vi.fn()
-}))
-
-vi.mock('@/store/gateway', async importOriginal => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  requestGatewayForAgent: vi.fn()
 }))
 
 // The active id the desktop holds is the *runtime* session id from
@@ -1774,16 +1768,14 @@ describe('usePromptActions submit / queue drain semantics', () => {
   afterEach(() => {
     cleanup()
     $connection.set(null)
-    vi.mocked(requestGatewayForAgent).mockReset()
     vi.restoreAllMocks()
   })
 
-  it('pins prompt.submit to the active registry connection when the remote session row is untagged', async () => {
+  it('dispatches prompt.submit through the window session router after a remote resume', async () => {
     $connection.set({ connectionId: 'hermes01', mode: 'remote' } as never)
     setSessions([sessionInfo({ id: 'stored-remote', profile: 'default' })])
 
     const ambientRequest = vi.fn(async () => ({}) as never)
-    vi.mocked(requestGatewayForAgent).mockResolvedValue({} as never)
 
     let handle: HarnessHandle | null = null
     await actRender(
@@ -1798,14 +1790,11 @@ describe('usePromptActions submit / queue drain semantics', () => {
     )
 
     expect(await handle!.submitText('continue remotely')).toBe(true)
-    expect(requestGatewayForAgent).toHaveBeenCalledWith(
-      'hermes01',
-      'default',
+    expect(ambientRequest).toHaveBeenCalledWith(
       'prompt.submit',
       { session_id: 'runtime-remote', text: 'continue remotely' },
       1_800_000
     )
-    expect(ambientRequest).not.toHaveBeenCalled()
   })
 
   it('clears a leftover interrupted flag on a fresh submit (so the new turn streams)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -22,17 +22,14 @@ import {
   updateComposerAttachment
 } from '@/store/composer'
 import { resetSessionBackground } from '@/store/composer-status'
-import { requestGatewayForAgent } from '@/store/gateway'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
 import {
   $busy,
-  $connection,
   $currentCwd,
   $messages,
   $terminalBackend,
-  getSessionOwnerHint,
   setActiveSessionId,
   setAwaitingResponse,
   setBusy,
@@ -486,30 +483,6 @@ export function usePromptActions({
     }
   }, [activeSessionId, composerAttachments, eagerlyUploadAttachment])
 
-  // Session resume can be routed through a registry connection while the
-  // render-time requestGateway still points at the local default socket. Keep
-  // every follow-up session RPC on the same composite owner; otherwise resume
-  // succeeds on HERMES01 and prompt.submit immediately fails locally with
-  // "session not found".
-  const requestForPromptSession = useCallback<GatewayRequest>(
-    (method, params = {}, timeoutMs) => {
-      const storedSessionId = selectedStoredSessionIdRef.current
-      const owner = storedSessionId ? getSessionOwnerHint(storedSessionId) : undefined
-      const ambientConnection = $connection.get()
-
-      const connectionId =
-        owner?.connectionId ||
-        (ambientConnection?.mode === 'remote' ? ambientConnection.connectionId?.trim() || '' : '')
-
-      if (connectionId) {
-        return requestGatewayForAgent(connectionId, owner?.profile || 'default', method, params, timeoutMs)
-      }
-
-      return timeoutMs === undefined ? requestGateway(method, params) : requestGateway(method, params, timeoutMs)
-    },
-    [requestGateway, selectedStoredSessionIdRef]
-  )
-
   const submitPromptText = useSubmitPrompt({
     activeSessionIdRef,
     busyRef,
@@ -518,7 +491,11 @@ export function usePromptActions({
     getRoutedStoredSessionId,
     getRuntimeIdForStoredSession,
     getRouteToken,
-    requestGateway: requestForPromptSession,
+    // The window dispatcher already resolves the target session's exact owner
+    // and, for prompt.submit, retains that socket through the terminal turn
+    // event. A private raw requestGatewayForAgent wrapper bypassed the latter
+    // and released the only client as soon as the prompt ACK arrived.
+    requestGateway,
     runtimeIdByStoredSessionIdRef,
     resumeStoredSession,
     selectedStoredSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/routed-turn-lease.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/routed-turn-lease.test.tsx
@@ -1,0 +1,234 @@
+import type { GatewayEvent } from '@hermes/shared'
+import { act, cleanup, render } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createSessionRpcDispatcher } from '@/app/contrib/session-rpc-dispatcher'
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import {
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  setPrimaryGateway
+} from '@/store/gateway'
+import {
+  _resetSessionOwnerHintsForTests,
+  setAwaitingResponse,
+  setBusy,
+  setMessages,
+  setSessionOwnerHint
+} from '@/store/session'
+
+import { clearSingleFlightSessionResumeState } from './single-flight-resume'
+
+import { usePromptActions } from '.'
+
+const RUNTIME_ID = 'rt-youtube'
+const STORED_ID = 'stored-youtube'
+
+interface FakeGateway {
+  close: ReturnType<typeof vi.fn>
+  connectionState: string
+  emit: (event: GatewayEvent) => void
+  request: ReturnType<typeof vi.fn>
+}
+
+const sockets: FakeGateway[] = []
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  HermesGateway: class {
+    connectionState = 'closed'
+    eventHandler: null | ((event: GatewayEvent) => void) = null
+    stateHandler: null | ((state: string) => void) = null
+    connect = vi.fn(async () => {
+      this.connectionState = 'open'
+    })
+    request = vi.fn(async (method: string) => {
+      if (this.connectionState !== 'open') {
+        throw new Error('gateway is not connected')
+      }
+
+      return method === 'prompt.submit' ? { status: 'streaming' } : {}
+    })
+    close = vi.fn(() => {
+      this.connectionState = 'closed'
+    })
+    emit = (event: GatewayEvent) => this.eventHandler?.(event)
+    onEvent = vi.fn((handler: (event: GatewayEvent) => void) => {
+      this.eventHandler = handler
+
+      return () => {
+        this.eventHandler = null
+      }
+    })
+    onState = vi.fn((handler: (state: string) => void) => {
+      this.stateHandler = handler
+
+      return () => {
+        this.stateHandler = null
+      }
+    })
+
+    constructor() {
+      sockets.push(this as unknown as FakeGateway)
+    }
+  },
+  getSession: vi.fn(async () => {
+    throw new Error('the exact owner hint should avoid a REST owner probe')
+  }),
+  setApiRequestConnection: vi.fn(),
+  setApiRequestProfile: vi.fn()
+}))
+
+interface HarnessHandle {
+  submitText: (text: string) => Promise<boolean>
+}
+
+function Harness({
+  onReady,
+  requestGateway
+}: {
+  onReady: (handle: HarnessHandle) => void
+  requestGateway: ReturnType<typeof createSessionRpcDispatcher>
+}) {
+  const activeSessionIdRef = useRef<string | null>(RUNTIME_ID)
+  const busyRef = useRef(false)
+  const selectedStoredSessionIdRef = useRef<string | null>(STORED_ID)
+  const runtimeIdByStoredSessionIdRef = useRef(new Map([[STORED_ID, RUNTIME_ID]]))
+  const stateRef = useRef<ClientSessionState>(createClientSessionState(STORED_ID))
+
+  const actions = usePromptActions({
+    activeSessionId: RUNTIME_ID,
+    activeSessionIdRef,
+    branchCurrentSession: async () => true,
+    busyRef,
+    createBackendSessionForSend: async () => RUNTIME_ID,
+    getRoutedStoredSessionId: () => STORED_ID,
+    getRuntimeIdForStoredSession: storedId => (storedId === STORED_ID ? RUNTIME_ID : null),
+    getRouteToken: () => 'stable-route',
+    handleSkinCommand: () => '',
+    openMemoryGraph: () => undefined,
+    refreshSessions: async () => undefined,
+    requestGateway,
+    resumeStoredSession: async () => undefined,
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionIdRef,
+    startFreshSessionDraft: () => undefined,
+    sttEnabled: false,
+    updateSessionState: (_sessionId, updater) => {
+      stateRef.current = updater(stateRef.current)
+
+      return stateRef.current
+    }
+  })
+
+  const { submitText } = actions
+
+  useEffect(() => {
+    onReady({
+      submitText: (...args) => act(async () => submitText(...args)) as Promise<boolean>
+    })
+  }, [onReady, submitText])
+
+  return null
+}
+
+describe('usePromptActions routed turn lease', () => {
+  beforeEach(() => {
+    sockets.length = 0
+    clearSingleFlightSessionResumeState()
+    closeSecondaryGateways()
+    configureGatewayRegistry({
+      // Isolate the whole-turn lease. A foreground pin is a separate safety
+      // net and must not make this transport-lifetime regression pass.
+      foregroundScopes: () => new Set(),
+      onEvent: vi.fn()
+    })
+    setPrimaryGateway(
+      {
+        connectionState: 'open',
+        request: vi.fn(async () => ({}))
+      } as never,
+      'default'
+    )
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnectionFor: vi.fn(async ({ connectionId, profile }) => ({
+        port: 5151,
+        profile,
+        token: `${connectionId}-${profile}-token`
+      })),
+      touchBackend: vi.fn(async () => undefined)
+    }
+    setSessionOwnerHint(STORED_ID, {
+      connectionId: 'local',
+      mode: 'local',
+      profile: 'youtube'
+    })
+    setMessages([])
+    setBusy(false)
+    setAwaitingResponse(false)
+  })
+
+  afterEach(() => {
+    cleanup()
+    closeSecondaryGateways()
+    _resetSessionOwnerHintsForTests({ storage: true })
+    setMessages([])
+    setBusy(false)
+    setAwaitingResponse(false)
+    vi.useRealTimers()
+    vi.clearAllMocks()
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('keeps the exact owner socket after prompt ACK until the turn terminal event', async () => {
+    vi.useFakeTimers()
+    const ambientRequest = vi.fn(async () => ({ ambient: true }))
+    const runtimeIdByStoredSessionIdRef = { current: new Map([[STORED_ID, RUNTIME_ID]]) }
+    const selectedStoredSessionIdRef = { current: STORED_ID as null | string }
+
+    const sessionStateByRuntimeIdRef = {
+      current: new Map([[RUNTIME_ID, createClientSessionState(STORED_ID)]])
+    }
+
+    const requestGateway = createSessionRpcDispatcher({
+      ambientRequest: ambientRequest as never,
+      runtimeIdByStoredSessionIdRef,
+      selectedStoredSessionIdRef,
+      sessionStateByRuntimeIdRef
+    })
+
+    let handle: HarnessHandle | null = null
+
+    await act(async () => {
+      render(<Harness onReady={next => (handle = next)} requestGateway={requestGateway} />)
+    })
+
+    expect(await handle!.submitText('long turn')).toBe(true)
+    expect(ambientRequest).not.toHaveBeenCalled()
+    expect(sockets).toHaveLength(1)
+    expect(sockets[0].request).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: RUNTIME_ID, text: 'long turn' },
+      1_800_000,
+      undefined
+    )
+
+    // prompt.submit ACKs while the model is still running. A request-scoped
+    // lease alone drops to zero here and closes the socket, arming the backend's
+    // 20-second client-gone reaper.
+    expect(sockets[0].close).not.toHaveBeenCalled()
+    expect(sockets[0].connectionState).toBe('open')
+
+    sockets[0].emit({
+      payload: { running: false },
+      session_id: RUNTIME_ID,
+      type: 'session.info'
+    } as GatewayEvent)
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(sockets[0].close).toHaveBeenCalledOnce()
+    expect(sockets[0].connectionState).toBe('closed')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -155,6 +155,7 @@ import {
   patchSessionWorkspace,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  removeRepresentedLocalInflightUser,
   removeRepresentedLocalLiveProjection,
   resolveResumedBusy,
   resolveSessionProfile,
@@ -1575,8 +1576,8 @@ export function useSessionActions({
 
               const withConcurrentChanges = overlayConcurrentMessageChanges(
                 resumedMessages,
-                localSnapshot,
-                currentMessages
+                removeRepresentedLocalInflightUser(localSnapshot, resumed),
+                removeRepresentedLocalInflightUser(currentMessages, resumed)
               )
 
               return chatMessageArraysEquivalent(currentMessages, withConcurrentChanges)
@@ -1603,8 +1604,8 @@ export function useSessionActions({
 
         const preferredWithRuntimeChanges = overlayConcurrentMessageChanges(
           preferredMessages,
-          resumeRuntimeBaselineMessages,
-          currentRuntimeMessages
+          removeRepresentedLocalInflightUser(resumeRuntimeBaselineMessages, resumed),
+          removeRepresentedLocalInflightUser(currentRuntimeMessages, resumed)
         )
 
         // #70449: same stale-snapshot guard as the warm path — a turn that

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -28,6 +28,7 @@ import {
   overlayConcurrentMessageChanges,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  removeRepresentedLocalInflightUser,
   removeRepresentedLocalLiveProjection,
   resolveResumedBusy,
   selectBranchMessages,
@@ -1678,7 +1679,71 @@ describe('removeRepresentedLocalLiveProjection', () => {
   })
 })
 
+describe('removeRepresentedLocalInflightUser', () => {
+  it('drops the represented optimistic user but keeps newer stream deltas and a racing prompt', () => {
+    const previous = [
+      msg('assistant-complete', 'assistant', 'finished answer'),
+      msg('user-current', 'user', 'current prompt'),
+      msg('assistant-stream-current', 'assistant', 'partial answer + newer delta', { pending: true }),
+      msg('user-racing', 'user', 'next prompt')
+    ]
+
+    const remaining = removeRepresentedLocalInflightUser(previous, runningProjection('current prompt'))
+
+    expect(remaining.map(message => message.id)).toEqual([
+      'assistant-complete',
+      'assistant-stream-current',
+      'user-racing'
+    ])
+  })
+
+  it('preserves an identical racing prompt that does not own a live assistant boundary', () => {
+    const previous = [
+      msg('assistant-complete', 'assistant', 'finished answer'),
+      msg('user-racing', 'user', 'current prompt')
+    ]
+
+    expect(removeRepresentedLocalInflightUser(previous, runningProjection('current prompt'))).toBe(previous)
+  })
+})
+
 describe('overlayConcurrentMessageChanges', () => {
+  it('does not re-append an optimistic user already represented by the resumed in-flight turn', () => {
+    const baseline = [
+      msg('stored-user', 'user', 'earlier prompt'),
+      msg('stored-assistant', 'assistant', 'earlier answer'),
+      msg('persisted-current', 'user', 'current prompt')
+    ]
+
+    const authoritative = [
+      ...baseline,
+      msg('assistant-stream-resumed', 'assistant', 'partial answer', { pending: true })
+    ]
+
+    const current = [
+      ...baseline.slice(0, 2),
+      msg('user-optimistic', 'user', 'current prompt'),
+      msg('assistant-stream-original', 'assistant', 'partial answer + delta', { pending: true })
+    ]
+
+    const projection = runningProjection('current prompt')
+
+    const overlaid = overlayConcurrentMessageChanges(
+      authoritative,
+      removeRepresentedLocalInflightUser(baseline, projection),
+      removeRepresentedLocalInflightUser(current, projection)
+    )
+
+    expect(overlaid.filter(message => message.role === 'user').map(message => message.id)).toEqual([
+      'stored-user',
+      'persisted-current'
+    ])
+    expect(overlaid.at(-1)).toMatchObject({
+      id: 'assistant-stream-original',
+      parts: [{ type: 'text', text: 'partial answer + delta' }]
+    })
+  })
+
   it('does not replace an authoritative row with an unchanged baseline cache row', () => {
     const baseline = [msg('shared-assistant', 'assistant', 'stale cached answer')]
     const authoritative = [msg('shared-assistant', 'assistant', 'completed persisted answer')]

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1094,6 +1094,59 @@ export function removeRepresentedLocalLiveProjection(
 }
 
 /**
+ * Remove only the optimistic user half of a live turn represented by a resume
+ * snapshot. The assistant half deliberately stays: it may have received deltas
+ * after the snapshot and overlayConcurrentMessageChanges must still graft
+ * those onto the resumed stream row.
+ *
+ * This is narrower than text dedupe. The matching user must be in the open
+ * tail and immediately own a synthetic live assistant boundary, so an
+ * intentionally repeated prompt typed after that boundary survives.
+ */
+export function removeRepresentedLocalInflightUser(
+  previousMessages: ChatMessage[],
+  projection: Pick<SessionResumeResponse, 'inflight'>
+): ChatMessage[] {
+  const inflightUser = projection.inflight?.user?.replace(/\s+/g, ' ').trim() ?? ''
+
+  if (!inflightUser) {
+    return previousMessages
+  }
+
+  let openTailStart = 0
+
+  for (let index = previousMessages.length - 1; index >= 0; index -= 1) {
+    const message = previousMessages[index]
+
+    if (message.role === 'assistant' && !message.pending) {
+      openTailStart = index + 1
+
+      break
+    }
+  }
+
+  const inflightUserIndex = previousMessages.findIndex(
+    (message, index) =>
+      index >= openTailStart &&
+      message.role === 'user' &&
+      message.id.startsWith('user-') &&
+      normalizedMessageText(message) === inflightUser
+  )
+
+  const assistant = previousMessages[inflightUserIndex + 1]
+
+  if (
+    inflightUserIndex < openTailStart ||
+    assistant?.role !== 'assistant' ||
+    !assistant.id.startsWith('assistant-stream-')
+  ) {
+    return previousMessages
+  }
+
+  return previousMessages.filter((_message, index) => index !== inflightUserIndex)
+}
+
+/**
  * Overlay messages that changed while activation waited on REST. Existing ids
  * replace the older activation row; only rows added or changed since the warm
  * cache baseline are appended. This is identity-based, never text-based.

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -58,6 +58,7 @@ const {
   requestGatewayForAgent,
   requestGatewayForProfile,
   retainGatewayForAgent,
+  retainGatewayForSessionTurn,
   setPrimaryGateway,
   setPrimaryGatewayConnection
 } = await import('./gateway')
@@ -486,6 +487,43 @@ describe('retainGatewayForAgent (#93602)', () => {
       touchBackend: vi.fn(async () => undefined)
     }
   }
+
+  it('reuses the primary socket when the exact registry owner is the primary route', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'remote-primary' })
+    installRegistryDesktop()
+
+    const release = await retainGatewayForAgent('remote-primary', 'default')
+
+    expect(secondaryGateways).toHaveLength(0)
+    expect(window.hermesDesktop!.getConnectionFor).not.toHaveBeenCalled()
+
+    release()
+    expect(primary.request).not.toHaveBeenCalled()
+  })
+
+  it('does not leave a phantom turn lease when an exact primary route is later re-homed', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'remote-primary' })
+    installRegistryDesktop()
+
+    // A primary has no refcount-disposal risk and its events bypass the
+    // Secondary terminal listener. This must therefore leave no turn key.
+    await retainGatewayForSessionTurn('remote-primary', 'default', 'runtime-1')
+
+    // The same route later becomes a real secondary. A stale primary key would
+    // make this call return a no-op and skip opening/holding the owner socket.
+    setPrimaryGatewayConnection({ connectionId: 'new-primary' })
+    const release = await retainGatewayForSessionTurn('remote-primary', 'default', 'runtime-1')
+
+    expect(secondaryGateways).toHaveLength(1)
+    expect(secondaryGateways[0].close).not.toHaveBeenCalled()
+
+    release()
+    expect(secondaryGateways[0].close).toHaveBeenCalledOnce()
+  })
 
   it('holds the registry socket across multiple leased requests — no mid-turn disposal', async () => {
     const primary = makePrimary()

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1054,6 +1054,14 @@ export async function retainGatewayForAgent(connectionId: null | string, profile
     return route.release
   }
 
+  // Mirror requestGatewayForAgent's primary-route collapse. The turn lease
+  // and the request must retain the SAME socket: otherwise an exact owner that
+  // names the registry-backed primary opens a duplicate secondary solely for
+  // the hold while prompt.submit itself correctly rides the primary.
+  if (isPrimaryRegistryRoute(connectionId, key)) {
+    return () => undefined
+  }
+
   if (!window.hermesDesktop?.getConnectionFor) {
     // No registry dialing in this build — nothing to hold; the request path
     // will throw its own actionable error.
@@ -1158,6 +1166,15 @@ export async function retainGatewayForSessionTurn(
   profile: string,
   sessionId: string
 ): Promise<() => void> {
+  // The primary socket is process-owned, not refcount-disposed, so it needs no
+  // routed turn hold. More importantly, primary events do not flow through a
+  // Secondary's terminal-event listener: registering a no-op lease here would
+  // leave a phantom key that can suppress the real hold if this route is later
+  // re-homed as a secondary.
+  if (isPrimaryRegistryRoute(connectionId, profile)) {
+    return () => undefined
+  }
+
   const scope = registryBackendScopeKey(connectionId, normKey(profile))
   const key = turnLeaseKey(scope, sessionId)
 

--- a/apps/desktop/src/store/session-states-foreground-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-foreground-scopes.test.ts
@@ -1,18 +1,22 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { createClientSessionState } from '@/lib/chat-runtime'
 import {
   $selectedStoredSessionId,
   _resetSessionOwnerHintsForTests,
   setActiveSessionId,
-  setSessionOwnerHint
+  setSessionOwnerHint,
+  setSessions
 } from '@/store/session'
 
 import {
   $sessionOwnerHoldRevision,
   $sessionTiles,
   _resetSessionOwnerHoldsForTests,
+  clearAllSessionStates,
   foregroundSessionScopes,
   holdSessionOwnerUntilForeground,
+  publishSessionState,
   recordSessionEventScope,
   releaseSessionOwnerHold
 } from './session-states'
@@ -26,10 +30,12 @@ import {
 
 afterEach(() => {
   $sessionTiles.set([])
+  clearAllSessionStates()
   setActiveSessionId(null)
   $selectedStoredSessionId.set(null)
   _resetSessionOwnerHoldsForTests()
   _resetSessionOwnerHintsForTests({ storage: true })
+  setSessions([])
   vi.useRealTimers()
 })
 
@@ -40,6 +46,66 @@ describe('foregroundSessionScopes: owner hold across the create → foreground g
     holdSessionOwnerUntilForeground('stored-fresh', omar)
 
     expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::omar']))
+  })
+
+  it('pins an existing selected main chat by its exact owner before the first routed event', () => {
+    const route = {
+      connectionId: 'local',
+      mode: 'local' as const,
+      profile: 'youtube'
+    }
+
+    setSessionOwnerHint('stored-youtube', route)
+    $selectedStoredSessionId.set('stored-youtube')
+    publishSessionState('rt-youtube', createClientSessionState('stored-youtube'))
+    setActiveSessionId('rt-youtube')
+
+    // Deliberately no recordSessionEventScope(): this is the prompt-ACK /
+    // reconnect window before the first owner-tagged stream frame. The exact
+    // registry socket still owns the selected main chat and every dispose path
+    // must see that composite scope rather than an unrelated bare profile.
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::youtube']))
+  })
+
+  it('accepts a complete exact hint alongside a compatible untagged row', () => {
+    setSessions([{ id: 'stored-youtube', profile: 'youtube' } as never])
+    setSessionOwnerHint('stored-youtube', { connectionId: 'local', profile: 'youtube' })
+    $selectedStoredSessionId.set('stored-youtube')
+    publishSessionState('rt-youtube', createClientSessionState('stored-youtube'))
+    setActiveSessionId('rt-youtube')
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::youtube']))
+  })
+
+  it('does not guess between same-id twins before the runtime source is known', () => {
+    setSessions([
+      { connection_id: 'local', id: 'stored-twin', profile: 'youtube' } as never,
+      { connection_id: 'cloud-a', id: 'stored-twin', profile: 'youtube' } as never
+    ])
+    setSessionOwnerHint('stored-twin', { connectionId: 'local', profile: 'youtube' })
+    setSessionOwnerHint('stored-twin', { connectionId: 'cloud-a', profile: 'youtube' })
+    $selectedStoredSessionId.set('stored-twin')
+    publishSessionState('rt-twin', createClientSessionState('stored-twin'))
+    setActiveSessionId('rt-twin')
+
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('fails closed when a persisted hint conflicts with a current connection-tagged row', () => {
+    setSessions([{ connection_id: 'local', id: 'stored-conflict', profile: 'youtube' } as never])
+    setSessionOwnerHint('stored-conflict', { connectionId: 'cloud-a', profile: 'youtube' })
+    $selectedStoredSessionId.set('stored-conflict')
+    publishSessionState('rt-conflict', createClientSessionState('stored-conflict'))
+    setActiveSessionId('rt-conflict')
+
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('does not indefinitely pin a stale selection with no matching active runtime', () => {
+    setSessionOwnerHint('stored-stale', { connectionId: 'local', profile: 'youtube' })
+    $selectedStoredSessionId.set('stored-stale')
+
+    expect(foregroundSessionScopes()).toEqual(new Set())
   })
 
   it('retires once the foreground publication covers it (selected primary thread / mounted tile)', () => {
@@ -54,6 +120,7 @@ describe('foregroundSessionScopes: owner hold across the create → foreground g
     // The first event from the owner socket records the runtime's scope; the
     // selected-thread rung now covers it and the hold retires for good.
     recordSessionEventScope({ connectionId: 'local', profile: 'omar', session_id: 'rt-fresh' })
+    publishSessionState('rt-fresh', createClientSessionState('stored-fresh'))
     setActiveSessionId('rt-fresh')
     expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::omar']))
     setActiveSessionId(null)
@@ -67,6 +134,24 @@ describe('foregroundSessionScopes: owner hold across the create → foreground g
     expect(foregroundSessionScopes()).toEqual(new Set(['conn:homelab::bot']))
     $sessionTiles.set([])
     expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('does not retire one session hold just because another foreground session shares its socket', () => {
+    setSessionOwnerHint('stored-y', omar)
+    $selectedStoredSessionId.set('stored-y')
+    publishSessionState('rt-y', createClientSessionState('stored-y'))
+    recordSessionEventScope({ connectionId: 'local', profile: 'omar', session_id: 'rt-y' })
+    setActiveSessionId('rt-y')
+    holdSessionOwnerUntilForeground('stored-x', omar)
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::omar']))
+
+    // Y leaves before X has published. X's own hold must keep the shared
+    // socket alive rather than having been retired by Y's unrelated scope.
+    setActiveSessionId(null)
+    $selectedStoredSessionId.set(null)
+    clearAllSessionStates()
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::omar']))
   })
 
   it('is released explicitly by the caller (failed create / drift close) and expires on its own', () => {

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -10,8 +10,18 @@ import {
   setWorkspaceScope,
   workspaceScopeKey
 } from '@/components/pane-shell/workspace-scope'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $activeSessionId, $connection, $selectedStoredSessionId, setSessions } from '@/store/session'
+import {
+  $activeSessionId,
+  $connection,
+  $selectedStoredSessionId,
+  $sessionResumeRequest,
+  _resetSessionOwnerHintsForTests,
+  getSessionOwnerHint,
+  setSessionOwnerHint,
+  setSessions
+} from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import type { SessionTile } from '@/store/session-states'
 import type * as SessionStatesModule from '@/store/session-states'
@@ -19,6 +29,7 @@ import {
   $focusedStoredSessionId,
   $sessionStates,
   $sessionTiles,
+  _resetSessionOwnerHoldsForTests,
   blankDraftTile,
   clearAllSessionStates,
   closeAllOpenSessionTiles,
@@ -33,6 +44,7 @@ import {
   openSessionTile,
   orderTilesByTree,
   patchSessionTile,
+  publishSessionState,
   recordSessionEventScope,
   releaseSessionTranscript,
   requestForOwnedSession,
@@ -105,6 +117,12 @@ describe('foregroundSessionScopes', () => {
 
 describe('resetTileRuntimeBindings', () => {
   afterEach(() => {
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $sessionResumeRequest.set(null)
+    _resetSessionOwnerHintsForTests({ storage: true })
+    _resetSessionOwnerHoldsForTests()
+    clearAllSessionStates()
     $sessionTiles.set([])
   })
 
@@ -198,6 +216,118 @@ describe('resetTileRuntimeBindings', () => {
     expect(ordinarySession).toMatchObject({ storedSessionId: 'stored-session' })
     expect(ordinarySession).not.toHaveProperty('runtimeId')
     expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set(['stored-barry-sibling-bot', 'stored-work-bot']))
+  })
+
+  it('matches a reconnect against the Desktop profile rather than its backend target alias', () => {
+    const invalidateRuntimeBindings = vi.fn()
+    setSessionTileDelegate({ invalidateRuntimeBindings } as unknown as SessionTileDelegate)
+    $sessionTiles.set([
+      {
+        ownerRoute: {
+          connectionId: 'cloud-a',
+          mode: 'remote',
+          profile: 'moxie',
+          targetProfile: 'default'
+        },
+        runtimeId: 'runtime-moxie-dead',
+        storedSessionId: 'stored-moxie',
+        workspaceMode: 'bots'
+      }
+    ])
+
+    resetTileRuntimeBindings({ connectionId: 'cloud-a', profile: 'moxie' })
+
+    expect($sessionTiles.get()[0]?.runtimeId).toBeUndefined()
+    expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set())
+  })
+
+  it('re-arms the active main chat before its first owner-tagged event when the exact socket reconnects', () => {
+    const invalidateRuntimeBindings = vi.fn()
+    setSessionTileDelegate({ invalidateRuntimeBindings } as unknown as SessionTileDelegate)
+    setSessionOwnerHint('stored-youtube', {
+      connectionId: 'local',
+      mode: 'local',
+      profile: 'youtube',
+      targetProfile: 'youtube'
+    })
+    $activeSessionId.set('runtime-youtube-old')
+    $selectedStoredSessionId.set('stored-youtube')
+    publishSessionState('runtime-youtube-old', createClientSessionState('stored-youtube'))
+
+    resetTileRuntimeBindings({ connectionId: 'local', profile: 'youtube' })
+
+    expect(invalidateRuntimeBindings).toHaveBeenCalledOnce()
+    expect($sessionResumeRequest.get()).toEqual({
+      ownerRoute: {
+        connectionId: 'local',
+        mode: 'local',
+        profile: 'youtube',
+        targetProfile: 'youtube'
+      },
+      sequence: expect.any(Number),
+      sessionId: 'stored-youtube'
+    })
+  })
+
+  it('does not rebind the active main chat for an unrelated owner reconnect', () => {
+    const invalidateRuntimeBindings = vi.fn()
+    setSessionTileDelegate({ invalidateRuntimeBindings } as unknown as SessionTileDelegate)
+    setSessionOwnerHint('stored-youtube', {
+      connectionId: 'local',
+      mode: 'local',
+      profile: 'youtube'
+    })
+    $activeSessionId.set('runtime-youtube-old')
+    $selectedStoredSessionId.set('stored-youtube')
+    publishSessionState('runtime-youtube-old', createClientSessionState('stored-youtube'))
+    recordSessionEventScope({
+      connectionId: 'local',
+      profile: 'youtube',
+      session_id: 'runtime-youtube-old'
+    })
+
+    resetTileRuntimeBindings({ connectionId: 'cloud-a', profile: 'youtube' })
+
+    expect($sessionResumeRequest.get()).toBeNull()
+    expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set(['stored-youtube']))
+  })
+
+  it('does not route a newly selected chat through the previous active runtime owner during a switch', () => {
+    setSessionTileDelegate({ invalidateRuntimeBindings: vi.fn() } as unknown as SessionTileDelegate)
+    setSessionOwnerHint('stored-b', {
+      connectionId: 'cloud-b',
+      mode: 'remote',
+      profile: 'youtube'
+    })
+    $activeSessionId.set('runtime-a')
+    $selectedStoredSessionId.set('stored-b')
+    publishSessionState('runtime-a', createClientSessionState('stored-a'))
+    recordSessionEventScope({ connectionId: 'local', profile: 'youtube', session_id: 'runtime-a' })
+
+    resetTileRuntimeBindings({ connectionId: 'local', profile: 'youtube' })
+
+    expect($sessionResumeRequest.get()).toBeNull()
+    expect(getSessionOwnerHint('stored-b')).toMatchObject({ connectionId: 'cloud-b', profile: 'youtube' })
+  })
+
+  it('preserves an active main binding owned by a still-live secondary across primary reconnect variants', () => {
+    const invalidateRuntimeBindings = vi.fn()
+    setSessionTileDelegate({ invalidateRuntimeBindings } as unknown as SessionTileDelegate)
+    setSessionOwnerHint('stored-work', {
+      connectionId: 'work-vps',
+      mode: 'remote',
+      profile: 'ceo'
+    })
+    $activeSessionId.set('runtime-work')
+    $selectedStoredSessionId.set('stored-work')
+    publishSessionState('runtime-work', createClientSessionState('stored-work'))
+    recordSessionEventScope({ connectionId: 'work-vps', profile: 'ceo', session_id: 'runtime-work' })
+
+    resetTileRuntimeBindings('legacy-primary')
+    expect(invalidateRuntimeBindings).toHaveBeenLastCalledWith(new Set(['stored-work']))
+
+    resetTileRuntimeBindings({ liveConnectionIds: new Set(['work-vps']) })
+    expect(invalidateRuntimeBindings).toHaveBeenLastCalledWith(new Set(['stored-work']))
   })
 
   it('unknown restarted identity preserves only Bot runtimes owned by provably-live connections', () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -16,7 +16,7 @@
  * itself here as the delegate so tile UI stays dependency-light.
  */
 
-import { LOCAL_CONNECTION_ID, registryBackendScopeKey } from '@hermes/shared'
+import { backendScopePrefix, LOCAL_CONNECTION_ID, registryBackendScopeKey } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import type { ClientSessionState } from '@/app/types'
@@ -45,10 +45,13 @@ import {
   $sessions,
   clearReadBaseline,
   getSessionOwnerHint,
+  getSessionOwnerHints,
+  idsShareLineage,
   knownSessionOwner,
   lineageAliases,
   markSessionRead,
   ownerLookupSessionRows,
+  requestSessionResume,
   sessionMatchesStoredId,
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
@@ -84,9 +87,18 @@ export const $sessionStates = atom<Record<string, ClientSessionState>>({})
 const sessionScopeByRuntimeId = new Map<string, string>()
 
 export function recordSessionEventScope(event: { connectionId?: string; profile?: string; session_id?: string }): void {
-  if (event.session_id && event.connectionId) {
-    sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(event.connectionId, event.profile))
+  const connectionId = event.connectionId?.trim()
+
+  if (event.session_id && connectionId) {
+    sessionScopeByRuntimeId.set(event.session_id, registryBackendScopeKey(connectionId, event.profile))
   }
+}
+
+/** Composite source scope recorded for a live runtime. This reuses the
+ *  pre-existing keep-set ledger; callers can match it to a complete durable
+ *  hint without introducing a second structured owner registry. */
+export function runtimeSessionScope(runtimeId: string): string | undefined {
+  return sessionScopeByRuntimeId.get(runtimeId)
 }
 
 /** Composite scopes of registry-sourced sessions that are live (busy or
@@ -204,6 +216,70 @@ export function _resetSessionOwnerHoldsForTests(): void {
  * a bounded TTL retires it, so nothing can close the socket that minted the
  * runtime before the first prompt lands.
  */
+function uniqueForegroundSessionOwner(
+  rows: readonly SessionInfo[],
+  storedSessionId: null | string
+): SessionOwnerScope {
+  if (!storedSessionId) {
+    return undefined
+  }
+
+  const aliases = lineageAliases(storedSessionId, rows)
+  const exactOwners = new Map<string, SessionOwnerRoute>()
+
+  for (const alias of aliases) {
+    for (const route of getSessionOwnerHints(alias)) {
+      exactOwners.set(registryBackendScopeKey(route.connectionId, route.profile), route)
+    }
+  }
+
+  const bareProfiles = new Set<string>()
+
+  for (const row of rows.filter(candidate => aliases.some(alias => sessionMatchesStoredId(candidate, alias)))) {
+    const connectionId = row.connection_id?.trim()
+    const profile = normalizeProfileKey(row.profile)
+
+    if (connectionId) {
+      const scope = registryBackendScopeKey(connectionId, profile)
+
+      exactOwners.set(scope, exactOwners.get(scope) ?? { connectionId, profile })
+    } else {
+      bareProfiles.add(profile)
+    }
+  }
+
+  if (exactOwners.size === 1) {
+    const owner = [...exactOwners.values()][0]
+
+    const compatibleProfiles = new Set([
+      normalizeProfileKey(owner.profile),
+      normalizeProfileKey(owner.targetProfile || owner.profile)
+    ])
+
+    return [...bareProfiles].every(profile => compatibleProfiles.has(profile)) ? owner : undefined
+  }
+
+  return exactOwners.size === 0 && bareProfiles.size === 1 ? [...bareProfiles][0] : undefined
+}
+
+function sessionOwnerHintForScope(
+  rows: readonly SessionInfo[],
+  storedSessionId: string,
+  scope: Pick<SessionOwnerRoute, 'connectionId' | 'profile'>
+): SessionOwnerRoute | undefined {
+  const aliases = [storedSessionId, ...lineageAliases(storedSessionId, rows).filter(id => id !== storedSessionId)]
+
+  for (const alias of aliases) {
+    const hint = getSessionOwnerHint(alias, scope)
+
+    if (hint) {
+      return hint
+    }
+  }
+
+  return undefined
+}
+
 export function foregroundSessionScopes(): Set<string> {
   const scopes = new Set<string>()
 
@@ -226,7 +302,36 @@ export function foregroundSessionScopes(): Set<string> {
 
   addRuntimeScope($activeSessionId.get() ?? undefined)
 
-  for (const tile of $sessionTiles.get()) {
+  // Before the first owner-tagged stream frame (and after a scoped reconnect),
+  // the selected main chat can have a durable exact owner but no runtime scope
+  // entry yet. Pin that owner just like a tile's persisted route: otherwise the
+  // exact socket is invisible to refcount/prune disposal while the main pane is
+  // visibly bound to it. A unique hint or connection-tagged row is exact;
+  // ambiguous same-id twins deliberately add nothing.
+  const activeRuntimeId = $activeSessionId.get()
+  const selectedStoredSessionId = $selectedStoredSessionId.get()
+  const ownerRows = ownerLookupSessionRows()
+  const activeStoredSessionId = activeRuntimeId ? storedSessionIdForRuntimeId(activeRuntimeId) : null
+
+  const selectedIsActive = Boolean(
+    activeStoredSessionId &&
+      selectedStoredSessionId &&
+      idsShareLineage(activeStoredSessionId, selectedStoredSessionId, ownerRows)
+  )
+
+  if (selectedIsActive) {
+    const selectedOwner = uniqueForegroundSessionOwner(ownerRows, selectedStoredSessionId)
+
+    if (typeof selectedOwner === 'string') {
+      scopes.add(normalizeProfileKey(selectedOwner))
+    } else {
+      addRouteScope(selectedOwner ?? undefined)
+    }
+  }
+
+  const foregroundTiles = $sessionTiles.get()
+
+  for (const tile of foregroundTiles) {
     addRuntimeScope(tile.runtimeId)
     addRouteScope(tile.ownerRoute)
   }
@@ -244,7 +349,17 @@ export function foregroundSessionScopes(): Set<string> {
           ? registryBackendScopeKey(hold.owner.connectionId.trim(), normalizeProfileKey(hold.owner.profile))
           : null
 
-    if (!scope || hold.until <= now || scopes.has(scope)) {
+    const selectedPublished = Boolean(
+      selectedIsActive &&
+        selectedStoredSessionId &&
+        idsShareLineage(storedSessionId, selectedStoredSessionId, ownerRows)
+    )
+
+    const tilePublished = foregroundTiles.some(tile =>
+      idsShareLineage(storedSessionId, tile.storedSessionId, ownerRows)
+    )
+
+    if (!scope || hold.until <= now || selectedPublished || tilePublished) {
       // This recompute was already triggered by the covering publication (or
       // is itself observing expiry), so avoid recursively publishing.
       forgetSessionOwnerHold(storedSessionId, false)
@@ -1200,7 +1315,10 @@ export function resetTileRuntimeBindings(
       return false
     }
 
-    return !reconnected.profile || (route.targetProfile || route.profile) === reconnected.profile
+    // openSecondary reports the Desktop route profile. targetProfile is the
+    // backend alias used inside RPC params and must not be compared with the
+    // registry key that owns this socket.
+    return !reconnected.profile || normalizeProfileKey(route.profile) === normalizeProfileKey(reconnected.profile)
   }
 
   const preservedStoredIds = new Set(
@@ -1214,10 +1332,104 @@ export function resetTileRuntimeBindings(
       .map(tile => tile.storedSessionId)
   )
 
+  const activeRuntimeId = $activeSessionId.get()
+  const selectedStoredSessionId = $selectedStoredSessionId.get()
+  const ownerRows = ownerLookupSessionRows()
+  const activeStoredSessionId = activeRuntimeId ? storedSessionIdForRuntimeId(activeRuntimeId) : null
+
+  const activeMainMatchesSelection = Boolean(
+    activeStoredSessionId &&
+      selectedStoredSessionId &&
+      idsShareLineage(activeStoredSessionId, selectedStoredSessionId, ownerRows)
+  )
+
+  const uniqueSelectedOwner = activeMainMatchesSelection
+    ? uniqueForegroundSessionOwner(ownerRows, selectedStoredSessionId)
+    : undefined
+
+  const uniqueSelectedOwnerRoute =
+    uniqueSelectedOwner && typeof uniqueSelectedOwner === 'object' ? uniqueSelectedOwner : undefined
+
+  const runtimeScope = activeRuntimeId ? runtimeSessionScope(activeRuntimeId) : undefined
+
+  const reconnectedOwnerScope =
+    reconnected?.connectionId && reconnected.profile
+      ? { connectionId: reconnected.connectionId, profile: reconnected.profile }
+      : undefined
+
+  const reconnectedScopeKey = reconnectedOwnerScope
+    ? registryBackendScopeKey(reconnectedOwnerScope.connectionId, reconnectedOwnerScope.profile)
+    : undefined
+
+  const selectedOwnerScope =
+    runtimeScope ??
+    (uniqueSelectedOwnerRoute
+      ? registryBackendScopeKey(uniqueSelectedOwnerRoute.connectionId, uniqueSelectedOwnerRoute.profile)
+      : undefined)
+
+  const reconnectsActiveMain = Boolean(
+    activeMainMatchesSelection &&
+      selectedOwnerScope &&
+      reconnectedScopeKey &&
+      selectedOwnerScope === reconnectedScopeKey
+  )
+
+  const activeMainOwnerUnaffected = Boolean(
+    activeMainMatchesSelection &&
+      selectedOwnerScope &&
+      (liveConnectionIds
+        ? [...liveConnectionIds].some(connectionId => selectedOwnerScope.startsWith(backendScopePrefix(connectionId)))
+        : reconnected?.connectionId
+          ? reconnected.profile
+            ? selectedOwnerScope !== reconnectedScopeKey
+            : !selectedOwnerScope.startsWith(backendScopePrefix(reconnected.connectionId))
+          : false)
+  )
+
+  // A reconnect must not invalidate an active main chat that is proven to live
+  // on another exact/still-live owner. Keep every lineage alias because the
+  // route and cache can straddle a compression id rotation.
+  if (
+    selectedStoredSessionId &&
+    activeMainOwnerUnaffected
+  ) {
+    for (const alias of lineageAliases(selectedStoredSessionId, ownerRows)) {
+      preservedStoredIds.add(alias)
+    }
+  }
+
   sessionTileDelegate()?.invalidateRuntimeBindings?.(preservedStoredIds)
 
   if (tiles.some(tile => tile.runtimeId && !preservedStoredIds.has(tile.storedSessionId))) {
     $sessionTiles.set(tiles.map(tile => (preservedStoredIds.has(tile.storedSessionId) ? tile : toStored(tile))))
+  }
+
+  if (reconnectsActiveMain && selectedStoredSessionId && reconnectedOwnerScope) {
+    // A scoped secondary can reconnect while the ambient/global gateway stays
+    // open, so useRouteResume never observes a closed→open edge. Re-arm the
+    // selected durable row explicitly; resumeSession supplies the existing
+    // single-flight and navigation-drift guards and cancels the backend orphan
+    // timer before its grace expires.
+    const scopedHint = sessionOwnerHintForScope(ownerRows, selectedStoredSessionId, reconnectedOwnerScope)
+
+    const scopedUniqueOwner =
+      uniqueSelectedOwnerRoute &&
+      registryBackendScopeKey(uniqueSelectedOwnerRoute.connectionId, uniqueSelectedOwnerRoute.profile) ===
+        reconnectedScopeKey
+        ? uniqueSelectedOwnerRoute
+        : undefined
+
+    // A runtime scope can disambiguate twins, but it cannot recover
+    // targetProfile/mode. When that stronger runtime evidence exists, accept
+    // only the complete hint for the same scope; never replace it with a stale
+    // unique route from another connection.
+    const ownerRoute = scopedHint ?? (runtimeScope ? undefined : scopedUniqueOwner)
+
+    if (!ownerRoute) {
+      return
+    }
+
+    requestSessionResume(selectedStoredSessionId, ownerRoute)
   }
 }
 


### PR DESCRIPTION
Fixes #97764.

Desktop could keep a stale runtime session ID after a non-default profile WebSocket dropped mid-turn, leaving the chat frozen.

This keeps the routed socket alive for the turn, resumes the durable session after reconnect/orphan reaping, and reconciles the transcript without duplicate prompt rows.

Tested with the full Desktop suite and a dev-mode Electron E2E that drops the profile socket mid-stream.