### PR TITLE
refactor(skills): move merge-reconciler to optional catalog as agent-merge-conflict-arbiter

### DIFF
--- a/optional-skills/autonomous-ai-agents/agent-merge-conflict-arbiter/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/agent-merge-conflict-arbiter/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: merge-reconciler
-description: "Neutral third-party resolution of agent merge conflicts."
+name: agent-merge-conflict-arbiter
+description: "Neutral arbiter for merge conflicts between two agents."
 version: 1.0.0
 author: Hermes Agent
 license: MIT
@@ -11,7 +11,7 @@ metadata:
     related_skills: [hermes-agent]
 ---
 
-# Merge Reconciler
+# Agent Merge-Conflict Arbiter
 
 Resolve a git merge conflict between two AGENTS' branches as an impartial third
 party. Agents resolving conflicts against a peer's work reliably either

--- a/tests/skills/test_agent_merge_conflict_arbiter_skill.py
+++ b/tests/skills/test_agent_merge_conflict_arbiter_skill.py
@@ -1,4 +1,4 @@
-"""Contract checks for the bundled merge-reconciler skill asset.
+"""Contract checks for the optional agent-merge-conflict-arbiter skill asset.
 
 Reads only the SKILL.md markdown asset — no .py source reads, no network.
 """
@@ -8,9 +8,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_PATH = (
     REPO_ROOT
-    / "skills"
+    / "optional-skills"
     / "autonomous-ai-agents"
-    / "merge-reconciler"
+    / "agent-merge-conflict-arbiter"
     / "SKILL.md"
 )
 
@@ -48,7 +48,7 @@ def test_frontmatter_required_fields():
     fm, _ = _frontmatter_and_body()
     for field in ("name", "description", "version", "author", "license", "platforms"):
         assert field in fm, f"missing frontmatter field: {field}"
-    assert fm["name"] == "merge-reconciler"
+    assert fm["name"] == "agent-merge-conflict-arbiter"
 
 
 def test_description_hardline():

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -960,7 +960,7 @@ abandons its own. Instead, create a reconciliation card assigned to a **third,
 neutral profile** with **both** conflicted cards linked as parents: the parent
 links carry both sides' completion summaries into the reconciler's context, so
 it receives both diffs *and* both intents. The bundled
-[`merge-reconciler` skill](https://github.com/NousResearch/hermes-agent/blob/main/skills/autonomous-ai-agents/merge-reconciler/SKILL.md)
+[`agent-merge-conflict-arbiter` optional skill](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/autonomous-ai-agents/agent-merge-conflict-arbiter/SKILL.md)
 gives that worker the full procedure: classify each conflicted hunk, resolve
 impartially, verify, and hand back a summary naming every decision.
 
@@ -984,7 +984,7 @@ path** should create a dedicated refactor/decomposition card for that file
 **before** queuing more work that touches it — splitting the magnet file is
 cheaper than reconciling every future collision it would cause. For conflicts
 that have *already* happened, use the reconciliation-card pattern above with
-the `merge-reconciler` skill; hotspot flagging is the upstream fix that keeps
+the `agent-merge-conflict-arbiter` optional skill; hotspot flagging is the upstream fix that keeps
 the reconciler from becoming a standing lane.
 
 ## Multi-tenant usage

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -703,7 +703,7 @@ EOF
 
 ### 调解冲突的 worker 分支
 
-在工程流水线（使用 worktree 的 P1/P2）中，两个 worker 的分支合并时可能发生冲突。不要让任一 worker 自行裁决 —— 发生冲突的 agent 缺乏对方的上下文，往往会覆盖对方的改动或放弃自己的改动。正确做法是：创建一张调解卡片，指派给**第三个中立配置文件**，并把**两张**冲突卡片都链接为其父任务：父任务链接会把双方的完成摘要带入调解者的上下文，使其同时获得双方的 diff *和*双方的意图。内置的 [`merge-reconciler` 技能](https://github.com/NousResearch/hermes-agent/blob/main/skills/autonomous-ai-agents/merge-reconciler/SKILL.md) 为该 worker 提供完整流程：对每个冲突块分类、公正地解决、验证，并在交回摘要中说明每一项决定。
+在工程流水线（使用 worktree 的 P1/P2）中，两个 worker 的分支合并时可能发生冲突。不要让任一 worker 自行裁决 —— 发生冲突的 agent 缺乏对方的上下文，往往会覆盖对方的改动或放弃自己的改动。正确做法是：创建一张调解卡片，指派给**第三个中立配置文件**，并把**两张**冲突卡片都链接为其父任务：父任务链接会把双方的完成摘要带入调解者的上下文，使其同时获得双方的 diff *和*双方的意图。内置的 [`agent-merge-conflict-arbiter` 技能](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/autonomous-ai-agents/agent-merge-conflict-arbiter/SKILL.md) 为该 worker 提供完整流程：对每个冲突块分类、公正地解决、验证，并在交回摘要中说明每一项决定。
 
 ### 并行战役中的碰撞热点（Collision hotspots）
 
@@ -713,7 +713,7 @@ EOF
 hotspot: hermes_cli/kanban_db.py — 本轮对 dispatch 循环的第三次冲突性编辑
 ```
 
-并在完成时的 `metadata` 中重复该标记。编排者（或查看看板的人类）如果看到**两条或更多 `hotspot:` 评论指向同一路径**，应在继续排入任何触碰该文件的工作**之前**，为该文件创建一张专门的重构/分解卡片 —— 拆分磁石文件比调解它未来引发的每一次冲突更便宜。对于*已经*发生的冲突，请使用上文的调解卡片模式配合 `merge-reconciler` 技能；hotspot 标记是上游修复，能避免调解者变成一条常设车道。
+并在完成时的 `metadata` 中重复该标记。编排者（或查看看板的人类）如果看到**两条或更多 `hotspot:` 评论指向同一路径**，应在继续排入任何触碰该文件的工作**之前**，为该文件创建一张专门的重构/分解卡片 —— 拆分磁石文件比调解它未来引发的每一次冲突更便宜。对于*已经*发生的冲突，请使用上文的调解卡片模式配合 `agent-merge-conflict-arbiter` 技能；hotspot 标记是上游修复，能避免调解者变成一条常设车道。
 
 ## 多租户使用
 


### PR DESCRIPTION
Maintainer-directed. The bundled merge-reconciler skill (#83063) serves exactly one scenario — two AGENTS' branches colliding during a parallel kanban campaign — which most installs never hit; it does not belong in every user's always-shipped skills index (~20 tok/call, plus a listing slot in the catalog every model scans).

**Moved**: skills/autonomous-ai-agents/merge-reconciler → optional-skills/autonomous-ai-agents/agent-merge-conflict-arbiter (installable through the skills hub, official source, like the other optional autonomous-ai-agents entries).

**Renamed**: 'merge-reconciler' read like a generic git merge helper. 'agent-merge-conflict-arbiter' carries the trigger in the name — it is a neutral third-party arbiter for conflicts BETWEEN TWO AGENTS, not a tool you point at your own conflicts. Frontmatter description rewritten within the 60-char hardline that the skill's own contract test enforces.

**Sweep**: contract test moved+renamed (9/9 green), kanban docs repointed (en + zh-Hans), zero stale refs (repo-wide grep clean). No core-code footprint — the original PR was skill+docs only and this stays that way.

**Effect**: shipped skills index drops one entry for every install; existing multi-agent users reinstall from the hub under the new name.