### PR TITLE
fix(desktop): raise venv-blocker scan timeout from 15s to 60s

### DIFF
--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -45,7 +45,13 @@ export type ScanOutcome =
 // Constants
 // ---------------------------------------------------------------------------
 
-const SCAN_TIMEOUT_MS = 15000
+// The venv-blocker scan invokes `python -m hermes_cli._scan_venv_blockers`
+// which enumerates all running processes via psutil.  On Windows hosts with
+// many running processes (400+) the scan takes 20-25 s.  The old 15 s hard
+// cap caused every update attempt to fail with a silent probe-failure on
+// such machines, with no actionable error surfaced in the UI (#98377).
+// Raised to 60 s — still bounded, but accommodates the realistic worst case.
+const SCAN_TIMEOUT_MS = 60000
 const SCAN_MODULE = 'hermes_cli._scan_venv_blockers'
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On Windows hosts with many running processes (400+), the psutil-based venv-blocker scan in \pps/desktop/electron/venv-blocker-scan.ts\ takes 20–25 s. The hard 15 s \SCAN_TIMEOUT_MS\ cap caused every in-app update to fail silently with a \probe-failure\ result — no actionable error was shown in the UI.

Measured in #98377:
\\\
run 1: 24 638 ms
run 2: 20 671 ms
run 3: 22 749 ms
\\\

## Fix

Raise \SCAN_TIMEOUT_MS\ from 15 000 → 60 000 ms. The scan is still bounded; 60 s covers the realistic worst case (25 s) with comfortable headroom.

Fixes #98377