### PR TITLE
fix(bedrock): stop the context probe escalating on rejections it cannot parse

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1868,6 +1868,16 @@ def probe_bedrock_context_length(model_id: str, region: str) -> Optional[int]:
     InternalServerException instead of a clean length error, and (b) stepping
     up discovers larger windows without over-padding smaller ones.
 
+    Escalation therefore only happens on **acceptance**, which is the one
+    outcome that leaves the window unbounded above.  A *rejection* is terminal:
+    the error shape is a property of the model, not of the payload size, so a
+    bigger prompt returns the identical error.  Bedrock has two shapes —
+
+        prompt is too long: 1444476 tokens > 1000000 maximum   (parseable)
+        Input is too long for requested model.                 (no number)
+
+    — and padding harder never converts the second into the first.
+
     Returns the detected window, or ``None`` if the probe could not run
     (missing credentials, network error, or no parseable limit) so the caller
     can fall back to the static table.
@@ -1884,6 +1894,7 @@ def probe_bedrock_context_length(model_id: str, region: str) -> Optional[int]:
         return None
 
     last_error = ""
+    largest_accepted = None
     for tier_tokens in _BEDROCK_PROBE_TIERS:
         pad_words = int(tier_tokens / _WORDS_PER_TOKEN)
         oversized = "data " * pad_words
@@ -1893,14 +1904,15 @@ def probe_bedrock_context_length(model_id: str, region: str) -> Optional[int]:
                 messages=[{"role": "user", "content": [{"text": oversized}]}],
                 inferenceConfig={"maxTokens": 8},
             )
-            # Accepted a prompt this large → the window is at least this tier.
-            # Returning the tier as a lower bound is safe and avoids inventing
-            # a number we can't confirm.
+            # Accepted a prompt this large → the window is at least this tier,
+            # but we have no upper bound yet.  This is the only outcome a bigger
+            # tier can improve on, so keep this as a floor and step up.
             logger.debug(
                 "Bedrock context probe for %s accepted ~%s-token prompt; "
                 "window is at least that", model_id, f"{tier_tokens:,}",
             )
-            return tier_tokens
+            largest_accepted = tier_tokens
+            continue
         except Exception as exc:
             msg = str(exc)
             last_error = msg
@@ -1911,10 +1923,17 @@ def probe_bedrock_context_length(model_id: str, region: str) -> Optional[int]:
                     model_id, f"{limit:,}",
                 )
                 return limit
-            # No parseable limit at this tier (opaque server error, auth,
-            # throttle).  Try the next, smaller-overage strategy is N/A here —
-            # tiers ascend — so just continue; if all fail we return None.
-            continue
+            # Rejected with nothing parseable — a numberless length error, or an
+            # opaque server/auth/throttle failure.  Escalating cannot help: the
+            # error shape follows the model, not the payload size, and per (a)
+            # above a larger payload is *more* likely to fail opaquely.  Stop
+            # rather than upload the next tier to learn the same nothing.
+            break
+
+    if largest_accepted is not None:
+        # An earlier tier was accepted and a later one gave us nothing better;
+        # the confirmed lower bound still beats falling back to the table.
+        return largest_accepted
 
     logger.debug(
         "Bedrock context probe for %s returned no parseable limit: %s",

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1012,6 +1012,125 @@ class TestBedrockContextProbe:
                 region="eu-central-1") == 1_000_000
 
 
+class TestBedrockContextProbeTierEscalation:
+    """Which outcome is allowed to step up to the next probe tier.
+
+    Escalation is only informative after an *acceptance*, because that is the
+    only outcome that leaves the window unbounded above.  A rejection is
+    terminal: the error shape follows the model, not the payload size, so a
+    bigger prompt returns the identical error.  Each tier is a multi-megabyte
+    upload from the user's machine (~7.2 MB then ~12.2 MB at the current tiers),
+    so a tier that cannot return new information must not be sent.
+    """
+
+    # Verbatim from live Bedrock, us-east-2, 2026-08-30.  claude-sonnet-4 and
+    # claude-sonnet-4-5 both return this shape, with no number to parse, at
+    # *every* tier (RequestIds 58d9ac48-48a0-4fa7-a513-1043c47105c0 at 1.3M and
+    # 4569eaad-2ade-4c4c-8c94-6809206b811e at 2.2M).
+    NUMBERLESS_LENGTH_ERROR = (
+        "An error occurred (ValidationException) when calling the Converse "
+        "operation: The model returned the following errors: Input is too long "
+        "for requested model."
+    )
+    # The other shape, from the same sweep (claude-opus-4-8, RequestId
+    # 8b984dbf-62df-42b2-a224-2b129f26418f).
+    NUMERIC_LENGTH_ERROR = (
+        "An error occurred (ValidationException) when calling the Converse "
+        "operation: The model returned the following errors: prompt is too "
+        "long: 1444476 tokens > 1000000 maximum"
+    )
+
+    def _client(self, *outcomes):
+        """A client whose successive converse() calls follow ``outcomes``.
+
+        An ``Exception`` instance is raised; anything else is returned.
+        """
+        client = MagicMock()
+        client.converse.side_effect = list(outcomes)
+        return client
+
+    def _probe(self, client):
+        from agent.bedrock_adapter import probe_bedrock_context_length
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client",
+                   return_value=client):
+            return probe_bedrock_context_length("any.model", "us-east-2")
+
+    def test_numberless_rejection_does_not_escalate(self):
+        """The regression this class exists for.
+
+        A numberless length error means *this model* does not report its
+        maximum.  The next tier returns the same numberless error, so sending it
+        uploads ~12.2 MB to learn exactly nothing.
+        """
+        client = self._client(
+            Exception(self.NUMBERLESS_LENGTH_ERROR),
+            Exception(self.NUMBERLESS_LENGTH_ERROR),
+        )
+        assert self._probe(client) is None
+        assert client.converse.call_count == 1, (
+            "probe escalated to a larger tier after a rejection it could not "
+            "parse; the larger request returns the identical error, so this is "
+            "a wasted multi-megabyte upload"
+        )
+
+    def test_opaque_failure_does_not_escalate(self):
+        """Same for a non-length failure.
+
+        Auth and throttle errors recur regardless of size, and per the
+        function's own docstring a *larger* payload is more likely to produce an
+        opaque InternalServerException — so stepping up is strictly worse.
+        """
+        client = self._client(
+            Exception("An error occurred (InternalServerException) ..."),
+            Exception("An error occurred (InternalServerException) ..."),
+        )
+        assert self._probe(client) is None
+        assert client.converse.call_count == 1
+
+    def test_parseable_rejection_returns_on_the_first_tier(self):
+        client = self._client(Exception(self.NUMERIC_LENGTH_ERROR))
+        assert self._probe(client) == 1_000_000
+        assert client.converse.call_count == 1
+
+    def test_acceptance_escalates_to_bound_the_window(self):
+        """Acceptance is the case escalation is *for*.
+
+        A prompt that large going through only proves ``>= tier``.  Stepping up
+        is what turns that into a real figure — the reason the docstring gives
+        for having tiers, which acceptance-returns-immediately never exercised.
+        """
+        client = self._client({"output": {}}, Exception(self.NUMERIC_LENGTH_ERROR))
+        assert self._probe(client) == 1_000_000
+        assert client.converse.call_count == 2
+
+    def test_accepted_floor_survives_a_useless_next_tier(self):
+        """A confirmed lower bound must not be thrown away.
+
+        Tier 1 was accepted, so the window is at least 1.3M.  If the escalated
+        request then fails opaquely (docstring reason (a): wildly oversized
+        payloads fail opaquely), returning ``None`` would discard a fact we
+        already established and fall back to a table value that may be lower.
+        """
+        from agent.bedrock_adapter import _BEDROCK_PROBE_TIERS
+        client = self._client(
+            {"output": {}},
+            Exception(self.NUMBERLESS_LENGTH_ERROR),
+        )
+        assert self._probe(client) == _BEDROCK_PROBE_TIERS[0]
+        assert client.converse.call_count == 2
+
+    def test_every_tier_accepted_returns_the_largest(self):
+        from agent.bedrock_adapter import _BEDROCK_PROBE_TIERS
+        client = self._client(*[{"output": {}} for _ in _BEDROCK_PROBE_TIERS])
+        assert self._probe(client) == _BEDROCK_PROBE_TIERS[-1]
+        assert client.converse.call_count == len(_BEDROCK_PROBE_TIERS)
+
+    def test_tiers_ascend(self):
+        """The floor/escalation logic assumes ascending tiers."""
+        from agent.bedrock_adapter import _BEDROCK_PROBE_TIERS
+        assert list(_BEDROCK_PROBE_TIERS) == sorted(_BEDROCK_PROBE_TIERS)
+        assert len(set(_BEDROCK_PROBE_TIERS)) == len(_BEDROCK_PROBE_TIERS)
+
 
 # ---------------------------------------------------------------------------
 # Tool-calling capability detection


### PR DESCRIPTION
Fixes #98520.

## What

`probe_bedrock_context_length()` escalates to the **larger** probe tier when a request is **rejected**, and returns immediately when one is **accepted**. Both branches are the wrong way round, and the consequence is that **tier 2 can never return information tier 1 didn't** — it is a 12.2 MB upload that is guaranteed to be wasted in every case it is reached.

A rejection is terminal, because the error shape follows the **model**, not the payload size. Bedrock has two shapes:

```
prompt is too long: 1444476 tokens > 1000000 maximum     ← parseable
Input is too long for requested model.                   ← no number
```

Padding harder never converts the second into the first. `claude-sonnet-4` and `claude-sonnet-4-5` return the numberless shape at *every* tier, so today they upload 7.2 MB, learn nothing, then upload a further **12.2 MB** to learn the same nothing before returning `None`.

Meanwhile the docstring's stated reason for having tiers at all —

> (b) stepping up discovers larger windows without over-padding smaller ones

— was never exercised, because acceptance `return`s instead of escalating. A model that accepts a 1.3M-token prompt returned `1_300_000` and never tried 2.2M. **Tier 2 was dead code for its documented purpose, and live only on the path where it cannot help.**

The in-code comment already half-noticed this:

```python
# No parseable limit at this tier (opaque server error, auth,
# throttle).  Try the next, smaller-overage strategy is N/A here —
# tiers ascend — so just continue; if all fail we return None.
continue
```

## The change

Swap which branch escalates:

| outcome | before | after |
|---|---|---|
| rejected, parseable `maximum` | return it | return it *(unchanged)* |
| rejected, nothing parseable | **escalate** | **stop**, return `None` |
| accepted | **return the tier** | **escalate**, keeping the tier as a floor |

Acceptance is the only outcome that leaves the window unbounded above, so it is the only one a larger tier can improve on. The floor matters for the hazard the docstring's reason (a) describes: if the escalated request fails opaquely because it is *wildly* oversized, the bound already confirmed by the accepted tier is returned rather than discarded.

`agent/bedrock_adapter.py` is +27/−8, all inside this one function plus its docstring. No config, no new env var, no signature or contract change — `None` still means "couldn't determine, fall back to the static table".

## Verified against live Bedrock

`us-east-2`, 2026-08-30, `boto3` 1.42.89 — A/B through the **production function**, counting real requests and bytes on the wire:

| model | error shape | before | after |
|---|---|---|---|
| `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | numberless | `None`, **2** requests, 19.4 MB | `None`, **1** request, **7.2 MB** |
| `us.anthropic.claude-sonnet-4-20250514-v1:0` | numberless | `None`, **2** requests, 19.4 MB | `None`, **1** request, **7.2 MB** |
| `us.anthropic.claude-opus-4-8` | numeric | `1000000`, 1 request, 7.2 MB | `1000000`, 1 request, 7.2 MB |

Identical results, 12.2 MB less uploaded for each affected model. Raw per-tier evidence with `x-amzn-RequestId`s for both shapes is in #98520 — including `claude-opus-4-8` returning the *same* `1000000` at tier 2 as at tier 1, which is the same point from the other direction: escalation adds nothing even when the error is parseable.

`RetryAttempts=0` on every call, so there is no boto3 retry amplification — the wasted 12.2 MB is uploaded exactly once, not per retry.

## Impact, stated fairly

This is a waste-and-clarity fix, not a correctness fix. The final answer was already right: `None` → static table → 200,000 for both sonnet models, which is correct, and `get_bedrock_context_length()` caches per model so the cost is paid once rather than every turn.

What it costs is a first-use stall. In-region the wasted tier is only ~0.8s, but the body is uploaded from the **user's** machine — on a 10 Mbps uplink 12.2 MB is roughly 10 seconds of startup hang with nothing on screen explaining it. The fix also makes tier 2 reachable for the purpose it was written for, which matters the first time AWS ships a window above 1.3M.

## Tests

`TestBedrockContextProbeTierEscalation`, 7 cases in `tests/agent/test_bedrock_adapter.py`, asserting `converse.call_count` — the point is not just the return value but that the second request is **not sent**. The numberless-error fixture is the verbatim string from the live sweep, with the RequestIds in a comment so a future reader can tell it is real rather than invented.

Honestly labelled: **5 of the 7 fail on unpatched `main`**; the other two (`test_parseable_rejection_returns_on_the_first_tier`, `test_tiers_ascend`) assert behaviour that already held and are there to pin it down, not as regression tests.

```
FAILED ...::test_numberless_rejection_does_not_escalate
FAILED ...::test_opaque_failure_does_not_escalate
FAILED ...::test_acceptance_escalates_to_bound_the_window
FAILED ...::test_accepted_floor_survives_a_useless_next_tier
FAILED ...::test_every_tier_accepted_returns_the_largest
5 failed, 2 passed
```

with e.g.

```
AssertionError: probe escalated to a larger tier after a rejection it could not
parse; the larger request returns the identical error, so this is a wasted
multi-megabyte upload
assert 2 == 1
```

## Relation to #33826 (merged)

#33669 established exactly this principle for the context-overflow **recovery** path — *"if the provider does not report a concrete max, don't guess with probe tiers"* — and #33826 implemented it in `agent/conversation_loop.py` and `agent/model_metadata.py`. The **discovery** path in `agent/bedrock_adapter.py` was not part of that change and still guessed, in the opposite direction. Different function, different module, no overlap; `tests/test_ctx_halving_fix.py` (that fix's regression test) is in the run below and still passes.

## Testing

- `pytest tests/agent/test_bedrock_adapter.py tests/agent/test_model_metadata.py tests/agent/test_bedrock_1m_context.py tests/agent/test_bedrock_empty_text_blocks.py tests/test_ctx_halving_fix.py` → **213 passed**
- new class alone → 7 passed; against unpatched `agent/bedrock_adapter.py` → 5 failed, 2 passed (above)
- `ruff check` → clean
- live A/B against real Bedrock → table above
