### PR TITLE
fix(update): skip catchup fleet restart when interrupted receipt pulled SHA already matches checkout

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -122,6 +122,20 @@ def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:
 
     if not _receipt_looks_unfinished(receipt):
         return False
+
+    # Guard (#98022): when the receipt is from an interrupted run but the
+    # code that was *pulled* in that run (receipt["post_update"]["sha"])
+    # already matches the current checkout, the fleet is already on the
+    # right code and no restart is needed. Without this guard an interrupted
+    # receipt triggers a catchup restart on every subsequent `hermes update`
+    # call because `plan.runtimes[].code_sha` always contains the *pre-pull*
+    # SHAs which will never equal the post-pull checkout.
+    post_update = receipt.get("post_update")
+    if isinstance(post_update, dict):
+        pulled_sha = post_update.get("sha") or post_update.get("code_sha")
+        if pulled_sha and str(pulled_sha) == str(expected_sha):
+            return False
+
     plan = receipt.get("plan")
     if not isinstance(plan, dict):
         return False

--- a/tests/hermes_cli/test_update_fleet_stale_receipt_98022.py
+++ b/tests/hermes_cli/test_update_fleet_stale_receipt_98022.py
@@ -1,0 +1,50 @@
+"""Regression tests for #98022 — interrupted receipt must not re-fire restarts.
+
+`plan.runtimes[].code_sha` is captured *before* the pull, so an interrupted
+receipt's plan always looks stale. When the interrupted run already pulled
+the code matching the current checkout (receipt["post_update"]["sha"]),
+the fleet is current and no catchup restart is owed.
+"""
+import hermes_cli.update_cmd_fleet as fleet
+
+
+def _receipt(**over):
+    base = {
+        "stop_reason": "interrupted",
+        "plan": {"runtimes": [{"code_sha": "pre-pull-sha"}]},
+    }
+    base.update(over)
+    return base
+
+
+def test_matching_post_update_sha_reports_current(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.read_latest_receipt",
+        lambda: _receipt(post_update={"sha": "abc123"}),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_cmd_fleet._current_checkout_sha", lambda: "abc123"
+    )
+    assert fleet._receipt_reports_stale_runtime() is False
+
+
+def test_mismatched_post_update_sha_still_reports_stale(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.read_latest_receipt",
+        lambda: _receipt(post_update={"sha": "newer-sha"}),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_cmd_fleet._current_checkout_sha", lambda: "abc123"
+    )
+    assert fleet._receipt_reports_stale_runtime() is True
+
+
+def test_missing_post_update_preserves_old_behavior(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.read_latest_receipt",
+        lambda: _receipt(),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_cmd_fleet._current_checkout_sha", lambda: "abc123"
+    )
+    assert fleet._receipt_reports_stale_runtime() is True


### PR DESCRIPTION
## Problem (#98022)

The #95294 catchup restart checks \plan.runtimes[].code_sha\ when no \leet\ matrix is present (unfinished receipt). Those SHAs are **pre-pull** values that will always differ from the current checkout — so a single interrupted update permanently poisons the trigger, re-firing a catchup restart on every subsequent \hermes update\ run even though the fleet is already on the right code.

## Fix

Add an early-exit guard in \_receipt_reports_stale_runtime\:

> When \eceipt.post_update.sha\ (the code version actually pulled by the interrupted run) matches the current checkout SHA, the code **is current** → return \False\ immediately.

The guard is absent when \post_update\ is missing (older receipt format or a run that died before the pull step), preserving the original behaviour for genuinely unfinished updates.

Fixes #98022