### PR TITLE
fix(memory): align Hindsight client pin at 0.9.2

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -72,7 +72,7 @@ class _RecallResult:
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+_MIN_CLIENT_VERSION = "0.9.2"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # ``metadata.source`` stamped on retained memories — OPT-IN, empty by default.

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.6.1"
+  - "hindsight-client==0.9.2"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.9.2"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
@@ -431,9 +431,12 @@ exclude-newer = "14 days"
 # tests/test_packaging_metadata.py::test_build_system_requires_exempt_from_exclude_newer.
 #
 # firecrawl-anydoc: same exact-pin shape (==0.2.4, hosted-OCR wiring PR).
+# hindsight-client: exact-pinned bridge release. The upgrade to 0.9.2 is
+# intentional; excluding it for 14 days would make the runtime and lockfile
+# revert to 0.6.1 on the next Hermes dependency sync.
 # The pin bump WAS the review; exclude-newer adds zero float protection to
 # an exact pin and would only delay the reviewed version 14 days.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, firecrawl-anydoc = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, firecrawl-anydoc = false, hindsight-client = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -286,6 +286,22 @@ def test_build_system_requires_exempt_from_exclude_newer():
     )
 
 
+def test_hindsight_client_pin_is_exempt_from_exclude_newer():
+    """The reviewed Hindsight bridge release must be resolvable immediately.
+
+    The relative cutoff previously hid 0.9.2, causing ``hermes update`` to
+    retain the obsolete 0.6.1 lock entry even after the bridge pin was bumped.
+    An exact dependency pin cannot float, so excluding it from the cutoff adds
+    no supply-chain risk and prevents an update-time rollback (#86992).
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    hindsight = data["project"]["optional-dependencies"]["hindsight"]
+    assert hindsight == ["hindsight-client==0.9.2"]
+    uv_cfg = data["tool"]["uv"]
+    assert uv_cfg["exclude-newer-package"].get("hindsight-client") is False
+    assert _locked_versions("hindsight-client") == {"0.9.2"}
+
+
 
 
 def _lazy_deps_by_feature():

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.9.2",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/uv.lock
+++ b/uv.lock
@@ -13,18 +13,19 @@ exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
 setuptools = false
-huggingface-hub = false
+nemo-relay = false
 vercel = false
 pillow = false
 unpaddedbase64 = false
+huggingface-hub = false
 h2 = false
 defusedxml = false
 aiohttp = false
 cryptography = false
-mcp = false
+hindsight-client = false
 python-olm = false
 firecrawl-anydoc = false
-nemo-relay = false
+mcp = false
 
 [manifest]
 overrides = [
@@ -1887,7 +1888,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.9.2" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
@@ -1986,7 +1987,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1996,9 +1997,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/21/18dd524c25d440466fa9377e4754b336cde0cc94bb566619913880198aa3/hindsight_client-0.9.2.tar.gz", hash = "sha256:bf6877da5d423395a4b0ac8ac8fc1836f5f5da271613a76e38903437af136ea1", size = 152096, upload-time = "2026-08-25T10:20:30.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/88ef406d96902a8ae6b6ba09afe8ac06bb4d3460eac1a7b741735ba41475/hindsight_client-0.9.2-py3-none-any.whl", hash = "sha256:31d26d116a07da5203bc913c5ed017de95d875edd5e295afad3c05373665ff6b", size = 358546, upload-time = "2026-08-25T10:20:29.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Updates Hermes's Hindsight client from the stale `0.6.1` pin to the reviewed `0.9.2` release across every enforcement path:

- the `hindsight` optional dependency and committed `uv.lock`
- the Hindsight provider minimum and plugin manifest
- `memory.hindsight` in `tools/lazy_deps.py`
- the relative `exclude-newer` exemption required to resolve this exact reviewed release immediately

Adds a regression test covering the pin, lock resolution, and `exclude-newer` exemption.

This prevents normal updates and lazy dependency healing from restoring the obsolete 0.6.1 client after an operator has moved to the 0.9.x Hindsight stack.

## Verification

```text
92 passed in 5.53s
uv lock --check
```

Refs #86992
