### PR TITLE
fix(relay): call pop_relay_scope directly instead of via run_in_session in _complete_logical

### DIFF
--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -987,12 +987,17 @@ def _complete_logical(
                 output.update({"model": model_name, "provider": provider_name})
                 if response_model_name is not None:
                     output["response_model"] = response_model_name
-            callback = lease.host.run_in_session
-            if operation_lease is not None:
-                callback = operation_lease.run_in_session
-            callback(
-                lease.session,
-                relay_runtime.pop_relay_scope,
+            # Call pop_relay_scope directly rather than routing through
+            # run_in_session.  run_in_session re-enters the session runner
+            # which re-binds the active-turn ContextVar to whatever turn is
+            # current at call time — under concurrent overlapping turns that
+            # can be a *different* turn, invalidating the logical-parent
+            # handle mid-flight and leaking the handle in logical_llm_calls
+            # (#97981).  pop_relay_scope is a plain function that operates
+            # only on the relay/handle objects passed to it; it requires no
+            # session-runner context, so routing it through run_in_session
+            # was never necessary.
+            relay_runtime.pop_relay_scope(
                 lease.host.relay,
                 handle,
                 output=output,


### PR DESCRIPTION
## Problem (#97981)

\_complete_logical\ in \gent/relay_llm.py\ routes \pop_relay_scope\ through \lease.host.run_in_session\ (or \operation_lease.run_in_session\). \un_in_session\ re-enters the session runner which re-binds the active-turn \ContextVar\ to whatever turn is current **at call time**. Under concurrent overlapping turns that can be a *different* turn — invalidating logical-parent handles mid-flight and leaking them in \logical_llm_calls\.

Downstream symptom: \logical_b is None\ assertions and \	est_relay_shared_metrics_runtime\ failing with handle leakage.

## Fix

Call \pop_relay_scope\ directly. It is a plain function that only operates on the \elay\ and \handle\ objects passed to it — it does not require session-runner context. Removing the wrapper ensures the close always executes in the logical context that opened it.

Fixes #97981