### PR TITLE
fix(a2a): set HERMES_CRON_SESSION in subprocess env so approvals respect cron_mode instead of waiting for a phantom terminal

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -875,6 +875,18 @@ class A2AAdapter(BasePlatformAdapter):
             if home:
                 env["HERMES_HOME"] = home
             env["HERMES_A2A_PEER"] = peer
+            # Mark as a non-interactive session so approval.py respects
+            # approvals.cron_mode (default "deny") instead of waiting the
+            # full approvals.timeout (default 300 s) for a human who will
+            # never appear.  Without this, any gated dangerous command
+            # stalls for 300 s, then the A2A caller has disconnected and
+            # the turn reply lands on a closed socket (BrokenPipeError).
+            # Reusing HERMES_CRON_SESSION is intentional: the desired
+            # behaviour is identical — block and let the agent reroute.
+            # Operators who want auto-approve can set
+            # approvals.cron_mode: approve in their config.yaml.
+            # Fixes #98488.
+            env.setdefault("HERMES_CRON_SESSION", "1")
             start = time.time()
             try:
                 proc = subprocess.run(


### PR DESCRIPTION
## Problem (#98488)

When an inbound A2A task trips the dangerous-command approval gate, the prompt is rendered to a TTY that does not exist. The turn stalls for the full \pprovals.timeout\ (300 s default), then returns \BLOCKED: Command timed out without user response\. By then the A2A caller has disconnected, causing:

\\\
BrokenPipeError: [Errno 32] Broken pipe
  File '.../plugins/platforms/a2a/adapter.py', line 195, in _json
\\\

## Fix

Set \HERMES_CRON_SESSION=1\ in the A2A subprocess env. \pproval.py\ already respects this to take the \pprovals.cron_mode\ path (default \deny\) rather than waiting for an interactive user. The turn fails immediately with a clear block message; the agent can route around it; no \BrokenPipeError\.

\setdefault\ is used so an existing \HERMES_CRON_SESSION\ in the gateway env is not overwritten. Operators who want auto-approve can set \pprovals.cron_mode: approve\.

Fixes #98488