### PR TITLE
feat: claude-code-cli provider — Claude subscription via the Claude Code CLI with real tool calls

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -522,10 +522,12 @@ def _refuse_checkpoint_required_on_codex_app_server(
     compress_context() guard alone cannot cover native turns that bypass
     Hermes compression entirely.
     """
-    if checkpoint_required and api_mode == "codex_app_server":
+    # claude_code has the same shape: the `claude` CLI compacts its own
+    # context and Hermes never sees a pre-compaction boundary (#25267).
+    if checkpoint_required and api_mode in {"codex_app_server", "claude_code"}:
         raise RuntimeError(
             "BLOCKED_MISSING_PREREQUISITE: compression.checkpoint_required "
-            "is incompatible with the codex_app_server API mode: the codex "
+            f"is incompatible with the {api_mode} API mode: the codex "
             "agent compacts its own thread without a truthful pre-compaction "
             "transcript boundary, so a required pre-compress checkpoint "
             "cannot be guaranteed. Disable compression.checkpoint_required "
@@ -715,8 +717,10 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "claude_code"}:
         agent.api_mode = api_mode
+    elif agent.provider == "claude-code-cli":
+        agent.api_mode = "claude_code"
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
     elif agent.provider in {"xai", "xai-oauth"}:
@@ -1283,6 +1287,16 @@ def init_agent(
         if not agent.quiet_mode:
             _gr_label = " + Guardrails" if agent._bedrock_guardrail_config else ""
             print(f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock, {agent._bedrock_region}{_gr_label})")
+    elif agent.api_mode == "claude_code":
+        # Claude Code subscription runtime — the `claude` CLI owns the network
+        # and authenticates with its setup-token. No HTTP client, no API key.
+        # See agent/claude_code_runtime.py (#25267).
+        agent.client = None
+        agent._client_kwargs = {}
+        agent.api_key = api_key or "claude-code-subscription"
+        agent.base_url = base_url or "claude-code://local"
+        if not agent.quiet_mode:
+            print(f"🤖 AI Agent initialized with model: {agent.model} (Claude Code subscription)")
     else:
         client_kwargs = {}
         if api_key and base_url:

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1413,6 +1413,21 @@ def _run_review_in_thread(
     if review_run is not None and review_run.cancel_requested.is_set():
         finish_background_review_run(agent, review_run)
         return
+    # claude_code runtime: the fork would spawn a second `claude` process that
+    # cannot reach the `memory` / `skill_manage` tools (they are
+    # _AGENT_LOOP_TOOLS, not exposable over MCP), so the review could never
+    # save anything. Refuse here — every caller (automatic turn-boundary
+    # review, /refine, the CLI review command) converges on this thread
+    # target (#25267).
+    if getattr(agent, "api_mode", None) == "claude_code":
+        logger.info(
+            "background review skipped: api_mode=claude_code cannot write "
+            "memory/skills from the claude subprocess (session=%s)",
+            getattr(agent, "session_id", None),
+        )
+        if review_run is not None:
+            finish_background_review_run(agent, review_run)
+        return
 
     # Local import to avoid a hard circular dep at module load.
     from run_agent import AIAgent

--- a/agent/claude_code_runtime.py
+++ b/agent/claude_code_runtime.py
@@ -1,0 +1,869 @@
+"""Claude Code runtime — hand a turn to a ``claude -p`` subprocess (#25267).
+
+Mirror of :mod:`agent.codex_runtime.run_codex_app_server_turn` for the
+``claude_code`` api_mode: the official Claude CLI owns the model loop and its
+native tools, Hermes' tools reach it over stdio MCP, and the CLI's stream-json
+events are projected back into Hermes' ``messages`` list so memory review,
+session persistence, and every gateway keep working unchanged.
+
+Sites that string-compare ``"codex_app_server"`` and what this runtime does
+about each (grep ``codex_app_server`` to audit):
+
+  MIRRORED
+    agent/conversation_loop.py   dispatch           -> ``elif api_mode == "claude_code"``
+    run_agent.py                 _run_*_turn         -> ``_run_claude_code_turn`` forwarder
+    run_agent.py                 interrupt()         -> forwards to ``_claude_code_session.request_interrupt``
+    run_agent.py                 close()             -> closes ``_claude_code_session``
+    agent/agent_init.py          valid api_mode set  -> ``"claude_code"`` added
+    agent/agent_init.py          checkpoint refusal  -> Claude Code compacts its own context, same as codex
+    agent/agent_init.py          client construction -> no OpenAI client; ``agent.client = None``
+    agent/turn_context.py        preflight compress  -> skipped (native compaction; == ``codex_app_server_auto: native``)
+    agent/turn_context.py        api-bytes stamp     -> skipped (the CLI never sees ``api_messages``)
+    agent/conversation_compression.py compress_context -> no-op boundary (native compaction only)
+    agent/background_review.py   _run_review_in_thread -> refused on claude_code for EVERY caller
+                                                        (automatic, /refine, CLI command): the fork
+                                                        would start a second `claude` that cannot
+                                                        reach the `memory` / `skill_manage` tools
+                                                        (they are _AGENT_LOOP_TOOLS, not MCP-exposable)
+    tui_gateway/server.py        image_routing       -> forces text mode for codex_app_server; claude
+                                                        images are not forwarded either (see
+                                                        _coerce_input_text) so the same downgrade applies
+    hermes_cli/runtime_provider.py _VALID_API_MODES  -> ``"claude_code"`` added; ``claude-code`` provider resolves
+                                                        with no base_url / api_key
+
+  NOT MIRRORED (deliberately)
+    run_agent.py                 steer()             -> codex has ``turn/steer``; stream-json has no
+                                                        equivalent. Falls through to the default
+                                                        next-turn queue.
+    agent/conversation_compression.py _compress_context_via_codex_app_server
+                                                     -> ``compression.codex_app_server_auto: hermes``
+                                                        has no analogue; Claude Code exposes no compact RPC.
+    agent/native_compaction.py                       -> codex-only accounting for the above.
+    hermes_cli/codex_runtime_switch.py, commands.py, banner.py, cli.py /codex-runtime,
+    gateway/slash_commands.py, codex_runtime_plugin_migration.py
+                                                     -> codex-specific opt-in UX (``model.openai_runtime``).
+                                                        claude_code is selected by provider, not a switch.
+    hermes_cli/config_defaults.py, gateway/run.py    -> ``compression.codex_app_server_auto`` config key.
+                                                        claude_code behaves as the ``native`` value of
+                                                        that knob, permanently: the CLI auto-compacts
+                                                        its own context, Hermes never summarizes the
+                                                        local mirror, and there is no ``hermes``/``off``
+                                                        analogue because the CLI exposes no compact RPC.
+    agent/transports/hermes_tools_mcp_server.py      -> docstring mentions only; shared as-is.
+
+Known gap shared with the codex runtime: Hermes tools that need the live
+agent loop (``memory``, ``delegate_task``, ``session_search``, ``todo``) are
+not exposed over MCP.
+
+TODO: background memory/skill review is skipped on this runtime (the guard
+lives in ``agent/background_review._run_review_in_thread`` so every caller —
+automatic, ``/refine``, CLI command — converges on it). The follow-up that
+would restore it is a stateless ``memory`` MCP tool backed by a fresh
+``MemoryStore`` loaded from disk per call, with the parent reloading its
+store after each turn.
+
+Isolation contract (HIGH-2 in review): the child is a Hermes-owned Claude
+Code — ``CLAUDE_CONFIG_DIR=$HERMES_HOME/claude-code``, cwd
+``$HERMES_HOME/claude-code/workspace`` (or ``claude_code.cwd``),
+``--setting-sources ""`` + ``--settings $HERMES_HOME/claude-code/settings.json``
+(deny list), ``--strict-mcp-config``, auto-memory off, and its own
+setup-token credential in ``$CLAUDE_CODE_OAUTH_TOKEN``. The user's
+``~/.claude`` (hooks, plugins, memory, transcripts, interactive login) is never
+read or written.
+"""
+
+from __future__ import annotations
+
+import atexit
+import glob
+import logging
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def combined_system_prompt(agent) -> str:
+    """The system prompt a chat_completions provider would receive.
+
+    ``conversation_loop`` sends ``_cached_system_prompt`` followed by
+    ``ephemeral_system_prompt`` (the gateway's per-request ``system`` message —
+    for the api_server path that is the caller's whole prompt) joined by a
+    blank line. The child must see exactly that, so the same combination is
+    baked into ``--append-system-prompt-file``.
+    """
+    base = getattr(agent, "_cached_system_prompt", None) or ""
+    ephemeral = getattr(agent, "ephemeral_system_prompt", None) or ""
+    if ephemeral:
+        return (base + "\n\n" + ephemeral).strip()
+    return base.strip()
+
+
+# ---------------------------------------------------------------------------
+# Warm-process registry
+#
+# api_server builds a fresh AIAgent per request (stateless by design; history
+# reloads from state.db). Caching the session on the agent instance therefore
+# spawned a new `claude` + warm-up per request and lost the prompt-cache
+# warmth the runtime exists for. Sessions are keyed by the Hermes session id
+# (the same key the CLI session id is derived from) and shared across agent
+# instances. Turns are serialised per session; idle processes are evicted.
+# ---------------------------------------------------------------------------
+
+DEFAULT_REGISTRY_IDLE_SECONDS = 600.0
+DEFAULT_MAX_SESSIONS = 8
+_REGISTRY_SWEEP_INTERVAL = 30.0
+#: Respawn rate guard: more than this many prompt-driven respawns inside the
+#: window means the caller's system prompt changes on (nearly) every request,
+#: which defeats the warm process and the prompt cache.
+_RESPAWN_WARN_COUNT = 3
+_RESPAWN_WARN_WINDOW = 60.0
+#: Temp files older than this in the config dir are leftovers from a crashed
+#: or pre-registry process and are removed on startup.
+_STALE_TEMP_AGE_SECONDS = 24 * 3600
+#: How long a second request for the same session waits for the in-flight
+#: turn before giving up with a clear error.
+_TURN_LOCK_WAIT_SECONDS = 15.0
+
+
+@dataclass
+class _RegistryEntry:
+    session: Any = None
+    turn_lock: threading.Lock = field(default_factory=threading.Lock)
+    last_used: float = field(default_factory=time.monotonic)
+    # Construction happens OUTSIDE the registry lock (config + session-map
+    # reads); ``ready`` gates readers until ``session`` is populated.
+    ready: threading.Event = field(default_factory=threading.Event)
+    respawn_times: list = field(default_factory=list)
+    respawn_warned: bool = False
+
+
+_REGISTRY: Dict[str, _RegistryEntry] = {}
+_REGISTRY_LOCK = threading.Lock()
+_SWEEPER_STARTED = False
+
+
+def _registry_key(agent) -> Optional[str]:
+    sid = str(getattr(agent, "session_id", "") or "").strip()
+    return sid or None
+
+
+def _start_sweeper_locked() -> None:
+    global _SWEEPER_STARTED
+    if _SWEEPER_STARTED:
+        return
+    _SWEEPER_STARTED = True
+
+    def _sweep_forever() -> None:
+        while True:
+            time.sleep(_REGISTRY_SWEEP_INTERVAL)
+            try:
+                sweep_idle_sessions(_idle_timeout_from_config())
+            except Exception:
+                logger.debug("claude-code registry sweep failed", exc_info=True)
+
+    threading.Thread(target=_sweep_forever, daemon=True, name="claude-code-registry").start()
+
+
+def _max_sessions_from_config() -> int:
+    try:
+        value = int(_claude_code_config().get("max_sessions") or DEFAULT_MAX_SESSIONS)
+    except (TypeError, ValueError):
+        value = DEFAULT_MAX_SESSIONS
+    return max(1, value)
+
+
+def _idle_timeout_from_config() -> float:
+    try:
+        return float(_claude_code_config().get("idle_timeout") or DEFAULT_REGISTRY_IDLE_SECONDS)
+    except (TypeError, ValueError):
+        return DEFAULT_REGISTRY_IDLE_SECONDS
+
+
+def sweep_idle_sessions(idle_seconds: float, *, now: Optional[float] = None) -> int:
+    """Close and drop every registered session idle for ``idle_seconds``.
+    Sessions with a turn in flight are never evicted. Returns the count."""
+    now = time.monotonic() if now is None else now
+    victims: list[tuple[str, _RegistryEntry]] = []
+    with _REGISTRY_LOCK:
+        for key, entry in list(_REGISTRY.items()):
+            if now - entry.last_used < idle_seconds:
+                continue
+            if not entry.turn_lock.acquire(blocking=False):
+                continue  # a turn is running
+            try:
+                victims.append((key, _REGISTRY.pop(key)))
+            finally:
+                entry.turn_lock.release()
+    for key, entry in victims:
+        logger.info("claude-code: evicting idle session %s (pid %s)", key[:12], entry.session.pid)
+        try:
+            entry.session.close()
+        except Exception:
+            pass
+    return len(victims)
+
+
+def evict_session(key: Optional[str]) -> None:
+    """Drop and close the registered session for ``key`` (retire / close)."""
+    if not key:
+        return
+    with _REGISTRY_LOCK:
+        entry = _REGISTRY.pop(key, None)
+    if entry is not None and entry.session is not None:
+        try:
+            entry.session.close()
+        except Exception:
+            pass
+
+
+def _shutdown_registry() -> None:
+    """atexit: close every warm child and unlink its temp prompt/MCP files."""
+    with _REGISTRY_LOCK:
+        keys = list(_REGISTRY)
+    for key in keys:
+        evict_session(key)
+
+
+atexit.register(_shutdown_registry)
+
+_STALE_TEMP_PRUNED = False
+
+
+def prune_stale_temp_files(config_dir: str, *, max_age: float = _STALE_TEMP_AGE_SECONDS) -> int:
+    """Remove ``system-prompt-*.md`` / ``hermes-claude-mcp-*.json`` leftovers
+    older than ``max_age`` seconds (crashed processes, pre-registry code).
+    Files younger than that may belong to a live child and are kept."""
+    removed = 0
+    cutoff = time.time() - max_age
+    for pattern in ("system-prompt-*.md", "hermes-claude-mcp-*.json"):
+        for path in glob.glob(os.path.join(config_dir, pattern)):
+            try:
+                if os.path.getmtime(path) < cutoff:
+                    os.unlink(path)
+                    removed += 1
+            except OSError:
+                pass
+    if removed:
+        logger.info("claude-code: removed %d stale temp file(s) from %s", removed, config_dir)
+    return removed
+
+
+def _prune_stale_temp_files_once() -> None:
+    global _STALE_TEMP_PRUNED
+    if _STALE_TEMP_PRUNED:
+        return
+    _STALE_TEMP_PRUNED = True
+    try:
+        from agent.transports.claude_code_session import claude_code_home
+
+        prune_stale_temp_files(claude_code_home())
+    except Exception:
+        logger.debug("claude-code: stale temp prune failed", exc_info=True)
+
+
+def registered_session_count() -> int:
+    with _REGISTRY_LOCK:
+        return len(_REGISTRY)
+
+
+class TurnInFlightError(RuntimeError):
+    """A second request for a session arrived while a turn was running."""
+
+
+def _evict_lru_locked(max_sessions: int) -> list[tuple[str, _RegistryEntry]]:
+    """Under ``_REGISTRY_LOCK``: pop the least-recently-used NOT-in-flight
+    entries until there is room for one more. Returns them for closing."""
+    victims: list[tuple[str, _RegistryEntry]] = []
+    while len(_REGISTRY) >= max_sessions:
+        candidates = sorted(_REGISTRY.items(), key=lambda kv: kv[1].last_used)
+        for key, entry in candidates:
+            if not entry.ready.is_set():
+                continue
+            if entry.turn_lock.acquire(blocking=False):
+                entry.turn_lock.release()
+                victims.append((key, _REGISTRY.pop(key)))
+                break
+        else:
+            break  # every entry is mid-turn; allow temporary overflow
+    return victims
+
+
+def _acquire_entry(agent) -> tuple[_RegistryEntry, bool]:
+    """Return ``(entry, created)`` for the agent's session, holding its turn
+    lock. Rebuilds a closed/dead session in place; agents without a session
+    id get a private, unregistered entry. Session construction runs outside
+    the registry lock (a placeholder entry + ``ready`` event serialises only
+    the readers of THAT key)."""
+    key = _registry_key(agent)
+    if key is None:
+        entry = _RegistryEntry(session=_build_session(agent))
+        entry.ready.set()
+        entry.turn_lock.acquire()
+        return entry, True
+    created = False
+    victims: list[tuple[str, _RegistryEntry]] = []
+    with _REGISTRY_LOCK:
+        _start_sweeper_locked()
+        entry = _REGISTRY.get(key)
+        if (
+            entry is not None
+            and entry.ready.is_set()
+            and (entry.session is None or getattr(entry.session, "_closed", False))
+        ):
+            _REGISTRY.pop(key, None)
+            entry = None
+        if entry is None:
+            victims = _evict_lru_locked(_max_sessions_from_config())
+            entry = _RegistryEntry()
+            _REGISTRY[key] = entry
+            created = True
+    for victim_key, victim in victims:
+        logger.info(
+            "claude-code: registry full (max_sessions=%d); evicting LRU session %s (pid %s)",
+            _max_sessions_from_config(), victim_key[:12], getattr(victim.session, "pid", None),
+        )
+        try:
+            victim.session.close()
+        except Exception:
+            pass
+    if created:
+        try:
+            entry.session = _build_session(agent)
+        except BaseException:
+            with _REGISTRY_LOCK:
+                if _REGISTRY.get(key) is entry:
+                    _REGISTRY.pop(key, None)
+            entry.ready.set()
+            raise
+        entry.ready.set()
+    elif not entry.ready.wait(timeout=_TURN_LOCK_WAIT_SECONDS) or entry.session is None:
+        raise TurnInFlightError(
+            f"session {key[:12]} is still being set up by another request; try again"
+        )
+    if not entry.turn_lock.acquire(timeout=_TURN_LOCK_WAIT_SECONDS):
+        raise TurnInFlightError(
+            f"another turn is still running for session {key[:12]}; try again"
+        )
+    if not created:
+        # The turn we waited on may have retired this entry (evicted + closed
+        # under its lock). Never hand out a dead session: drop our reference
+        # and acquire again, which rebuilds it.
+        with _REGISTRY_LOCK:
+            stale = _REGISTRY.get(key) is not entry
+        if stale or entry.session is None or getattr(entry.session, "_closed", False):
+            entry.turn_lock.release()
+            return _acquire_entry(agent)
+    entry.last_used = time.monotonic()
+    return entry, created
+
+
+def _note_respawn(entry: _RegistryEntry, key: Optional[str]) -> None:
+    """Rate guard for prompt-driven respawns (see _RESPAWN_WARN_COUNT)."""
+    now = time.monotonic()
+    entry.respawn_times = [t for t in entry.respawn_times if now - t < _RESPAWN_WARN_WINDOW] + [now]
+    if len(entry.respawn_times) > _RESPAWN_WARN_COUNT and not entry.respawn_warned:
+        entry.respawn_warned = True
+        logger.warning(
+            "claude-code: session %s respawned %d times in %.0fs because its system "
+            "prompt changes every request; make the prompt stable (no timestamps / "
+            "per-request content) or the warm process and prompt cache are lost",
+            (key or "-")[:12], len(entry.respawn_times), _RESPAWN_WARN_WINDOW,
+        )
+
+
+def _claude_code_config() -> Dict[str, Any]:
+    """The optional ``claude_code:`` block from config.yaml.
+
+    Keys (all optional)::
+
+        claude_code:
+          binary: claude            # path to the CLI
+          oauth_token_env: CLAUDE_CODE_OAUTH_TOKEN  # env var holding `claude setup-token`
+          cwd: ""                   # child working dir (default $HERMES_HOME/claude-code/workspace)
+          deny: []                  # permissions.deny rules for the first-written settings.json
+          permission_mode: ""       # override: default|acceptEdits|plan|dontAsk|bypassPermissions
+          allowed_tools: []         # override the native-tool allowlist
+          expose_hermes_tools: true # register hermes-tools MCP server
+          extra_args: []            # appended verbatim to the claude command line
+          resume: true              # --resume the CLI transcript of a resumed Hermes session
+          turn_timeout: 600         # whole-turn bound (seconds)
+          silence_timeout: 300      # max silence between two CLI events inside a turn
+          idle_timeout: 600         # evict a warm `claude` process idle this long (registry)
+          max_sessions: 8           # warm processes kept at once (LRU eviction beyond this)
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        block = load_config().get("claude_code")
+    except Exception:
+        block = None
+    return dict(block) if isinstance(block, dict) else {}
+
+
+def _coerce_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value))
+        except ValueError:
+            return 0
+    return 0
+
+
+def _record_claude_code_usage(agent, turn) -> Dict[str, Any]:
+    """Translate the CLI ``result.usage`` block into Hermes accounting.
+
+    Claude Code reports Anthropic-shaped usage: ``input_tokens``,
+    ``output_tokens``, ``cache_read_input_tokens``,
+    ``cache_creation_input_tokens``. Hermes' canonical prompt bucket is
+    uncached input + cache read + cache write. Subscription usage has no
+    per-token price, so cost is recorded as included.
+    """
+    agent.session_api_calls += 1
+    usage = getattr(turn, "token_usage_last", None)
+    if not isinstance(usage, dict) or not usage:
+        if getattr(agent, "_session_db", None) and agent.session_id:
+            try:
+                if not agent._session_db_created:
+                    agent._ensure_db_session()
+                agent._session_db.queue_token_counts(
+                    agent.session_id,
+                    model=agent.model,
+                    billing_provider=agent.provider,
+                    billing_base_url=agent.base_url,
+                    billing_mode="subscription_included",
+                    api_call_count=1,
+                )
+            except Exception as exc:
+                logger.debug("claude-code api-call persistence failed: %s", exc)
+        return {}
+
+    from agent.usage_pricing import CanonicalUsage
+
+    canonical = CanonicalUsage(
+        input_tokens=_coerce_int(usage.get("input_tokens")),
+        output_tokens=_coerce_int(usage.get("output_tokens")),
+        cache_read_tokens=_coerce_int(usage.get("cache_read_input_tokens")),
+        cache_write_tokens=_coerce_int(usage.get("cache_creation_input_tokens")),
+        reasoning_tokens=0,
+        raw_usage=usage,
+    )
+    prompt_tokens = canonical.prompt_tokens
+    completion_tokens = canonical.output_tokens
+    total_tokens = canonical.total_tokens
+    usage_dict = {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "input_tokens": canonical.input_tokens,
+        "output_tokens": canonical.output_tokens,
+        "cache_read_tokens": canonical.cache_read_tokens,
+        "cache_write_tokens": canonical.cache_write_tokens,
+        "reasoning_tokens": 0,
+    }
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        try:
+            compressor.update_from_response(usage_dict)
+            window = getattr(turn, "model_context_window", None)
+            if isinstance(window, int) and window > 0:
+                compressor.context_length = window
+        except Exception:
+            logger.debug("claude-code usage update failed", exc_info=True)
+
+    agent.session_prompt_tokens += prompt_tokens
+    agent.session_completion_tokens += completion_tokens
+    agent.session_total_tokens += total_tokens
+    agent.session_input_tokens += canonical.input_tokens
+    agent.session_output_tokens += canonical.output_tokens
+    agent.session_cache_read_tokens += canonical.cache_read_tokens
+    agent.session_cache_write_tokens += canonical.cache_write_tokens
+    agent.session_cost_status = "included"
+    agent.session_cost_source = "claude-code-subscription"
+
+    if getattr(agent, "_session_db", None) and agent.session_id:
+        try:
+            if not agent._session_db_created:
+                agent._ensure_db_session()
+            agent._session_db.queue_token_counts(
+                agent.session_id,
+                input_tokens=canonical.input_tokens,
+                output_tokens=canonical.output_tokens,
+                cache_read_tokens=canonical.cache_read_tokens,
+                cache_write_tokens=canonical.cache_write_tokens,
+                reasoning_tokens=0,
+                estimated_cost_usd=None,
+                cost_status="included",
+                cost_source="claude-code-subscription",
+                billing_provider=agent.provider,
+                billing_base_url=agent.base_url,
+                billing_mode="subscription_included",
+                model=agent.model,
+                api_call_count=1,
+            )
+        except Exception as exc:
+            logger.debug("claude-code token persistence failed: %s", exc)
+
+    return {
+        **usage_dict,
+        "last_prompt_tokens": prompt_tokens,
+        "estimated_cost_usd": None,
+        "cost_status": "included",
+        "cost_source": "claude-code-subscription",
+    }
+
+
+def make_claude_code_event_bridge(agent) -> Callable[[dict], None]:
+    """Wire session events into Hermes' gateway UI callbacks.
+
+    Same contract as ``make_codex_app_server_event_bridge`` (#33200): text
+    deltas -> ``_fire_stream_delta``, thinking -> ``_fire_reasoning_delta``,
+    tool lifecycle -> ``tool_progress_callback`` / ``tool_start_callback`` /
+    ``tool_complete_callback``, commentary before a tool call ->
+    ``_emit_interim_assistant_message``. Every callback is guarded so a buggy
+    display hook can never tear down the turn.
+    """
+
+    def _call(name: str, *args: Any, **kwargs: Any) -> None:
+        fn = getattr(agent, name, None)
+        if fn is None:
+            return
+        try:
+            fn(*args, **kwargs)
+        except Exception:
+            logger.debug("%s raised", name, exc_info=True)
+
+    def on_event(event: dict) -> None:
+        if not isinstance(event, dict):
+            return
+        kind = event.get("kind")
+        if kind == "text_delta":
+            _call("_fire_stream_delta", event.get("text") or "")
+        elif kind == "reasoning_delta":
+            _call("_fire_reasoning_delta", event.get("text") or "")
+        elif kind == "tool_started":
+            name = event.get("name") or "tool"
+            args = event.get("args") or {}
+            _call("tool_progress_callback", "tool.started", name, event.get("preview"), args)
+            _call("tool_start_callback", event.get("call_id"), name, args)
+        elif kind == "tool_completed":
+            name = event.get("name") or "tool"
+            _call(
+                "tool_progress_callback", "tool.completed", name, None, None,
+                duration=event.get("duration"), is_error=bool(event.get("is_error")),
+                result=event.get("result"),
+            )
+            _call(
+                "tool_complete_callback", event.get("call_id"), name,
+                event.get("args") or {}, event.get("result"),
+            )
+        elif kind == "assistant_message":
+            if not getattr(agent, "show_commentary", True):
+                return
+            text = event.get("text") or ""
+            if text.strip():
+                _call("_emit_interim_assistant_message", {"role": "assistant", "content": text})
+        elif kind == "status":
+            _call("_emit_status", event.get("text") or "")
+
+    return on_event
+
+
+# Namespace for deriving the CLI session id from the Hermes session id. A
+# deterministic id means a resumed Hermes session can ``--resume`` its CLI
+# transcript without persisting anything extra (mirrors how the codex runtime
+# only *returns* ``codex_thread_id`` — nothing downstream stores it).
+_CLAUDE_SESSION_NAMESPACE = uuid.UUID("6f1c0d2e-7b3a-4c8e-9a5d-2f4b8c1e7d90")
+
+
+def _claude_session_id_for(agent) -> str:
+    hermes_sid = str(getattr(agent, "session_id", "") or "").strip()
+    if not hermes_sid:
+        return str(uuid.uuid4())
+    return str(uuid.uuid5(_CLAUDE_SESSION_NAMESPACE, f"hermes:{hermes_sid}"))
+
+
+def _build_session(agent):
+    from agent.transports.claude_code_session import ClaudeCodeSession
+
+    _prune_stale_temp_files_once()
+
+    from agent.transports.claude_code_session import DEFAULT_OAUTH_TOKEN_ENV
+
+    cfg = _claude_code_config()
+    # Dedicated workspace by default — NOT the Hermes process cwd ($HOME for
+    # the gateway), so CLAUDE.md discovery and transcript slugs never key off
+    # wherever Hermes happened to be launched.
+    cwd = str(cfg.get("cwd") or "").strip() or None
+
+    # ``--yolo`` / ``approvals.mode: off`` / the gateway /yolo toggle are the
+    # user's explicit "don't gate me" — the only route to bypassPermissions
+    # besides tools.terminal.security_mode=unrestricted.
+    security_mode = os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto")
+    try:
+        from tools.approval import is_approval_bypass_active
+
+        if is_approval_bypass_active():
+            security_mode = "unrestricted"
+    except Exception:
+        logger.debug("claude-code: approval-bypass lookup failed", exc_info=True)
+
+    allowed = cfg.get("allowed_tools")
+    extra_args = cfg.get("extra_args")
+    deny = cfg.get("deny")
+    # Approval prompt: defer to Hermes' standard flow when the CLI thread
+    # installed one (same source the codex runtime uses). Gateway / cron
+    # contexts have none -> gated tools are denied with a message.
+    approval_callback = _approval_callback()
+    hermes_sid = str(getattr(agent, "session_id", "") or "").strip() or None
+    return ClaudeCodeSession(
+        cwd=cwd,
+        oauth_token_env=str(cfg.get("oauth_token_env") or DEFAULT_OAUTH_TOKEN_ENV),
+        deny_rules=[str(r) for r in deny] if isinstance(deny, list) and deny else None,
+        session_id=_claude_session_id_for(agent),
+        session_key=hermes_sid,
+        resume=bool(cfg.get("resume", True)),
+        approval_callback=approval_callback,
+        claude_bin=str(cfg.get("binary") or "claude"),
+        model=getattr(agent, "model", None),
+        security_mode=security_mode,
+        permission_mode=str(cfg.get("permission_mode") or "") or None,
+        allowed_tools=[str(t) for t in allowed] if isinstance(allowed, list) else None,
+        system_prompt=combined_system_prompt(agent),
+        expose_hermes_tools=bool(cfg.get("expose_hermes_tools", True)),
+        extra_args=[str(a) for a in extra_args] if isinstance(extra_args, list) else None,
+        on_event=make_claude_code_event_bridge(agent),
+    )
+
+
+def run_claude_code_turn(
+    agent,
+    *,
+    user_message: str,
+    original_user_message: Any,
+    messages: List[Dict[str, Any]],
+    effective_task_id: str,
+    should_review_memory: bool = False,
+) -> Dict[str, Any]:
+    """Run one turn through the Claude Code subprocess.
+
+    Called from run_conversation() when ``agent.api_mode == "claude_code"``.
+    Returns the same dict shape as the chat_completions path.
+    """
+    if getattr(agent, "compression_checkpoint_required", False) is True:
+        from agent.conversation_compression import _checkpoint_blocked
+
+        raise _checkpoint_blocked(
+            "claude_code owns the authoritative context and compacts it "
+            "without a truthful pre-compaction transcript boundary"
+        )
+
+    cfg = _claude_code_config()
+    registry_key = _registry_key(agent)
+    try:
+        entry, created = _acquire_entry(agent)
+    except TurnInFlightError as exc:
+        return {
+            "final_response": str(exc),
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": True,
+            "interrupted": False,
+            "error": str(exc),
+        }
+    session = entry.session
+    # The registry hands the same process to every AIAgent instance of a
+    # session; point its UI/approval hooks at THIS instance for the turn and
+    # expose it for interrupt()/close() forwarding.
+    session.rebind(
+        on_event=make_claude_code_event_bridge(agent),
+        approval_callback=_approval_callback(),
+    )
+    agent._claude_code_session = session
+    try:
+        # The system prompt (Hermes' cached prompt + the gateway's ephemeral
+        # prompt) is baked into the process at spawn. If either changed —
+        # memory rebuilt, /model, a new per-request system message —
+        # respawn so the CLI sees the new one (same CLI session, resumed).
+        wanted_prompt = combined_system_prompt(agent)
+        if not created and session.needs_respawn(wanted_prompt):
+            logger.info("claude-code: system prompt changed; respawning session")
+            _note_respawn(entry, registry_key)
+            try:
+                session.restart(system_prompt=wanted_prompt)
+            except Exception:
+                logger.warning("claude-code respawn failed; rebuilding session", exc_info=True)
+                try:
+                    session.close()
+                except Exception:
+                    pass
+                session = _build_session(agent)
+                entry.session = session
+                agent._claude_code_session = session
+
+        # NOTE: the user message is ALREADY in ``messages`` (appended by
+        # run_conversation before dispatch). Do not append it again.
+        try:
+            session.ensure_started()
+            turn = session.run_turn(
+                user_input=user_message,
+                turn_timeout=float(cfg.get("turn_timeout") or 600.0),
+                idle_timeout=float(cfg.get("silence_timeout") or 300.0),
+            )
+        except Exception as exc:
+            logger.exception("claude-code turn failed")
+            evict_session(registry_key)
+            try:
+                session.close()
+            except Exception:
+                pass
+            agent._claude_code_session = None
+            _user_interrupted = bool(getattr(agent, "_interrupt_requested", False))
+            _interrupt_message = (
+                getattr(agent, "_interrupt_message", None) if _user_interrupted else None
+            )
+            if _user_interrupted:
+                agent.clear_interrupt()
+            return {
+                "final_response": f"Claude Code turn failed: {exc}",
+                "messages": messages,
+                "api_calls": 0,
+                "completed": False,
+                "partial": True,
+                "interrupted": _user_interrupted,
+                **({"interrupt_message": _interrupt_message} if _interrupt_message else {}),
+                "error": str(exc),
+            }
+        entry.last_used = time.monotonic()
+        if getattr(turn, "should_retire", False):
+            # Retire while still holding the turn lock: a request waiting on
+            # this session must wake to a fresh process, not to one we are
+            # about to close underneath it.
+            logger.warning("claude-code session retired (turn error: %s)", turn.error)
+            evict_session(registry_key)
+            try:
+                session.close()
+            except Exception:
+                pass
+            agent._claude_code_session = None
+    finally:
+        entry.turn_lock.release()
+    return _finish_turn(
+        agent, turn, cfg,
+        registry_key=registry_key, session=session,
+        user_message=user_message, original_user_message=original_user_message,
+        messages=messages, should_review_memory=should_review_memory,
+    )
+
+
+def _approval_callback():
+    try:
+        from tools.terminal_tool import _get_approval_callback
+
+        return _get_approval_callback()
+    except Exception:
+        return None
+
+
+def _finish_turn(
+    agent, turn, cfg, *, registry_key, session, user_message, original_user_message,
+    messages, should_review_memory,
+) -> Dict[str, Any]:
+    """Post-turn bookkeeping shared with the codex runtime shape."""
+
+    _user_interrupted = bool(
+        turn.interrupted and getattr(agent, "_interrupt_requested", False)
+    )
+    _interrupt_message = (
+        getattr(agent, "_interrupt_message", None) if _user_interrupted else None
+    )
+    if _user_interrupted:
+        agent.clear_interrupt()
+
+    if turn.projected_messages:
+        from agent.message_metadata import append_message
+
+        for projected in turn.projected_messages:
+            append_message(messages, projected)
+        # Early-return path: flush the projected rows ourselves (idempotent
+        # via _DB_PERSISTED_MARKER; the user turn was flushed at turn start).
+        if getattr(agent, "_session_db", None) is not None:
+            try:
+                flush_ok = agent._flush_messages_to_session_db(messages)
+            except Exception:
+                flush_ok = False
+                logger.warning("claude-code projected-message flush failed", exc_info=True)
+            if flush_ok is False:
+                logger.warning(
+                    "claude-code turn was delivered but could NOT be persisted "
+                    "to the session DB (session=%s)",
+                    getattr(agent, "session_id", None),
+                )
+
+    agent._iters_since_skill = (
+        getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
+    )
+    usage_result = _record_claude_code_usage(agent, turn)
+
+    should_review_skills = False
+    if (
+        agent._skill_nudge_interval > 0
+        and agent._iters_since_skill >= agent._skill_nudge_interval
+        and "skill_manage" in agent.valid_tool_names
+    ):
+        should_review_skills = True
+        agent._iters_since_skill = 0
+
+    if not turn.interrupted and turn.error is None:
+        try:
+            agent._sync_external_memory_for_turn(
+                original_user_message=original_user_message,
+                final_response=turn.final_text,
+                interrupted=False,
+                messages=messages,
+            )
+        except Exception:
+            logger.debug("external memory sync raised", exc_info=True)
+
+    # Background review is refused inside background_review._run_review_in_thread
+    # for this api_mode (every caller converges there); nothing to gate here.
+    if (
+        turn.final_text
+        and not turn.interrupted
+        and (should_review_memory or should_review_skills)
+    ):
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=list(messages),
+                review_memory=should_review_memory,
+                review_skills=should_review_skills,
+            )
+        except Exception:
+            logger.debug("background review spawn raised", exc_info=True)
+
+    final_text = turn.final_text
+    if turn.error and not final_text:
+        final_text = turn.error
+    return {
+        "final_response": final_text,
+        "messages": messages,
+        "api_calls": 1,
+        "completed": not turn.interrupted and turn.error is None,
+        "partial": turn.interrupted or turn.error is not None,
+        "interrupted": _user_interrupted,
+        **({"interrupt_message": _interrupt_message} if _interrupt_message else {}),
+        "error": turn.error,
+        "agent_persisted": True,
+        "claude_session_id": turn.session_id,
+        **usage_result,
+    }

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2830,6 +2830,31 @@ def compress_context(
     checkpoint_required = (
         getattr(agent, "compression_checkpoint_required", False) is True
     )
+    # Claude Code sessions: the `claude` CLI compacts its own context and
+    # exposes no compaction RPC, so there is nothing truthful Hermes can do
+    # here — a local summary would not shrink the real context. Equivalent
+    # to ``codex_app_server_auto: native`` with no other mode (#25267).
+    if getattr(agent, "api_mode", None) == "claude_code":
+        if checkpoint_required:
+            raise _checkpoint_blocked(
+                "claude_code owns the authoritative context and does not "
+                "expose a truthful pre-compaction transcript boundary"
+            )
+        logger.info(
+            "claude_code compaction skipped: the claude CLI compacts its own "
+            "context (session=%s messages=%d tokens=~%s)",
+            getattr(agent, "session_id", None) or "none",
+            len(messages),
+            f"{approx_tokens:,}" if approx_tokens else "unknown",
+        )
+        _restore_compressor_attempt_state(
+            agent.context_compressor, _compressor_attempt_snapshot,
+            attempt_generation=_attempt_generation,
+        )
+        existing_prompt = getattr(agent, "_cached_system_prompt", None)
+        if not existing_prompt:
+            existing_prompt = agent._build_system_prompt(system_message)
+        return messages, existing_prompt
     if getattr(agent, "api_mode", None) == "codex_app_server":
         if checkpoint_required:
             raise _checkpoint_blocked(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2025,6 +2025,17 @@ def run_conversation(
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
         )
+    # Same shape for the Claude Code subscription runtime: the official
+    # `claude` CLI owns the loop and its native tools; Hermes tools reach it
+    # over MCP. See agent/claude_code_runtime.py (#25267).
+    if agent.api_mode == "claude_code":
+        return agent._run_claude_code_turn(
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=_should_review_memory,
+        )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         _redirect_text = agent._drain_pending_redirect()

--- a/agent/transports/claude_code_session.py
+++ b/agent/transports/claude_code_session.py
@@ -1,0 +1,1595 @@
+"""Session adapter for the ``claude_code`` runtime (#25267).
+
+Drives the official ``claude`` CLI as a long-lived subprocess in
+bidirectional ``stream-json`` mode so a Hermes turn can run on a Claude
+*subscription* (a long-lived ``claude setup-token`` credential) while still
+making real tool calls:
+
+* Claude Code's native tools (Bash, Read, Write, Edit, Glob, Grep, WebSearch,
+  WebFetch, ...) run inside the CLI exactly as they do in a terminal session.
+* Hermes' own tool surface (web_search / web_extract / browser_* / vision /
+  image_generate / skills / TTS / kanban_*) is exposed to the CLI over stdio
+  MCP via ``agent.transports.hermes_tools_mcp_server`` — the same server the
+  ``codex_app_server`` runtime uses. The model sees them as
+  ``mcp__hermes-tools__<tool>``.
+
+Why a subprocess and not the Anthropic Messages transport: subscription
+credentials must only ever be touched by the official CLI. Nothing here reads,
+extracts, or forwards a token — ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN``
+are deliberately *stripped* from the child environment so an inherited API
+key can never silently bill an API account instead of the subscription.
+
+Lifecycle::
+
+    session = ClaudeCodeSession(cwd="/home/x/proj", model="sonnet")
+    session.ensure_started()                      # spawn + warm-up + system/init
+    result = session.run_turn(user_input="hello") # blocks until the `result` event
+    # result.final_text          -> assistant text returned to the caller
+    # result.projected_messages  -> {role, content, tool_calls, tool_call_id} dicts
+    # result.tool_iterations     -> how many tool calls completed (skill nudge counter)
+    # result.interrupted         -> True if request_interrupt() fired mid-turn
+    session.close()
+
+One process per Hermes session, NOT one per turn: the conversation lives in
+the CLI's context and every turn after the first hits the prompt cache
+(measured in the reference Swift implementation: ~4.7s to first token cold vs
+~0.8s warm).
+
+Protocol facts this module is built on (Claude Code 2.1.x, verified live):
+
+* The CLI emits **nothing** — not even ``system/init`` — until it has received
+  a first user message on stdin. Waiting for init before sending deadlocks
+  both sides forever, hence the warm-up turn in :meth:`ensure_started`.
+* Events are newline-delimited JSON objects on stdout: ``system`` (subtype
+  ``init``), ``stream_event`` (raw Anthropic SSE frames, only with
+  ``--include-partial-messages``), ``assistant``, ``user`` (tool results echoed
+  back), ``rate_limit_event`` and the terminal ``result``.
+* MCP tools are *deferred*: the model may call the CLI's own ``ToolSearch``
+  tool first to load ``mcp__hermes-tools__*`` definitions. That is normal and
+  is projected like any other native tool call.
+* ``--append-system-prompt`` is fixed for the life of the process, so Hermes'
+  system prompt is captured at spawn time. A changed prompt requires a
+  respawn (see ``system_prompt`` / :meth:`needs_respawn`).
+
+Threading model: single caller (AIAgent's conversation thread). A reader
+thread owns stdout and pushes parsed lines onto a queue; ``run_turn`` polls
+that queue synchronously so it behaves like the existing chat_completions
+loop. Process identity is checked wherever a background thread reports exit,
+so a subprocess we deliberately killed can never clear the state of its
+healthy replacement.
+"""
+
+from __future__ import annotations
+
+import getpass
+import json
+import logging
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from agent.redact import redact_sensitive_text
+
+logger = logging.getLogger(__name__)
+
+#: MCP server name registered in ``--mcp-config``. Tool names on the wire are
+#: ``mcp__<server>__<tool>``; keep this stable — it is part of the allowlist.
+HERMES_TOOLS_MCP_SERVER_NAME = "hermes-tools"
+_MCP_TOOL_PREFIX = f"mcp__{HERMES_TOOLS_MCP_SERVER_NAME}__"
+
+#: Native Claude Code tools that are pre-approved in ``auto`` mode. This is
+#: today's Moe posture (``dontAsk`` + a deny list) and Hermes' own ``auto``
+#: terminal mode: the shell runs unprompted, and the ONLY gate is the deny
+#: list in the Hermes-owned ``settings.json`` passed via ``--settings`` (see
+#: :data:`DEFAULT_DENY_RULES`). Anything NOT on this allowlist still goes
+#: through the ``can_use_tool`` approval bridge below.
+_AUTO_MODE_ALLOWED_TOOLS: tuple[str, ...] = (
+    "Bash", "Read", "Write", "Edit", "MultiEdit", "NotebookEdit",
+    "Glob", "Grep", "LS", "WebSearch", "WebFetch", "TodoWrite", "Task",
+    "ToolSearch",
+)
+#: Read-only native tools that are safe to pre-approve when the user asked
+#: for approval on everything mutating.
+_APPROVAL_MODE_ALLOWED_TOOLS: tuple[str, ...] = (
+    "Read", "Glob", "Grep", "LS", "WebSearch", "WebFetch", "TodoWrite",
+    "ToolSearch",
+)
+
+# Hermes ``tools.terminal.security_mode`` -> (claude --permission-mode,
+# pre-approved native tools). ``bypassPermissions`` is ONLY reachable through
+# the user's own ``unrestricted`` / ``yolo`` choice — never as a default —
+# because in ``-p`` mode it disables Claude Code's permission layer entirely.
+#
+# ``approval-required`` maps to ``default`` mode with only read-only tools
+# pre-approved. Everything else (Bash, Write, Edit, ...) is GATED, not
+# removed: the CLI is started with ``--permission-prompt-tool stdio`` and asks
+# Hermes over the stream-json control channel (``can_use_tool``) before each
+# non-allowlisted call. The request is routed through Hermes' own approval
+# callback (the same one the codex runtime uses); with no interactive
+# approver wired (gateway/cron) it is denied with a message the model sees.
+# :meth:`ClaudeCodeSession.ensure_started` logs + emits a one-time ``status``
+# event in that no-approver case so the degradation is never silent.
+_HERMES_TO_CLAUDE_PERMISSION: dict[str, tuple[str, tuple[str, ...]]] = {
+    "auto": ("acceptEdits", _AUTO_MODE_ALLOWED_TOOLS),
+    "approval-required": ("default", _APPROVAL_MODE_ALLOWED_TOOLS),
+    "unrestricted": ("bypassPermissions", ()),
+    # Backstop alias used by some skills/tests.
+    "yolo": ("bypassPermissions", ()),
+}
+# Unknown modes fail CLOSED to the most restrictive non-bypass mapping.
+_FAIL_CLOSED_SECURITY_MODE = "approval-required"
+
+#: Message shown once per session when gated tools will be denied because
+#: no interactive approver is available in this context.
+APPROVAL_MODE_NOTICE = (
+    "approval-required: no interactive approver in this context, so shell "
+    "and file-writing tools will be denied (set tools.terminal.security_mode: "
+    "auto to run them under the Hermes-owned deny list)"
+)
+#: Denial text the model sees when a gated tool is refused.
+_DENY_NO_APPROVER = (
+    "Denied by Hermes: approval-required mode and no interactive approver is "
+    "available for this session."
+)
+_DENY_TIMEOUT = "Denied by Hermes: the approval prompt timed out without a response."
+_DENY_USER = "Denied by the Hermes user."
+#: Approval choices from tools.approval.prompt_dangerous_approval that allow
+#: exactly this one call. `session`/`always` are also honoured as allow but
+#: are not persisted into Claude Code rules — Hermes' allowlist owns that.
+_ALLOW_CHOICES = frozenset({"once", "session", "always"})
+#: Name of the per-config-dir file mapping Hermes session keys to the CLI
+#: session id actually in use (needed when a --resume fallback rotated it).
+SESSION_MAP_FILENAME = "hermes-sessions.json"
+SESSION_MAP_LOCK_FILENAME = ".hermes-sessions.lock"
+#: The CLI's own wording when a session id cannot be used (both strings are
+#: present in the 2.1.251 binary). Only these justify rotating the id — any
+#: other warm-up failure (auth, rate limit, MCP crash) must keep it, or a
+#: later healthy start would silently lose the conversation.
+_SESSION_REJECTION_MARKERS = (
+    "no conversation found with session id",
+    "is already in use",
+)
+
+
+def is_session_id_rejection(error_text: Optional[str]) -> bool:
+    lowered = (error_text or "").lower()
+    return any(marker in lowered for marker in _SESSION_REJECTION_MARKERS)
+
+#: Default ``permissions.deny`` rules written into the Hermes-owned
+#: ``settings.json`` the first time the runtime starts. Mirrors the deny list
+#: Moe ships in ``~/.moe/.claude/settings.json``. Users extend/replace it via
+#: ``claude_code.deny`` in config.yaml (applied only when the file is first
+#: written) or by editing the file directly — Hermes never overwrites it.
+DEFAULT_DENY_RULES: tuple[str, ...] = (
+    "Bash(rm -rf *)",
+    "Bash(sudo *)",
+    "Bash(git push *)",
+    "Bash(osascript -e 'tell application \"Messages\"*)",
+    "mcp__claude_ai_Gmail__send_message",
+    "mcp__claude_ai_Gmail__reply",
+    "mcp__claude_ai_Gmail__forward",
+    "mcp__claude_ai_Gmail__trash_message",
+    "mcp__claude_ai_Gmail__trash_thread",
+    "mcp__claude_ai_Google_Drive__share_file",
+    "mcp__claude_ai_Google_Drive__trash_file",
+)
+#: JSON key carrying the provenance note in the managed settings file.
+SETTINGS_MARKER_KEY = "_hermes"
+SETTINGS_MARKER_TEXT = (
+    "Written once by Hermes (claude_code runtime). Edit freely — Hermes "
+    "never overwrites this file. Delete it to regenerate the defaults."
+)
+
+#: Default env var carrying the long-lived Claude Code credential.
+DEFAULT_OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
+
+_VALID_PERMISSION_MODES = frozenset(
+    {"default", "acceptEdits", "plan", "bypassPermissions", "dontAsk"}
+)
+
+# Text the warm-up turn asks for. Kept tiny: it costs one model round-trip
+# and lands in the CLI's conversation context for the life of the process.
+_WARMUP_PROMPT = "Reply with only the word: ready"
+
+# After an interrupt control request, how long to wait for the CLI's own
+# `result` before killing the process.
+_INTERRUPT_GRACE_SECONDS = 5.0
+
+# How many tailing stderr lines to attach to a user-facing error.
+_STDERR_TAIL_LINES = 12
+_STDERR_KEEP_LINES = 200
+
+# Queue sentinels emitted by the reader thread. Never valid stream-json.
+_EOF = object()
+
+
+@dataclass
+class TurnResult:
+    """Result of one user -> assistant -> tools turn through ``claude -p``.
+
+    Same field set as ``codex_app_server_session.TurnResult`` so
+    ``agent/claude_code_runtime.py`` can return the exact dict shape the
+    conversation loop and every gateway already understand.
+    """
+
+    final_text: str = ""
+    projected_messages: list[dict] = field(default_factory=list)
+    tool_iterations: int = 0
+    interrupted: bool = False
+    error: Optional[str] = None
+    session_id: Optional[str] = None
+    token_usage_last: Optional[dict[str, Any]] = None
+    token_usage_total: Optional[dict[str, Any]] = None
+    model_context_window: Optional[int] = None
+    compacted: bool = False
+    # The CLI exited, stopped answering, or reported an auth failure: the
+    # caller should drop the session so the next turn respawns from scratch.
+    should_retire: bool = False
+
+
+def resolve_permission(security_mode: Optional[str]) -> tuple[str, tuple[str, ...]]:
+    """Map a Hermes terminal security mode to ``(permission_mode, allowed_tools)``."""
+    key = str(security_mode or "auto").strip().lower() or "auto"
+    if key not in _HERMES_TO_CLAUDE_PERMISSION:
+        logger.warning(
+            "unknown tools.terminal.security_mode %r; failing closed to %s",
+            security_mode, _FAIL_CLOSED_SECURITY_MODE,
+        )
+        key = _FAIL_CLOSED_SECURITY_MODE
+    return _HERMES_TO_CLAUDE_PERMISSION[key]
+
+
+def hermes_tool_name(wire_name: str) -> str:
+    """``mcp__hermes-tools__web_search`` -> ``web_search``; native names pass through."""
+    if isinstance(wire_name, str) and wire_name.startswith(_MCP_TOOL_PREFIX):
+        return wire_name[len(_MCP_TOOL_PREFIX):] or wire_name
+    return wire_name or "tool"
+
+
+def claude_code_home() -> str:
+    """``$HERMES_HOME/claude-code`` — the Hermes-owned Claude Code config dir.
+
+    Everything the CLI persists (settings, ``.claude.json``, transcripts,
+    auto-memory if it were enabled, plugins) lives here instead of in the
+    user's ``~/.claude``. Hermes turns must never fire the user's hooks, load
+    their plugins, or write into their personal memory/transcripts.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        root = str(get_hermes_home())
+    except Exception:  # pragma: no cover - defensive
+        root = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
+    return os.path.join(root, "claude-code")
+
+
+def default_workspace_dir() -> str:
+    """Dedicated cwd for the child so transcripts/CLAUDE.md discovery never
+    key off wherever the Hermes process happened to be started."""
+    return os.path.join(claude_code_home(), "workspace")
+
+
+def ensure_settings_file(
+    path: str, deny_rules: Optional[list[str]] = None
+) -> str:
+    """Write the Hermes-owned Claude Code ``settings.json`` if it is absent.
+
+    Existing files are never touched (the marker key records provenance, the
+    same pattern the Gemini policy file uses) so user edits survive.
+    """
+    if os.path.exists(path):
+        return path
+    rules = list(deny_rules) if deny_rules else list(DEFAULT_DENY_RULES)
+    payload = {
+        SETTINGS_MARKER_KEY: SETTINGS_MARKER_TEXT,
+        "permissions": {"deny": rules},
+    }
+    directory = os.path.dirname(path) or "."
+    _makedirs_or_explain(directory)
+    fd, tmp = _mkstemp_or_explain(prefix=".settings-", suffix=".json", directory=directory)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def _makedirs_or_explain(directory: str) -> None:
+    try:
+        os.makedirs(directory, exist_ok=True)
+    except PermissionError as exc:
+        raise RuntimeError(
+            f"Claude Code runtime cannot create {directory}: permission denied. "
+            "Fix the permissions on that directory, or set claude_code.cwd / "
+            "HERMES_HOME to a writable location."
+        ) from exc
+
+
+def load_session_map(config_dir: str) -> dict[str, str]:
+    path = os.path.join(config_dir, SESSION_MAP_FILENAME)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return {str(k): str(v) for k, v in data.items()} if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _mkstemp_or_explain(*, prefix: str, suffix: str, directory: str) -> tuple[int, str]:
+    try:
+        return tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=directory)
+    except PermissionError as exc:
+        raise RuntimeError(
+            f"Claude Code runtime cannot write into {directory}: permission "
+            "denied. Fix the permissions on that directory, or set "
+            "claude_code.cwd / HERMES_HOME to a writable location."
+        ) from exc
+
+
+def save_session_mapping(config_dir: str, session_key: str, claude_session_id: str) -> None:
+    """Persist ``session_key -> claude_session_id`` (atomic, 0600).
+
+    The read-modify-write is serialised with ``flock`` on a sidecar lock file
+    so two sessions rotating at the same time cannot drop each other's entry.
+    """
+    _makedirs_or_explain(config_dir)
+    lock_path = os.path.join(config_dir, SESSION_MAP_LOCK_FILENAME)
+    with open(lock_path, "a+", encoding="utf-8") as lock_fh:
+        try:
+            import fcntl
+
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        except (ImportError, OSError):  # pragma: no cover - Windows / odd FS
+            pass
+        data = load_session_map(config_dir)
+        data[session_key] = claude_session_id
+        fd, tmp = _mkstemp_or_explain(prefix=".sessions-", suffix=".json", directory=config_dir)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2)
+            os.replace(tmp, os.path.join(config_dir, SESSION_MAP_FILENAME))
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+
+def resolve_oauth_token(token_env: str = DEFAULT_OAUTH_TOKEN_ENV) -> str:
+    """Return the long-lived Claude Code credential, or raise with a fix.
+
+    The runtime uses its own ``CLAUDE_CONFIG_DIR``, which also means its own
+    credential store — the user's interactive keychain login is deliberately
+    NOT shared. Two reasons: (1) isolation — Hermes must not be able to log
+    the user out; (2) correctness — several long-lived ``claude`` processes
+    sharing ONE interactive login rotate the OAuth refresh token underneath
+    each other, and every refresh by one child logs the others out ("OAuth
+    session expired and could not be refreshed"). One token owned by Hermes
+    ends that race. Hermes never reads the value except to place it in the
+    child's environment.
+    """
+    token = (os.environ.get(token_env) or "").strip()
+    if not token:
+        raise RuntimeError(
+            f"Claude Code runtime needs a long-lived token in ${token_env}. "
+            "Run `claude setup-token` (uses your Claude subscription), put the "
+            f"result in {token_env} in ~/.hermes/.env, and retry. "
+            "(Change the variable name with claude_code.oauth_token_env.)"
+        )
+    return token
+
+
+def build_child_env(
+    base_env: Optional[dict[str, str]] = None,
+    *,
+    config_dir: Optional[str] = None,
+    token_env: str = DEFAULT_OAUTH_TOKEN_ENV,
+    oauth_token: Optional[str] = None,
+) -> dict[str, str]:
+    """Environment for the ``claude`` child.
+
+    * Starts from Hermes' sanitized subprocess env (Tier-1 gateway/infra
+      secrets always stripped). Provider credentials are inherited because
+      the hermes-tools MCP server — spawned *by* the CLI — needs tool API
+      keys (Firecrawl, browser, TTS, ...).
+    * ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN`` are removed so the CLI
+      can only authenticate with the subscription token. This is the whole
+      point of the runtime, not an optimisation.
+    * ``CLAUDE_CODE_OAUTH_TOKEN`` carries the Hermes-owned setup-token (see
+      :func:`resolve_oauth_token` for why it is not the keychain login).
+    * ``CLAUDE_CONFIG_DIR`` points at :func:`claude_code_home` so settings,
+      transcripts, ``.claude.json`` and plugins are Hermes-owned;
+      ``CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`` keeps the CLI from writing its
+      own memory files at all (Hermes owns memory).
+    * ``USER`` / ``LOGNAME`` / ``HOME`` are guaranteed present: a child
+      spawned from a GUI app or a stripped service env otherwise fails to
+      locate its own state even when everything is configured.
+    """
+    if base_env is None:
+        try:
+            from tools.environments.local import hermes_subprocess_env
+
+            env = hermes_subprocess_env(inherit_credentials=True)
+        except Exception:  # pragma: no cover - import-time fallback
+            env = dict(os.environ)
+    else:
+        env = dict(base_env)
+    # Anything that could redirect the CLI away from the subscription (API
+    # key, alt endpoint, Bedrock/Vertex routing) or pin a model behind
+    # Hermes' back is stripped.
+    for key in (
+        "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL", "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX",
+    ):
+        env.pop(key, None)
+    token = oauth_token if oauth_token is not None else os.environ.get(token_env)
+    if token:
+        # SECURITY NOTE (measured live on Claude Code 2.1.251): this variable
+        # IS visible to model-run shell commands — `env` inside the child's
+        # Bash tool prints it, and the CLI has no per-tool env sanitisation
+        # setting. It cannot be stripped: the CLI reads it to authenticate.
+        # Mitigations are (a) it is a dedicated setup-token that can be
+        # revoked without touching the user's own login, (b) the deny list
+        # in settings.json, (c) Hermes' output redaction. Treat anything the
+        # child can run as able to read this token.
+        env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+    env["CLAUDE_CONFIG_DIR"] = config_dir or claude_code_home()
+    env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
+    home = env.get("HOME") or os.path.expanduser("~")
+    env["HOME"] = home
+    user = env.get("USER") or env.get("LOGNAME")
+    if not user:
+        try:
+            user = getpass.getuser()
+        except Exception:
+            user = ""
+    if user:
+        env.setdefault("USER", user)
+        env.setdefault("LOGNAME", user)
+    # The CLI is itself an agent; make sure it can find the tool binaries a
+    # login shell would. Cheap to prepend, harmless if already present.
+    extra_path = ":".join(
+        p for p in (
+            os.path.join(home, ".local", "bin"),
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+        )
+        if p not in (env.get("PATH") or "").split(":")
+    )
+    if extra_path:
+        env["PATH"] = f"{extra_path}:{env.get('PATH') or '/usr/bin:/bin'}"
+    return env
+
+
+def resume_transcript_exists(config_dir: str, session_id: str) -> bool:
+    """True when the CLI already has a transcript for ``session_id`` under
+    ``config_dir`` (``projects/<cwd-slug>/<id>.jsonl``), i.e. ``--resume``
+    can restore it."""
+    root = os.path.join(config_dir, "projects")
+    try:
+        for entry in os.scandir(root):
+            if entry.is_dir() and os.path.exists(
+                os.path.join(entry.path, f"{session_id}.jsonl")
+            ):
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def write_mcp_config(
+    *,
+    python_executable: Optional[str] = None,
+    project_root: Optional[str] = None,
+    directory: Optional[str] = None,
+) -> str:
+    """Write the ``--mcp-config`` JSON that launches ``hermes_tools_mcp_server``.
+
+    The server runs on the *same* interpreter as this process so it sees the
+    same installed tools and config. Only non-secret env is written to the
+    file; everything else is inherited from the CLI's environment (which is
+    :func:`build_child_env`).
+    """
+    py = python_executable or sys.executable
+    root = project_root or os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    server_env: dict[str, str] = {
+        "PYTHONPATH": root,
+        "HERMES_QUIET": "1",
+        "HERMES_REDACT_SECRETS": "true",
+    }
+    for passthrough in ("HERMES_HOME", "HERMES_KANBAN_TASK", "HERMES_KANBAN_DB"):
+        value = os.environ.get(passthrough)
+        if value:
+            server_env[passthrough] = value
+    payload = {
+        "mcpServers": {
+            HERMES_TOOLS_MCP_SERVER_NAME: {
+                "type": "stdio",
+                "command": py,
+                "args": ["-m", "agent.transports.hermes_tools_mcp_server"],
+                "cwd": root,
+                "env": server_env,
+            }
+        }
+    }
+    if directory:
+        _makedirs_or_explain(directory)
+    fd, path = _mkstemp_or_explain(
+        prefix="hermes-claude-mcp-", suffix=".json", directory=directory or tempfile.gettempdir()
+    )
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+    return path
+
+
+def _content_text(content: Any) -> str:
+    """Flatten an Anthropic content value (str or block list) to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text" and isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+                elif block.get("type") == "tool_result":
+                    parts.append(_content_text(block.get("content")))
+            elif isinstance(block, str):
+                parts.append(block)
+        return "".join(parts)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _format_tool_args(args: Any) -> str:
+    try:
+        return json.dumps(args if args is not None else {}, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return json.dumps({"arguments": str(args)})
+
+
+def _tool_preview(name: str, args: Any) -> Optional[str]:
+    """Short human-readable preview for the tool.started bubble."""
+    if not isinstance(args, dict) or not args:
+        return None
+    if name == "Bash":
+        desc = args.get("description") or args.get("command") or ""
+        return str(desc)[:120] or None
+    for key in ("file_path", "path", "pattern", "query", "url", "prompt"):
+        value = args.get(key)
+        if isinstance(value, str) and value:
+            return value[:120]
+    try:
+        return json.dumps(args, ensure_ascii=False)[:120]
+    except (TypeError, ValueError):
+        return None
+
+
+class ClaudeCodeSession:
+    """One long-lived ``claude -p`` process per Hermes session.
+
+    The child is a *Hermes-owned* Claude Code, not the user's: its own
+    ``CLAUDE_CONFIG_DIR`` (settings, transcripts, ``.claude.json``), its own
+    credential (a setup-token in ``$CLAUDE_CODE_OAUTH_TOKEN``), a dedicated
+    workspace cwd, ``--setting-sources ""`` (no ``~/.claude`` / project /
+    local settings, hence no user hooks or plugins), ``--settings`` pointing
+    at the Hermes-managed deny list, ``--strict-mcp-config`` (only the
+    hermes-tools server) and auto-memory disabled.
+
+    Not thread-safe from the caller's perspective — one caller drives it at a
+    time (AIAgent's conversation thread). :meth:`request_interrupt` is the one
+    method that may be called from another thread.
+    """
+
+    def __init__(
+        self,
+        *,
+        cwd: Optional[str] = None,
+        claude_bin: str = "claude",
+        model: Optional[str] = None,
+        security_mode: Optional[str] = None,
+        permission_mode: Optional[str] = None,
+        allowed_tools: Optional[list[str]] = None,
+        system_prompt: Optional[str] = None,
+        expose_hermes_tools: bool = True,
+        mcp_config_path: Optional[str] = None,
+        extra_args: Optional[list[str]] = None,
+        env: Optional[dict[str, str]] = None,
+        on_event: Optional[Callable[[dict], None]] = None,
+        warmup: bool = True,
+        startup_timeout: float = 90.0,
+        config_dir: Optional[str] = None,
+        settings_path: Optional[str] = None,
+        deny_rules: Optional[list[str]] = None,
+        oauth_token_env: str = DEFAULT_OAUTH_TOKEN_ENV,
+        session_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+        resume: bool = True,
+        approval_callback: Optional[Callable[..., str]] = None,
+    ) -> None:
+        self._config_dir = config_dir or claude_code_home()
+        self._cwd = cwd or default_workspace_dir()
+        self._settings_path = settings_path or os.path.join(
+            self._config_dir, "settings.json"
+        )
+        self._deny_rules = list(deny_rules) if deny_rules else None
+        self._oauth_token_env = oauth_token_env
+        self._claude_bin = claude_bin
+        self._model = (model or "").strip() or None
+        mode, tools = resolve_permission(security_mode)
+        if permission_mode:
+            if permission_mode not in _VALID_PERMISSION_MODES:
+                raise ValueError(
+                    f"invalid claude permission_mode {permission_mode!r}; "
+                    f"expected one of {sorted(_VALID_PERMISSION_MODES)}"
+                )
+            mode = permission_mode
+        self._permission_mode = mode
+        self._allowed_tools: list[str] = list(allowed_tools) if allowed_tools is not None else list(tools)
+        self._system_prompt = system_prompt or ""
+        self._system_prompt_path: Optional[str] = None
+        self._expose_hermes_tools = expose_hermes_tools
+        self._mcp_config_path = mcp_config_path
+        self._owns_mcp_config = False
+        self._extra_args = list(extra_args or [])
+        self._env_override = env
+        self._on_event = on_event
+        self._warmup = warmup
+        self._startup_timeout = startup_timeout
+        # The CLI session id is chosen by Hermes (``--session-id``) so a
+        # resumed Hermes session can ``--resume`` the same CLI transcript.
+        # ``session_key`` (the Hermes session id) indexes a small map in the
+        # config dir: when a ``--resume`` is rejected we must rotate to a fresh
+        # uuid (the CLI refuses ``--session-id`` for an id whose transcript
+        # exists: "Session ID ... is already in use"), and later resumes have
+        # to find that rotated id.
+        self._session_key = session_key
+        mapped = load_session_map(self._config_dir).get(session_key) if session_key else None
+        self._requested_session_id = mapped or session_id or str(uuid.uuid4())
+        self._resume = resume
+        self._resume_configured = resume
+        # Hermes' approval prompt (tools.approval.prompt_dangerous_approval
+        # signature via tools.terminal_tool's registered callback). None in
+        # gateway/cron contexts -> gated tools are denied.
+        self._approval_callback = approval_callback
+        self._resumed = False
+        self._notice_emitted = False
+
+        self._proc: Optional[subprocess.Popen] = None
+        self._lines: "queue.Queue[Any]" = queue.Queue()
+        self._stderr_lines: list[str] = []
+        self._stderr_lock = threading.Lock()
+        self._write_lock = threading.Lock()
+        self._interrupt_event = threading.Event()
+        self._turn_active = False
+        self._session_id: Optional[str] = None
+        self._init_info: Optional[dict] = None
+        self._closed = False
+        self._exit_code: Optional[int] = None
+        self._pid: Optional[int] = None
+        self._reader_thread: Optional[threading.Thread] = None
+
+    # ---------- introspection ----------
+
+    @property
+    def session_id(self) -> Optional[str]:
+        return self._session_id
+
+    @property
+    def requested_session_id(self) -> str:
+        return self._requested_session_id
+
+    @property
+    def resumed(self) -> bool:
+        """True when the live process was started with ``--resume``."""
+        return self._resumed
+
+    @property
+    def pid(self) -> Optional[int]:
+        return self._pid
+
+    @property
+    def init_info(self) -> Optional[dict]:
+        """The ``system/init`` payload (tools, mcp_servers, model, ...)."""
+        return self._init_info
+
+    @property
+    def system_prompt(self) -> str:
+        return self._system_prompt
+
+    @property
+    def config_dir(self) -> str:
+        return self._config_dir
+
+    @property
+    def cwd(self) -> str:
+        return self._cwd
+
+    def is_alive(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    def rebind(
+        self,
+        *,
+        on_event: Optional[Callable[[dict], None]] = None,
+        approval_callback: Optional[Callable[..., str]] = None,
+    ) -> None:
+        """Point the UI / approval hooks at a new owner. A warm process is
+        shared across AIAgent instances (api_server builds one per request),
+        so each turn re-targets the callbacks at the instance driving it."""
+        self._on_event = on_event
+        self._approval_callback = approval_callback
+
+    def needs_respawn(self, system_prompt: Optional[str]) -> bool:
+        """``--append-system-prompt-file`` is read at spawn; a changed prompt
+        needs a fresh process to take effect."""
+        return (system_prompt or "") != self._system_prompt
+
+    # ---------- lifecycle ----------
+
+    def _write_system_prompt_file(self) -> Optional[str]:
+        """The prompt goes through a file, not argv: it is several KB (ARG_MAX)
+        and argv is visible to every local user via ``ps``."""
+        if not self._system_prompt:
+            return None
+        if self._system_prompt_path:
+            try:
+                os.unlink(self._system_prompt_path)
+            except OSError:
+                pass
+        fd, path = _mkstemp_or_explain(
+            prefix="system-prompt-", suffix=".md", directory=self._config_dir
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(self._system_prompt)
+        self._system_prompt_path = path
+        return path
+
+    def _build_command(self, *, resume: bool) -> list[str]:
+        cmd = [
+            self._claude_bin,
+            "-p",
+            "--verbose",
+            "--input-format", "stream-json",
+            "--output-format", "stream-json",
+            "--include-partial-messages",
+            "--permission-mode", self._permission_mode,
+            # No ~/.claude, project or local settings: no user hooks, no user
+            # plugins, no user allow rules. Only the file below applies.
+            "--setting-sources", "",
+            "--settings", self._settings_path,
+            # Only the MCP servers in --mcp-config (or none at all).
+            "--strict-mcp-config",
+        ]
+        if self._permission_mode != "bypassPermissions":
+            # Route every non-allowlisted tool call through Hermes' approval
+            # path over the stream-json control channel instead of the
+            # non-interactive default (silent denial).
+            cmd += ["--permission-prompt-tool", "stdio"]
+        if resume:
+            cmd += ["--resume", self._requested_session_id]
+        else:
+            cmd += ["--session-id", self._requested_session_id]
+        if self._model:
+            cmd += ["--model", self._model]
+        allowed = list(self._allowed_tools)
+        if self._expose_hermes_tools and self._mcp_config_path:
+            cmd += ["--mcp-config", self._mcp_config_path]
+            # Pre-approve every Hermes tool: they are already gated by
+            # Hermes' own pre_tool_call hooks and the operator chose to expose
+            # them. Without this, ``default`` mode silently denies them.
+            allowed.append(f"mcp__{HERMES_TOOLS_MCP_SERVER_NAME}")
+        if allowed and self._permission_mode != "bypassPermissions":
+            cmd += ["--allowedTools", ",".join(dict.fromkeys(allowed))]
+        if self._system_prompt_path:
+            cmd += ["--append-system-prompt-file", self._system_prompt_path]
+        cmd += self._extra_args
+        return cmd
+
+    def ensure_started(self) -> str:
+        """Spawn the CLI (idempotent) and return its session id.
+
+        Sends the warm-up message *before* waiting for ``system/init`` — the
+        CLI is silent until it has a user message — and blocks until the
+        warm-up's ``result`` arrives so auth failures surface here rather than
+        on the user's first real turn. If ``--resume`` was attempted and the
+        CLI rejected it (unknown session), respawns once with a fresh
+        ``--session-id`` and logs.
+        """
+        if self.is_alive() and self._session_id:
+            return self._session_id
+        if self._closed:
+            raise RuntimeError("ClaudeCodeSession is closed")
+        token = resolve_oauth_token(self._oauth_token_env)
+        _makedirs_or_explain(self._config_dir)
+        _makedirs_or_explain(self._cwd)
+        ensure_settings_file(self._settings_path, self._deny_rules)
+        if self._expose_hermes_tools and not self._mcp_config_path:
+            self._mcp_config_path = write_mcp_config(directory=self._config_dir)
+            self._owns_mcp_config = True
+        self._write_system_prompt_file()
+
+        transcript_exists = resume_transcript_exists(
+            self._config_dir, self._requested_session_id
+        )
+        resume = self._resume and transcript_exists
+        if transcript_exists and not resume:
+            # The CLI refuses ``--session-id`` for an id that already has a
+            # transcript ("Session ID ... is already in use"). Resume is off
+            # (config) or was abandoned earlier, so start a fresh id now
+            # instead of failing forever on the same one.
+            self._rotate_session_id("resume disabled but a transcript exists")
+        self._spawn(token, resume=resume)
+        if self._warmup:
+            warm = self._run_turn_locked(
+                _WARMUP_PROMPT, silent=True, turn_timeout=self._startup_timeout,
+            )
+            if warm.error and resume and is_session_id_rejection(warm.error):
+                # Only the CLI's own "cannot use this session id" verdict
+                # justifies rotating. Any other warm-up failure (auth, rate
+                # limit, MCP crash) keeps the id so a later healthy start
+                # still resumes the conversation.
+                self._rotate_session_id(
+                    f"--resume rejected: {warm.error.splitlines()[0]}"
+                )
+                self._stop_process()
+                self._resume = False
+                self._spawn(token, resume=False)
+                warm = self._run_turn_locked(
+                    _WARMUP_PROMPT, silent=True, turn_timeout=self._startup_timeout,
+                )
+            if warm.error:
+                self.close()
+                raise RuntimeError(warm.error)
+            # A fresh spawn (after a rotation) has a usable transcript from
+            # now on; restore the configured resume behaviour so a later
+            # restart() resumes it instead of rotating again.
+            self._resume = self._resume_configured
+        if (
+            self._permission_mode == "default"
+            and self._approval_callback is None
+            and not self._notice_emitted
+        ):
+            # Never silent: gated tools will be denied because nobody can
+            # answer the prompt in this context. Tell the operator once.
+            self._notice_emitted = True
+            logger.warning("claude-code: %s", APPROVAL_MODE_NOTICE)
+            self._emit({"kind": "status", "text": APPROVAL_MODE_NOTICE})
+        return self._session_id or ""
+
+    def _rotate_session_id(self, reason: str) -> None:
+        old_id = self._requested_session_id
+        self._requested_session_id = str(uuid.uuid4())
+        logger.warning(
+            "claude-code: rotating CLI session id %s -> %s (%s)",
+            old_id[:8], self._requested_session_id[:8], reason,
+        )
+        if self._session_key:
+            try:
+                save_session_mapping(
+                    self._config_dir, self._session_key, self._requested_session_id,
+                )
+            except Exception:
+                logger.warning("claude-code: could not persist session map", exc_info=True)
+
+    def _spawn(self, token: str, *, resume: bool) -> None:
+        cmd = self._build_command(resume=resume)
+        env = build_child_env(
+            self._env_override,
+            config_dir=self._config_dir,
+            token_env=self._oauth_token_env,
+            oauth_token=token,
+        )
+        try:
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
+            creationflags = windows_hide_flags()
+        except Exception:  # pragma: no cover
+            creationflags = 0
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                cwd=self._cwd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=0,
+                env=env,
+                creationflags=creationflags,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"claude CLI not found at {self._claude_bin!r}. Install with: "
+                "npm i -g @anthropic-ai/claude-code, then run `claude setup-token`."
+            ) from exc
+        self._proc = proc
+        self._pid = proc.pid
+        self._exit_code = None
+        self._session_id = None
+        self._init_info = None
+        self._resumed = resume
+        self._lines = queue.Queue()
+        with self._stderr_lock:
+            self._stderr_lines = []
+        self._reader_thread = threading.Thread(
+            target=self._read_stdout, args=(proc,), daemon=True,
+            name="claude-code-stdout",
+        )
+        self._reader_thread.start()
+        threading.Thread(
+            target=self._read_stderr, args=(proc,), daemon=True,
+            name="claude-code-stderr",
+        ).start()
+        logger.info(
+            "claude-code session spawned: pid=%s model=%s permission=%s "
+            "config_dir=%s cwd=%s %s=%s",
+            proc.pid, self._model or "default", self._permission_mode,
+            self._config_dir, self._cwd,
+            "resume" if resume else "session-id", self._requested_session_id[:8],
+        )
+
+    def restart(self, *, system_prompt: Optional[str] = None) -> str:
+        """Kill the current CLI and spawn a fresh one, resuming the same CLI
+        session id so conversation context survives (e.g. when the baked-in
+        system prompt changed). The old process' reader thread is left to
+        unwind on its own; its identity check keeps it from touching the
+        replacement's state.
+        """
+        if system_prompt is not None:
+            self._system_prompt = system_prompt
+        self._stop_process()
+        return self.ensure_started()
+
+    def _stop_process(self) -> None:
+        proc, self._proc = self._proc, None
+        if proc is not None:
+            try:
+                if proc.stdin and not proc.stdin.closed:
+                    proc.stdin.close()
+            except Exception:
+                pass
+            if proc.poll() is None:
+                try:
+                    proc.terminate()
+                    proc.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    try:
+                        proc.kill()
+                        proc.wait(timeout=3)
+                    except Exception:
+                        pass
+                except Exception:
+                    pass
+        self._session_id = None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._stop_process()
+        for attr in ("_system_prompt_path",):
+            path = getattr(self, attr)
+            if path:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+                setattr(self, attr, None)
+        if self._owns_mcp_config and self._mcp_config_path:
+            try:
+                os.unlink(self._mcp_config_path)
+            except OSError:
+                pass
+            self._mcp_config_path = None
+            self._owns_mcp_config = False
+
+    def __enter__(self) -> "ClaudeCodeSession":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # ---------- interrupt ----------
+
+    def request_interrupt(self) -> None:
+        """Idempotent: ask the active turn to stop. Safe from any thread."""
+        self._interrupt_event.set()
+        proc = self._proc
+        if self._turn_active and proc is not None and proc.poll() is None:
+            # stream-json control channel: the CLI aborts the in-flight model
+            # request / tool and emits a `result` for the cut-short turn.
+            self._write(
+                {
+                    "type": "control_request",
+                    "request_id": uuid.uuid4().hex,
+                    "request": {"subtype": "interrupt"},
+                }
+            )
+
+    # ---------- reader threads ----------
+
+    def _read_stdout(self, proc: subprocess.Popen) -> None:
+        stream = proc.stdout
+        assert stream is not None
+        try:
+            for raw in iter(stream.readline, b""):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    with self._stderr_lock:
+                        self._stderr_lines.append(
+                            "[stdout] " + line.decode("utf-8", "replace")[:500]
+                        )
+                    continue
+                if isinstance(obj, dict):
+                    self._lines.put(obj)
+        except Exception:  # pragma: no cover - pipe torn down under us
+            logger.debug("claude-code stdout reader stopped", exc_info=True)
+        finally:
+            # Identity check: a reader belonging to a process we replaced
+            # during retire/respawn must not report EOF into the queue of the
+            # healthy replacement.
+            if proc is self._proc:
+                self._exit_code = proc.poll()
+                self._lines.put(_EOF)
+
+    def _read_stderr(self, proc: subprocess.Popen) -> None:
+        stream = proc.stderr
+        assert stream is not None
+        try:
+            for raw in iter(stream.readline, b""):
+                text = raw.decode("utf-8", "replace").rstrip()
+                if not text:
+                    continue
+                with self._stderr_lock:
+                    self._stderr_lines.append(text)
+                    if len(self._stderr_lines) > _STDERR_KEEP_LINES:
+                        del self._stderr_lines[:-_STDERR_KEEP_LINES]
+                logger.debug("claude-code stderr: %s", text)
+        except Exception:  # pragma: no cover
+            pass
+
+    def stderr_tail(self, n: int = _STDERR_TAIL_LINES) -> list[str]:
+        with self._stderr_lock:
+            return list(self._stderr_lines[-n:])
+
+    def _format_error(self, prefix: str, detail: str = "") -> str:
+        base = f"{prefix}: {detail}" if detail else prefix
+        tail = self.stderr_tail()
+        joined = "\n".join(t for t in tail if t.strip())
+        if not joined:
+            return base
+        return f"{base}\nclaude stderr (last {len(tail)} lines):\n" + redact_sensitive_text(
+            joined, force=True
+        )
+
+    # ---------- writing ----------
+
+    def _write(self, payload: dict) -> bool:
+        proc = self._proc
+        if proc is None or proc.stdin is None or proc.stdin.closed:
+            return False
+        data = (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
+        with self._write_lock:
+            try:
+                proc.stdin.write(data)
+                proc.stdin.flush()
+                return True
+            except (BrokenPipeError, OSError, ValueError):
+                return False
+
+    @staticmethod
+    def _user_message(text: str) -> dict:
+        return {
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+        }
+
+    # ---------- per-turn ----------
+
+    def run_turn(
+        self,
+        user_input: Any,
+        *,
+        turn_timeout: float = 600.0,
+        idle_timeout: float = 300.0,
+    ) -> TurnResult:
+        """Send one user message and block until the CLI's ``result`` event.
+
+        ``turn_timeout`` bounds the whole turn; ``idle_timeout`` bounds the
+        silence between two events (a wedged CLI emits nothing at all).
+        """
+        text = _coerce_input_text(user_input)
+        if not self.is_alive():
+            result = TurnResult(should_retire=True)
+            result.error = self._format_error(
+                "claude process is not running",
+                f"exit code {self._exit_code}" if self._exit_code is not None else "",
+            )
+            return result
+        if self._interrupt_event.is_set():
+            # A hard stop arrived while we were spawning; honor it rather than
+            # erasing the signal underneath the caller.
+            self._interrupt_event.clear()
+            return TurnResult(interrupted=True, session_id=self._session_id)
+        return self._run_turn_locked(
+            text, silent=False, turn_timeout=turn_timeout, idle_timeout=idle_timeout
+        )
+
+    def _emit(self, event: dict) -> None:
+        if self._on_event is None:
+            return
+        try:
+            self._on_event(event)
+        except Exception:
+            logger.debug("claude-code on_event hook raised", exc_info=True)
+
+    def _run_turn_locked(
+        self,
+        text: str,
+        *,
+        silent: bool,
+        turn_timeout: float,
+        idle_timeout: float = 300.0,
+    ) -> TurnResult:
+        result = TurnResult(session_id=self._session_id)
+        proc = self._proc
+        if proc is None:
+            result.error = "claude process is not running"
+            result.should_retire = True
+            return result
+
+        self._turn_active = True
+        self._interrupt_event.clear()
+        if not self._write(self._user_message(text)):
+            self._turn_active = False
+            result.error = self._format_error("could not write to claude stdin")
+            result.should_retire = True
+            return result
+
+        deadline = time.monotonic() + turn_timeout
+        projector = _TurnProjector(self, silent=silent)
+        saw_result = False
+        try:
+            while True:
+                now = time.monotonic()
+                if now >= deadline:
+                    result.error = self._format_error(
+                        f"claude turn exceeded {int(turn_timeout)}s"
+                    )
+                    result.should_retire = True
+                    break
+                wait = min(idle_timeout, deadline - now)
+                if self._interrupt_event.is_set():
+                    # request_interrupt() already sent the control request;
+                    # give the CLI a short grace period to emit its `result`.
+                    wait = min(wait, _INTERRUPT_GRACE_SECONDS)
+                try:
+                    obj = self._lines.get(timeout=wait)
+                except queue.Empty:
+                    if self._interrupt_event.is_set():
+                        # The CLI ignored the interrupt: kill it rather than
+                        # leave the user waiting on a turn they cancelled.
+                        self._kill(proc)
+                        result.should_retire = True
+                        break
+                    result.error = self._format_error(
+                        f"claude produced no output for {int(idle_timeout)}s"
+                    )
+                    result.should_retire = True
+                    break
+                if obj is _EOF:
+                    # Only the live process' reader may enqueue _EOF (identity
+                    # check in _read_stdout), so this is authoritative.
+                    code = self._exit_code if self._exit_code is not None else proc.poll()
+                    result.error = self._format_error(
+                        f"claude exited unexpectedly (code {code})"
+                    )
+                    result.should_retire = True
+                    break
+                if obj.get("type") == "control_request":
+                    self._handle_control_request(obj, silent=silent)
+                    continue
+                if projector.handle(obj, result):
+                    saw_result = True
+                    break
+        finally:
+            self._turn_active = False
+
+        if saw_result:
+            # Drain anything the CLI already flushed behind `result` (e.g. a
+            # trailing rate_limit_event) so it cannot leak into the next turn.
+            self._drain_pending(projector, result)
+        if self._interrupt_event.is_set():
+            result.interrupted = True
+        self._interrupt_event.clear()
+        projector.finish(result)
+        if not silent:
+            logger.info(
+                "claude-code turn finished: session=%s tools=%d chars=%d error=%s",
+                (self._session_id or "")[:8], result.tool_iterations,
+                len(result.final_text), bool(result.error),
+            )
+        return result
+
+    # ---------- permission prompts (``--permission-prompt-tool stdio``) ----------
+
+    def _handle_control_request(self, obj: dict, *, silent: bool) -> None:
+        request = obj.get("request") or {}
+        request_id = obj.get("request_id")
+        if not isinstance(request, dict) or request.get("subtype") != "can_use_tool":
+            # Unknown control request: answer so the CLI does not hang.
+            self._write_control_response(request_id, behavior="deny", message="unsupported control request")
+            return
+        behavior, message = self.decide_permission(request, silent=silent)
+        self._write_control_response(request_id, behavior=behavior, message=message,
+                                     updated_input=request.get("input"))
+
+    def _write_control_response(
+        self, request_id: Any, *, behavior: str, message: str = "",
+        updated_input: Any = None,
+    ) -> None:
+        inner: dict[str, Any] = {"behavior": behavior}
+        if behavior == "allow":
+            # The CLI expects the (possibly edited) input echoed back on allow.
+            inner["updatedInput"] = updated_input if isinstance(updated_input, dict) else {}
+        else:
+            inner["message"] = message or _DENY_USER
+        self._write(
+            {
+                "type": "control_response",
+                "response": {"subtype": "success", "request_id": request_id, "response": inner},
+            }
+        )
+
+    def decide_permission(self, request: dict, *, silent: bool = False) -> tuple[str, str]:
+        """Route a ``can_use_tool`` request through Hermes' approval prompt.
+
+        Mirrors ``CodexAppServerSession._decide_exec_approval``: protocol
+        routing only — mode/timeout policy lives in ``tools/approval.py``
+        behind the callback. Returns ``(behavior, message)``.
+        """
+        tool_name = str(request.get("tool_name") or "tool")
+        args = request.get("input") if isinstance(request.get("input"), dict) else {}
+        if tool_name == "Bash":
+            command = str(args.get("command") or "")
+            description = str(args.get("description") or request.get("description") or "")
+        else:
+            command = f"{tool_name} {_format_tool_args(args)}"[:500]
+            description = str(request.get("description") or f"Claude Code requests {tool_name}")
+        description = f"Claude Code requests {tool_name}" + (f" — {description}" if description else "")
+        if self._approval_callback is None:
+            logger.info("claude-code: denying %s (no approver wired)", tool_name)
+            return "deny", _DENY_NO_APPROVER
+        try:
+            choice = self._approval_callback(command, description, allow_permanent=False)
+        except Exception:
+            logger.exception("claude-code: approval callback raised; denying %s", tool_name)
+            return "deny", "Denied by Hermes: the approval prompt failed."
+        choice = str(choice or "").strip().lower()
+        if choice in _ALLOW_CHOICES:
+            return "allow", ""
+        if choice == "timeout":
+            return "deny", _DENY_TIMEOUT
+        return "deny", _DENY_USER
+
+    def _kill(self, proc: subprocess.Popen) -> None:
+        if proc.poll() is not None:
+            return
+        try:
+            proc.kill()
+            proc.wait(timeout=3)
+        except Exception:
+            pass
+
+    def _drain_pending(self, projector: "_TurnProjector", result: TurnResult) -> None:
+        end = time.monotonic() + 0.05
+        while True:
+            try:
+                obj = self._lines.get(timeout=max(0.0, end - time.monotonic()))
+            except queue.Empty:
+                return
+            if obj is _EOF:
+                # Keep the sentinel for the next run_turn to observe.
+                self._lines.put(_EOF)
+                return
+            projector.handle(obj, result, post_result=True)
+
+
+def _coerce_input_text(user_input: Any) -> str:
+    """Flatten a Hermes user message (str or multipart list) to text."""
+    if isinstance(user_input, str):
+        return user_input
+    if isinstance(user_input, list):
+        parts: list[str] = []
+        for item in user_input:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    parts.append(str(item.get("text") or ""))
+                elif item.get("type") == "image_url":
+                    parts.append("[image attached — not forwarded to claude]")
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(p for p in parts if p)
+    return str(user_input or "")
+
+
+class _TurnProjector:
+    """Folds one turn's stream-json events into a :class:`TurnResult`.
+
+    Emits UI events through the session's ``on_event`` hook with a small,
+    runtime-agnostic vocabulary (``text_delta``, ``reasoning_delta``,
+    ``tool_started``, ``tool_completed``, ``assistant_message``, ``status``,
+    ``init``) so ``claude_code_runtime`` can bridge them into Hermes' gateway
+    callbacks without knowing the wire format.
+    """
+
+    def __init__(self, session: ClaudeCodeSession, *, silent: bool) -> None:
+        self._s = session
+        self._silent = silent
+        self._text_parts: list[str] = []          # streamed deltas (fallback)
+        self._assistant_texts: list[str] = []     # authoritative text blocks
+        self._pending_tools: dict[str, dict] = {}  # tool_use id -> {name,args,t0}
+        self._pending_interim: Optional[str] = None  # text not yet known to be commentary
+        self._saw_stream_text = False
+
+    # -- public --
+
+    def handle(self, obj: dict, result: TurnResult, *, post_result: bool = False) -> bool:
+        """Consume one event. Returns True when it was the terminal ``result``."""
+        etype = obj.get("type")
+        if etype == "system":
+            self._on_system(obj, result)
+        elif etype == "stream_event":
+            self._on_stream_event(obj)
+        elif etype == "assistant":
+            self._on_assistant(obj, result)
+        elif etype == "user":
+            self._on_user(obj, result)
+        elif etype == "rate_limit_event":
+            self._on_rate_limit(obj)
+        elif etype == "result":
+            if post_result:
+                return False
+            self._on_result(obj, result)
+            return True
+        return False
+
+    def finish(self, result: TurnResult) -> None:
+        if not result.final_text:
+            if self._assistant_texts:
+                # The last text block is the answer; earlier ones were
+                # commentary around tool calls and were emitted as interim
+                # messages (and are all in projected_messages for history).
+                result.final_text = self._assistant_texts[-1].strip()
+            elif self._text_parts:
+                result.final_text = "".join(self._text_parts).strip()
+        if result.final_text and not result.projected_messages:
+            # Text-only turn whose `assistant` event we never saw (e.g. an
+            # interrupt cut the stream): still record what the user saw.
+            result.projected_messages.append(
+                {"role": "assistant", "content": result.final_text}
+            )
+
+    # -- handlers --
+
+    def _on_system(self, obj: dict, result: TurnResult) -> None:
+        if obj.get("subtype") != "init":
+            return
+        sid = obj.get("session_id")
+        if isinstance(sid, str) and sid:
+            self._s._session_id = sid
+            result.session_id = sid
+        self._s._init_info = obj
+        servers = obj.get("mcp_servers") or []
+        for server in servers:
+            if (
+                isinstance(server, dict)
+                and server.get("name") == HERMES_TOOLS_MCP_SERVER_NAME
+                and server.get("status") not in (None, "connected")
+            ):
+                logger.warning(
+                    "hermes-tools MCP server status=%s — Hermes tools may be "
+                    "unavailable inside claude", server.get("status"),
+                )
+        self._s._emit({"kind": "init", "session_id": sid, "info": obj})
+
+    def _on_stream_event(self, obj: dict) -> None:
+        ev = obj.get("event") or {}
+        if not isinstance(ev, dict) or ev.get("type") != "content_block_delta":
+            return
+        delta = ev.get("delta") or {}
+        if not isinstance(delta, dict):
+            return
+        dtype = delta.get("type")
+        if dtype == "text_delta":
+            text = delta.get("text")
+            if isinstance(text, str) and text:
+                self._text_parts.append(text)
+                self._saw_stream_text = True
+                if not self._silent:
+                    self._s._emit({"kind": "text_delta", "text": text})
+        elif dtype == "thinking_delta":
+            text = delta.get("thinking")
+            if isinstance(text, str) and text and not self._silent:
+                self._s._emit({"kind": "reasoning_delta", "text": text})
+
+    def _on_assistant(self, obj: dict, result: TurnResult) -> None:
+        msg = obj.get("message") or {}
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            return
+        texts: list[str] = []
+        tool_calls: list[dict] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                text = block.get("text")
+                if isinstance(text, str) and text.strip():
+                    texts.append(text)
+            elif btype == "tool_use":
+                call_id = str(block.get("id") or f"toolu_{uuid.uuid4().hex[:24]}")
+                wire_name = str(block.get("name") or "tool")
+                name = hermes_tool_name(wire_name)
+                args = block.get("input")
+                if not isinstance(args, dict):
+                    args = {"input": args}
+                tool_calls.append(
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": name, "arguments": _format_tool_args(args)},
+                    }
+                )
+                self._pending_tools[call_id] = {
+                    "name": name, "wire_name": wire_name, "args": args,
+                    "t0": time.monotonic(),
+                }
+                if not self._silent:
+                    self._s._emit(
+                        {
+                            "kind": "tool_started", "call_id": call_id, "name": name,
+                            "wire_name": wire_name, "args": args,
+                            "preview": _tool_preview(wire_name, args),
+                        }
+                    )
+        if not texts and not tool_calls:
+            return
+        joined = "\n".join(texts)
+        if tool_calls and self._pending_interim and not self._silent:
+            # Text that arrived in an earlier `assistant` event turned out to
+            # be commentary before a tool call: surface it as an interim
+            # message so chat surfaces show it before the tool bubble.
+            self._s._emit(
+                {"kind": "assistant_message", "text": self._pending_interim, "interim": True}
+            )
+            self._pending_interim = None
+        if texts:
+            self._assistant_texts.append(joined)
+            # Deltas already streamed this text live; the block is the
+            # authoritative copy for history. Reset the fallback buffer so a
+            # later text block isn't double-counted.
+            self._text_parts = []
+            if tool_calls:
+                if not self._silent:
+                    self._s._emit({"kind": "assistant_message", "text": joined, "interim": True})
+            else:
+                self._pending_interim = joined
+        message: dict[str, Any] = {"role": "assistant", "content": joined if texts else None}
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        result.projected_messages.append(message)
+
+    def _on_user(self, obj: dict, result: TurnResult) -> None:
+        msg = obj.get("message") or {}
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            return
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                continue
+            call_id = str(block.get("tool_use_id") or "")
+            text = _content_text(block.get("content"))
+            is_error = bool(block.get("is_error"))
+            pending = self._pending_tools.pop(call_id, None)
+            name = pending["name"] if pending else "tool"
+            if is_error and text and not text.startswith("[error]"):
+                text = f"[error] {text}"
+            result.projected_messages.append(
+                {"role": "tool", "tool_call_id": call_id, "content": text}
+            )
+            result.tool_iterations += 1
+            if not self._silent:
+                duration = (
+                    time.monotonic() - pending["t0"] if pending else None
+                )
+                self._s._emit(
+                    {
+                        "kind": "tool_completed", "call_id": call_id, "name": name,
+                        "args": pending["args"] if pending else {},
+                        "result": text, "is_error": is_error, "duration": duration,
+                    }
+                )
+
+    def _on_rate_limit(self, obj: dict) -> None:
+        info = obj.get("rate_limit_info") or {}
+        windows = info.get("unifiedWindows") if isinstance(info, dict) else None
+        if not isinstance(windows, dict):
+            return
+        worst, label = 0.0, ""
+        for name, window in windows.items():
+            if not isinstance(window, dict):
+                continue
+            util = window.get("utilization")
+            if isinstance(util, (int, float)) and util > worst:
+                worst, label = float(util), str(name).replace("_", " ")
+        if worst >= 0.9 and not self._silent:
+            self._s._emit(
+                {
+                    "kind": "status",
+                    "text": f"heads up — {int(worst * 100)}% of your {label} limit used",
+                }
+            )
+
+    def _on_result(self, obj: dict, result: TurnResult) -> None:
+        usage = obj.get("usage")
+        if isinstance(usage, dict) and usage:
+            result.token_usage_last = dict(usage)
+            if isinstance(obj.get("total_cost_usd"), (int, float)):
+                result.token_usage_last["total_cost_usd"] = obj["total_cost_usd"]
+        model_usage = obj.get("modelUsage")
+        if isinstance(model_usage, dict):
+            for entry in model_usage.values():
+                window = entry.get("contextWindow") if isinstance(entry, dict) else None
+                if isinstance(window, int) and window > 0:
+                    result.model_context_window = window
+                    break
+        text = obj.get("result")
+        if obj.get("is_error"):
+            detail = text if isinstance(text, str) and text else obj.get("subtype") or "unknown error"
+            result.error = self._s._format_error("claude turn failed", str(detail))
+            lowered = str(detail).lower()
+            if (
+                "not logged in" in lowered
+                or "failed to authenticate" in lowered
+                or "oauth" in lowered and "expired" in lowered
+                or "invalid api key" in lowered
+            ):
+                result.error = (
+                    f"{result.error}\nClaude Code credential rejected. Run "
+                    "`claude setup-token` and update $CLAUDE_CODE_OAUTH_TOKEN, "
+                    "then retry."
+                )
+                result.should_retire = True
+            return
+        subtype = obj.get("subtype")
+        if isinstance(subtype, str) and subtype.startswith("error"):
+            # e.g. error_max_turns / error_during_execution without is_error
+            result.error = self._s._format_error(f"claude turn ended with {subtype}")
+        if isinstance(text, str) and text.strip() and not self._assistant_texts:
+            result.final_text = text.strip()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -995,7 +995,8 @@ def build_turn_context(
         _preflight_deferred = _defer_preflight(_preflight_tokens)
         # Codex app-server threads are compacted by the codex agent itself;
         # Hermes only initiates compaction in "hermes" mode (#36801).
-        _codex_native_auto = (
+        # claude_code always compacts natively inside the CLI (#25267).
+        _codex_native_auto = getattr(agent, "api_mode", None) == "claude_code" or (
             getattr(agent, "api_mode", None) == "codex_app_server"
             and str(
                 getattr(
@@ -1044,9 +1045,12 @@ def build_turn_context(
                 _compress_block_reason = f"cooldown:{_cooldown_secs:.0f}"
         elif _codex_native_auto:
             logger.info(
-                "Skipping Hermes preflight compression for codex app-server "
+                "Skipping Hermes preflight compression for %s "
                 "(mode=%s); Hermes will not start thread compaction here.",
-                getattr(agent, "codex_app_server_auto_compaction", "native"),
+                getattr(agent, "api_mode", None),
+                "native"
+                if getattr(agent, "api_mode", None) == "claude_code"
+                else getattr(agent, "codex_app_server_auto_compaction", "native"),
             )
         else:
             _should_compress_now = _compressor.should_compress(_preflight_tokens)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -52,6 +52,8 @@ model:
   #   "nous-api"     - Nous Portal API key (requires: NOUS_API_KEY)
   #   "anthropic"    - Direct Anthropic API (requires: ANTHROPIC_API_KEY)
   #   "openai-codex" - OpenAI Codex (requires: hermes auth)
+  #   "claude-code-cli" - Claude subscription via the Claude Code CLI (requires: `claude` installed
+  #                    and CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`; see claude_code: below)
   #   "copilot"      - GitHub Copilot / GitHub Models (requires: GITHUB_TOKEN)
   #   "gemini"      - Use Google AI Studio direct (requires: GOOGLE_API_KEY or GEMINI_API_KEY)
   #   "zai"         - Use z.ai / ZhipuAI GLM models (requires: GLM_API_KEY)
@@ -244,6 +246,34 @@ model:
 #     models:
 #       gpt-5.4:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
+
+# =============================================================================
+# Claude Code CLI runtime (provider: claude-code-cli)
+# =============================================================================
+# Runs each turn through a Hermes-owned `claude -p` subprocess so a Claude
+# subscription works with real tool calls (Hermes tools are exposed to it over
+# stdio MCP). The child is isolated from the user's own Claude Code state
+# (own CLAUDE_CONFIG_DIR, cwd, settings, no auto-memory) and authenticates
+# with a long-lived setup-token, never the interactive keychain login.
+#
+# claude_code:
+#   binary: claude                  # path or name of the Claude Code CLI
+#   cwd: ~/.hermes/claude-code/workspace
+#   oauth_token_env: CLAUDE_CODE_OAUTH_TOKEN   # env var holding `claude setup-token` output
+#   permission_mode: ""             # override: acceptEdits | default | bypassPermissions
+#                                   # (default derives from tools.terminal.security_mode:
+#                                   #  auto -> acceptEdits + deny list, approval-required -> default
+#                                   #  with the permission bridge, unrestricted -> bypassPermissions)
+#   allowed_tools: []               # extra --allowedTools entries
+#   deny: []                        # seeds ~/.hermes/claude-code/settings.json permissions.deny
+#                                   # on first start, e.g. ["Bash(git push *)", "Bash(sudo *)"]
+#   expose_hermes_tools: true       # expose Hermes tools to the child over MCP
+#   resume: true                    # --resume the child's transcript across Hermes sessions
+#   turn_timeout: 1800              # seconds per turn before the child is retired
+#   silence_timeout: 300            # seconds without CLI output inside a turn
+#   idle_timeout: 600               # seconds a warm child is kept between turns
+#   max_sessions: 8                 # warm children kept at once (LRU eviction)
+#   extra_args: []                  # appended to the `claude` argv verbatim
 
 # =============================================================================
 # Unified Timeouts (operation deadlines)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -282,6 +282,16 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="oauth_external",
         inference_base_url=DEFAULT_QWEN_BASE_URL,
     ),
+    # Claude subscription driven through the `claude` CLI subprocess. No
+    # inference URL: the CLI owns the network and its own setup-token (#25267).
+    # NOTE: "claude-code" (no -cli) stays an alias of the anthropic API-key
+    # provider for backward compatibility.
+    "claude-code-cli": ProviderConfig(
+        id="claude-code-cli",
+        name="Claude Subscription (Claude Code CLI)",
+        auth_type="oauth_external",
+        inference_base_url="",
+    ),
     "lmstudio": ProviderConfig(
         id="lmstudio",
         name="LM Studio",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1312,6 +1312,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models via API key or Claude Code)"),
+    ProviderEntry("claude-code-cli", "Claude Subscription (Claude Code CLI)", "Claude Pro/Max subscription via the `claude` CLI subprocess (Claude Code native tools + Hermes tools over MCP)"),
     ProviderEntry("openai-codex",   "ChatGPT or Codex Subscription", "ChatGPT or Codex Subscription (Sign in with your ChatGPT account, uses Codex models)"),
     ProviderEntry("openai-api",     "OpenAI API",               "OpenAI API (api.openai.com, API key)"),
     ProviderEntry("alibaba",        "Qwen Cloud",               "Qwen Cloud / DashScope (Qwen + multi-provider)"),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -65,6 +65,14 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         auth_type="oauth_external",
         base_url_override="https://chatgpt.com/backend-api/codex",
     ),
+    # Claude subscription via the `claude` CLI subprocess (api_mode
+    # claude_code). No HTTP endpoint; the placeholder URL keeps catalog and
+    # doctor consumers that expect a base_url happy (#25267).
+    "claude-code-cli": HermesOverlay(
+        transport="claude_code",
+        auth_type="oauth_external",
+        base_url_override="claude-code://local",
+    ),
     "openai-api": HermesOverlay(
         transport="codex_responses",
         base_url_override="https://api.openai.com/v1",
@@ -444,6 +452,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "moa": "Mixture of Agents",
     "nous": "Nous Portal",
     "openai-codex": "ChatGPT or Codex Subscription",
+    "claude-code-cli": "Claude Subscription (Claude Code CLI)",
     "copilot-acp": "GitHub Copilot ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -427,6 +427,12 @@ def _copilot_runtime_api_mode(
         return "chat_completions"
 
 
+# Canonical id + aliases of the Claude Code CLI provider (kept in sync with
+# plugins/model-providers/claude-code/__init__.py).
+CLAUDE_CODE_CLI_PROVIDER_NAMES = frozenset(
+    {"claude-code-cli", "claude-subscription", "claude_code_cli"}
+)
+
 _VALID_API_MODES = {
     "chat_completions",
     "codex_responses",
@@ -438,6 +444,9 @@ _VALID_API_MODES = {
     # `model.openai_runtime == "codex_app_server"` AND provider in
     # {"openai", "openai-codex"}. Default is unchanged.
     "codex_app_server",
+    # Claude subscription through the official `claude` CLI (provider
+    # `claude-code-cli`). Selected by provider, not by a runtime switch (#25267).
+    "claude_code",
 }
 
 
@@ -1885,6 +1894,22 @@ def resolve_runtime_provider(
             "base_url": "moa://local",
             "api_key": "moa-virtual-provider",
             "source": "moa-virtual-provider",
+            "requested_provider": requested_provider,
+        }
+
+    # Claude subscription via the Claude Code CLI (#25267). There is no HTTP
+    # endpoint and no key here: the `claude` subprocess authenticates with the
+    # setup-token in $CLAUDE_CODE_OAUTH_TOKEN. Placeholders keep downstream
+    # "has credentials" checks satisfied without ever touching a real token.
+    # Aliases mirror the ProviderProfile so `--provider claude-subscription`
+    # cannot fall through to the OpenRouter/custom resolvers.
+    if requested_provider in CLAUDE_CODE_CLI_PROVIDER_NAMES:
+        return {
+            "provider": "claude-code-cli",
+            "api_mode": "claude_code",
+            "base_url": "claude-code://local",
+            "api_key": "claude-code-subscription",
+            "source": "claude-code-cli",
             "requested_provider": requested_provider,
         }
 

--- a/plugins/model-providers/claude-code/__init__.py
+++ b/plugins/model-providers/claude-code/__init__.py
@@ -1,0 +1,29 @@
+"""Claude subscription via the Claude Code CLI (``claude_code`` api_mode).
+
+Turns are handed to a long-lived, Hermes-owned ``claude -p`` subprocess that
+authenticates with a ``claude setup-token`` credential from
+``$CLAUDE_CODE_OAUTH_TOKEN`` — no API key, no keychain access, and no token
+is ever read out of the CLI. See ``agent/claude_code_runtime.py`` (#25267).
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+claude_code = ProviderProfile(
+    name="claude-code-cli",
+    aliases=("claude-subscription", "claude_code_cli"),
+    api_mode="claude_code",
+    auth_type="oauth_external",
+    env_vars=(),  # credential is CLAUDE_CODE_OAUTH_TOKEN, consumed by the CLI only
+    base_url="",  # no HTTP endpoint — the CLI owns the network
+    display_name="Claude (subscription via Claude Code)",
+    description=(
+        "Claude Pro/Max subscription through the official `claude` CLI, with "
+        "Claude Code's native tools plus Hermes tools over MCP"
+    ),
+    signup_url="https://claude.ai/",
+    supports_health_check=False,
+    fallback_models=("opus", "sonnet", "haiku"),
+)
+
+register_provider(claude_code)

--- a/plugins/model-providers/claude-code/plugin.yaml
+++ b/plugins/model-providers/claude-code/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-code-provider
+kind: model-provider
+version: 1.0.0
+description: Claude subscription via the Claude Code CLI (stream-json runtime)
+author: Nous Research

--- a/run_agent.py
+++ b/run_agent.py
@@ -3376,6 +3376,17 @@ class AIAgent:
                         "Failed to interrupt Codex app-server turn",
                         exc_info=True,
                     )
+        # Same for the Claude Code subprocess runtime (#25267).
+        if getattr(self, "api_mode", None) == "claude_code":
+            _cc_session = getattr(self, "_claude_code_session", None)
+            _cc_interrupt = getattr(_cc_session, "request_interrupt", None)
+            if callable(_cc_interrupt):
+                try:
+                    _cc_interrupt()
+                except Exception:
+                    logger.debug(
+                        "Failed to interrupt Claude Code turn", exc_info=True,
+                    )
 
         # A cron turn performs its API request on the conversation thread to
         # avoid the nested interrupt-worker deadlock.  Unlike the normal worker
@@ -4714,6 +4725,14 @@ class AIAgent:
             if codex_session is not None:
                 self._codex_session = None
                 codex_session.close()
+        except Exception:
+            pass
+        # 6d. Same ownership rule for the Claude Code subprocess (#25267).
+        try:
+            claude_code_session = getattr(self, "_claude_code_session", None)
+            if claude_code_session is not None:
+                self._claude_code_session = None
+                claude_code_session.close()
         except Exception:
             pass
 
@@ -9118,6 +9137,19 @@ class AIAgent:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+
+    def _run_claude_code_turn(
+        self,
+        *,
+        user_message: str,
+        original_user_message: Any,
+        messages: List[Dict[str, Any]],
+        effective_task_id: str,
+        should_review_memory: bool = False,
+    ) -> Dict[str, Any]:
+        """Forwarder — see ``agent.claude_code_runtime.run_claude_code_turn``."""
+        from agent.claude_code_runtime import run_claude_code_turn
+        return run_claude_code_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
 
 def main(
     query: str = None,

--- a/tests/agent/test_claude_code_runtime.py
+++ b/tests/agent/test_claude_code_runtime.py
@@ -1,0 +1,233 @@
+"""run_claude_code_turn — prompt combination and the warm-process registry.
+
+Drives the runtime with minimal agent stand-ins and the fake `claude` CLI so
+the two live gateway bugs stay fixed: the gateway's ephemeral system prompt
+must reach the child, and a session must keep ONE warm process across the
+per-request AIAgent instances api_server builds.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent import claude_code_runtime as rt
+
+_FAKE = Path(__file__).parent / "transports" / "fake_claude_cli.py"
+
+
+@pytest.fixture(autouse=True)
+def _env(tmp_path: Path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "fake-setup-token")
+    wrapper = tmp_path / "claude"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        f"exec {json.dumps(sys.executable)} {json.dumps(str(_FAKE))} \"$@\"\n"
+    )
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setattr(rt, "_claude_code_config", lambda: {"binary": str(wrapper), "expose_hermes_tools": False})
+    # Fresh registry per test.
+    with rt._REGISTRY_LOCK:
+        rt._REGISTRY.clear()
+    yield home
+    for key in list(rt._REGISTRY):
+        rt.evict_session(key)
+
+
+def _agent(session_id: str, *, cached="BASE-PROMPT", ephemeral=None) -> SimpleNamespace:
+    """The attributes run_claude_code_turn touches on a real AIAgent."""
+    a = SimpleNamespace(
+        session_id=session_id,
+        _cached_system_prompt=cached,
+        ephemeral_system_prompt=ephemeral,
+        model="sonnet",
+        api_mode="claude_code",
+        provider="claude-code-cli",
+        base_url="claude-code://local",
+        api_key="x",
+        _interrupt_requested=False,
+        _interrupt_message=None,
+        _skill_nudge_interval=0,
+        _iters_since_skill=0,
+        valid_tool_names=set(),
+        _session_db=None,
+        session_api_calls=0,
+        session_prompt_tokens=0, session_completion_tokens=0, session_total_tokens=0,
+        session_input_tokens=0, session_output_tokens=0,
+        session_cache_read_tokens=0, session_cache_write_tokens=0,
+        session_cost_status=None, session_cost_source=None,
+        context_compressor=None,
+        show_commentary=True,
+    )
+    a.clear_interrupt = lambda: None
+    a._sync_external_memory_for_turn = lambda **kw: None
+    a._spawn_background_review = lambda **kw: None
+    return a
+
+
+def _turn(agent, text="hello"):
+    messages = [{"role": "user", "content": text}]
+    return rt.run_claude_code_turn(
+        agent, user_message=text, original_user_message=text,
+        messages=messages, effective_task_id="t",
+    )
+
+
+def _prompt_file_text(session) -> str:
+    return Path(session._system_prompt_path).read_text()
+
+
+class TestEphemeralPrompt:
+    def test_ephemeral_prompt_reaches_the_child(self):
+        agent = _agent("s1", ephemeral="MARKER-EPH")
+        result = _turn(agent)
+        assert result["completed"] is True
+        text = _prompt_file_text(agent._claude_code_session)
+        assert text == "BASE-PROMPT\n\nMARKER-EPH"  # same join as conversation_loop
+        assert agent._claude_code_session.system_prompt == rt.combined_system_prompt(agent)
+
+    def test_changed_ephemeral_prompt_respawns_with_new_content(self):
+        first = _agent("s2", ephemeral="MARKER-ONE")
+        _turn(first)
+        session = first._claude_code_session
+        pid_one = session.pid
+        second = _agent("s2", ephemeral="MARKER-TWO")
+        _turn(second)
+        assert second._claude_code_session is session  # same registry entry
+        assert session.pid != pid_one  # respawned
+        assert _prompt_file_text(session).endswith("MARKER-TWO")
+
+
+class TestRegistry:
+    def test_two_agent_instances_share_one_process(self):
+        a1 = _agent("shared", ephemeral="E")
+        r1 = _turn(a1, "one")
+        pid = a1._claude_code_session.pid
+        a2 = _agent("shared", ephemeral="E")
+        r2 = _turn(a2, "two")
+        assert r1["completed"] and r2["completed"]
+        assert a2._claude_code_session is a1._claude_code_session
+        assert a2._claude_code_session.pid == pid  # one spawn, same pid
+        assert rt.registered_session_count() == 1
+
+    def test_different_sessions_get_different_processes(self):
+        a1, a2 = _agent("A"), _agent("B")
+        _turn(a1)
+        _turn(a2)
+        assert a1._claude_code_session is not a2._claude_code_session
+        assert a1._claude_code_session.pid != a2._claude_code_session.pid
+        assert rt.registered_session_count() == 2
+
+    def test_idle_timeout_evicts(self):
+        a = _agent("idle")
+        _turn(a)
+        session = a._claude_code_session
+        assert session.is_alive()
+        assert rt.sweep_idle_sessions(0.0, now=time.monotonic() + 1) == 1
+        assert rt.registered_session_count() == 0
+        assert not session.is_alive()
+        # Next turn for that session rebuilds transparently.
+        b = _agent("idle")
+        assert _turn(b)["completed"] is True
+        assert b._claude_code_session is not session
+
+    def test_retire_evicts(self):
+        a = _agent("crash")
+        result = _turn(a, "please CRASH")
+        assert result["completed"] is False
+        assert rt.registered_session_count() == 0
+        assert a._claude_code_session is None
+
+    def test_hooks_rebound_to_the_current_agent(self):
+        a1 = _agent("hooks")
+        seen1, seen2 = [], []
+        a1._fire_stream_delta = seen1.append
+        _turn(a1, "first")
+        a2 = _agent("hooks")
+        a2._fire_stream_delta = seen2.append
+        _turn(a2, "second")
+        assert "".join(seen1) == "echo: first"
+        assert "".join(seen2) == "echo: second"
+
+
+class TestRegistryHardening:
+    def test_retire_happens_under_the_turn_lock(self, monkeypatch, tmp_path):
+        """A waiter on a retired session must get a fresh process, never the
+        one being closed underneath it."""
+        import threading
+
+        cfg = rt._claude_code_config()
+        monkeypatch.setattr(rt, "_claude_code_config", lambda: {**cfg, "turn_timeout": 1.0, "silence_timeout": 0.4})
+        a = _agent("retire")
+        _turn(a, "warm")
+        first_pid = a._claude_code_session.pid
+        results = {}
+
+        def waiter():
+            b = _agent("retire")
+            results["b"] = _turn(b, "after")
+            results["pid"] = b._claude_code_session.pid
+
+        t = threading.Thread(target=waiter)
+        # A's turn hangs -> silence timeout -> should_retire; B is queued on the lock.
+        import time as _t
+        threading.Timer(0.1, t.start).start()
+        ra = _turn(a, "HANG")
+        t.join(timeout=30)
+        assert ra["completed"] is False and "no output" in (ra["error"] or "")
+        assert results["b"]["completed"] is True
+        assert "exited unexpectedly" not in (results["b"]["error"] or "")
+        assert results["pid"] != first_pid
+
+    def test_max_sessions_lru_eviction(self, monkeypatch, caplog):
+        cfg = rt._claude_code_config()
+        monkeypatch.setattr(rt, "_claude_code_config", lambda: {**cfg, "max_sessions": 2})
+        a1, a2, a3 = _agent("L1"), _agent("L2"), _agent("L3")
+        _turn(a1); _turn(a2)
+        s1 = a1._claude_code_session
+        with caplog.at_level("INFO", logger="agent.claude_code_runtime"):
+            _turn(a3)
+        assert rt.registered_session_count() == 2
+        assert not s1.is_alive()
+        assert "evicting LRU session L1" in caplog.text
+        with rt._REGISTRY_LOCK:
+            assert set(rt._REGISTRY) == {"L2", "L3"}
+
+    def test_respawn_rate_guard_warns_once(self, caplog):
+        with caplog.at_level("WARNING", logger="agent.claude_code_runtime"):
+            for i in range(6):
+                _turn(_agent("dyn", ephemeral=f"per-request-{i}"))
+        warnings = [r for r in caplog.records if "changes every request" in r.getMessage()]
+        assert len(warnings) == 1
+
+    def test_shutdown_registry_closes_children_and_temp_files(self):
+        a = _agent("exit")
+        _turn(a)
+        s = a._claude_code_session
+        prompt = s._system_prompt_path
+        assert prompt and Path(prompt).exists()
+        rt._shutdown_registry()
+        assert rt.registered_session_count() == 0
+        assert not s.is_alive()
+        assert not Path(prompt).exists()
+
+    def test_prune_stale_temp_files(self, tmp_path):
+        import os, time as _t
+        cfg = tmp_path / "cc"
+        cfg.mkdir()
+        old = cfg / "system-prompt-old.md"; old.write_text("x")
+        old_mcp = cfg / "hermes-claude-mcp-old.json"; old_mcp.write_text("{}")
+        fresh = cfg / "system-prompt-new.md"; fresh.write_text("y")
+        stale = _t.time() - 2 * 24 * 3600
+        os.utime(old, (stale, stale)); os.utime(old_mcp, (stale, stale))
+        assert rt.prune_stale_temp_files(str(cfg)) == 2
+        assert fresh.exists() and not old.exists() and not old_mcp.exists()

--- a/tests/agent/transports/fake_claude_cli.py
+++ b/tests/agent/transports/fake_claude_cli.py
@@ -1,0 +1,239 @@
+"""A stand-in for the ``claude`` CLI that speaks stream-json from canned fixtures.
+
+Used by ``test_claude_code_session.py`` so the session adapter can be driven
+end-to-end (real subprocess, real pipes, real reader threads) without the
+Claude Code binary or a subscription.
+
+Protocol facts it reproduces on purpose:
+
+* Emits NOTHING until the first user message arrives on stdin (the real CLI
+  does the same — see ClaudeCodeSession.ensure_started).
+* ``system/init`` is sent once, right before the first turn's events.
+* Text turns stream ``stream_event`` text deltas, then the ``assistant``
+  message, then ``result``.
+* A message containing ``TOOL`` performs an MCP tool call:
+  ``assistant`` (tool_use) -> ``user`` (tool_result) -> ``assistant`` (text)
+  -> ``result``.
+* ``TRAILER`` appends a ``rate_limit_event`` immediately after ``result`` in
+  the same flush (drain test).
+* ``CRASH`` exits with status 3 without a ``result``.
+* ``HANG`` never answers until a ``control_request`` interrupt arrives, then
+  emits a ``result``.
+* ``PERM`` (only when ``--permission-prompt-tool stdio`` is on argv) asks
+  permission for a Bash call via ``control_request/can_use_tool`` and waits
+  for the ``control_response``: allow -> ``tool_result`` "PERM-RAN";
+  deny -> ``tool_result`` ``is_error`` carrying the message.
+* With ``FAKE_CLAUDE_REJECT_RESUME=1`` and ``--resume`` on argv the fake
+  answers the first user message with an error ``result`` ("No conversation
+  found"), like the real CLI does for an unusable transcript. With
+  ``--session-id`` naming an id listed in ``FAKE_CLAUDE_USED_IDS``
+  (comma-separated) it exits 1 with "already in use", also like the CLI.
+
+Argv and environment are recorded to ``$FAKE_CLAUDE_RECORD`` (JSON) so the
+tests can assert on the spawn contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+SESSION_ID = "sess-fake-0001"
+
+
+def _emit(obj: dict) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def _text_turn(text: str, *, trailer: bool = False) -> None:
+    for i in range(0, len(text), 4):
+        _emit(
+            {
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": text[i:i + 4]},
+                },
+            }
+        )
+    _emit(
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+            "session_id": SESSION_ID,
+        }
+    )
+    _result(text)
+    if trailer:
+        _emit(
+            {
+                "type": "rate_limit_event",
+                "rate_limit_info": {"unifiedWindows": {"five_hour": {"utilization": 0.1}}},
+            }
+        )
+
+
+def _result(text: str, *, is_error: bool = False) -> None:
+    _emit(
+        {
+            "type": "result",
+            "subtype": "success" if not is_error else "error_during_execution",
+            "is_error": is_error,
+            "result": text,
+            "session_id": SESSION_ID,
+            "num_turns": 1,
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 5,
+                "cache_read_input_tokens": 100,
+                "cache_creation_input_tokens": 7,
+            },
+            "total_cost_usd": 0.0,
+            "modelUsage": {"claude-fake": {"contextWindow": 200000}},
+        }
+    )
+
+
+def _tool_turn() -> None:
+    _emit(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Let me search."},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_fake_1",
+                        "name": "mcp__hermes-tools__web_search",
+                        "input": {"query": "swift version"},
+                    },
+                ],
+            },
+        }
+    )
+    _emit(
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_fake_1",
+                        "content": [{"type": "text", "text": "Swift 6.2"}],
+                    }
+                ],
+            },
+        }
+    )
+    _text_turn("The version is 6.2")
+
+
+def main() -> int:
+    record = os.environ.get("FAKE_CLAUDE_RECORD")
+    if record:
+        with open(record, "w", encoding="utf-8") as fh:
+            json.dump(
+                {"argv": sys.argv[1:], "env": dict(os.environ), "pid": os.getpid(), "cwd": os.getcwd()},
+                fh,
+            )
+
+    argv = sys.argv[1:]
+    prompt_tool = "--permission-prompt-tool" in argv
+    resume_id = argv[argv.index("--resume") + 1] if "--resume" in argv else None
+    reject_resume = resume_id is not None and (
+        os.environ.get("FAKE_CLAUDE_REJECT_RESUME") == "1"
+        or os.environ.get("FAKE_CLAUDE_REJECT_RESUME_ID") == resume_id
+    )
+    if "--session-id" in argv:
+        sid = argv[argv.index("--session-id") + 1]
+        used = [x for x in os.environ.get("FAKE_CLAUDE_USED_IDS", "").split(",") if x]
+        if sid in used:
+            sys.stderr.write(f"Error: Session ID {sid} is already in use.\n")
+            return 1
+
+    inited = False
+    hanging = False
+    pending_perm = None
+    for raw in sys.stdin:
+        line = raw.strip()
+        if not line:
+            continue
+        msg = json.loads(line)
+        if msg.get("type") == "control_request":
+            if hanging and (msg.get("request") or {}).get("subtype") == "interrupt":
+                hanging = False
+                _emit({"type": "control_response", "response": {"subtype": "success", "request_id": msg.get("request_id")}})
+                _result("interrupted")
+            continue
+        if msg.get("type") == "control_response":
+            resp = (msg.get("response") or {})
+            if pending_perm and resp.get("request_id") == pending_perm:
+                pending_perm = None
+                inner = resp.get("response") or {}
+                if inner.get("behavior") == "allow":
+                    _emit({"type": "user", "message": {"role": "user", "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_perm_1", "content": "PERM-RAN", "is_error": False}]}})
+                    _text_turn("ran it")
+                else:
+                    _emit({"type": "user", "message": {"role": "user", "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_perm_1",
+                         "content": inner.get("message") or "denied", "is_error": True}]}})
+                    _text_turn("it was denied")
+            continue
+        if msg.get("type") != "user":
+            continue
+        if not inited:
+            inited = True
+            _emit(
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "session_id": SESSION_ID,
+                    "tools": ["Bash", "Read", "ToolSearch"],
+                    "mcp_servers": [{"name": "hermes-tools", "status": "connected"}],
+                    "model": "claude-fake",
+                    "permissionMode": "acceptEdits",
+                }
+            )
+        content = msg["message"]["content"]
+        text = "".join(b.get("text", "") for b in content if isinstance(b, dict))
+        if reject_resume:
+            sys.stderr.write("No conversation found with session ID\n"); sys.stderr.flush()
+            _result("No conversation found with session ID", is_error=True)
+            continue
+        if os.environ.get("FAKE_CLAUDE_FAIL_WARMUP") == "auth":
+            _result("Failed to authenticate: OAuth session expired and could not be refreshed", is_error=True)
+            continue
+        if "PERM" in text and prompt_tool:
+            _emit({"type": "assistant", "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "toolu_perm_1", "name": "Bash",
+                 "input": {"command": "touch marker", "description": "make a marker"}}]}})
+            pending_perm = "req-perm-1"
+            _emit({"type": "control_request", "request_id": pending_perm, "request": {
+                "subtype": "can_use_tool", "tool_name": "Bash", "display_name": "Bash",
+                "input": {"command": "touch marker", "description": "make a marker"},
+                "description": "make a marker", "permission_suggestions": [], "tool_use_id": "toolu_perm_1"}})
+            continue
+        if "CRASH" in text:
+            sys.stdout.flush()
+            os._exit(3)
+        if "HANG" in text:
+            hanging = True
+            continue
+        if "TOOL" in text:
+            _tool_turn()
+        elif "ready" in text:
+            _text_turn("ready")
+        else:
+            _text_turn(f"echo: {text}", trailer="TRAILER" in text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent/transports/test_claude_code_session.py
+++ b/tests/agent/transports/test_claude_code_session.py
@@ -1,0 +1,601 @@
+"""Tests for ClaudeCodeSession — drive turns through a fake ``claude`` binary.
+
+The fake (``fake_claude_cli.py``) is a real subprocess speaking stream-json
+over real pipes, so these tests cover the parts that a mocked client cannot:
+the warm-up-before-init handshake, reader-thread EOF/identity handling,
+post-result draining, interrupt via the control channel, and retirement on
+an unexpected exit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import stat
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from agent.transports import claude_code_session as session_mod
+from agent.transports.claude_code_session import (
+    DEFAULT_DENY_RULES,
+    SETTINGS_MARKER_KEY,
+    ClaudeCodeSession,
+    build_child_env,
+    ensure_settings_file,
+    hermes_tool_name,
+    resolve_oauth_token,
+    resolve_permission,
+    resume_transcript_exists,
+    write_mcp_config,
+)
+
+_FAKE = Path(__file__).with_name("fake_claude_cli.py")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path: Path, monkeypatch):
+    """Every session in these tests gets a scratch HERMES_HOME (so the
+    Hermes-owned CLAUDE_CONFIG_DIR lands under tmp) and a fake setup-token."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "fake-setup-token")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-must-not-leak")
+    return home
+
+
+@pytest.fixture
+def fake_claude(tmp_path: Path):
+    """Return (claude_bin, record_path): a wrapper script + where the fake
+    dumps its argv/env."""
+    record = tmp_path / "record.json"
+    wrapper = tmp_path / "claude"
+    wrapper.write_text(
+        "#!/bin/sh\n"
+        f"export FAKE_CLAUDE_RECORD={json.dumps(str(record))}\n"
+        f"exec {json.dumps(sys.executable)} {json.dumps(str(_FAKE))} \"$@\"\n"
+    )
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+    return str(wrapper), record
+
+
+def _session(fake_claude, **kwargs) -> ClaudeCodeSession:
+    claude_bin, _ = fake_claude
+    events: list[dict] = []
+    kwargs.setdefault("on_event", events.append)
+    kwargs.setdefault("expose_hermes_tools", False)
+    kwargs.setdefault("startup_timeout", 20.0)
+    session = ClaudeCodeSession(claude_bin=claude_bin, **kwargs)
+    session._test_events = events  # type: ignore[attr-defined]
+    return session
+
+
+class TestStaticHelpers:
+    def test_child_env_strips_api_keys_and_guarantees_identity(self):
+        env = build_child_env(
+            {"ANTHROPIC_API_KEY": "sk-ant-should-not-leak", "ANTHROPIC_AUTH_TOKEN": "x", "PATH": "/usr/bin"},
+            config_dir="/cfg",
+        )
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_AUTH_TOKEN" not in env
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "fake-setup-token"
+        assert env["CLAUDE_CONFIG_DIR"] == "/cfg"
+        assert env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] == "1"
+        assert env["USER"] and env["LOGNAME"] == env["USER"]
+        assert env["HOME"]
+
+    @pytest.mark.parametrize(
+        "mode, expected_mode, must_allow",
+        [
+            ("auto", "acceptEdits", "Bash"),
+            ("approval-required", "default", "Read"),
+            ("unrestricted", "bypassPermissions", None),
+            ("yolo", "bypassPermissions", None),
+            (None, "acceptEdits", "Bash"),
+        ],
+    )
+    def test_permission_mapping(self, mode, expected_mode, must_allow):
+        got_mode, allowed = resolve_permission(mode)
+        assert got_mode == expected_mode
+        if must_allow:
+            assert must_allow in allowed
+
+    def test_unknown_security_mode_fails_closed(self):
+        got_mode, allowed = resolve_permission("garbage")
+        assert got_mode == "default"  # approval-required mapping, never auto/bypass
+        assert "Bash" not in allowed and "Write" not in allowed
+
+    def test_oauth_token_is_required(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        with pytest.raises(RuntimeError, match="claude setup-token"):
+            resolve_oauth_token()
+        monkeypatch.setenv("MY_TOKEN", "abc")
+        assert resolve_oauth_token("MY_TOKEN") == "abc"
+
+    def test_settings_file_written_once_with_default_deny_list(self, tmp_path):
+        path = str(tmp_path / "cc" / "settings.json")
+        ensure_settings_file(path)
+        data = json.loads(Path(path).read_text())
+        assert data["permissions"]["deny"] == list(DEFAULT_DENY_RULES)
+        assert "Bash(git push *)" in data["permissions"]["deny"]
+        assert SETTINGS_MARKER_KEY in data
+        # User edits survive: a second call with different rules is a no-op.
+        Path(path).write_text('{"permissions": {"deny": ["Bash(custom *)"]}}')
+        ensure_settings_file(path, ["Bash(other *)"])
+        assert json.loads(Path(path).read_text())["permissions"]["deny"] == ["Bash(custom *)"]
+
+    def test_resume_transcript_lookup(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        sid = "11111111-2222-4333-8444-555555555555"
+        assert resume_transcript_exists(str(cfg), sid) is False
+        (cfg / "projects" / "-some-cwd").mkdir(parents=True)
+        (cfg / "projects" / "-some-cwd" / f"{sid}.jsonl").write_text("{}\n")
+        assert resume_transcript_exists(str(cfg), sid) is True
+
+    def test_approval_required_never_preapproves_bash(self):
+        _, allowed = resolve_permission("approval-required")
+        assert "Bash" not in allowed and "Write" not in allowed
+
+    def test_hermes_tool_name_strips_mcp_prefix(self):
+        assert hermes_tool_name("mcp__hermes-tools__web_search") == "web_search"
+        assert hermes_tool_name("Bash") == "Bash"
+
+    def test_mcp_config_launches_hermes_tools_server(self, tmp_path):
+        path = write_mcp_config(directory=str(tmp_path))
+        payload = json.loads(Path(path).read_text())
+        server = payload["mcpServers"]["hermes-tools"]
+        assert server["command"] == sys.executable
+        assert server["args"] == ["-m", "agent.transports.hermes_tools_mcp_server"]
+        # Secrets are inherited from the process env, never written to disk.
+        assert not any(k.endswith("_API_KEY") for k in server["env"])
+
+
+class TestLifecycle:
+    def test_warmup_is_sent_before_init_and_surfaces_session_id(self, fake_claude):
+        session = _session(fake_claude, system_prompt="SYS-PROMPT", model="sonnet")
+        try:
+            sid = session.ensure_started()
+            assert sid == "sess-fake-0001"
+            assert session.init_info["mcp_servers"][0]["status"] == "connected"
+            # The fake emits init only after it has read a user line, so the
+            # only way init_info is populated is warm-up -> init -> result.
+            _, record = fake_claude
+            rec = json.loads(record.read_text())
+            argv = rec["argv"]
+            assert argv[:2] == ["-p", "--verbose"]
+            assert "--input-format" in argv and "stream-json" in argv
+            assert "--include-partial-messages" in argv
+            prompt_file = argv[argv.index("--append-system-prompt-file") + 1]
+            assert Path(prompt_file).read_text() == "SYS-PROMPT"
+            assert argv[argv.index("--model") + 1] == "sonnet"
+            assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
+            assert "ANTHROPIC_API_KEY" not in rec["env"]
+            assert rec["env"]["USER"]
+            # Warm-up is silent: nothing reached the UI hook except init.
+            kinds = {e["kind"] for e in session._test_events}
+            assert kinds == {"init"}
+            assert session.ensure_started() == sid  # idempotent
+        finally:
+            session.close()
+
+    def test_child_is_hermes_owned_claude_code(self, fake_claude, _isolated_hermes_home):
+        """HIGH-2: exact argv + env of the isolation contract."""
+        home = _isolated_hermes_home
+        session = _session(fake_claude, system_prompt="SYS", expose_hermes_tools=True)
+        try:
+            session.ensure_started()
+            _, record = fake_claude
+            rec = json.loads(record.read_text())
+            argv, env = rec["argv"], rec["env"]
+            cfg_dir = str(home / "claude-code")
+            assert env["CLAUDE_CONFIG_DIR"] == cfg_dir
+            assert env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] == "1"
+            assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "fake-setup-token"
+            assert "ANTHROPIC_API_KEY" not in env and "ANTHROPIC_AUTH_TOKEN" not in env
+            assert env["HOME"] and env["USER"] and env["LOGNAME"]
+            assert rec["cwd"] == str(home / "claude-code" / "workspace")
+            assert argv[argv.index("--setting-sources") + 1] == ""
+            assert argv[argv.index("--settings") + 1] == str(home / "claude-code" / "settings.json")
+            assert "--strict-mcp-config" in argv
+            assert argv[argv.index("--session-id") + 1] == session.requested_session_id
+            assert "--resume" not in argv
+            # Prompt travels through a file inside the Hermes-owned dir, not argv.
+            assert "--append-system-prompt" not in argv
+            prompt_file = argv[argv.index("--append-system-prompt-file") + 1]
+            assert prompt_file.startswith(cfg_dir)
+            assert Path(prompt_file).read_text() == "SYS"
+            # The deny list was materialised.
+            settings = json.loads((home / "claude-code" / "settings.json").read_text())
+            assert "Bash(git push *)" in settings["permissions"]["deny"]
+        finally:
+            session.close()
+        assert not Path(prompt_file).exists()
+
+    def test_resumes_existing_transcript(self, fake_claude, _isolated_hermes_home):
+        sid = "11111111-2222-4333-8444-555555555555"
+        cfg = _isolated_hermes_home / "claude-code" / "projects" / "-ws"
+        cfg.mkdir(parents=True)
+        (cfg / f"{sid}.jsonl").write_text("{}\n")
+        session = _session(fake_claude, session_id=sid)
+        try:
+            session.ensure_started()
+            _, record = fake_claude
+            argv = json.loads(record.read_text())["argv"]
+            assert argv[argv.index("--resume") + 1] == sid
+            assert "--session-id" not in argv
+            assert session.resumed is True
+        finally:
+            session.close()
+
+    def test_approval_required_without_approver_warns_once(self, fake_claude):
+        session = _session(fake_claude, security_mode="approval-required")
+        try:
+            session.ensure_started()
+            statuses = [e["text"] for e in session._test_events if e["kind"] == "status"]
+            assert statuses and "no interactive approver" in statuses[0]
+            _, record = fake_claude
+            argv = json.loads(record.read_text())["argv"]
+            assert argv[argv.index("--permission-mode") + 1] == "default"
+            assert argv[argv.index("--permission-prompt-tool") + 1] == "stdio"
+            assert "Bash" not in argv[argv.index("--allowedTools") + 1].split(",")
+        finally:
+            session.close()
+
+    def test_resume_rejected_rotates_to_fresh_id_and_persists(self, fake_claude, _isolated_hermes_home, monkeypatch):
+        sid = "11111111-2222-4333-8444-555555555555"
+        cfg = _isolated_hermes_home / "claude-code"
+        (cfg / "projects" / "-ws").mkdir(parents=True)
+        (cfg / "projects" / "-ws" / f"{sid}.jsonl").write_text("{}\n")
+        monkeypatch.setenv("FAKE_CLAUDE_REJECT_RESUME", "1")
+        # The real CLI refuses --session-id for an id whose transcript exists.
+        monkeypatch.setenv("FAKE_CLAUDE_USED_IDS", sid)
+        session = _session(fake_claude, session_id=sid, session_key="hermes-sess-1")
+        try:
+            session.ensure_started()
+            new_id = session.requested_session_id
+            assert new_id != sid and session.resumed is False
+            result = session.run_turn("after fallback")
+            assert result.error is None and result.final_text == "echo: after fallback"
+            mapping = json.loads((cfg / "hermes-sessions.json").read_text())
+            assert mapping == {"hermes-sess-1": new_id}
+        finally:
+            session.close()
+        # A later session for the same Hermes session picks up the rotated id.
+        monkeypatch.delenv("FAKE_CLAUDE_REJECT_RESUME")
+        again = _session(fake_claude, session_id=sid, session_key="hermes-sess-1")
+        try:
+            assert again.requested_session_id == new_id
+            again.ensure_started()
+            assert again.run_turn("hello").final_text == "echo: hello"
+        finally:
+            again.close()
+
+    def test_mcp_config_flag_and_allowlist(self, fake_claude, tmp_path):
+        session = _session(fake_claude, expose_hermes_tools=True)
+        try:
+            session.ensure_started()
+            _, record = fake_claude
+            argv = json.loads(record.read_text())["argv"]
+            mcp_path = argv[argv.index("--mcp-config") + 1]
+            assert Path(mcp_path).exists()
+            allowed = argv[argv.index("--allowedTools") + 1].split(",")
+            assert "mcp__hermes-tools" in allowed and "Bash" in allowed
+        finally:
+            session.close()
+        assert not Path(mcp_path).exists()  # temp file cleaned on close
+
+    def test_bypass_permissions_only_when_unrestricted(self, fake_claude):
+        session = _session(fake_claude, security_mode="unrestricted")
+        try:
+            session.ensure_started()
+            _, record = fake_claude
+            argv = json.loads(record.read_text())["argv"]
+            assert argv[argv.index("--permission-mode") + 1] == "bypassPermissions"
+            assert "--allowedTools" not in argv
+        finally:
+            session.close()
+
+    def test_close_idempotent_and_kills_process(self, fake_claude):
+        session = _session(fake_claude)
+        session.ensure_started()
+        assert session.is_alive()
+        session.close()
+        session.close()
+        assert not session.is_alive()
+
+
+class TestRunTurn:
+    def test_text_turn_projects_message_and_streams_deltas(self, fake_claude):
+        session = _session(fake_claude)
+        try:
+            session.ensure_started()
+            result = session.run_turn("hello there")
+            assert result.error is None
+            assert result.final_text == "echo: hello there"
+            assert result.projected_messages == [
+                {"role": "assistant", "content": "echo: hello there"}
+            ]
+            assert result.tool_iterations == 0
+            assert result.session_id == "sess-fake-0001"
+            assert result.token_usage_last["cache_read_input_tokens"] == 100
+            assert result.model_context_window == 200000
+            deltas = "".join(
+                e["text"] for e in session._test_events if e["kind"] == "text_delta"
+            )
+            assert deltas == "echo: hello there"
+        finally:
+            session.close()
+
+    def test_tool_use_is_projected_as_tool_calls_and_tool_result(self, fake_claude):
+        session = _session(fake_claude)
+        try:
+            session.ensure_started()
+            result = session.run_turn("please TOOL")
+            assert result.error is None
+            assert result.tool_iterations == 1
+            assert result.final_text == "The version is 6.2"
+            roles = [m["role"] for m in result.projected_messages]
+            assert roles == ["assistant", "tool", "assistant"]
+            call = result.projected_messages[0]["tool_calls"][0]
+            assert call["id"] == "toolu_fake_1"
+            assert call["function"]["name"] == "web_search"  # MCP prefix stripped
+            assert json.loads(call["function"]["arguments"]) == {"query": "swift version"}
+            tool_msg = result.projected_messages[1]
+            assert tool_msg["tool_call_id"] == "toolu_fake_1"
+            assert tool_msg["content"] == "Swift 6.2"
+            kinds = [e["kind"] for e in session._test_events]
+            assert "tool_started" in kinds and "tool_completed" in kinds
+            started = next(e for e in session._test_events if e["kind"] == "tool_started")
+            assert started["wire_name"] == "mcp__hermes-tools__web_search"
+            assert started["name"] == "web_search"
+            interim = [e for e in session._test_events if e["kind"] == "assistant_message"]
+            assert interim and interim[0]["text"] == "Let me search."
+        finally:
+            session.close()
+
+    def test_stdout_is_drained_before_turn_is_declared_finished(self, fake_claude):
+        session = _session(fake_claude)
+        try:
+            session.ensure_started()
+            result = session.run_turn("say TRAILER")
+            assert result.error is None
+            # The fake flushed a rate_limit_event right behind `result`; it
+            # must be consumed now, not surface at the start of the next turn.
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline and not session._lines.empty():
+                time.sleep(0.01)
+            assert session._lines.empty()
+            follow_up = session.run_turn("second")
+            assert follow_up.final_text == "echo: second"
+        finally:
+            session.close()
+
+    def test_same_process_serves_consecutive_turns(self, fake_claude):
+        session = _session(fake_claude)
+        try:
+            session.ensure_started()
+            pid = session.pid
+            session.run_turn("one")
+            session.run_turn("two")
+            assert session.pid == pid and session.is_alive()
+        finally:
+            session.close()
+
+
+class TestRetirement:
+    def test_nonzero_exit_mid_turn_retires_session(self, fake_claude):
+        session = _session(fake_claude)
+        try:
+            session.ensure_started()
+            result = session.run_turn("please CRASH")
+            assert result.should_retire is True
+            assert result.error and "exited unexpectedly (code 3)" in result.error
+            assert not session.is_alive()
+            # A subsequent turn on the dead process fails fast, no hang.
+            again = session.run_turn("hello")
+            assert again.should_retire is True and again.error
+        finally:
+            session.close()
+
+    def test_stale_reader_exit_does_not_poison_replacement(self, fake_claude):
+        session = _session(fake_claude)
+        try:
+            session.ensure_started()
+            old_pid = session.pid
+            old_reader = session._reader_thread
+            assert old_reader is not None
+            session.restart(system_prompt="NEW-PROMPT")
+            assert session.pid != old_pid
+            # Let the retired process' reader hit EOF and run its finally.
+            old_reader.join(timeout=5)
+            assert not old_reader.is_alive()
+            # Identity check: the stale EOF must not have been enqueued for
+            # the healthy replacement.
+            assert not any(
+                item is session_mod._EOF for item in list(session._lines.queue)
+            )
+            result = session.run_turn("after restart")
+            assert result.error is None and result.final_text == "echo: after restart"
+            assert session.needs_respawn("NEW-PROMPT") is False
+        finally:
+            session.close()
+
+    def test_interrupt_unblocks_turn(self, fake_claude):
+        session = _session(fake_claude)
+        try:
+            session.ensure_started()
+            box: queue.Queue = queue.Queue()
+
+            def _run():
+                box.put(session.run_turn("HANG forever", turn_timeout=30, idle_timeout=30))
+
+            t = threading.Thread(target=_run, daemon=True)
+            t.start()
+            time.sleep(0.3)
+            started = time.monotonic()
+            session.request_interrupt()
+            result = box.get(timeout=10)
+            assert result.interrupted is True
+            assert time.monotonic() - started < 8
+            # The CLI answered the interrupt itself, so the process is reusable.
+            assert session.is_alive()
+            assert session.run_turn("still here").final_text == "echo: still here"
+        finally:
+            session.close()
+
+    def test_idle_timeout_retires(self, fake_claude):
+        session = _session(fake_claude)
+        try:
+            session.ensure_started()
+            result = session.run_turn("HANG", turn_timeout=5, idle_timeout=0.3)
+            assert result.should_retire is True
+            assert "no output" in (result.error or "")
+        finally:
+            session.close()
+
+
+class TestPermissionPrompt:
+    """``--permission-prompt-tool stdio``: can_use_tool routed to Hermes approvals."""
+
+    def _run(self, fake_claude, callback):
+        session = _session(
+            fake_claude, security_mode="approval-required", approval_callback=callback
+        )
+        try:
+            session.ensure_started()
+            return session.run_turn("please PERM"), session
+        finally:
+            session.close()
+
+    def test_approve_runs_the_tool(self, fake_claude):
+        seen = []
+
+        def approve(command, description, **kw):
+            seen.append((command, description, kw))
+            return "once"
+
+        result, session = self._run(fake_claude, approve)
+        assert result.error is None
+        assert seen and seen[0][0] == "touch marker"
+        assert "Claude Code requests Bash" in seen[0][1]
+        assert seen[0][2] == {"allow_permanent": False}
+        tool_msg = next(m for m in result.projected_messages if m["role"] == "tool")
+        assert tool_msg["content"] == "PERM-RAN"
+        assert result.final_text == "ran it"
+        # No "no approver" notice when a callback is wired.
+        assert not [e for e in session._test_events if e["kind"] == "status"]
+
+    def test_deny_yields_error_tool_result(self, fake_claude):
+        result, _ = self._run(fake_claude, lambda *a, **k: "deny")
+        assert result.error is None  # the turn itself completes
+        tool_msg = next(m for m in result.projected_messages if m["role"] == "tool")
+        assert tool_msg["content"].startswith("[error]")
+        assert "Denied by the Hermes user" in tool_msg["content"]
+        assert result.final_text == "it was denied"
+
+    def test_no_approver_denies(self, fake_claude):
+        result, session = self._run(fake_claude, None)
+        tool_msg = next(m for m in result.projected_messages if m["role"] == "tool")
+        assert "no interactive approver" in tool_msg["content"]
+        assert result.final_text == "it was denied"
+        assert [e for e in session._test_events if e["kind"] == "status"]
+
+    def test_timeout_denies(self, fake_claude):
+        result, _ = self._run(fake_claude, lambda *a, **k: "timeout")
+        tool_msg = next(m for m in result.projected_messages if m["role"] == "tool")
+        assert "timed out" in tool_msg["content"]
+
+    def test_callback_exception_denies(self, fake_claude):
+        def boom(*a, **k):
+            raise RuntimeError("ui gone")
+
+        result, _ = self._run(fake_claude, boom)
+        tool_msg = next(m for m in result.projected_messages if m["role"] == "tool")
+        assert "approval prompt failed" in tool_msg["content"]
+
+
+class TestSessionIdRotation:
+    SID = "11111111-2222-4333-8444-555555555555"
+
+    def _transcript(self, home):
+        cfg = home / "claude-code"
+        (cfg / "projects" / "-ws").mkdir(parents=True, exist_ok=True)
+        (cfg / "projects" / "-ws" / f"{self.SID}.jsonl").write_text("{}\n")
+        return cfg
+
+    def test_resume_disabled_with_existing_transcript_rotates_before_spawn(
+        self, fake_claude, _isolated_hermes_home, monkeypatch
+    ):
+        cfg = self._transcript(_isolated_hermes_home)
+        monkeypatch.setenv("FAKE_CLAUDE_USED_IDS", self.SID)  # CLI: "already in use"
+        session = _session(fake_claude, session_id=self.SID, session_key="k1", resume=False)
+        try:
+            session.ensure_started()
+            assert session.requested_session_id != self.SID
+            _, record = fake_claude
+            argv = json.loads(record.read_text())["argv"]
+            assert "--resume" not in argv
+            assert argv[argv.index("--session-id") + 1] == session.requested_session_id
+            assert session.run_turn("x").final_text == "echo: x"
+            assert json.loads((cfg / "hermes-sessions.json").read_text())["k1"] == session.requested_session_id
+        finally:
+            session.close()
+
+    def test_non_rejection_warmup_error_keeps_id(self, fake_claude, _isolated_hermes_home, monkeypatch):
+        cfg = self._transcript(_isolated_hermes_home)
+        monkeypatch.setenv("FAKE_CLAUDE_FAIL_WARMUP", "auth")
+        session = _session(fake_claude, session_id=self.SID, session_key="k1")
+        with pytest.raises(RuntimeError, match="Failed to authenticate"):
+            session.ensure_started()
+        assert session.requested_session_id == self.SID
+        assert not (cfg / "hermes-sessions.json").exists()
+
+    def test_rejection_marker_detection(self):
+        from agent.transports.claude_code_session import is_session_id_rejection
+
+        assert is_session_id_rejection("Error: No conversation found with session ID abc")
+        assert is_session_id_rejection("Session ID abc is already in use.")
+        assert not is_session_id_rejection("Failed to authenticate: OAuth session expired")
+        assert not is_session_id_rejection(None)
+
+    def test_session_map_concurrent_writes_keep_all_entries(self, tmp_path):
+        from agent.transports.claude_code_session import load_session_map, save_session_mapping
+
+        cfg = str(tmp_path / "cfg")
+        workers = [
+            threading.Thread(target=save_session_mapping, args=(cfg, f"key-{i}", f"id-{i}"))
+            for i in range(16)
+        ]
+        for t in workers:
+            t.start()
+        for t in workers:
+            t.join()
+        assert load_session_map(cfg) == {f"key-{i}": f"id-{i}" for i in range(16)}
+
+    def test_resume_is_restored_after_a_rotation(self, fake_claude, _isolated_hermes_home, monkeypatch):
+        """rejection -> rotate -> prompt change -> restart resumes the NEW
+        transcript instead of rotating a second time."""
+        cfg = self._transcript(_isolated_hermes_home)
+        monkeypatch.setenv("FAKE_CLAUDE_REJECT_RESUME_ID", self.SID)
+        monkeypatch.setenv("FAKE_CLAUDE_USED_IDS", self.SID)
+        session = _session(fake_claude, session_id=self.SID, session_key="k1", system_prompt="P1")
+        try:
+            session.ensure_started()
+            new_id = session.requested_session_id
+            assert new_id != self.SID
+            # The real CLI would have written this transcript during the fresh spawn.
+            (cfg / "projects" / "-ws" / f"{new_id}.jsonl").write_text("{}\n")
+            session.restart(system_prompt="P2")
+            assert session.requested_session_id == new_id  # no second rotation
+            assert session.resumed is True
+            _, record = fake_claude
+            argv = json.loads(record.read_text())["argv"]
+            assert argv[argv.index("--resume") + 1] == new_id
+            assert session.run_turn("x").final_text == "echo: x"
+        finally:
+            session.close()

--- a/tests/hermes_cli/test_claude_code_cli_provider.py
+++ b/tests/hermes_cli/test_claude_code_cli_provider.py
@@ -1,0 +1,34 @@
+"""claude-code-cli provider resolution — every alias must reach the runtime,
+never fall through to OpenRouter/custom (#25267)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.runtime_provider import (
+    CLAUDE_CODE_CLI_PROVIDER_NAMES,
+    resolve_runtime_provider,
+)
+
+
+@pytest.mark.parametrize("name", sorted(CLAUDE_CODE_CLI_PROVIDER_NAMES))
+def test_every_alias_resolves_to_the_claude_code_runtime(name, monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    runtime = resolve_runtime_provider(requested=name)
+    assert runtime["provider"] == "claude-code-cli"
+    assert runtime["api_mode"] == "claude_code"
+    assert runtime["base_url"] == "claude-code://local"
+    assert runtime["requested_provider"] == name
+
+
+def test_aliases_match_the_provider_profile():
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("claude-code-cli")
+    assert {profile.name, *profile.aliases} == set(CLAUDE_CODE_CLI_PROVIDER_NAMES)
+
+
+def test_claude_code_alias_still_means_anthropic():
+    from hermes_cli.auth import resolve_provider
+
+    assert resolve_provider("claude-code") == "anthropic"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -179,6 +179,73 @@ model:
 `--provider claude` and `--provider claude-code` also work as shorthand for `--provider anthropic`.
 :::
 
+### Claude subscription via the Claude Code CLI (`claude-code-cli`)
+
+Use a Claude Pro/Max subscription **with real tool calls** by letting Hermes drive the
+official `claude` CLI as a subprocess (`api_mode: claude_code`). Claude Code's native
+tools (Bash, Read, Write, Edit, Glob, Grep, WebSearch, WebFetch) run inside the CLI, and
+Hermes' own tools (web search/extract, browser, vision, image generation, skills, TTS)
+are exposed to it over MCP. No API key and no token is ever read out of the CLI.
+
+```bash
+claude setup-token                     # once — prints a long-lived token
+echo 'CLAUDE_CODE_OAUTH_TOKEN=...' >> ~/.hermes/.env
+hermes chat --provider claude-code-cli --model sonnet
+```
+
+**Setup-token requirement.** The runtime refuses to start without
+`CLAUDE_CODE_OAUTH_TOKEN` (rename the variable with `claude_code.oauth_token_env`). It
+deliberately does *not* share your interactive `claude` login: several long-lived
+`claude` processes sharing one login rotate the OAuth refresh token underneath each
+other and log each other out. One token owned by Hermes ends that race.
+
+**Isolation guarantees.** The child is a Hermes-owned Claude Code, never yours:
+
+- `CLAUDE_CONFIG_DIR=$HERMES_HOME/claude-code` — its own settings, `.claude.json`,
+  transcripts and credential store; nothing under `~/.claude` is read or written.
+- `--setting-sources ""` — your user/project/local settings, hooks and plugins are not
+  loaded. `--strict-mcp-config` — only the `hermes-tools` MCP server.
+- `--settings $HERMES_HOME/claude-code/settings.json` — a deny list Hermes writes once
+  (`Bash(rm -rf *)`, `Bash(sudo *)`, `Bash(git push *)`, Messages/Gmail/Drive
+  send/trash/share tools). Edit the file freely; Hermes never overwrites it. Seed a
+  different list with `claude_code.deny` before the first run.
+- Working directory `$HERMES_HOME/claude-code/workspace` (or `claude_code.cwd`), and
+  `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` — Hermes owns memory.
+
+**Permission modes** (from `tools.terminal.security_mode`):
+
+| security_mode | `claude --permission-mode` | shell |
+|---|---|---|
+| `auto` (default) | `acceptEdits` + pre-approved Bash/file/web tools | runs, gated only by the deny list |
+| `approval-required` | `default` + read-only tools, `--permission-prompt-tool stdio` | **gated** — every Bash/Write/Edit call is sent to Hermes' approval prompt; with no interactive approver (gateway, cron) it is denied with a message the model sees, and Hermes tells you once per session |
+| `unrestricted` / `yolo` (or `--yolo`) | `bypassPermissions` | unrestricted |
+
+Unknown values fail closed to `approval-required`. Context compaction is done by the
+CLI itself (like `compression.codex_app_server_auto: native`); background memory/skill
+review is skipped on this runtime because the `memory` tool cannot be reached from a
+subprocess. A resumed Hermes session `--resume`s the same CLI transcript; if the CLI
+rejects the resume, Hermes rotates to a fresh session id and remembers it in
+`$HERMES_HOME/claude-code/hermes-sessions.json`.
+
+**Warm processes.** One `claude` process is kept per Hermes session and shared across
+requests (the gateway builds a fresh agent per request; the process outlives it), so
+every turn after the first hits the prompt cache. The system prompt — Hermes' prompt
+plus the request's `system` message — is baked in at spawn; if it changes, the process
+is restarted (resuming the same CLI transcript). Keep that prompt **stable across
+requests** (no timestamps or per-request content): more than 3 restarts in a minute
+logs a warning and defeats the cache.
+
+```yaml
+claude_code:
+  idle_timeout: 600      # seconds a warm process may sit idle before it is closed
+  silence_timeout: 300   # max silence between two CLI events inside a turn
+  max_sessions: 8        # warm processes kept at once; least-recently-used is closed beyond this
+  turn_timeout: 600      # whole-turn bound
+```
+
+`--provider claude-code` (without `-cli`) remains a shorthand for the `anthropic` API-key
+provider.
+
 ### GitHub Copilot
 
 Hermes supports GitHub Copilot as a first-class provider with two modes:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
@@ -130,7 +130,33 @@ model:
 
 :::tip 别名
 `--provider claude` 和 `--provider claude-code` 也可作为 `--provider anthropic` 的简写。
+
+另外，`--provider claude-code-cli` 通过官方 `claude` CLI 子进程使用 Claude 订阅（需要 `claude setup-token` 生成的 `CLAUDE_CODE_OAUTH_TOKEN`，并在独立的 `$HERMES_HOME/claude-code` 配置目录中运行；`approval-required` 模式下 Bash/写文件等工具会经由 Hermes 审批提示放行或拒绝）。详见英文文档。
 :::
+
+### 通过 Claude Code CLI 使用 Claude 订阅（`claude-code-cli`）
+
+让 Hermes 以子进程方式驱动官方 `claude` CLI（`api_mode: claude_code`），从而用 Claude Pro/Max
+订阅进行**真正的工具调用**：Claude Code 的原生工具（Bash、Read、Write、Edit、Glob、Grep、WebSearch、
+WebFetch）在 CLI 内运行，Hermes 自己的工具（网页搜索/抽取、浏览器、视觉、图像生成、技能、TTS）通过 MCP
+暴露给它。不需要 API Key，也不会从 CLI 读取任何令牌。
+
+```bash
+claude setup-token                     # 仅需一次，输出长期令牌
+echo 'CLAUDE_CODE_OAUTH_TOKEN=...' >> ~/.hermes/.env
+hermes chat --provider claude-code-cli --model sonnet
+```
+
+- 必须提供 `CLAUDE_CODE_OAUTH_TOKEN`（可用 `claude_code.oauth_token_env` 改名）；不会共享你的交互式 `claude` 登录。
+- 子进程完全由 Hermes 拥有：`CLAUDE_CONFIG_DIR=$HERMES_HOME/claude-code`、`--setting-sources ""`（不加载你的 hooks/插件）、
+  `--strict-mcp-config`、Hermes 只写一次的拒绝列表 `settings.json`、独立工作目录、关闭自动记忆。
+- 权限模式来自 `tools.terminal.security_mode`：`auto` 预先放行 Bash/文件/网页工具（受拒绝列表约束）；
+  `approval-required` 通过 `--permission-prompt-tool stdio` 把每次 Bash/Write/Edit 交给 Hermes 审批，无审批者时拒绝；
+  未知值回退到 `approval-required`；只有 `unrestricted`/`yolo` 才会 `bypassPermissions`。
+- 每个 Hermes 会话保持一个热进程并跨请求复用；系统提示应在请求间保持稳定，否则会频繁重启。
+  相关配置：`claude_code.idle_timeout`（默认 600 秒）、`silence_timeout`（300）、`max_sessions`（8）、`turn_timeout`（600）。
+
+`--provider claude-code`（不带 `-cli`）仍是 `anthropic` API Key 提供商的简写。详见英文文档。
 
 ### GitHub Copilot
 


### PR DESCRIPTION
## What does this PR do?

Adds a `claude_code` api_mode and a `claude-code-cli` provider so Hermes can use a **Claude subscription with real tool calls**, by driving the official Claude Code CLI (`claude -p --input-format stream-json --output-format stream-json`) as a long-lived, Hermes-owned subprocess — the same shape as the existing `codex_app_server` runtime. Hermes's tools are exposed to the child over stdio MCP (`hermes_tools_mcp_server`), so Claude calls `web_search`, `browser_*`, etc. natively; Claude Code's own tools (Bash, Read, Edit…) keep working.

Why this approach: subscription OAuth cannot be used directly against the API (Anthropic's consumer terms), and the community proxy route strips tool calls and starts a cold process per request. Spawning the official CLI is the path Anthropic's own docs describe; only the CLI ever touches the credential.

The child is **isolated from the user's personal Claude Code state**: its own `CLAUDE_CONFIG_DIR` under `$HERMES_HOME/claude-code`, its own cwd, `--setting-sources ""` + `--settings <Hermes-written deny list>`, `--strict-mcp-config`, auto-memory off. It authenticates with a long-lived setup-token (`claude setup-token` → `CLAUDE_CODE_OAUTH_TOKEN`), never the interactive keychain login — which also avoids refresh-token rotation races with the user's own `claude` sessions.

Permission modes map from `tools.terminal.security_mode`: `auto` → `acceptEdits` + deny list; `approval-required` → `default` with `--permission-prompt-tool stdio` routed through Hermes's approval callback (`can_use_tool` control requests); `unrestricted`/`yolo` → `bypassPermissions`. Unknown values fail closed.

On the `api_server` gateway path (fresh `AIAgent` per request) a module-level registry keeps one warm child per Hermes session (per-session turn lock, idle/LRU eviction, atexit cleanup), and the request's ephemeral system prompt is baked into the child's `--append-system-prompt-file` (respawn + `--resume` when it changes).

## Related Issue

Fixes #25267

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/transports/claude_code_session.py` — `ClaudeCodeSession`: spawn, warm-up-before-init, stream-json projection (text, tool_use/result, usage), drain-before-finish, process-identity checks, interrupt, `--resume` with session-id rotation only on the CLI's own rejection, permission-prompt bridge, isolation flags/env, temp files 0600.
- `agent/claude_code_runtime.py` — `run_claude_code_turn` (same return shape as `run_codex_app_server_turn`), UI event bridge, usage accounting, warm-session registry, `combined_system_prompt`, `codex_app_server` site audit in the docstring.
- `plugins/model-providers/claude-code/` — `claude-code-cli` ProviderProfile (aliases `claude-subscription`, `claude_code_cli`). `claude-code` remains an alias for the `anthropic` API-key provider (unchanged).
- Wiring: `agent/conversation_loop.py`, `run_agent.py`, `agent/agent_init.py`, `agent/turn_context.py`, `agent/conversation_compression.py`, `agent/background_review.py` (review skipped on this runtime — its tools can't run over stateless MCP), `hermes_cli/{auth,models,providers,runtime_provider}.py`.
- Tests: `tests/agent/transports/{fake_claude_cli.py,test_claude_code_session.py}`, `tests/agent/test_claude_code_runtime.py`, `tests/hermes_cli/test_claude_code_cli_provider.py` — fake CLI speaking stream-json; no network.
- Docs: `website/docs/integrations/providers.md` (en) + zh-Hans section; `cli-config.yaml.example` `claude_code:` block.

## How to Test

1. Install Claude Code (`claude --version` ≥ 2.1), sign in, run `claude setup-token` and `export CLAUDE_CODE_OAUTH_TOKEN=...`.
2. `hermes chat -Q --oneshot --provider claude-code-cli --model sonnet -q "Reply with exactly: OK"` → `OK`.
3. Tool call through MCP: `... -q "Use the web_search tool to find the current Swift version, reply with just the number"` — verbose output shows `tool_use: web_search` and the answer.
4. Isolation: after a turn, `~/.claude/projects/*/memory` is untouched; the child's transcript is under `$HERMES_HOME/claude-code/projects/`.
5. Deny list: in `auto` mode ask it to `git push` in a scratch repo → `Permission to use Bash … has been denied`, remote unchanged.
6. `pytest tests/agent/transports/test_claude_code_session.py tests/agent/test_claude_code_runtime.py tests/hermes_cli/test_claude_code_cli_provider.py -q` → 56 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` — full run via `scripts/run_tests.sh`: no regressions versus the base commit (127 failures, all pre-existing on upstream main in an offline environment; details in the comment below)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Claude Code 2.1.251, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no workflow change)
- [x] Cross-platform: the runtime requires the `claude` CLI; macOS/Linux tested paths only. Windows untested — the CLI exists there but the process-group and pipe handling have not been exercised.

## Notes for reviewers

- `approval-required` mode relies on `--permission-prompt-tool stdio`, which is absent from `claude --help` but present in the 2.1.251 binary and verified live; if a future CLI drops it, the mode falls back to read-only tools with a loud status line.
- Known, inherent to the CLI: `CLAUDE_CODE_OAUTH_TOKEN` is visible to shell commands the model runs (Hermes's terminal tool deliberately doesn't strip it either). Documented in the runtime; containment is the deny list + a revocable setup-token.
- Background memory/skill review is skipped on this runtime (its tools are `_AGENT_LOOP_TOOLS` and can't be exposed over stateless MCP); a stateless memory tool over MCP is a possible follow-up.

