### PR TITLE
fix(cli): warn when --output is used with --quick backup (#98369)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -2063,6 +2063,14 @@ def prune_quick_snapshots(
 
 def run_quick_backup(args) -> None:
     """CLI entry point for hermes backup --quick."""
+    output = getattr(args, "output", None)
+    if output:
+        import sys
+        print(
+            "Warning: --output is not supported with --quick; "
+            "quick snapshots are stored in the state-snapshots directory.",
+            file=sys.stderr,
+        )
     label = getattr(args, "label", None)
     snap_id = create_quick_snapshot(label=label)
     if snap_id:


### PR DESCRIPTION
## Summary

Fixes #98369.

`hermes backup --quick -o /tmp/out.zip` silently ignored the `-o` flag — no file was written at the requested path, no warning was printed, and the command exited 0.

## Root Cause

`run_quick_backup()` reads only `args.label`; it never touches `args.output`. The non-quick path (`run_backup()`) honours `args.output` at line 803. The parser accepts `--output` for both branches without complaint.

## Fix

Emit a stderr warning when `--output` is combined with `--quick`, since quick snapshots are directory-based (stored in `state-snapshots/`) and don't produce a single output file.

## Changes

- `hermes_cli/backup.py`: `run_quick_backup()` — check for `args.output` and print a warning to stderr if set.

## Testing

```sh
hermes backup --quick -o /tmp/test.zip
# Expected: warning on stderr + snapshot still created normally
hermes backup --quick
# Expected: no warning, snapshot created
```
