### PR TITLE
fix(agent): use EXCLUDED_SKILL_DIRS in scan_skill_commands (#98044)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -443,6 +443,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import (
+            EXCLUDED_SKILL_DIRS,
             get_external_skills_dirs,
             get_project_skills_dirs,
             iter_project_skill_files,
@@ -467,7 +468,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                 else iter_skill_index_files(scan_dir, "SKILL.md")
             )
             for skill_md in _iter:
-                if any(part in {'.git', '.github', '.hub', '.archive'} for part in skill_md.parts):
+                if any(part in EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -31,6 +31,7 @@ EXCLUDED_SKILL_DIRS = frozenset(
         ".github",
         ".hub",
         ".archive",
+        "_archive",
         ".venv",
         "venv",
         "node_modules",


### PR DESCRIPTION
## Summary

Fixes #98044.

`scan_skill_commands()` used a hardcoded inline set `{'.git', '.github', '.hub', '.archive'}` to skip directories, while the authoritative `EXCLUDED_SKILL_DIRS` in `agent/skill_utils.py` contains 14 entries. This caused the scanner to walk into `venv/`, `node_modules/`, `__pycache__/` and other support directories under `~/.hermes/skills/`.

Additionally, `_archive/` (a non-dot-prefix alternative to `.archive/`) was not excluded anywhere, causing archived skills to remain live and invocable.

## Changes

- `agent/skill_commands.py`: Import `EXCLUDED_SKILL_DIRS` from `agent.skill_utils` and use it instead of the inline 4-entry set.
- `agent/skill_utils.py`: Add `"_archive"` to `EXCLUDED_SKILL_DIRS` so non-dot-prefix archive directories are also excluded.

## Testing

```sh
# Verify the scanner no longer walks into venv/node_modules
mkdir -p ~/.hermes/skills/venv/test-skill
echo '---
name: test-skill
description: test
---
# Test' > ~/.hermes/skills/venv/test-skill/SKILL.md
hermes skills list  # Should NOT show test-skill
rm -rf ~/.hermes/skills/venv
```
