### PR TITLE
fix(cli): fall back to local merge-base when GitHub compare returns None (#98214)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4140,11 +4140,22 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
                 # Local commits on top of the remote tip — not behind.
                 print("✓ Already up to date.")
                 return
-            if counted is not None:
+            if counted is None:
+                # GitHub compare API returned no result (local SHA unknown to
+                # GitHub, e.g. shallow clone with local commits).  Fall back
+                # to a local merge-base check: if the remote tip is an
+                # ancestor of HEAD, we are up to date.
+                _mb = subprocess.run(
+                    git_cmd + ["merge-base", "--is-ancestor", target_sha, "HEAD"],
+                    cwd=_m().PROJECT_ROOT, capture_output=True, text=True,
+                )
+                if _mb.returncode == 0:
+                    print("✓ Already up to date.")
+                    return
+                print(f"⚕ Update available (behind {compare_branch}).")
+            else:
                 commits_word = "commit" if counted == 1 else "commits"
                 print(f"⚕ Update available: {counted} {commits_word} behind {compare_branch}.")
-            else:
-                print(f"⚕ Update available (behind {compare_branch}).")
             print(f"  Run '{recommended_update_command()}' to install.")
         return
 


### PR DESCRIPTION
## Summary

Fixes #98214.

On a shallow checkout with local commits (the `update_in_place` workflow), `hermes update --check` falsely reports "Update available (behind origin/main)" even when the checkout is genuinely up to date.

## Root Cause

`_github_compare_behind()` returns `None` when the local HEAD SHA is unknown to GitHub (shallow clone + local commits). The shallow fast-path in `_cmd_update_check()` had no case for `None` — it fell through to the `else` branch that prints "Update available (behind ...)".

**Unknown was reported as behind.**

## Fix

When `_github_compare_behind()` returns `None`, fall back to `git merge-base --is-ancestor target_sha HEAD`. If the remote tip is an ancestor of HEAD (exit code 0), the checkout is up to date — report accordingly instead of falsely claiming it's behind.

## Changes

- `hermes_cli/update_cmd.py`: `_cmd_update_check()` shallow fast-path — add `merge-base --is-ancestor` fallback when GitHub compare returns `None`.

## Testing

```sh
# Shallow clone with local commits on top of upstream tip
git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /tmp/test-shallow
cd /tmp/test-shallow
git commit --allow-empty -m "local commit"
hermes update --check
# Expected: "✓ Already up to date." (not "Update available")
```
