### PR TITLE
fix(agent): add absorbed_into to skill_manage schema (#97959)

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -2132,6 +2132,14 @@ SKILL_MANAGE_SCHEMA = {
                         "file_content": {
                             "type": "string",
                             "description": "Content for write_file."
+                        },
+                        "absorbed_into": {
+                            "type": "string",
+                            "description": (
+                                "Delete only: name of the umbrella skill that "
+                                "absorbs this skill's content. Required for "
+                                "curator consolidation deletes."
+                            )
                         }
                     },
                     "required": ["name", "action"]


### PR DESCRIPTION
## Summary

Fixes #97959.

The curator's consolidation pass instructs the review agent to archive absorbed skills with `skill_manage(action="delete", absorbed_into=<umbrella>)`. The handler accepts `absorbed_into`, but the parameter was deliberately omitted from `SKILL_MANAGE_SCHEMA`. Models that strictly follow the tool schema therefore never emit it, every consolidation delete is refused by `_curator_consolidation_delete_guard`, and the pass ends with zero consolidations while reporting success.

## Fix

Add `absorbed_into` as an optional string property in the `delete` operation's schema so schema-compliant models can declare the umbrella skill that absorbs the deleted skill's content.

## Changes

- `tools/skill_manager_tool.py`: Add `absorbed_into` property to `SKILL_MANAGE_SCHEMA` items properties.

## Testing

```sh
# Run curator consolidation — delete ops should now include absorbed_into
hermes curator run --sync --consolidate
# Check logs: consolidated_this_run should be > 0 (not 0)
```
