### PR TITLE
fix: pass normalized context to plugin senders

### DIFF
--- a/tests/tools/test_send_message_plugin_extensibility.py
+++ b/tests/tools/test_send_message_plugin_extensibility.py
@@ -14,7 +14,7 @@ import pytest
 
 from gateway.config import Platform
 from gateway.platform_registry import PlatformEntry, platform_registry
-from tools.send_message_tool import resolve_send_target, send_message_tool
+from tools.send_message_tool import _send_to_platform, resolve_send_target, send_message_tool
 
 
 @pytest.fixture
@@ -150,6 +150,56 @@ def test_host_send_honors_sync_and_async_plugin_handlers(plugin_platform, async_
     assert result["platform"] == name
     assert result["chat_id"] == "@alice@example.com"
     assert seen[-1]["args"]["subject"] == "greeting"
+
+
+@pytest.mark.asyncio
+async def test_plugin_handler_receives_normalized_context_without_model_args(
+    plugin_platform,
+):
+    name, entry, _seen = plugin_platform
+    platform, pconfig, _config = _config_for(name)
+    received = []
+
+    async def handler(args, chat_id, platform_name, config, *, normalized):
+        received.append(
+            {
+                "args": args,
+                "chat_id": chat_id,
+                "platform_name": platform_name,
+                "config": config,
+                "normalized": normalized,
+            }
+        )
+        return {"success": True, "message_id": "normalized-id"}
+
+    entry.send_message_handler = handler
+    media_files = [("/tmp/report.pdf", False)]
+
+    result = await _send_to_platform(
+        platform,
+        pconfig,
+        "channel-1",
+        "Scheduled report",
+        thread_id="thread-1",
+        media_files=media_files,
+        force_document=True,
+    )
+
+    assert result == {"success": True, "message_id": "normalized-id"}
+    assert received == [
+        {
+            "args": {},
+            "chat_id": "channel-1",
+            "platform_name": name,
+            "config": pconfig,
+            "normalized": {
+                "message": "Scheduled report",
+                "thread_id": "thread-1",
+                "media_files": media_files,
+                "force_document": True,
+            },
+        }
+    ]
 
 
 def test_cli_and_cron_share_plugin_target_normalization(plugin_platform, monkeypatch, capsys):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -86,6 +86,11 @@ _CAPTIONABLE_EXTS = _IMAGE_EXTS | _VIDEO_EXTS | {
 _TELEGRAM_CAPTION_LIMIT = 1024
 _DEFAULT_CAPTION_LIMIT = 4096
 
+# Versioned capability for platform plugins that need the host-normalized send
+# payload. Plugins can feature-detect this constant and decline to register a
+# full-request handler on older hosts that only pass model-facing ``args``.
+PLUGIN_SEND_HANDLER_NORMALIZED_CONTEXT = 1
+
 def prepare_send_message_platforms() -> None:
     """Load enabled standalone plugins before tool schemas/cache keys are built."""
     from hermes_cli.plugins import discover_plugins
@@ -971,6 +976,44 @@ async def _send_via_adapter(
     }
 
 
+async def _call_plugin_send_handler(
+    handler,
+    args,
+    chat_id,
+    platform_name,
+    pconfig,
+    *,
+    message,
+    thread_id,
+    media_files,
+    force_document,
+):
+    """Invoke a plugin handler while preserving four-argument compatibility."""
+    import inspect
+
+    kwargs = {}
+    try:
+        parameters = inspect.signature(handler).parameters.values()
+        if any(
+            parameter.name == "normalized"
+            or parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters
+        ):
+            kwargs["normalized"] = {
+                "message": message,
+                "thread_id": thread_id,
+                "media_files": media_files,
+                "force_document": force_document,
+            }
+    except (TypeError, ValueError):
+        pass
+
+    result = handler(args or {}, chat_id, platform_name, pconfig, **kwargs)
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
 async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
     """Route a message to the appropriate platform sender.
 
@@ -1048,6 +1091,34 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         chunks = BasePlatformAdapter.truncate_message(message, max_len, len_fn=_len_fn)
     else:
         chunks = [message]
+
+    # Dynamically registered platform handlers own their complete send path.
+    # Dispatch them once, before the generic non-media rejection/chunk loop,
+    # and pass the host-normalized payload when the handler opts into it. This
+    # keeps cron/CLI calls (which have no model-facing ``args``) lossless while
+    # preserving the legacy four-argument handler contract.
+    from gateway.config import _BUILTIN_PLATFORM_VALUES
+
+    if platform_name not in _BUILTIN_PLATFORM_VALUES:
+        from gateway.platform_registry import platform_registry
+
+        entry = platform_registry.get(platform_name)
+        handler = entry.send_message_handler if entry is not None else None
+        if handler is not None:
+            try:
+                return await _call_plugin_send_handler(
+                    handler,
+                    args,
+                    chat_id,
+                    platform_name,
+                    pconfig,
+                    message=message,
+                    thread_id=thread_id,
+                    media_files=media_files,
+                    force_document=force_document,
+                )
+            except Exception as e:
+                return {"error": f"Plugin send_message handler failed: {e}"}
 
     # --- Telegram: special handling for media attachments ---
     # _send_telegram now owns text chunking internally — it formats the full


### PR DESCRIPTION
## Summary

Pass the host-normalized delivery context to plugin `send_message_handler` implementations that opt into the widened contract.

The context includes:

- normalized message text
- filtered media files
- resolved `thread_id`
- `force_document`

Legacy four-argument sync and async plugin handlers remain supported through signature detection.

## Why

Plugin handlers previously received only model-facing `args`. Cron, CLI, and manual callers can invoke `_send_to_platform()` with `args=None` while supplying normalized text/media/thread values directly. A plugin full-request handler could therefore receive an empty request and reject an otherwise valid scheduled send.

## Verification

- `11 passed` in `tests/tools/test_send_message_plugin_extensibility.py`
- Python compilation, Ruff, and `git diff --check` passed
- rebased onto current canonical `main`
- joint core ↔ Fluxer probe preserved a no-args scheduled message, media tuple, thread, and document mode
- independent hostile review before publication: PASS, no actionable P1/P2 findings

## Plugin compatibility

The corresponding Fluxer plugin change is https://github.com/elkimek/hermes-fluxer-plugin/pull/7

The Fluxer plugin gates its widened handler registration on the versioned host capability. Older hosts retain the existing standalone sender rather than enabling an incompatible handler.
