### PR TITLE
fix(compression): compacted native-Codex sessions no longer false-trigger 600s local compression mid-turn (#96995, #97602, salvage #97006)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7671,7 +7671,9 @@ def run_conversation(
                         agent,
                         messages,
                         active_system_prompt or "",
-                        estimate_messages_tokens_rough(messages),
+                        estimate_request_tokens_rough(
+                            messages, tools=agent.tools or None
+                        ),
                     )
 
                 if (

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7660,8 +7660,18 @@ def run_conversation(
                     # these add 20-30K tokens the messages-only
                     # estimate misses, which can skip compression
                     # past the configured threshold (#14695).
-                    _real_tokens = estimate_request_tokens_rough(
-                        messages, tools=agent.tools or None
+                    # Route-aware (#96995/#97602 class): on a compacted
+                    # native-Codex session the generic durable-history
+                    # figure overstates the wire and would false-trigger
+                    # compression here exactly like the pre-API guard —
+                    # this fallback runs precisely when no provider usage
+                    # is available (post-disconnect / gateway restart),
+                    # the unanchored case from #97602's repro.
+                    _real_tokens = _midturn_request_pressure_tokens(
+                        agent,
+                        messages,
+                        active_system_prompt or "",
+                        estimate_messages_tokens_rough(messages),
                     )
 
                 if (

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -126,6 +126,51 @@ RUN_BUDGET_WRAPUP_NOTICE = (
 )
 
 
+def _midturn_request_pressure_tokens(
+    agent: Any,
+    api_messages: List[Dict[str, Any]],
+    effective_system: str,
+    approx_tokens: int,
+) -> int:
+    """Token figure the mid-turn pre-API compression guard compares.
+
+    When the upcoming request is eligible for native Responses compaction the
+    transport will checkpoint-prune the payload before sending, so the generic
+    durable-history estimate overstates the wire by orders of magnitude on a
+    compacted session and fires a 600s local compression the main request
+    never needed (#96995). Mirror the turn-prologue preflight (#96644 /
+    #96155): use the pruned estimate when native eligibility is proven, the
+    generic message+tools figure otherwise.
+
+    The native estimator adds the system prompt and tool schemas itself and
+    its converter skips system-role rows, so passing the assembled
+    ``api_messages`` (which carries the system row) alongside
+    ``effective_system`` counts the system prompt exactly once.
+    """
+    try:
+        from agent.codex_responses_adapter import (
+            estimate_native_responses_preflight_tokens,
+        )
+
+        native = estimate_native_responses_preflight_tokens(
+            agent,
+            api_messages,
+            system_prompt=effective_system or "",
+            tools=getattr(agent, "tools", None) or None,
+        )
+        if isinstance(native, int) and not isinstance(native, bool) and native >= 0:
+            return native
+    except Exception:
+        logger.debug(
+            "native Responses mid-turn estimate unavailable; "
+            "using generic transcript estimate",
+            exc_info=True,
+        )
+    return approx_tokens + (
+        _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
+    )
+
+
 def _review_input_budget_exhausted(agent: Any) -> bool:
     """True when a detached review fork has replayed its aggregate input budget.
 
@@ -2608,8 +2653,14 @@ def run_conversation(
         # separately (compression needs them: 50+ tools = 20-30K tokens).
         # total_chars is a rough (~) proxy — verbose log + hook metric only.
         approx_tokens = estimate_messages_tokens_rough(api_messages)
-        request_pressure_tokens = approx_tokens + (
-            _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
+        # Route-aware pressure: when the upcoming request is eligible for
+        # native Responses compaction the transport will checkpoint-prune
+        # the payload before sending — the generic durable-history figure
+        # overstates the wire by orders of magnitude on a compacted session
+        # and fires a 600s local compression the main request never needed
+        # (#96995, mirroring the turn-prologue preflight #96644/#96155).
+        request_pressure_tokens = _midturn_request_pressure_tokens(
+            agent, api_messages, effective_system or "", approx_tokens
         )
         # Usage-anchored override: when the last provider response's exact
         # usage is still valid for the durable transcript, replace the

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -883,10 +883,15 @@ def build_turn_context(
         _idle_gap = time.time() - getattr(agent, "_last_activity_ts", time.time())
         if _idle_gap >= _idle_after:
             _compressor = agent.context_compressor
-            _idle_tokens = estimate_request_tokens_rough(
+            # Route-aware pressure (#96995/#97602 class): on a compacted
+            # native-Codex session the generic durable-history figure
+            # overstates the wire by orders of magnitude and would fire an
+            # idle compaction the next request never needed. Reuse the
+            # preflight estimator (anchor → native pruned → generic).
+            _idle_tokens = _preflight_request_tokens(
+                agent,
                 messages,
-                system_prompt=active_system_prompt or "",
-                tools=agent.tools or None,
+                active_system_prompt or "",
             )
             # Post-compression target size: don't summarise a thread already
             # below what compaction would reduce it to.
@@ -1297,10 +1302,16 @@ def build_turn_context(
                 if callable(_clear_warn):
                     _clear_warn()
             else:
-                _uncompressed_tokens = estimate_request_tokens_rough(
+                # Route-aware (#96995/#97602 class): the warn site in the
+                # conversation loop now measures the checkpoint-pruned wire
+                # payload on native-Codex sessions, so the re-arm must use
+                # the same figure — otherwise a compacted session that fits
+                # on the wire never clears the dedup and future genuine
+                # overflow warnings stay suppressed.
+                _uncompressed_tokens = _preflight_request_tokens(
+                    agent,
                     messages,
-                    system_prompt=active_system_prompt or "",
-                    tools=agent.tools or None,
+                    active_system_prompt or "",
                 )
                 if _uncompressed_tokens <= _ctx_len:
                     _clear_warn = getattr(

--- a/tests/agent/test_native_preflight_estimate.py
+++ b/tests/agent/test_native_preflight_estimate.py
@@ -98,3 +98,51 @@ def test_preflight_wrapper_falls_back_to_generic_when_ineligible():
     generic = estimate_request_tokens_rough(messages)
 
     assert _preflight_request_tokens(agent, messages, "") == generic
+
+
+# ── Mid-turn pre-API guard parity (#96995) ────────────────────────────────
+# The mid-turn guard in conversation_loop must measure the same pruned wire
+# payload the turn-prologue preflight does (#96644/#96155); before #96995 it
+# used the generic durable-history estimate and false-tripped 600s local
+# compression on compacted native-Codex sessions.
+
+
+def test_midturn_pressure_uses_pruned_estimate_when_eligible():
+    from agent.conversation_loop import (
+        _midturn_request_pressure_tokens,
+        estimate_messages_tokens_rough,
+    )
+
+    agent = _codex_agent()
+    messages = [{"role": "system", "content": "be brief"}] + _history_with_checkpoint()
+    native = estimate_native_responses_preflight_tokens(
+        agent, messages, system_prompt="be brief"
+    )
+    generic = estimate_messages_tokens_rough(messages)
+
+    assert native is not None
+    assert generic > native * 2
+    # The assembled api_messages carry the system row; the helper must not
+    # double-count it (converter skips system rows, system_prompt adds it once).
+    assert _midturn_request_pressure_tokens(
+        agent, messages, "be brief", generic
+    ) == native
+
+
+def test_midturn_pressure_falls_back_to_generic_plus_tools_when_ineligible():
+    from agent.conversation_loop import (
+        _estimate_tools_tokens_rough,
+        _midturn_request_pressure_tokens,
+        estimate_messages_tokens_rough,
+    )
+
+    agent = _codex_agent(
+        api_mode="chat_completions",
+        tools=[{"type": "function", "function": {"name": "t", "parameters": {}}}],
+    )
+    messages = [{"role": "system", "content": "be brief"}] + _history_with_checkpoint()
+    approx = estimate_messages_tokens_rough(messages)
+
+    assert _midturn_request_pressure_tokens(
+        agent, messages, "be brief", approx
+    ) == approx + _estimate_tools_tokens_rough(agent.tools)


### PR DESCRIPTION
## Summary
The mid-turn pre-API pressure guard now measures the same route-aware checkpoint-pruned wire payload as the turn-prologue preflight (#96644), so compacted native-Codex sessions stop false-triggering 240–600s local compressions the actual request never needed.

Root cause: #96644 fixed only the turn-start estimator; the independent mid-turn guard in `agent/conversation_loop.py` still estimated the full assembled durable history (~867K observed) instead of the pruned native payload (~145K).

## Changes
- `agent/conversation_loop.py`: mid-turn pre-API guard routes through the native-aware pruned estimator (cherry-pick of #97006, @liuhao1024)
- `agent/turn_context.py`: follow-up widening — idle-triggered compaction, overflow-warn re-arm, and the post-response `should_compress` fallback (the no-provider-usage-anchor path, i.e. first request after a gateway restart — #97602's exact repro) now use the same route-aware estimate
- Deliberately unchanged: provider-proven overflow recovery, progress-delta pairs, manual/display estimates (generic figure is the correct scale for those)

## Validation
Deterministic credential-free probe on a synthetic checkpointed codex_responses history: generic estimate 1,037,241 tokens vs route-aware pruned estimate 6,036 (171x). 47 targeted tests pass including the PR's mid-turn parity tests.

Fixes #96995. Fixes #97602. Salvage of #97006 — authorship preserved for @liuhao1024.

## Infographic

![No more false compression](https://v3b.fal.media/files/b/0aa868ed/3flbOGFEy2lhUHINrI3Al_gV2oo7Qv.png)
