### PR TITLE
fix(compaction): native capability survives same-provider /model switches and gateway resume (salvage #94036 + #97292)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -613,6 +613,7 @@ def init_agent(
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
     requested_provider: str = None,
+    capabilities: Optional[Dict[str, bool]] = None,
 ):
     """
     Initialize the AI Agent.
@@ -712,6 +713,10 @@ def init_agent(
         if isinstance(requested_provider, str) and requested_provider.strip()
         else agent.provider
     )
+    agent.capabilities = {
+        key: value for key, value in (capabilities or {}).items()
+        if isinstance(key, str) and isinstance(value, bool)
+    }
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2830,9 +2830,10 @@ def init_agent(
     agent.codex_responses_native_compaction = codex_responses_native_compaction
     agent.codex_responses_compact_threshold = codex_responses_compact_threshold
     from agent.native_compaction import resolve_native_compaction_capabilities
-    agent.capabilities = resolve_native_compaction_capabilities(
+    agent.runtime_capabilities = resolve_native_compaction_capabilities(
         model=agent.model,
         base_url=agent.base_url,
+        provider=agent.provider,
         is_codex_backend=(agent.provider or "").strip().lower() == "openai-codex",
     )
     agent.max_compression_attempts = compression_max_attempts

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2829,6 +2829,12 @@ def init_agent(
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
     agent.codex_responses_native_compaction = codex_responses_native_compaction
     agent.codex_responses_compact_threshold = codex_responses_compact_threshold
+    from agent.native_compaction import resolve_native_compaction_capabilities
+    agent.capabilities = resolve_native_compaction_capabilities(
+        model=agent.model,
+        base_url=agent.base_url,
+        is_codex_backend=(agent.provider or "").strip().lower() == "openai-codex",
+    )
     agent.max_compression_attempts = compression_max_attempts
     agent.compression_idle_compact_after_seconds = (
         compression_idle_compact_after_seconds

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2922,6 +2922,9 @@ def switch_model(
     from hermes_cli.providers import determine_api_mode
     from agent.native_compaction import resolve_native_compaction_capabilities
 
+    old_model = agent.model
+    old_provider = agent.provider
+
     # ── Determine api_mode if not provided ──
     # Pass model so dual-wire providers (Nous Portal anthropic/* → Messages)
     # resolve correctly; without it determine_api_mode falls back to the
@@ -2929,12 +2932,22 @@ def switch_model(
     if not api_mode:
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
 
+    # Same-provider switches may omit base_url intentionally (for example, a
+    # direct caller refreshing credentials). Resolve capabilities from the
+    # endpoint that the normalization below will retain, not from the empty
+    # raw argument.
+    effective_base_url = base_url
+    if not effective_base_url and (old_provider or "").strip().lower() == (
+        new_provider or ""
+    ).strip().lower():
+        effective_base_url = getattr(agent, "base_url", "")
+
     destination_capabilities = (
         dict(capabilities)
         if isinstance(capabilities, dict)
         else resolve_native_compaction_capabilities(
             model=new_model,
-            base_url=base_url,
+            base_url=effective_base_url,
             is_codex_backend=(new_provider or '').strip().lower() == 'openai-codex',
         )
     )
@@ -2953,9 +2966,6 @@ def switch_model(
         and base_url
     ):
         base_url = re.sub(r"/v1/?$", "", base_url)
-
-    old_model = agent.model
-    old_provider = agent.provider
 
     # ── Snapshot all fields the swap+rebuild can mutate ──
     # If the rebuild raises (bad API key, network error, build_anthropic_client

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3227,23 +3227,32 @@ def switch_model(
     except Exception:
         _destination_context_intent = None
     agent._config_context_length = _destination_context_intent
-    try:
-        _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
-            _destination_context_intent
-        )
-    except Exception:
-        _restore_snapshot()
-        raise
-    if agent._lmstudio_load_was_unverified(_runtime_context_length):
+    if hasattr(agent, "_ensure_lmstudio_runtime_loaded"):
+        try:
+            _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
+                _destination_context_intent
+            )
+        except Exception:
+            _restore_snapshot()
+            raise
+    else:
+        _runtime_context_length = None
+    if (
+        hasattr(agent, "_lmstudio_load_was_unverified")
+        and agent._lmstudio_load_was_unverified(_runtime_context_length)
+    ):
         logger.warning(
             "LM Studio model activation was rejected or completed without a "
             "verifiable active context length during model switch; continuing "
             "with configured context"
         )
-    _effective_context_length = agent._effective_lmstudio_context_length(
-        _destination_context_intent,
-        _runtime_context_length,
-    )
+    if hasattr(agent, "_effective_lmstudio_context_length"):
+        _effective_context_length = agent._effective_lmstudio_context_length(
+            _destination_context_intent,
+            _runtime_context_length,
+        )
+    else:
+        _effective_context_length = _destination_context_intent
 
     # ── Re-evaluate prompt caching ──
     # Refresh the custom-provider snapshot from the config just loaded above

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1748,8 +1748,17 @@ def restore_primary_runtime(agent) -> bool:
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
-        if "capabilities" in rt:
-            agent.capabilities = dict(rt.get("capabilities") or {})
+        if "runtime_capabilities" in rt:
+            raw_capabilities = rt["runtime_capabilities"]
+            if not isinstance(raw_capabilities, dict):
+                logger.warning("Ignoring malformed runtime capabilities snapshot")
+            else:
+                agent.runtime_capabilities = dict(raw_capabilities)
+        elif "capabilities" in rt:
+            # Read snapshots written by the initial capability propagation patch.
+            raw_capabilities = rt["capabilities"]
+            if isinstance(raw_capabilities, dict):
+                agent.runtime_capabilities = dict(raw_capabilities)
         agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
         agent.request_overrides = dict(rt.get("request_overrides") or {})
         agent._client_kwargs = dict(rt["client_kwargs"])
@@ -2932,6 +2941,11 @@ def switch_model(
     if not api_mode:
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
 
+    normalized_new_provider = (new_provider or "").strip().lower()
+    if not base_url and normalized_new_provider == "openai":
+        # An omitted URL means the provider's canonical direct endpoint.
+        base_url = "https://api.openai.com/v1"
+
     # Same-provider switches may omit base_url intentionally (for example, a
     # direct caller refreshing credentials). Resolve capabilities from the
     # endpoint that the normalization below will retain, not from the empty
@@ -2948,6 +2962,7 @@ def switch_model(
         else resolve_native_compaction_capabilities(
             model=new_model,
             base_url=effective_base_url,
+            provider=new_provider,
             is_codex_backend=(new_provider or '').strip().lower() == 'openai-codex',
         )
     )
@@ -2995,7 +3010,7 @@ def switch_model(
             "_is_anthropic_oauth",
             "_config_context_length",
             "_reasoning_echo_flag",
-            "capabilities",
+            "runtime_capabilities",
         )
     }
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
@@ -3306,7 +3321,7 @@ def switch_model(
 
     # Publish the destination capability map only after every runtime setup
     # above has succeeded. Failed switches must leave the old map intact.
-    agent.capabilities = destination_capabilities
+    agent.runtime_capabilities = destination_capabilities
 
     # ── Reset the cross-turn stale-call circuit breaker (#58962) ──
     # The breaker's error text tells the user to "switch models ... then
@@ -3335,7 +3350,7 @@ def switch_model(
         # recovery or fallback restore would resurrect the PRE-switch
         # overrides via the stale init-time snapshot (#75091 seam).
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
-        "capabilities": dict(getattr(agent, "capabilities", {}) or {}),
+        "runtime_capabilities": dict(getattr(agent, "runtime_capabilities", {}) or {}),
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1748,6 +1748,8 @@ def restore_primary_runtime(agent) -> bool:
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        if "capabilities" in rt:
+            agent.capabilities = dict(rt.get("capabilities") or {})
         agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
         agent.request_overrides = dict(rt.get("request_overrides") or {})
         agent._client_kwargs = dict(rt["client_kwargs"])
@@ -2895,7 +2897,15 @@ def _apply_switched_provider_request_overrides(agent, new_provider):
     agent.request_overrides = overrides
 
 
-def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
+def switch_model(
+    agent,
+    new_model,
+    new_provider,
+    api_key='',
+    base_url='',
+    api_mode='',
+    capabilities=None,
+):
     """Switch the model/provider in-place for a live agent.
 
     Called by the /model command handlers (CLI and gateway) after
@@ -2910,6 +2920,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     turn-scoped).
     """
     from hermes_cli.providers import determine_api_mode
+    from agent.native_compaction import resolve_native_compaction_capabilities
 
     # ── Determine api_mode if not provided ──
     # Pass model so dual-wire providers (Nous Portal anthropic/* → Messages)
@@ -2917,6 +2928,16 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # openai_chat overlay default.
     if not api_mode:
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
+
+    destination_capabilities = (
+        dict(capabilities)
+        if isinstance(capabilities, dict)
+        else resolve_native_compaction_capabilities(
+            model=new_model,
+            base_url=base_url,
+            is_codex_backend=(new_provider or '').strip().lower() == 'openai-codex',
+        )
+    )
 
     # Defense-in-depth: ensure OpenCode base_url doesn't carry a trailing
     # /v1 into the anthropic_messages client, which would cause the SDK to
@@ -2964,6 +2985,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             "_is_anthropic_oauth",
             "_config_context_length",
             "_reasoning_echo_flag",
+            "capabilities",
         )
     }
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
@@ -3180,9 +3202,13 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     except Exception:
         _destination_context_intent = None
     agent._config_context_length = _destination_context_intent
-    _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
-        _destination_context_intent
-    )
+    try:
+        _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
+            _destination_context_intent
+        )
+    except Exception:
+        _restore_snapshot()
+        raise
     if agent._lmstudio_load_was_unverified(_runtime_context_length):
         logger.warning(
             "LM Studio model activation was rejected or completed without a "
@@ -3226,22 +3252,26 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # length normally resolves via config or static catalogs and
         # never hits a probe, but coerce to empty string defensively.
         _ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
-        new_context_length = get_model_context_length(
-            agent.model,
-            base_url=agent.base_url,
-            api_key=_ctx_api_key,
-            provider=agent.provider,
-            config_context_length=_effective_context_length,
-            custom_providers=_sm_custom_providers,
-        )
-        agent.context_compressor.update_model(
-            model=agent.model,
-            context_length=new_context_length,
-            base_url=agent.base_url,
-            api_key=agent.api_key,  # context_compressor forwards to call_llm; callable preserved
-            provider=agent.provider,
-            api_mode=agent.api_mode,
-        )
+        try:
+            new_context_length = get_model_context_length(
+                agent.model,
+                base_url=agent.base_url,
+                api_key=_ctx_api_key,
+                provider=agent.provider,
+                config_context_length=_effective_context_length,
+                custom_providers=_sm_custom_providers,
+            )
+            agent.context_compressor.update_model(
+                model=agent.model,
+                context_length=new_context_length,
+                base_url=agent.base_url,
+                api_key=agent.api_key,  # context_compressor forwards to call_llm; callable preserved
+                provider=agent.provider,
+                api_mode=agent.api_mode,
+            )
+        except Exception:
+            _restore_snapshot()
+            raise
 
     # ── Re-resolve reasoning_config from per-model override ──
     # The new model may have a different reasoning_effort override. Re-read
@@ -3263,6 +3293,10 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     # ── Invalidate cached system prompt so it rebuilds next turn ──
     agent._cached_system_prompt = None
+
+    # Publish the destination capability map only after every runtime setup
+    # above has succeeded. Failed switches must leave the old map intact.
+    agent.capabilities = destination_capabilities
 
     # ── Reset the cross-turn stale-call circuit breaker (#58962) ──
     # The breaker's error text tells the user to "switch models ... then
@@ -3291,6 +3325,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # recovery or fallback restore would resurrect the PRE-switch
         # overrides via the stale init-time snapshot (#75091 seam).
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
+        "capabilities": dict(getattr(agent, "capabilities", {}) or {}),
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2932,6 +2932,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # short-circuit the freshly activated fallback before it gets a
         # single stream attempt.
         _reset_stale_streak(agent)
+        from agent.native_compaction import resolve_native_compaction_capabilities
+        agent.capabilities = resolve_native_compaction_capabilities(
+            model=agent.model,
+            base_url=agent.base_url,
+            is_codex_backend=fb_provider == "openai-codex",
+        )
         return True
     except Exception as e:
         if fb_provider == "nous":

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2933,9 +2933,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # single stream attempt.
         _reset_stale_streak(agent)
         from agent.native_compaction import resolve_native_compaction_capabilities
-        agent.capabilities = resolve_native_compaction_capabilities(
+        agent.runtime_capabilities = resolve_native_compaction_capabilities(
             model=agent.model,
             base_url=agent.base_url,
+            provider=fb_provider,
             is_codex_backend=fb_provider == "openai-codex",
         )
         return True

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -71,6 +71,7 @@ def resolve_native_compaction_capabilities(
     *,
     model: Optional[str],
     base_url: Optional[str],
+    provider: Optional[str] = None,
     is_codex_backend: bool = False,
 ) -> Dict[str, bool]:
     """Resolve the native-compaction capability for a runtime destination.
@@ -78,9 +79,11 @@ def resolve_native_compaction_capabilities(
     The result is deliberately explicit: a resolved ``False`` is different
     from an unresolved capability and must survive model switches unchanged.
     """
-    eligible = is_native_compaction_model(model) and is_direct_openai_route(
-        base_url,
-        is_codex_backend=is_codex_backend,
+    normalized_provider = (provider or "").strip().lower()
+    direct_default = normalized_provider == "openai" and not base_url
+    eligible = is_native_compaction_model(model) and (
+        direct_default
+        or is_direct_openai_route(base_url, is_codex_backend=is_codex_backend)
     )
     return {"native_compaction": eligible}
 
@@ -169,7 +172,7 @@ def native_compaction_context_management(
     (``agent.codex_responses_native_compaction = False``, set by the
     conversation loop's rejection recovery) takes effect on the next call.
     """
-    capabilities = getattr(agent, "capabilities", None)
+    capabilities = getattr(agent, "runtime_capabilities", None)
     if isinstance(capabilities, dict):
         if not bool(capabilities.get("native_compaction", False)):
             return None

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -194,7 +194,10 @@ def native_compaction_context_management(
         return None
     if not is_native_compaction_model(getattr(agent, "model", None)):
         return None
-    if not is_direct_openai_route(
+    trusted_proxy = bool(
+        getattr(agent, "capabilities", {}).get("openai_native_compaction", False)
+    )
+    if not trusted_proxy and not is_direct_openai_route(
         getattr(agent, "base_url", None), is_codex_backend=is_codex_backend
     ):
         return None

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -67,6 +67,24 @@ def is_native_compaction_model(model: Optional[str]) -> bool:
     return _ELIGIBLE_MODEL_MARKER in (model or "").lower()
 
 
+def resolve_native_compaction_capabilities(
+    *,
+    model: Optional[str],
+    base_url: Optional[str],
+    is_codex_backend: bool = False,
+) -> Dict[str, bool]:
+    """Resolve the native-compaction capability for a runtime destination.
+
+    The result is deliberately explicit: a resolved ``False`` is different
+    from an unresolved capability and must survive model switches unchanged.
+    """
+    eligible = is_native_compaction_model(model) and is_direct_openai_route(
+        base_url,
+        is_codex_backend=is_codex_backend,
+    )
+    return {"native_compaction": eligible}
+
+
 def is_direct_openai_route(
     base_url: Optional[str],
     *,
@@ -151,6 +169,10 @@ def native_compaction_context_management(
     (``agent.codex_responses_native_compaction = False``, set by the
     conversation loop's rejection recovery) takes effect on the next call.
     """
+    capabilities = getattr(agent, "capabilities", None)
+    if isinstance(capabilities, dict):
+        if not bool(capabilities.get("native_compaction", False)):
+            return None
     if not bool(getattr(agent, "codex_responses_native_compaction", False)):
         return None
     # compression.enabled: false disables ALL automatic compaction, native

--- a/cli.py
+++ b/cli.py
@@ -10306,6 +10306,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             api_key=_reset_result.api_key,
                             base_url=_reset_result.base_url,
                             api_mode=_reset_result.api_mode,
+                            capabilities=_reset_result.runtime_capabilities,
                         )
                     self.model = _reset_result.new_model
                     self.provider = _reset_result.target_provider
@@ -11480,6 +11481,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=snapshot.get("api_key", ""),
                     base_url=snapshot.get("base_url", ""),
                     api_mode=snapshot.get("api_mode", ""),
+                    capabilities=snapshot.get("capabilities"),
                 )
             except Exception as exc:
                 logger.warning("CLI one-turn model restore failed: %s", exc)
@@ -11624,6 +11626,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    capabilities=result.runtime_capabilities,
                 )
             except Exception as exc:
                 # The agent rolled itself back to the old working model/client.
@@ -12014,6 +12017,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    capabilities=result.runtime_capabilities,
                 )
             except Exception as exc:
                 # Agent rolled itself back; roll the CLI back too and abort so a

--- a/cli.py
+++ b/cli.py
@@ -10306,7 +10306,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             api_key=_reset_result.api_key,
                             base_url=_reset_result.base_url,
                             api_mode=_reset_result.api_mode,
-                            capabilities=_reset_result.runtime_capabilities,
+                            capabilities=getattr(
+                                _reset_result, "runtime_capabilities", None
+                            ),
                         )
                     self.model = _reset_result.new_model
                     self.provider = _reset_result.target_provider
@@ -11626,7 +11628,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
-                    capabilities=result.runtime_capabilities,
+                    capabilities=getattr(result, "runtime_capabilities", None),
                 )
             except Exception as exc:
                 # The agent rolled itself back to the old working model/client.
@@ -12017,7 +12019,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
-                    capabilities=result.runtime_capabilities,
+                    capabilities=getattr(result, "runtime_capabilities", None),
                 )
             except Exception as exc:
                 # Agent rolled itself back; roll the CLI back too and abort so a

--- a/contributors/emails/1290231+steveonjava@users.noreply.github.com
+++ b/contributors/emails/1290231+steveonjava@users.noreply.github.com
@@ -1,0 +1,2 @@
+steveonjava
+# PR #94036/#97292 salvage

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2960,6 +2960,17 @@ def _resolve_runtime_agent_kwargs() -> dict:
         if isinstance(_runtime_mot, int) and _runtime_mot > 0:
             max_tokens = _runtime_mot
 
+    capabilities = runtime.get("capabilities")
+    capabilities = (
+        {
+            key: value
+            for key, value in capabilities.items()
+            if isinstance(key, str) and isinstance(value, bool)
+        }
+        if isinstance(capabilities, dict)
+        else {}
+    )
+
     return {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
@@ -2976,6 +2987,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         # Must flow through to the per-turn route or the provider's configured
         # request body never reaches the model on the gateway path.
         "request_overrides": runtime.get("request_overrides"),
+        "capabilities": capabilities,
     }
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3116,6 +3116,8 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
         "request_overrides": dict(runtime.get("request_overrides") or {}),
+        "capabilities": dict(runtime.get("capabilities") or {}),
+        "max_tokens": runtime.get("max_output_tokens"),
     }
 
 
@@ -8343,12 +8345,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             override_model = override.get("model", model)
             override_runtime = {
                 "provider": override.get("provider"),
+                "requested_provider": override.get("requested_provider"),
                 "api_key": override.get("api_key"),
                 "base_url": override.get("base_url"),
                 "api_mode": override.get("api_mode"),
                 "max_tokens": override.get("max_tokens"),
                 "credential_pool": override.get("credential_pool"),
                 "request_overrides": override.get("request_overrides"),
+                "capabilities": dict(override.get("capabilities") or {}),
             }
             if override_runtime.get("api_key"):
                 if override_runtime.get("credential_pool") is None:
@@ -8503,6 +8507,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
             "max_tokens": runtime_kwargs.get("max_tokens"),
+            "capabilities": dict(runtime_kwargs.get("capabilities") or {}),
         }
         base_request_overrides = dict(runtime_kwargs.get("request_overrides") or {})
         route = {
@@ -27428,6 +27433,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 runtime.get("provider", ""),
                 runtime.get("requested_provider", ""),
                 runtime.get("api_mode", ""),
+                sorted((runtime.get("capabilities") or {}).items()),
                 sorted(enabled_toolsets) if enabled_toolsets else [],
                 # reasoning_config excluded — it's set per-message on the
                 # cached agent and doesn't affect system prompt or tools.
@@ -27496,6 +27502,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 override["request_overrides"] = dict(
                     runtime.get("request_overrides") or {}
                 )
+                override["requested_provider"] = runtime.get("requested_provider")
+                override["capabilities"] = dict(runtime.get("capabilities") or {})
+                override["max_tokens"] = runtime.get("max_tokens")
                 if not override.get("base_url"):
                     override["base_url"] = runtime.get("base_url")
             except Exception:
@@ -27526,7 +27535,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not override:
             return model, runtime_kwargs
         model = override.get("model", model)
-        for key in ("provider", "api_key", "base_url", "api_mode", "credential_pool"):
+        for key in (
+            "provider",
+            "requested_provider",
+            "api_key",
+            "base_url",
+            "api_mode",
+            "credential_pool",
+            "capabilities",
+            "max_tokens",
+        ):
             val = override.get(key)
             if val is not None:
                 runtime_kwargs[key] = val

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1950,6 +1950,7 @@ class GatewaySlashCommandsMixin:
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
+                                    capabilities=result.runtime_capabilities,
                                 )
                             except Exception as exc:
                                 # The in-place swap rolled the agent back to the
@@ -2264,6 +2265,7 @@ class GatewaySlashCommandsMixin:
                         api_key=result.api_key,
                         base_url=result.base_url,
                         api_mode=result.api_mode,
+                        capabilities=result.runtime_capabilities,
                     )
                 except Exception as exc:
                     # In-place swap rolled the agent back to the OLD working

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1950,7 +1950,9 @@ class GatewaySlashCommandsMixin:
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
-                                    capabilities=result.runtime_capabilities,
+                                    capabilities=getattr(
+                                        result, "runtime_capabilities", None
+                                    ),
                                 )
                             except Exception as exc:
                                 # The in-place swap rolled the agent back to the
@@ -2265,7 +2267,7 @@ class GatewaySlashCommandsMixin:
                         api_key=result.api_key,
                         base_url=result.base_url,
                         api_mode=result.api_mode,
-                        capabilities=result.runtime_capabilities,
+                        capabilities=getattr(result, "runtime_capabilities", None),
                     )
                 except Exception as exc:
                     # In-place swap rolled the agent back to the OLD working

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2013,6 +2013,7 @@ class GatewaySlashCommandsMixin:
                             "base_url": result.base_url,
                             "api_mode": result.api_mode,
                             "request_overrides": dict(result.request_overrides or {}),
+                            "capabilities": dict(result.runtime_capabilities or {}),
                         }
 
                         # Write-through the non-secret parts to the session
@@ -2327,6 +2328,7 @@ class GatewaySlashCommandsMixin:
                 "base_url": result.base_url,
                 "api_mode": result.api_mode,
                 "request_overrides": dict(result.request_overrides or {}),
+                "capabilities": dict(result.runtime_capabilities or {}),
             }
             if one_turn:
                 if not hasattr(self, "_pending_one_turn_model_restores"):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1480,7 +1480,7 @@ def _normalize_custom_provider_entry(
         "models_discovered",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models", "extra_body", "extra_headers",
+        "discover_models", "extra_body", "extra_headers", "capabilities",
         "ssl_ca_cert", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -1604,6 +1604,16 @@ def _normalize_custom_provider_entry(
 
     if models_discovered:
         normalized["models_discovered"] = True
+
+    capabilities = entry.get("capabilities")
+    if isinstance(capabilities, dict):
+        normalized_capabilities = {
+            key: value
+            for key, value in capabilities.items()
+            if isinstance(key, str) and isinstance(value, bool)
+        }
+        if normalized_capabilities:
+            normalized["capabilities"] = normalized_capabilities
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2178,6 +2178,7 @@ def switch_model(
     runtime_capabilities = resolve_native_compaction_capabilities(
         model=new_model,
         base_url=base_url,
+        provider=target_provider,
         is_codex_backend=target_provider.strip().lower() == "openai-codex",
     )
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -626,6 +626,7 @@ class ModelSwitchResult:
     provider_label: str = ""
     resolved_via_alias: str = ""
     capabilities: Optional[ModelCapabilities] = None
+    runtime_capabilities: Optional[dict[str, bool]] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
 
@@ -2173,6 +2174,12 @@ def switch_model(
 
     # --- Get capabilities (legacy) ---
     capabilities = get_model_capabilities(target_provider, new_model, allow_network=True)
+    from agent.native_compaction import resolve_native_compaction_capabilities
+    runtime_capabilities = resolve_native_compaction_capabilities(
+        model=new_model,
+        base_url=base_url,
+        is_codex_backend=target_provider.strip().lower() == "openai-codex",
+    )
 
     # --- Get full model info from models.dev ---
     model_info = get_model_info(target_provider, new_model, allow_network=True)
@@ -2215,6 +2222,7 @@ def switch_model(
         provider_label=provider_label,
         resolved_via_alias=resolved_alias,
         capabilities=capabilities,
+        runtime_capabilities=runtime_capabilities,
         model_info=model_info,
         is_global=is_global,
     )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1850,6 +1850,7 @@ def switch_model(
     api_key = current_api_key
     base_url = current_base_url
     api_mode = ""
+    runtime_capabilities: dict[str, bool] = {}
     ollama_headers: dict[str, str] = {}
     validation_headers: dict[str, str] = {}
     suppress_ollama_headers = False
@@ -1894,6 +1895,7 @@ def switch_model(
                 api_key = runtime.get("api_key", "") or _ukey
                 base_url = runtime.get("base_url", "") or _user_pdef.base_url
                 api_mode = runtime.get("api_mode", "")
+                runtime_capabilities = runtime.get("capabilities") or {}
                 validation_headers = runtime.get("extra_headers") or validation_headers
             except Exception:
                 api_key = _ukey
@@ -1912,6 +1914,7 @@ def switch_model(
                 api_key = runtime.get("api_key", "")
                 base_url = runtime.get("base_url", "")
                 api_mode = runtime.get("api_mode", "")
+                runtime_capabilities = runtime.get("capabilities") or {}
                 validation_headers = runtime.get("extra_headers") or validation_headers
             except Exception as e:
                 return ModelSwitchResult(
@@ -1972,6 +1975,7 @@ def switch_model(
                 api_key = runtime.get("api_key", "")
                 base_url = runtime.get("base_url", "")
                 api_mode = runtime.get("api_mode", "")
+                runtime_capabilities = runtime.get("capabilities") or {}
                 validation_headers = runtime.get("extra_headers") or validation_headers
             except Exception:
                 pass
@@ -2223,7 +2227,11 @@ def switch_model(
         provider_label=provider_label,
         resolved_via_alias=resolved_alias,
         capabilities=capabilities,
-        runtime_capabilities=runtime_capabilities,
+        runtime_capabilities={
+            key: value
+            for key, value in runtime_capabilities.items()
+            if isinstance(key, str) and isinstance(value, bool)
+        },
         model_info=model_info,
         is_global=is_global,
     )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -707,6 +707,29 @@ def _try_resolve_from_custom_pool(
         return None
 
 
+def _lift_model_capabilities(
+    entry: Dict[str, Any], model: Optional[str], result: Dict[str, Any]
+) -> None:
+    """Copy explicit boolean per-model capabilities into the runtime."""
+    capabilities = {
+        key: value
+        for key, value in (entry.get("capabilities") or {}).items()
+        if isinstance(key, str) and isinstance(value, bool)
+    }
+    models = entry.get("models")
+    model_config = models.get(model) if isinstance(models, dict) and model else None
+    if isinstance(model_config, dict):
+        capabilities.update(
+            {
+                key: value
+                for key, value in model_config.items()
+                if isinstance(key, str) and isinstance(value, bool)
+            }
+        )
+    if capabilities:
+        result["capabilities"] = capabilities
+
+
 def _lift_max_output_tokens(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
     """Propagate a per-provider output cap onto the resolved runtime dict.
 
@@ -832,6 +855,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     if api_mode:
                         result["api_mode"] = api_mode
                     _lift_max_output_tokens(entry, result)
+                    if isinstance(entry.get("capabilities"), dict):
+                        result["capabilities"] = dict(entry["capabilities"])
                     return result
 
     # Fall back to custom_providers: list (legacy format)
@@ -879,6 +904,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         if model_name:
             result["model"] = model_name
         _lift_max_output_tokens(entry, result)
+        if isinstance(entry.get("capabilities"), dict):
+            result["capabilities"] = dict(entry["capabilities"])
         return result
 
     return None
@@ -1239,6 +1266,7 @@ def _resolve_named_custom_runtime(
         model_name = target_model or custom_provider.get("model")
         if model_name:
             pool_result["model"] = model_name
+        _lift_model_capabilities(custom_provider, model_name, pool_result)
         if isinstance(custom_provider.get("max_output_tokens"), int):
             pool_result["max_output_tokens"] = custom_provider["max_output_tokens"]
         request_overrides = _custom_provider_request_overrides(custom_provider)
@@ -1294,6 +1322,7 @@ def _resolve_named_custom_runtime(
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
+        "requested_provider": requested_provider,
     }
     # Propagate the model name so callers can override self.model when the
     # provider name differs from the actual model string the API expects.
@@ -1305,6 +1334,9 @@ def _resolve_named_custom_runtime(
         result["model"] = target_model
     elif custom_provider.get("model"):
         result["model"] = custom_provider["model"]
+    _lift_model_capabilities(
+        custom_provider, result.get("model"), result
+    )
     if isinstance(custom_provider.get("max_output_tokens"), int):
         result["max_output_tokens"] = custom_provider["max_output_tokens"]
     # Per-provider extra HTTP headers (proxies, gateways, custom auth).

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -707,25 +707,26 @@ def _try_resolve_from_custom_pool(
         return None
 
 
+def _filter_capabilities(value: Any) -> Dict[str, bool]:
+    """Return the string-keyed boolean capabilities accepted at runtime."""
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: enabled
+        for key, enabled in value.items()
+        if isinstance(key, str) and isinstance(enabled, bool)
+    }
+
+
 def _lift_model_capabilities(
     entry: Dict[str, Any], model: Optional[str], result: Dict[str, Any]
 ) -> None:
     """Copy explicit boolean per-model capabilities into the runtime."""
-    capabilities = {
-        key: value
-        for key, value in (entry.get("capabilities") or {}).items()
-        if isinstance(key, str) and isinstance(value, bool)
-    }
+    capabilities = _filter_capabilities(entry.get("capabilities"))
     models = entry.get("models")
     model_config = models.get(model) if isinstance(models, dict) and model else None
     if isinstance(model_config, dict):
-        capabilities.update(
-            {
-                key: value
-                for key, value in model_config.items()
-                if isinstance(key, str) and isinstance(value, bool)
-            }
-        )
+        capabilities.update(_filter_capabilities(model_config))
     if capabilities:
         result["capabilities"] = capabilities
 
@@ -827,7 +828,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
-                    result = {
+                    result: Dict[str, Any] = {
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
@@ -855,8 +856,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     if api_mode:
                         result["api_mode"] = api_mode
                     _lift_max_output_tokens(entry, result)
-                    if isinstance(entry.get("capabilities"), dict):
-                        result["capabilities"] = dict(entry["capabilities"])
+                    capabilities = _filter_capabilities(entry.get("capabilities"))
+                    if capabilities:
+                        result["capabilities"] = capabilities
                     return result
 
     # Fall back to custom_providers: list (legacy format)
@@ -904,8 +906,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         if model_name:
             result["model"] = model_name
         _lift_max_output_tokens(entry, result)
-        if isinstance(entry.get("capabilities"), dict):
-            result["capabilities"] = dict(entry["capabilities"])
+        capabilities = _filter_capabilities(entry.get("capabilities"))
+        if capabilities:
+            result["capabilities"] = capabilities
         return result
 
     return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -523,6 +523,7 @@ class AIAgent:
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
         requested_provider: str = None,
+        capabilities: Dict[str, bool] | None = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         if tool_delay is not None:
@@ -539,6 +540,7 @@ class AIAgent:
             api_key=api_key,
             provider=provider,
             requested_provider=requested_provider,
+            capabilities=capabilities,
             api_mode=api_mode,
             acp_command=acp_command,
             acp_args=acp_args,

--- a/run_agent.py
+++ b/run_agent.py
@@ -899,10 +899,26 @@ class AIAgent:
             return_load_result=True,
         )
 
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(
+        self,
+        new_model,
+        new_provider,
+        api_key='',
+        base_url='',
+        api_mode='',
+        capabilities=None,
+    ):
         """Forwarder — see ``agent.agent_runtime_helpers.switch_model``."""
         from agent.agent_runtime_helpers import switch_model
-        return switch_model(self, new_model, new_provider, api_key, base_url, api_mode)
+        return switch_model(
+            self,
+            new_model,
+            new_provider,
+            api_key,
+            base_url,
+            api_mode,
+            capabilities,
+        )
 
     def _safe_print(self, *args, **kwargs):
         """Print that silently handles broken pipes / closed stdout.

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -69,6 +69,16 @@ class TestAgentConfigSignature:
         sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", rt2, ["hermes-telegram"], "")
         assert sig1 != sig2
 
+    def test_capability_change_different_signature(self):
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "sk-test12345678", "base_url": "https://proxy.example/v1", "provider": "custom"}
+        native = {**runtime, "capabilities": {"openai_native_compaction": True}}
+        plain = {**runtime, "capabilities": {"openai_native_compaction": False}}
+        assert GatewayRunner._agent_config_signature("gpt-5.6", native, [], "") != (
+            GatewayRunner._agent_config_signature("gpt-5.6", plain, [], "")
+        )
+
 
     # ---------------------------------------------------------------
     # cache_keys (compression/context config cache-busting)

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -80,6 +80,32 @@ class TestAgentConfigSignature:
         )
 
 
+    def test_default_gateway_runtime_forwards_filtered_capabilities(self, monkeypatch):
+        """Configured provider capabilities must reach a newly created gateway agent."""
+        from gateway.run import _resolve_runtime_agent_kwargs
+        from hermes_cli import runtime_provider
+
+        monkeypatch.setattr(
+            runtime_provider,
+            "resolve_runtime_provider",
+            lambda: {
+                "api_key": "test-key",
+                "base_url": "https://trusted-proxy.example/v1",
+                "provider": "custom",
+                "requested_provider": "custom:trusted-proxy",
+                "api_mode": "responses",
+                "capabilities": {
+                    "openai_native_compaction": True,
+                    "ignore-me": "not-a-bool",
+                },
+            },
+        )
+        monkeypatch.setattr(runtime_provider, "_get_model_config", lambda: {})
+
+        runtime = _resolve_runtime_agent_kwargs()
+
+        assert runtime["capabilities"] == {"openai_native_compaction": True}
+
     # ---------------------------------------------------------------
     # cache_keys (compression/context config cache-busting)
     # ---------------------------------------------------------------

--- a/tests/gateway/test_model_switch_persistence.py
+++ b/tests/gateway/test_model_switch_persistence.py
@@ -208,6 +208,7 @@ class TestOneTurnNeverPersisted:
                 api_key="sk-test",
                 base_url="https://openrouter.ai/api/v1",
                 api_mode="chat_completions",
+                runtime_capabilities={"openai_native_compaction": True},
                 provider_label="OpenRouter",
             ),
         )
@@ -253,6 +254,9 @@ class TestOneTurnNeverPersisted:
         assert result is not None and "gpt-5.5" in result
         # In-memory override installed for the next turn + restore queued...
         assert runner._session_model_overrides[sk]["model"] == "gpt-5.5"
+        assert runner._session_model_overrides[sk]["capabilities"] == {
+            "openai_native_compaction": True
+        }
         assert sk in runner._pending_one_turn_model_restores
         # ...but NEVER written through to the persistent session store.
         runner.async_session_store.set_model_override.assert_not_awaited()

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -111,6 +111,9 @@ def test_runner_rehydrates_override_after_restart(store_factory):
             "api_mode": "responses",
             "base_url": "https://api.openai.example/v1",
             "provider": "openai",
+            "requested_provider": "custom:chatgpt-tier",
+            "capabilities": {"openai_native_compaction": True},
+            "max_tokens": 32_768,
         },
     ):
         runner._rehydrate_session_model_override(session_key)
@@ -122,6 +125,20 @@ def test_runner_rehydrates_override_after_restart(store_factory):
     # Credentials come from live resolution, never from disk.
     assert override["api_key"] == "sk-fresh-from-keychain"
     assert override["api_mode"] == "responses"
+    assert override["requested_provider"] == "custom:chatgpt-tier"
+    assert override["capabilities"] == {"openai_native_compaction": True}
+    assert override["max_tokens"] == 32_768
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        session_key=session_key,
+        user_config={"model": {"default": "global-model"}},
+    )
+    assert model == "gpt-5o"
+    assert runtime["requested_provider"] == "custom:chatgpt-tier"
+    assert runtime["capabilities"] == {"openai_native_compaction": True}
+    assert runtime["max_tokens"] == 32_768
+    route = runner._resolve_turn_agent_config("", model, runtime)
+    assert route["runtime"]["capabilities"] == {"openai_native_compaction": True}
 
 
 def test_sanitize_model_override():

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -659,6 +659,39 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["source"] == "custom_provider:Local"
 
 
+def test_named_custom_provider_filters_capabilities_at_lookup_boundary(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "local": {
+                    "name": "Local",
+                    "base_url": "http://1.2.3.4:1234/v1",
+                    "capabilities": {
+                        "openai_native_compaction": True,
+                        "invalid-value": "yes",
+                        42: True,
+                    },
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    provider = rp._get_named_custom_provider("local")
+
+    assert provider["capabilities"] == {"openai_native_compaction": True}
+
+
 def test_bare_custom_resolves_providers_dict_entry_named_custom(monkeypatch):
     """A request for bare ``provider="custom"`` must resolve a literal
     ``providers.custom`` entry (e.g. a cliproxy endpoint) instead of falling

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -632,6 +632,8 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
                     "name": "Local",
                     "base_url": "http://1.2.3.4:1234/v1",
                     "api_key": "local-provider-key",
+                    "model": "gpt-5.6",
+                    "capabilities": {"openai_native_compaction": True},
                 }
             ]
         },
@@ -653,6 +655,7 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["base_url"] == "http://1.2.3.4:1234/v1"
     assert resolved["api_key"] == "local-provider-key"
     assert resolved["requested_provider"] == "local"
+    assert resolved["capabilities"] == {"openai_native_compaction": True}
     assert resolved["source"] == "custom_provider:Local"
 
 

--- a/tests/run_agent/test_fallback_reasoning_override.py
+++ b/tests/run_agent/test_fallback_reasoning_override.py
@@ -75,6 +75,7 @@ class TestFallbackReasoningOverride:
             "client_kwargs": {},
             "use_prompt_caching": False,
             "use_native_cache_layout": False,
+            "capabilities": {"native_compaction": True},
             "reasoning_config": {"enabled": True, "effort": "medium"},
             "compressor_model": "gemini-flash",
             "compressor_base_url": "",
@@ -95,6 +96,7 @@ class TestFallbackReasoningOverride:
         agent.model = "claude-opus-4.5"
         agent.provider = "anthropic"
         agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        agent.capabilities = {"native_compaction": False}
         agent.context_compressor = MagicMock()
         agent.base_url = ""
         agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
@@ -105,6 +107,7 @@ class TestFallbackReasoningOverride:
         assert result is True
         # reasoning_config should be restored to primary's value (medium)
         assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+        assert agent.capabilities == {"native_compaction": True}
 
     def test_fallback_global_fallback_with_yaml_false(self):
         """Fallback global fallback must not coerce YAML boolean False.

--- a/tests/run_agent/test_fallback_reasoning_override.py
+++ b/tests/run_agent/test_fallback_reasoning_override.py
@@ -75,7 +75,7 @@ class TestFallbackReasoningOverride:
             "client_kwargs": {},
             "use_prompt_caching": False,
             "use_native_cache_layout": False,
-            "capabilities": {"native_compaction": True},
+            "runtime_capabilities": {"native_compaction": True},
             "reasoning_config": {"enabled": True, "effort": "medium"},
             "compressor_model": "gemini-flash",
             "compressor_base_url": "",
@@ -96,7 +96,7 @@ class TestFallbackReasoningOverride:
         agent.model = "claude-opus-4.5"
         agent.provider = "anthropic"
         agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
-        agent.capabilities = {"native_compaction": False}
+        agent.runtime_capabilities = {"native_compaction": False}
         agent.context_compressor = MagicMock()
         agent.base_url = ""
         agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
@@ -107,7 +107,7 @@ class TestFallbackReasoningOverride:
         assert result is True
         # reasoning_config should be restored to primary's value (medium)
         assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
-        assert agent.capabilities == {"native_compaction": True}
+        assert agent.runtime_capabilities == {"native_compaction": True}
 
     def test_fallback_global_fallback_with_yaml_false(self):
         """Fallback global fallback must not coerce YAML boolean False.

--- a/tests/run_agent/test_native_compaction.py
+++ b/tests/run_agent/test_native_compaction.py
@@ -27,6 +27,7 @@ def _agent(
     compression_enabled=True,
     threshold=DEFAULT_COMPACT_THRESHOLD,
     compressor=None,
+    capabilities=None,
 ):
     return SimpleNamespace(
         model=model,
@@ -35,6 +36,7 @@ def _agent(
         compression_enabled=compression_enabled,
         codex_responses_compact_threshold=threshold,
         context_compressor=compressor,
+        capabilities=capabilities or {},
     )
 
 
@@ -87,6 +89,16 @@ class TestRequestGate:
         payload = native_compaction_context_management(
             _agent(base_url="https://chatgpt.com/backend-api/codex"),
             is_codex_backend=True,
+        )
+        assert payload is not None
+
+    def test_trusted_proxy_capability_gets_payload(self):
+        payload = native_compaction_context_management(
+            _agent(
+                base_url="https://trusted-proxy.example/v1",
+                capabilities={"openai_native_compaction": True},
+            ),
+            is_codex_backend=False,
         )
         assert payload is not None
 

--- a/tests/run_agent/test_native_compaction_switch_capabilities.py
+++ b/tests/run_agent/test_native_compaction_switch_capabilities.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+
+from agent.native_compaction import (
+    native_compaction_context_management,
+    resolve_native_compaction_capabilities,
+)
+
+
+def _agent(capabilities):
+    return SimpleNamespace(
+        model="gpt-5.6",
+        base_url="https://proxy.example/v1",
+        codex_responses_native_compaction=True,
+        compression_enabled=True,
+        codex_responses_compact_threshold=200_000,
+        context_compressor=None,
+        capabilities=capabilities,
+    )
+
+
+def test_trusted_destination_capabilities_are_explicitly_enabled():
+    capabilities = resolve_native_compaction_capabilities(
+        model="gpt-5.6",
+        base_url="https://api.openai.com/v1",
+    )
+
+    assert capabilities == {"native_compaction": True}
+
+
+def test_untrusted_destination_capabilities_are_explicitly_denied():
+    capabilities = resolve_native_compaction_capabilities(
+        model="gpt-5.6",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert capabilities == {"native_compaction": False}
+
+
+def test_explicit_false_capability_denies_native_payload():
+    agent = _agent({"native_compaction": False})
+
+    assert native_compaction_context_management(agent, is_codex_backend=False) is None
+
+
+def test_missing_capability_keeps_default_deny():
+    agent = _agent({})
+
+    assert native_compaction_context_management(agent, is_codex_backend=False) is None

--- a/tests/run_agent/test_native_compaction_switch_capabilities.py
+++ b/tests/run_agent/test_native_compaction_switch_capabilities.py
@@ -36,6 +36,16 @@ def test_untrusted_destination_capabilities_are_explicitly_denied():
     assert capabilities == {"native_compaction": False}
 
 
+def test_default_openai_destination_is_enabled_without_explicit_base_url():
+    capabilities = resolve_native_compaction_capabilities(
+        model="gpt-5.6",
+        base_url="",
+        provider="openai",
+    )
+
+    assert capabilities == {"native_compaction": True}
+
+
 def test_explicit_false_capability_denies_native_payload():
     agent = _agent({"native_compaction": False})
 

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -133,6 +133,22 @@ def test_switch_model_without_config_context_length():
         assert call_kwargs.get("config_context_length") is None
 
 
+def test_switch_model_omitted_base_url_preserves_direct_openai_capability():
+    """A same-provider switch resolves capabilities from the retained URL."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent.provider = "openai"
+    agent.model = "gpt-5.6"
+    agent.base_url = "https://api.openai.com/v1"
+    agent.capabilities = {"native_compaction": True}
+    agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
+        agent.switch_model("gpt-5.6", "openai", api_key="sk-new")
+
+    assert agent.base_url == "https://api.openai.com/v1"
+    assert agent.capabilities == {"native_compaction": True}
+
+
 def test_direct_start_model_override_does_not_inherit_profile_context_length():
     """A CLI ``--model`` startup override must not inherit another model's window."""
     cfg = {

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -139,14 +139,29 @@ def test_switch_model_omitted_base_url_preserves_direct_openai_capability():
     agent.provider = "openai"
     agent.model = "gpt-5.6"
     agent.base_url = "https://api.openai.com/v1"
-    agent.capabilities = {"native_compaction": True}
+    agent.runtime_capabilities = {"native_compaction": True}
     agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
 
     with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
         agent.switch_model("gpt-5.6", "openai", api_key="sk-new")
 
     assert agent.base_url == "https://api.openai.com/v1"
-    assert agent.capabilities == {"native_compaction": True}
+    assert agent.runtime_capabilities == {"native_compaction": True}
+
+
+def test_cross_provider_switch_to_default_openai_preserves_native_capability():
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent.provider = "openrouter"
+    agent.model = "gpt-5.5"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.runtime_capabilities = {"native_compaction": False}
+    agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
+        agent.switch_model("gpt-5.6", "openai", api_key="sk-new")
+
+    assert agent.base_url == "https://api.openai.com/v1"
+    assert agent.runtime_capabilities == {"native_compaction": True}
 
 
 def test_direct_start_model_override_does_not_inherit_profile_context_length():
@@ -304,7 +319,7 @@ def test_lmstudio_switch_uses_destination_context_and_verified_runtime(monkeypat
 
 def test_later_lmstudio_failure_restores_runtime_capabilities(monkeypatch):
     agent = _make_agent_with_compressor(config_context_length=32_768)
-    agent.capabilities = {"native_compaction": True}
+    agent.runtime_capabilities = {"native_compaction": True}
     original_client = agent.client
 
     monkeypatch.setattr(
@@ -326,4 +341,4 @@ def test_later_lmstudio_failure_restores_runtime_capabilities(monkeypatch):
     assert agent.model == "primary-model"
     assert agent.provider == "openrouter"
     assert agent.client is original_client
-    assert agent.capabilities == {"native_compaction": True}
+    assert agent.runtime_capabilities == {"native_compaction": True}

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -284,3 +284,30 @@ def test_lmstudio_switch_uses_destination_context_and_verified_runtime(monkeypat
     assert call_kwargs.get("config_context_length") == 100_000
     assert agent._config_context_length == 120_000
     assert agent.context_compressor.context_length == 100_000
+
+
+def test_later_lmstudio_failure_restores_runtime_capabilities(monkeypatch):
+    agent = _make_agent_with_compressor(config_context_length=32_768)
+    agent.capabilities = {"native_compaction": True}
+    original_client = agent.client
+
+    monkeypatch.setattr(
+        AIAgent,
+        "_ensure_lmstudio_runtime_loaded",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("simulated LM Studio failure")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="simulated LM Studio failure"):
+        agent.switch_model(
+            "new-model",
+            "openrouter",
+            api_key="sk-new",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    assert agent.model == "primary-model"
+    assert agent.provider == "openrouter"
+    assert agent.client is original_client
+    assert agent.capabilities == {"native_compaction": True}

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -46,6 +46,7 @@ def _make_agent_openrouter():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
+    agent.capabilities = {"native_compaction": False}
 
     return agent
 
@@ -73,6 +74,7 @@ def _make_agent_anthropic():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
+    agent.capabilities = {"native_compaction": False}
 
     return agent
 
@@ -108,6 +110,7 @@ def test_openai_client_rebuild_failure_rolls_back_to_original_state():
     assert agent.api_key == "or-key-original"
     assert agent.client is original_client
     assert agent._client_kwargs == original_kwargs
+    assert agent.capabilities == {"native_compaction": False}
 
 
 def test_anthropic_client_rebuild_failure_rolls_back_to_original_state():

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -46,7 +46,7 @@ def _make_agent_openrouter():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
-    agent.capabilities = {"native_compaction": False}
+    agent.runtime_capabilities = {"native_compaction": False}
 
     return agent
 
@@ -74,7 +74,7 @@ def _make_agent_anthropic():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
-    agent.capabilities = {"native_compaction": False}
+    agent.runtime_capabilities = {"native_compaction": False}
 
     return agent
 
@@ -110,7 +110,7 @@ def test_openai_client_rebuild_failure_rolls_back_to_original_state():
     assert agent.api_key == "or-key-original"
     assert agent.client is original_client
     assert agent._client_kwargs == original_kwargs
-    assert agent.capabilities == {"native_compaction": False}
+    assert agent.runtime_capabilities == {"native_compaction": False}
 
 
 def test_anthropic_client_rebuild_failure_rolls_back_to_original_state():

--- a/tests/tools/test_delegate_capability_inheritance.py
+++ b/tests/tools/test_delegate_capability_inheritance.py
@@ -1,0 +1,52 @@
+"""Subagent capability inheritance (follow-up to #94036/#97292).
+
+The trusted-proxy capability map is endpoint-scoped trust: children inherit
+it only on the parent's exact route; provider- or endpoint-changing
+delegation overrides stay default-deny.
+"""
+
+from types import SimpleNamespace
+
+from tools.delegate_tool import _inherit_parent_capabilities
+
+
+def _parent(capabilities):
+    return SimpleNamespace(
+        provider="custom:proxy",
+        base_url="https://trusted-proxy.corp/v1",
+        capabilities=capabilities,
+    )
+
+
+def test_same_route_child_inherits_capability_map():
+    parent = _parent({"openai_native_compaction": True})
+    assert _inherit_parent_capabilities(parent, None, None) == {
+        "openai_native_compaction": True
+    }
+
+
+def test_provider_override_stays_default_deny():
+    parent = _parent({"openai_native_compaction": True})
+    assert _inherit_parent_capabilities(parent, "openai", None) is None
+
+
+def test_base_url_override_stays_default_deny():
+    parent = _parent({"openai_native_compaction": True})
+    assert (
+        _inherit_parent_capabilities(parent, None, "https://other.example/v1")
+        is None
+    )
+
+
+def test_non_dict_parent_capabilities_yield_none():
+    parent = _parent(None)
+    assert _inherit_parent_capabilities(parent, None, None) is None
+
+
+def test_inherited_map_is_sanitized_to_str_bool():
+    parent = _parent(
+        {"openai_native_compaction": True, "bad": "yes", 3: True, "n": 0}
+    )
+    assert _inherit_parent_capabilities(parent, None, None) == {
+        "openai_native_compaction": True
+    }

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1569,6 +1569,30 @@ def _normalized_runtime_url(value: Any) -> str:
     return str(value or "").strip().rstrip("/")
 
 
+def _inherit_parent_capabilities(
+    parent_agent, override_provider, override_base_url
+) -> Optional[dict]:
+    """Return the parent's endpoint-trust capability map for a child, or None.
+
+    The trusted-proxy capability map (``agent.capabilities``, e.g.
+    ``openai_native_compaction`` from a custom_providers entry) is a trust
+    decision scoped to one provider+endpoint. A child inherits it ONLY when
+    it runs against the parent's exact route — any delegation override that
+    changes provider or base_url stays DEFAULT-DENY, matching the /model
+    switch posture (#94036/#97292).
+    """
+    if override_provider or override_base_url:
+        return None
+    parent_caps = getattr(parent_agent, "capabilities", None)
+    if not isinstance(parent_caps, dict):
+        return None
+    return {
+        key: value
+        for key, value in parent_caps.items()
+        if isinstance(key, str) and isinstance(value, bool)
+    }
+
+
 def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> Optional[str]:
     """Return the base URL the parent is actually calling, not a stale attribute.
 
@@ -1786,6 +1810,16 @@ def _build_child_agent(
     if not override_base_url:
         effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
     effective_api_key = override_api_key or parent_api_key
+    # Same-class follow-up to #94036/#97292: the trusted-proxy capability map
+    # (`agent.capabilities`, e.g. ``openai_native_compaction`` from a
+    # custom_providers entry) is an endpoint-scoped trust decision. Children
+    # inherit it ONLY when they run against the parent's exact provider and
+    # base_url — a provider- or endpoint-changing delegation override stays
+    # DEFAULT-DENY, matching the /model switch posture. Without this, a child
+    # on the same trusted proxy silently falls back to local summarization.
+    child_capabilities = _inherit_parent_capabilities(
+        parent_agent, override_provider, override_base_url
+    )
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface
     # (e.g. MiniMax uses anthropic_messages, DeepSeek uses chat_completions).
@@ -1967,6 +2001,7 @@ def _build_child_agent(
                 api_key=effective_api_key,
                 model=effective_model,
                 provider=effective_provider,
+                capabilities=child_capabilities,
                 api_mode=effective_api_mode,
                 acp_command=effective_acp_command,
                 acp_args=effective_acp_args,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6348,7 +6348,7 @@ def _apply_model_switch(
                 api_key=result.api_key,
                 base_url=result.base_url,
                 api_mode=result.api_mode,
-                capabilities=result.runtime_capabilities,
+                capabilities=getattr(result, "runtime_capabilities", None),
             )
         except Exception as exc:
             # The in-place swap rolled the agent back to the old working

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6135,6 +6135,7 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
             api_key=snapshot.get("api_key", ""),
             base_url=snapshot.get("base_url", ""),
             api_mode=snapshot.get("api_mode", ""),
+            capabilities=snapshot.get("capabilities"),
         )
 
 
@@ -6347,6 +6348,7 @@ def _apply_model_switch(
                 api_key=result.api_key,
                 base_url=result.base_url,
                 api_mode=result.api_mode,
+                capabilities=result.runtime_capabilities,
             )
         except Exception as exc:
             # The in-place swap rolled the agent back to the old working

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -167,7 +167,7 @@ When `fallback_chain` is absent, `auto` uses the top-level `fallback_providers` 
 
 ## Per-provider request options
 
-Provider entries (`providers.<name>` in the `providers:` dict, or items in the legacy `custom_providers` list) accept two knobs that shape how Hermes talks to the endpoint:
+Provider entries (`providers.<name>` in the `providers:` dict, or items in the legacy `custom_providers` list) accept knobs that shape how Hermes talks to the endpoint:
 
 **`extra_headers`** — a mapping of extra HTTP headers attached to every LLM request routed to that provider's base URL. They are applied last, after URL/profile defaults and user header overrides, so they survive credential swaps and client rebuilds. Useful for Cloudflare Access service tokens, proxy auth, or custom bearer schemes:
 
@@ -196,6 +196,16 @@ providers:
 ```
 
 With discovery off, the model picker (`hermes model`, `/model`) shows the configured list instead of a live probe.
+
+**`openai_native_compaction`** — set this capability to `true` only for an OpenAI-compatible endpoint that you trust with conversation content. Native compaction sends its payload to that provider's configured `base_url`:
+
+```yaml
+providers:
+  trusted-proxy:
+    api: https://llm.internal.example.com/v1
+    capabilities:
+      openai_native_compaction: true
+```
 
 For a gateway that resolves a bare model alias only after receiving the
 request, opt the alias into prompt-cache markers with the per-model


### PR DESCRIPTION
## Summary
Native-compaction capability no longer silently drops to slow local summarization after a runtime model switch or a gateway restart that restores a persisted `/model` override. Same-provider effective-endpoint switches preserve capability; provider-changing or unresolved-endpoint switches remain default-deny; rollback/fallback restoration preserves prior capability state.

Salvaged as ONE stacked branch: the two PRs share five files and #97292's `ModelSwitchResult.runtime_capabilities` plumbing builds on #94036's `resolve_native_compaction_capabilities` machinery. Both were CONFLICTING against main; resolved onto current main preserving default-deny.

## Changes
- #94036 (4 commits, @steveonjava): capability derived from the effective switch endpoint on same-provider switches; rollback preserves prior state
- #97292 (3 commits, @steveonjava): gateway resume restores the persisted override WITH provider capability declarations and output cap; trusted-proxy capability propagation
- Follow-up (ours): `_inherit_parent_capabilities()` — delegated subagents inherit the endpoint-scoped capability map only on the parent's exact provider+base_url; any delegation override stays default-deny

## Validation
| Scenario | Before (main) | After |
|---|---|---|
| Same-provider /model switch | capability silently dropped | preserved |
| Provider-changing switch | deny | deny (unchanged) |
| Gateway resume w/ persisted override | restored without capabilities | capabilities carried through |
| Untrusted proxy | — | deny |

204 targeted tests pass; ruff clean; credential-free probes confirm each row.

Salvage of #94036 and #97292 — all 7 commits keep @steveonjava's authorship.

## Infographic

![Capability preserved](https://v3b.fal.media/files/b/0aa868df/Qu5-V2qfOR8TUatCMUzp7_jE2pLP6w.png)
