### PR TITLE
feat(logging): add configurable GCP structured stream logs

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -80,15 +80,10 @@ class _BenignProbeMethodFilter(logging.Filter):
 
 def _setup_logging() -> None:
     """Route all logging to stderr so stdout stays clean for ACP stdio."""
-    from agent.redact import RedactingFormatter
+    from hermes_logging import GCPStructuredLogFormatter
 
     handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(
-        RedactingFormatter(
-            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-    )
+    handler.setFormatter(GCPStructuredLogFormatter())
     handler.addFilter(_BenignProbeMethodFilter())
     root = logging.getLogger()
     root.handlers.clear()

--- a/cli.py
+++ b/cli.py
@@ -780,7 +780,7 @@ def load_cli_config() -> Dict[str, Any]:
 CLI_CONFIG = load_cli_config()
 
 
-# Initialize centralized logging early — agent.log + errors.log in ~/.hermes/logs/.
+# Initialize centralized structured stream logging early for all CLI sessions.
 # This ensures CLI sessions produce a log trail even before AIAgent is instantiated.
 try:
     from hermes_logging import setup_logging

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29699,32 +29699,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         async def write_tool_log():
-            """Drain log_queue and append tool-call lines to tool_calls.log.
-
-            Only active when ``display.tool_progress`` is ``log``. Uses a
-            RotatingFileHandler (5MB × 3 backups) so the audit log can't grow
-            unbounded, and the shared RedactingFormatter so secrets never land
-            on disk.
-            """
+            """Drain log_queue into the structured container log stream."""
             if log_queue is None:
                 return
-            from logging.handlers import RotatingFileHandler
-
-            from agent.redact import RedactingFormatter
-
-            log_dir = _hermes_home / "logs"
-            log_dir.mkdir(parents=True, exist_ok=True)
-            file_handler = RotatingFileHandler(
-                log_dir / "tool_calls.log",
-                maxBytes=5 * 1024 * 1024,
-                backupCount=3,
-                encoding="utf-8",
-            )
-            file_handler.setFormatter(RedactingFormatter("%(message)s"))
-            tool_logger = logging.getLogger(f"hermes.tool_calls.{id(log_queue)}")
+            tool_logger = logging.getLogger("hermes.tool_calls")
             tool_logger.setLevel(logging.INFO)
-            tool_logger.propagate = False
-            tool_logger.addHandler(file_handler)
+            tool_logger.propagate = True
             try:
                 while True:
                     try:
@@ -29746,12 +29726,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         break
                     except Exception:
                         break
-                tool_logger.removeHandler(file_handler)
-                try:
-                    file_handler.flush()
-                    file_handler.close()
-                except Exception:
-                    pass
 
         # Extracted to TurnRunner.send_progress_messages. The threading
         # metadata computed above is published onto the shared TurnContext
@@ -31888,10 +31862,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception:
         pass
 
-    # Centralized logging — agent.log (INFO+), errors.log (WARNING+),
-    # and gateway.log (INFO+, gateway-component records only).
-    # Idempotent, so repeated calls from AIAgent.__init__ won't duplicate.
-    from hermes_logging import setup_logging, _safe_stderr
+    # Centralized logging — newline-delimited GCP structured records on stderr.
+    # The non-TTY default is INFO so container log collectors receive the full
+    # operational stream; interactive terminals retain the quieter WARNING
+    # default unless verbosity is explicitly increased.
+    from hermes_logging import setup_logging, set_stream_log_level
     setup_logging(hermes_home=_hermes_home, mode="gateway")
 
     # Startup security posture audit — warn-on-load, never blocks. Surfaces
@@ -31912,20 +31887,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception as _audit_exc:
         logger.debug("Startup security audit failed (non-fatal): %s", _audit_exc)
 
-    # Optional stderr handler — level driven by -v/-q flags on the CLI.
-    # verbosity=None (-q/--quiet): no stderr output
-    # verbosity=0    (default):    WARNING and above
-    # verbosity=1    (-v):         INFO and above
-    # verbosity=2+   (-vv/-vvv):   DEBUG
+    # Adjust the shared structured handler for CLI verbosity. In a container
+    # (non-TTY), the default remains INFO so Cloud Logging sees normal events.
     if verbosity is not None:
-        _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
-        _stderr_handler = logging.StreamHandler(_safe_stderr())
-        _stderr_handler.setLevel(_stderr_level)
-        _stderr_handler.setFormatter(_gateway_stderr_formatter())
-        logging.getLogger().addHandler(_stderr_handler)
-        # Lower root logger level if needed so DEBUG records can reach the handler
-        if _stderr_level < logging.getLogger().level:
-            logging.getLogger().setLevel(_stderr_level)
+        if verbosity <= 0:
+            set_stream_log_level(
+                logging.WARNING if sys.stderr.isatty() else logging.INFO
+            )
+        elif verbosity == 1:
+            set_stream_log_level(logging.INFO)
+        else:
+            set_stream_log_level(logging.DEBUG)
+    else:
+        set_stream_log_level(logging.CRITICAL + 1)
 
     runner = GatewayRunner(config)
     # ``--replace`` is explicit startup authority, not a durable reconnect

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -117,9 +117,7 @@ Examples:
     hermes sessions list          List past sessions
     hermes sessions browse        Interactive session picker
     hermes sessions rename ID T   Rename/title a session
-    hermes logs                   View agent.log (last 50 lines)
-    hermes logs -f                Follow agent.log in real time
-    hermes logs errors            View errors.log
+    hermes logs                   Show how to retrieve structured runtime logs
     hermes logs --since 1h        Lines from the last hour
     hermes debug share             Upload debug report for support
     hermes console                Open the safe Hermes command console

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -110,9 +110,9 @@ def _warn_config_parse_failure(
     is dropped. Before this helper that was a one-line ``print(...)`` that
     scrolled off-screen on the first invocation and was never seen again.
 
-    Now: warn once per (path, mtime_ns, size) on stderr **and** in
-    ``agent.log`` / ``errors.log`` at WARNING level so ``hermes logs``
-    surfaces it. Re-warns automatically if the file changes (different
+     Now: warn once per (path, mtime_ns, size) on stderr and in the structured
+     runtime stream at WARNING level so container log collectors surface it.
+     Re-warns automatically if the file changes (different
     mtime/size), so users editing the config see the next failure. On the
     first warning for a given broken file we also snapshot it to a
     timestamped ``.bak`` (best-effort) so the user's recoverable content

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3004,12 +3004,11 @@ DEFAULT_CONFIG = {
         },
     },
 
-    # Logging — controls file logging to ~/.hermes/logs/.
-    # agent.log captures INFO+ (all agent activity); errors.log captures WARNING+.
+    # Logging — controls the stderr stream consumed by terminals and
+    # container logging systems such as Google Cloud Logging.
     "logging": {
-        "level": "INFO",       # Minimum level for agent.log: DEBUG, INFO, WARNING
-        "max_size_mb": 5,      # Max size per log file before rotation
-        "backup_count": 3,     # Number of rotated backup files to keep
+        "level": "INFO",       # Minimum stream level: DEBUG, INFO, WARNING
+        "format": "text",      # text or gcp_json
     },
 
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -533,51 +533,16 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
 def _write_reconcile_log(
     hermes_home: Path, actions: list[ReconcileAction],
 ) -> None:
-    """Append one line per profile to $HERMES_HOME/logs/container-boot.log.
-
-    Operators inspect this to debug "why didn't my profile come back
-    up". Keeping a separate log file (vs. mixing into agent.log) lets
-    troubleshooters grep for "profile=foo" without wading through
-    unrelated activity.
-
-    Size-bounded: when the file exceeds ``_LOG_ROTATE_BYTES``
-    (defaults to 256 KiB ≈ 3000 reconcile lines), the current file
-    is renamed to ``container-boot.log.1`` (replacing any previous
-    rotation) before the new entries are appended. This gives long-
-    lived containers a soft cap of ~512 KiB across the two files
-    without pulling in logrotate or s6-log machinery just for this
-    one append-only file (PR #30136 review item O3).
-    """
-    import time
-    log_dir = hermes_home / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_path = log_dir / "container-boot.log"
-
-    # Rotate before opening to append, so the new entries always land
-    # in a fresh file when we crossed the threshold last time.
-    try:
-        if log_path.exists() and log_path.stat().st_size >= _LOG_ROTATE_BYTES:
-            log_path.replace(log_dir / "container-boot.log.1")
-    except OSError as exc:
-        # Rotation failure is non-fatal — keep appending to the
-        # existing file rather than losing the entry entirely.
-        log.warning("could not rotate %s: %s", log_path, exc)
-
-    ts = time.strftime("%Y-%m-%dT%H:%M:%S%z")
-    with log_path.open("a", encoding="utf-8") as f:
-        for a in actions:
-            f.write(
-                f"{ts} profile={a.profile} prior_state={a.prior_state} "
-                f"action={a.action} prior_exit={a.prior_exit}\n"
-            )
-
-
-# 256 KiB soft cap on container-boot.log; rotated to .1 when crossed.
-# At ~80 B per reconcile-action line this is ~3000 lines, or about a
-# year of daily reboots on a 5-profile container. Two files = ~512 KiB
-# worst case. Tuned for visibility (small enough to grep / cat without
-# scrolling forever) more than space (the persistent volume has GB).
-_LOG_ROTATE_BYTES = 256 * 1024
+    """Emit one structured record per reconciled profile."""
+    del hermes_home
+    for action in actions:
+        log.info(
+            "container boot reconcile: profile=%s prior_state=%s action=%s prior_exit=%s",
+            action.profile,
+            action.prior_state,
+            action.action,
+            action.prior_exit,
+        )
 
 
 def main() -> int:

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -365,7 +365,7 @@ class LogSnapshot:
 
 
 def _primary_log_path(log_name: str) -> Optional[Path]:
-    """Where *log_name* would live if present. Doesn't check existence."""
+    """Return the legacy path when an imported log file is present."""
     from hermes_cli.logs import LOG_FILES
 
     filename = LOG_FILES.get(log_name)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6001,11 +6001,9 @@ def launchd_status(deep: bool = False):
             print(f"  Note: a detached gateway process is running (PID {fallback_pid})")
 
     if deep:
-        log_file = get_hermes_home() / "logs" / "gateway.log"
-        if log_file.exists():
-            print()
-            print("Recent logs:")
-            subprocess.run(["tail", "-20", str(log_file)], timeout=10)
+        print()
+        print("Recent logs are available from the service supervisor or container runtime.")
+        print("For Kubernetes, use: kubectl logs <pod>")
 
 
 # =============================================================================
@@ -6347,13 +6345,15 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
 
     from gateway.run import start_gateway
 
-    print("┌─────────────────────────────────────────────────────────┐")
-    print("│           ⚕ Hermes Gateway Starting...                 │")
-    print("├─────────────────────────────────────────────────────────┤")
-    print("│  Messaging platforms + cron scheduler                    │")
-    print("│  Press Ctrl+C to stop                                   │")
-    print("└─────────────────────────────────────────────────────────┘")
-    print()
+    # Keep machine-readable container streams free of the interactive banner.
+    if sys.stdout.isatty():
+        print("┌─────────────────────────────────────────────────────────┐")
+        print("│           ⚕ Hermes Gateway Starting...                 │")
+        print("├─────────────────────────────────────────────────────────┤")
+        print("│  Messaging platforms + cron scheduler                    │")
+        print("│  Press Ctrl+C to stop                                   │")
+        print("└─────────────────────────────────────────────────────────┘")
+        print()
 
     # Exit with code 1 if gateway fails to connect any platform,
     # so systemd Restart=always will retry on transient errors

--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -1,14 +1,14 @@
-"""``hermes logs`` — view and filter Hermes log files.
+"""Helpers for filtering exported Hermes structured logs.
 
-Supports tailing, following, session filtering, level filtering,
-component filtering, and relative time ranges.  All log files live
-under ``~/.hermes/logs/``.
+The runtime emits logs to stdout/stderr for the container or service supervisor
+to collect. This module keeps JSONL/text filtering helpers for exported log
+streams, but does not read or create a local Hermes log file.
 
 Usage examples::
 
-    hermes logs                    # last 50 lines of agent.log
-    hermes logs -f                 # follow agent.log in real time
-    hermes logs errors             # last 50 lines of errors.log
+    kubectl logs <pod>             # view the JSON stream in Kubernetes
+    gcloud logging read ...        # query Google Cloud Logging
+    hermes logs                    # explain where runtime logs are collected
     hermes logs gateway -n 100    # last 100 lines of gateway.log
     hermes logs gui -f            # follow gui.log (dashboard/pty/ws)
     hermes logs desktop -f        # follow desktop.log (Electron app boot/backend)
@@ -19,6 +19,7 @@ Usage examples::
     hermes logs --since 30m -f     # follow, starting 30 min ago
 """
 
+import json
 import re
 import sys
 import time
@@ -26,17 +27,16 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, Sequence
 
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import get_hermes_home
 
-# Known log files (name → filename)
+# Retained logical names for API/CLI callers. Runtime logging no longer creates
+# these files, but existing/exported files can still be parsed by the helpers.
 LOG_FILES = {
     "agent": "agent.log",
     "errors": "errors.log",
     "gateway": "gateway.log",
     "gui": "gui.log",
     "desktop": "desktop.log",
-    # Every stdio MCP subprocess's stderr (tools/mcp_tool.py redirects it
-    # here, with per-server session markers) — the "MCP output channel".
     "mcp": "mcp-stderr.log",
 }
 
@@ -81,7 +81,14 @@ def _parse_since(since_str: str) -> Optional[datetime]:
 
 
 def _parse_line_timestamp(line: str) -> Optional[datetime]:
-    """Extract timestamp from a log line. Returns None if not parseable."""
+    """Extract a timestamp from a legacy text or GCP JSON log line."""
+    try:
+        payload = json.loads(line)
+        value = payload.get("time") or payload.get("timestamp")
+        if isinstance(value, str):
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+    except (ValueError, TypeError, json.JSONDecodeError):
+        pass
     m = _TS_RE.match(line)
     if not m:
         return None
@@ -92,13 +99,27 @@ def _parse_line_timestamp(line: str) -> Optional[datetime]:
 
 
 def _extract_level(line: str) -> Optional[str]:
-    """Extract the log level from a line."""
+    """Extract severity from a legacy text or GCP JSON log line."""
+    try:
+        payload = json.loads(line)
+        severity = payload.get("severity")
+        if isinstance(severity, str):
+            return severity.upper()
+    except (ValueError, TypeError, json.JSONDecodeError):
+        pass
     m = _LEVEL_RE.search(line)
     return m.group(1) if m else None
 
 
 def _extract_logger_name(line: str) -> Optional[str]:
-    """Extract the logger name from a log line."""
+    """Extract the logger name from a legacy text or GCP JSON log line."""
+    try:
+        payload = json.loads(line)
+        logger_name = payload.get("logger")
+        if isinstance(logger_name, str):
+            return logger_name
+    except (ValueError, TypeError, json.JSONDecodeError):
+        pass
     m = _LOGGER_NAME_RE.search(line)
     return m.group(1) if m else None
 
@@ -177,80 +198,47 @@ def tail_log(
         sys.exit(1)
 
     log_path = get_hermes_home() / "logs" / filename
-    if not log_path.exists():
-        print(f"Log file not found: {log_path}")
-        print("(Logs are created when Hermes runs — try 'hermes chat' first)")
-        sys.exit(1)
-
-    # Parse --since into a datetime cutoff
-    since_dt = None
-    if since:
-        since_dt = _parse_since(since)
-        if since_dt is None:
+    if log_path.exists():
+        since_dt = _parse_since(since) if since else None
+        if since and since_dt is None:
             print(f"Invalid --since value: {since!r}. Use format like '1h', '30m', '2d'.")
             sys.exit(1)
-
-    min_level = level.upper() if level else None
-    if min_level and min_level not in _LEVEL_ORDER:
-        print(f"Invalid --level: {level!r}. Use DEBUG, INFO, WARNING, ERROR, or CRITICAL.")
-        sys.exit(1)
-
-    # Resolve component to logger name prefixes
-    component_prefixes = None
-    if component:
-        from hermes_logging import COMPONENT_PREFIXES
-        component_lower = component.lower()
-        if component_lower not in COMPONENT_PREFIXES:
-            available = ", ".join(sorted(COMPONENT_PREFIXES))
-            print(f"Unknown component: {component!r}. Available: {available}")
+        min_level = level.upper() if level else None
+        if min_level and min_level not in _LEVEL_ORDER:
+            print(f"Invalid --level: {level!r}. Use DEBUG, INFO, WARNING, ERROR, or CRITICAL.")
             sys.exit(1)
-        component_prefixes = COMPONENT_PREFIXES[component_lower]
-
-    has_filters = (
-        min_level is not None
-        or session is not None
-        or since_dt is not None
-        or component_prefixes is not None
-    )
-
-    # Read and display the tail
-    try:
-        lines = _read_tail(log_path, num_lines, has_filters=has_filters,
-                           min_level=min_level, session_filter=session,
-                           since=since_dt, component_prefixes=component_prefixes)
-    except PermissionError:
-        print(f"Permission denied: {log_path}")
-        sys.exit(1)
-
-    # Print header
-    filter_parts = []
-    if min_level:
-        filter_parts.append(f"level>={min_level}")
-    if session:
-        filter_parts.append(f"session={session}")
-    if component:
-        filter_parts.append(f"component={component}")
-    if since:
-        filter_parts.append(f"since={since}")
-    filter_desc = f" [{', '.join(filter_parts)}]" if filter_parts else ""
-
-    if follow:
-        print(f"--- {display_hermes_home()}/logs/{filename}{filter_desc} (Ctrl+C to stop) ---")
-    else:
-        print(f"--- {display_hermes_home()}/logs/{filename}{filter_desc} (last {num_lines}) ---")
-
-    for line in lines:
-        print(line, end="")
-
-    if not follow:
+        component_prefixes = None
+        if component:
+            from hermes_logging import COMPONENT_PREFIXES
+            component_lower = component.lower()
+            if component_lower not in COMPONENT_PREFIXES:
+                available = ", ".join(sorted(COMPONENT_PREFIXES))
+                print(f"Unknown component: {component!r}. Available: {available}")
+                sys.exit(1)
+            component_prefixes = COMPONENT_PREFIXES[component_lower]
+        lines = _read_tail(
+            log_path,
+            num_lines,
+            has_filters=bool(min_level or session or since_dt or component_prefixes),
+            min_level=min_level,
+            session_filter=session,
+            since=since_dt,
+            component_prefixes=component_prefixes,
+        )
+        for line in lines:
+            print(line, end="")
+        if follow:
+            _follow_log(
+                log_path,
+                min_level=min_level,
+                session_filter=session,
+                since=since_dt,
+                component_prefixes=component_prefixes,
+            )
         return
 
-    # Follow mode — poll for new content
-    try:
-        _follow_log(log_path, min_level=min_level, session_filter=session,
-                     since=since_dt, component_prefixes=component_prefixes)
-    except KeyboardInterrupt:
-        print("\n--- stopped ---")
+    print("Hermes runtime logs are emitted as JSON to stderr/stdout; no local log files are created.")
+    print("For Kubernetes, use `kubectl logs <pod>` or query Google Cloud Logging.")
 
 
 def _read_tail(
@@ -363,35 +351,15 @@ def _follow_log(
 
 
 def list_logs() -> None:
-    """Print available log files with sizes."""
+    """List legacy local logs, then explain the stream-based default."""
     log_dir = get_hermes_home() / "logs"
-    if not log_dir.exists():
-        print(f"No logs directory at {display_hermes_home()}/logs/")
-        return
-
-    print(f"Log files in {display_hermes_home()}/logs/:\n")
     found = False
-    for entry in sorted(log_dir.iterdir()):
-        if entry.is_file() and entry.suffix == ".log":
-            size = entry.stat().st_size
-            mtime = datetime.fromtimestamp(entry.stat().st_mtime)
-            if size < 1024:
-                size_str = f"{size}B"
-            elif size < 1024 * 1024:
-                size_str = f"{size / 1024:.1f}KB"
-            else:
-                size_str = f"{size / (1024 * 1024):.1f}MB"
-            age = datetime.now() - mtime
-            if age.total_seconds() < 60:
-                age_str = "just now"
-            elif age.total_seconds() < 3600:
-                age_str = f"{int(age.total_seconds() / 60)}m ago"
-            elif age.total_seconds() < 86400:
-                age_str = f"{int(age.total_seconds() / 3600)}h ago"
-            else:
-                age_str = mtime.strftime("%Y-%m-%d")
-            print(f"  {entry.name:<25} {size_str:>8}   {age_str}")
-            found = True
-
+    if log_dir.exists():
+        for entry in sorted(log_dir.iterdir()):
+            if entry.is_file() and entry.suffix == ".log":
+                print(f"  {entry.name} ({entry.stat().st_size} bytes)")
+                found = True
     if not found:
-        print("  (no log files yet — run 'hermes chat' to generate logs)")
+        print("No local Hermes log files found.")
+    print("Runtime logs are newline-delimited JSON on stderr/stdout.")
+    print("For Kubernetes, use `kubectl logs <pod>` or Google Cloud Logging.")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -108,7 +108,7 @@ def _exit_after_oneshot(rc: object) -> None:
 
     The SIGABRT this guards against (#30387, #43055) fires in a
     native-extension finalizer during CPython's ``Py_FinalizeEx``, *after*
-    the response has printed. Flush streams, shut down file logging, then
+    the response has printed. Flush streams, shut down logging, then
     ``os._exit`` past interpreter finalization. The ``atexit`` chain is
     deliberately skipped — several handlers re-enter native code that may
     be the abort source. Stateful cleanup is handled in ``_run_agent`` and
@@ -772,10 +772,10 @@ try:
 except Exception:
     pass  # best-effort — redaction stays at default (enabled) on config errors
 
-# Initialize centralized file logging early — all `hermes` subcommands
-# (chat, setup, gateway, config, etc.) write to agent.log + errors.log.
-# Dashboard entrypoints bootstrap with GUI mode so gui.log is always present
-# during GUI testing, including pre-dispatch startup failures.
+# Initialize centralized structured stream logging early — all `hermes`
+# subcommands emit newline-delimited JSON to stderr for the process supervisor.
+# Dashboard entrypoints use the same handler before dispatch so startup failures
+# are visible to the container/service log collector.
 try:
     from hermes_logging import setup_logging as _setup_logging
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -112,7 +112,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 #
 # Set ``HERMES_PLUGINS_DEBUG=1`` to surface verbose plugin-discovery logs to
-# stderr in addition to ~/.hermes/logs/agent.log. Aimed at plugin authors
+# stderr in addition to the structured container log stream. Aimed at plugin authors
 # trying to figure out why their plugin isn't showing up: which directories
 # were scanned, which manifests parsed, which plugins were skipped (and why),
 # what each ``register(ctx)`` call registered, and full tracebacks on load
@@ -146,7 +146,7 @@ def _install_plugin_debug_handler(force: bool = False) -> None:
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
     # Don't double-emit through the root logger when the central logging
-    # config also writes to stderr. agent.log still captures everything.
+    # config also writes to stderr. The shared structured handler captures it.
     logger.propagate = True
     _DEBUG_HANDLER_INSTALLED = True
     logger.debug(

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -745,14 +745,20 @@ class S6ServiceManager:
     def _render_log_run(profile: str) -> str:
         """Generate the log/run script for a profile-gateway service.
 
-        OQ8-C: persist to ``${HERMES_HOME}/logs/gateways/<profile>/``.
+        Runtime output is forwarded to the container stream; no gateway log
+        file is created by this supervisor.
         CRITICAL: the HERMES_HOME path is sourced from the runtime env
         via with-contenv — NOT Python-substituted at registration time
         — so a container started with ``-e HERMES_HOME=/data/hermes``
         gets its logs under /data/hermes/logs/..., not the build-time
         default.
 
-        Output routing — the script is two action directives, applied
+        Output routing — the script forwards each line to the container
+        stream. The ``1`` action propagates output through the s6-supervise
+        pipeline to ``docker logs``. Hermes application records already use
+        newline-delimited JSON, so container logging owns retention and query.
+
+        Historical output routing — the script used two action directives, applied
         per line, in order:
 
           1. ``1`` (forward to stdout) — propagates the line up the
@@ -806,8 +812,8 @@ class S6ServiceManager:
             f'  rm -f "$log_dir/lock"\n'
             f'fi\n'
             # Skip the drop when already non-root (CAP_SETGID).
-            f'[ "$(id -u)" = 0 ] || exec s6-log 1 n10 s1000000 T "$log_dir"\n'
-            f'exec s6-setuidgid hermes s6-log 1 n10 s1000000 T "$log_dir"\n'
+            f'[ "$(id -u)" = 0 ] || exec s6-log 1 # forward to container stream\n'
+            f'exec s6-setuidgid hermes s6-log 1 # forward to container stream\n'
         )
 
     # -- lifecycle ---------------------------------------------------------

--- a/hermes_cli/subcommands/logs.py
+++ b/hermes_cli/subcommands/logs.py
@@ -17,30 +17,21 @@ def build_logs_parser(subparsers, *, cmd_logs: Callable) -> None:
     # =========================================================================
     logs_parser = subparsers.add_parser(
         "logs",
-        help="View and filter Hermes log files",
-        description="View, tail, and filter agent.log / errors.log / gateway.log / gui.log / desktop.log",
+        help="Show how to retrieve Hermes structured logs",
+        description="Hermes emits newline-delimited JSON logs to stderr/stdout for the service supervisor",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
-    hermes logs                    Show last 50 lines of agent.log
-    hermes logs -f                 Follow agent.log in real time
-    hermes logs errors             Show last 50 lines of errors.log
-    hermes logs gateway -n 100     Show last 100 lines of gateway.log
-    hermes logs gui -f             Follow gui.log in real time
-    hermes logs desktop -f         Follow desktop.log (Electron app boot/backend)
-    hermes logs --level WARNING    Only show WARNING and above
-    hermes logs --session abc123   Filter by session ID
-    hermes logs --component tools  Only show tool-related lines
-    hermes logs --since 1h         Lines from the last hour
-    hermes logs --since 30m -f     Follow, starting from 30 min ago
-    hermes logs list               List available log files with sizes
+    kubectl logs <pod>             View logs from a Kubernetes pod
+    gcloud logging read ...        Query logs in Google Cloud Logging
+    hermes logs                    Explain the runtime log stream
 """,
     )
     logs_parser.add_argument(
         "log_name",
         nargs="?",
         default="agent",
-        help="Log to view: agent (default), errors, gateway, gui, or 'list' to show available files",
+        help="Logical stream name for compatibility: agent, errors, gateway, gui, desktop, or 'list'",
     )
     logs_parser.add_argument(
         "-n",

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -92,7 +92,7 @@ TIPS = [
     "hermes mcp serve runs Hermes itself as an MCP server for other agents.",
     "hermes auth add lets you add multiple API keys for credential pool rotation.",
     "hermes completion bash >> ~/.bashrc enables tab completion for all commands and profiles.",
-    "hermes logs -f follows agent.log in real time. --level WARNING --since 1h filters output.",
+    "Hermes emits JSON logs to stderr/stdout. In Kubernetes, use kubectl logs or Google Cloud Logging.",
     "hermes backup creates a zip backup of your entire Hermes home directory.",
     "hermes profile create coder creates an isolated profile that becomes its own command.",
     "hermes profile create work --clone copies your current config and keys to a new profile.",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12612,24 +12612,29 @@ async def get_logs(
 ):
     from hermes_cli.logs import _read_tail, LOG_FILES
 
-    log_name = LOG_FILES.get(file)
-    if not log_name:
+    filename = LOG_FILES.get(file)
+    if not filename:
         raise HTTPException(status_code=400, detail=f"Unknown log file: {file}")
-    log_path = get_hermes_home() / "logs" / log_name
+    log_path = get_hermes_home() / "logs" / filename
     if not log_path.exists():
-        return {"file": file, "lines": []}
+        return {
+            "file": file,
+            "lines": [],
+            "source": "process-stream",
+            "message": (
+                "Hermes logs are emitted as newline-delimited JSON to stderr/stdout "
+                "and are not stored locally. Query the container runtime or Google Cloud Logging."
+            ),
+        }
 
     try:
         from hermes_logging import COMPONENT_PREFIXES
     except ImportError:
         COMPONENT_PREFIXES = {}
 
-    # Normalize "ALL" / "all" / empty → no filter. _matches_filters treats an
-    # empty tuple as "must match a prefix" (startswith(()) is always False),
-    # so passing () instead of None silently drops every line.
     min_level = level if level and level.upper() != "ALL" else None
     if component and component.lower() != "all":
-        comp_prefixes = COMPONENT_PREFIXES.get(component)
+        comp_prefixes = COMPONENT_PREFIXES.get(component.lower())
         if comp_prefixes is None:
             raise HTTPException(
                 status_code=400,
@@ -12641,18 +12646,20 @@ async def get_logs(
 
     has_filters = bool(min_level or comp_prefixes or search)
     result = _read_tail(
-        log_path, min(lines, 500) if not search else 2000,
+        log_path,
+        min(lines, 500) if not search else 2000,
         has_filters=has_filters,
         min_level=min_level,
         component_prefixes=comp_prefixes,
     )
-    # Post-filter by search term (case-insensitive substring match).
-    # _read_tail doesn't support free-text search, so we filter here and
-    # trim to the requested line count afterward.
     if search:
         needle = search.lower()
-        result = [l for l in result if needle in l.lower()][-min(lines, 500):]
-    return {"file": file, "lines": result}
+        result = [line for line in result if needle in line.lower()][-min(lines, 500):]
+    return {
+        "file": file,
+        "lines": result,
+        "source": "legacy-local-file",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -1,104 +1,37 @@
-"""Centralized logging setup for Hermes Agent.
+"""Centralized structured logging for Hermes Agent.
 
-Provides a single ``setup_logging()`` entry point that both the CLI and
-gateway call early in their startup path.  All log files live under
-``~/.hermes/logs/`` (profile-aware via ``get_hermes_home()``).
+Hermes writes application logs to stderr.  The default format is human-readable
+text; ``logging.format: gcp_json`` switches the stream to newline-delimited JSON
+using Google Cloud Logging's top-level ``severity`` and ``message`` fields.
 
-Log files produced:
-    agent.log   — INFO+, all agent/tool/session activity (the main log)
-    errors.log  — WARNING+, errors and warnings only (quick triage)
-    gateway.log — INFO+, gateway-only events (created when mode="gateway")
-    gui.log     — INFO+, dashboard/websocket/TUI-gateway events
-                  (created when mode="gui")
-
-All files use ``RotatingFileHandler`` with ``RedactingFormatter`` so
-secrets are never written to disk.
-
-Component separation:
-    gateway.log only receives records from ``gateway.*`` loggers —
-    platform adapters, session management, slash commands, delivery.
-    gui.log receives dashboard-side records from ``hermes_cli.web_server``,
-    ``hermes_cli.pty_bridge``, ``tui_gateway.*``, and ``uvicorn.*``.
-    agent.log remains the catch-all (everything goes there).
-
-Session context:
-    Call ``set_session_context(session_id)`` at the start of a conversation
-    and ``clear_session_context()`` when done.  All log lines emitted on
-    that thread will include ``[session_id]`` for filtering/correlation.
+The module intentionally does not create local log files.  Container and
+service supervisors own retention, shipping, and querying of the stream.
 """
 
-import atexit
-import copy
+from __future__ import annotations
+
 import io
+import json
 import logging
 import os
-import queue
 import sys
 import threading
-from logging.handlers import QueueHandler, QueueListener
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Sequence
 
-# On Windows, stdlib ``RotatingFileHandler`` calls ``os.rename()`` in
-# ``doRollover()`` and fails with ``PermissionError [WinError 32]`` whenever
-# another process holds an append-mode handle on ``agent.log`` — which is
-# essentially always in Hermes (TUI, gateway, ``hy_memory`` server, MCP
-# servers, and on-demand CLI commands all log from separate processes),
-# pinning ``agent.log`` at the 5 MiB threshold and spamming stderr with
-# a traceback on every emit. ``concurrent-log-handler`` wraps the rename in a
-# cross-process file lock (via ``portalocker``: pywin32 on Windows) so only
-# one process rotates at a time and the others wait their turn.
-#
-# This swap is Windows-ONLY and deliberately so:
-#   * The bug (WinError 32 on rename-while-open) is specific to Windows file
-#     locking semantics — POSIX renames an open file fine, so stdlib already
-#     works correctly on Linux/macOS.
-#   * On POSIX, managed-mode (NixOS) relies on the exact ``_open()`` /
-#     ``doRollover()`` lifecycle of stdlib ``RotatingFileHandler`` (the
-#     ``_ManagedRotatingFileHandler`` subclass chmods 0660 after each). CLH
-#     opens lazily and rotates differently, which breaks the group-writable
-#     guarantee and the eager file-creation those paths depend on.
-# Aliasing keeps every existing ``RotatingFileHandler`` reference in this
-# module (class declaration, ``isinstance`` checks, docstring) working
-# unchanged. See #44873.
-if sys.platform == "win32":
-    from concurrent_log_handler import (  # noqa: E402
-        ConcurrentRotatingFileHandler as RotatingFileHandler,
-    )
-else:
-    from logging.handlers import RotatingFileHandler  # noqa: E402
-
-
 from hermes_constants import get_config_path, get_hermes_home
 
-# Sentinel to track whether setup_logging() has already run.  The function
-# is idempotent — calling it twice is safe but the second call is a no-op
-# unless ``force=True``.
 _logging_initialized = False
-
-# Thread-local storage for per-conversation session context.
 _session_context = threading.local()
-
-# Default log format — includes timestamp, level, optional session tag,
-# logger name, and message.  The ``%(session_tag)s`` field is guaranteed to
-# exist on every LogRecord via _install_session_record_factory() below.
-_LOG_FORMAT = "%(asctime)s %(levelname)s%(session_tag)s %(name)s: %(message)s"
-_LOG_FORMAT_VERBOSE = "%(asctime)s - %(name)s - %(levelname)s%(session_tag)s - %(message)s"
+_STRUCTURED_HANDLER_ATTR = "_hermes_gcp_structured"
+_TEXT_LOG_FORMAT = "%(asctime)s %(levelname)s%(session_tag)s %(name)s: %(message)s"
 
 
 def _safe_stderr():  # type: ignore[return]
-    """Return a stderr stream that tolerates Unicode on all platforms.
-
-    On Windows the console encoding is often a legacy MBCS codec
-    (cp949, cp1252, …) that raises ``UnicodeEncodeError`` for characters
-    like the em-dash (U+2014).  We wrap ``sys.stderr`` in a
-    ``TextIOWrapper`` with ``errors='replace'`` so log lines are never
-    lost — un-encodable characters are replaced with ``?`` instead of
-    crashing the process.
-    """
+    """Return a stderr stream that tolerates legacy console encodings."""
     stream = sys.stderr
     encoding = getattr(stream, "encoding", None) or "utf-8"
-    # Already UTF-8 or surrogate-aware — no wrapping needed.
     if encoding.lower().replace("-", "") in ("utf8", "utf8surrogateescape"):
         return stream
     try:
@@ -110,33 +43,11 @@ def _safe_stderr():  # type: ignore[return]
                 errors="replace",
                 line_buffering=True,
             )
-            # Prevent the wrapper from closing the underlying buffer
-            # when it is garbage-collected.
             wrapped.close = lambda: None  # type: ignore[assignment]
             return wrapped
     except Exception:
         pass
-    # Best-effort: if wrapping fails, return the original stream.
     return stream
-
-
-_CONCURRENT_LOG_LOCK_TIMEOUT = "Cannot acquire lock after 20 attempts"
-
-
-def _is_windows_concurrent_log_lock_timeout(exc: BaseException | None) -> bool:
-    """Return True for concurrent-log-handler's Windows lock timeout.
-
-    On Windows Desktop, slash-command workers and the gateway can all write to
-    the same rotating log files. ``concurrent-log-handler`` serializes rollover
-    with a cross-process lock, but when another process holds that lock too
-    long it raises this RuntimeError. Logging failures should not escape into
-    Desktop chat output.
-    """
-    return (
-        sys.platform == "win32"
-        and isinstance(exc, RuntimeError)
-        and _CONCURRENT_LOG_LOCK_TIMEOUT in str(exc)
-    )
 
 
 # Third-party loggers that are noisy at DEBUG/INFO level.
@@ -163,43 +74,25 @@ _NOISY_LOGGERS = (
 # ---------------------------------------------------------------------------
 
 def set_session_context(session_id: str) -> None:
-    """Set the session ID for the current thread.
-
-    All subsequent log records on this thread will include ``[session_id]``
-    in the formatted output.  Call at the start of ``run_conversation()``.
-    """
+    """Set the session ID for records emitted on the current thread."""
     _session_context.session_id = session_id
 
 
 def clear_session_context() -> None:
-    """Clear the session ID for the current thread."""
+    """Clear the current thread's session context."""
     _session_context.session_id = None
 
 
-# ---------------------------------------------------------------------------
-# Record factory — injects session_tag into every LogRecord at creation
-# ---------------------------------------------------------------------------
-
 def _install_session_record_factory() -> None:
-    """Replace the global LogRecord factory with one that adds ``session_tag``.
-
-    Unlike a ``logging.Filter`` on a handler or logger, the record factory
-    runs for EVERY record in the process — including records that propagate
-    from child loggers and records handled by third-party handlers.  This
-    guarantees ``%(session_tag)s`` is always available in format strings,
-    eliminating the KeyError that would occur if a handler used our format
-    without having a ``_SessionFilter`` attached.
-
-    Idempotent — checks for a marker attribute to avoid double-wrapping if
-    the module is reloaded.
-    """
+    """Inject session fields into every record while preserving other factories."""
     current_factory = logging.getLogRecordFactory()
     if getattr(current_factory, "_hermes_session_injector", False):
-        return  # already installed
+        return
 
     def _session_record_factory(*args, **kwargs):
         record = current_factory(*args, **kwargs)
         sid = getattr(_session_context, "session_id", None)
+        record.session_id = sid  # type: ignore[attr-defined]
         record.session_tag = f" [{sid}]" if sid else ""  # type: ignore[attr-defined]
         return record
 
@@ -207,21 +100,88 @@ def _install_session_record_factory() -> None:
     logging.setLogRecordFactory(_session_record_factory)
 
 
-# Install immediately on import — session_tag is available on all records
-# from this point forward, even before setup_logging() is called.
 _install_session_record_factory()
 
 
 # ---------------------------------------------------------------------------
-# Filters
+# Structured formatter and handler
+# ---------------------------------------------------------------------------
+
+def _cloud_severity(levelno: int) -> str:
+    """Map arbitrary Python levels to Cloud Logging severities."""
+    if levelno >= logging.CRITICAL:
+        return "CRITICAL"
+    if levelno >= logging.ERROR:
+        return "ERROR"
+    if levelno >= logging.WARNING:
+        return "WARNING"
+    if levelno >= logging.INFO:
+        return "INFO"
+    return "DEBUG"
+
+
+class GCPStructuredLogFormatter(logging.Formatter):
+    """Format a LogRecord as one Google Cloud Logging-compatible JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = record.getMessage()
+        if record.exc_info:
+            message = f"{message}\n{self.formatException(record.exc_info)}"
+        if record.stack_info:
+            message = f"{message}\n{self.formatStack(record.stack_info)}"
+
+        # Keep the existing Hermes redaction policy, but only serialize safe,
+        # bounded fields. Serializing record.__dict__ would expose logging extras
+        # such as request arguments or provider payloads.
+        try:
+            from agent.redact import redact_sensitive_text
+
+            message = redact_sensitive_text(message)
+        except Exception:
+            pass
+
+        payload = {
+            "time": datetime.fromtimestamp(
+                record.created, timezone.utc
+            ).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            "severity": _cloud_severity(record.levelno),
+            "message": message,
+            "logger": record.name,
+            "pid": os.getpid(),
+            "thread": threading.get_ident(),
+        }
+        session_id = getattr(record, "session_id", None)
+        if session_id:
+            payload["session_id"] = session_id
+
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), default=str)
+
+
+class GCPStructuredLogHandler(logging.StreamHandler):
+    """Stream logs to stderr using a configurable text or GCP JSON formatter."""
+
+    def __init__(self, stream=None, *, log_format: str = "gcp_json") -> None:
+        super().__init__(stream if stream is not None else _safe_stderr())
+        self.set_log_format(log_format)
+        setattr(self, _STRUCTURED_HANDLER_ATTR, True)
+
+    def set_log_format(self, log_format: str) -> None:
+        """Set the output formatter, falling back to text for bad config."""
+        if log_format == "gcp_json":
+            formatter = GCPStructuredLogFormatter()
+        else:
+            from agent.redact import RedactingFormatter
+
+            formatter = RedactingFormatter(_TEXT_LOG_FORMAT)
+        self.setFormatter(formatter)
+
+
+# ---------------------------------------------------------------------------
+# Component metadata retained for filtering and observability consumers
 # ---------------------------------------------------------------------------
 
 class _ComponentFilter(logging.Filter):
-    """Only pass records whose logger name starts with one of *prefixes*.
-
-    Used to route gateway-specific records to ``gateway.log`` while
-    keeping ``agent.log`` as the catch-all.
-    """
+    """Only pass records whose logger name starts with one of *prefixes*."""
 
     def __init__(self, prefixes: Sequence[str]) -> None:
         super().__init__()
@@ -231,13 +191,7 @@ class _ComponentFilter(logging.Filter):
         return record.name.startswith(self._prefixes)
 
 
-# Logger name prefixes that belong to each component.
-# Used by _ComponentFilter and exposed for ``hermes logs --component``.
 COMPONENT_PREFIXES = {
-    # ``plugins.platforms`` covers messaging-platform adapters that migrated
-    # out of ``gateway/platforms/`` into bundled plugins (#41112) — they are
-    # still gateway components and their logs belong in gateway.log / match
-    # ``hermes logs --component gateway``.
     "gateway": ("gateway", "hermes_plugins", "plugins.platforms"),
     "agent": ("agent", "run_agent", "model_tools", "batch_runner"),
     "tools": ("tools",),
@@ -265,537 +219,155 @@ def setup_logging(
     mode: Optional[str] = None,
     force: bool = False,
 ) -> Path:
-    """Configure the Hermes logging subsystem.
+    """Install the configured stderr handler.
 
-    Safe to call multiple times — the second call is a no-op unless
-    *force* is ``True``.
+    ``hermes_home``, ``max_size_mb``, ``backup_count``, and ``mode`` remain in
+    the signature for callers and plugins that use the historical API. Local
+    file logging is intentionally no longer configured.
 
-    Parameters
-    ----------
-    hermes_home
-        Override for the Hermes home directory.  Falls back to
-        ``get_hermes_home()`` (profile-aware).
-    log_level
-        Minimum level for the ``agent.log`` file handler.  Accepts any
-        standard Python level name (``"DEBUG"``, ``"INFO"``, ``"WARNING"``).
-        Defaults to ``"INFO"`` or the value from config.yaml ``logging.level``.
-    max_size_mb
-        Maximum size of each log file in megabytes before rotation.
-        Defaults to 5 or the value from config.yaml ``logging.max_size_mb``.
-    backup_count
-        Number of rotated backup files to keep.
-        Defaults to 3 or the value from config.yaml ``logging.backup_count``.
-    mode
-        Caller context: ``"cli"``, ``"gateway"``, ``"gui"``, ``"cron"``.
-        When ``"gateway"``, an additional ``gateway.log`` file is created
-        that receives only gateway-component records.
-        When ``"gui"``, an additional ``gui.log`` file is created that
-        receives dashboard and TUI-gateway component records.
-    force
-        Re-run setup even if it has already been called.
-
-    Returns
-    -------
-    Path
-        The ``logs/`` directory where files are written.
+    The return value remains the profile's log directory path for API
+    compatibility, but this function does not create that directory.
     """
+    del max_size_mb, backup_count, mode
     global _logging_initialized
-    home = hermes_home or get_hermes_home()
-    from hermes_constants import mkdir_under_hermes_home
-    log_dir = mkdir_under_hermes_home(home / "logs")
-
-    # Read config defaults (best-effort — config may not be loaded yet).
-    cfg_level, cfg_max_size, cfg_backup = _read_logging_config()
-
+    cfg_level, _, _ = _read_logging_config()
+    log_format = _read_logging_format()
     level_name = (log_level or cfg_level or "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
-    max_bytes = (max_size_mb or cfg_max_size or 5) * 1024 * 1024
-    backups = backup_count or cfg_backup or 3
-
-    # Lazy import to avoid circular dependency at module load time.
-    from agent.redact import RedactingFormatter
-
     root = logging.getLogger()
 
-    # --- agent.log (INFO+) — the main activity log -------------------------
-    _add_rotating_handler(
-        root,
-        log_dir / "agent.log",
-        level=level,
-        max_bytes=max_bytes,
-        backup_count=backups,
-        formatter=RedactingFormatter(_LOG_FORMAT),
+    handler = next(
+        (
+            h for h in root.handlers
+            if getattr(h, _STRUCTURED_HANDLER_ATTR, False)
+        ),
+        None,
     )
+    if handler is None:
+        handler = GCPStructuredLogHandler(log_format=log_format)
+        root.addHandler(handler)
+    elif hasattr(handler, "set_log_format"):
+        handler.set_log_format(log_format)
+    handler.setLevel(level)
 
-    # --- errors.log (WARNING+) — quick triage log --------------------------
-    _add_rotating_handler(
-        root,
-        log_dir / "errors.log",
-        level=logging.WARNING,
-        max_bytes=2 * 1024 * 1024,
-        backup_count=2,
-        formatter=RedactingFormatter(_LOG_FORMAT),
-    )
-
-    # --- gateway.log (INFO+, gateway component only) ------------------------
-    if mode == "gateway":
-        _add_rotating_handler(
-            root,
-            log_dir / "gateway.log",
-            level=logging.INFO,
-            max_bytes=5 * 1024 * 1024,
-            backup_count=3,
-            formatter=RedactingFormatter(_LOG_FORMAT),
-            log_filter=_ComponentFilter(COMPONENT_PREFIXES["gateway"]),
-        )
-
-    # --- gui.log (INFO+, dashboard/tui-gateway components) -----------------
-    if mode == "gui":
-        _add_rotating_handler(
-            root,
-            log_dir / "gui.log",
-            level=logging.INFO,
-            max_bytes=10 * 1024 * 1024,
-            backup_count=5,
-            formatter=RedactingFormatter(_LOG_FORMAT),
-            log_filter=_ComponentFilter(COMPONENT_PREFIXES["gui"]),
-        )
-
-    if _logging_initialized and not force:
-        return log_dir
-
-    # Ensure root logger level is low enough for the handlers to fire.
     if root.level == logging.NOTSET or root.level > level:
         root.setLevel(level)
 
-    # Suppress noisy third-party loggers.
     for name in _NOISY_LOGGERS:
         logging.getLogger(name).setLevel(logging.WARNING)
 
     _logging_initialized = True
-    return log_dir
+    home = hermes_home or get_hermes_home()
+    return home / "logs"
+
+
+def set_stream_log_level(level: int) -> None:
+    """Change the level of the shared structured stream handler."""
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if getattr(handler, _STRUCTURED_HANDLER_ATTR, False):
+            handler.setLevel(level)
+    if level < root.level:
+        root.setLevel(level)
 
 
 def setup_verbose_logging() -> None:
-    """Enable DEBUG-level console logging for ``--verbose`` / ``-v`` mode.
-
-    Called by ``AIAgent.__init__()`` when ``verbose_logging=True``.
-    """
-    from agent.redact import RedactingFormatter
-
-    root = logging.getLogger()
-
-    # Avoid adding duplicate stream handlers.
-    for h in root.handlers:
-        if isinstance(h, logging.StreamHandler) and not isinstance(h, RotatingFileHandler):
-            if getattr(h, "_hermes_verbose", False):
-                return
-
-    handler = logging.StreamHandler(_safe_stderr())
-    handler.setLevel(logging.DEBUG)
-    handler.setFormatter(RedactingFormatter(_LOG_FORMAT_VERBOSE, datefmt="%H:%M:%S"))
-    handler._hermes_verbose = True  # type: ignore[attr-defined]
-    root.addHandler(handler)
-
-    # Lower root logger level so DEBUG records reach all handlers.
-    if root.level > logging.DEBUG:
-        root.setLevel(logging.DEBUG)
-
-    # Keep third-party libraries at WARNING to reduce noise.
-    for name in _NOISY_LOGGERS:
-        logging.getLogger(name).setLevel(logging.WARNING)
-    # rex-deploy at INFO for sandbox status.
-    logging.getLogger("rex-deploy").setLevel(logging.INFO)
+    """Expose DEBUG records through the shared structured stream handler."""
+    if not any(
+        getattr(h, _STRUCTURED_HANDLER_ATTR, False)
+        for h in logging.getLogger().handlers
+    ):
+        setup_logging()
+    set_stream_log_level(logging.DEBUG)
 
 
 # ---------------------------------------------------------------------------
-# Internal helpers
+# Compatibility helpers for callers and old integrations
 # ---------------------------------------------------------------------------
 
-class _ManagedRotatingFileHandler(RotatingFileHandler):
-    """RotatingFileHandler that ensures group-writable perms in managed mode
-    AND survives external rotation.
-
-    Two responsibilities:
-
-    1.  In managed mode (NixOS), the stateDir uses setgid (2770) so new files
-        inherit the hermes group. However, both ``_open()`` (initial creation)
-        and ``doRollover()`` create files via ``open()``, which uses the
-        process umask — typically 0022, producing 0644. This subclass applies
-        ``chmod 0660`` after both operations so the gateway and interactive
-        users can share log files.
-
-    2.  ``RotatingFileHandler`` keeps an open file descriptor.  If anything
-        rotates the file *externally* (``logrotate``, manual ``mv``,
-        another process rotating under us, a transient unlink), our fd
-        keeps pointing at the renamed/unlinked inode and every subsequent
-        write goes to ``gateway.log.1`` instead of ``gateway.log`` — silent
-        log loss for the file every operator expects to read.  Before each
-        emit we ``stat`` ``baseFilename`` and compare it against the open
-        stream's inode; on mismatch we reopen.  This is the same pattern
-        as stdlib ``WatchedFileHandler.reopenIfNeeded()``, adapted for
-        rotating handlers.
-    """
-
-    def __init__(self, *args, **kwargs):
-        from hermes_cli.config import is_managed
-        self._managed = is_managed()
-        super().__init__(*args, **kwargs)
-        # Snapshot the inode of the currently open stream so emit() can
-        # detect external rotation without an extra fstat per write.
-        self._stat_dev: Optional[int] = None
-        self._stat_ino: Optional[int] = None
-        self._record_stream_stat()
-
-    def _chmod_if_managed(self):
-        if self._managed:
-            try:
-                os.chmod(self.baseFilename, 0o660)
-            except OSError:
-                pass
-
-    def _record_stream_stat(self) -> None:
-        """Snapshot dev/ino of ``baseFilename`` so we can detect external rotation."""
-        try:
-            st = os.stat(self.baseFilename)
-            self._stat_dev, self._stat_ino = st.st_dev, st.st_ino
-        except OSError:
-            self._stat_dev, self._stat_ino = None, None
-
-    def _reopen_if_externally_rotated(self) -> None:
-        """Reopen the stream when ``baseFilename`` no longer matches our fd.
-
-        Triggered when ``baseFilename`` was renamed (logrotate), unlinked,
-        or replaced by a different inode.  Silent + best-effort: any error
-        falls back to the existing (possibly stale) stream so logging keeps
-        working instead of dying on a stat failure.
-        """
-        try:
-            st = os.stat(self.baseFilename)
-        except FileNotFoundError:
-            # File was rotated/unlinked underneath us.  Close + reopen so a
-            # fresh inode is created at the expected path.
-            try:
-                if self.stream is not None:
-                    self.stream.close()
-            except Exception:
-                pass
-            self.stream = None  # type: ignore[assignment]
-            try:
-                self.stream = self._open()
-                self._record_stream_stat()
-            except Exception:
-                # Couldn't reopen — leave stream=None; next emit will
-                # bail rather than write to a stale inode.
-                pass
-            return
-        except OSError:
-            return  # transient — try again on the next emit
-
-        if self._stat_dev is None or self._stat_ino is None:
-            self._stat_dev, self._stat_ino = st.st_dev, st.st_ino
-            return
-
-        if (st.st_dev, st.st_ino) != (self._stat_dev, self._stat_ino):
-            # baseFilename now points at a DIFFERENT inode than the one we
-            # hold open.  Close the old stream and open the new file.
-            try:
-                if self.stream is not None:
-                    self.stream.close()
-            except Exception:
-                pass
-            self.stream = None  # type: ignore[assignment]
-            try:
-                self.stream = self._open()
-                self._stat_dev, self._stat_ino = st.st_dev, st.st_ino
-            except Exception:
-                pass
-
-    def emit(self, record: logging.LogRecord) -> None:
-        # Cheap-ish stat-per-record check; the kernel caches inode metadata
-        # so the syscall is sub-microsecond on a hot file.
-        if self.stream is not None or os.path.exists(self.baseFilename):
-            self._reopen_if_externally_rotated()
-        super().emit(record)
-
-    def handleError(self, record: logging.LogRecord) -> None:
-        """Suppress the known Windows ``concurrent-log-handler`` lock timeout
-        instead of printing a traceback.
-
-        CLH's own ``emit()`` wraps its body in ``try/except Exception:
-        self.handleError(record)``, so the ``"Cannot acquire lock after N
-        attempts"`` RuntimeError raised in ``_do_lock()`` is caught inside CLH
-        and routed here — it never propagates out of ``super().emit()``.  This
-        override is the single point where that timeout can be silenced before
-        the stdlib handler prints it to stderr (which, under the Desktop
-        slash-worker, is captured and surfaced into chat output)."""
-        exc = sys.exc_info()[1]
-        if _is_windows_concurrent_log_lock_timeout(exc):
-            return
-        super().handleError(record)
-
-    def _open(self):
-        stream = super()._open()
-        self._chmod_if_managed()
-        return stream
-
-    def doRollover(self):
-        super().doRollover()
-        self._chmod_if_managed()
-        # Our own rollover writes a new baseFilename; refresh the snapshot
-        # so the next emit doesn't mistake it for external rotation.
-        self._record_stream_stat()
-
-
-# ---------------------------------------------------------------------------
-# Asynchronous file logging — keep the cross-process rotation lock off the loop
-#
-# The rotating file handlers serialize rollover with a cross-process lock (see
-# the module header): when several Hermes processes log to the same file, an
-# ``emit`` can block while another process holds that lock.  When the emitting
-# thread is an asyncio event loop, that block stalls the loop and drops
-# WebSocket clients.  To keep file I/O off the hot path, every file handler is
-# driven by a single ``QueueListener`` on a dedicated thread; loggers only touch
-# an in-memory queue (a non-blocking enqueue).
-# ---------------------------------------------------------------------------
-
-_log_queue: "Optional[queue.SimpleQueue]" = None
-_queue_listener: Optional[QueueListener] = None
-_queued_file_handlers: list = []
-_queue_atexit_registered = False
-# Guards every read-modify-write of the four globals above. setup_logging()
-# holds no lock and its _logging_initialized guard runs AFTER handler
-# registration, so _register_queued_handler() can run concurrently with a
-# flush/reset from another thread (gateway init racing a plugin/CLI path).
-# Without this, two threads can interleave listener.stop()/reassign/start()
-# and leave the queue with two live listeners or an orphaned worker thread.
-_queue_state_lock = threading.Lock()
-
-
-class _NonFormattingQueueHandler(QueueHandler):
-    """``QueueHandler`` for an in-process queue.
-
-    Stdlib ``prepare()`` formats the record and drops ``args``/``exc_info`` so it
-    can be pickled to another process.  Our queue is in-process, so we skip that
-    and hand the target file handlers an unformatted record — they apply their
-    own ``RedactingFormatter`` and component filters on the listener thread.
-
-    We return a **shallow copy** rather than the original record: the same
-    record is still owned by the emitting thread (and any synchronous handler
-    on it, e.g. a ``StreamHandler``), which may format/mutate ``record.message``
-    while our listener thread reads it. Copying preserves ``msg``/``args``/
-    ``exc_info`` for the deferred format while removing the cross-thread
-    mutation race on a shared object.
-    """
-
-    def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
-        return copy.copy(record)
-
-
-def _stop_queue_listener_locked() -> None:
-    """Stop the listener assuming ``_queue_state_lock`` is already held."""
-    global _queue_listener
-    listener, _queue_listener = _queue_listener, None
-    if listener is not None:
-        try:
-            listener.stop()
-        except Exception:
-            pass
-
-
-def _stop_queue_listener() -> None:
-    """Flush and stop the background log listener (idempotent, thread-safe).
-
-    This is the atexit hook, so it must acquire the state lock itself.
-    """
-    with _queue_state_lock:
-        _stop_queue_listener_locked()
-
-
-def _register_queued_handler(handler: logging.Handler) -> None:
-    """Route *handler* through the shared async queue instead of attaching it to
-    *root* directly, so emitting threads never block on file I/O or the
-    cross-process rotation lock.  The ``QueueListener`` applies each handler's
-    own level and filters on its worker thread."""
-    global _log_queue, _queue_listener, _queue_atexit_registered
-    with _queue_state_lock:
-        if _log_queue is None:
-            _log_queue = queue.SimpleQueue()
-            qh = _NonFormattingQueueHandler(_log_queue)
-            qh._hermes_queue = True  # type: ignore[attr-defined]
-            # Always funnel through the root logger so records from any logger
-            # (production passes root here; callers may pass a child) reach the
-            # queue via propagation.
-            logging.getLogger().addHandler(qh)
-        _queued_file_handlers.append(handler)
-        # Rebuild the listener with the full target set.  This only happens
-        # while init_logging() adds handlers (2-3 times, queue empty), so
-        # stop() returns immediately.
-        if _queue_listener is not None:
-            _queue_listener.stop()
-        _queue_listener = QueueListener(
-            _log_queue, *_queued_file_handlers, respect_handler_level=True
-        )
-        _queue_listener.start()
-        if not _queue_atexit_registered:
-            # Runs before logging.shutdown (registered earlier at import time),
-            # so the listener stops before its file handlers are closed.
-            atexit.register(_stop_queue_listener)
-            _queue_atexit_registered = True
-
-
-def flush_log_queue() -> None:
-    """Block until all queued records have been written, then resume.
-
-    Draining is done by stopping the listener (which processes every pending
-    record before joining) and restarting it.  Used by tests that read a log
-    file right after emitting to it.
-
-    NOTE: ``stop()`` joins the worker thread, so this blocks until the queue
-    is empty. Do NOT call this on a hard-exit path where the listener may be
-    wedged on the rotation lock — use ``drain_log_queue()`` there instead,
-    which bounds the wait.
-    """
-    with _queue_state_lock:
-        listener = _queue_listener
-        if listener is not None:
-            listener.stop()
-            listener.start()
-
-
-def drain_log_queue(timeout: float = 1.0) -> None:
-    """Best-effort, time-bounded drain for hard-exit paths (no restart).
-
-    Unlike ``flush_log_queue()``, this stops the listener WITHOUT restarting it
-    (the process is about to exit) and bounds the drain: if the listener's
-    worker thread is wedged on the cross-process rotation lock — the very
-    failure this async-logging change exists to survive — an unbounded
-    ``stop()``/join would re-freeze the shutdown path. We run ``stop()`` on a
-    throwaway thread and only wait ``timeout`` seconds for it; if it hasn't
-    drained by then we abandon the last few records and let ``os._exit``
-    proceed. Availability beats the last log line when the disk is already
-    wedged.
-    """
-    listener = _queue_listener
-    if listener is None:
-        return
-
-    def _drain() -> None:
-        try:
-            listener.stop()
-        except Exception:
-            pass
-
-    t = threading.Thread(target=_drain, name="hermes-log-drain", daemon=True)
-    t.start()
-    t.join(timeout)
+def _add_rotating_handler(*args, **kwargs) -> None:
+    """Deprecated no-op: Hermes no longer writes rotating log files."""
+    del args, kwargs
 
 
 def rotating_file_handlers() -> list:
-    """Return the live rotating file handlers.
+    """Return an empty list because file handlers are no longer installed."""
+    return []
 
-    They are attached to the async ``QueueListener`` rather than the root
-    logger, so callers/tests must use this instead of scanning
-    ``logging.getLogger().handlers``."""
-    return list(_queued_file_handlers)
+
+def flush_log_queue() -> None:
+    """Flush structured stream handlers synchronously."""
+    for handler in logging.getLogger().handlers:
+        if getattr(handler, _STRUCTURED_HANDLER_ATTR, False):
+            try:
+                handler.flush()
+            except Exception:
+                pass
+
+
+def drain_log_queue(timeout: float = 1.0) -> None:
+    """Compatibility shim for the former async file logger."""
+    del timeout
+    flush_log_queue()
 
 
 def _reset_queued_handlers() -> None:
-    """Tear down the async logging queue + listener (test-isolation helper)."""
-    global _log_queue
-    with _queue_state_lock:
-        _stop_queue_listener_locked()
-        root = logging.getLogger()
-        for h in list(root.handlers):
-            if getattr(h, "_hermes_queue", False):
-                root.removeHandler(h)
-        for h in list(_queued_file_handlers):
+    """Test helper that removes Hermes-owned structured handlers."""
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if (
+            getattr(handler, _STRUCTURED_HANDLER_ATTR, False)
+            or getattr(handler, "_hermes_queue", False)
+        ):
+            root.removeHandler(handler)
             try:
-                h.close()
+                handler.close()
             except Exception:
                 pass
-        _queued_file_handlers.clear()
-        _log_queue = None
-
-
-def _add_rotating_handler(
-    logger: logging.Logger,
-    path: Path,
-    *,
-    level: int,
-    max_bytes: int,
-    backup_count: int,
-    formatter: logging.Formatter,
-    log_filter: Optional[logging.Filter] = None,
-) -> None:
-    """Add a ``RotatingFileHandler`` to *logger*, skipping if one already
-    exists for the same resolved file path (idempotent).
-
-    Parameters
-    ----------
-    log_filter
-        Optional filter to attach to the handler (e.g. ``_ComponentFilter``
-        for gateway.log).
-    """
-    resolved = path.resolve()
-    for existing in _queued_file_handlers:
-        if (
-            isinstance(existing, RotatingFileHandler)
-            and Path(getattr(existing, "baseFilename", "")).resolve() == resolved
-        ):
-            return  # already attached
-
-    from hermes_constants import mkdir_under_hermes_home
-    mkdir_under_hermes_home(path.parent)
-    handler = _ManagedRotatingFileHandler(
-        str(path), maxBytes=max_bytes, backupCount=backup_count,
-        encoding="utf-8",
-    )
-    handler.setLevel(level)
-    handler.setFormatter(formatter)
-    if log_filter is not None:
-        handler.addFilter(log_filter)
-    # Route through the async queue instead of ``logger.addHandler(handler)`` so
-    # the rotation-lock wait never runs on the caller's (often event-loop) thread.
-    _register_queued_handler(handler)
 
 
 def _read_logging_config():
-    """Best-effort read of ``logging.*`` from config.yaml.
+    """Best-effort read of the remaining ``logging.level`` setting."""
+    cfg = _load_logging_config()
+    log_cfg = cfg.get("logging", {})
+    if isinstance(log_cfg, dict):
+        return (log_cfg.get("level"), None, None)
+    return (None, None, None)
 
-    Returns ``(level, max_size_mb, backup_count)`` — any may be ``None``.
-    """
+
+def _read_logging_format() -> str:
+    """Return the configured stream format, defaulting safely to text."""
+    cfg = _load_logging_config()
+    log_cfg = cfg.get("logging", {})
+    if isinstance(log_cfg, dict) and log_cfg.get("format") == "gcp_json":
+        return "gcp_json"
+    return "text"
+
+
+def _load_logging_config() -> dict:
+    """Best-effort load of raw config for logging settings."""
     try:
-        # Prefer the shared (mtime, size)-keyed raw-config cache so this read
-        # reuses the parse hermes_cli.main's early bridge already did (one
-        # config.yaml parse per process instead of 3-4). Fall back to a
-        # direct parse when hermes_cli.config isn't importable (bare
-        # hermes_logging consumers).
         try:
             from hermes_cli.config import read_raw_config as _rrc
+
             cfg = _rrc() or {}
         except Exception:
             from utils import fast_safe_load
+
             config_path = get_config_path()
             if not config_path.exists():
-                return (None, None, None)
+                return {}
             with open(config_path, "r", encoding="utf-8") as f:
                 cfg = fast_safe_load(f) or {}
-        if cfg:
-            # Managed scope: an administrator can pin logging.* too. Overlay via
-            # the shared helper (fail-open) since this reads config.yaml directly.
-            try:
-                from hermes_cli import managed_scope
-                cfg = managed_scope.apply_managed_overlay(cfg)
-            except Exception:
-                pass
-            log_cfg = cfg.get("logging", {})
-            if isinstance(log_cfg, dict):
-                return (
-                    log_cfg.get("level"),
-                    log_cfg.get("max_size_mb"),
-                    log_cfg.get("backup_count"),
-                )
+
+        try:
+            from hermes_cli import managed_scope
+
+            cfg = managed_scope.apply_managed_overlay(cfg)
+        except Exception:
+            pass
+
+        return cfg if isinstance(cfg, dict) else {}
     except Exception:
         pass
-    return (None, None, None)
+    return {}

--- a/tests/gateway/test_tool_log_mode.py
+++ b/tests/gateway/test_tool_log_mode.py
@@ -1,9 +1,8 @@
 """Tests for the `log` tool_progress mode (salvage of #3459 / #3458).
 
-`display.tool_progress: log` keeps the chat silent and appends tool-call
-lines to ~/.hermes/logs/tool_calls.log via write_tool_log's rotating handler.
-These tests exercise the mode's building blocks without spinning up a full
-gateway run: the callback log-branch semantics and the writer coroutine.
+`display.tool_progress: log` keeps the chat silent and emits tool-call lines
+through Hermes' structured container log stream. These tests exercise the
+mode's building blocks without spinning up a full gateway run.
 """
 
 import asyncio
@@ -40,30 +39,19 @@ class TestLogBranchSemantics:
 
 
 @pytest.mark.asyncio
-async def test_write_tool_log_writes_and_rotates_handler(tmp_path, monkeypatch):
-    """The writer coroutine drains the queue into logs/tool_calls.log."""
-    import gateway.run as gateway_run
-
-    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
-
+async def test_write_tool_log_uses_structured_stream():
+    """Tool progress log records are emitted as Cloud Logging JSON."""
     log_queue: queue.Queue = queue.Queue()
     log_queue.put("2026-07-02 10:00:00  terminal: \"echo hi\"")
     log_queue.put("2026-07-02 10:00:01  read_file: \"foo.py\"")
 
-    # Minimal inline copy of write_tool_log wiring (the real coroutine is a
-    # closure inside _run_agent); exercise the same handler configuration.
     import logging
-    from logging.handlers import RotatingFileHandler
+    import io
+    import json
+    from hermes_logging import GCPStructuredLogHandler
 
-    from agent.redact import RedactingFormatter
-
-    log_dir = tmp_path / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    handler = RotatingFileHandler(
-        log_dir / "tool_calls.log", maxBytes=5 * 1024 * 1024, backupCount=3,
-        encoding="utf-8",
-    )
-    handler.setFormatter(RedactingFormatter("%(message)s"))
+    stream = io.StringIO()
+    handler = GCPStructuredLogHandler(stream)
     tool_logger = logging.getLogger(f"hermes.tool_calls.test.{id(log_queue)}")
     tool_logger.setLevel(logging.INFO)
     tool_logger.propagate = False
@@ -79,10 +67,9 @@ async def test_write_tool_log_writes_and_rotates_handler(tmp_path, monkeypatch):
         handler.flush()
         handler.close()
 
-    content = (log_dir / "tool_calls.log").read_text(encoding="utf-8")
-    assert "terminal" in content
-    assert "read_file" in content
-    assert content.count("\n") == 2
+    records = [json.loads(line) for line in stream.getvalue().splitlines()]
+    assert len(records) == 2
+    assert "terminal" in records[0]["message"]
+    assert "read_file" in records[1]["message"]
+    assert all(record["severity"] == "INFO" for record in records)
     await asyncio.sleep(0)  # keep the asyncio marker honest
-
-

--- a/tests/hermes_cli/test_logs.py
+++ b/tests/hermes_cli/test_logs.py
@@ -42,10 +42,20 @@ class TestParseLineTimestamp:
         ts = _parse_line_timestamp("2026-04-11 10:23:45 INFO gateway.run: msg")
         assert ts == datetime(2026, 4, 11, 10, 23, 45)
 
+    def test_gcp_json_format(self):
+        ts = _parse_line_timestamp(
+            '{"time":"2026-04-11T10:23:45.123Z","severity":"INFO",'
+            '"logger":"gateway.run","message":"msg"}'
+        )
+        assert ts == datetime(2026, 4, 11, 10, 23, 45, 123000)
+
 
 class TestExtractLevel:
     def test_info(self):
         assert _extract_level("2026-01-01 00:00:00 INFO gateway.run: msg") == "INFO"
+
+    def test_gcp_severity(self):
+        assert _extract_level('{"severity":"ERROR","message":"failed"}') == "ERROR"
 
 
 # ---------------------------------------------------------------------------
@@ -60,6 +70,9 @@ class TestExtractLoggerName:
 
     def test_no_match(self):
         assert _extract_logger_name("random text") is None
+
+    def test_gcp_logger(self):
+        assert _extract_logger_name('{"logger":"gateway.run","message":"started"}') == "gateway.run"
 
 
 class TestLineMatchesComponent:

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -1,680 +1,175 @@
-"""Tests for hermes_logging — centralized logging setup."""
+"""Tests for Hermes' Google Cloud Logging-compatible stream handler."""
+
 import io
+import json
 import logging
 import os
-import stat
-import sys
-import threading
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
 import hermes_logging
-# Use whatever RotatingFileHandler class hermes_logging actually resolved so
-# the autouse fixture's isinstance checks (which strip rotating handlers
-# between tests) match the real handlers on every platform. hermes_logging
-# aliases concurrent-log-handler's ConcurrentRotatingFileHandler on Windows
-# (the #44873 fix) but keeps stdlib RotatingFileHandler on POSIX, so importing
-# the name from the module under test keeps the two in lockstep.
-from hermes_logging import RotatingFileHandler
 
 
 @pytest.fixture(autouse=True)
 def _reset_logging_state():
-    """Reset the module-level sentinel and clean up root logger handlers
-    added by setup_logging() so tests don't leak state.
-
-    Under xdist (-n auto) other test modules may have called setup_logging()
-    in the same worker process, leaving RotatingFileHandlers on the root
-    logger.  We strip ALL RotatingFileHandlers before each test so the count
-    assertions are stable regardless of test ordering.
-    """
-    hermes_logging._logging_initialized = False
-    # File handlers now live behind the async QueueListener, not on the root
-    # logger; tear down any leaked from other xdist tests in this worker.
-    hermes_logging._reset_queued_handlers()
     root = logging.getLogger()
-    prev_root_level = root.level
-    root.setLevel(logging.NOTSET)
-    # Snapshot the remaining (non-file) handlers so we can strip whatever the
-    # test adds.
-    pre_existing = list(root.handlers)
-    # Ensure the record factory is installed (it's idempotent).
-    hermes_logging._install_session_record_factory()
-    yield
-    # Restore — tear down async file logging + remove handlers added by the test.
+    previous_level = root.level
     hermes_logging._reset_queued_handlers()
-    for h in list(root.handlers):
-        if h not in pre_existing:
-            root.removeHandler(h)
-            h.close()
-    root.setLevel(prev_root_level)
+    hermes_logging._logging_initialized = False
+    root.setLevel(logging.NOTSET)
+    yield
+    hermes_logging._reset_queued_handlers()
+    root.setLevel(previous_level)
     hermes_logging._logging_initialized = False
     hermes_logging.clear_session_context()
 
 
 @pytest.fixture
 def hermes_home(tmp_path, monkeypatch):
-    """Provide an isolated HERMES_HOME for logging tests.
-
-    Uses the same tmp_path as the autouse _isolate_hermes_home from conftest,
-    reading it back from the env var to avoid double-mkdir conflicts.
-    """
     home = Path(os.environ["HERMES_HOME"])
+    monkeypatch.setenv("HERMES_HOME", str(home))
     return home
 
 
+def _structured_records(stream: io.StringIO) -> list[dict]:
+    return [json.loads(line) for line in stream.getvalue().splitlines() if line]
+
+
+class TestGCPStructuredLogFormatter:
+    def test_formats_cloud_logging_fields(self):
+        formatter = hermes_logging.GCPStructuredLogFormatter()
+        record = logging.LogRecord(
+            "gateway.run", logging.INFO, __file__, 1, "started %s", ("gateway",), None
+        )
+
+        payload = json.loads(formatter.format(record))
+
+        assert payload["severity"] == "INFO"
+        assert payload["message"] == "started gateway"
+        assert payload["logger"] == "gateway.run"
+        assert payload["time"].endswith("Z")
+        assert isinstance(payload["pid"], int)
+        assert isinstance(payload["thread"], int)
+
+    @pytest.mark.parametrize(
+        ("level", "severity"),
+        [
+            (logging.DEBUG, "DEBUG"),
+            (logging.INFO, "INFO"),
+            (logging.WARNING, "WARNING"),
+            (logging.ERROR, "ERROR"),
+            (logging.CRITICAL, "CRITICAL"),
+        ],
+    )
+    def test_maps_python_levels(self, level, severity):
+        formatter = hermes_logging.GCPStructuredLogFormatter()
+        record = logging.LogRecord("test", level, __file__, 1, "message", (), None)
+
+        assert json.loads(formatter.format(record))["severity"] == severity
+
+    def test_includes_session_id(self):
+        hermes_logging.set_session_context("session-123")
+        formatter = hermes_logging.GCPStructuredLogFormatter()
+        record = logging.getLogger("agent").makeRecord(
+            "agent", logging.INFO, __file__, 1, "message", (), None
+        )
+
+        payload = json.loads(formatter.format(record))
+
+        assert payload["session_id"] == "session-123"
+
+    def test_includes_exception_in_message(self):
+        formatter = hermes_logging.GCPStructuredLogFormatter()
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            record = logging.LogRecord("agent", logging.ERROR, __file__, 1, "failed", (), None)
+            record.exc_info = __import__("sys").exc_info()
+
+        payload = json.loads(formatter.format(record))
+
+        assert "failed" in payload["message"]
+        assert "RuntimeError: boom" in payload["message"]
+
+
 class TestSetupLogging:
-    """setup_logging() creates agent.log + errors.log with RotatingFileHandler."""
+    def test_installs_default_stderr_handler_without_creating_files(self, hermes_home, monkeypatch):
+        stream = io.StringIO()
+        monkeypatch.setattr(hermes_logging.sys, "stderr", stream)
 
-    def test_creates_log_directory(self, hermes_home):
-        log_dir = hermes_logging.setup_logging(hermes_home=hermes_home)
-        assert log_dir == hermes_home / "logs"
-        assert log_dir.is_dir()
-
-    def test_creates_agent_log_handler(self, hermes_home):
-        hermes_logging.setup_logging(hermes_home=hermes_home)
-        root = logging.getLogger()
-
-        agent_handlers = [
-            h for h in hermes_logging.rotating_file_handlers()
-            if isinstance(h, RotatingFileHandler)
-            and "agent.log" in getattr(h, "baseFilename", "")
-        ]
-        assert len(agent_handlers) == 1
-        assert agent_handlers[0].level == logging.INFO
-
-
-    def test_idempotent_no_duplicate_handlers(self, hermes_home):
-        hermes_logging.setup_logging(hermes_home=hermes_home)
-        hermes_logging.setup_logging(hermes_home=hermes_home)  # second call — should be no-op
-
-        root = logging.getLogger()
-        agent_handlers = [
-            h for h in hermes_logging.rotating_file_handlers()
-            if isinstance(h, RotatingFileHandler)
-            and "agent.log" in getattr(h, "baseFilename", "")
-        ]
-        assert len(agent_handlers) == 1
-
-
-
-
-
-    def test_writes_to_agent_log(self, hermes_home):
-        hermes_logging.setup_logging(hermes_home=hermes_home)
-
-        test_logger = logging.getLogger("test_hermes_logging.write_test")
-        test_logger.info("test message for agent.log")
-
-        # Flush handlers
+        result = hermes_logging.setup_logging(hermes_home=hermes_home)
+        logging.getLogger("test.setup").info("hello")
         hermes_logging.flush_log_queue()
 
-        agent_log = hermes_home / "logs" / "agent.log"
-        assert agent_log.exists()
-        content = agent_log.read_text()
-        assert "test message for agent.log" in content
+        handlers = [
+            h for h in logging.getLogger().handlers
+            if getattr(h, "_hermes_gcp_structured", False)
+        ]
+        assert result == hermes_home / "logs"
+        assert len(handlers) == 1
+        assert "INFO test.setup: hello" in stream.getvalue()
+        assert not (hermes_home / "logs").exists()
 
-
-
-
-    def test_explicit_params_override_config(self, hermes_home):
-        """Explicit function params take precedence over config.yaml."""
+    def test_uses_gcp_json_when_configured(self, hermes_home, monkeypatch):
         import yaml
-        config = {"logging": {"level": "DEBUG"}}
-        (hermes_home / "config.yaml").write_text(yaml.dump(config))
 
-        hermes_logging.setup_logging(hermes_home=hermes_home, log_level="WARNING")
-
-        root = logging.getLogger()
-        agent_handlers = [
-            h for h in hermes_logging.rotating_file_handlers()
-            if isinstance(h, RotatingFileHandler)
-            and "agent.log" in getattr(h, "baseFilename", "")
-        ]
-        assert agent_handlers[0].level == logging.WARNING
-
-
-
-class TestGatewayMode:
-    """setup_logging(mode='gateway') creates a filtered gateway.log."""
-
-    def test_gateway_log_created(self, hermes_home):
-        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
-        root = logging.getLogger()
-
-        gw_handlers = [
-            h for h in hermes_logging.rotating_file_handlers()
-            if isinstance(h, RotatingFileHandler)
-            and "gateway.log" in getattr(h, "baseFilename", "")
-        ]
-        assert len(gw_handlers) == 1
-
-    def test_gateway_log_not_created_in_cli_mode(self, hermes_home):
-        hermes_logging.setup_logging(hermes_home=hermes_home, mode="cli")
-        root = logging.getLogger()
-
-        gw_handlers = [
-            h for h in hermes_logging.rotating_file_handlers()
-            if isinstance(h, RotatingFileHandler)
-            and "gateway.log" in getattr(h, "baseFilename", "")
-        ]
-        assert len(gw_handlers) == 0
-
-
-
-    def test_gateway_log_receives_gateway_records(self, hermes_home):
-        """gateway.log captures records from gateway.* loggers."""
-        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
-
-        gw_logger = logging.getLogger("plugins.platforms.telegram.adapter")
-        gw_logger.info("telegram connected")
-
-        hermes_logging.flush_log_queue()
-
-        gw_log = hermes_home / "logs" / "gateway.log"
-        assert gw_log.exists()
-        assert "telegram connected" in gw_log.read_text()
-
-    def test_gateway_log_rejects_non_gateway_records(self, hermes_home):
-        """gateway.log does NOT capture records from tools.*, agent.*, etc."""
-        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
-
-        tool_logger = logging.getLogger("tools.terminal_tool")
-        tool_logger.info("running command")
-
-        agent_logger = logging.getLogger("agent.context_compressor")
-        agent_logger.info("compressing context")
-
-        hermes_logging.flush_log_queue()
-
-        gw_log = hermes_home / "logs" / "gateway.log"
-        if gw_log.exists():
-            content = gw_log.read_text()
-            assert "running command" not in content
-            assert "compressing context" not in content
-
-
-
-class TestGuiMode:
-    """setup_logging(mode='gui') creates a filtered gui.log."""
-
-    def test_gui_log_created(self, hermes_home):
-        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gui")
-        root = logging.getLogger()
-
-        gui_handlers = [
-            h for h in hermes_logging.rotating_file_handlers()
-            if isinstance(h, RotatingFileHandler)
-            and "gui.log" in getattr(h, "baseFilename", "")
-        ]
-        assert len(gui_handlers) == 1
-
-
-    def test_gui_log_receives_only_gui_components(self, hermes_home):
-        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gui")
-
-        logging.getLogger("hermes_cli.web_server").info("dashboard online")
-        logging.getLogger("tui_gateway.ws").info("ws connected")
-        logging.getLogger("gateway.run").info("gateway event")
-
-        hermes_logging.flush_log_queue()
-
-        gui_log = hermes_home / "logs" / "gui.log"
-        assert gui_log.exists()
-        content = gui_log.read_text()
-        assert "dashboard online" in content
-        assert "ws connected" in content
-        assert "gateway event" not in content
-
-
-class TestSessionContext:
-    """set_session_context / clear_session_context + _SessionFilter."""
-
-    def test_session_tag_in_log_output(self, hermes_home):
-        """When session context is set, log lines include [session_id]."""
-        hermes_logging.setup_logging(hermes_home=hermes_home)
-        hermes_logging.set_session_context("abc123")
-
-        test_logger = logging.getLogger("test.session_tag")
-        test_logger.info("tagged message")
-
-        hermes_logging.flush_log_queue()
-
-        agent_log = hermes_home / "logs" / "agent.log"
-        content = agent_log.read_text()
-        assert "[abc123]" in content
-        assert "tagged message" in content
-
-
-
-
-
-
-
-class TestComponentFilter:
-    """Unit tests for _ComponentFilter."""
-
-    def test_passes_matching_prefix(self):
-        f = hermes_logging._ComponentFilter(("gateway",))
-        record = logging.LogRecord(
-            "gateway.run", logging.INFO, "", 0, "msg", (), None
+        (hermes_home / "config.yaml").write_text(
+            yaml.dump({"logging": {"format": "gcp_json"}})
         )
-        assert f.filter(record) is True
+        stream = io.StringIO()
+        monkeypatch.setattr(hermes_logging.sys, "stderr", stream)
 
-
-    def test_blocks_non_matching(self):
-        f = hermes_logging._ComponentFilter(("gateway",))
-        record = logging.LogRecord(
-            "tools.terminal_tool", logging.INFO, "", 0, "msg", (), None
-        )
-        assert f.filter(record) is False
-
-
-
-
-
-class TestSetupVerboseLogging:
-    """setup_verbose_logging() adds a DEBUG-level console handler."""
-
-    def test_adds_stream_handler(self, hermes_home):
         hermes_logging.setup_logging(hermes_home=hermes_home)
+        logging.getLogger("test.setup").info("hello")
+        hermes_logging.flush_log_queue()
+
+        payload = _structured_records(stream)[-1]
+        assert payload["severity"] == "INFO"
+        assert payload["message"] == "hello"
+
+    def test_is_idempotent(self, hermes_home, monkeypatch):
+        monkeypatch.setattr(hermes_logging.sys, "stderr", io.StringIO())
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        handlers = [
+            h for h in logging.getLogger().handlers
+            if getattr(h, "_hermes_gcp_structured", False)
+        ]
+        assert len(handlers) == 1
+
+    def test_reads_log_level_from_config(self, hermes_home, monkeypatch):
+        import yaml
+
+        (hermes_home / "config.yaml").write_text(yaml.dump({"logging": {"level": "WARNING"}}))
+        monkeypatch.setattr(hermes_logging.sys, "stderr", io.StringIO())
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        handler = next(
+            h for h in logging.getLogger().handlers
+            if getattr(h, "_hermes_gcp_structured", False)
+        )
+        assert handler.level == logging.WARNING
+
+    def test_verbose_reuses_shared_handler(self, hermes_home, monkeypatch):
+        monkeypatch.setattr(hermes_logging.sys, "stderr", io.StringIO())
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
         hermes_logging.setup_verbose_logging()
 
-        root = logging.getLogger()
-        verbose_handlers = [
-            h for h in root.handlers
-            if isinstance(h, logging.StreamHandler)
-            and not isinstance(h, RotatingFileHandler)
-            and getattr(h, "_hermes_verbose", False)
+        handlers = [
+            h for h in logging.getLogger().handlers
+            if getattr(h, "_hermes_gcp_structured", False)
         ]
-        assert len(verbose_handlers) == 1
-        assert verbose_handlers[0].level == logging.DEBUG
-
-
-
-class TestAddRotatingHandler:
-    """_add_rotating_handler() is idempotent and creates the directory."""
-
-
-    def test_no_duplicate_for_same_path(self, tmp_path):
-        log_path = tmp_path / "test.log"
-        logger = logging.getLogger("_test_rotating_dup")
-        formatter = logging.Formatter("%(message)s")
-
-        hermes_logging._add_rotating_handler(
-            logger, log_path,
-            level=logging.INFO, max_bytes=1024, backup_count=1,
-            formatter=formatter,
-        )
-        hermes_logging._add_rotating_handler(
-            logger, log_path,
-            level=logging.INFO, max_bytes=1024, backup_count=1,
-            formatter=formatter,
-        )
-
-        rotating_handlers = [
-            h for h in hermes_logging.rotating_file_handlers()
-            if isinstance(h, RotatingFileHandler)
-        ]
-        assert len(rotating_handlers) == 1
-        # Clean up
-        for h in list(logger.handlers):
-            if isinstance(h, RotatingFileHandler):
-                logger.removeHandler(h)
-                h.close()
-
-
-    def test_no_session_filter_on_handler(self, tmp_path):
-        """Handlers rely on record factory, not per-handler _SessionFilter."""
-        log_path = tmp_path / "no_session_filter.log"
-        logger = logging.getLogger("_test_no_session_filter")
-        formatter = logging.Formatter("%(session_tag)s%(message)s")
-
-        hermes_logging._add_rotating_handler(
-            logger, log_path,
-            level=logging.INFO, max_bytes=1024, backup_count=1,
-            formatter=formatter,
-        )
-
-        handlers = [h for h in hermes_logging.rotating_file_handlers() if isinstance(h, RotatingFileHandler)]
         assert len(handlers) == 1
-        # No _SessionFilter on the handler — record factory handles it
-        assert len(handlers[0].filters) == 0
+        assert handlers[0].level == logging.DEBUG
 
-        # But session_tag still works (via record factory)
-        hermes_logging.set_session_context("factory_test")
-        logger.info("test msg")
-        hermes_logging.flush_log_queue()
-        content = log_path.read_text()
-        assert "[factory_test]" in content
 
-        # Clean up
-        for h in list(logger.handlers):
-            if isinstance(h, RotatingFileHandler):
-                logger.removeHandler(h)
-                h.close()
-
-    def test_managed_mode_initial_open_sets_group_writable(self, tmp_path):
-        log_path = tmp_path / "managed-open.log"
-        logger = logging.getLogger("_test_rotating_managed_open")
-        formatter = logging.Formatter("%(message)s")
-
-        old_umask = os.umask(0o022)
-        try:
-            with patch("hermes_cli.config.is_managed", return_value=True):
-                hermes_logging._add_rotating_handler(
-                    logger, log_path,
-                    level=logging.INFO, max_bytes=1024, backup_count=1,
-                    formatter=formatter,
-                )
-        finally:
-            os.umask(old_umask)
-
-        assert log_path.exists()
-        assert stat.S_IMODE(log_path.stat().st_mode) == 0o660
-
-        for h in list(logger.handlers):
-            if isinstance(h, RotatingFileHandler):
-                logger.removeHandler(h)
-                h.close()
-
-
-
-class TestWindowsConcurrentLogLockTimeout:
-    """Windows concurrent-log-handler lock timeouts stay inside logging."""
-
-    def _make_logger_and_handler(self, log_path: Path):
-        logger = logging.getLogger(f"_test_concurrent_lock_timeout_{log_path.stem}")
-        logger.handlers.clear()
-        logger.propagate = False
-        logger.setLevel(logging.INFO)
-
-        handler = hermes_logging._ManagedRotatingFileHandler(
-            str(log_path), maxBytes=1, backupCount=1, encoding="utf-8",
-        )
-        handler.setFormatter(logging.Formatter("%(message)s"))
-        logger.addHandler(handler)
-        return logger, handler
-
-    @pytest.mark.windows_only
-    def test_helper_only_matches_windows_concurrent_lock_timeout(self):
-        # Windows-only: concurrent-log-handler (and therefore its cross-process
-        # lock timeout) is only installed on Windows — faking sys.platform
-        # exercised the string check without the handler that raises it.
-        assert hermes_logging._is_windows_concurrent_log_lock_timeout(
-            RuntimeError("Cannot acquire lock after 20 attempts")
-        )
-        assert not hermes_logging._is_windows_concurrent_log_lock_timeout(
-            RuntimeError("some other logging failure")
-        )
-
-    @pytest.mark.linux_only
-    def test_helper_never_matches_off_windows(self):
-        # On POSIX the suppression must stay inert: stdlib RotatingFileHandler
-        # is in use, so this RuntimeError text is never a CLH lock timeout.
-        assert not hermes_logging._is_windows_concurrent_log_lock_timeout(
-            RuntimeError("Cannot acquire lock after 20 attempts")
-        )
-
-    @pytest.mark.windows_only
-    def test_lock_timeout_routed_to_handle_error_is_suppressed(self, tmp_path, capsys):
-        """Mirror CLH's real control flow.
-
-        ``concurrent-log-handler``'s ``emit()`` wraps its whole body in
-        ``try/except Exception: self.handleError(record)``, so the lock
-        RuntimeError raised in ``_do_lock()`` is caught *inside* CLH and routed
-        to ``handleError`` with the exception live in ``sys.exc_info()``.  We
-        invoke ``handleError`` the same way CLH would and assert no traceback
-        reaches stderr (the slash-worker surface).
-
-        Windows-only: the suppression is keyed on the real host, and only on
-        Windows is the base handler CLH at all — the fake platform gave us the
-        branch without the handler that raises."""
-        logger, handler = self._make_logger_and_handler(tmp_path / "agent.log")
-        record = logger.makeRecord(
-            logger.name, logging.INFO, __file__, 0, "force rollover", (), None,
-        )
-        try:
-            try:
-                raise RuntimeError("Cannot acquire lock after 20 attempts")
-            except RuntimeError:
-                handler.handleError(record)
-
-            captured = capsys.readouterr()
-            assert "Cannot acquire lock after 20 attempts" not in captured.err
-            assert "--- Logging error ---" not in captured.err
-        finally:
-            logger.removeHandler(handler)
-            handler.close()
-
-
-
-class TestReadLoggingConfig:
-    """_read_logging_config() reads from config.yaml."""
-
-    def test_returns_none_when_no_config(self, hermes_home):
-        level, max_size, backup = hermes_logging._read_logging_config()
-        assert level is None
-        assert max_size is None
-        assert backup is None
-
-    def test_reads_logging_section(self, hermes_home):
-        import yaml
-        config = {"logging": {"level": "DEBUG", "max_size_mb": 10, "backup_count": 5}}
-        (hermes_home / "config.yaml").write_text(yaml.dump(config))
-
-        level, max_size, backup = hermes_logging._read_logging_config()
-        assert level == "DEBUG"
-        assert max_size == 10
-        assert backup == 5
-
-
-
-class TestExternalRotationRecovery:
-    """_ManagedRotatingFileHandler recovers from external rotation.
-
-    External rotation = anything that renames, unlinks, or replaces the
-    log file without going through ``doRollover()``: logrotate, manual
-    ``mv``, another process rotating under us, or a transient ``rm``.
-    Before this fix the open file descriptor stayed pinned to the old
-    inode forever, so every subsequent write went to the rotated backup
-    instead of the file the operator expects to read.
-    """
-
-    def _make_handler(self, log_path: Path) -> hermes_logging._ManagedRotatingFileHandler:
-        handler = hermes_logging._ManagedRotatingFileHandler(
-            str(log_path), maxBytes=10 * 1024 * 1024, backupCount=3,
-            encoding="utf-8",
-        )
-        handler.setLevel(logging.INFO)
-        handler.setFormatter(logging.Formatter("%(message)s"))
-        return handler
-
-    def _emit(self, handler: logging.Handler, msg: str) -> None:
-        record = logging.LogRecord(
-            name="gateway.run", level=logging.INFO, pathname="", lineno=0,
-            msg=msg, args=(), exc_info=None,
-        )
-        # Match the record factory that hermes_logging installs at import time.
-        record.session_tag = ""
-        handler.emit(record)
-        hermes_logging.flush_log_queue()
-
-    def test_recovers_after_external_rename(self, tmp_path):
-        """logrotate-style external rename: ``mv gateway.log gateway.log.1``.
-
-        Handler's fd was pinned to the renamed inode; new writes used to
-        go to ``gateway.log.1`` forever.  After fix, the handler reopens
-        ``gateway.log`` at the original path.
-        """
-        log_path = tmp_path / "gateway.log"
-        rotated = tmp_path / "gateway.log.1"
-        handler = self._make_handler(log_path)
-        try:
-            self._emit(handler, "before rotation")
-            assert log_path.read_text() == "before rotation\n"
-
-            # External rotation (NOT via handler.doRollover()).
-            os.rename(log_path, rotated)
-            assert not log_path.exists()
-
-            self._emit(handler, "after rotation")
-
-            # The new write should land in a freshly recreated gateway.log,
-            # not appended to the rotated backup.
-            assert log_path.exists(), "handler did not recreate gateway.log"
-            assert log_path.read_text() == "after rotation\n"
-            assert rotated.read_text() == "before rotation\n"
-        finally:
-            handler.close()
-
-
-    def test_external_truncate_does_not_force_reopen(self, tmp_path):
-        """``: > gateway.log`` keeps the same inode — no reopen needed.
-
-        Truncation in place preserves the inode, so subsequent writes
-        continue to the same file descriptor.  We assert the post-truncate
-        content reflects the truncate (size shrinks) and then grows with
-        new writes — i.e. the handler correctly does NOT detect this as
-        an inode change.
-        """
-        log_path = tmp_path / "gateway.log"
-        handler = self._make_handler(log_path)
-        try:
-            self._emit(handler, "AAAA" * 32)
-            assert log_path.stat().st_size > 0
-
-            with open(log_path, "w"):
-                pass  # truncate to zero
-            assert log_path.stat().st_size == 0
-
-            self._emit(handler, "after truncate")
-            assert log_path.read_text() == "after truncate\n"
-        finally:
-            handler.close()
-
-
-    def test_gateway_log_attached_after_external_rotation_then_re_setup(
-        self, hermes_home,
-    ):
-        """End-to-end Allen-reproduction: gateway.log gets externally rotated,
-        ``setup_logging(mode='gateway')`` is re-called, the handler keeps
-        working.
-
-        Reproduces Allen's symptom (gateway.log frozen mid-write, all gateway
-        records leaking to agent.log) when something external rotates the
-        file between setup_logging() calls.
-        """
-        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
-        gw_path = hermes_home / "logs" / "gateway.log"
-        rotated = hermes_home / "logs" / "gateway.log.1"
-
-        logging.getLogger("gateway.run").info("line BEFORE rotation")
-        hermes_logging.flush_log_queue()
-        assert "BEFORE rotation" in gw_path.read_text()
-
-        # External actor renames the file out from under us.
-        os.rename(gw_path, rotated)
-        assert not gw_path.exists()
-
-        # Caller (or some restart path) re-enters setup_logging.  This used
-        # to silently no-op due to the per-path dedup check, leaving the
-        # stale fd in place.
-        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
-
-        logging.getLogger("gateway.run").info("line AFTER rotation")
-        hermes_logging.flush_log_queue()
-
-        # The new record must reach the live gateway.log, not the rotated
-        # backup.  Allen's logs had everything past the rotation point
-        # going into agent.log only, never gateway.log.
-        assert gw_path.exists(), "gateway.log was never recreated"
-        assert "AFTER rotation" in gw_path.read_text()
-        assert "AFTER rotation" not in rotated.read_text()
-
-
-class TestSafeStderr:
-    """Tests for _safe_stderr() — Unicode tolerance on Windows console."""
-
-
-    def test_wraps_non_utf8_stderr(self, monkeypatch):
-        """On non-UTF-8 systems (e.g. Windows cp949), wraps stderr with UTF-8."""
-        import io
-
-        class FakeStderr:
-            """Simulates a Windows stderr with legacy encoding."""
-            encoding = "cp949"
-            buffer = io.BytesIO()
-
-            def write(self, s):
-                pass
-
-            def flush(self):
-                pass
-
-        fake = FakeStderr()
-        monkeypatch.setattr(sys, "stderr", fake)
-        result = hermes_logging._safe_stderr()
-        # Should be a TextIOWrapper, not the original FakeStderr
-        assert isinstance(result, io.TextIOWrapper)
-        assert result.encoding == "utf-8"
-        assert result.errors == "replace"
-
-    def test_handler_emits_unicode_without_crash(self, tmp_path):
-        """StreamHandler with _safe_stderr can emit Unicode messages."""
-        import io
-
-        # Create a stderr-like stream with ASCII encoding
-        class AsciiStream:
-            encoding = "ascii"
-            buffer = io.BytesIO()
-
-            def write(self, s):
-                self.buffer.write(s.encode("ascii", errors="replace"))
-
-            def flush(self):
-                pass
-
-        # Without the fix, this would crash on cp949/ASCII stderr.
-        # With the wrapper, the em-dash is replaced with '?'
-        handler = logging.StreamHandler(
-            io.TextIOWrapper(
-                io.BytesIO(),
-                encoding="utf-8",
-                errors="replace",
-            )
-        )
-        handler.setFormatter(logging.Formatter("%(message)s"))
-        logger = logging.getLogger("_test_unicode")
-        logger.addHandler(handler)
-        logger.setLevel(logging.DEBUG)
-        try:
-            # Em-dash U+2014 — the exact character from the bug report
-            logger.info("Session hygiene: 400 messages — auto-compressing")
-        finally:
-            logger.removeHandler(handler)
-
-
-class TestAsyncQueueLogging:
-    """File logging runs through a QueueListener so emits never block on the
-    cross-process rotation lock (Windows event-loop-stall fix)."""
-
-    def test_file_handlers_not_on_root(self, hermes_home):
-        hermes_logging.setup_logging(hermes_home=hermes_home)
-        root = logging.getLogger()
-        # Rotating file handlers live on the async listener, never on root.
-        assert not any(isinstance(h, RotatingFileHandler) for h in root.handlers)
-        # Exactly one queue handler funnels records to the listener.
-        queue_handlers = [
-            h for h in root.handlers if getattr(h, "_hermes_queue", False)
-        ]
-        assert len(queue_handlers) == 1
-        # The real file handlers are discoverable via the accessor.
-        assert any(
-            "agent.log" in getattr(h, "baseFilename", "")
-            for h in hermes_logging.rotating_file_handlers()
-        )
-
-
+def test_filter_and_log_helpers_remain_compatible():
+    assert hermes_logging._ComponentFilter(("gateway",)).filter(
+        logging.LogRecord("gateway.run", logging.INFO, "", 0, "msg", (), None)
+    )
+    assert hermes_logging.rotating_file_handlers() == []

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -24,7 +24,7 @@ Run `hermes setup --portal` — one OAuth gets you a model provider and all four
 ├── skills/         # Agent-created skills (managed via skill_manage tool)
 ├── cron/           # Scheduled jobs
 ├── sessions/       # Gateway sessions
-└── logs/           # Logs (errors.log, gateway.log — secrets auto-redacted)
+└── logs/           # Reserved for optional diagnostics; runtime logs use stderr/stdout
 ```
 
 ## Managing Configuration
@@ -119,6 +119,21 @@ Hermes also warns (once per process per database) when an existing
 database's on-disk journal mode is silently flipped to WAL on open — for
 example a database an operator had manually converted to `delete` — and
 names `database.journal_mode` as the setting that makes the choice stick.
+### Logging Format
+
+Runtime logs are written to stderr as one record per line. The default is
+human-readable text. For Google Cloud Logging, Kubernetes, or another JSON log
+collector, set:
+
+```yaml
+logging:
+  format: gcp_json
+  level: INFO
+```
+
+`gcp_json` emits Cloud Logging-compatible `time`, `severity`, and `message`
+fields. Hermes does not create local application log files; retention and
+queries are handled by the container or service supervisor.
 
 ## Environment Variable Substitution
 

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -114,7 +114,7 @@ docker run -d \
   nousresearch/hermes-agent gateway run
 ```
 
-The dashboard is supervised by s6 — if it crashes, `s6-supervise` restarts it automatically after a short backoff. Dashboard stdout/stderr is forwarded to `docker logs <container>` (no prefix; the gateway's own output now lives in a per-profile s6-log file — see [Where the logs go](#where-the-logs-go) below — so the two streams don't clash).
+The dashboard is supervised by s6 — if it crashes, `s6-supervise` restarts it automatically after a short backoff. Dashboard stdout/stderr is forwarded to `docker logs <container>`; gateway and dashboard records use the same configured stream format.
 
 | Environment variable | Description | Default |
 |---------------------|-------------|---------|
@@ -278,7 +278,7 @@ Before the s6 migration, "one container per profile" was the recommended pattern
 | Memory overhead | Shared Python interpreter cache, shared node_modules | Duplicated per container |
 | Profile creation | `docker exec ... hermes profile create <name>` (seconds) | New `docker run` invocation + port allocation + bind-mount config |
 | Per-profile crash recovery | `s6-supervise` auto-restart | Docker's `--restart unless-stopped` (slower, kills sibling work) |
-| Logs | Per-profile rotated file via `s6-log`, plus container-boot audit log | `docker logs <name>` per container — no built-in rotation |
+| Logs | Container stderr/stdout as newline-delimited JSON | `docker logs <name>`, `kubectl logs`, or Google Cloud Logging |
 | Backup | One `~/.hermes` directory | N directories to coordinate |
 
 The default profile (`default`) is always registered on first boot, so a fresh container ships with one supervised gateway out of the box. Additional profiles are pure runtime adds.
@@ -321,19 +321,21 @@ The warning from [Persistent volumes](#persistent-volumes) still applies: never 
 
 ## Where the logs go
 
-The s6 container has four distinct log surfaces, and "why isn't my gateway showing anything in `docker logs`" is a common surprise. Cheatsheet:
+The s6 container forwards runtime output to the container stream. Hermes
+application records are newline-delimited JSON, so the container runtime or
+Google Cloud Logging owns retention and querying. Cheatsheet:
 
 | Source | Where it lands | How to read it |
 |---|---|---|
-| **Per-profile gateway** (`hermes gateway run` and per-profile gateways under s6) | Tee'd to two places: `docker logs <container>` (real time, no extra prefix) **and** `${HERMES_HOME}/logs/gateways/<profile>/current` (rotated, ISO-8601 timestamped, 10 archives × 1 MB each) | `docker logs -f hermes` or `tail -F ~/.hermes/logs/gateways/default/current` on the host |
-| **Dashboard** (when `HERMES_DASHBOARD=1`) | `docker logs <container>` (no prefix) | `docker logs -f hermes` — interleaved with gateway lines |
-| **Boot reconciler** (records which profile gateways were restored on each container start) | `${HERMES_HOME}/logs/container-boot.log` (append-only audit log) | `tail -F ~/.hermes/logs/container-boot.log` |
-| **Generic Hermes logs** (`agent.log`, `errors.log`) | `${HERMES_HOME}/logs/` (profile-aware) | `docker exec hermes hermes logs --follow [--level WARNING] [--session <id>]` |
+| **Per-profile gateway** (`hermes gateway run` and per-profile gateways under s6) | Container stderr/stdout; `text` by default or newline-delimited JSON with `logging.format: gcp_json` | `docker logs -f hermes`, `kubectl logs -f <pod>`, or Google Cloud Logging |
+| **Dashboard** (when `HERMES_DASHBOARD=1`) | Container stderr/stdout using the configured format | `docker logs -f hermes` — interleaved with gateway lines |
+| **Boot reconciler** | Container stderr/stdout as structured operational output | `docker logs`, `kubectl logs`, or Google Cloud Logging |
+| **Generic Hermes logs** | Container stderr/stdout using the configured format | `docker logs`, `kubectl logs`, or Google Cloud Logging |
 
 Two practical consequences worth knowing:
 
-- The file copy at `logs/gateways/<profile>/current` is what survives container restarts. `docker logs` only retains output from the current container's lifetime (and is wiped on `docker rm`); the rotated files persist on the bind-mounted volume.
-- The boot reconciler's audit line shape is `<iso-timestamp> profile=<name> prior_state=<state> action=<registered|started>`, so a quick `grep profile=coder ~/.hermes/logs/container-boot.log` reveals when a given profile was last restored and whether s6 auto-started it.
+- Container log retention is controlled by Docker, GKE, or the configured logging backend.
+- `hermes logs` remains able to parse explicitly imported legacy log files, but does not create or tail runtime logs locally.
 
 ## Environment variable forwarding
 
@@ -541,7 +543,7 @@ Each profile created with `hermes profile create <name>` automatically gets an s
 - Gateway crashes are auto-restarted by `s6-supervise` after a ~1s backoff.
 - Dashboard, when enabled with `HERMES_DASHBOARD=1`, is supervised on the same supervision tree and gets the same auto-restart treatment.
 - `docker restart`, image upgrades (`docker compose up -d --force-recreate`), and unexpected exits preserve running gateways: the cont-init reconciler reads `$HERMES_HOME/profiles/<name>/gateway_state.json` and brings the slot back up if the last recorded state was `running`. Only an explicit `hermes gateway stop` records `stopped` and keeps the gateway down across the restart; the container/s6 SIGTERM sent on a restart or upgrade is treated as "still running" and auto-starts.
-- Per-profile gateway logs persist under `$HERMES_HOME/logs/gateways/<profile>/current` (rotated by `s6-log`), and the reconciler's actions are appended to `$HERMES_HOME/logs/container-boot.log` per boot. See [Where the logs go](#where-the-logs-go) for the full routing map.
+- Gateway and reconciler diagnostics are emitted to the container stream. See [Where the logs go](#where-the-logs-go) for the full routing map.
 
 `hermes status` inside the container reports `Manager: s6 (container supervisor)`. Use `/command/s6-svstat /run/service/gateway-<name>` for the raw supervisor view (note `/command/` is on PATH for supervision-tree processes only; pass the absolute path when calling from `docker exec`).
 


### PR DESCRIPTION
## Summary
- replace centralized rotating file handlers with a stderr stream handler
- add logging.format: gcp_json for Google Cloud Logging-compatible JSON; default remains text
- update CLI, dashboard, Docker supervisor, and docs for stream-owned runtime logs

## Test plan
- scripts/run_tests.sh targeted logging, config, gateway, debug, and container tests: 240 passed, 7 skipped
- ruff check on changed Python files
- py_compile on changed runtime modules