### PR TITLE
fix(mcp): add safe application health checks

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14330,7 +14330,14 @@ def cmd_plugins(args):
 def cmd_mcp(args):
     from hermes_cli.mcp_config import mcp_command
 
-    mcp_command(args)
+    rc = mcp_command(args)
+    # mcp_command now propagates handler exit codes; honor non-zero so
+    # `hermes mcp test` (and friends) report failure to callers — CI,
+    # orchestrators, watchdogs — instead of silently returning 0.
+    # Handlers that don't override rc continue to flow as None, which
+    # we treat as success (rc=0).
+    if isinstance(rc, int) and rc != 0:
+        sys.exit(rc)
 
 
 def cmd_claw(args):

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -719,7 +719,12 @@ def cmd_mcp_list(args=None):
 # ─── hermes mcp test ──────────────────────────────────────────────────────────
 
 def cmd_mcp_test(args):
-    """Test connection to an MCP server."""
+    """Test connection to an MCP server.
+
+    Exit codes:
+      0 — connection succeeded and at least one tool was discovered
+      1 — connection failed, server not found, or zero tools discovered
+    """
     name = args.name
     servers = _get_mcp_servers()
 
@@ -728,7 +733,7 @@ def cmd_mcp_test(args):
         available = list(servers.keys())
         if available:
             _info(f"Available: {', '.join(available)}")
-        return
+        return 1
 
     cfg = servers[name]
     print()
@@ -767,7 +772,11 @@ def cmd_mcp_test(args):
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
         _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
-        return
+        return 1
+
+    if not tools:
+        _error("Connected but server reported no tools.")
+        return 1
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")
     _success(f"Tools discovered: {len(tools)}")
@@ -1084,7 +1093,16 @@ def mcp_command(args):
 
     handler = handlers.get(action)
     if handler:
-        handler(args)
+        result = handler(args)
+        # Propagate explicit exit codes from handlers so the CLI surface
+        # matches what callers (CI, orchestrators, watchdogs) need to react
+        # to. Handlers returning None (the historical contract for
+        # success-or-soft-warning) keep the legacy rc=0 default; integer
+        # returns are honored as-is. Non-int truthy returns fall back to
+        # rc=0 to avoid breaking call sites that haven't been audited yet.
+        if isinstance(result, int):
+            return result
+        return 0
     else:
         # No subcommand — drop the user into the catalog picker. This is the
         # "try enabling and it flows you into setup" UX matching `hermes plugin`.

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -9,6 +9,7 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 """
 
 import asyncio
+from collections.abc import Mapping
 import logging
 import math
 import os
@@ -332,16 +333,33 @@ def _parse_configured_health_check(
     return tool_name, arguments
 
 
-def _health_field(value: Any, snake: str, camel: str, default: Any = None) -> Any:
-    if isinstance(value, dict):
-        return value.get(snake, value.get(camel, default))
-    return getattr(value, snake, getattr(value, camel, default))
+_HEALTH_VALUE_MISSING = object()
+_HEALTH_VALUE_CONFLICT = object()
+
+
+def _health_value(value: Any, field: str, default: Any = _HEALTH_VALUE_MISSING) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(field, default)
+    return getattr(value, field, default)
+
+
+def _health_alias_value(value: Any, snake: str, camel: str) -> Any:
+    """Return an alias value, failing closed when both spellings disagree."""
+    snake_value = _health_value(value, snake)
+    camel_value = _health_value(value, camel)
+    if snake_value is not _HEALTH_VALUE_MISSING and camel_value is not _HEALTH_VALUE_MISSING:
+        if type(snake_value) is not type(camel_value) or snake_value != camel_value:
+            return _HEALTH_VALUE_CONFLICT
+        return snake_value
+    if snake_value is not _HEALTH_VALUE_MISSING:
+        return snake_value
+    return camel_value
 
 
 def _health_tool_is_read_only(tool: Any) -> bool:
     """Interpret the MCP read-only annotation without importing runtime internals."""
-    annotations = _health_field(tool, "annotations", "annotations")
-    return _health_field(annotations, "read_only_hint", "readOnlyHint", False) is True
+    annotations = _health_value(tool, "annotations")
+    return _health_alias_value(annotations, "read_only_hint", "readOnlyHint") is True
 
 
 async def _run_configured_health_check(
@@ -353,7 +371,7 @@ async def _run_configured_health_check(
         (
             tool
             for tool in getattr(server, "_tools", [])
-            if getattr(tool, "name", None) == tool_name
+            if _health_value(tool, "name", None) == tool_name
         ),
         None,
     )
@@ -376,7 +394,10 @@ async def _run_configured_health_check(
         logger.debug("MCP application health check failed for '%s'", tool_name)
         raise RuntimeError("configured health check RPC failed") from None
 
-    if _health_field(result, "is_error", "isError", False):
+    error_state = _health_alias_value(result, "is_error", "isError")
+    if error_state is _HEALTH_VALUE_CONFLICT:
+        raise RuntimeError("configured health check returned an ambiguous error state")
+    if error_state is not _HEALTH_VALUE_MISSING and error_state is not False:
         raise RuntimeError("configured health check returned an error")
     return tool_name
 
@@ -429,11 +450,14 @@ def _probe_single_server(
         )
         try:
             for t in server._tools:
-                desc = getattr(t, "description", "") or ""
+                tool_display_name = _health_value(t, "name", None)
+                if not isinstance(tool_display_name, str):
+                    continue
+                desc = _health_value(t, "description", "") or ""
                 # Truncate long descriptions for display
                 if len(desc) > 80:
                     desc = desc[:77] + "..."
-                tools_found.append((t.name, desc))
+                tools_found.append((tool_display_name, desc))
             if health_check is not None:
                 health_tool_name = await _run_configured_health_check(
                     server, health_check

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -10,6 +10,7 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 
 import asyncio
 import logging
+import math
 import os
 import re
 import time
@@ -275,8 +276,118 @@ def _resolve_mcp_server_config(config: dict) -> dict:
     return _interpolate_env_vars(config)
 
 
+def _is_json_value(value: Any) -> bool:
+    """Return whether ``value`` is an exact JSON-compatible value.
+
+    ``json.dumps`` would coerce tuple values and non-string mapping keys, which
+    makes a configured health request differ from its YAML declaration. Reject
+    those shapes rather than silently transforming a tool's arguments.
+    """
+    if value is None or isinstance(value, (str, bool, int)):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, list):
+        return all(_is_json_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(isinstance(key, str) and _is_json_value(item) for key, item in value.items())
+    return False
+
+
+def _parse_configured_health_check(
+    config: dict,
+) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """Validate an optional safe application health-check tool declaration.
+
+    MCP connection setup and ``tools/list`` can succeed before a server checks
+    application credentials. A server owner may therefore opt into an
+    application-level test with ``health_check.tool`` and static
+    ``health_check.arguments``. The tool must later advertise
+    ``readOnlyHint=true`` before this probe will call it.
+
+    Hermes deliberately does not guess a tool name or manufacture arguments:
+    tool semantics are server-specific, and an unconfigured test must remain
+    discovery-only rather than risk a mutation.
+    """
+    raw = config.get("health_check")
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("health_check must be a mapping")
+    unknown = set(raw) - {"tool", "arguments"}
+    if unknown:
+        raise ValueError("health_check supports only 'tool' and 'arguments'")
+    tool_name = raw.get("tool")
+    if (
+        not isinstance(tool_name, str)
+        or not tool_name
+        or tool_name != tool_name.strip()
+    ):
+        raise ValueError("health_check.tool must be a non-empty string without padding")
+    if "arguments" not in raw:
+        raise ValueError("health_check.arguments must be an exact JSON object")
+    arguments = raw["arguments"]
+    if not isinstance(arguments, dict) or not _is_json_value(arguments):
+        raise ValueError("health_check.arguments must be an exact JSON object")
+    return tool_name, arguments
+
+
+def _health_field(value: Any, snake: str, camel: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(snake, value.get(camel, default))
+    return getattr(value, snake, getattr(value, camel, default))
+
+
+def _health_tool_is_read_only(tool: Any) -> bool:
+    """Interpret the MCP read-only annotation without importing runtime internals."""
+    annotations = _health_field(tool, "annotations", "annotations")
+    return _health_field(annotations, "read_only_hint", "readOnlyHint", False) is True
+
+
+async def _run_configured_health_check(
+    server: Any, health_check: Tuple[str, Dict[str, Any]]
+) -> str:
+    """Run one opt-in, read-only application probe without exposing its result."""
+    tool_name, arguments = health_check
+    advertised_tool = next(
+        (
+            tool
+            for tool in getattr(server, "_tools", [])
+            if getattr(tool, "name", None) == tool_name
+        ),
+        None,
+    )
+    if advertised_tool is None:
+        raise RuntimeError(
+            f"configured health check tool '{tool_name}' was not advertised by the server"
+        )
+    if not _health_tool_is_read_only(advertised_tool):
+        raise RuntimeError(
+            f"configured health check tool '{tool_name}' must advertise readOnlyHint=true"
+        )
+
+    try:
+        result = await server.session.call_tool(tool_name, arguments=arguments)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        # Do not log a remote tool error or its payload: a server may echo
+        # sensitive request/application context in a failed health response.
+        logger.debug("MCP application health check failed for '%s'", tool_name)
+        raise RuntimeError("configured health check RPC failed") from None
+
+    if _health_field(result, "is_error", "isError", False):
+        raise RuntimeError("configured health check returned an error")
+    return tool_name
+
+
 def _probe_single_server(
-    name: str, config: dict, connect_timeout: Optional[float] = None, *, details: Optional[dict] = None
+    name: str,
+    config: dict,
+    connect_timeout: Optional[float] = None,
+    *,
+    details: Optional[dict] = None,
+    run_health_check: bool = False,
 ) -> List[Tuple[str, str]]:
     """Temporarily connect to one MCP server, list its tools, disconnect.
 
@@ -285,7 +396,8 @@ def _probe_single_server(
 
     ``details``: optional dict the probe fills with extra capability counts
     (``prompts``, ``resources``) — an out-param so the return shape stays
-    stable for existing CLI callers.
+    stable for existing CLI callers. ``run_health_check`` is intentionally
+    false by default: only ``hermes mcp test`` may invoke the opt-in tool.
     """
     issues = validate_mcp_server_entry(name, config)
     if issues:
@@ -300,6 +412,7 @@ def _probe_single_server(
     )
 
     config = _resolve_mcp_server_config(config)
+    health_check = _parse_configured_health_check(config) if run_health_check else None
     if connect_timeout is None:
         raw_timeout = config.get("connect_timeout", 30)
         try:
@@ -321,6 +434,12 @@ def _probe_single_server(
                 if len(desc) > 80:
                     desc = desc[:77] + "..."
                 tools_found.append((t.name, desc))
+            if health_check is not None:
+                health_tool_name = await _run_configured_health_check(
+                    server, health_check
+                )
+                if details is not None:
+                    details["health_check"] = health_tool_name
             if details is not None:
                 # Gate the capability probes exactly like runtime utility-tool
                 # registration (tools.mcp_tool._select_utility_schemas):
@@ -766,20 +885,28 @@ def cmd_mcp_test(args):
 
     # Attempt connection
     start = time.monotonic()
+    details: Dict[str, Any] = {}
     try:
-        tools = _probe_single_server(name, cfg)
+        tools = _probe_single_server(name, cfg, details=details, run_health_check=True)
         elapsed_ms = (time.monotonic() - start) * 1000
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
         _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
         return 1
-
     if not tools:
         _error("Connected but server reported no tools.")
         return 1
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")
     _success(f"Tools discovered: {len(tools)}")
+    health_tool_name = details.get("health_check")
+    if health_tool_name:
+        _success(f"Application health check passed: {health_tool_name}")
+    else:
+        _warning(
+            "Discovery-only test: this does not verify application credentials. "
+            "Configure a read-only health_check to probe one."
+        )
 
     if tools:
         print()

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -707,10 +707,15 @@ class TestConfiguredApplicationHealthCheck:
 
         async def call_tool(name, arguments):
             calls.append((name, arguments))
-            return SimpleNamespace(is_error=False)
+            return {"isError": False}
 
         async def connect(_name, _config):
-            return self._server([self._Tool("memory_recall", True)], call_tool)
+            tool = SimpleNamespace(
+                name="memory_recall",
+                description="",
+                annotations=SimpleNamespace(read_only_hint=True),
+            )
+            return self._server([tool], call_tool)
 
         monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
         details = {}
@@ -793,6 +798,208 @@ class TestConfiguredApplicationHealthCheck:
                 run_health_check=True,
             )
         assert calls == []
+
+    @pytest.mark.parametrize(
+        "annotations",
+        [
+            None,
+            {"readOnlyHint": False},
+            {"readOnlyHint": "true"},
+            {"read_only_hint": True, "readOnlyHint": False},
+            {"read_only_hint": False, "readOnlyHint": True},
+        ],
+    )
+    def test_probe_rejects_unsafe_health_annotations_without_calling_it(
+        self, monkeypatch, annotations
+    ):
+        import hermes_cli.mcp_config as mc
+        from types import SimpleNamespace
+
+        calls = []
+
+        async def call_tool(name, arguments):
+            calls.append((name, arguments))
+            raise AssertionError("unsafe health tool must never run")
+
+        async def connect(_name, _config):
+            tool = SimpleNamespace(
+                name="memory_recall", description="", annotations=annotations
+            )
+            return self._server([tool], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+
+        with pytest.raises(RuntimeError, match="readOnlyHint=true"):
+            mc._probe_single_server(
+                "lucy",
+                {
+                    "url": "https://mcp.example.test",
+                    "health_check": {"tool": "memory_recall", "arguments": {}},
+                },
+                run_health_check=True,
+            )
+        assert calls == []
+
+    def test_probe_calls_generic_mapping_advertised_health_tool(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+        from types import MappingProxyType, SimpleNamespace
+
+        calls = []
+
+        async def call_tool(name, arguments):
+            calls.append((name, arguments))
+            return SimpleNamespace(is_error=False)
+
+        async def connect(_name, _config):
+            return self._server(
+                [
+                    MappingProxyType(
+                        {
+                            "name": "memory_recall",
+                            "description": "read only status",
+                            "annotations": MappingProxyType({"readOnlyHint": True}),
+                        }
+                    )
+                ],
+                call_tool,
+            )
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+        assert mc._probe_single_server(
+            "lucy",
+            {
+                "url": "https://mcp.example.test",
+                "health_check": {"tool": "memory_recall", "arguments": {}},
+            },
+            run_health_check=True,
+        ) == [("memory_recall", "read only status")]
+        assert calls == [("memory_recall", {})]
+
+    def test_probe_rejects_conflicting_generic_mapping_annotations_without_calling_it(
+        self, monkeypatch
+    ):
+        import hermes_cli.mcp_config as mc
+        from types import MappingProxyType, SimpleNamespace
+
+        calls = []
+
+        async def call_tool(name, arguments):
+            calls.append((name, arguments))
+            raise AssertionError("conflicting health-tool annotations must never run")
+
+        async def connect(_name, _config):
+            tool = SimpleNamespace(
+                name="memory_recall",
+                description="",
+                annotations=MappingProxyType(
+                    {"read_only_hint": True, "readOnlyHint": False}
+                ),
+            )
+            return self._server([tool], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+
+        with pytest.raises(RuntimeError, match="readOnlyHint=true"):
+            mc._probe_single_server(
+                "lucy",
+                {
+                    "url": "https://mcp.example.test",
+                    "health_check": {"tool": "memory_recall", "arguments": {}},
+                },
+                run_health_check=True,
+            )
+        assert calls == []
+
+    def test_probe_hides_dict_health_tool_error_payload(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+
+        async def call_tool(_name, _arguments):
+            return {"isError": True, "content": ["sensitive server payload"]}
+
+        async def connect(_name, _config):
+            return self._server([self._Tool("memory_recall", True)], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+
+        with pytest.raises(RuntimeError, match="configured health check returned an error") as excinfo:
+            mc._probe_single_server(
+                "lucy",
+                {
+                    "url": "https://mcp.example.test",
+                    "health_check": {"tool": "memory_recall", "arguments": {}},
+                },
+                run_health_check=True,
+            )
+        assert "sensitive server payload" not in str(excinfo.value)
+
+    def test_probe_hides_generic_mapping_health_tool_error_payload(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+        from types import MappingProxyType
+
+        async def call_tool(_name, _arguments):
+            return MappingProxyType(
+                {"isError": True, "content": ["sensitive server payload"]}
+            )
+
+        async def connect(_name, _config):
+            return self._server([self._Tool("memory_recall", True)], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+
+        with pytest.raises(RuntimeError, match="configured health check returned an error") as excinfo:
+            mc._probe_single_server(
+                "lucy",
+                {
+                    "url": "https://mcp.example.test",
+                    "health_check": {"tool": "memory_recall", "arguments": {}},
+                },
+                run_health_check=True,
+            )
+        assert "sensitive server payload" not in str(excinfo.value)
+
+    def test_probe_rejects_conflicting_generic_mapping_result_aliases(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+        from types import MappingProxyType
+
+        async def call_tool(_name, _arguments):
+            return MappingProxyType({"is_error": False, "isError": True})
+
+        async def connect(_name, _config):
+            return self._server([self._Tool("memory_recall", True)], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+
+        with pytest.raises(RuntimeError, match="error"):
+            mc._probe_single_server(
+                "lucy",
+                {
+                    "url": "https://mcp.example.test",
+                    "health_check": {"tool": "memory_recall", "arguments": {}},
+                },
+                run_health_check=True,
+            )
+
+    def test_probe_hides_health_check_rpc_exception_payload(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+
+        async def call_tool(_name, _arguments):
+            raise RuntimeError("sensitive server payload")
+
+        async def connect(_name, _config):
+            return self._server([self._Tool("memory_recall", True)], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+
+        with pytest.raises(RuntimeError, match="configured health check RPC failed") as excinfo:
+            mc._probe_single_server(
+                "lucy",
+                {
+                    "url": "https://mcp.example.test",
+                    "health_check": {"tool": "memory_recall", "arguments": {}},
+                },
+                run_health_check=True,
+            )
+        assert "sensitive server payload" not in str(excinfo.value)
 
     def test_probe_rejects_unadvertised_health_tool_without_calling_it(self, monkeypatch):
         import hermes_cli.mcp_config as mc

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -445,6 +445,48 @@ class TestMcpTest:
         out = capsys.readouterr().out
         assert "Connected" in out
         assert "Tools discovered: 2" in out
+        assert "does not verify application credentials" in out
+
+    def test_test_reports_configured_application_health_check(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "lucy": {
+                "url": "https://mcp.example.test",
+                "health_check": {
+                    "tool": "memory_recall",
+                    "arguments": {"query": "__hermes_health_check__"},
+                },
+            },
+        })
+
+        def mock_probe(name, config, *, details=None, **_kw):
+            assert name == "lucy"
+            assert config["health_check"]["tool"] == "memory_recall"
+            assert _kw["run_health_check"] is True
+            assert details is not None
+            details["health_check"] = "memory_recall"
+            return [("memory_recall", "Read approved memory")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="lucy"))
+        out = capsys.readouterr().out
+        assert "Application health check passed: memory_recall" in out
+        assert "does not verify application credentials" not in out
+
+    def test_test_failure_returns_nonzero(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {"lucy": {"url": "https://mcp.example.test"}})
+
+        def mock_probe(*_args, **_kwargs):
+            raise RuntimeError("configured health check returned an error")
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", mock_probe)
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        assert cmd_mcp_test(_make_args(name="lucy")) == 1
+        assert "Connection failed" in capsys.readouterr().out
 
     def test_probe_uses_configured_connect_timeout(self, monkeypatch):
         """OAuth-capable probes must not hard-code a short 30s timeout."""
@@ -631,6 +673,174 @@ class TestProbeEnvResolution:
 
         assert tools == [("do_thing", "a tool")]
         assert seen["config"]["headers"]["Authorization"] == "Bearer jwt-token-xyz"
+
+
+class TestConfiguredApplicationHealthCheck:
+    """An opt-in tool probe proves application auth without guessing a tool."""
+
+    class _Tool:
+        def __init__(self, name: str, read_only: bool):
+            self.name = name
+            self.description = ""
+            self.annotations = {"readOnlyHint": read_only}
+
+    @staticmethod
+    def _server(tools, call_tool):
+        class _Session:
+            async def call_tool(self, name, arguments):
+                return await call_tool(name, arguments)
+
+        class _Server:
+            _tools = tools
+            session = _Session()
+
+            async def shutdown(self):
+                return None
+
+        return _Server()
+
+    def test_probe_calls_configured_read_only_health_tool(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+        from types import SimpleNamespace
+
+        calls = []
+
+        async def call_tool(name, arguments):
+            calls.append((name, arguments))
+            return SimpleNamespace(is_error=False)
+
+        async def connect(_name, _config):
+            return self._server([self._Tool("memory_recall", True)], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+        details = {}
+        tools = mc._probe_single_server(
+            "lucy",
+            {
+                "url": "https://mcp.example.test",
+                "health_check": {
+                    "tool": "memory_recall",
+                    "arguments": {"query": "__hermes_health_check__"},
+                },
+            },
+            details=details,
+            run_health_check=True,
+        )
+
+        assert tools == [("memory_recall", "")]
+        assert calls == [("memory_recall", {"query": "__hermes_health_check__"})]
+        assert details["health_check"] == "memory_recall"
+
+    def test_regular_probe_never_runs_the_configured_health_tool(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+        from types import SimpleNamespace
+
+        calls = []
+
+        async def call_tool(name, arguments):
+            calls.append((name, arguments))
+            return SimpleNamespace(is_error=False)
+
+        async def connect(_name, _config):
+            return self._server([self._Tool("memory_recall", True)], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+        mc._probe_single_server(
+            "lucy",
+            {
+                "url": "https://mcp.example.test",
+                "health_check": {"tool": "memory_recall", "arguments": {}},
+            },
+        )
+        assert calls == []
+
+    @pytest.mark.parametrize(
+        "health_check",
+        [
+            {"tool": "memory_recall"},
+            {"tool": " memory_recall", "arguments": {}},
+            {"tool": "memory_recall", "arguments": {"nested": {1: "bad"}}},
+            {"tool": "memory_recall", "arguments": {"value": float("nan")}},
+        ],
+    )
+    def test_health_check_rejects_non_exact_json_config(self, health_check):
+        import hermes_cli.mcp_config as mc
+
+        with pytest.raises(ValueError):
+            mc._parse_configured_health_check({"health_check": health_check})
+
+    def test_probe_rejects_non_read_only_health_tool_without_calling_it(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+
+        calls = []
+
+        async def call_tool(name, arguments):
+            calls.append((name, arguments))
+            raise AssertionError("non-read-only health tool must never run")
+
+        async def connect(_name, _config):
+            return self._server([self._Tool("memory_propose", False)], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+
+        with pytest.raises(RuntimeError, match="readOnlyHint=true"):
+            mc._probe_single_server(
+                "lucy",
+                {
+                    "url": "https://mcp.example.test",
+                    "health_check": {"tool": "memory_propose", "arguments": {}},
+                },
+                run_health_check=True,
+            )
+        assert calls == []
+
+    def test_probe_rejects_unadvertised_health_tool_without_calling_it(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+
+        calls = []
+
+        async def call_tool(name, arguments):
+            calls.append((name, arguments))
+            raise AssertionError("unadvertised health tool must never run")
+
+        async def connect(_name, _config):
+            return self._server([self._Tool("memory_recall", True)], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+
+        with pytest.raises(RuntimeError, match="was not advertised"):
+            mc._probe_single_server(
+                "lucy",
+                {
+                    "url": "https://mcp.example.test",
+                    "health_check": {"tool": "memory_proposal_status", "arguments": {}},
+                },
+                run_health_check=True,
+            )
+        assert calls == []
+
+    def test_probe_hides_health_tool_error_payload(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+        from types import SimpleNamespace
+
+        async def call_tool(_name, _arguments):
+            return SimpleNamespace(is_error=True, content=["sensitive server payload"])
+
+        async def connect(_name, _config):
+            return self._server([self._Tool("memory_recall", True)], call_tool)
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", connect)
+
+        with pytest.raises(RuntimeError, match="configured health check returned an error") as excinfo:
+            mc._probe_single_server(
+                "lucy",
+                {
+                    "url": "https://mcp.example.test",
+                    "health_check": {"tool": "memory_recall", "arguments": {}},
+                },
+                run_health_check=True,
+            )
+        assert "sensitive server payload" not in str(excinfo.value)
 
 
 class TestProbeCapabilityGating:
@@ -830,6 +1040,21 @@ class TestDispatcher:
         mcp_command(_make_args(mcp_action=None))
         out = capsys.readouterr().out
         assert "Commands:" in out or "No MCP servers" in out
+
+    def test_dispatcher_propagates_mcp_test_failure(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+
+        monkeypatch.setattr(mc, "cmd_mcp_test", lambda _args: 1)
+        assert mc.mcp_command(_make_args(mcp_action="test")) == 1
+
+    def test_main_mcp_wrapper_propagates_failure(self, monkeypatch):
+        import hermes_cli.mcp_config as mc
+        from hermes_cli.main import cmd_mcp
+
+        monkeypatch.setattr(mc, "mcp_command", lambda _args: 1)
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp(_make_args(mcp_action="test"))
+        assert exc_info.value.code == 1
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1270,7 +1270,7 @@ Manage MCP (Model Context Protocol) server configurations and run Hermes as an M
 | `add <name> [--url URL] [--command CMD] [--auth oauth\|header] [--args ...]` | Add a custom MCP server with automatic tool discovery. `--args` passes the remaining argv to the stdio command, so put it last. |
 | `remove <name>` (alias: `rm`) | Remove an MCP server from config. |
 | `list` (alias: `ls`) | List configured MCP servers. |
-| `test <name>` | Test connection to an MCP server. |
+| `test <name>` | Test connection and discovery, then run the configured safe application health check when present. |
 | `configure <name>` (alias: `config`) | Toggle tool selection for a server. |
 | `login <name>` | Force re-authentication for an OAuth-based MCP server. |
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -39,6 +39,9 @@ mcp_servers:
       exclude: []
       resources: true
       prompts: true
+    health_check:             # optional; only used by `hermes mcp test <name>`
+      tool: "read_status"
+      arguments: {}
 ```
 
 ## Server keys
@@ -59,8 +62,42 @@ mcp_servers:
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
 | `skip_preflight` | bool | HTTP | Bypass the fail-fast content-type probe for valid Streamable HTTP endpoints whose HEAD/GET answers a non-MCP content type (default: `false`) |
 | `tools` | mapping | both | Filtering and utility-tool policy |
+| `health_check` | mapping | both | Optional safe application probe run by `hermes mcp test <name>` after discovery; see [Application health checks](#application-health-checks) |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
+
+## Application health checks
+
+`hermes mcp test <name>` always verifies that Hermes can connect and discover
+server tools. Those protocol operations can succeed before a server checks the
+credentials used by its application tools. To verify a safe application-level
+request too, opt in with a fixed read-only tool call:
+
+```yaml
+mcp_servers:
+  internal_api:
+    url: "https://mcp.internal.example.com/mcp"
+    headers:
+      Authorization: "Bearer ${INTERNAL_API_TOKEN}"
+    health_check:
+      tool: "read_status"
+      arguments:
+        scope: "self"
+```
+
+The `tool` must be a non-empty advertised tool name and `arguments` must be a
+JSON object. Hermes refuses to call the tool unless the server advertises it
+with `annotations.readOnlyHint: true`; it never guesses a tool name or invokes
+one without this explicit configuration. The annotation is a server-supplied
+hint, not a security guarantee, so configure only a known read-only tool on a
+server you trust. An MCP tool error makes the test fail, but its response
+payload is not printed.
+
+Choose a small, non-mutating request that the server authenticates, such as a
+read of the caller's own profile or a deliberately narrow search. Do not place
+credentials in `arguments`; keep them in `env` or `headers` as usual. Without a
+`health_check`, Hermes labels the result as discovery-only rather than claiming
+that application credentials were verified.
 
 ## `tools` policy keys
 


### PR DESCRIPTION
## Summary
- Adds an optional, explicitly configured application-level health check to `hermes mcp test <name>` after MCP discovery.
- Requires an advertised tool, explicit JSON-object arguments, and exact read-only annotations; aliases and result states fail closed on conflicts.
- Keeps ordinary probes/runtime MCP registration discovery-only, documents credential-safe config, and adds regression coverage for typed-object, dict, and generic-Mapping MCP representations.

## Validation
- `TestConfiguredApplicationHealthCheck`: 20 passed
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_security.py -q`: 103 passed
- ACP regression set: 256 passed using the healthy shared dev venv
- Independent exact-current review: PASS
- Full suite was executed. Its 19 failures across eight unrelated files reproduce exactly at parent `9f275bfb`; the two provider-discovery failures were traced to untracked provider directories in the original worktree and pass in a clean worktree at this head.

## Dependency
- Depends on #70287 (`fix/mcp-cli-exit-code`). GitHub cannot use that external-fork branch as a PR base, so this targets `main` and temporarily includes its two commits.

No runtime tool-registration changes.