### PR TITLE
fix(desktop): route session branches through the parent's owning connection

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-owner-route.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-owner-route.test.ts
@@ -11,3 +11,28 @@ describe('SessionTilePane owner-scoped listing', () => {
     expect(source).not.toMatch(/void resolveStoredSession\(storedSessionId\)\s*\n/)
   })
 })
+
+describe('SessionTileChrome owner ladder', () => {
+  // A tile opened without an explicit route (openSessionTile with no
+  // workspaceScope — how a branch child is opened) has no tile ownerRoute, so
+  // the tile route ALONE leaves ownerRoute undefined and requestForSessionProfile
+  // falls back to the ambient socket. The session's own row/hint rung is what
+  // keeps its model + composer RPCs on the backend that owns it.
+  it('falls back to the session row owner when the tile carries no route', () => {
+    expect(source).toContain(
+      'sessionTileOwnerRoute(storedSessionId) ?? knownSessionOwner(ownerLookupSessionRows(), storedSessionId)'
+    )
+  })
+
+  it('does not resolve the chrome owner from the tile route alone', () => {
+    // The pre-fix shape: `const ownerRoute = sessionTileOwnerRoute(storedSessionId)`
+    // with no fallback rung.
+    expect(source).not.toMatch(/const ownerRoute = sessionTileOwnerRoute\(storedSessionId\)\s*\n/)
+  })
+
+  it('narrows a bare profile owner to an object route', () => {
+    // knownSessionOwner may return a bare profile string, which carries no
+    // connection and must not be handed to requestForSessionProfile as a route.
+    expect(source).toContain("typeof resolvedOwner === 'object'")
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -44,10 +44,12 @@ import {
   $gatewayState,
   $selectedStoredSessionId,
   $sessions,
+  knownSessionOwner,
+  ownerLookupSessionRows,
   sessionMatchesStoredId,
   sessionPinId
 } from '@/store/session'
-import { requestForSessionProfile } from '@/store/session-request-router'
+import { requestForSessionProfile, type SessionOwnerRoute } from '@/store/session-request-router'
 import {
   $sessionStates,
   $sessionTileDelegateRevision,
@@ -157,7 +159,38 @@ function TileChat({
 }) {
   const { gateway, requestGateway } = useGatewayRequest()
   const queryClient = useQueryClient()
-  const ownerRoute = sessionTileOwnerRoute(storedSessionId)
+
+  // Owner ladder, same as useSessionTileActions (session-tile-actions.ts:99-103):
+  // this tile's explicit route first, then the session row's own
+  // (connection, profile) tag — knownSessionOwner also folds in the owner hint.
+  // A tile opened without an explicit route — e.g. a branch child, which
+  // openSessionTile creates with no workspaceScope — has no tile route, so the
+  // row/hint rung is the only thing keeping this tile's model + composer RPCs
+  // on the backend that owns the session instead of the ambient one.
+  //
+  // Resolved on every render (cheap id lookups) so it cannot go stale against
+  // the tile store, the recents/cron/messaging rows, or the hint map. Only the
+  // resulting IDENTITY is memoised, on primitives, because knownSessionOwner
+  // mints a fresh object per call and requestTileGateway below is keyed on it.
+  const resolvedOwner =
+    sessionTileOwnerRoute(storedSessionId) ?? knownSessionOwner(ownerLookupSessionRows(), storedSessionId)
+
+  const ownerConnectionId = resolvedOwner && typeof resolvedOwner === 'object' ? resolvedOwner.connectionId : ''
+  const ownerProfile = resolvedOwner && typeof resolvedOwner === 'object' ? resolvedOwner.profile : ''
+  const ownerTargetProfile = resolvedOwner && typeof resolvedOwner === 'object' ? resolvedOwner.targetProfile : undefined
+
+  // A bare profile string carries no connection and is not a usable route here.
+  const ownerRoute = useMemo<SessionOwnerRoute | undefined>(
+    () =>
+      ownerConnectionId
+        ? {
+            connectionId: ownerConnectionId,
+            profile: ownerProfile,
+            ...(ownerTargetProfile ? { targetProfile: ownerTargetProfile } : {})
+          }
+        : undefined,
+    [ownerConnectionId, ownerProfile, ownerTargetProfile]
+  )
 
   const requestTileGateway = useCallback(
     <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal): Promise<T> =>

--- a/apps/desktop/src/app/session/hooks/branch-owner-routing.integration.test.ts
+++ b/apps/desktop/src/app/session/hooks/branch-owner-routing.integration.test.ts
@@ -1,0 +1,127 @@
+/**
+ * End-to-end owner routing for BRANCH (the #97764-adjacent strand).
+ *
+ * The unit tests in use-session-actions.test.tsx mock `@/store/gateway`, so
+ * they prove the branch path ASKS for the right route. They cannot prove the
+ * routing layer HONOURS it. This file mocks nothing inside the router: the real
+ * `requestGatewayForAgent` runs against a fake Electron bridge + transport, so
+ * a regression that re-collapses a registry route onto the ambient socket fails
+ * here even if the call-site assertions still pass.
+ *
+ * Reproduces the reported shape: a session owned by a remote connection
+ * ("pandora") is branched while a different backend is active. Before the fix
+ * the create rode the ambient socket and the child was created on the wrong
+ * backend (or nowhere), stranding an optimistic sidebar row on an id no backend
+ * owned — "Couldn't load this session".
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Every socket the registry dials, and every RPC that travelled over one.
+const dialed: { connectionId: string; profile: string }[] = []
+const sent: { method: string; params: Record<string, unknown>; url: string }[] = []
+
+class FakeHermesGateway {
+  connectionState = 'closed'
+  private url = ''
+
+  async connect(wsUrl: string) {
+    if (typeof wsUrl !== 'string' || !wsUrl.startsWith('ws')) {
+      throw new Error(`bad ws url: ${String(wsUrl)}`)
+    }
+
+    this.url = wsUrl
+    this.connectionState = 'open'
+  }
+
+  async request<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    sent.push({ method, params, url: this.url })
+
+    if (method === 'session.create' || method === 'session.branch') {
+      return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as T
+    }
+
+    return {} as T
+  }
+
+  close() {
+    this.connectionState = 'closed'
+  }
+
+  onEvent(_listener: (event: unknown) => void) {
+    return () => undefined
+  }
+
+  onState(_listener: (state: unknown) => void) {
+    return () => undefined
+  }
+
+  onStateChange(_listener: (state: unknown) => void) {
+    return () => undefined
+  }
+
+  on() {}
+  off() {}
+  addEventListener() {}
+  removeEventListener() {}
+}
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  HermesGateway: FakeHermesGateway,
+  setApiRequestConnection: vi.fn()
+}))
+
+describe('branch owner routing (real router, faked transport)', () => {
+  beforeEach(() => {
+    dialed.length = 0
+    sent.length = 0
+    vi.resetModules()
+
+    // A registry with two backends exposing the SAME profile name — the exact
+    // ambiguity that makes profile-only routing wrong.
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnection: async () => ({ mode: 'local' }),
+      getConnectionFor: async ({ connectionId, profile }: { connectionId: string; profile: string }) => {
+        dialed.push({ connectionId, profile })
+
+        return { connectionId, mode: 'remote', profile }
+      },
+      getGatewayWsUrlFor: async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+        `ws://${connectionId}/gateway?profile=${profile}`,
+      touchBackend: async () => undefined
+    }
+  })
+
+  it('dials the parent connection and sends the create over that socket', async () => {
+    const { requestGatewayForAgent } = await import('@/store/gateway')
+
+    await requestGatewayForAgent('pandora', 'default', 'session.create', {
+      parent_session_id: 'stored-parent',
+      source: 'desktop'
+    })
+
+    // The registry resolved a socket for the PARENT's connection...
+    expect(dialed).toContainEqual({ connectionId: 'pandora', profile: 'default' })
+
+    // ...and the create actually travelled over that socket.
+    const create = sent.find(entry => entry.method === 'session.create')
+    expect(create).toBeDefined()
+    expect(create!.url).toContain('pandora')
+    expect(create!.params).toMatchObject({ parent_session_id: 'stored-parent' })
+  })
+
+  it('keeps two same-named profiles on separate sockets', async () => {
+    const { requestGatewayForAgent } = await import('@/store/gateway')
+
+    await requestGatewayForAgent('pandora', 'default', 'session.create', { source: 'desktop' })
+    await requestGatewayForAgent('other-box', 'default', 'session.create', { source: 'desktop' })
+
+    const urls = sent.filter(entry => entry.method === 'session.create').map(entry => entry.url)
+
+    expect(urls).toHaveLength(2)
+    // Same profile name, different backends — they must NOT share a socket.
+    expect(new Set(urls).size).toBe(2)
+    expect(urls.some(url => url.includes('pandora'))).toBe(true)
+    expect(urls.some(url => url.includes('other-box'))).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1693,6 +1693,122 @@ describe('branchStoredSession desktop source tagging', () => {
     })
   })
 
+  // A branch belongs to the backend that OWNS its parent. Routing on profile
+  // alone silently sends session.create to whatever socket is active, so a
+  // remote-owned parent branched while another connection is active creates
+  // the child on the wrong backend — or nowhere — while the sidebar still
+  // paints an optimistic row that can never hydrate ("Couldn't load this
+  // session"). Same ownership contract removeSession already honours.
+  it('routes a connection-tagged parent branch through its owning connection', async () => {
+    const ambientRequest = vi.fn(async () => ({}) as never)
+
+    vi.mocked(requestGatewayForAgent).mockImplementation((async (
+      _connectionId: null | string,
+      _profile: string,
+      method: string
+    ) => {
+      if (method === 'session.create') {
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    }) as never)
+
+    setSessions([
+      storedSession({ connection_id: 'pandora', id: 'stored-parent', message_count: 1, profile: 'default' })
+    ])
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    // The create must ride the parent's own (connection, profile) socket...
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'pandora',
+      'default',
+      'session.create',
+      expect.objectContaining({ parent_session_id: 'stored-parent', source: 'desktop' })
+    )
+    // ...and never the ambient socket, which may serve a different machine.
+    expect(ambientRequest).not.toHaveBeenCalledWith('session.create', expect.anything())
+  })
+
+  // The parent transcript read must land on the owning backend too: reading it
+  // from the ambient socket returns nothing for a foreign-owned parent, which
+  // aborts the branch as "nothing to branch" before any create is attempted.
+  it('reads a connection-tagged parent transcript from its owning connection', async () => {
+    const ambientRequest = vi.fn(async () => ({}) as never)
+
+    vi.mocked(requestGatewayForAgent).mockImplementation((async (
+      _connectionId: null | string,
+      _profile: string,
+      method: string
+    ) => {
+      if (method === 'session.create') {
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    }) as never)
+
+    setSessions([
+      storedSession({ connection_id: 'pandora', id: 'stored-parent', message_count: 1, profile: 'default' })
+    ])
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    expect(getAllSessionMessages).toHaveBeenCalledWith('stored-parent', {
+      connectionId: 'pandora',
+      profile: 'default'
+    })
+  })
+
+  // An untagged row (single-backend users, the overwhelmingly common case)
+  // must keep the ambient path exactly as before — no behaviour change.
+  it('keeps an untagged parent branch on the ambient socket', async () => {
+    let createParams: Record<string, unknown> | undefined
+
+    const ambientRequest = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(requestGatewayForAgent).mockClear()
+    setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    expect(createParams).toMatchObject({ parent_session_id: 'stored-parent', source: 'desktop' })
+    expect(requestGatewayForAgent).not.toHaveBeenCalled()
+  })
+
   it('branches an open live chat via session.branch with a trimmed message count (bug #1/#3 fix)', async () => {
     let branchParams: Record<string, unknown> | undefined
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1777,6 +1777,46 @@ describe('branchStoredSession desktop source tagging', () => {
     })
   })
 
+  // The create landing on the right backend is only half the job: the sidebar
+  // row must be TAGGED with that owner too. An untagged optimistic row inherits
+  // the ambient profile, so every later owner lookup (resume/hydrate/prompt)
+  // routes to the wrong backend and the chat pane spins forever on a session
+  // that backend never had.
+  it('tags the optimistic branch row with the parent connection owner', async () => {
+    const ambientRequest = vi.fn(async () => ({}) as never)
+
+    vi.mocked(requestGatewayForAgent).mockImplementation((async (
+      _connectionId: null | string,
+      _profile: string,
+      method: string
+    ) => {
+      if (method === 'session.create') {
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    }) as never)
+
+    setSessions([
+      storedSession({ connection_id: 'pandora', id: 'stored-parent', message_count: 1, profile: 'default' })
+    ])
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    const row = $sessions.get().find(session => session.id === 'branch-stored')
+    expect(row).toBeDefined()
+    expect(row!.connection_id).toBe('pandora')
+    expect(row!.profile).toBe('default')
+  })
+
   // An untagged row (single-backend users, the overwhelmingly common case)
   // must keep the ambient path exactly as before — no behaviour change.
   it('keeps an untagged parent branch on the ambient socket', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2015,13 +2015,22 @@ export function useSessionActions({
           : 0
 
         setFreshDraftReady(false)
+        // Stamp the optimistic row with the branch's EXACT owner. Without it the
+        // row inherits $activeGatewayProfile and carries no connection_id, so a
+        // child correctly created on the parent's remote backend is listed as
+        // belonging to whichever backend happens to be active. Every later
+        // owner lookup off that row (resume, hydrate, prompt) then routes to the
+        // wrong machine and the chat pane spins on a session that backend never
+        // had — the create is right, the row is a lie. Mirrors the routed
+        // creates at the top of this file, which already pass their route here.
         upsertOptimisticSession(
           branched,
           routedSessionId,
           copy.branchTitle(siblings + 1).toLowerCase(),
           preview,
           parentStoredId,
-          parent ? parent.last_active || parent.started_at : undefined
+          parent ? parent.last_active || parent.started_at : undefined,
+          ownerRoute ?? null
         )
         ensureSessionState(branched.session_id, routedSessionId)
         updateSessionState(

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2004,6 +2004,19 @@ export function useSessionActions({
         const effectiveBranchMessages = responseBranchMessages.length ? responseBranchMessages : branchMessages
         const routedSessionId = branched.stored_session_id ?? branched.session_id
         const preview = effectiveBranchMessages.map(({ content }) => content).find(Boolean) ?? null
+
+        // Record the exact owner and pin its socket THE MOMENT the create
+        // returns, before the optimistic row / tile publication can lose a
+        // race with the gateway pruner. A draft branch child exists only as a
+        // runtime on the owning backend (the stored row lands on first turn),
+        // so a prune in this gap orphan-reaps it and the tile enters the
+        // resume→reclaim flicker loop (#93892 shape). Mirrors the two routed
+        // creates at the top of this file.
+        if (ownerRoute) {
+          setSessionOwnerHint(routedSessionId, ownerRoute)
+          holdSessionOwnerUntilForeground(routedSessionId, ownerRoute)
+        }
+
         // Draft until submit: nest under the parent at the parent's recency so it
         // doesn't bubble to the top until a real message lands (backend persists
         // + auto-names it then). The selected row survives refreshes (sessionsToKeep).
@@ -2060,7 +2073,17 @@ export function useSessionActions({
         if (parentStoredId !== null && selectedStoredSessionIdRef.current === parentStoredId) {
           await resumeSession(routedSessionId)
         } else {
-          openSessionTile(routedSessionId, 'center')
+          // Carry the exact owner onto the tile: its persisted ownerRoute is
+          // what pins the owning backend's socket in the gateway keep-set
+          // (openTileGatewayScopes) for the tile's whole lifetime. Without it
+          // a remote-owned branch child's tile pinned nothing, the pruner
+          // closed the owner socket, the backend reaped the draft runtime,
+          // and the tile looped resume→reclaim until the storm breaker
+          // latched "Couldn't open this session".
+          openSessionTile(routedSessionId, 'center', undefined, null, {
+            ownerRoute,
+            workspaceMode: 'sessions'
+          })
           patchSessionTile(routedSessionId, { runtimeId: branched.session_id })
           revealTreePane(`session-tile:${routedSessionId}`)
         }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -100,6 +100,8 @@ import {
 import { isSessionOwnerResolutionError } from '@/store/session-owner-resolution'
 import {
   requestForSessionProfile,
+  type SessionOwnerRoute,
+  sessionOwnerRouteFromRow,
   type SessionOwnerScope,
   type SessionProfileRoute
 } from '@/store/session-request-router'
@@ -1946,27 +1948,48 @@ export function useSessionActions({
       parentStoredId: null | string,
       cwd?: string,
       profile?: null | string,
-      branchCount?: number
+      branchCount?: number,
+      ownerRoute?: SessionOwnerRoute
     ): Promise<boolean> => {
       creatingSessionRef.current = true
 
       try {
-        // A branch belongs to its parent's OWNING profile. Swapping the live
-        // gateway first AND passing `profile` on the create mirrors
-        // desktopSessionCreateParams/resumeSession: in app-global remote mode
-        // one backend serves every profile, so an omitted profile silently
-        // lands the branch on the launch (default) profile — the "session
-        // jumps between profiles after branching" bug. The swap also makes
-        // upsertOptimisticSession's $activeGatewayProfile stamp correct.
-        await ensureGatewayProfile(profile)
+        // A branch belongs to its parent's OWNING backend. Two facets, and both
+        // matter once more than one connection is configured:
+        //
+        // 1. PROFILE — passing `profile` on the create mirrors
+        //    desktopSessionCreateParams/resumeSession: in app-global remote mode
+        //    one backend serves every profile, so an omitted profile silently
+        //    lands the branch on the launch (default) profile — the "session
+        //    jumps between profiles after branching" bug.
+        // 2. CONNECTION — a profile name alone does not identify a backend when
+        //    several connections expose the same name. Routing on profile only
+        //    sends session.create to whatever socket happens to be active, so
+        //    branching a remote-owned parent from another connection creates the
+        //    child on the wrong backend (or nowhere), while the optimistic
+        //    sidebar row below still points at an id no backend owns — the
+        //    "Couldn't load this session" strand. removeSession already routes
+        //    by (connection, profile); this is the same ownership contract.
+        //
+        // An untagged parent keeps the historic profile-only path exactly.
+        if (ownerRoute) {
+          await ensureGatewayAgent(ownerRoute.connectionId, ownerRoute.profile)
+        } else {
+          await ensureGatewayProfile(profile)
+        }
+
+        const requestBranchGateway = <T,>(method: string, params: Record<string, unknown>): Promise<T> =>
+          ownerRoute
+            ? requestGatewayForAgent<T>(ownerRoute.connectionId, ownerRoute.profile, method, params)
+            : requestGateway<T>(method, params)
 
         // No title: the backend auto-names the branch from its parent's lineage.
         const branched = sourceSessionId
-          ? await requestGateway<SessionCreateResponse>('session.branch', {
+          ? await requestBranchGateway<SessionCreateResponse>('session.branch', {
               session_id: sourceSessionId,
               ...(branchCount !== undefined ? { count: branchCount } : {})
             })
-          : await requestGateway<SessionCreateResponse>('session.create', {
+          : await requestBranchGateway<SessionCreateResponse>('session.create', {
               cols: 96,
               source: 'desktop',
               ...(cwd && { cwd }),
@@ -2086,9 +2109,17 @@ export function useSessionActions({
       let authoritativeMessages: ChatMessage[] | null = null
       const profile = await resolveSessionProfile(storedSessionId)
 
+      // The open chat's exact owner, when its row carries a connection tag.
+      // Same contract as branchStoredSession: the transcript read and the
+      // branch RPC must both land on the backend that owns the parent, not on
+      // whichever socket is active.
+      const ownerRoute = storedSessionId
+        ? sessionOwnerRouteFromRow($sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)))
+        : undefined
+
       if (storedSessionId) {
         try {
-          const persisted = await getAllSessionMessages(storedSessionId, profile)
+          const persisted = await getAllSessionMessages(storedSessionId, ownerRoute ?? profile)
           const hydrated = toChatMessages(persisted.messages)
 
           if (hydrated.length) {
@@ -2136,7 +2167,8 @@ export function useSessionActions({
         storedSessionId,
         startingCwd,
         profile,
-        messageId ? branchMessages.length : undefined
+        messageId ? branchMessages.length : undefined,
+        ownerRoute
       )
     },
     [activeSessionIdRef, busyRef, copy, forkBranch, getRouteToken, selectedStoredSessionIdRef]
@@ -2158,9 +2190,22 @@ export function useSessionActions({
 
       const profile = sessionProfile ?? stored?.profile
 
+      // An exact owner from the parent row — connection AND profile. Undefined
+      // for an untagged row, which keeps the ambient/profile-only path.
+      const ownerRoute = sessionOwnerRouteFromRow(stored)
+
       try {
-        await ensureGatewayProfile(profile)
-        const { messages } = await getAllSessionMessages(storedSessionId, profile)
+        if (ownerRoute) {
+          await ensureGatewayAgent(ownerRoute.connectionId, ownerRoute.profile)
+        } else {
+          await ensureGatewayProfile(profile)
+        }
+
+        // Read the parent transcript from the backend that OWNS it. A bare
+        // profile scope resolves against the active connection, which for a
+        // foreign-owned parent holds no such session: the read comes back empty
+        // and the branch aborts as "nothing to branch" before any create.
+        const { messages } = await getAllSessionMessages(storedSessionId, ownerRoute ?? profile)
         const branchMessages = toBranchMessages(toChatMessages(messages))
 
         if (!branchMessages.length) {
@@ -2169,7 +2214,15 @@ export function useSessionActions({
           return false
         }
 
-        return await forkBranch(branchMessages, null, stored?.id ?? storedSessionId, stored?.cwd?.trim(), profile)
+        return await forkBranch(
+          branchMessages,
+          null,
+          stored?.id ?? storedSessionId,
+          stored?.cwd?.trim(),
+          profile,
+          undefined,
+          ownerRoute
+        )
       } catch (err) {
         notifyError(err, copy.branchFailed)
 

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -36,7 +36,7 @@ import {
   setSessions,
   setSessionsLoading
 } from '@/store/session'
-import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
+import { $sessionTiles, $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
 
 import { refreshCronJobs as refreshCronJobsStore } from '../../cron/cron-actions'
 
@@ -79,6 +79,15 @@ function sessionsToKeep(scope?: string): Set<string> {
     ...$pinnedSessionIds.get(),
     ...getRecentlySettledSessionIds()
   ])
+
+  // Open tiles are user-visible state exactly like the selected row: a branch
+  // child is a DRAFT until its first real turn, so the aggregator can't return
+  // it — without this the next background refresh silently dropped the
+  // optimistic `draft: branch #N` row while its tab was open, and the sidebar
+  // showed no trace of the branch until first send.
+  for (const tile of $sessionTiles.get()) {
+    keep.add(tile.storedSessionId)
+  }
 
   const active = $selectedStoredSessionId.get()
 

--- a/apps/desktop/src/store/session-states-foreground-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-foreground-scopes.test.ts
@@ -69,6 +69,25 @@ describe('foregroundSessionScopes: owner hold across the create → foreground g
     expect(foregroundSessionScopes()).toEqual(new Set())
   })
 
+  it('does not retire a hold for a tile that carries neither the route nor a scoped runtime', () => {
+    const pandora = { connectionId: '100-125-133-71-9119', mode: 'remote' as const, profile: 'default' }
+
+    holdSessionOwnerUntilForeground('stored-branch', pandora)
+    // The pre-fix branch path: openSessionTile with no workspaceScope mints a
+    // route-less tile. It pins nothing, so its mere existence must not retire
+    // the hold — that reopened the create→foreground gap and the pruner closed
+    // the owner socket under the draft runtime (resume→reclaim loop, #93892).
+    $sessionTiles.set([{ storedSessionId: 'stored-branch' }])
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:100-125-133-71-9119::default']))
+
+    // Once the tile actually names the owner (persisted route), it covers the
+    // hold and the hold retires for good.
+    $sessionTiles.set([{ ownerRoute: pandora, storedSessionId: 'stored-branch' }])
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:100-125-133-71-9119::default']))
+    $sessionTiles.set([])
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
   it('is released explicitly by the caller (failed create / drift close) and expires on its own', () => {
     vi.useFakeTimers()
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -200,6 +200,32 @@ describe('resetTileRuntimeBindings', () => {
     expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set(['stored-barry-sibling-bot', 'stored-work-bot']))
   })
 
+  it('keeps an owner-routed SESSIONS tile (branch child) bound across an unrelated reconnect', () => {
+    const invalidateRuntimeBindings = vi.fn()
+    setSessionTileDelegate({ invalidateRuntimeBindings } as unknown as SessionTileDelegate)
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: '100-125-133-71-9119', mode: 'remote', profile: 'default' },
+        runtimeId: 'runtime-branch-live',
+        storedSessionId: 'stored-branch-child',
+        workspaceMode: 'sessions'
+      }
+    ])
+
+    // A flapping sibling connection reconnects; the branch child's runtime
+    // lives on its parent's backend and must keep its binding — dropping it
+    // re-arms the tile's resume, and repeated sibling flaps latch the
+    // resume-storm error card over a healthy session.
+    resetTileRuntimeBindings({ connectionId: 'other-ssh-source', profile: 'default' })
+
+    expect($sessionTiles.get()[0]?.runtimeId).toBe('runtime-branch-live')
+    expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set(['stored-branch-child']))
+
+    // Its OWN connection reconnecting still drops the binding for re-resume.
+    resetTileRuntimeBindings({ connectionId: '100-125-133-71-9119', profile: 'default' })
+    expect($sessionTiles.get()[0]?.runtimeId).toBeUndefined()
+  })
+
   it('unknown restarted identity preserves only Bot runtimes owned by provably-live connections', () => {
     // Legacy remote primary: no registry connectionId to scope by. The dead
     // owner can't be named, so keep only owners we know are alive elsewhere —
@@ -242,6 +268,27 @@ describe('SessionTile workspace scope', () => {
     $layoutTree.set(null)
     $selectedStoredSessionId.set(null)
     $sessionTiles.set([])
+  })
+
+  it('persists a sessions-mode owner route so a branch child tile pins its owning socket', () => {
+    const ownerRoute = { connectionId: '100-125-133-71-9119', mode: 'remote' as const, profile: 'default' }
+
+    openSessionTile('branch-child', 'center', undefined, null, { ownerRoute, workspaceMode: 'sessions' })
+
+    expect($sessionTiles.get()).toEqual([
+      expect.objectContaining({ ownerRoute, storedSessionId: 'branch-child', workspaceMode: 'sessions' })
+    ])
+  })
+
+  it('keeps an existing sessions-mode owner route on a route-less re-scope', () => {
+    const ownerRoute = { connectionId: '100-125-133-71-9119', mode: 'remote' as const, profile: 'default' }
+
+    openSessionTile('branch-child', 'center', undefined, null, { ownerRoute, workspaceMode: 'sessions' })
+    // A plain sidebar re-open routes through setSessionTileWorkspaceScope with
+    // no route — absence of information, not a revocation.
+    setSessionTileWorkspaceScope('branch-child', { workspaceMode: 'sessions' })
+
+    expect($sessionTiles.get()).toEqual([expect.objectContaining({ ownerRoute, storedSessionId: 'branch-child' })])
   })
 
   it('stores an exact Bot owner and keeps it through placement patches', () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1122,7 +1122,12 @@ export function setSessionTileWorkspaceScope(storedSessionId: string, scope: Ses
 
   const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
   const workspaceOwnerKey = scope.workspaceMode === 'bots' ? scope.workspaceOwnerKey : undefined
-  const ownerRoute = scope.workspaceMode === 'bots' ? scope.ownerRoute : undefined
+  // Sessions-mode re-opens (sidebar click on an already-tiled session) pass no
+  // route; that is absence of information, not a revocation — keep the exact
+  // owner the tile was opened with (a branch child's parent connection) so a
+  // plain re-open can't unpin the owning socket. Bot scopes stay authoritative
+  // both ways: they always name their route explicitly.
+  const ownerRoute = scope.workspaceMode === 'bots' ? scope.ownerRoute : (scope.ownerRoute ?? tile?.ownerRoute)
   const workspaceTabTitle = scope.workspaceMode === 'bots' ? scope.workspaceTabTitle : undefined
 
   if (
@@ -1206,8 +1211,15 @@ export function resetTileRuntimeBindings(
   const preservedStoredIds = new Set(
     tiles
       .filter(
+        // Any tile with an EXACT owner route — bot tabs always, and a
+        // sessions tile whose opener stamped one (a branch child on its
+        // parent's connection). Its runtime lives on that owner's socket,
+        // not the ambient gateway, so an unrelated connection's reconnect
+        // must not drop the binding: each drop re-arms the tile's resume,
+        // and a flapping sibling connection turns that into 4+ re-resumes
+        // inside the storm window — latching the "keeps losing its backend
+        // runtime" card over a session that is actually healthy.
         tile =>
-          tile.workspaceMode === 'bots' &&
           Boolean(tile.ownerRoute?.connectionId) &&
           (!(reconnected || liveConnectionIds) || !belongsToReconnectedRuntime(tile))
       )
@@ -1386,7 +1398,15 @@ export function openSessionTile(
         anchor: dock,
         before,
         dir,
-        ownerRoute: workspaceScope.workspaceMode === 'bots' ? workspaceScope.ownerRoute : undefined,
+        // The owner route pins the owning backend's socket in the gateway
+        // keep-set (openTileGatewayScopes / foregroundSessionScopes) for as
+        // long as the tile is open. Bot tabs always carry one; a sessions-mode
+        // tile carries one when its opener knows the exact owner — e.g. a
+        // branch child created on its parent's owning connection, whose
+        // draft runtime is otherwise orphan-reaped the moment the pruner
+        // closes the unpinned socket (the resume/reclaim flicker loop,
+        // #93892 shape).
+        ownerRoute: workspaceScope.ownerRoute,
         storedSessionId,
         workspaceMode: workspaceScope.workspaceMode,
         workspaceOwnerKey,


### PR DESCRIPTION
## Problem

Branching a session that belongs to one connection while a different connection is active leaves the new chat permanently stuck. The sidebar paints its row — `draft: branch #1`, nested under the parent — and the chat pane spins forever, eventually landing on:

> **Couldn't load this session**
> The connection to this session failed and automatic retries gave up. Check that the gateway is running, then try again.

Retry re-runs the same mis-routed resume, so it never recovers.

There are two independent defects on this path, and fixing only the first leaves the symptom fully intact.

## Defect 1 — the create goes to the wrong backend

`branchStoredSession` and `branchCurrentSession` resolved only the parent's **profile**:

```ts
const profile = sessionProfile ?? stored?.profile

await ensureGatewayProfile(profile)
const { messages } = await getAllSessionMessages(storedSessionId, profile)
```

…then dispatched through the ambient `requestGateway`. A profile name does not identify a backend once more than one connection is configured — several connections routinely expose a profile called `default`. `ensureGatewayProfile` swaps on the profile key alone and has no notion of which connection that profile belongs to, so both the parent transcript read and the `session.create` / `session.branch` RPC land on whichever socket happens to be active.

This is an inconsistency inside the existing code, not a missing capability. `removeSession`, about fifty lines below in the same file, already routes by the full owner:

```ts
const removedOwner: SessionOwnerScope = removed?.connection_id
  ? { connectionId: removed.connection_id, profile: removed.profile || 'default' }
  : profile
```

Registry rows are explicitly tagged for exactly this purpose — `fetchRegistrySessionRows` in `electron/profile-session-routing.ts` sets `session.connection_id = connectionId` on every spliced row so that "opens route correctly".

The transcript read is the quieter half: reading a foreign-owned parent from the active socket returns nothing, so the branch aborts early as "nothing to branch" and no create is attempted at all.

**Fix:** derive the owner with `sessionOwnerRouteFromRow`, activate with `ensureGatewayAgent(connectionId, profile)`, dispatch with `requestGatewayForAgent(...)`, and pass the same owner scope to `getAllSessionMessages`. Both arms of `forkBranch` are covered — `session.branch` for the open chat, `session.create` for a sidebar right-click.

## Defect 2 — the row then lies about who owns it

With the create correctly routed, the symptom persisted, because the row inserted afterwards was untagged.

`upsertOptimisticSession` stamps the row's profile from `$activeGatewayProfile` and **omits `connection_id` entirely** when no owner is passed (`utils.ts:1318-1342`), and it also skips `setSessionOwnerHint`. The branch call site passed no owner, so the child got **neither a row tag nor a hint**.

That matters because `resumeSession`'s owner ladder begins:

```ts
const ownerRoute = capturedOwner || getSessionOwnerHint(storedSessionId)
```

and `forkBranch` calls `resumeSession` without a `capturedOwner` — so the missing hint alone is enough to send the resume to whichever backend is active. The row tag is the second mechanism, consulted by the row-based rungs of the same ladder. The two sibling routed creates in this file already pass their route here; branch simply never did.

**The tile path had the same defect one rung further out.** Branching a session that is *not* the currently-open chat opens a tile rather than resuming, and `SessionTileChrome` resolved its owner from the tile route alone:

```ts
const ownerRoute = sessionTileOwnerRoute(storedSessionId)
```

`openSessionTile` is called for a branch child with no `workspaceScope`, and `session-states.ts` only persists a tile `ownerRoute` in bots mode — so that tile had no owner and its model + composer RPCs fell back to the ambient socket. Its sibling in `session-tile-actions.ts:99-103` already uses the correct tile-route-then-row ladder; this aligns them.

An untagged parent row reproduces the previous ambient behaviour exactly, so single-connection users are unaffected.

## Verification

Reproduced and fixed against **two real gateways**: the desktop's own local backend plus a second `hermes serve` instance registered as a remote connection, with a parent session seeded on the remote.

Driving the **actual sidebar context menu → Branch** in a running dev app:

| | remote backend log | resulting sidebar row |
|---|---|---|
| after fix | `ws closed … messages=11 … detached_sessions=1` | `connection_id: "rigremote"`, stable across 16 polls / 8s |
| before fix | *never saw the request* | no `connection_id` at all |

The child's `model` (`z-ai/glm-5.2`) and `cwd` (`/home/zeus/projects`) in the create response are the **remote's** config, not the local backend's — independent confirmation of which machine answered.

Routing was also checked one level down: running the same `session.create` through `requestGatewayForAgent` vs the ambient `requestGatewayForProfile` shows the remote gateway observing the create only on the owner-routed path.

## Tests

- four call-site regressions in `use-session-actions.test.tsx`: the create rides the owning `(connection, profile)` socket; the transcript read carries the same owner scope; the optimistic row is tagged with the parent's owner; an untagged parent still uses the ambient socket
- three source-contract assertions in `session-tile-owner-route.test.ts` covering the tile owner ladder and the bare-profile narrowing
- `branch-owner-routing.integration.test.ts` mocks nothing inside the router — the real `requestGatewayForAgent` runs against a fake Electron bridge and transport, so a regression that re-collapses a registry route onto the ambient socket fails even when the call-site assertions still pass

Each fix was confirmed to fail before the change: without the row stamp the new test reports `expected undefined to be 'pandora'`.

Full desktop suite green — **6828 tests, 688 files** — with `tsc --noEmit` and eslint clean (no warnings).


## Follow-up in this PR: the socket itself (41c8b3888b0)

Field testing the first two commits against a real remote (branching a remote-owned parent while another connection was active) surfaced a third layer. Routing and row-stamping held — the create landed on the owning backend, the sidebar row was tagged, every individual resume succeeded — but the tile still flickered and eventually latched:

> **Couldn't open this session**
> Session keeps losing its backend runtime right after resuming — retry to resume it again.

That message is the tile's resume-storm breaker (`TILE_RESUME_STORM_LIMIT`, #93892): more than 4 *successful* resumes in 120s. The RPCs were right; the **owning socket** was the casualty. Nothing durable named the owner, so the gateway keep-set never pinned it:

- `openSessionTile` persisted a tile `ownerRoute` only for `workspaceMode === 'bots'`. The branch tile pinned nothing in `openTileGatewayScopes` / `foregroundSessionScopes`; the idle pruner closed the owner socket, the backend orphan-reaped the draft runtime, `session.reclaimed` unbound the tile, resume re-armed and succeeded on a fresh socket that the next recompute closed again — around the loop until the breaker latched. Now a sessions-mode opener that knows the exact owner persists it, and a route-less re-scope (plain sidebar re-open) no longer clobbers it.
- `forkBranch` never called `setSessionOwnerHint` / `holdSessionOwnerUntilForeground` after the create, unlike both sibling routed creates in the same file — leaving the create → tile-publication gap unpinned. Added, mirroring the siblings; the hold retires once the tile's own route covers the scope.
- `resetTileRuntimeBindings` preserved cross-connection runtime bindings only for bot tabs, so an unrelated flapping connection (an SSH source re-dialing) dropped the branch tile's healthy binding on every reconnect — the same storm by another path. Any owner-routed tile is preserved now; the owner's own reconnect still drops the binding for re-resume. This deliberately widens reconnect preservation from bot tabs to all owner-routed tiles — flagged for review.

UX half of the report: the optimistic `draft: branch #N` row survived sidebar refreshes only via `sessionsToKeep()`, which had no rung for open tiles — a sidebar-branch never selects the child, so the next background refresh silently dropped the row and nothing indicated a branch had happened until the first message persisted it. Open tiles' stored ids now join the keep set; the draft row appears immediately and stays.

**Verification** (dev app, remote-owned parent, sibling connection flapping): draft row visible immediately and stable across refreshes; tile carries `{connectionId, profile}`; first turn accepted and completed by the owning backend (`tui prompt accepted` → `turn finished status=complete` in its gateway log); no storm/error card through the full 120s window — before this commit the card latched at ~20s under the same conditions. Each of the three fixes was reverted individually to confirm its regression test fails (RED). Full suite green on this branch: 6765 tests / 684 files, `tsc --noEmit` and eslint clean.
