### PR TITLE
fix(approval): unattended webhook/API sessions no longer stall 300s on dangerous-command approval (#37284, salvage #37317)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2520,6 +2520,16 @@ DEFAULT_CONFIG = {
     #             safe; mirrors cron_mode deny)
     #   approve — auto-approve all dangerous commands in single-query mode
     #
+    # unattended_mode — what to do when a session on an unattended
+    # programmatic platform (webhook, msgraph_webhook, api_server) hits a
+    # dangerous command. These surfaces bind a session platform like chat
+    # gateways do, but have no send_exec_approval and no /approve channel —
+    # a pending approval there just blocks for the full timeout with nobody
+    # to answer (#37284, #87509):
+    #   deny    — block the command instantly and let the agent find another
+    #             way (default, safe; mirrors cron_mode deny)
+    #   approve — auto-approve all dangerous commands on unattended platforms
+    #
     # timeout — seconds to wait for the user's approve/deny before failing
     # closed (deny). Shared by the CLI prompt and gateway/messaging waits.
     # Messaging approvals arrive as a push notification the user may not see
@@ -2530,6 +2540,7 @@ DEFAULT_CONFIG = {
         "timeout": 300,
         "cron_mode": "deny",
         "single_query_mode": "deny",
+        "unattended_mode": "deny",
         # Operator-customizable policy text for smart approvals. When
         # non-empty, this is appended to the smart-approval guardian's
         # SYSTEM prompt (trusted channel) as additional rules — e.g.

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -705,15 +705,17 @@ class TestGatewayProtection:
 
 
 class TestWebhookApprovalExclusion:
-    """Webhook sessions must NOT be treated as gateway approval contexts.
+    """Unattended platform sessions must NOT be treated as gateway approval contexts.
 
-    The webhook adapter has no ``send_exec_approval`` method and no way to
-    receive ``/approve`` replies.  If a webhook session triggers a dangerous
-    command and falls through to the gateway approval branch, the session
-    blocks for the full timeout (60-300 s) with no human who can resolve it.
+    The webhook / msgraph_webhook / api_server adapters have no
+    ``send_exec_approval`` method and no way to receive ``/approve`` replies.
+    If such a session triggers a dangerous command and falls through to the
+    gateway approval branch, the session blocks for the full timeout
+    (60-300 s) with no human who can resolve it (#37284, #87509).
 
-    Fix: ``_is_gateway_approval_context()`` returns ``False`` when the
-    session platform is ``"webhook"``.
+    Fix: ``_is_gateway_approval_context()`` returns ``False`` for platforms
+    in ``_UNATTENDED_APPROVAL_PLATFORMS``; the decision is governed by
+    ``approvals.unattended_mode`` (default deny) instead.
     """
 
     def test_webhook_platform_returns_false(self, monkeypatch):
@@ -725,6 +727,19 @@ class TestWebhookApprovalExclusion:
         monkeypatch.setenv("HERMES_SESSION_PLATFORM", "webhook")
 
         assert _is_gateway_approval_context() is False
+
+    def test_all_unattended_platforms_return_false(self, monkeypatch):
+        """Every unattended programmatic platform is excluded, not just webhook."""
+        from tools.approval import (
+            _UNATTENDED_APPROVAL_PLATFORMS,
+            _is_gateway_approval_context,
+        )
+
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        for platform in _UNATTENDED_APPROVAL_PLATFORMS:
+            monkeypatch.setenv("HERMES_SESSION_PLATFORM", platform)
+            assert _is_gateway_approval_context() is False, platform
 
     def test_non_webhook_gateway_session_returns_true(self, monkeypatch):
         """Non-webhook gateway sessions (e.g. Telegram) are still gateway contexts."""
@@ -755,13 +770,55 @@ class TestWebhookApprovalExclusion:
 
         assert _is_gateway_approval_context() is False
 
-    def test_webhook_dangerous_command_auto_approves(self, monkeypatch):
-        """Webhook sessions that trigger dangerous commands auto-approve with a warning.
+    def _isolate(self, monkeypatch):
+        """Neutralize host leakage: yolo frozen at import time + real config."""
+        import tools.approval as approval_mod
 
-        This is the non-interactive, non-gateway path - safe because the
-        command does not execute in an interactive context where the user
-        could be tricked.
+        monkeypatch.setattr(approval_mod, "_YOLO_MODE_FROZEN", False)
+        monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "smart")
+
+    def test_webhook_dangerous_command_denies_by_default(self, monkeypatch):
+        """Webhook sessions that trigger dangerous commands DENY instantly.
+
+        Deny-by-default (approvals.unattended_mode: deny) mirrors cron: an
+        unattended session must never silently execute a flagged command,
+        and must never block waiting for an approval nobody can answer.
+        The deny message tells the agent how the operator can opt in.
         """
+        from tools.approval import check_all_command_guards
+
+        self._isolate(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "webhook")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-webhook-session")
+
+        result = check_all_command_guards("sudo systemctl restart nginx", "local")
+        assert result["approved"] is False
+        assert "unattended platform" in result["message"]
+        assert "approvals.unattended_mode" in result["message"]
+
+    def test_webhook_dangerous_command_approves_when_opted_in(self, monkeypatch):
+        """approvals.unattended_mode: approve restores the old auto-approve path."""
+        import tools.approval as approval_mod
+        from tools.approval import check_all_command_guards
+
+        self._isolate(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "webhook")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-webhook-session")
+        monkeypatch.setattr(
+            approval_mod, "_get_unattended_approval_mode", lambda: "approve"
+        )
+
+        result = check_all_command_guards("sudo systemctl restart nginx", "local")
+        assert result["approved"] is True
+
+    def test_webhook_safe_command_still_approves(self, monkeypatch):
+        """Non-dangerous commands on unattended platforms are unaffected."""
         from tools.approval import check_all_command_guards
 
         monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
@@ -770,9 +827,39 @@ class TestWebhookApprovalExclusion:
         monkeypatch.setenv("HERMES_SESSION_PLATFORM", "webhook")
         monkeypatch.setenv("HERMES_SESSION_KEY", "test-webhook-session")
 
-        result = check_all_command_guards("sudo systemctl restart nginx", "local")
-        # Should auto-approve (non-interactive, non-gateway path)
+        result = check_all_command_guards("ls -la /tmp", "local")
         assert result["approved"] is True
+
+    def test_api_server_dangerous_command_denies_by_default(self, monkeypatch):
+        """api_server sessions get the same instant deny (#87509)."""
+        from tools.approval import check_all_command_guards
+
+        self._isolate(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "api_server")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-api-session")
+
+        result = check_all_command_guards("sudo systemctl restart nginx", "local")
+        assert result["approved"] is False
+        assert "api_server" in result["message"]
+
+    def test_execute_code_denied_on_unattended_platform(self, monkeypatch):
+        """execute_code is denied instantly on unattended platforms (parity with cron)."""
+        from tools.approval import check_execute_code_guard
+
+        self._isolate(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "webhook")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-webhook-session")
+
+        result = check_execute_code_guard("import os", "local")
+        assert result["approved"] is False
+        assert "approvals.unattended_mode" in result["message"]
 
 
 class TestNormalizationBypass:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -702,6 +702,79 @@ class TestGatewayProtection:
         assert dangerous is False
 
 
+
+
+class TestWebhookApprovalExclusion:
+    """Webhook sessions must NOT be treated as gateway approval contexts.
+
+    The webhook adapter has no ``send_exec_approval`` method and no way to
+    receive ``/approve`` replies.  If a webhook session triggers a dangerous
+    command and falls through to the gateway approval branch, the session
+    blocks for the full timeout (60-300 s) with no human who can resolve it.
+
+    Fix: ``_is_gateway_approval_context()`` returns ``False`` when the
+    session platform is ``"webhook"``.
+    """
+
+    def test_webhook_platform_returns_false(self, monkeypatch):
+        """Webhook sessions are not gateway approval contexts."""
+        from tools.approval import _is_gateway_approval_context
+
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "webhook")
+
+        assert _is_gateway_approval_context() is False
+
+    def test_non_webhook_gateway_session_returns_true(self, monkeypatch):
+        """Non-webhook gateway sessions (e.g. Telegram) are still gateway contexts."""
+        from tools.approval import _is_gateway_approval_context
+
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+
+        assert _is_gateway_approval_context() is True
+
+    def test_cron_session_returns_false_regardless_of_platform(self, monkeypatch):
+        """Cron sessions are never gateway approval contexts."""
+        from tools.approval import _is_gateway_approval_context
+
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+
+        assert _is_gateway_approval_context() is False
+
+    def test_no_platform_returns_false(self, monkeypatch):
+        """No session platform means not a gateway context."""
+        from tools.approval import _is_gateway_approval_context
+
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+
+        assert _is_gateway_approval_context() is False
+
+    def test_webhook_dangerous_command_auto_approves(self, monkeypatch):
+        """Webhook sessions that trigger dangerous commands auto-approve with a warning.
+
+        This is the non-interactive, non-gateway path - safe because the
+        command does not execute in an interactive context where the user
+        could be tricked.
+        """
+        from tools.approval import check_all_command_guards
+
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "webhook")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-webhook-session")
+
+        result = check_all_command_guards("sudo systemctl restart nginx", "local")
+        # Should auto-approve (non-interactive, non-gateway path)
+        assert result["approved"] is True
+
+
 class TestNormalizationBypass:
     """Obfuscation techniques must not bypass dangerous command detection."""
 

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -98,7 +98,11 @@ class TestCronContextVarDetection:
     def test_explicit_blank_masks_leaked_cron_env_for_gateway_classification(self, monkeypatch):
         monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
-        tokens = set_session_vars(platform="api_server", cron_session="")
+        # A chat platform: unattended programmatic platforms (webhook,
+        # msgraph_webhook, api_server) are intentionally NOT gateway
+        # approval contexts anymore (#37284/#87509) — this test's subject
+        # is the blank-cron-ContextVar masking, not platform policy.
+        tokens = set_session_vars(platform="telegram", cron_session="")
         try:
             assert approval_module._is_cron_approval_context() is False
             assert approval_module._is_gateway_approval_context() is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -303,12 +303,23 @@ def _is_gateway_approval_context() -> bool:
     ``approvals.cron_mode`` config, not interactive resolve — letting cron
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
+
+    Webhook sessions are excluded for the same reason: the webhook adapter
+    has no ``send_exec_approval`` and no way to receive ``/approve``
+    replies.  Submitting a pending approval in a webhook context blocks
+    the session for the full approval timeout (60-300 s) with no human
+    who can resolve it.  Webhook dangerous-command handling falls through
+    to the non-interactive path (auto-approve with warning, or deny if
+    running inside a cron context).
     """
     if _is_cron_approval_context():
         return False
+    platform = _get_session_platform()
+    if platform == "webhook":
+        return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
-    return bool(_get_session_platform())
+    return bool(platform)
 
 
 def _resolve_cli_approval_callback(approval_callback=None):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -265,6 +265,32 @@ def _is_cron_approval_context() -> bool:
         return env_var_enabled("HERMES_CRON_SESSION")
 
 
+#: Gateway platforms that are programmatic/unattended: no human is on the
+#: other end to answer an approval prompt, and the adapter has no
+#: ``send_exec_approval`` / ``/approve`` surface. Approval decisions for
+#: these sessions are governed by ``approvals.unattended_mode`` config
+#: (default deny), mirroring ``approvals.cron_mode`` — never by an
+#: interactive round-trip that would block for the full approval timeout
+#: with nobody to answer (#37284, #87509).
+_UNATTENDED_APPROVAL_PLATFORMS = frozenset({
+    "webhook",
+    "msgraph_webhook",
+    "api_server",
+})
+
+
+def _is_unattended_platform_approval_context() -> bool:
+    """True when the session platform is a programmatic/unattended surface.
+
+    Webhook, msgraph_webhook, and api_server sessions bind
+    ``HERMES_SESSION_PLATFORM`` like chat gateways do, but there is no human
+    who can resolve a pending approval. Treating them as gateway approval
+    contexts blocks the session for the full approval timeout (60-300s) and
+    then fails closed anyway — the deadlock in #37284/#87509.
+    """
+    return _get_session_platform() in _UNATTENDED_APPROVAL_PLATFORMS
+
+
 def _is_single_query_approval_context() -> bool:
     """True when the current approval decision is from a single-query (-q) session.
 
@@ -304,22 +330,21 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
 
-    Webhook sessions are excluded for the same reason: the webhook adapter
-    has no ``send_exec_approval`` and no way to receive ``/approve``
-    replies.  Submitting a pending approval in a webhook context blocks
-    the session for the full approval timeout (60-300 s) with no human
-    who can resolve it.  Webhook dangerous-command handling falls through
-    to the non-interactive path (auto-approve with warning, or deny if
-    running inside a cron context).
+    Unattended programmatic platforms (webhook, msgraph_webhook, api_server)
+    are excluded for the same reason: those adapters have no
+    ``send_exec_approval`` and no way to receive ``/approve`` replies.
+    Submitting a pending approval there blocks the session for the full
+    approval timeout (60-300 s) with no human who can resolve it (#37284,
+    #87509). Their dangerous-command handling is governed by
+    ``approvals.unattended_mode`` config (default deny), mirroring cron.
     """
     if _is_cron_approval_context():
         return False
-    platform = _get_session_platform()
-    if platform == "webhook":
+    if _is_unattended_platform_approval_context():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
-    return bool(platform)
+    return bool(_get_session_platform())
 
 
 def _resolve_cli_approval_callback(approval_callback=None):
@@ -3522,6 +3547,25 @@ def _get_single_query_approval_mode() -> str:
         return "deny"
 
 
+def _get_unattended_approval_mode() -> str:
+    """Read the unattended-platform approval mode from config.
+
+    Governs webhook / msgraph_webhook / api_server sessions (the
+    ``_UNATTENDED_APPROVAL_PLATFORMS`` set). Returns 'deny' or 'approve';
+    default deny — an unattended programmatic session should never silently
+    run a flagged action unless the operator explicitly trusts it.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+        mode = str(cfg_get(config, "approvals", "unattended_mode", default="deny")).lower().strip()
+        if mode in {"approve", "off", "allow", "yes"}:
+            return "approve"
+        return "deny"
+    except Exception:
+        return "deny"
+
+
 def _strip_shell_comments(command: str) -> str:
     """Strip shell-style comments from a command before LLM assessment.
 
@@ -3711,6 +3755,7 @@ def _run_approval_gate(
     approval_callback=None,
     cron_deny_message: str,
     single_query_deny_message: str,
+    unattended_deny_message: str = "",
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
@@ -3810,6 +3855,26 @@ def _run_approval_gate(
                     "description": description,
                 }
             # cron_mode: approve — fall through to auto-approve below.
+        elif _is_unattended_platform_approval_context():
+            # Unattended programmatic platforms (webhook/msgraph_webhook/
+            # api_server): respect unattended_mode config. Resolves instantly
+            # — never a pending approval nobody can answer (#37284, #87509).
+            if _get_unattended_approval_mode() == "deny":
+                return {
+                    "approved": False,
+                    "message": unattended_deny_message or (
+                        f"BLOCKED: approval required ({description}) but this "
+                        "session runs on an unattended platform "
+                        f"({_get_session_platform()}) with no user present to "
+                        "approve it. Find an alternative approach that avoids "
+                        "this action. To allow flagged actions on unattended "
+                        "platforms, set approvals.unattended_mode: approve in "
+                        "config.yaml."
+                    ),
+                    "pattern_key": pattern_key,
+                    "description": description,
+                }
+            # unattended_mode: approve — fall through to auto-approve below.
         elif fail_closed_when_no_human:
             # Non-cron, non-interactive, no gateway: no human can answer.
             # The plugin-escalation path opts in to fail-closed here so a
@@ -4859,6 +4924,66 @@ def check_all_command_guards(command: str, env_type: str,
                             ),
                         }
                     # else: tirith_fail_open is True — allow as before
+        # Unattended programmatic platforms (webhook/msgraph_webhook/
+        # api_server): respect unattended_mode config (#37284, #87509).
+        # Mirrors the cron branch above, tirith parity included.
+        if _is_unattended_platform_approval_context() and not _is_cron_approval_context():
+            if _get_unattended_approval_mode() == "deny":
+                _ua_platform = _get_session_platform()
+                is_dangerous, _pk, description = detect_dangerous_command(command)
+                if is_dangerous:
+                    return {
+                        "approved": False,
+                        "message": (
+                            f"BLOCKED: Command flagged as dangerous ({description}) "
+                            f"but this session runs on an unattended platform "
+                            f"({_ua_platform}) with no user present to approve it. "
+                            "Find an alternative approach that avoids this command. "
+                            "To allow dangerous commands on unattended platforms, "
+                            "set approvals.unattended_mode: approve in config.yaml."
+                        ),
+                    }
+                # Tirith parity with the cron branch: content-level threats
+                # are caught even when pattern detection misses.
+                try:
+                    from tools.tirith_security import check_command_security
+                    _ua_tirith = check_command_security(command)
+                    if _ua_tirith.get("action") in ("block", "warn"):
+                        _ua_desc = _format_tirith_description(_ua_tirith)
+                        return {
+                            "approved": False,
+                            "message": (
+                                f"BLOCKED: {_ua_desc} "
+                                f"but this session runs on an unattended platform "
+                                f"({_ua_platform}) with no user present to approve it. "
+                                "Find an alternative approach that avoids this command. "
+                                "To allow dangerous commands on unattended platforms, "
+                                "set approvals.unattended_mode: approve in config.yaml."
+                            ),
+                        }
+                except ImportError:
+                    _ua_fail_open = True  # safe default if config is unreadable
+                    try:
+                        from hermes_cli.config import load_config_readonly as _load_cfg
+                        _sec = (_load_cfg() or {}).get("security", {}) or {}
+                        if _sec.get("tirith_enabled", True):
+                            _ua_fail_open = _sec.get("tirith_fail_open", True)
+                    except Exception:
+                        pass
+                    if not _ua_fail_open:
+                        return {
+                            "approved": False,
+                            "message": (
+                                "BLOCKED: the Tirith security scanner could not be "
+                                "imported and security.tirith_fail_open is false, "
+                                "so this command cannot be silently allowed — and "
+                                f"this session runs on an unattended platform "
+                                f"({_ua_platform}) with no user present to approve it. "
+                                "Find an alternative approach, install tirith, or set "
+                                "approvals.unattended_mode: approve in config.yaml."
+                            ),
+                        }
+                    # else: tirith_fail_open is True — allow as before
         return {"approved": True, "message": None}
 
     # --- Phase 1: Gather findings from both checks ---
@@ -5380,6 +5505,29 @@ def check_execute_code_guard(code: str, env_type: str,
                     "to approve it. Use normal tools instead, or set "
                     "approvals.cron_mode: approve only if this cron profile "
                     "is intentionally trusted."
+                ),
+                "pattern_key": pattern_key,
+                "description": description,
+                "outcome": "blocked",
+                "user_consent": False,
+            }
+        return {"approved": True, "message": None}
+
+    # Unattended programmatic platforms (webhook/msgraph_webhook/api_server):
+    # no user is present to approve arbitrary code either. Mirrors the cron
+    # branch above; governed by approvals.unattended_mode (#37284, #87509).
+    if _is_unattended_platform_approval_context():
+        if _get_unattended_approval_mode() == "deny":
+            return {
+                "approved": False,
+                "message": (
+                    "BLOCKED: execute_code runs arbitrary local Python "
+                    "(including subprocess calls that bypass shell-string "
+                    "approval checks). This session runs on an unattended "
+                    f"platform ({_get_session_platform()}) with no user "
+                    "present to approve it. Use normal tools instead, or set "
+                    "approvals.unattended_mode: approve only if sessions on "
+                    "this surface are intentionally trusted."
                 ),
                 "pattern_key": pattern_key,
                 "description": description,

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -35,6 +35,7 @@ approvals:
   timeout: 300                    # seconds to wait for user response (default: 300)
   cron_mode: deny                 # deny | approve — what cron jobs do when they hit a dangerous command
   single_query_mode: deny         # deny | approve — what single-query (-q) sessions do on a dangerous command
+  unattended_mode: deny           # deny | approve — what webhook/API sessions do on a dangerous command
   mcp_reload_confirm: true        # /reload-mcp asks before invalidating the MCP tool cache
   destructive_slash_confirm: true # /clear, /new, /reset, /undo prompt before discarding state
 ```
@@ -47,6 +48,7 @@ The full set of keys:
 | `timeout` | `300` | Seconds Hermes waits for an approval reply before timing out. |
 | `cron_mode` | `deny` | How [cron jobs](./features/cron.md) behave headlessly when they trigger a dangerous-command prompt. `deny` blocks the command (the agent must find another path); `approve` auto-approves everything in cron context. |
 | `single_query_mode` | `deny` | How one-shot [`hermes chat -q`](./cli.md) sessions behave when they trigger a dangerous-command prompt. A `-q` session runs a single turn and exits with no user waiting to answer prompts; `deny` blocks the command (the agent must find another path), `approve` auto-approves everything in single-query context. Mirrors `cron_mode`. |
+| `unattended_mode` | `deny` | How sessions on unattended programmatic platforms (webhook, msgraph_webhook, api_server) behave when they trigger a dangerous-command prompt. These surfaces have no human who can answer `/approve`, so instead of blocking for the full approval timeout, `deny` blocks the command instantly (the agent must find another path) and `approve` auto-approves everything in unattended context. Mirrors `cron_mode`. |
 | `mcp_reload_confirm` | `true` | When true, `/reload-mcp` asks before rebuilding the MCP tool set. Rebuilding invalidates the provider prompt cache (tool schemas live in the system prompt), so the next message re-sends full input tokens. Users who click **Always Approve** flip this key to `false`. |
 | `destructive_slash_confirm` | `true` | When true, destructive session slash commands (`/clear`, `/new`, `/reset`, `/undo`) prompt before discarding conversation state. Three-option dialog (Approve Once / Always Approve / Cancel) routed through native yes/no buttons on Telegram, Discord, and Slack; text fallback elsewhere. Users who click **Always Approve** flip this key to `false`. The TUI also honors this setting for its `/clear`, `/new`, and `/reset` modal; `HERMES_TUI_NO_CONFIRM=1` force-skips that modal regardless of the configured value. |
 


### PR DESCRIPTION
## Summary
Sessions on unattended programmatic platforms (webhook, msgraph_webhook, api_server) no longer stall for the full approval timeout when they hit a dangerous-command gate — the decision resolves instantly via a new `approvals.unattended_mode` config key (default `deny`), mirroring `cron_mode`.

Root cause: these platforms bind `HERMES_SESSION_PLATFORM` like chat gateways do, so `_is_gateway_approval_context()` routed them into the interactive `/approve` wait — but their adapters have no `send_exec_approval` and no reply channel, so nobody can ever answer. The session blocked 60–300s and then failed closed anyway (#37284, #87509). Observed live Aug 30: a memory-watchdog webhook run sat the full 300s on an approval, which held up a `hermes update` gateway drain for 5+ minutes.

Salvages #37317 by @liuhao1024 (webhook exclusion + tests, authorship preserved) with the policy flipped from auto-approve-with-warning to deny-by-default, and the fix widened from webhook-only to the whole unattended class.

## Changes
- `tools/approval.py`: `_UNATTENDED_APPROVAL_PLATFORMS` frozenset + `_is_unattended_platform_approval_context()`; excluded from gateway approval context (cherry-picked from #37317, widened)
- `tools/approval.py`: `approvals.unattended_mode` reader (`deny`/`approve`, default deny); deny branches in `_run_approval_gate`, `check_all_command_guards` (with tirith parity, mirroring the cron branch), and `check_execute_code_guard` (the #87509 sibling site)
- `hermes_cli/config_defaults.py`: `approvals.unattended_mode: deny` default + comment
- `website/docs/user-guide/security.md`: key documented in the approvals table
- `tests/tools/test_approval.py`: contributor's exclusion tests kept; auto-approve test flipped to deny-default; added opt-in/approve, safe-command, api_server, and execute_code coverage

## Validation
| Scenario (real `check_all_command_guards`, isolated HERMES_HOME, webhook session) | Before (origin/main) | After |
|---|---|---|
| Dangerous command | pending approval submitted → waits `approvals.timeout` → fail closed | instant deny (0.04s) with actionable message |
| Safe command | approved | approved |
| `unattended_mode: approve` | n/a | auto-approves (old #37317 behavior, now opt-in) |
| execute_code | one-shot gateway approval nobody can answer | instant deny |

Targeted tests: `tests/tools/test_approval.py` + `test_approval_config_readonly.py` — 121/121 pass.

**Live repro:** confirmed on origin/main (pending-approval path taken in a real webhook-session subprocess) and instant-deny confirmed on this branch, same harness.

Fixes #37284. Fixes the api_server half of #87509. Complementary to #71661 (addressable cross-platform approvals), which remains a valid follow-up for users who WANT remote approval of webhook sessions.

## Infographic

![Unattended approvals — deny by default](https://v3b.fal.media/files/b/0aa869c1/OlUzIx72NavzYvwGuEY7o_anBqxLZU.png)
