### PR TITLE
fix(cron): deliver secondary-profile cron jobs via their own adapters

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -558,6 +558,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -582,6 +583,7 @@ class InProcessCronScheduler(CronScheduler):
                 stop_event,
                 profile_homes=profile_homes,
                 adapters=adapters,
+                profile_adapters=profile_adapters,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
@@ -653,6 +655,7 @@ class InProcessCronScheduler(CronScheduler):
         *,
         profile_homes,
         adapters=None,
+        profile_adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -664,6 +667,14 @@ class InProcessCronScheduler(CronScheduler):
         agent execution to that profile's home — mirroring how
         ``_profile_runtime_scope`` scopes the multiplexed inbound path and
         ``web_server.py`` scopes per-profile cron API calls.
+
+        ``profile_adapters`` maps profile name → that profile's live adapter
+        map (``{Platform: adapter}``). When provided, each profile ticks with
+        ITS OWN adapters so cron deliveries issued from a secondary profile's
+        store ride that profile's bot identity instead of the default
+        profile's. Fall back to the shared ``adapters`` map for profiles not
+        present in the map (default profile, or a gateway that never started
+        secondary adapters).
         """
         import logging
         from cron.scheduler import tick as cron_tick
@@ -681,6 +692,7 @@ class InProcessCronScheduler(CronScheduler):
             len(profile_homes),
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
+        profile_adapters = profile_adapters or {}
 
         # Recovery + initial heartbeat for every profile.
         # A profile may have been deleted since this snapshot was taken;
@@ -712,12 +724,20 @@ class InProcessCronScheduler(CronScheduler):
                 else:
                     for entry in _existing_profile_homes(profile_homes):
                         home = entry[1] if isinstance(entry, tuple) else entry
+                        profile_name = entry[0] if isinstance(entry, tuple) else None
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
+                                # A secondary profile's own adapters carry its
+                                # bot identity; without this, every profile's
+                                # cron delivery rides the DEFAULT profile's
+                                # adapters (wrong bot for DM deliveries).
+                                tick_adapters = adapters
+                                if profile_name and profile_name in profile_adapters:
+                                    tick_adapters = profile_adapters.get(profile_name)
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -559,6 +559,7 @@ class InProcessCronScheduler(CronScheduler):
         can_dispatch=None,
         profile_homes=None,
         profile_adapters=None,
+        default_profile=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -584,6 +585,7 @@ class InProcessCronScheduler(CronScheduler):
                 profile_homes=profile_homes,
                 adapters=adapters,
                 profile_adapters=profile_adapters,
+                default_profile=default_profile,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
@@ -656,6 +658,7 @@ class InProcessCronScheduler(CronScheduler):
         profile_homes,
         adapters=None,
         profile_adapters=None,
+        default_profile=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -669,12 +672,14 @@ class InProcessCronScheduler(CronScheduler):
         ``web_server.py`` scopes per-profile cron API calls.
 
         ``profile_adapters`` maps profile name → that profile's live adapter
-        map (``{Platform: adapter}``). When provided, each profile ticks with
-        ITS OWN adapters so cron deliveries issued from a secondary profile's
-        store ride that profile's bot identity instead of the default
-        profile's. Fall back to the shared ``adapters`` map for profiles not
-        present in the map (default profile, or a gateway that never started
-        secondary adapters).
+        map (``{Platform: adapter}``), populated once that profile's bot
+        connects. The shared ``adapters`` set belongs to the DEFAULT profile
+        only. A secondary profile is delivered via ITS OWN map only — it must
+        NEVER fall back to the default profile's ``adapters`` (that ships its
+        cron output through the wrong bot), so before its adapter connects —
+        map absent or empty — it simply does not deliver this tick.
+        ``default_profile`` names the profile that owns the shared ``adapters``
+        (the multiplex list always serves ``"default"`` first).
         """
         import logging
         from cron.scheduler import tick as cron_tick
@@ -723,21 +728,27 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in _existing_profile_homes(profile_homes):
+                        _pname = entry[0] if isinstance(entry, tuple) else None
                         home = entry[1] if isinstance(entry, tuple) else entry
-                        profile_name = entry[0] if isinstance(entry, tuple) else None
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
-                                # A secondary profile's own adapters carry its
-                                # bot identity; without this, every profile's
-                                # cron delivery rides the DEFAULT profile's
-                                # adapters (wrong bot for DM deliveries).
-                                tick_adapters = adapters
-                                if profile_name and profile_name in profile_adapters:
-                                    tick_adapters = profile_adapters.get(profile_name)
+                                # Deliver each profile's cron via ITS OWN adapters.
+                                # The shared `adapters` set belongs to the default
+                                # profile only. A secondary profile uses its own map
+                                # in profile_adapters[name], which is populated only
+                                # once that profile's bot connects. A secondary must
+                                # NEVER fall back to the default profile's `adapters`
+                                # (that ships its cron output through the wrong bot),
+                                # so before its adapter connects — map absent or empty
+                                # — it simply does not deliver this tick.
+                                if _pname is None or _pname == default_profile:
+                                    _tick_adapters = adapters
+                                else:
+                                    _tick_adapters = (profile_adapters or {}).get(_pname) or {}
                                 cron_tick(
                                     verbose=False,
-                                    adapters=tick_adapters,
+                                    adapters=_tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32298,23 +32298,25 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                # Per-profile adapters so each profile's cron output is
+                # delivered via its own bot/adapter instead of the default
+                # profile's.
+                cron_start_kwargs["profile_adapters"] = getattr(
+                    runner, "_profile_adapters", None
+                )
+                # runner.adapters belongs to the default profile, which
+                # profiles_to_serve() names "default" in its multiplex list.
+                # Thread that identity so the ticker reserves the shared
+                # adapters for the default profile alone and never routes a
+                # secondary's cron through the default bot (even before its
+                # adapter connects, when profile_adapters[name] is still
+                # absent/empty).
+                cron_start_kwargs["default_profile"] = "default"
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),
                     [p[0] if isinstance(p, tuple) else p for p in profile_homes],
                 )
-                # Give each served profile its own live adapter map so cron
-                # deliveries from a secondary profile's store ride that
-                # profile's bot identity (e.g. agent-fund reports arrive as
-                # DMs from the agent-fund bot, not the default/PA bot).
-                profile_adapters = getattr(runner, "_profile_adapters", None) or {}
-                if profile_adapters:
-                    cron_start_kwargs["profile_adapters"] = profile_adapters
-                    logger.info(
-                        "Cron scheduler will route deliveries per profile for %d secondary profile(s): %s",
-                        len(profile_adapters),
-                        list(profile_adapters.keys()),
-                    )
         except Exception as exc:
             logger.warning(
                 "Could not resolve profile homes for multiplex cron: %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32303,6 +32303,18 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                     len(profile_homes),
                     [p[0] if isinstance(p, tuple) else p for p in profile_homes],
                 )
+                # Give each served profile its own live adapter map so cron
+                # deliveries from a secondary profile's store ride that
+                # profile's bot identity (e.g. agent-fund reports arrive as
+                # DMs from the agent-fund bot, not the default/PA bot).
+                profile_adapters = getattr(runner, "_profile_adapters", None) or {}
+                if profile_adapters:
+                    cron_start_kwargs["profile_adapters"] = profile_adapters
+                    logger.info(
+                        "Cron scheduler will route deliveries per profile for %d secondary profile(s): %s",
+                        len(profile_adapters),
+                        list(profile_adapters.keys()),
+                    )
         except Exception as exc:
             logger.warning(
                 "Could not resolve profile homes for multiplex cron: %s",

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -640,6 +640,63 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_ticker_uses_profile_adapters_for_cron_delivery(tmp_path, monkeypatch):
+    """Cron deliveries from a secondary profile must ride that profile's own
+    adapters (its bot identity), not the default profile's. Regression test:
+    multiplex cron always delivered through the DEFAULT adapters, so
+    agent-fund cron reports arrived as DMs from the PA bot even though the
+    job ran in the agent-fund profile context."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    p1 = tmp_path / "default"
+    p2 = tmp_path / "home-ops"
+    for d in (p1, p2):
+        (d / "cron").mkdir(parents=True)
+
+    profile_homes = [("default", p1), ("home-ops", p2)]
+
+    # Record which adapters map each tick() invocation received.
+    adapters_seen: list[dict] = []
+
+    def _tracking_tick(*args, **kwargs):
+        adapters_seen.append(kwargs.get("adapters"))
+        return 0
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+
+    default_adapters = {"default-platform": object()}
+    home_ops_adapters = {"home-ops-platform": object()}
+
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": profile_homes,
+                "adapters": default_adapters,
+                "profile_adapters": {"home-ops": home_ops_adapters},
+            },
+            daemon=True,
+        )
+        t.start()
+        deadline = time.monotonic() + 10
+        while len(adapters_seen) < 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    assert len(adapters_seen) >= 2, f"Expected >= 2 tick calls, got {len(adapters_seen)}"
+    # Both profiles must have been ticked, and each with its own adapters map:
+    assert any(a is default_adapters for a in adapters_seen), \
+        "default profile must tick with the default adapters"
+    assert any(a is home_ops_adapters for a in adapters_seen), \
+        "secondary profile must tick with ITS OWN adapters, not the default's"
+
+
 def test_multiplex_ticker_skips_deleted_profile_from_startup_snapshot(tmp_path):
     """A stale profile_homes entry must not recreate a deleted profile."""
     import cron.jobs as jobs

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -678,6 +678,7 @@ def test_multiplex_ticker_uses_profile_adapters_for_cron_delivery(tmp_path, monk
                 "profile_homes": profile_homes,
                 "adapters": default_adapters,
                 "profile_adapters": {"home-ops": home_ops_adapters},
+                "default_profile": "default",
             },
             daemon=True,
         )
@@ -695,6 +696,101 @@ def test_multiplex_ticker_uses_profile_adapters_for_cron_delivery(tmp_path, monk
         "default profile must tick with the default adapters"
     assert any(a is home_ops_adapters for a in adapters_seen), \
         "secondary profile must tick with ITS OWN adapters, not the default's"
+
+
+def _run_multiplex_capture(tmp_path, *, profile_adapters, shared_adapters):
+    """Run the multiplex ticker one full cycle and return the ``adapters``
+    object passed to ``tick()`` for the default profile and the secondary
+    profile (in ``profile_homes`` order: default first, secondary second)."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    p_default = tmp_path / "default"
+    p_sec = tmp_path / "home-ops"
+    for d in (p_default, p_sec):
+        (d / "cron").mkdir(parents=True)
+    profile_homes = [("default", p_default), ("home-ops", p_sec)]
+
+    captured: list = []  # adapters seen per tick call; order follows profile_homes
+
+    def _capturing_tick(*args, **kwargs):
+        captured.append(kwargs.get("adapters"))
+        return 0
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+    with patch("cron.scheduler.tick", side_effect=_capturing_tick), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": profile_homes,
+                "adapters": shared_adapters,
+                "profile_adapters": profile_adapters,
+                "default_profile": "default",
+            },
+            daemon=True,
+        )
+        t.start()
+        deadline = time.monotonic() + 10
+        while len(captured) < 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    assert len(captured) >= 2, f"expected >= 2 tick calls, got {len(captured)}"
+    return captured[0], captured[1]  # (default, secondary) of the first cycle
+
+
+def test_multiplex_default_profile_uses_shared_adapters(tmp_path):
+    """The default profile's cron is delivered via the shared ``adapters`` set
+    (which belongs to the default profile)."""
+    shared = {"kind": "shared"}
+    default_ad, _ = _run_multiplex_capture(
+        tmp_path, profile_adapters={"home-ops": {"kind": "secondary"}},
+        shared_adapters=shared,
+    )
+    assert default_ad is shared
+
+
+def test_multiplex_connected_secondary_uses_its_own_adapters(tmp_path):
+    """A connected secondary is delivered via ITS OWN adapters, not the shared
+    default-profile set."""
+    shared = {"kind": "shared"}
+    sec = {"kind": "secondary"}
+    default_ad, sec_ad = _run_multiplex_capture(
+        tmp_path, profile_adapters={"home-ops": sec}, shared_adapters=shared,
+    )
+    assert default_ad is shared
+    assert sec_ad is sec
+
+
+def test_multiplex_empty_secondary_does_not_fall_back_to_shared(tmp_path):
+    """A secondary whose adapter map is present-but-empty (its bot has not
+    connected yet) must NOT fall back to the default profile's shared adapters
+    — otherwise its cron output ships through the wrong bot. It receives an
+    empty adapter set and simply does not deliver this tick."""
+    shared = {"kind": "shared"}
+    default_ad, sec_ad = _run_multiplex_capture(
+        tmp_path, profile_adapters={"home-ops": {}}, shared_adapters=shared,
+    )
+    assert default_ad is shared
+    assert sec_ad is not shared
+    assert not sec_ad  # empty → no delivery, not the default bot
+
+
+def test_multiplex_missing_secondary_does_not_fall_back_to_shared(tmp_path):
+    """A secondary absent from profile_adapters entirely (its adapter map has
+    not been created yet) also must not fall back to the shared adapters."""
+    shared = {"kind": "shared"}
+    default_ad, sec_ad = _run_multiplex_capture(
+        tmp_path, profile_adapters={}, shared_adapters=shared,
+    )
+    assert default_ad is shared
+    assert sec_ad is not shared
+    assert not sec_ad
 
 
 def test_multiplex_ticker_skips_deleted_profile_from_startup_snapshot(tmp_path):


### PR DESCRIPTION
## Problem

With `multiplex_profiles`, one gateway process serves several Hermes profiles, each with its own bot identity (Telegram/Discord/…). Cron jobs are ticked per profile store, but **every cron delivery went out through the default profile's adapter map** (`runner.adapters`). The secondary profiles' own adapters live in `runner._profile_adapters` and were never handed to the scheduler.

Visible symptom in a multi-bot setup: a job fired from a secondary profile store delivered its DM to the user **from the default profile's bot identity** — or failed outright where the default bot token cannot resolve the target chat. Job execution was correctly scoped per profile (skills, memory, store), only the delivery identity was wrong.

## Root cause

`InProcessCronScheduler._start_multiplex` ticks every profile home with the single shared `adapters` map. `gateway/run.py` built `cron_start_kwargs` with only `adapters` — secondary adapter maps (`runner._profile_adapters`) never reached the scheduler.

## Fix

- `cron/scheduler_provider.py`: `start()` and `_start_multiplex()` accept an optional `profile_adapters` (profile name → that profile's live adapter map). The multiplex tick loop extracts the profile name from each `profile_homes` entry and, for secondary profiles, ticks with `profile_adapters.get(profile_name) or {}` — **never falling back to the default profile's adapters**. If a secondary profile's adapter map is absent or empty (e.g. its bot has not connected yet during startup), that profile simply does not deliver this tick instead of sending through the wrong bot identity. The default profile (or a `None` name) keeps ticking with the shared `adapters` map, which it owns.
- `gateway/run.py`: pass `runner._profile_adapters` and the default profile name into `cron_start_kwargs` when secondary adapters exist.
- `tests/cron/test_scheduler_provider.py`: regression tests asserting (a) the default profile ticks with the shared adapters, (b) a connected secondary profile ticks with its own adapters, (c) a secondary profile without an adapter entry gets an empty map — no fallback to the default bot.

No behavior change for single-profile or non-multiplex installations: the parameters default to `None`, the default profile path is unchanged, and the gateway only injects `profile_adapters` when secondary adapters actually exist. Verified: existing multiplex tests stay green.

## Tests

- New: `tests/cron/test_scheduler_provider.py` — four policy tests (default-shared / connected-own / empty-no-fallback / missing-no-fallback) plus the existing per-profile adapter regression test, extended for the `default_profile` parameter (RED before fix, GREEN after)
- `tests/cron/`: 1052 passed, 10 skipped (1 pre-existing, approval-setting-dependent failure — fails identically on clean main)
- `tests/gateway/test_multiplex_profile_authz.py`: 6 passed

## Notes

The no-fallback policy for secondary profiles mirrors the safety rule from #73363: an unconnected secondary profile must stay silent rather than deliver through the wrong bot. Ported manually onto current main because `scheduler_provider.py` gained `fire_claimed` / `_existing_profile_homes` / misfire backstop since the original patch.