### PR TITLE
fix(ci): fail aggregate gate on cancelled jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,8 +205,8 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────────────
   # Gate: runs after everything. ``if: always()`` ensures it reports a
-  # status even when some deps were skipped. Only actual ``failure``
-  # results cause it to fail; ``skipped`` is treated as success.
+  # status even when some deps were skipped. Intentional ``skipped`` results
+  # are accepted; cancelled or otherwise incomplete dependencies must fail.
   #
   # Branch protection should require ONLY this check.
   #
@@ -256,13 +256,17 @@ jobs:
           print(f'needs-json={json.dumps(compact)}')
           with open('$GITHUB_OUTPUT', 'a') as f:
               f.write(f'needs-json={json.dumps(compact)}\n')
-          failed = [name for name, info in needs.items() if info['result'] == 'failure']
+          blocked = [
+              name
+              for name, info in needs.items()
+              if info['result'] not in ('success', 'skipped')
+          ]
           for name, info in sorted(needs.items()):
               result = info['result']
               icon = '✅' if result in ('success', 'skipped') else '❌'
               print(f'{icon} {name}: {result}')
-          if failed:
-              print(f'::error::{len(failed)} job(s) failed: {\", \".join(failed)}')
+          if blocked:
+              print(f'::error::{len(blocked)} job(s) did not succeed or skip: {\", \".join(blocked)}')
               sys.exit(1)
           print('All checks passed (or were skipped)')
           "


### PR DESCRIPTION
Fixes #98557.

## Problem

`all-checks-pass` only treated the literal `failure` result as blocking. If `detect` was cancelled, every lane depending on its outputs could skip and the aggregate gate still reported success despite no test decision having been made.

## Fix

Keep intentional `skipped` lanes accepted, but treat every dependency result other than `success` or `skipped` as blocking. This covers `cancelled` and avoids silently accepting incomplete/unknown result states.

The aggregate output/icons remain unchanged; only the exit decision and nearby workflow comment are tightened.

## Validation

- refreshed onto current upstream `main` (`21b2095d00a98b8ad7b5c60b10587619c852cdb8`);
- branch is exactly one focused commit ahead and zero commits behind;
- final duplicate search still finds no other open PR covering #98557 / this cancelled aggregate-gate path;
- fresh hosted CI, Docker, and Nix checks are running on head `68ca8e5b9ea2ec6be9fb4eecafef67ff2cd5896f`.

Focused gate semantics remain:
- success + intentional skipped lanes -> pass
- cancelled dependency -> block
- failed dependency -> block
- empty/incomplete result -> block