### PR TITLE
perf(state): defer sidebar preview/last_active fetch to after LIMIT in list_sessions_rich (19s -> 0.03s)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10663,16 +10663,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 _desc = [d[0] for d in cursor.description]
                 _id_i = _desc.index("id")
                 _ids = [r[_id_i] for r in rows]
-                _ph = ",".join("?" * len(_ids))
-                _cur2 = conn.execute(
-                    "SELECT s.id AS _bid,"
-                    " COALESCE((SELECT " + _PREVIEW_RAW_SELECT + " FROM messages m"
-                    " WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL"
-                    " AND " + _PREVIEW_ELIGIBLE_SQL +
-                    " ORDER BY m.timestamp, m.id LIMIT 1), '') AS _preview_raw,"
-                    " " + _sql_session_last_active("s") + " AS last_active"
-                    " FROM sessions s WHERE s.id IN (" + _ph + ")", _ids)
-                _bf = {r[0]: (r[1], r[2]) for r in _cur2.fetchall()}
+                # Chunk the IN(...) fetch: the dashboard router caps pages at
+                # 100, but CLI callers (sessions_cmd multiplies the requested
+                # limit by 4; console_engine passes the raw CLI limit) can
+                # exceed the classic 999 host-variable cap on SQLite builds
+                # that still default to it.
+                _bf = {}
+                for _i in range(0, len(_ids), 500):
+                    _chunk = _ids[_i:_i + 500]
+                    _ph = ",".join("?" * len(_chunk))
+                    _cur2 = conn.execute(
+                        "SELECT s.id AS _bid,"
+                        " COALESCE((SELECT " + _PREVIEW_RAW_SELECT + " FROM messages m"
+                        " WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL"
+                        " AND " + _PREVIEW_ELIGIBLE_SQL +
+                        " ORDER BY m.timestamp, m.id LIMIT 1), '') AS _preview_raw,"
+                        " " + _sql_session_last_active("s") + " AS last_active"
+                        " FROM sessions s WHERE s.id IN (" + _ph + ")", _chunk)
+                    _bf.update({r[0]: (r[1], r[2]) for r in _cur2.fetchall()})
                 rows = [
                     dict(zip(_desc + ["_preview_raw", "last_active"],
                              tuple(r) + _bf.get(r[_id_i], ("", None))))

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10615,15 +10615,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     GROUP BY root_id
                 )
                 SELECT {_sel}{prompt_select},
-                    COALESCE(
-                        (SELECT {_PREVIEW_RAW_SELECT}
-                         FROM messages m
-                         WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                           AND {_PREVIEW_ELIGIBLE_SQL}
-                         ORDER BY m.timestamp, m.id LIMIT 1),
-                        ''
-                    ) AS _preview_raw,
-                    {_sql_session_last_active("s")} AS last_active,
                     COALESCE(cm.effective_last_active, s.started_at) AS _effective_last_active
                 FROM sessions s
                 LEFT JOIN chain_max cm ON cm.root_id = s.id
@@ -10658,6 +10649,35 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._read_ctx() as conn:
             cursor = conn.execute(query, params)
             rows = cursor.fetchall()
+            if order_by_last_active and rows:
+                # Defer preview/last_active to after LIMIT: ordering by the
+                # chain-projected recency forces SQLite to evaluate the select
+                # list for every candidate row, and the preview subquery reads
+                # each session's first-user-message content page. On a DB with
+                # ~1.6k sessions and large message payloads that made the
+                # dashboard sidebar's order=recent query take ~19s; fetching
+                # previews only for the page's rows brings it to ~30ms warm
+                # (measured; see PR description). The created-order path above
+                # is untouched -- its ORDER BY s.started_at lets LIMIT apply
+                # early, so the inline subqueries only ever run for page rows.
+                _desc = [d[0] for d in cursor.description]
+                _id_i = _desc.index("id")
+                _ids = [r[_id_i] for r in rows]
+                _ph = ",".join("?" * len(_ids))
+                _cur2 = conn.execute(
+                    "SELECT s.id AS _bid,"
+                    " COALESCE((SELECT " + _PREVIEW_RAW_SELECT + " FROM messages m"
+                    " WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL"
+                    " AND " + _PREVIEW_ELIGIBLE_SQL +
+                    " ORDER BY m.timestamp, m.id LIMIT 1), '') AS _preview_raw,"
+                    " " + _sql_session_last_active("s") + " AS last_active"
+                    " FROM sessions s WHERE s.id IN (" + _ph + ")", _ids)
+                _bf = {r[0]: (r[1], r[2]) for r in _cur2.fetchall()}
+                rows = [
+                    dict(zip(_desc + ["_preview_raw", "last_active"],
+                             tuple(r) + _bf.get(r[_id_i], ("", None))))
+                    for r in rows
+                ]
         sessions = []
         for row in rows:
             s = self._session_row_dict(row)


### PR DESCRIPTION
## Problem

The dashboard sidebar (`/api/sessions?order=recent`) was taking **~19 seconds** to load on a real deployment: ~1.6k listable sessions, 39k messages, 705MB `state.db` on a NAS HDD. Every page load, every time.

## Root cause

The recent-order branch of `list_sessions_rich` sorts by `COALESCE(cm.effective_last_active, s.started_at)`, which comes from the recursive compression-chain CTE. Because the ordering key is computed per candidate row, SQLite must evaluate the **whole select list for every listable session** before `ORDER BY ... LIMIT` can discard all but the page's rows — and the select list contains:

* the `_preview_raw` correlated subquery, which fetches each session's first user message and runs `SUBSTR` on its `content` (a big-payload column), and
* the `_sql_session_last_active` scalar subquery.

That's ~1.6k content-page reads per sidebar load, thrown away for all but 20 rows. Attribution by ablation on the captured SQL (removing either the chain ordering or the preview subquery individually dropped the query from 19.3s to 0.02–0.07s; the cost is the combination).

## Fix

Trim the recent-order SELECT to the compact columns + ordering key, and after `fetchall()` backfill `_preview_raw` and `last_active` for the surviving page rows with a single `WHERE s.id IN (...)` query (<= limit + backfilled pins' worth of rows). The created-order path is untouched — its `ORDER BY s.started_at` already lets LIMIT apply early, so its inline subqueries only ever ran for page rows.

## Measurements (705MB state.db, 1.6k sessions, 39k messages)

| | before | after |
|---|---|---|
| order=recent limit=20 (warm) | 19.3s | **0.03s** |
| first load after page-cache eviction | 19.3s | ~9.5s once (messages-index pages), then warm |

Correctness: same rows in the same order, same previews, same `last_active` values; on a lookup miss the backfill coalesces to `''` / `None` exactly like the old `COALESCE(..., '')` did.

## Tests

```
python -m pytest tests/test_hermes_state.py -k "last_active or list_sessions" -x -q   # 5 passed
python -m pytest tests/test_session_skill_previews.py tests/test_session_system_prompt_dedup.py -x -q  # 21 passed
```

The patch is running in production on the deployment where the 19s latency was measured (applied via a container-start patch script; this PR is the same change upstreamed).