### PR TITLE
fix(desktop): latch dead-session 4001s off approval.pending and goal polls

### DIFF
--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -1,4 +1,3 @@
-import { JsonRpcGatewayError } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import { translateNow } from '@/i18n'
@@ -10,6 +9,7 @@ import { $goalsBySession, type GoalStatus } from './goals'
 import { dispatchNativeNotification } from './native-notifications'
 import { notifyError } from './notifications'
 import { $sessions, lineageAliases } from './session'
+import { isSessionGone, isSessionGoneForBackgroundPolling, markSessionGone } from './session-gone'
 import { $sessionStates } from './session-states'
 import { $subagentsBySession, type SubagentProgress } from './subagents'
 import { $todosBySession } from './todos'
@@ -392,48 +392,18 @@ export function reconcileBackgroundProcesses(sid: string, procs: GatewayProcessE
  *  The status stack re-polls `process.list` every 5s while a running row is on
  *  screen, so treating 4001 as transient meant re-sending the same dead id
  *  forever: one runtime id accumulated 18,614 gateway rejections in a single day
- *  (#94219 fallout). Latch the id here and skip it until something rebinds it. */
-const goneSessions = new Set<string>()
-
-/** Gateway JSON-RPC code for "session not found" (tui_gateway _sess_nowait). */
-const GATEWAY_SESSION_NOT_FOUND_CODE = 4001
-
-/** A gone session is unrecoverable for THIS runtime id; a timeout or transport
- *  blip is not. Only the former may stop the poll — misclassifying a transient
- *  failure would silently freeze the status stack on a healthy session.
+ *  (#94219 fallout). Latch the id here and skip it until something rebinds it.
  *
- *  Match the gateway's 4001 code when the error carries one (JsonRpcGatewayError
- *  from a structured RPC rejection) — a message substring alone could latch on
- *  an unrelated error class that merely mentions "session not found" (e.g. a
- *  wrapped tool/report string). The message fallback survives only for errors
- *  with no numeric code at all, where the frame's structure was lost. */
-export function isSessionGoneForBackgroundPolling(error: unknown): boolean {
-  if (error instanceof JsonRpcGatewayError && typeof error.code === 'number') {
-    return error.code === GATEWAY_SESSION_NOT_FOUND_CODE
-  }
-
-  const message = error instanceof Error ? error.message : String(error ?? '')
-
-  return /session not found/i.test(message)
-}
-
-/** Clear the gone-latch. Called with a session id when a fresh runtime binds to
- *  it (so polling resumes), or with no argument to reset everything (tests). */
-export function resetBackgroundPollingGuard(sid?: string): void {
-  if (sid) {
-    goneSessions.delete(sid)
-
-    return
-  }
-
-  goneSessions.clear()
-}
+ *  The latch itself now lives in ./session-gone so approval.pending and the
+ *  goal-status poll share one set AND one clear path (#94219 only ever fixed
+ *  this poller). Re-exported here so existing importers are untouched. */
+export { isSessionGoneForBackgroundPolling, resetBackgroundPollingGuard } from './session-gone'
 
 /** Pull the session's live process snapshot from the gateway. */
 export async function refreshBackgroundProcesses(sid: string): Promise<void> {
   const gateway = $gateway.get()
 
-  if (!sid || !gateway || goneSessions.has(sid)) {
+  if (!sid || !gateway || isSessionGone(sid)) {
     return
   }
 
@@ -445,7 +415,7 @@ export async function refreshBackgroundProcesses(sid: string): Promise<void> {
     // A gone session never comes back under this runtime id: stop polling it,
     // or the 5s timer hammers the gateway with 4001s for the window's lifetime.
     if (isSessionGoneForBackgroundPolling(error)) {
-      goneSessions.add(sid)
+      markSessionGone(sid)
 
       return
     }

--- a/apps/desktop/src/store/goals.test.ts
+++ b/apps/desktop/src/store/goals.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $goalsBySession, applyGoalStatusText, clearSessionGoal } from './goals'
+import { $gateway } from './gateway'
+import { $goalsBySession, applyGoalStatusText, clearSessionGoal, refreshSessionGoal } from './goals'
+import { resetBackgroundPollingGuard } from './session-gone'
 
 describe('goal store', () => {
   afterEach(() => {
@@ -106,5 +108,49 @@ describe('goal store', () => {
     applyGoalStatusText('s2', '⏸ Goal (paused, 20/20 turns): other work', { hydrate: true })
 
     expect($goalsBySession.get().s2).toMatchObject({ status: 'paused', title: 'other work' })
+  })
+})
+
+describe('refreshSessionGoal dead-session guard', () => {
+  beforeEach(() => {
+    resetBackgroundPollingGuard()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    $goalsBySession.set({})
+    $gateway.set(null as never)
+    resetBackgroundPollingGuard()
+  })
+
+  it('latches off a reaped runtime instead of re-asking on every refresh trigger', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    $gateway.set({ request } as never)
+
+    await refreshSessionGoal('s1')
+    expect(request).toHaveBeenCalledTimes(1)
+
+    // Before the latch, every refresh trigger re-sent the slash.exec poll to a
+    // runtime the gateway no longer held (#94219 shape).
+    await refreshSessionGoal('s1')
+    await refreshSessionGoal('s1')
+
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not latch on transient failures', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('request timed out after 30s')
+    })
+
+    $gateway.set({ request } as never)
+
+    await refreshSessionGoal('s1')
+    await refreshSessionGoal('s1')
+
+    expect(request).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/desktop/src/store/goals.ts
+++ b/apps/desktop/src/store/goals.ts
@@ -3,6 +3,7 @@ import { atom } from 'nanostores'
 import { keyedTimeouts } from '@/lib/keyed-timeouts'
 
 import { $gateway } from './gateway'
+import { isSessionGone, isSessionGoneForBackgroundPolling, markSessionGone } from './session-gone'
 
 export type GoalStatus = 'active' | 'done' | 'paused' | 'waiting'
 
@@ -163,7 +164,7 @@ export function applyGoalStatusText(sid: string, text: string, opts?: { hydrate?
 export async function refreshSessionGoal(sid: string): Promise<void> {
   const gateway = $gateway.get()
 
-  if (!sid || !gateway) {
+  if (!sid || !gateway || isSessionGone(sid)) {
     return
   }
 
@@ -171,7 +172,15 @@ export async function refreshSessionGoal(sid: string): Promise<void> {
     const result = await gateway.request<{ output?: string }>('slash.exec', { command: 'goal status', session_id: sid })
 
     applyGoalStatusText(sid, result?.output ?? '', { hydrate: true })
-  } catch {
+  } catch (error) {
+    // A reaped runtime is terminal for this id — latch it off rather than
+    // re-asking on every refresh trigger (#94219 shape).
+    if (isSessionGoneForBackgroundPolling(error)) {
+      markSessionGone(sid)
+
+      return
+    }
+
     // Best-effort: older gateways or detached sessions simply won't hydrate it.
   }
 }

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { clearClarifyRequest, setClarifyRequest } from './clarify'
 import {
@@ -17,6 +17,7 @@ import {
   setSudoRequest
 } from './prompts'
 import { $activeSessionId } from './session'
+import { resetBackgroundPollingGuard } from './session-gone'
 
 // Prompts are parked per-session; the exported $*Request views are scoped to the
 // active session, so each test focuses the session it's asserting on.
@@ -128,6 +129,62 @@ describe('approval prompt store', () => {
       ['approval.pending', { session_id: 's1' }],
       ['approval.received', { request_id: 'r1', session_id: 's1' }]
     ])
+  })
+})
+
+describe('replayPendingApproval dead-session guard', () => {
+  beforeEach(() => {
+    resetBackgroundPollingGuard()
+  })
+
+  afterEach(() => {
+    resetBackgroundPollingGuard()
+  })
+
+  it('latches off a reaped runtime instead of re-driving 4001s on every event', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    // First replay discovers the runtime is gone…
+    await replayPendingApproval({ request } as never, 's1')
+    expect(request).toHaveBeenCalledTimes(1)
+
+    // …and every re-drive after that must skip the wire entirely. The callers
+    // (use-message-stream, assistant-ui/tool/approval) swallow the rejection
+    // and re-drive on each gateway event, so without the latch a reaped
+    // window streams rejected approval.pending RPCs for its whole life.
+    await replayPendingApproval({ request } as never, 's1')
+    await replayPendingApproval({ request } as never, 's1')
+
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('still throws transient failures so callers keep their existing retry semantics', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('request timed out after 30s')
+    })
+
+    await expect(replayPendingApproval({ request } as never, 's1')).rejects.toThrow('timed out')
+
+    // Not latched — the next gateway event may find the session alive again.
+    await expect(replayPendingApproval({ request } as never, 's1')).rejects.toThrow('timed out')
+
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('resumes polling once a fresh runtime rebinds the session', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    await replayPendingApproval({ request } as never, 's1')
+    expect(request).toHaveBeenCalledTimes(1)
+
+    resetBackgroundPollingGuard('s1')
+
+    await replayPendingApproval({ request } as never, 's1')
+    expect(request).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -2,6 +2,7 @@ import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { $clarifyRequest, $clarifyRequests } from './clarify'
 import { $activeSessionId } from './session'
+import { isSessionGone, isSessionGoneForBackgroundPolling, markSessionGone } from './session-gone'
 
 // Blocking interactive prompts the gateway raises mid-turn. Each maps to a
 // `*.request` event the Python side emits while it blocks the agent thread
@@ -131,9 +132,28 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
     return
   }
 
-  const rawResult = await gateway.request('approval.pending', {
-    session_id: sessionId
-  })
+  // A reaped runtime answers 4001 forever; without this latch the replay is
+  // re-driven on every gateway event and the window streams rejected RPCs for
+  // its whole life (the same #94219 failure process.list already guards).
+  if (isSessionGone(sessionId)) {
+    return
+  }
+
+  let rawResult: unknown
+
+  try {
+    rawResult = await gateway.request('approval.pending', {
+      session_id: sessionId
+    })
+  } catch (error) {
+    if (isSessionGoneForBackgroundPolling(error)) {
+      markSessionGone(sessionId)
+
+      return
+    }
+
+    throw error
+  }
 
   const result =
     rawResult && typeof rawResult === 'object' ? (rawResult as { approvals?: PendingApprovalPayload[] }) : {}

--- a/apps/desktop/src/store/session-gone.ts
+++ b/apps/desktop/src/store/session-gone.ts
@@ -1,0 +1,60 @@
+// Shared "this runtime id is gone" latch for every background poller.
+//
+// When a runtime is reaped the gateway answers session-scoped RPCs with 4001
+// ("session not found", tui_gateway `_sess_nowait`). That is TERMINAL for the
+// id — no retry can recover it — so each poller must stop re-sending it. The
+// `process.list` status-stack poll learned this the hard way (#94219: one id
+// accumulated 18,614 rejections in a day), but `approval.pending` and the
+// `goal status` slash poll kept hammering, which is what a reaped window's
+// steady stream of rejected RPCs came from.
+//
+// The latch lives here (no imports from ./goals, ./prompts or
+// ./composer-status) so all three pollers can share ONE set and, crucially,
+// ONE clear path: whatever rebinds a fresh runtime resets every poller at once.
+import { JsonRpcGatewayError } from '@hermes/shared'
+
+const goneSessions = new Set<string>()
+
+/** Gateway JSON-RPC code for "session not found" (tui_gateway _sess_nowait). */
+const GATEWAY_SESSION_NOT_FOUND_CODE = 4001
+
+/** A gone session is unrecoverable for THIS runtime id; a timeout or transport
+ *  blip is not. Only the former may stop the poll — misclassifying a transient
+ *  failure would silently freeze the caller on a healthy session.
+ *
+ *  Match the gateway's 4001 code when the error carries one (JsonRpcGatewayError
+ *  from a structured RPC rejection) — a message substring alone could latch on
+ *  an unrelated error class that merely mentions "session not found" (e.g. a
+ *  wrapped tool/report string). The message fallback survives only for errors
+ *  with no numeric code at all, where the frame's structure was lost. */
+export function isSessionGoneForBackgroundPolling(error: unknown): boolean {
+  if (error instanceof JsonRpcGatewayError && typeof error.code === 'number') {
+    return error.code === GATEWAY_SESSION_NOT_FOUND_CODE
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return /session not found/i.test(message)
+}
+
+/** True while `sid` is latched off — skip the poll entirely. */
+export function isSessionGone(sid: string): boolean {
+  return goneSessions.has(sid)
+}
+
+/** Latch `sid` off until something rebinds a fresh runtime to it. */
+export function markSessionGone(sid: string): void {
+  goneSessions.add(sid)
+}
+
+/** Clear the gone-latch. Called with a session id when a fresh runtime binds to
+ *  it (so polling resumes), or with no argument to reset everything (tests). */
+export function resetBackgroundPollingGuard(sid?: string): void {
+  if (sid) {
+    goneSessions.delete(sid)
+
+    return
+  }
+
+  goneSessions.clear()
+}


### PR DESCRIPTION
## What does this PR do?

When a runtime id is reaped, `tui_gateway`'s `_sess_nowait` rejects every session-scoped RPC with `4001 "session not found"` — a terminal condition for that id. The `process.list` status-stack poll already latches the dead id off (#94219), but two other pollers never received the guard:

- `store/prompts.ts` → `replayPendingApproval` (`approval.pending`): no try/catch and no latch; callers swallow the rejection and it is re-driven on every gateway event.
- `store/goals.ts` → `refreshSessionGoal` (`slash.exec` `goal status`): a bare `catch {}` with no latch, so it re-asks on every refresh trigger.

The result is a window whose runtime was reaped streaming rejected RPCs for the rest of its life (measured in the issue: 1.6 rejections/sec sustained, worst single id 694 rejections), with a user-visible symptom of the composer losing focus mid-keystroke while the rejected-RPC error path runs.

This PR extracts the existing latch from `composer-status.ts` into a dependency-free `store/session-gone.ts` and routes all three pollers through the same gone-set:

- One shared set means one clear path: `resetBackgroundPollingGuard` is already called on every fresh-runtime rebind (`use-gateway-boot.ts`, `composer/status-stack/index.tsx`, `store/gateway.ts`), so a rebind resumes all three pollers and none can latch off permanently.
- The module has no imports from `./goals`, `./prompts` or `./composer-status`, so there is no import cycle (`composer-status.ts` already imports `./goals`).
- `composer-status.ts` re-exports `isSessionGoneForBackgroundPolling` and `resetBackgroundPollingGuard` so existing import sites are untouched.
- Transient failures (timeouts, transport blips) still retry and rethrow exactly as before — only the terminal 4001 class latches.

## Related Issue

Fixes #98554

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session-gone.ts` (new): the shared gone-latch — `isSessionGone`, `markSessionGone`, `isSessionGoneForBackgroundPolling`, `resetBackgroundPollingGuard`, moved verbatim from `composer-status.ts`.
- `apps/desktop/src/store/composer-status.ts`: inline latch replaced by the shared module; helpers re-exported so external importers are unchanged.
- `apps/desktop/src/store/goals.ts`: `refreshSessionGoal` skips latched ids and latches on a 4001 instead of silently retrying forever.
- `apps/desktop/src/store/prompts.ts`: `replayPendingApproval` skips latched ids, catches 4001 to latch, and rethrows anything transient.
- `apps/desktop/src/store/prompts.test.ts`: regression tests — 4001 latches off re-drives, transient errors still throw and retry, a runtime rebind resumes polling.
- `apps/desktop/src/store/goals.test.ts`: regression tests — 4001 latches off refresh triggers, transient errors do not latch.

## How to Test

1. `cd apps/desktop && npx vitest run src/store/prompts.test.ts src/store/goals.test.ts src/store/composer-status.test.ts`
   Observed result: 47 passed (3 files), including the 5 new dead-session-guard tests.
2. `npx vitest run` (full desktop suite)
   Observed result: 8715 passed / 1 failed — the single failure is `electron/managed-ssh-update.test.ts` ("POSIX managed launcher executes the updater command…"), which fails identically on a clean `upstream/main` checkout (it mis-creates macOS `/var/folders` temp paths as workspace-relative directories), i.e. pre-existing and unrelated to this change.
3. `npx tsc -p . --noEmit && npx tsc -p tsconfig.electron.json --noEmit && npx tsc -p tsconfig.e2e.json --noEmit` — all clean.
4. `npx eslint src/ electron/` — clean.

Manual shape (from the issue): open a Desktop session, let its runtime be reaped (WS drop past the orphan-reap grace), leave the window open — after this fix the gateway log shows one rejection per dead id and then silence, and typing in that window is no longer interrupted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (desktop TypeScript change; full desktop vitest suite run instead, see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure TypeScript store logic, no platform APIs touched
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A