### PR TITLE
fix(hindsight): preserve the official embedded lifecycle with MCP 2

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -17,6 +17,9 @@ from hermes_constants import get_hermes_home
 from hermes_cli.secret_prompt import masked_secret_prompt
 
 _CANCELLED = -1
+_DEFAULT_DEPENDENCY_INSTALL_TIMEOUT = 120
+_HEAVY_DEPENDENCY_INSTALL_TIMEOUT = 600
+_HINDSIGHT_EMBED_SPEC = "hindsight-embed==0.9.2"
 
 
 def _provider_pip_dependencies(provider_name: str, declared: list) -> list:
@@ -24,11 +27,11 @@ def _provider_pip_dependencies(provider_name: str, declared: list) -> list:
 
     ``plugin.yaml`` declares the provider's baseline bridge packages, but
     some providers install mode-dependent extras at setup time that the
-    manifest can't express. Hindsight's ``local_embedded`` mode installs
-    ``hindsight-all`` (daemon + embedder + client) during
-    ``hermes memory setup`` — if the update-time refresh only reinstalled
-    the declared ``hindsight-client``, the embedded daemon would stay
-    broken after a venv rebuild stripped ``hindsight-embed`` (#70636).
+    manifest can't express. Hindsight's ``local_embedded`` mode needs its
+    lightweight embed manager in addition to the client. The manager launches
+    ``hindsight-api`` out of process (using its version-matched ``uvx`` fallback),
+    which keeps the API's MCP-1 dependency tree separate from Hermes' MCP-2
+    client while preserving the official setup/update lifecycle (#95855).
     """
     deps = list(declared or [])
     if provider_name == "hindsight":
@@ -39,10 +42,27 @@ def _provider_pip_dependencies(provider_name: str, declared: list) -> list:
             mode = cfg.get("mode", "")
             # "local" is a legacy alias for "local_embedded"
             if mode in {"local", "local_embedded"}:
-                deps.append("hindsight-all")
+                deps.append(_HINDSIGHT_EMBED_SPEC)
         except Exception:
             pass
     return deps
+
+
+def _dependency_install_timeout(pip_deps: list[str]) -> int:
+    """Return the provider install budget for a dependency set.
+
+    The Hindsight embed manager is small, but first use may resolve its
+    version-matched API runtime and the setup/update contract must allow the
+    same multi-minute window as a cold local-embedded install. Other memory
+    bridges retain the existing fast-fail budget.
+    """
+    names = {
+        (re.match(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*", spec) or [spec])[0].lower()
+        for spec in pip_deps
+    }
+    if "hindsight-embed" in names:
+        return _HEAVY_DEPENDENCY_INSTALL_TIMEOUT
+    return _DEFAULT_DEPENDENCY_INSTALL_TIMEOUT
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +160,7 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
         "honcho-ai": "honcho",
         "mem0ai": "mem0",
         "hindsight-client": "hindsight_client",
-        "hindsight-all": "hindsight",
+        "hindsight-embed": "hindsight_embed",
     }
 
     # Check which packages need installation.
@@ -170,7 +190,7 @@ def _install_dependencies(provider_name: str, *, force: bool = False) -> None:
 
     manual_cmd = f"uv pip install {' '.join(missing)}"
     try:
-        outcome = install_specs(missing, timeout=120)
+        outcome = install_specs(missing, timeout=_dependency_install_timeout(missing))
         if outcome.ok:
             print(f"  ✓ Installed {', '.join(missing)}")
         elif outcome.blocked:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2814,8 +2814,8 @@ def _refresh_active_memory_provider_dependencies() -> None:
     """Refresh pip dependencies for the configured external memory provider.
 
     Memory-provider bridge packages are declared in each provider's
-    ``plugin.yaml`` (plus mode-dependent extras like Hindsight's
-    ``hindsight-all``), NOT in Hermes' editable-install extras or
+    ``plugin.yaml`` (plus mode-dependent extras like Hindsight's lightweight
+    ``hindsight-embed`` manager), NOT in Hermes' editable-install extras or
     ``LAZY_DEPS`` alone — so the core dependency reinstall above can strip
     or downgrade them (#53272 mem0ai, #70636 hindsight-embed). Re-run the
     provider's declared install for the ACTIVE provider only, after the

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6296,7 +6296,7 @@ _MEMORY_PROVIDER_IMPORT_NAMES = {
     "honcho-ai": "honcho",
     "mem0ai": "mem0",
     "hindsight-client": "hindsight_client",
-    "hindsight-all": "hindsight",
+    "hindsight-embed": "hindsight_embed",
 }
 
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -28,7 +28,7 @@ Connects to the Hindsight Cloud API. Requires an API key from [ui.hindsight.vect
 
 ### Local Embedded
 
-Hermes spins up a local Hindsight daemon with built-in PostgreSQL. Requires an LLM API key for memory extraction and synthesis. The daemon starts automatically in the background on first use and stops after 5 minutes of inactivity.
+Hermes manages a local Hindsight daemon with built-in PostgreSQL through Hindsight's published embed manager. The manager launches a version-matched `hindsight-api` process (using its isolated `uvx` fallback when needed), so the daemon's dependencies do not replace Hermes' own MCP client packages. The daemon starts automatically in the background on first use and stops after 5 minutes of inactivity.
 
 Supports any OpenAI-compatible LLM endpoint (llama.cpp, vLLM, LM Studio, etc.) — pick `openai_compatible` as the provider and enter the base URL.
 
@@ -145,6 +145,6 @@ Available in `hybrid` and `tools` memory modes:
 | `HINDSIGHT_BUDGET` | Override recall budget |
 | `HINDSIGHT_MODE` | Override mode (`cloud`, `local_embedded`, `local_external`) |
 
-## Client Version
+## Runtime Versions
 
-Requires `hindsight-client >= 0.6.1`. The plugin auto-upgrades on session start if an older version is detected.
+Hermes pins `hindsight-client == 0.9.2`. `local_embedded` additionally uses `hindsight-embed == 0.9.2`; install and repair both through `hermes memory setup` / `hermes update` rather than installing `hindsight-all` into the Hermes environment.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -255,6 +255,12 @@ class _ManagedEmbeddedHindsight:
         return self._manager.get_url(self.profile)
 
     @property
+    def client(self):
+        """Return the high-level client, matching HindsightEmbedded's contract."""
+        self._ensure_started()
+        return self._client
+
+    @property
     def is_running(self) -> bool:
         return (
             self._started

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -72,7 +72,9 @@ class _RecallResult:
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+_MIN_CLIENT_VERSION = "0.9.2"
+_CLIENT_RUNTIME_SPEC = "hindsight-client==0.9.2"
+_EMBED_RUNTIME_SPEC = "hindsight-embed==0.9.2"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # ``metadata.source`` stamped on retained memories — OPT-IN, empty by default.
@@ -152,25 +154,18 @@ def _export_port_health_grace_timeout(config: dict[str, Any]) -> None:
 
 
 def _check_local_runtime() -> tuple[bool, str | None]:
-    """Return whether local embedded Hindsight imports cleanly.
+    """Return whether Hermes can manage a local embedded Hindsight daemon.
 
-    On older CPUs, importing the local Hindsight stack can raise a runtime
-    error from NumPy before the daemon starts. Treat that as "unavailable"
-    so Hermes can degrade gracefully instead of repeatedly trying to start
-    a broken local memory backend.
-
-    The embedded daemon computes embeddings via ``sentence_transformers``
-    (transformers + huggingface-hub). Importing ``hindsight`` /
-    ``hindsight_embed`` alone succeeds even when that stack is broken, so
-    without importing it here the probe would falsely report the backend
-    healthy and ``hermes memory status`` would stay green while the daemon
-    aborts at startup on every retain/recall. Import it too so the probe (and
-    status) reports the real ImportError.
+    Do not import the ``hindsight`` all-in-one facade here. It eagerly imports
+    the API server and FastMCP stack into Hermes' process, where Hindsight's
+    MCP-1 requirement conflicts with Hermes' MCP-2 client. The lightweight
+    embed manager already launches the API out of process through its isolated,
+    version-matched ``uvx`` fallback; Hermes only needs that manager and the
+    HTTP client in its own environment (#95855).
     """
     try:
-        importlib.import_module("hindsight")
         importlib.import_module("hindsight_embed.daemon_embed_manager")
-        importlib.import_module("sentence_transformers")
+        importlib.import_module("hindsight_client").Hindsight
         return True, None
     except Exception as exc:
         return False, str(exc)
@@ -179,26 +174,103 @@ def _check_local_runtime() -> tuple[bool, str | None]:
 def _local_runtime_hint(reason: str | None) -> str:
     """Actionable install guidance when the local_embedded runtime is missing.
 
-    ``local_embedded`` imports ``from hindsight import HindsightEmbedded``, which
-    is provided only by the ``hindsight-all`` package (its wheel ships the
-    top-level ``hindsight`` module). ``plugin.yaml`` declares only
-    ``hindsight-client`` (enough for cloud / local_external), so a user who
-    selected local_embedded without going through ``hermes memory setup`` — a
-    hand-written config, the legacy ``"mode": "local"`` alias, or a restored
-    backup — hits ``ModuleNotFoundError: No module named 'hindsight'``.
-    NousResearch/hermes-agent#7718.
+    ``local_embedded`` uses Hindsight's lightweight embed manager plus its HTTP
+    client. A hand-written/restored config can omit either package, so point the
+    operator back to the supported setup flow without suggesting
+    ``hindsight-all`` (which conflicts with Hermes' MCP-2 runtime).
     """
     text = (reason or "").lower()
-    if "no module named" in text and ("hindsight'" in text or 'hindsight"' in text
-                                      or "hindsight_embed" in text):
+    if "no module named" in text and (
+        "hindsight_embed" in text or "hindsight_client" in text
+    ):
         return (
-            f" Install the embedded runtime with: uv pip install --python "
-            f"{sys.executable} hindsight-all — or run 'hermes memory setup'. "
-            "(local_embedded needs the 'hindsight-all' package, which provides the "
-            "top-level 'hindsight' module; 'hindsight-client' alone only covers "
-            "cloud / local_external.)"
+            f" Run 'hermes memory setup' to restore the supported local_embedded "
+            f"runtime (hindsight-client + hindsight-embed) for {sys.executable}."
         )
     return ""
+
+
+class _ManagedEmbeddedHindsight:
+    """Hindsight client backed by the upstream out-of-process embed manager.
+
+    This mirrors the lifecycle surface Hermes used from ``HindsightEmbedded``
+    without importing the all-in-one server facade into the Hermes process.
+    Dependency and daemon version selection remain owned by the published
+    Hindsight packages: ``hindsight-embed`` resolves ``hindsight-api`` at its
+    own version through ``uvx`` when no compatible sibling binary is present.
+    """
+
+    def __init__(self, *, profile: str, daemon_config: dict[str, str]):
+        from hindsight_client import Hindsight
+        from hindsight_embed import get_embed_manager
+
+        self.profile = profile
+        self.config = dict(daemon_config)
+        self._client_type = Hindsight
+        self._manager = get_embed_manager()
+        self._client = None
+        self._lock = threading.Lock()
+        self._started = False
+        self._closed = False
+
+    def _discard_stale_client(self) -> None:
+        client = self._client
+        self._client = None
+        self._started = False
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                logger.debug("Error closing stale Hindsight client", exc_info=True)
+
+    def _ensure_started(self) -> None:
+        if self._started and self._client is not None:
+            if self._manager.is_running(self.profile):
+                return
+            self._discard_stale_client()
+
+        with self._lock:
+            if self._started and self._client is not None:
+                if self._manager.is_running(self.profile):
+                    return
+                self._discard_stale_client()
+            if self._closed:
+                raise RuntimeError("Cannot use embedded Hindsight after it has been closed")
+            if not self._manager.ensure_running(self.config, self.profile):
+                raise RuntimeError(
+                    f"Failed to start daemon for Hindsight profile '{self.profile}'"
+                )
+            self._client = self._client_type(
+                base_url=self._manager.get_url(self.profile)
+            )
+            self._started = True
+
+    def __getattr__(self, name: str):
+        self._ensure_started()
+        return getattr(self._client, name)
+
+    @property
+    def url(self) -> str:
+        self._ensure_started()
+        return self._manager.get_url(self.profile)
+
+    @property
+    def is_running(self) -> bool:
+        return (
+            self._started
+            and not self._closed
+            and self._client is not None
+            and self._manager.is_running(self.profile)
+        )
+
+    def close(self, stop_daemon: bool = False) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._discard_stale_client()
+            if stop_daemon:
+                self._manager.stop(self.profile)
+            self._closed = True
 
 
 def _ensure_cloud_client_dependency() -> None:
@@ -982,10 +1054,9 @@ class HindsightMemoryProvider(MemoryProvider):
         env_writes: dict = {}
 
         # Step 2: Install/upgrade deps for selected mode
-        cloud_dep = f"hindsight-client>={_MIN_CLIENT_VERSION}"
-        local_dep = "hindsight-all"
+        cloud_dep = _CLIENT_RUNTIME_SPEC
         if mode == "local_embedded":
-            deps_to_install = [local_dep]
+            deps_to_install = [cloud_dep, _EMBED_RUNTIME_SPEC]
         elif mode == "local_external":
             deps_to_install = [cloud_dep]
         else:
@@ -1015,9 +1086,13 @@ class HindsightMemoryProvider(MemoryProvider):
         print("\n  Checking dependencies...")
         # Environment-aware install: sealed hosted venvs redirect to the durable
         # data-volume target instead of writing to /opt/hermes (NS-605).
+        from hermes_cli.memory_setup import _dependency_install_timeout
         from tools.lazy_deps import install_specs
 
-        outcome = install_specs(deps_to_install, timeout=120)
+        outcome = install_specs(
+            deps_to_install,
+            timeout=_dependency_install_timeout(deps_to_install),
+        )
         if outcome.ok:
             print("  ✓ Dependencies up to date")
         elif outcome.blocked:
@@ -1247,40 +1322,46 @@ class HindsightMemoryProvider(MemoryProvider):
                     pass
                 except Exception as _e:
                     raise ImportError(str(_e))
-                from hindsight import HindsightEmbedded
-                HindsightEmbedded.__del__ = lambda self: None
-                llm_provider = self._config.get("llm_provider", "")
-                if llm_provider in {"openai_compatible", "openrouter"}:
-                    llm_provider = "openai"
-                logger.debug("Creating HindsightEmbedded client (profile=%s, provider=%s)",
-                             self._config.get("profile", "hermes"), llm_provider)
-                kwargs = dict(
-                    profile=self._config.get("profile", "hermes"),
-                    llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or get_secret("HINDSIGHT_LLM_API_KEY", ""),
-                    llm_model=self._config.get("llm_model", ""),
-                )
-                if self._llm_base_url:
-                    kwargs["llm_base_url"] = self._llm_base_url
+                base_config = self._config if isinstance(self._config, dict) else {}
                 idle_timeout = _parse_int_setting(
-                    self._config.get("idle_timeout")
-                    if self._config.get("idle_timeout") is not None
+                    base_config.get("idle_timeout")
+                    if base_config.get("idle_timeout") is not None
                     else os.environ.get("HINDSIGHT_IDLE_TIMEOUT", self._idle_timeout),
                     _DEFAULT_IDLE_TIMEOUT,
                 )
                 self._idle_timeout = idle_timeout
-                kwargs["idle_timeout"] = idle_timeout
-                self._client = HindsightEmbedded(**kwargs)
+                runtime_config: dict[str, Any] = dict(base_config)
+                runtime_config["idle_timeout"] = idle_timeout
+                if self._llm_base_url:
+                    runtime_config["llm_base_url"] = self._llm_base_url
+                llm_api_key = (
+                    base_config.get("llmApiKey")
+                    or base_config.get("llm_api_key")
+                    or get_secret("HINDSIGHT_LLM_API_KEY", "")
+                )
+                profile = base_config.get("profile", "hermes")
+                logger.debug(
+                    "Creating managed embedded Hindsight client (profile=%s)",
+                    profile,
+                )
+                self._client = _ManagedEmbeddedHindsight(
+                    profile=profile,
+                    daemon_config=_build_embedded_profile_env(
+                        runtime_config,
+                        llm_api_key=llm_api_key,
+                    ),
+                )
             else:
                 _ensure_cloud_client_dependency()
                 from hindsight_client import Hindsight
                 timeout = self._timeout or _DEFAULT_TIMEOUT
-                kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
-                if self._api_key:
-                    kwargs["api_key"] = self._api_key
                 logger.debug("Creating Hindsight cloud client (url=%s, has_key=%s, timeout=%s)",
-                             self._api_url, bool(self._api_key), kwargs["timeout"])
-                self._client = Hindsight(**kwargs)
+                             self._api_url, bool(self._api_key), float(timeout))
+                self._client = Hindsight(
+                    base_url=self._api_url,
+                    api_key=self._api_key or None,
+                    timeout=float(timeout),
+                )
         return self._client
 
     def _run_sync(self, coro):
@@ -1810,18 +1891,19 @@ class HindsightMemoryProvider(MemoryProvider):
                     dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 
                     client = self._get_client()
-                    profile = self._config.get("profile", "hermes")
+                    base_config = self._config if isinstance(self._config, dict) else {}
+                    profile = base_config.get("profile", "hermes")
 
                     # Update the profile .env to match our current config so
                     # the daemon always starts with the right settings.
                     # If the config changed and the daemon is running, stop it.
-                    profile_env = _embedded_profile_env_path(self._config)
-                    expected_env = _build_embedded_profile_env(self._config)
+                    profile_env = _embedded_profile_env_path(base_config)
+                    expected_env = _build_embedded_profile_env(base_config)
                     saved = _load_simple_env(profile_env)
                     config_changed = saved != expected_env
 
                     if config_changed:
-                        profile_env = _materialize_embedded_profile_env(self._config)
+                        profile_env = _materialize_embedded_profile_env(base_config)
                         if client._manager.is_running(profile):
                             with open(log_path, "a", encoding="utf-8") as f:
                                 f.write("\n=== Config changed, restarting daemon ===\n")
@@ -2440,7 +2522,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     if inner_client is not None and hasattr(inner_client, "aclose"):
                         _run_sync(inner_client.aclose())
                         try:
-                            self._client._client = None
+                            setattr(self._client, "_client", None)
                         except Exception:
                             pass
                     try:

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.6.1"
+  - "hindsight-client==0.9.2"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.9.2"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
@@ -414,7 +414,7 @@ exclude-newer = "14 days"
 # cutoff can still brick installs. Exempting exact pins is pure brick-risk
 # removal at no supply-chain cost. Guarded by
 # tests/test_packaging_metadata.py::test_build_system_requires_exempt_from_exclude_newer.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false, hindsight-client = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -67,6 +68,45 @@ def test_write_env_vars_strips_line_separators_and_nul(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+def test_local_embedded_uses_lightweight_upstream_runtime_packages(tmp_path, monkeypatch):
+    """The official update path must not install hindsight-all beside MCP 2.x."""
+    hermes_home = tmp_path / "hermes-home"
+    config_path = hermes_home / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(json.dumps({"mode": "local_embedded"}), encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: hermes_home)
+
+    deps = memory_setup._provider_pip_dependencies(
+        "hindsight", ["hindsight-client==0.9.2"]
+    )
+
+    assert deps == ["hindsight-client==0.9.2", "hindsight-embed==0.9.2"]
+    assert all(not spec.startswith("hindsight-all") for spec in deps)
+
+
+def test_local_external_keeps_client_only(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    config_path = hermes_home / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(json.dumps({"mode": "local_external"}), encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: hermes_home)
+
+    deps = memory_setup._provider_pip_dependencies(
+        "hindsight", ["hindsight-client==0.9.2"]
+    )
+
+    assert deps == ["hindsight-client==0.9.2"]
+
+
+def test_dependency_install_timeout_extends_embedded_manager_only():
+    assert memory_setup._dependency_install_timeout(
+        ["hindsight-client==0.9.2", "hindsight-embed==0.9.2"]
+    ) == 600
+    assert memory_setup._dependency_install_timeout(
+        ["hindsight-client==0.9.2"]
+    ) == 120
+
+
 
 
 
@@ -96,6 +136,38 @@ def test_install_dependencies_force_reinstalls_versioned_specs(tmp_path, monkeyp
 
     assert installed, "force=True must reach the install step"
     assert any("mem0ai>=2.0.10,<3" in specs for specs in installed)
+
+
+def test_update_reinstalls_official_local_embedded_dependencies(tmp_path, monkeypatch):
+    """`hermes update` force-refresh preserves the complete embedded contract."""
+    import yaml as _yaml
+
+    plugin_dir = tmp_path / "hindsight-plugin"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        _yaml.safe_dump({"pip_dependencies": ["hindsight-client==0.9.2"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("plugins.memory.find_provider_dir", lambda name: plugin_dir)
+    hermes_home = tmp_path / "hermes-home"
+    config_path = hermes_home / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(json.dumps({"mode": "local_embedded"}), encoding="utf-8")
+    monkeypatch.setattr(memory_setup, "get_hermes_home", lambda: hermes_home)
+
+    installed = []
+
+    def fake_install_specs(specs, timeout=120):
+        installed.append((list(specs), timeout))
+        return SimpleNamespace(ok=True, blocked=False, reason="", stderr="")
+
+    monkeypatch.setattr("tools.lazy_deps.install_specs", fake_install_specs)
+
+    memory_setup._install_dependencies("hindsight", force=True)
+
+    assert installed == [
+        (["hindsight-client==0.9.2", "hindsight-embed==0.9.2"], 600)
+    ]
 
 
 def test_cmd_status_memory_tool_gate_disabled(capsys, monkeypatch):

--- a/tests/plugins/memory/test_hindsight_local_runtime_hint.py
+++ b/tests/plugins/memory/test_hindsight_local_runtime_hint.py
@@ -1,11 +1,4 @@
-"""NousResearch/hermes-agent#7718 — actionable message when local_embedded
-runtime (`hindsight-all`) is missing.
-
-`local_embedded` imports `from hindsight import HindsightEmbedded`, provided
-only by `hindsight-all`. When it's absent the provider disables itself; the
-disable warning should point the user at the fix rather than just echoing
-`No module named 'hindsight'`.
-"""
+"""Actionable local_embedded runtime checks for the MCP-2-safe package split."""
 
 import sys
 
@@ -13,16 +6,35 @@ import plugins.memory.hindsight as hs
 from plugins.memory.hindsight import HindsightMemoryProvider, _local_runtime_hint
 
 
-def test_hint_for_missing_hindsight_all():
-    hint = _local_runtime_hint("No module named 'hindsight'")
-    assert "hindsight-all" in hint
+def test_hint_for_missing_hindsight_embed():
+    hint = _local_runtime_hint("No module named 'hindsight_embed'")
+    assert "hindsight-embed" in hint
+    assert "hindsight-all" not in hint
     assert "hermes memory setup" in hint
     assert sys.executable in hint
 
 
-def test_hint_for_missing_hindsight_embed():
-    hint = _local_runtime_hint("No module named 'hindsight_embed.daemon_embed_manager'")
-    assert "hindsight-all" in hint
+def test_hint_for_missing_hindsight_client():
+    hint = _local_runtime_hint("No module named 'hindsight_client'")
+    assert "hindsight-client" in hint
+    assert "hindsight-all" not in hint
+
+
+def test_local_runtime_probe_avoids_full_server_stack(monkeypatch):
+    calls = []
+
+    def fake_import(name):
+        calls.append(name)
+        if name == "hindsight_client":
+            return type("ClientModule", (), {"Hindsight": object})
+        return object()
+
+    monkeypatch.setattr(hs.importlib, "import_module", fake_import)
+
+    assert hs._check_local_runtime() == (True, None)
+    assert calls == ["hindsight_embed.daemon_embed_manager", "hindsight_client"]
+    assert "hindsight" not in calls
+    assert "sentence_transformers" not in calls
 
 
 def test_no_hint_for_unrelated_runtime_error():
@@ -37,9 +49,10 @@ def test_no_hint_for_unrelated_runtime_error():
 
 def test_unavailable_reason_surfaces_hint_for_local_embedded(monkeypatch):
     monkeypatch.setattr(hs, "_load_config", lambda: {"mode": "local_embedded"})
-    monkeypatch.setattr(hs, "_check_local_runtime", lambda: (False, "No module named 'hindsight'"))
+    monkeypatch.setattr(hs, "_check_local_runtime", lambda: (False, "No module named 'hindsight_embed'"))
     reason = HindsightMemoryProvider().unavailable_reason()
-    assert "hindsight-all" in reason
+    assert "hindsight-embed" in reason
+    assert "hindsight-all" not in reason
     assert reason == reason.strip()  # no leading/trailing whitespace
 
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -399,6 +399,7 @@ class TestConfig:
         )
         assert created[0].kwargs == {"base_url": "http://127.0.0.1:9177"}
         assert client.url == "http://127.0.0.1:9177"
+        assert getattr(client, "client") is created[0]
 
 
 class TestPostSetup:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -345,14 +345,31 @@ class TestConfig:
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
 
 
-    def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
-        captured = {}
+    def test_get_client_uses_embed_manager_without_importing_hindsight_all(self, monkeypatch):
+        manager = MagicMock()
+        manager.ensure_running.return_value = True
+        manager.get_url.return_value = "http://127.0.0.1:9177"
+        manager.is_running.return_value = True
 
-        class FakeHindsightEmbedded:
+        created = []
+
+        class FakeHindsight:
             def __init__(self, **kwargs):
-                captured.update(kwargs)
+                self.kwargs = kwargs
+                created.append(self)
 
-        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+        monkeypatch.setitem(
+            sys.modules,
+            "hindsight_embed",
+            SimpleNamespace(get_embed_manager=lambda: manager),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "hindsight_client",
+            SimpleNamespace(Hindsight=FakeHindsight),
+        )
+        monkeypatch.delitem(sys.modules, "hindsight", raising=False)
+        monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
 
         p = HindsightMemoryProvider()
@@ -366,13 +383,53 @@ class TestConfig:
         }
         p._llm_base_url = "http://localhost:8060/v1"
 
-        p._get_client()
+        client = p._get_client()
+        client._ensure_started()
 
-        assert captured["idle_timeout"] == 0
-        assert captured["llm_provider"] == "openai"
+        manager.ensure_running.assert_called_once_with(
+            {
+                "HINDSIGHT_API_LLM_PROVIDER": "openai",
+                "HINDSIGHT_API_LLM_API_KEY": "test-key",
+                "HINDSIGHT_API_LLM_MODEL": "test-model",
+                "HINDSIGHT_API_LOG_LEVEL": "info",
+                "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT": "0",
+                "HINDSIGHT_API_LLM_BASE_URL": "http://localhost:8060/v1",
+            },
+            "hermes",
+        )
+        assert created[0].kwargs == {"base_url": "http://127.0.0.1:9177"}
+        assert client.url == "http://127.0.0.1:9177"
 
 
 class TestPostSetup:
+    def test_local_embedded_setup_installs_lightweight_runtime_with_extended_timeout(
+        self, tmp_path, monkeypatch
+    ):
+        import tools.lazy_deps as lazy_deps_mod
+
+        selections = iter([1, 0])  # local_embedded, openai
+        monkeypatch.setattr(
+            "hermes_cli.memory_setup._curses_select",
+            lambda *args, **kwargs: next(selections),
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "test-key")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+        calls = []
+
+        def fake_install_specs(specs, timeout=120):
+            calls.append((list(specs), timeout))
+            return lazy_deps_mod.InstallSpecsResult(ok=True)
+
+        monkeypatch.setattr(lazy_deps_mod, "install_specs", fake_install_specs)
+
+        HindsightMemoryProvider().post_setup(str(tmp_path), {"memory": {}})
+
+        assert calls == [
+            (["hindsight-client==0.9.2", "hindsight-embed==0.9.2"], 600)
+        ]
+
     def test_setup_cancel_at_mode_picker_writes_nothing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -286,6 +286,30 @@ def test_build_system_requires_exempt_from_exclude_newer():
     )
 
 
+def test_hindsight_client_pin_and_embedded_runtime_versions_stay_aligned():
+    """Setup, update, lazy repair, and lockfile must select one Hindsight line."""
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    assert data["project"]["optional-dependencies"]["hindsight"] == [
+        "hindsight-client==0.9.2"
+    ]
+    assert data["tool"]["uv"]["exclude-newer-package"].get("hindsight-client") is False
+    assert _locked_versions("hindsight-client") == {"0.9.2"}
+
+    plugin_manifest = (REPO_ROOT / "plugins" / "memory" / "hindsight" / "plugin.yaml").read_text(
+        encoding="utf-8"
+    )
+    lazy_deps = (REPO_ROOT / "tools" / "lazy_deps.py").read_text(encoding="utf-8")
+    setup = (REPO_ROOT / "hermes_cli" / "memory_setup.py").read_text(encoding="utf-8")
+    provider = (REPO_ROOT / "plugins" / "memory" / "hindsight" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
+    assert '"hindsight-client==0.9.2"' in plugin_manifest
+    assert '"memory.hindsight": ("hindsight-client==0.9.2",)' in lazy_deps
+    assert '_HINDSIGHT_EMBED_SPEC = "hindsight-embed==0.9.2"' in setup
+    assert '_CLIENT_RUNTIME_SPEC = "hindsight-client==0.9.2"' in provider
+    assert '_EMBED_RUNTIME_SPEC = "hindsight-embed==0.9.2"' in provider
+
+
 
 
 def _lazy_deps_by_feature():

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.9.2",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/uv.lock
+++ b/uv.lock
@@ -13,17 +13,18 @@ exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
 setuptools = false
-h2 = false
+huggingface-hub = false
 vercel = false
 pillow = false
 unpaddedbase64 = false
+h2 = false
 defusedxml = false
 aiohttp = false
 cryptography = false
-mcp = false
+hindsight-client = false
 python-olm = false
+mcp = false
 nemo-relay = false
-huggingface-hub = false
 
 [manifest]
 overrides = [
@@ -1868,7 +1869,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.9.2" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
@@ -1966,7 +1967,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1976,9 +1977,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/21/18dd524c25d440466fa9377e4754b336cde0cc94bb566619913880198aa3/hindsight_client-0.9.2.tar.gz", hash = "sha256:bf6877da5d423395a4b0ac8ac8fc1836f5f5da271613a76e38903437af136ea1", size = 152096, upload-time = "2026-08-25T10:20:30.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/88ef406d96902a8ae6b6ba09afe8ac06bb4d3460eac1a7b741735ba41475/hindsight_client-0.9.2-py3-none-any.whl", hash = "sha256:31d26d116a07da5203bc913c5ed017de95d875edd5e295afad3c05373665ff6b", size = 358546, upload-time = "2026-08-25T10:20:29.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes the supported Hindsight `local_embedded` lifecycle without putting Hindsight's server dependency graph into Hermes' MCP 2 environment.

- install `hindsight-client==0.9.2` for all Hindsight modes
- install `hindsight-embed==0.9.2` for `local_embedded`
- use Hindsight's upstream embed manager to launch the matching `uvx hindsight-api@0.9.2` server out of process
- stop installing `hindsight-all` into Hermes' managed environment
- give provider-aware setup/update installs a 600-second timeout
- align plugin metadata, lazy dependency registration, extras, lockfile, docs, setup UI, and updater behavior
- preserve the `HindsightEmbedded.client` wrapper contract in the lightweight adapter

## Why

Hermes currently pins MCP 2, while the `hindsight-all` server stack resolves through MCP 1.x. Installing both into one environment either downgrades/breaks Hermes' MCP surface or fails dependency checks. Hindsight's published `hindsight-embed` manager already provides the intended boundary and starts a version-matched API through `uvx`, so Hermes can retain lifecycle ownership without maintaining a private server integration.

Related: #95855. This also subsumes the dependency-version part of #98527.

## Verification

- 109 targeted setup/provider/packaging tests passed
- 167 memory-setup web-server tests passed
- follow-up provider regression suite: 85 passed
- Ruff passed for changed Python files
- real disposable `hermes memory setup hindsight` selected `local_embedded` and exited 0
- installed environment verified as:
  - `mcp==2.0.0`
  - `hindsight-client==0.9.2`
  - `hindsight-embed==0.9.2`
  - no `hindsight-all`, `hindsight-api-slim`, or `fastmcp-slim` in Hermes
- `uv pip check`: compatible
- provider resolved server command `uvx hindsight-api@0.9.2`
- `/health`: HTTP 200 with database connected
- forced update-time dependency refresh re-established the same package set

Eight broad update-command tests also fail unchanged on clean `origin/main` because they inspect the live macOS launchd gateway instead of an isolated fixture; they are not introduced by this patch.
