### PR TITLE
fix(model-picker): honor excluded_providers for the virtual MoA row

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -4008,7 +4008,12 @@ def list_picker_providers(
         for_picker=True,
         excluded_providers=excluded_providers,
     )
-    if include_moa:
+    excluded = {
+        str(provider).strip().lower()
+        for provider in (excluded_providers or [])
+        if str(provider).strip()
+    }
+    if include_moa and "moa" not in excluded:
         providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)
 
     filtered: List[dict] = []

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -19,6 +19,7 @@ from hermes_cli.model_switch import (
     _fetch_picker_live_models,
     _save_discovered_models_to_config,
     list_authenticated_providers,
+    list_picker_providers,
     switch_model,
 )
 from hermes_cli.providers import resolve_provider_full
@@ -1683,6 +1684,20 @@ def test_excluded_providers_hides_builtin_row(monkeypatch):
     assert not any(p["slug"] == "openrouter" for p in filtered), (
         "excluded_providers=['openrouter'] must hide the openrouter row"
     )
+
+
+def test_excluded_providers_hides_virtual_moa_row(monkeypatch):
+    """The virtual MoA picker row must honor the same exclusion setting."""
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers", lambda **kwargs: []
+    )
+
+    filtered = list_picker_providers(
+        include_moa=True,
+        excluded_providers=["moa"],
+    )
+
+    assert not any(p["slug"] == "moa" for p in filtered)
 
 
 def test_custom_provider_context_length_models_dict_still_probes(monkeypatch):


### PR DESCRIPTION
## Bug

`model_catalog.excluded_providers` filters real providers out of the model picker (`hermes model`), but the synthetic `moa` (Mixture-of-Agents) row is injected *after* that filtering pass in `list_picker_providers()`, so adding `moa` to `excluded_providers` had no effect — the MoA row still showed up.

## Fix

Compute the excluded-provider set once, before the MoA injection branch, and skip injecting the row when `moa` is in it — the same treatment real providers already get.

## Testing

- Added `test_excluded_providers_hides_virtual_moa_row` (regression test).
- Full `tests/hermes_cli/test_model_switch_custom_providers.py` suite: 71 passed, 0 failed, on top of current `main` (66666f6e2e).

Small, targeted, single call-site fix — no other behavior changed.