### PR TITLE
fix(agent): fail over cron turns on provider timeouts

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1231,7 +1231,11 @@ def classify_api_error(
     # ── 8. Transport / timeout heuristics ───────────────────────────
 
     if error_type in _TRANSPORT_ERROR_TYPES or isinstance(error, (TimeoutError, ConnectionError, OSError)):
-        return _result(FailoverReason.timeout, retryable=True)
+        return _result(
+            FailoverReason.timeout,
+            retryable=True,
+            should_fallback=True,
+        )
 
     # ── 9. Fallback: unknown ────────────────────────────────────────
 
@@ -2048,7 +2052,11 @@ def _classify_by_message(
     # loop rebuilds the client instead of treating the turn as an empty
     # model response.
     if any(p in error_msg for p in _TIMEOUT_MESSAGE_PATTERNS):
-        return result_fn(FailoverReason.timeout, retryable=True)
+        return result_fn(
+            FailoverReason.timeout,
+            retryable=True,
+            should_fallback=True,
+        )
 
     # Connection-establishment / DNS failure message patterns — same shim
     # problem as the timeout patterns above: the wrapping exception type is
@@ -2058,7 +2066,11 @@ def _classify_by_message(
     # client rebuild apply. Never routes to compression: a connection that
     # was never established is not a context-overflow signal.
     if any(p in error_msg for p in _CONNECTION_MESSAGE_PATTERNS):
-        return result_fn(FailoverReason.timeout, retryable=True)
+        return result_fn(
+            FailoverReason.timeout,
+            retryable=True,
+            should_fallback=True,
+        )
 
     return None
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -459,6 +459,16 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.timeout
         assert result.retryable is True
 
+    def test_timeout_is_retryable_and_requests_provider_fallback(self):
+        """A stale non-streaming provider call must hand off to the next
+        provider instead of exhausting the cron turn on the same backend."""
+        result = classify_api_error(
+            TimeoutError("Non-streaming API call timed out after 180s with no response")
+        )
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+        assert result.should_fallback is True
+
     def test_400_bad_request_still_non_retryable_format_error(self):
         """Guard the boundary: a genuine 400 Bad Request must remain a
         non-retryable format_error and must not be swept up by the 408 branch."""


### PR DESCRIPTION
## Problem

Cron jobs with a configured provider fallback chain never fail over when the
primary provider times out. The turn exhausts its retries on the dead
provider and dies with:

```
RuntimeError: Non-streaming API call timed out after 180s with no response (threshold: 180s)
API calls: 0
```

No fallback provider is ever attempted, even though `fallback_providers` is
configured. A nightly job observed in production: primary Ollama Cloud
timed out after 180s, `API calls: 0`, duration 549s, and the configured
fallback chain (Nous Portal → OpenRouter → local oMLX) was never reached.

## Root cause

In `agent/error_classifier.py`, transport/timeout errors are classified as
`retryable=True` but `should_fallback=False`:

- `_TRANSPORT_ERROR_TYPES` and `isinstance(error, (TimeoutError, ConnectionError, OSError))`
- `_TIMEOUT_MESSAGE_PATTERNS`
- `_CONNECTION_MESSAGE_PATTERNS`

A retryable-but-no-fallback classification makes the conversation loop keep
retrying the same failing provider until the turn budget is exhausted, then
ends the turn — the fallback chain is never activated. Every other
recoverable error class (429, 5xx) already requests fallback; timeouts are
the only path that gets stuck retrying into the void.

## Fix

Add `should_fallback=True` to all three timeout/transport/connection
classification paths. A provider that cannot respond within the deadline
is no more likely to respond on the next attempt than one returning 429;
it should hand off to the next configured provider instead of burning the
turn.

## Tests

Added regression test `test_timeout_is_retryable_and_requests_provider_fallback`
asserting timeouts remain retryable but now request provider fallback.

- `pytest tests/agent/test_error_classifier.py` — 123 passed
- `pytest tests/run_agent/test_provider_fallback.py` — 46 passed
- `pytest tests/run_agent/test_32646_fallback_429_after_timeout.py` — 5 passed

## Related

- #33729 — fast-fail 503/529 capacity errors to fallback chain (complementary:
  that PR covers server errors, this covers transport timeouts)
