### PR TITLE
fix(streaming): read reasoning from delta.model_extra for custom OpenAI-compatible providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4248,8 +4248,27 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if hasattr(chunk, "model") and chunk.model:
                 model_name = chunk.model
 
-            # Accumulate reasoning content
-            reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+            # Accumulate reasoning content.
+            # Primary: SDK-promoted attributes (native DeepSeek / Moonshot).
+            # Fallback: model_extra dict — custom OpenAI-compatible gateways
+            # (e.g. a relay fronting deepseek-v4-flash) forward reasoning as
+            # an extra SSE field.  The SDK (openai>=1.54) promotes known extras
+            # from its known-model schema; an *unknown* provider is not in the
+            # schema, so reasoning lands in model_extra but NOT on the delta
+            # object as a named attr.  Without this fallback, streaming
+            # reasoning is silently dropped after the first tool call on custom
+            # providers (#98224).
+            reasoning_text = (
+                getattr(delta, "reasoning_content", None)
+                or getattr(delta, "reasoning", None)
+            )
+            if not reasoning_text and hasattr(delta, "model_extra"):
+                _delta_extra = getattr(delta, "model_extra", None) or {}
+                if isinstance(_delta_extra, dict):
+                    reasoning_text = (
+                        _delta_extra.get("reasoning_content")
+                        or _delta_extra.get("reasoning")
+                    )
             if reasoning_text:
                 # Summary-part models (gpt-5.x and other Responses relays) send
                 # one complete markdown block per delta with no separator, so


### PR DESCRIPTION
## Problem (#98224)

Custom OpenAI-compatible gateways that front reasoning models (DeepSeek, GLM) forward reasoning as an extra SSE field. The OpenAI SDK promotes it from \delta.model_extra\ to a named attribute **only when it recognises the provider** in its schema. For unknown/custom providers, reasoning lands only in \model_extra['reasoning']\ — NOT on \delta.reasoning\ or \delta.reasoning_content\.

The streaming accumulator in \gent/chat_completion_helpers.py\ read only the named attributes, so **streaming reasoning was silently dropped after the first tool call** on custom providers. The built-in \pi.deepseek.com\ provider worked because the SDK promotes the field for known endpoints.

## Fix

Add a \model_extra\ fallback in the streaming delta loop (lines 4251–4264). When neither \delta.reasoning_content\ nor \delta.reasoning\ is set, check \delta.model_extra\ for the same keys. No behaviour change for built-in providers where the SDK already promotes the field.

Fixes #98224