### PR TITLE
fix(desktop): clear queue-drain failure counters on mount to prevent misleading banner after restart

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -53,6 +53,15 @@ export function useBackgroundQueueDrain({
   const retryTimersRef = useRef<number[]>([])
   const [retryTick, setRetryTick] = useState(0)
 
+  // On mount, clear any failure counters carried over from a previous process.
+  // After an app restart all session runtimes are reaped; the backend is
+  // starting up fresh, so previous failure counts that tripped MAX_AUTO_DRAIN
+  // do NOT represent real send failures — they were rejections against a dead
+  // runtime.  Resetting on mount gives each entry a clean slate so the banner
+  // is not shown on the first interaction after a restart (#98015).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { drainFailuresRef.current.clear() }, [])
+
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
     submitTextRef.current = submitText


### PR DESCRIPTION
## Problem (#98015)

After an app restart all session runtimes are reaped. The composer queue persists in \localStorage\, so queued entries survive. On first drain attempt after restart, \untimeIdByStoredSessionIdRef\ has no entry yet (runtime is reconnecting), so \submitText\ returns \alse\. After 4 fast retries the hook shows the \queueStuckTitle\ / \queueStuckBody\ banner — even though the message is safely in the queue and will send once the runtime is ready.

## Fix

Clear \drainFailuresRef\ on mount. Each fresh process starts with a clean slate so the banner never fires because of reaped runtimes from a previous process. The banner still fires for genuine send failures in the same process lifetime.

Fixes #98015