### PR TITLE
fix(install): add hard timeout to Electron binary download in install.ps1 to unblock stalled connectivity

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3918,11 +3918,27 @@ function Restore-ElectronDist {
     $prevMirror = $env:ELECTRON_MIRROR
     if ($Mirror) { $env:ELECTRON_MIRROR = $Mirror }
     try {
-        # Out-Host so the downloader's progress shows on the console WITHOUT
-        # leaking into this function's return value (PowerShell returns every
-        # object left on the output stream, so a bare pipe here would make the
-        # boolean below ambiguous).
-        & $node.Source $installer 2>&1 | ForEach-Object { "$_" } | Out-Host
+        # Run install.js with a hard wall-clock timeout.
+        # On networks with poor GitHub connectivity (e.g. mainland China) the
+        # Electron binary download can stall silently for 20+ minutes (#98049).
+        # Use the same run_with_timeout pattern as the node-deps stage (600s
+        # default, overridable via ELECTRON_DOWNLOAD_TIMEOUT env var).
+        $electronDlTimeoutSec = 600
+        if ($env:ELECTRON_DOWNLOAD_TIMEOUT -match '^\d+$') {
+            $electronDlTimeoutSec = [int]$env:ELECTRON_DOWNLOAD_TIMEOUT
+        }
+        $job = Start-Job -ScriptBlock {
+            param($nodeSrc, $inst)
+            & $nodeSrc $inst 2>&1
+        } -ArgumentList $node.Source, $installer
+        $finished = Wait-Job -Job $job -Timeout $electronDlTimeoutSec
+        if ($finished) {
+            Receive-Job -Job $job | ForEach-Object { "$_" } | Out-Host
+        } else {
+            Stop-Job -Job $job
+            Write-Warn "Electron download timed out after ${electronDlTimeoutSec}s — will retry with mirror."
+        }
+        Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
     } catch {
     } finally {
         $env:ELECTRON_MIRROR = $prevMirror


### PR DESCRIPTION
## Problem (#98049)

On networks with poor GitHub CDN connectivity (mainland China), \electron/install.js\ stalls with zero throughput for 20+ minutes. \install.ps1\'s \Restore-ElectronDist\ ran \
ode install.js\ without a timeout, blocking the entire bootstrap indefinitely.

## Fix

Wrap the \
ode install.js\ call in \Start-Job\ + \Wait-Job\ with a 600 s timeout (overridable via \ELECTRON_DOWNLOAD_TIMEOUT\ env var). When the download stalls the job is killed and \Restore-ElectronDist\ returns \\False\, allowing \Try-RestoreElectronDist\ to retry with the fallback \ELECTRON_MIRROR\ — the same recovery path that already handles explicit network failures.

Fixes #98049