### PR TITLE
feat(kanban): add non_dispatchable_assignees gate for human-owner lanes

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2811,6 +2811,12 @@ DEFAULT_CONFIG = {
         # the assigned profile with the bundled sdlc-review skill. Disable for
         # boards where every review is performed manually from the dashboard.
         "review_dispatch": True,
+        # Assignees the dispatcher must never spawn workers for, even though
+        # they are real Hermes profiles — e.g. a human-owner lane created for
+        # identity/shared memory with no model configured. Listed lanes are
+        # treated like control-plane lanes: their cards are skipped as
+        # non-spawnable in both the ready and review columns.
+        "non_dispatchable_assignees": [],
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9569,12 +9569,18 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     ).fetchall()
     if not rows:
         return False
+    # ``kanban.non_dispatchable_assignees`` lanes are never spawned, so
+    # they are "correctly idle" — otherwise a human-owner lane parked in
+    # ready would fire a permanent false "dispatcher stuck" warning.
+    _exempt = non_dispatchable_assignees()
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
         # Can't introspect — assume spawnable, preserve legacy behavior.
         return True
     for row in rows:
+        if row["assignee"].lower() in _exempt:
+            continue
         if profile_exists(row["assignee"]):
             return True
     return False
@@ -9595,11 +9601,14 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     ).fetchall()
     if not rows:
         return False
+    _exempt = non_dispatchable_assignees()
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
         return True
     for row in rows:
+        if row["assignee"].lower() in _exempt:
+            continue
         if profile_exists(row["assignee"]):
             return True
     return False
@@ -9619,6 +9628,50 @@ def review_dispatch_enabled() -> bool:
         )
     except Exception:
         return True
+
+
+def non_dispatchable_assignees() -> set:
+    """Assignees the dispatcher must never spawn workers for.
+
+    ``kanban.non_dispatchable_assignees: [<profile>, ...]`` opts a real,
+    addressable Hermes profile out of autonomous dispatch entirely — the
+    per-assignee counterpart of ``kanban.review_dispatch``. The canonical
+    use case is a human-owner lane: a real profile (created for identity
+    and shared memory) with no model configured. ``profile_exists`` is
+    ``True`` for such a lane, so without this list the dispatcher spawns a
+    worker that exits immediately, and the block-recurrence breaker files
+    a card that was waiting on a person as ``blocked``.
+
+    Entries are normalized with the same rules as profile directories, so
+    a title-cased dashboard label still matches its lowercase lane.
+    """
+    try:
+        from hermes_cli.config import load_config
+        raw = (load_config() or {}).get("kanban", {}).get(
+            "non_dispatchable_assignees", []
+        )
+    except Exception:
+        return set()
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return set()
+    try:
+        from hermes_cli.profiles import normalize_profile_name
+    except Exception:
+        normalize_profile_name = None  # type: ignore[assignment]
+    out = set()
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        if normalize_profile_name is not None:
+            try:
+                out.add(normalize_profile_name(entry))
+                continue
+            except Exception:
+                pass
+        out.add(entry.strip().lower())
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -10111,6 +10164,10 @@ def _dispatch_once_locked(
     # We also resolve profile_exists once here for the same reason.
     _default_assignee = (default_assignee or "").strip() or None
     _default_assignee_resolved = False
+    # Per-assignee dispatch exemption: resolve the operator's
+    # non-dispatchable list once per tick so a human-owner lane is never
+    # spawned, no matter how many of its cards sit in the queue.
+    _non_dispatchable = non_dispatchable_assignees()
     if _default_assignee:
         try:
             from hermes_cli.profiles import profile_exists as _pe
@@ -10190,6 +10247,14 @@ def _dispatch_once_locked(
             # this distinction to suppress spurious "stuck" warnings on
             # multi-lane setups where the ready queue is steadily full
             # of human-pulled work.
+            result.skipped_nonspawnable.append(row["id"])
+            continue
+        # Opted out of autonomous dispatch via
+        # ``kanban.non_dispatchable_assignees`` — a real profile (so the
+        # check above passed) that must never be spawned, such as a
+        # human-owner lane. Same bucket as terminal lanes: expected
+        # steady-state, not an operator-actionable failure.
+        if row_assignee.lower() in _non_dispatchable:
             result.skipped_nonspawnable.append(row["id"])
             continue
         # Per-profile concurrency cap (#21582): even if there's global
@@ -10338,6 +10403,13 @@ def _dispatch_once_locked(
         except Exception:
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row["assignee"]):
+            result.skipped_nonspawnable.append(row["id"])
+            continue
+        # ``kanban.non_dispatchable_assignees`` applies to the review lane
+        # too: a human-owner lane opted out of autonomous dispatch must
+        # not get a reviewer spawned behind the back of the ready loop's
+        # exemption.
+        if row["assignee"].lower() in _non_dispatchable:
             result.skipped_nonspawnable.append(row["id"])
             continue
         if _per_profile_cap is not None:

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -414,6 +414,91 @@ def test_review_dispatch_gate_prevents_phantom_reviewer(
         assert tid in [s[0] for s in res_on.spawned]
 
 
+def test_non_dispatchable_assignee_exempt_from_ready_and_review(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``kanban.non_dispatchable_assignees`` must stop the dispatcher from
+    spawning a real-but-human lane in BOTH columns.
+
+    A human-owner lane is a real profile (``profile_exists`` is True), so the
+    nonexistent-profile guard cannot catch it: without the exemption the
+    worker spawns, exits on the missing model, and the block-recurrence
+    breaker files a waiting-on-a-person card as ``blocked``. Flipping the
+    list off proves the exemption — not something else — suppressed the
+    spawn."""
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    # Every assignee is a real profile: only the exemption list can stop
+    # a spawn.
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"non_dispatchable_assignees": ["product-owner"]}},
+    )
+
+    with kb.connect() as conn:
+        human_ready = kb.create_task(conn, title="human lane", assignee="product-owner")
+        bot_ready = kb.create_task(conn, title="bot lane", assignee="worker")
+        human_review = kb.create_task(conn, title="human review", assignee="product-owner")
+        claimed = kb.claim_task(conn, human_review)
+        assert claimed is not None
+        kb.request_review(
+            conn, human_review, summary="done",
+            expected_run_id=claimed.current_run_id,
+        )
+        assert kb.get_task(conn, human_review).status == "review"
+
+        res = kb.dispatch_once(conn, dry_run=True)
+        spawned_ids = [s[0] for s in res.spawned]
+
+        # The human lane is skipped in both columns, bucketed as
+        # non-spawnable (steady-state, not operator-actionable).
+        assert human_ready not in spawned_ids
+        assert human_review not in spawned_ids
+        assert human_ready in res.skipped_nonspawnable
+        assert human_review in res.skipped_nonspawnable
+        # Real autonomous workers are unaffected.
+        assert bot_ready in spawned_ids
+
+        # Telemetry: a queue holding ONLY exempt lanes is correctly idle,
+        # not stuck.
+        assert kb.has_spawnable_ready(conn) is True  # bot lane present
+        conn.execute("DELETE FROM tasks WHERE assignee = 'worker'")
+        assert kb.has_spawnable_ready(conn) is False
+        assert kb.has_spawnable_review(conn) is False
+
+        # Exemption off -> the human lane is spawned again (proves the gate).
+        monkeypatch.setattr(
+            cfgmod, "load_config",
+            lambda *a, **k: {"kanban": {"non_dispatchable_assignees": []}},
+        )
+        res_on = kb.dispatch_once(conn, dry_run=True)
+        assert human_ready in [s[0] for s in res_on.spawned]
+
+
+def test_non_dispatchable_assignee_matches_case_insensitively(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dashboard tools may pass title-cased display labels; the exemption
+    must match them against the lowercase lane the same way profile
+    validation does."""
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"non_dispatchable_assignees": ["Product-Owner"]}},
+    )
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="human lane", assignee="product-owner")
+        res = kb.dispatch_once(conn, dry_run=True)
+        assert tid not in [s[0] for s in res.spawned]
+        assert tid in res.skipped_nonspawnable
+
+
 def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
     kanban_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Adds `kanban.non_dispatchable_assignees: [<profile>, ...]` to opt a real Hermes profile out of autonomous dispatch entirely — the per-assignee counterpart of `kanban.review_dispatch`. 

A **human-owner lane** is a real profile (created for identity and shared memory) with no model configured: `profile_exists` returns `True`, so the existing nonexistent-profile guard cannot catch it. Without this list, the dispatcher spawns a worker that exits immediately on the missing model, and the block-recurrence breaker files a card that was waiting on a person as `blocked`.

The request in #98560 described 22 such stuck cards before the reporter deployed an external job racing the dispatch tick — a strong signal this is a real fleet pain.

## Changes

- Add `kanban.non_dispatchable_assignees` config; normalize entries with `normalize_profile_name` so title-cased dashboard labels match the lowercase lane.
- Resolve the list once per tick alongside `profile_exists`, consult it in both ready and review loops, and bucket matches into `skipped_nonspawnable` (steady-state, not operator-actionable).
- Apply the exemption to `has_spawnable_ready` / `has_spawnable_review` so health telemetry sees a queue full of exempt lanes as "correctly idle", not "dispatcher stuck".
- Tests: exempt lane is skipped in both columns; other assignees spawn; title-cased config matches lowercase lane; telemetry behaves correctly.

## Testing

```sh
uv run pytest -xv tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_default_assignee.py
# 23 passed in 2.38s
```

Full kanban suite passing on my fork — this change touches the ready/review dispatch paths, the two busiest hot loops, so CI's broader platform matrix will verify there's no cross-platform drift.

Closes #98560
