### PR TITLE
fix(state): reduce _READ_POOL_MAX 8→4 to halve peak state.db file-descriptor budget

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -382,7 +382,23 @@ _READ_OPEN_RETRY_SECONDS = 60.0
 # close. Once permits are gone the read path degrades to the locked writer
 # connection instead of opening more descriptors — slower under load, which is
 # the correct trade against a process-wide wedge the supervisor cannot see.
-_READ_POOL_MAX = 8
+# Read-connection pool ceiling per SessionDB instance.
+#
+# Each open connection holds two file descriptors (state.db + state.db-wal).
+# A gateway process runs at least two SessionDB instances (tui_gateway +
+# gateway/run.py shared db), so the peak fd budget is:
+#
+#   instances × pool_max × 2 fds/conn + 2 writer fds/instance
+#
+# With pool_max=8: 2 × 8 × 2 + 2 × 2 = 36 fds from state.db alone.
+# On macOS the default soft RLIMIT_NOFILE is 256; combined with httpx
+# sockets and subprocess pipes a long-lived gateway with many worker threads
+# exhausted the limit (#98573).
+#
+# Reduce to 4: 2 × 4 × 2 + 2 × 2 = 20 fds — a 45 % reduction in the
+# worst case, with minimal read latency regression (WAL readers share pages
+# in the page cache; the 4th+ concurrent reader is uncommon in practice).
+_READ_POOL_MAX = 4
 
 # Import-time snapshot used by _default_db_path() to detect a deliberately
 # re-pointed DEFAULT_DB_PATH (tests monkeypatch the constant directly).


### PR DESCRIPTION
## Problem (#98573)

A long-lived gateway holds ≥2 \SessionDB\ instances. With \_READ_POOL_MAX=8\, peak \state.db\ fd usage is \2 × 8 × 2 + 4 = 36\ fds (each connection holds \state.db\ + \state.db-wal\). Combined with httpx sockets and subprocess pipes this exhausts the macOS 256-fd soft \RLIMIT_NOFILE\, causing \OSError: Too many open files\ in unrelated code paths on a healthy process the supervisor never restarts.

## Fix

Reduce \_READ_POOL_MAX\ from \8\ to \4\. Peak drops to 20 fds — a 45% reduction. WAL read-concurrency is shared via the page cache; the 4th+ simultaneous reader is uncommon in practice. The fallback overflow path (degrade to the locked writer connection) is already implemented and measured by \_read_permit_exhausted\.

Fixes #98573