### PR TITLE
fix: surface provider queueing/rate-limit backoff in live UI status

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1632,9 +1632,8 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     elapsed=_elapsed,
                 )
                 agent._emit_wait_notice(
-                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                    f"{int(_elapsed)}s with no response yet (provider may be slow "
-                    f"or overloaded{_recovery})"
+                    f"⏳ 等待 {api_kwargs.get('model', 'the provider')} — "
+                    f"已 {int(_elapsed)} 秒无响应（对方可能较慢或过载{_recovery}）"
                 )
             except Exception:
                 logger.debug("wait-notice construction failed", exc_info=True)
@@ -1682,8 +1681,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
             except Exception:
                 pass
             agent._emit_wait_notice(
-                f"⚠ no response from provider in {int(_elapsed)}s — "
-                f"reconnecting..."
+                f"⚠ 无响应：对方 {int(_elapsed)} 秒未返回 — 正在重新连接..."
             )
             agent._touch_activity(
                 f"codex stream killed after {int(_elapsed)}s with no first byte"
@@ -5181,9 +5179,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 else:
                     _recovery = ""
                 agent._emit_wait_notice(
-                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                    f"{_waiting_secs}s with no output yet (provider may be "
-                    f"slow or overloaded, or the model is thinking{_recovery})"
+                    f"⏳ 等待 {api_kwargs.get('model', 'the provider')} — "
+                    f"已 {_waiting_secs} 秒无输出（对方可能较慢或过载，"
+                    f"或模型正在思考{_recovery}）"
                 )
             else:
                 # Chunks are flowing — keep the activity tracker fresh but
@@ -5243,8 +5241,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()
             agent._emit_wait_notice(
-                f"⚠ no output from provider for {int(_stale_elapsed)}s — "
-                f"reconnecting..."
+                f"⚠ 无输出：对方 {int(_stale_elapsed)} 秒未返回 — 正在重新连接..."
             )
             agent._touch_activity(
                 f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -612,15 +612,15 @@ def _provider_wait_notice_text(
     """Live wait-state line for provider queueing/rate-limit backoff.
 
     Surfaced through ``_emit_wait_notice`` → ``thinking.delta`` on
-    CLI/TUI/Desktop. The desktop provider-wait row only renders text whose
-    prefix matches ``⏳ waiting on`` (see apps/desktop/src/store/provider-wait.ts
+    CLI/TUI/Desktop. The desktop provider-wait row renders text whose prefix
+    matches ``⏳ waiting on``/``⏳ 等待`` (see apps/desktop/src/store/provider-wait.ts
     ``providerWaitText``), so keep that phrasing — a 429 from a queueing
     provider (e.g. coding-plan Token Plan) otherwise reads as a frozen turn
     while Hermes silently backs off.
     """
     return (
-        f"⏳ waiting on {model} — provider queueing/rate-limited, "
-        f"retrying in {wait_time:.0f}s (attempt {retry_count}/{max_retries})"
+        f"⏳ 等待 {model} — 对方排队/限流中，"
+        f"{wait_time:.0f} 秒后重试（第 {retry_count}/{max_retries} 次）"
     )
 
 
@@ -7124,9 +7124,8 @@ def run_conversation(
                     # without a distinct notice the user only sees a generic
                     # thinking spinner ("infinite thinking", #64434).
                     agent._emit_wait_notice(
-                        f"↻ model returned reasoning with no final answer — "
-                        f"asking it to continue "
-                        f"({agent._codex_incomplete_retries}/3)"
+                        f"↻ 模型已返回推理但无最终答复 — "
+                        f"正在请它继续（{agent._codex_incomplete_retries}/3）"
                     )
                     agent._session_messages = messages
                     continue

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -603,6 +603,27 @@ def _ra():
     return run_agent
 
 
+def _provider_wait_notice_text(
+    model: Any,
+    retry_count: int,
+    max_retries: int,
+    wait_time: float,
+) -> str:
+    """Live wait-state line for provider queueing/rate-limit backoff.
+
+    Surfaced through ``_emit_wait_notice`` → ``thinking.delta`` on
+    CLI/TUI/Desktop. The desktop provider-wait row only renders text whose
+    prefix matches ``⏳ waiting on`` (see apps/desktop/src/store/provider-wait.ts
+    ``providerWaitText``), so keep that phrasing — a 429 from a queueing
+    provider (e.g. coding-plan Token Plan) otherwise reads as a frozen turn
+    while Hermes silently backs off.
+    """
+    return (
+        f"⏳ waiting on {model} — provider queueing/rate-limited, "
+        f"retrying in {wait_time:.0f}s (attempt {retry_count}/{max_retries})"
+    )
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -3559,12 +3580,18 @@ def run_conversation(
                             }
                         time.sleep(0.2)
                         # Touch activity every ~30s so the gateway's inactivity
-                        # monitor knows we're alive during backoff waits.
+                        # monitor knows we're alive during backoff waits.  Also
+                        # surface the wait on the live spinner/status line
+                        # (CLI/TUI/Desktop thinking.delta) — a provider that is
+                        # queueing or rate-limiting (429) otherwise reads as a
+                        # frozen turn with no explanation.
                         _backoff_touch_counter += 1
                         if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
-                            agent._touch_activity(
-                                f"retry backoff ({retry_count}/{max_retries}), "
-                                f"{int(sleep_end - time.time())}s remaining"
+                            _remaining_s = int(sleep_end - time.time())
+                            agent._emit_wait_notice(
+                                _provider_wait_notice_text(
+                                    agent.model, retry_count, max_retries, _remaining_s
+                                )
                             )
                     if _retry.restart_with_redirected_messages:
                         break  # rebuild this iteration from the correction
@@ -6669,6 +6696,22 @@ def run_conversation(
                         agent._emit_status(_rate_limit_status)
                     else:
                         agent._buffer_status(_rate_limit_status)
+                    # Immediate live wait notice (CLI/TUI/Desktop thinking.delta):
+                    # a 429 from a queueing provider (e.g. coding-plan Token Plan)
+                    # otherwise reads as a frozen turn while Hermes silently backs
+                    # off. The desktop provider-wait row matches the "⏳ waiting on"
+                    # prefix, so keep that phrasing.
+                    try:
+                        agent._emit_wait_notice(
+                            _provider_wait_notice_text(
+                                agent.model,
+                                retry_count + 1,
+                                max_retries,
+                                wait_time,
+                            )
+                        )
+                    except Exception:
+                        logger.debug("rate-limit wait notice failed", exc_info=True)
                 else:
                     agent._buffer_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")
                 logger.warning(
@@ -6706,12 +6749,18 @@ def run_conversation(
                         }
                     time.sleep(0.2)  # Check interrupt every 200ms
                     # Touch activity every ~30s so the gateway's inactivity
-                    # monitor knows we're alive during backoff waits.
+                    # monitor knows we're alive during backoff waits.  Also
+                    # surface the wait on the live spinner/status line
+                    # (CLI/TUI/Desktop thinking.delta) — a rate-limited or
+                    # overloaded provider (429) otherwise reads as a frozen
+                    # turn while Hermes silently retries.
                     _backoff_touch_counter += 1
                     if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
-                        agent._touch_activity(
-                            f"error retry backoff ({retry_count}/{max_retries}), "
-                            f"{int(sleep_end - time.time())}s remaining"
+                        _remaining_s = int(sleep_end - time.time())
+                        agent._emit_wait_notice(
+                            _provider_wait_notice_text(
+                                agent.model, retry_count, max_retries, _remaining_s
+                            )
                         )
                 if _retry.restart_with_redirected_messages:
                     # Leave the retry loop — the check right below rebuilds this

--- a/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.test.tsx
@@ -70,6 +70,16 @@ describe('ResponseLoadingIndicator timer', () => {
 
     expect(screen.getByText('⏳ waiting on local-model — 30s with no output yet')).toBeTruthy()
   })
+
+  it('renders the Chinese queueing wait notice from the 429 backoff path', () => {
+    $activeSessionId.set('session-a')
+    $turnStartedAt.set(Date.now())
+    setSessionProviderWait('session-a', '⏳ 等待 qwen3.8-flash — 对方排队/限流中，45 秒后重试（第 2/4 次）')
+
+    renderIndicator()
+
+    expect(screen.getByText('⏳ 等待 qwen3.8-flash — 对方排队/限流中，45 秒后重试（第 2/4 次）')).toBeTruthy()
+  })
 })
 
 // The status line sits between tool rows and thinking headers, which the

--- a/apps/desktop/src/store/provider-wait.ts
+++ b/apps/desktop/src/store/provider-wait.ts
@@ -45,5 +45,5 @@ export function clearAllProviderWaits(): void {
 export function providerWaitText(text: string): string {
   const value = text.trim()
 
-  return /^(?:⏳|⚠|↻)\s*(?:waiting on|no (?:output|response)|model returned)/i.test(value) ? value : ''
+  return /^(?:⏳|⚠|↻)\s*(?:waiting on|no (?:output|response)|model returned|等待|无(?:输出|响应)|模型已返回)/i.test(value) ? value : ''
 }

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -230,7 +230,7 @@ def test_moa_heartbeat_survives_infinite_stale_timeout(monkeypatch):
 
     assert result is response
     assert len(notices) == 1
-    assert "waiting on openai-xai-wide" in notices[0]
+    assert "等待 openai-xai-wide" in notices[0]
     assert "auto-reconnect" not in notices[0]
 
 

--- a/tests/run_agent/test_wait_state_visibility.py
+++ b/tests/run_agent/test_wait_state_visibility.py
@@ -10,6 +10,7 @@ gateway's "⏳ Working — N min" heartbeat includes).
 
 from __future__ import annotations
 
+import re
 import sys
 import time
 import types
@@ -63,6 +64,44 @@ def test_emit_wait_notice_without_callback_still_touches_activity(tmp_path, monk
     assert "waiting on test-model" in agent.get_activity_summary()["last_activity_desc"]
 
 
+
+
+def test_backoff_wait_notice_matches_desktop_provider_wait_contract(tmp_path, monkeypatch):
+    """The 429/queueing backoff notice must survive the desktop's
+    ``providerWaitText`` filter — that row only renders text whose prefix
+    matches ``⏳ waiting on`` / ``⚠ no output`` / ``↻ model returned``.
+    Regression guard: if someone rewrites the phrasing and breaks the
+    cross-surface contract, the queueing hint silently vanishes from the UI
+    and the user is back to an unexplained frozen spinner.
+    """
+    from agent.conversation_loop import _provider_wait_notice_text
+
+    # Mirror of apps/desktop/src/store/provider-wait.ts providerWaitText().
+    provider_wait_re = re.compile(
+        r"^(?:⏳|⚠|↻)\s*(?:waiting on|no (?:output|response)|model returned)",
+        re.I,
+    )
+
+    notice = _provider_wait_notice_text("qwen3.8-flash", 2, 4, 45.0)
+    assert provider_wait_re.match(notice), f"desktop would drop this notice: {notice!r}"
+    assert "qwen3.8-flash" in notice
+    assert "45s" in notice
+    assert "(attempt 2/4)" in notice
+
+
+def test_backoff_wait_notice_roundtrip_to_thinking_callback(tmp_path, monkeypatch):
+    """The helper's output flows through _emit_wait_notice into the live
+    thinking_callback (the thinking.delta bridge) unchanged."""
+    from agent.conversation_loop import _provider_wait_notice_text
+
+    seen: list = []
+    agent = _make_agent(tmp_path, monkeypatch, thinking_callback=seen.append)
+    notice = _provider_wait_notice_text("qwen3.8-flash", 3, 4, 12.0)
+
+    agent._emit_wait_notice(notice)
+
+    assert seen == [notice]
+    assert "waiting on qwen3.8-flash" in agent.get_activity_summary()["last_activity_desc"]
 
 
 def test_nonstream_wait_loop_emits_explained_notice(tmp_path, monkeypatch):

--- a/tests/run_agent/test_wait_state_visibility.py
+++ b/tests/run_agent/test_wait_state_visibility.py
@@ -78,15 +78,15 @@ def test_backoff_wait_notice_matches_desktop_provider_wait_contract(tmp_path, mo
 
     # Mirror of apps/desktop/src/store/provider-wait.ts providerWaitText().
     provider_wait_re = re.compile(
-        r"^(?:⏳|⚠|↻)\s*(?:waiting on|no (?:output|response)|model returned)",
+        r"^(?:⏳|⚠|↻)\s*(?:waiting on|no (?:output|response)|model returned|等待|无(?:输出|响应)|模型已返回)",
         re.I,
     )
 
     notice = _provider_wait_notice_text("qwen3.8-flash", 2, 4, 45.0)
     assert provider_wait_re.match(notice), f"desktop would drop this notice: {notice!r}"
     assert "qwen3.8-flash" in notice
-    assert "45s" in notice
-    assert "(attempt 2/4)" in notice
+    assert "45" in notice
+    assert "2/4" in notice
 
 
 def test_backoff_wait_notice_roundtrip_to_thinking_callback(tmp_path, monkeypatch):
@@ -101,7 +101,7 @@ def test_backoff_wait_notice_roundtrip_to_thinking_callback(tmp_path, monkeypatc
     agent._emit_wait_notice(notice)
 
     assert seen == [notice]
-    assert "waiting on qwen3.8-flash" in agent.get_activity_summary()["last_activity_desc"]
+    assert "等待 qwen3.8-flash" in agent.get_activity_summary()["last_activity_desc"]
 
 
 def test_nonstream_wait_loop_emits_explained_notice(tmp_path, monkeypatch):
@@ -147,6 +147,6 @@ def test_nonstream_wait_loop_emits_explained_notice(tmp_path, monkeypatch):
     finally:
         stop["flag"] = True
 
-    reconnect_notices = [s for s in seen if "reconnecting" in s]
+    reconnect_notices = [s for s in seen if "重新连接" in s]
     assert reconnect_notices, f"expected a reconnect wait-notice, saw: {seen}"
-    assert "no response from provider" in reconnect_notices[0]
+    assert "无响应" in reconnect_notices[0]


### PR DESCRIPTION
## Summary
When a provider returns 429 (queueing/rate-limited — e.g. coding-plan Token Plan), the retry loop silently backs off 5–120s while CLI/TUI/Desktop show an unexplained frozen spinner. The wait was only buffered (`_buffer_status`) and dropped on eventual success, so users could not tell a queueing provider from a hung turn.

This emits the existing `_emit_wait_notice` (→ `thinking.delta` → desktop provider-wait row) at three points:
- immediately when a 429/overload is classified (with attempt count + wait time)
- every ~30s during the invalid-response backoff heartbeat
- every ~30s during the exception-path backoff heartbeat

The notice text is generated by a new `_provider_wait_notice_text()` helper so the cross-surface contract (desktop `providerWaitText` prefix match) is unit-testable.

**Localization**: all user-facing wait/reconnect notices are now Chinese (the operator's language):
- `⏳ 等待 qwen3.8-flash — 对方排队/限流中，45 秒后重试（第 2/4 次）`
- `⚠ 无响应：对方 30 秒未返回 — 正在重新连接...`
- `⚠ 无输出：对方 30 秒未返回 — 正在重新连接...`
- `↻ 模型已返回推理但无最终答复 — 正在请它继续（1/3）`
- plus the existing 30s no-output / TTFB reconnect lines

**Desktop filter**: `providerWaitText` previously matched only English prefixes (`⏳ waiting on` / `⚠ no output` / `↻ model returned`), which would silently drop the localized text. Extended to also match `⏳ 等待` / `⚠ 无输出|无响应` / `↻ 模型已返回`.

## Test Plan
- Python: `tests/run_agent/test_wait_state_visibility.py` — desktop-contract regex mirror (bilingual), roundtrip through `thinking_callback`, reconnect notice. `tests/agent/test_codex_ttfb_watchdog.py` updated for localized phrasing. 13/13 pass.
- Desktop: `status.test.tsx` adds a Chinese queueing-notice render case.
