### PR TITLE
fix(tools): re-bridge terminal env per profile home, not once per process

### DIFF
--- a/tests/tools/test_docker_session_isolation.py
+++ b/tests/tools/test_docker_session_isolation.py
@@ -44,8 +44,14 @@ def _clean_state(monkeypatch):
     with terminal_tool._session_cwd_lock:
         before_cwd = dict(terminal_tool._session_cwd)
         terminal_tool._session_cwd.clear()
-    # The config→env bridge is one-shot; mark it done so tests control env vars.
-    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
+    # The config→env bridge runs once per Hermes home; mark it done for the
+    # active home so tests control env vars directly.
+    from hermes_constants import hermes_home_key
+    monkeypatch.setattr(
+        terminal_tool,
+        "_terminal_config_bridge_state",
+        {"home": hermes_home_key(), "owned": set()},
+    )
     yield
     terminal_tool._task_env_overrides.clear()
     terminal_tool._task_env_overrides.update(before_overrides)

--- a/tests/tools/test_terminal_degraded_mode.py
+++ b/tests/tools/test_terminal_degraded_mode.py
@@ -27,9 +27,12 @@ def isolated_env(tmp_path, monkeypatch):
     import tools.terminal_tool as tt
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
-    # The one-shot config bridge would overwrite our TERMINAL_* test vars
-    # from the developer's real config.yaml; mark it as already attempted.
-    monkeypatch.setattr(tt, "_terminal_config_bridge_attempted", True)
+    # The config bridge would overwrite our TERMINAL_* test vars from the
+    # developer's real config.yaml; mark it as already run for this home.
+    from hermes_constants import hermes_home_key
+    monkeypatch.setattr(
+        tt, "_terminal_config_bridge_state", {"home": hermes_home_key(), "owned": set()}
+    )
 
     def _clear():
         with tt._env_lock:

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -11,13 +11,13 @@ import os
 import pytest
 
 import tools.terminal_tool as terminal_tool
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
 
 
 @pytest.fixture(autouse=True)
 def _reset_bridge_state(monkeypatch):
     """Each test starts with an un-attempted bridge and clean mapped env."""
-    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_state", None)
     for name in (
         "TERMINAL_ENV",
         "TERMINAL_CWD",
@@ -152,3 +152,65 @@ def test_bridge_config_failure_does_not_crash(monkeypatch):
 
     assert config["env_type"] == "ssh"
     assert config["ssh_host"] == "example.test"
+
+
+def test_profile_switch_serves_each_profiles_terminal_backend(tmp_path):
+    """A unified dashboard backend serves non-default profiles under a
+    context-local HERMES_HOME override; each profile must execute commands
+    with ITS configured terminal backend, not the launch profile's (#98581 —
+    profiles with ``terminal.backend: docker`` ran on the host instead)."""
+    launch_home = tmp_path / "root"
+    docker_home = tmp_path / "root" / "profiles" / "web"
+    docker_home.mkdir(parents=True)
+    (launch_home / "config.yaml").write_text("terminal:\n  backend: local\n")
+    (docker_home / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n  docker_image: sandbox/image:1\n"
+    )
+
+    launch_token = set_hermes_home_override(str(launch_home))
+    try:
+        assert terminal_tool._get_env_config()["env_type"] == "local"
+
+        profile_token = set_hermes_home_override(str(docker_home))
+        try:
+            config = terminal_tool._get_env_config()
+        finally:
+            reset_hermes_home_override(profile_token)
+
+        assert config["env_type"] == "docker"
+        assert config["docker_image"] == "sandbox/image:1"
+        assert os.environ["TERMINAL_ENV"] == "docker"
+
+        # Back on the launch profile: the profile's docker selection must
+        # not stick, and the launch backend applies again.
+        assert terminal_tool._get_env_config()["env_type"] == "local"
+        assert os.environ["TERMINAL_ENV"] == "local"
+    finally:
+        reset_hermes_home_override(launch_token)
+
+
+def test_profile_switch_drops_launch_terminal_selection(tmp_path):
+    """TERMINAL_* vars owned by the launch profile's bridge must not survive a
+    switch to a profile without a terminal section — the unconfigured profile
+    falls back to the local default, not the launch profile's backend."""
+    launch_home = tmp_path / "root"
+    plain_home = tmp_path / "root" / "profiles" / "plain"
+    plain_home.mkdir(parents=True)
+    (launch_home / "config.yaml").write_text("terminal:\n  backend: docker\n")
+    (plain_home / "config.yaml").write_text("agent:\n  max_turns: 100\n")
+
+    launch_token = set_hermes_home_override(str(launch_home))
+    try:
+        assert terminal_tool._get_env_config()["env_type"] == "docker"
+        assert os.environ["TERMINAL_ENV"] == "docker"
+
+        profile_token = set_hermes_home_override(str(plain_home))
+        try:
+            config = terminal_tool._get_env_config()
+        finally:
+            reset_hermes_home_override(profile_token)
+
+        assert config["env_type"] == "local"
+        assert os.environ["TERMINAL_ENV"] == "local"
+    finally:
+        reset_hermes_home_override(launch_token)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1703,11 +1703,18 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
-# One-shot guard for the config-fallback bridge below.  Purely an
-# optimization: after the first attempt either TERMINAL_ENV is set (bridge
-# succeeded — merged config always carries terminal.backend) or the import
-# failed and retrying every call would be wasted work.
-_terminal_config_bridge_attempted = False
+# Guard for the config-fallback bridge below, keyed by Hermes home.  The
+# bridge runs at most once per active home: within one home it is purely an
+# optimization (after the first attempt either TERMINAL_ENV is set or the
+# import failed and retrying every call would be wasted work), but a unified
+# dashboard/serve process serves several profiles through the context-local
+# HERMES_HOME override, and each profile must bridge its OWN terminal.* config
+# (#98581).  ``owned`` are the TERMINAL_* vars the previous home's bridge (or
+# the launch-time CLI bridge) wrote, so a profile switch can drop them before
+# re-bridging — a stale ``TERMINAL_ENV=local`` from the launch profile must
+# never leak into a profile whose config selects docker.
+_terminal_config_bridge_state: Optional[Dict[str, Any]] = None
+_terminal_config_bridge_lock = threading.Lock()
 
 
 def _ensure_terminal_env_bridged() -> None:
@@ -1723,38 +1730,66 @@ def _ensure_terminal_env_bridged() -> None:
     config.yaml selects ``terminal.backend: docker``, running commands on the
     host the user intended to sandbox (#63141, #54449, #61115, #65696).
 
+    The bridge is re-run whenever the active Hermes home changes (context-local
+    profile override → ``HERMES_HOME`` env → platform default), so one unified
+    dashboard backend serves each profile's terminal backend instead of latching
+    the launch profile's for the whole process (#98581) — the same re-bridge
+    ``web_server.py`` already performs per-request for the embedded chat PTY.
+
     Explicit terminal config keys win: when config.yaml has a ``terminal``
     section, each key present there overrides its matching env value (which may
     be stale from ``hermes setup``). Environment values for omitted terminal
     keys are preserved. When no terminal section exists, exported/.env values
     keep working unchanged.
     """
-    global _terminal_config_bridge_attempted
-    if _terminal_config_bridge_attempted:
-        return
-    _terminal_config_bridge_attempted = True
-    try:
-        from hermes_cli.config import apply_terminal_config_to_env, read_raw_config
+    global _terminal_config_bridge_state
+    from hermes_constants import hermes_home_key
 
-        # If config.yaml has an explicit terminal section, bridge with
-        # override enabled. The helper only overrides env vars for keys present
-        # in that raw section; merged defaults remain backfill-only. Without a
-        # terminal section, preserve an existing TERMINAL_ENV selection or
-        # backfill defaults when no selection exists.
-        raw_config = read_raw_config()
-        has_terminal_section = isinstance(raw_config.get("terminal"), dict)
+    home = hermes_home_key()
+    with _terminal_config_bridge_lock:
+        state = _terminal_config_bridge_state
+        if state is not None and state["home"] == home:
+            return
+        owned: set = set()
+        try:
+            from hermes_cli.config import (
+                apply_terminal_config_to_env,
+                read_raw_config,
+                terminal_config_owned_env_vars,
+            )
 
-        if has_terminal_section:
-            # Explicit terminal keys in config.yaml win over matching env values.
-            apply_terminal_config_to_env(env=None, override=True)
-        elif "TERMINAL_ENV" not in os.environ:
-            # No terminal section in config.yaml, TERMINAL_ENV not set —
-            # backfill from config defaults
-            apply_terminal_config_to_env(env=None, override=False)
-    except Exception:
-        # Never let a config problem take the terminal tool down — the
-        # historical local default still applies.
-        logger.debug("terminal config → env fallback bridge failed", exc_info=True)
+            # Drop the TERMINAL_* vars the previous home's bridge explicitly
+            # owned before resolving the new home's selection, mirroring the
+            # dashboard PTY re-bridge in web_server.py. Operator-exported
+            # values for keys neither home configured are preserved.
+            if state is not None:
+                for env_var in state["owned"]:
+                    os.environ.pop(env_var, None)
+
+            # If config.yaml has an explicit terminal section, bridge with
+            # override enabled. The helper only overrides env vars for keys
+            # present in that raw section; merged defaults remain backfill-only.
+            # Without a terminal section, preserve an existing TERMINAL_ENV
+            # selection or backfill defaults when no selection exists.
+            raw_config = read_raw_config()
+            raw_terminal = raw_config.get("terminal")
+            has_terminal_section = isinstance(raw_terminal, dict)
+
+            if has_terminal_section:
+                # Explicit terminal keys in config.yaml win over matching env values.
+                apply_terminal_config_to_env(env=None, override=True)
+                owned = terminal_config_owned_env_vars(raw_terminal)
+            elif "TERMINAL_ENV" not in os.environ:
+                # No terminal section in config.yaml, TERMINAL_ENV not set —
+                # backfill from config defaults
+                apply_terminal_config_to_env(env=None, override=False)
+        except Exception:
+            # Never let a config problem take the terminal tool down — the
+            # historical local default still applies. Record the attempt for
+            # this home so a permanently broken import does not retry on every
+            # call (same waste-avoidance as the original one-shot flag).
+            logger.debug("terminal config → env fallback bridge failed", exc_info=True)
+        _terminal_config_bridge_state = {"home": home, "owned": owned}
 
 
 def _get_env_config() -> Dict[str, Any]:


### PR DESCRIPTION
## What does this PR do?

The terminal config→env bridge in `tools/terminal_tool.py` (`_ensure_terminal_env_bridged`) was guarded by a one-shot module-global flag, so the first profile context the process saw — the launch profile — latched its `TERMINAL_*` selection for the whole process. In a unified dashboard backend (`hermes dashboard` without `--isolated`), every non-default profile served through the profile switcher therefore executed terminal-tool commands with the **launch profile's** terminal backend. Profiles configured with `terminal.backend: docker` ran commands **on the host** — a sandbox escape (#98581).

This keys the bridge guard by the **active Hermes home** (context-local profile override → `HERMES_HOME` env → platform default, via the existing `hermes_home_key()` helper) instead of a bare bool:

- when the active home changes, the `TERMINAL_*` vars the previous home's bridge (or the launch-time CLI bridge) explicitly **owned** — computed with the existing `terminal_config_owned_env_vars()` helper — are dropped before re-bridging, so a stale `TERMINAL_ENV=local` from the launch profile can never leak into a profile whose config selects docker;
- the re-bridge then resolves the new home's `terminal.*` config (`read_raw_config`/`apply_terminal_config_to_env` already resolve through `get_hermes_home()`, which honors the context-local override);
- within one home the bridge still runs at most once, and a failed attempt is still recorded for that home (same waste-avoidance as the original one-shot flag);
- a lock keeps the pop→bridge→record sequence atomic across threads.

This mirrors the per-profile re-bridge `hermes_cli/web_server.py` already performs for the embedded chat PTY (`_config_profile_scope` + `apply_terminal_config_to_env`); this PR applies the same pattern to the terminal-tool execution path the agent itself uses. Every caller of `_ensure_terminal_env_bridged` (`_get_env_config`, `_session_isolation_enabled`, `_docker_persistent_profile_scoped`) benefits.

## Related Issue

Fixes #98581

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/terminal_tool.py` — replaced the one-shot `_terminal_config_bridge_attempted` bool with `_terminal_config_bridge_state` (`{home, owned}`); `_ensure_terminal_env_bridged` now re-runs when the active Hermes home changes, dropping the previous home's explicitly-owned `TERMINAL_*` vars first (fail-closed for sandboxed profiles).
- `tests/tools/test_terminal_env_bridge.py` — updated the autouse fixture for the new state shape; added two regressions: profile switch serves each profile's own backend (local→docker→local round-trip) and a launch-owned `TERMINAL_ENV` selection does not survive a switch to a profile without a terminal section.
- `tests/tools/test_docker_session_isolation.py`, `tests/tools/test_terminal_degraded_mode.py` — updated fixtures that pinned the old flag to pin the new per-home state instead (no behavior change for those suites).

## How to Test

1. Create two profiles: a launch profile with `terminal.backend: local` and a second with `terminal.backend: docker` (+ `docker_image`).
2. Start a unified backend: `hermes dashboard --no-open --skip-build`.
3. Switch to the docker profile and ask the agent to run: `if [ -f /.dockerenv ]; then echo IN DOCKER; else echo ON HOST; fi`.
   - Before: reports `ON HOST` (the launch profile's backend). Observed result after this PR: `IN DOCKER`, and `TERMINAL_ENV=docker` is bridged from that profile's config.yaml; switching back to the launch profile restores `local`.
4. Unit tests: `pytest tests/tools/ -k terminal -q` → 294 passed, 3 skipped; `pytest tests/tools/test_terminal_env_bridge.py tests/tools/test_docker_session_isolation.py tests/tools/test_terminal_degraded_mode.py tests/hermes_cli/test_web_server_profile_unification.py -q` → all pass (includes the two new regressions).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (env-var logic is platform-neutral; path keys normalized by `hermes_home_key` via `os.path.normcase`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A