### PR TITLE
fix(desktop): honour arrowed slash-picker highlight on bare '/' query (Enter sends correct command)

### DIFF
--- a/apps/desktop/src/app/chat/composer/composer-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.test.ts
@@ -112,6 +112,18 @@ describe('implicitSlashAcceptIndex', () => {
     expect(implicitSlashAcceptIndex('review', rows, 0, true)).toBe(0)
   })
 
+  // Regression for #98535: bare `/` + arrow-key selection must commit the
+  // highlighted row, not return null.  Before the fix, `!typed` fired first
+  // and the explicit-pick branch was never reached.
+  it('honours an arrowed pick on a bare `/` query', () => {
+    expect(implicitSlashAcceptIndex('/', rows, 1, true)).toBe(1)
+    expect(implicitSlashAcceptIndex('/', rows, 2, true)).toBe(2)
+  })
+
+  it('still returns null on a bare `/` with no arrow-key selection', () => {
+    expect(implicitSlashAcceptIndex('/', rows, 0, false)).toBeNull()
+  })
+
   it('matches an arg-stage prefix against the full completion text', () => {
     expect(implicitSlashAcceptIndex('personality alic', ['/personality alice', '/personality none'], 0, false)).toBe(0)
   })

--- a/apps/desktop/src/app/chat/composer/composer-utils.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.ts
@@ -104,14 +104,18 @@ export function implicitSlashAcceptIndex(
   activeIndex: number,
   activeExplicit: boolean
 ): number | null {
+  // A deliberately arrowed highlight ALWAYS wins — "Enter means I want this
+  // one", even on a bare `/` query where no command name has been typed yet.
+  // This must be checked before the `!typed` early-return so an explicit pick
+  // is never suppressed on a bare `/` (#98535).
+  if (activeExplicit && itemTexts[activeIndex] != null) {
+    return activeIndex
+  }
+
   const typed = slashCompletionToken(query)
 
   if (!typed) {
     return null
-  }
-
-  if (activeExplicit && itemTexts[activeIndex] != null) {
-    return activeIndex
   }
 
   const exact = itemTexts.findIndex(text => slashCompletionToken(text) === typed)


### PR DESCRIPTION
## Problem (#98535)

In \implicitSlashAcceptIndex()\, the \!typed\ guard fires **before** the \ctiveExplicit\ branch. On a bare \/\ query, \slashCompletionToken('/')\ returns \''\ which is falsy, so the function returns \
ull\ immediately — even when the user arrow-key selected a specific command. The caller then does \	riggerItems[-1]\ (undefined) and falls through to sending the bare \/\.

## Fix

Move the \ctiveExplicit\ guard above the \!typed\ early-return. A deliberately arrowed highlight always wins regardless of query content.

## Tests

Two new regression cases in \composer-utils.test.ts\:
- bare \/\ + arrow-key → returns the highlighted index
- bare \/\ + no arrow-key → still returns \
ull\

Fixes #98535