### PR TITLE
fix(desktop): bypass alreadyActive cache skip on explicit pathname navigation to fix SSH session click

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -164,7 +164,14 @@ export function useRouteResume({
       // rebinds/reaps the session on its side, and trusting it strands Desktop on
       // a dead id ("session not found"). An explicit plugin reselect similarly
       // bypasses the warm-id skip when the focused transcript disappeared.
-      if ((gatewayBecameOpen || explicitlyRequested || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
+      //
+      // Also bypass `alreadyActive` on an explicit pathname navigation
+      // (pathnameChanged): a sidebar click in SSH/remote mode can arrive with a
+      // stale runtime id cached from before the previous disconnect, making
+      // `alreadyActive=true` even though the session runtime no longer exists on
+      // the gateway.  Trusting the cache in that case silently skips the RPC and
+      // leaves the user staring at the loading spinner forever (#97809).
+      if ((gatewayBecameOpen || explicitlyRequested || !alreadyActive || pathnameChanged) && shouldResume && !creatingSessionRef.current) {
         if (explicitlyRequested) {
           handledResumeRequestRef.current = sessionResumeRequest.sequence
         }


### PR DESCRIPTION
## Problem (#97809)

In SSH/remote mode, a cached runtime id from before a disconnect makes \lreadyActive=true\ even when the session runtime no longer exists on the gateway. The resume gate (\use-route-resume.ts\) skips the RPC because none of \(gatewayBecameOpen | explicitlyRequested | !alreadyActive)\ is true, leaving the user on the loading spinner forever after clicking an existing session.

## Fix

Include \pathnameChanged\ in the bypass condition. An explicit sidebar click always changes the pathname, so the resume RPC always fires regardless of the cached runtime id. The \esumeSession\ fast-path restores cheaply if the runtime IS still live; if not, a fresh one is obtained.

The \lreadyActive\ optimisation is still honoured on in-place reconnects and gateway-became-open events where \pathnameChanged\ is false.

Fixes #97809