### PR TITLE
feat(zai): add Responses API provider support

### DIFF
--- a/plugins/model-providers/zai-responses/__init__.py
+++ b/plugins/model-providers/zai-responses/__init__.py
@@ -1,0 +1,162 @@
+"""Z.AI Responses API provider profile (api.z.ai/api/v1).
+
+Z.AI exposes its GLM models on separate, independently-billed endpoints:
+
+  - ``https://api.z.ai/api/paas/v4``        — OpenAI Chat Completions wire,
+    served by the built-in ``zai`` provider profile (left untouched here).
+  - ``https://api.z.ai/api/coding/paas/v4`` — Coding Plan endpoint.
+  - ``https://api.z.ai/api/v1``             — **OpenAI Responses wire**
+    (``POST /v1/responses``), the endpoint this profile declares.
+
+The Responses endpoint is what Hermes' ``codex_responses`` transport speaks
+natively (same shape as the ``api.openai.com`` and ``api.x.ai`` lanes).
+Until this profile existed, reaching it required a hand-written
+``providers:`` entry in config.yaml with ``transport: codex_responses``;
+registering it as a first-class plugin profile makes
+``--provider zai-responses`` work out of the box. The same ``GLM_API_KEY``
+variable the ``zai`` profile uses authenticates both endpoints;
+``ZAI_API_KEY`` / ``Z_AI_API_KEY`` are accepted as aliases for parity and
+``ZAI_RESPONSES_BASE_URL`` overrides the endpoint (relays/proxies).
+
+Live-verified against api.z.ai (Aug 2026):
+
+* ``POST /api/v1/responses`` with ``model: glm-5.3-flash`` → HTTP 200
+  (streaming tool-calling turn).
+* ``GET /api/v1/models`` → HTTP 200 with a ``{"models": [...]}`` envelope
+  keyed by ``slug`` (plus ``supported_in_api``), NOT the OpenAI
+  ``{"data": [...]}``/``id`` shape — hence the ``fetch_models`` override
+  and the standalone :func:`parse_zai_responses_models` parser.
+  Catalog served at validation time: ``glm-5.3``, ``glm-5.3-flash``,
+  ``glm-5-turbo``.
+
+Reverse hostname mapping deliberately stays pointed at the ``zai`` profile
+(``api.z.ai`` in ``agent/model_metadata.py``): this profile only adds an
+alternate wire for the same host, so no collision entry is registered.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile, _profile_user_agent
+
+logger = logging.getLogger(__name__)
+
+ZAI_RESPONSES_DEFAULT_BASE_URL = "https://api.z.ai/api/v1"
+
+
+def _base_url() -> str:
+    """Allow a base-URL override via ``ZAI_RESPONSES_BASE_URL`` (relays)."""
+    return (
+        os.getenv("ZAI_RESPONSES_BASE_URL", "").strip().rstrip("/")
+        or ZAI_RESPONSES_DEFAULT_BASE_URL
+    )
+
+
+def parse_zai_responses_models(data: Any) -> list[str] | None:
+    """Parse Z.ai's ``/api/v1/models`` payload into model ID strings.
+
+    Z.ai serves ``{"models": [{"slug": ..., "supported_in_api": ...}]}``
+    where ``slug`` is the model id the Responses endpoint accepts.
+    Entries with ``supported_in_api: false`` are skipped. Returns None
+    when nothing usable is present so callers fall back to the profile's
+    ``fallback_models``.
+    """
+    if not isinstance(data, dict):
+        return None
+    entries = data.get("models")
+    if not isinstance(entries, list):
+        return None
+    ids: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        slug = str(entry.get("slug") or "").strip()
+        if not slug:
+            continue
+        if entry.get("supported_in_api") is False:
+            continue
+        ids.append(slug)
+    # Dedupe, preserve listing order.
+    return list(dict.fromkeys(ids)) or None
+
+
+class ZaiResponsesProfile(ProviderProfile):
+    """Z.AI GLM models on the native OpenAI Responses wire."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the live catalog, parsing Z.ai's ``{"models": [...]}`` shape.
+
+        The base-class implementation sends the same auth/UA headers but
+        only parses OpenAI ``{"data": [...]}/"id"`` envelopes, so it would
+        return None on a healthy Z.ai response. Transport/auth handling is
+        mirrored here; parsing goes through
+        :func:`parse_zai_responses_models`.
+        """
+        caller_base = (base_url or "").strip()
+        if caller_base and caller_base.rstrip("/") != (self.base_url or "").rstrip("/"):
+            # User-configured base_url (proxy/relay): probe it directly.
+            url = caller_base.rstrip("/") + "/models"
+        else:
+            url = (self.models_url or "").strip() or (
+                self.base_url.rstrip("/") + "/models"
+            )
+
+        import urllib.request
+
+        from hermes_cli.urllib_security import open_credentialed_url
+
+        req = urllib.request.Request(url)
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _profile_user_agent())
+        for k, v in self.default_headers.items():
+            req.add_header(k, v)
+        try:
+            with open_credentialed_url(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+        except Exception as exc:
+            logger.debug("fetch_models(%s): %s", self.name, exc)
+            return None
+        return parse_zai_responses_models(data)
+
+
+zai_responses = ZaiResponsesProfile(
+    name="zai-responses",
+    aliases=("zai-v1", "glm-responses"),
+    api_mode="codex_responses",
+    # GLM_API_KEY is Z.ai's documented variable; ZAI_API_KEY / Z_AI_API_KEY
+    # are accepted aliases for parity with the ``zai`` profile.
+    # ZAI_RESPONSES_BASE_URL overrides the endpoint (relay/proxy setups).
+    env_vars=(
+        "GLM_API_KEY",
+        "ZAI_API_KEY",
+        "Z_AI_API_KEY",
+        "ZAI_RESPONSES_BASE_URL",
+    ),
+    display_name="Z.AI (Responses API)",
+    description="Z.AI / GLM on the native OpenAI Responses wire (api.z.ai/api/v1)",
+    signup_url="https://z.ai/",
+    base_url=_base_url(),
+    auth_type="api_key",
+    # Catalog verified live 2026-08-30 (GET /api/v1/models, HTTP 200):
+    # exactly these three slugs are served with supported_in_api enabled.
+    fallback_models=(
+        "glm-5.3",
+        "glm-5.3-flash",
+        "glm-5-turbo",
+    ),
+)
+
+register_provider(zai_responses)

--- a/plugins/model-providers/zai-responses/plugin.yaml
+++ b/plugins/model-providers/zai-responses/plugin.yaml
@@ -1,0 +1,5 @@
+name: zai-responses-provider
+kind: model-provider
+version: 1.0.0
+description: Z.AI / GLM on the native OpenAI Responses API (api.z.ai/api/v1)
+author: ecourn

--- a/tests/hermes_cli/test_zai_responses_provider.py
+++ b/tests/hermes_cli/test_zai_responses_provider.py
@@ -1,0 +1,228 @@
+"""Behavior contracts for the Z.AI Responses API provider (api.z.ai/api/v1).
+
+Z.AI serves its GLM models on independently-billed endpoints: the built-in
+``zai`` profile owns the Chat Completions wire (``/api/paas/v4``), this
+plugin profile owns the native OpenAI Responses wire (``/api/v1/responses``).
+These tests pin the profile registration, alias resolution, auth/registry
+auto-wiring, wire-mode detection, and the ``{"models": [...]}/"slug"``
+catalog parsing the generic OpenAI ``{"data": [...]}/"id"`` parser would
+miss — all without network access.
+"""
+
+import json
+import sys
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_api_key_provider_credentials,
+    resolve_provider,
+)
+from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_LABELS
+from hermes_cli.providers import determine_api_mode, get_label, get_provider
+from providers import get_provider_profile
+
+# Realistic subset of GET https://api.z.ai/api/v1/models (verified live,
+# HTTP 200, 2026-08-30): envelope keyed by "models", entries keyed by
+# "slug", with a supported_in_api flag and vendor metadata alongside.
+ZAI_MODELS_PAYLOAD = {
+    "models": [
+        {
+            "slug": "glm-5.3",
+            "display_name": "glm-5.3",
+            "description": "Z.ai's latest flagship model",
+            "context_window": 1048576,
+            "supported_in_api": True,
+        },
+        {
+            "slug": "glm-5.3-flash",
+            "display_name": "glm-5.3-flash",
+            "context_window": 1048576,
+            "supported_in_api": True,
+        },
+        {
+            "slug": "glm-5-turbo",
+            "display_name": "glm-5-turbo",
+            "supported_in_api": True,
+        },
+        {
+            "slug": "glm-5.3-preview-internal",
+            "display_name": "internal preview",
+            "supported_in_api": False,
+        },
+    ]
+}
+
+
+def _profile():
+    profile = get_provider_profile("zai-responses")
+    assert profile is not None
+    return profile
+
+
+def _zai_responses_module():
+    """The plugin module, via the registered profile (router-test idiom)."""
+    profile = _profile()
+    return sys.modules[type(profile).__module__]
+
+
+class TestProfileRegistration:
+    def test_profile_loads_with_responses_wire(self):
+        profile = _profile()
+        assert profile.name == "zai-responses"
+        assert profile.display_name == "Z.AI (Responses API)"
+        # The entire point of the profile: the Responses endpoint, NOT the
+        # Chat Completions endpoint owned by the ``zai`` profile.
+        assert profile.base_url == "https://api.z.ai/api/v1"
+        assert profile.api_mode == "codex_responses"
+        assert profile.auth_type == "api_key"
+
+    def test_env_vars_cover_documented_key_and_aliases(self):
+        profile = _profile()
+        assert profile.env_vars[:3] == ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY")
+        assert "ZAI_RESPONSES_BASE_URL" in profile.env_vars
+
+    def test_fallback_models_match_live_catalog(self):
+        # Catalog verified live 2026-08-30: exactly these slugs are served.
+        assert _profile().fallback_models == (
+            "glm-5.3",
+            "glm-5.3-flash",
+            "glm-5-turbo",
+        )
+
+    def test_canonical_providers_and_label(self):
+        assert "zai-responses" in [p.slug for p in CANONICAL_PROVIDERS]
+        assert _PROVIDER_LABELS["zai-responses"] == "Z.AI (Responses API)"
+        assert get_label("zai-responses") == "Z.AI (Responses API)"
+
+
+class TestAliasResolution:
+    @pytest.mark.parametrize("alias", ["zai-responses", "zai-v1", "glm-responses"])
+    def test_aliases_resolve_to_profile(self, alias):
+        assert resolve_provider(alias) == "zai-responses"
+
+    def test_built_in_zai_profile_is_not_shadowed(self):
+        # Same host, different wire: the Chat Completions profile must keep
+        # resolving exactly as before this plugin existed.
+        assert resolve_provider("zai") == "zai"
+        assert resolve_provider("glm") == "zai"
+        assert PROVIDER_REGISTRY["zai"].inference_base_url == (
+            "https://api.z.ai/api/paas/v4"
+        )
+        zai_profile = get_provider_profile("zai")
+        assert zai_profile is not None
+        assert zai_profile.base_url == "https://api.z.ai/api/paas/v4"
+
+
+class TestRegistryAutoWiring:
+    def test_registry_entry(self):
+        pconfig = PROVIDER_REGISTRY["zai-responses"]
+        assert pconfig.id == "zai-responses"
+        assert pconfig.name == "Z.AI (Responses API)"
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.inference_base_url == "https://api.z.ai/api/v1"
+        # Base-URL override vars are stripped from the key vars and routed
+        # to base_url_env_var by the registry auto-extension.
+        assert pconfig.api_key_env_vars == (
+            "GLM_API_KEY",
+            "ZAI_API_KEY",
+            "Z_AI_API_KEY",
+        )
+        assert pconfig.base_url_env_var == "ZAI_RESPONSES_BASE_URL"
+
+    def test_credentials_resolve_from_glm_api_key(self, monkeypatch):
+        monkeypatch.setenv("GLM_API_KEY", "zai-responses-test-key")
+        creds = resolve_api_key_provider_credentials("zai-responses")
+        assert creds["provider"] == "zai-responses"
+        assert creds["api_key"] == "zai-responses-test-key"
+        assert creds["base_url"] == "https://api.z.ai/api/v1"
+
+    def test_wire_mode_detection(self):
+        provider = get_provider("zai-responses")
+        assert provider is not None
+        assert provider.id == "zai-responses"
+        assert provider.base_url == "https://api.z.ai/api/v1"
+        assert (
+            determine_api_mode("zai-responses", "https://api.z.ai/api/v1")
+            == "codex_responses"
+        )
+
+
+class TestCatalogParsing:
+    def test_parse_models_slug_envelope(self):
+        parsed = _zai_responses_module().parse_zai_responses_models(ZAI_MODELS_PAYLOAD)
+        assert parsed == ["glm-5.3", "glm-5.3-flash", "glm-5-turbo"]
+
+    def test_parse_models_dedupes_preserving_order(self):
+        payload = {
+            "models": [
+                {"slug": "glm-5.3-flash", "supported_in_api": True},
+                {"slug": "glm-5.3"},
+                {"slug": "glm-5.3-flash", "supported_in_api": True},
+            ]
+        }
+        parsed = _zai_responses_module().parse_zai_responses_models(payload)
+        assert parsed == ["glm-5.3-flash", "glm-5.3"]
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            {},
+            {"models": []},
+            {"models": "nope"},
+            {"data": [{"id": "openai-shape"}]},
+            {"models": [{"id": "no-slug"}, {"slug": ""}, "not-a-dict"]},
+        ],
+    )
+    def test_parse_models_returns_none_without_usable_entries(self, payload):
+        parser = _zai_responses_module().parse_zai_responses_models
+        assert parser(payload) is None
+
+
+class TestFetchModels:
+    @staticmethod
+    def _patch_urlopen(monkeypatch, payload):
+        """Stub the credentialed opener; capture the request for assertions."""
+        captured = {}
+
+        class _FakeResponse:
+            def read(self):
+                return json.dumps(payload).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        def _fake_open(req, timeout=None):
+            captured["req"] = req
+            captured["timeout"] = timeout
+            return _FakeResponse()
+
+        monkeypatch.setattr(
+            "hermes_cli.urllib_security.open_credentialed_url", _fake_open
+        )
+        return captured
+
+    def test_fetch_models_parses_zai_envelope_and_sends_bearer(self, monkeypatch):
+        captured = self._patch_urlopen(monkeypatch, ZAI_MODELS_PAYLOAD)
+        profile = _profile()
+
+        assert profile.fetch_models(api_key="k-123") == [
+            "glm-5.3",
+            "glm-5.3-flash",
+            "glm-5-turbo",
+        ]
+        req = captured["req"]
+        assert req.full_url == "https://api.z.ai/api/v1/models"
+        assert req.headers.get("Authorization") == "Bearer k-123"
+
+    def test_fetch_models_returns_none_on_failure(self, monkeypatch):
+        def _boom(req, timeout=None):
+            raise OSError("network down")
+
+        monkeypatch.setattr("hermes_cli.urllib_security.open_credentialed_url", _boom)
+        assert _profile().fetch_models(api_key="k-123") is None


### PR DESCRIPTION
## Summary

Z.AI serves GLM models on a native OpenAI **Responses** wire at `https://api.z.ai/api/v1` (`POST /v1/responses`), separate from the Chat Completions endpoint (`/api/paas/v4`) already covered by the built-in `zai` profile. Until now, reaching the Responses wire required a hand-written `providers:` entry in `config.yaml` with `transport: codex_responses`. This PR registers it as a first-class plugin profile so `--provider zai-responses` works out of the box.

The change is **purely additive** (3 new files, no existing file touched):

- `plugins/model-providers/zai-responses/` — declarative `ProviderProfile` (`api_key` auth, `api_mode="codex_responses"`), same pattern as the `xai` profile. Auto-wires into `PROVIDER_REGISTRY`, aliases, `CANONICAL_PROVIDERS`, doctor and the picker via the existing registry auto-extension (no edits to `auth.py` / `runtime_provider.py` needed).
  - Keys: `GLM_API_KEY` (Z.ai's documented variable, shared with the `zai` profile) with `ZAI_API_KEY` / `Z_AI_API_KEY` aliases; `ZAI_RESPONSES_BASE_URL` overrides the endpoint for relays.
  - `fetch_models` override parses Z.ai's `{"models": [...]}` / `slug` catalog shape — the generic `{"data": [...]}` / `id` parser returns nothing on a healthy Z.ai response.
  - `fallback_models` pinned to the live catalog: `glm-5.3`, `glm-5.3-flash`, `glm-5-turbo`.
- `tests/hermes_cli/test_zai_responses_provider.py` — 21 behavior contracts (registration, alias resolution, registry auto-wiring, wire-mode detection, catalog parsing incl. `supported_in_api: false` filtering, bearer-auth fetch via stubbed opener). All offline, no network, no real keys.

The existing `zai` profile, its aliases, and the `api.z.ai` reverse hostname mapping are untouched; user `providers:` config still takes precedence, so nothing changes for existing setups.

## Live validation

Verified against the real endpoint (2026-08-30):

- `POST https://api.z.ai/api/v1/responses` with `model: glm-5.3-flash` → HTTP 200 (streaming tool-calling turn).
- `GET https://api.z.ai/api/v1/models` → HTTP 200, `{"models": [{"slug": ..., "supported_in_api": ...}]}` envelope (the shape the parser handles).
- End-to-end one-shot run: `hermes chat -q hi --oneshot --provider zai-responses --model glm-5.3-flash` succeeds **both** with a developer config and in a clean `HERMES_HOME` containing no `providers:` entry — plugin-only resolution, proving the manual-config workaround is no longer needed.

## Test evidence

`scripts/run_tests.sh` (canonical runner):

- `tests/hermes_cli/test_zai_responses_provider.py` — 21 passed
- `tests/hermes_cli/test_auxiliary_named_custom_providers.py` — 19 passed
- `tests/hermes_cli/test_api_key_providers.py` + `test_runtime_provider_resolution.py` + `test_nebius_token_factory_provider.py` — 186 passed (alias/registry/non-shadowing guards)
- `tests/agent/test_model_metadata.py` — 111 passed (URL→provider mapping auto-extension)

`ruff check` / `ruff format --check` / `ty check` clean on the new files.

## Notes

- No secrets are included: keys appear only as env-var *names*; live checks were run locally with an untracked key.
- Reverse hostname mapping (`api.z.ai` → `zai` in `model_metadata.py`) is deliberately left pointing at the existing profile: this plugin only adds an alternate wire for the same host.
