### PR TITLE
fix(compression): stop slow relays from trapping sessions in failed compaction

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9218,7 +9218,13 @@ class _ChatStreamAccumulator:
         self.resp_model = model or ""
 
     def feed(self, chunk: Any) -> None:
-        _notify_aux_progress()
+        # A host timeout revokes the compression fence before detaching the
+        # worker. Stop consuming the provider stream as soon as its next event
+        # arrives so empty keepalives cannot keep a cancelled logical attempt
+        # alive (or trigger fallback calls) until the much larger wire ceiling.
+        cancel_check = _capture_aux_cancel_check()
+        if callable(cancel_check) and _captured_aux_cancel_requested(cancel_check):
+            raise AuxiliaryExplicitCancellation()
         if (
             self._total_ceiling is not None
             and (time.monotonic() - self._started) >= self._total_ceiling
@@ -9249,7 +9255,16 @@ class _ChatStreamAccumulator:
         )
         if reasoning_piece and isinstance(reasoning_piece, str):
             self.reasoning_parts.append(reasoning_piece)
-        for tc in (getattr(delta, "tool_calls", None) or []):
+        tool_call_deltas = getattr(delta, "tool_calls", None) or []
+        # Only model output is forward progress. OpenAI-compatible relays may
+        # emit empty SSE keepalive chunks indefinitely; counting those as
+        # progress resets the host's inactivity timer and turns a 120-second
+        # no-output budget into the full 600-second compression ceiling.
+        # Reasoning and tool-call deltas are genuine generation and continue
+        # to keep slow-but-working models alive.
+        if piece or reasoning_piece or tool_call_deltas:
+            _notify_aux_progress()
+        for tc in tool_call_deltas:
             idx = getattr(tc, "index", 0) or 0
             acc = self.tool_calls_acc.setdefault(
                 idx, {"id": "", "name": "", "arguments": []}

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -77,6 +77,7 @@ from agent.model_metadata import (
     estimate_request_tokens_rough,
 )
 from agent.session_activity import ActivityProvenance, normalize_activity_provenance
+from hermes_cli.route_identity import normalize_route_base_url
 
 logger = logging.getLogger(__name__)
 
@@ -1775,9 +1776,9 @@ def check_compression_model_feasibility(agent: Any) -> None:
         same_model = str(aux_model or "").strip() == str(
             getattr(agent, "model", "") or ""
         ).strip()
-        same_route = str(aux_base_url or "").rstrip("/") == str(
-            getattr(agent, "base_url", "") or ""
-        ).rstrip("/")
+        same_route = normalize_route_base_url(
+            aux_base_url
+        ) == normalize_route_base_url(getattr(agent, "base_url", ""))
         if aux_context_override is None and same_model and same_route:
             aux_context_override = getattr(agent, "_config_context_length", None)
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1760,11 +1760,32 @@ def check_compression_model_feasibility(agent: Any) -> None:
         _raw_aux_key = getattr(client, "api_key", "")
         aux_api_key = "" if (callable(_raw_aux_key) and not isinstance(_raw_aux_key, str)) else str(_raw_aux_key or "")
 
+        # When auxiliary.compression inherits the exact main runtime, its
+        # context window has the same source of truth as the main request.
+        # Reusing only the auxiliary-specific override here made a configured
+        # model.context_length disappear at the feasibility boundary: the main
+        # compressor used the explicit value while this probe fell back to the
+        # generic custom-endpoint tier. Besides contradictory telemetry, that
+        # could lower the live compression threshold to a value the user had
+        # explicitly overridden. A separately routed aux model must still
+        # resolve independently.
+        aux_context_override = getattr(
+            agent, "_aux_compression_context_length_config", None
+        )
+        same_model = str(aux_model or "").strip() == str(
+            getattr(agent, "model", "") or ""
+        ).strip()
+        same_route = str(aux_base_url or "").rstrip("/") == str(
+            getattr(agent, "base_url", "") or ""
+        ).rstrip("/")
+        if aux_context_override is None and same_model and same_route:
+            aux_context_override = getattr(agent, "_config_context_length", None)
+
         aux_context = get_model_context_length(
             aux_model,
             base_url=aux_base_url,
             api_key=aux_api_key,
-            config_context_length=getattr(agent, "_aux_compression_context_length_config", None),
+            config_context_length=aux_context_override,
             # Each model must be resolved with its own provider so that
             # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
             # are invoked for the correct client, not inherited from the main model.
@@ -3150,6 +3171,13 @@ def compress_context(
         # atomic summary in half (#23975). Explicit stop surfaces set a separate
         # Event atomically; never infer cause from the racy message fields.
         _hard_cancel_event = getattr(agent, "_hard_interrupt_requested", None)
+
+        def _compression_cancel_requested() -> bool:
+            return bool(
+                (_hard_cancel_event is not None and _hard_cancel_event.is_set())
+                or (commit_fence is not None and commit_fence.is_cancelled)
+            )
+
         try:
             # F6: never start expensive summary work for an already-cancelled
             # fence (a stale queued job admitted after host departure).
@@ -3162,7 +3190,7 @@ def compress_context(
                 compressed = messages
             else:
                 with aux_progress_hook(_progress_hook), aux_interrupt_protection(
-                    cancel_event=_hard_cancel_event
+                    cancel_check=_compression_cancel_requested
                 ):
                     compressed = compress_fn(messages, **compress_kwargs)
                     # Freeze a hard stop that arrived after the final provider

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.auxiliary_client import (
+    AuxiliaryExplicitCancellation,
     _acreate_with_stream,
     _aggregate_chat_stream,
     _aggregate_chat_stream_async,
@@ -22,6 +23,7 @@ from agent.auxiliary_client import (
     _create_with_progress,
     _notify_aux_progress,
     _provider_requires_stream,
+    aux_interrupt_protection,
     aux_progress_hook,
 )
 from agent.conversation_compression import CompressionCommitFence
@@ -131,8 +133,27 @@ class TestCreateWithProgress:
         assert result.choices[0].message.reasoning == "thinking..."
         assert result.choices[0].finish_reason == "stop"
         assert result.usage.total_tokens == 7
-        # 1 dispatch tick + 1 per chunk
+        # 1 dispatch tick + 1 per content/reasoning chunk
         assert len(ticks) >= len(chunks) + 1
+
+    def test_empty_keepalive_chunks_do_not_reset_progress_timeout(self):
+        chunks = [
+            SimpleNamespace(id="keepalive", model="m1", choices=[], usage=None),
+            _chunk(content=None),
+            _chunk(content="summary", finish_reason="stop"),
+        ]
+        client = _FakeClient(stream_chunks=chunks)
+        ticks = []
+
+        with aux_progress_hook(lambda: ticks.append(1)):
+            result = _create_with_progress(
+                client, {"model": "m1", "messages": [], "timeout": 30},
+            )
+
+        assert result.choices[0].message.content == "summary"
+        # Request dispatch and the actual summary token count as progress;
+        # empty SSE keepalives must not keep a stalled attempt alive.
+        assert len(ticks) == 2
 
     def test_streaming_rejected_falls_back_to_plain_call(self):
         client = _FakeClient(
@@ -177,6 +198,27 @@ class TestAggregateChatStream:
         assert tool_calls[0].function.name == "do_thing"
         assert tool_calls[0].function.arguments == '{"a": 1}'
         assert result.choices[0].finish_reason == "tool_calls"
+
+    def test_cancelled_compression_stops_keepalive_stream(self):
+        closed = []
+        fence = CompressionCommitFence()
+        assert fence.try_cancel_before_commit() is True
+
+        class _KeepaliveStream:
+            def __iter__(self):
+                while True:
+                    yield SimpleNamespace(
+                        id="keepalive", model="m1", choices=[], usage=None
+                    )
+
+            def close(self):
+                closed.append(True)
+
+        with aux_interrupt_protection(cancel_check=lambda: fence.is_cancelled):
+            with pytest.raises(AuxiliaryExplicitCancellation):
+                _aggregate_chat_stream(_KeepaliveStream())
+
+        assert closed == [True]
 
 
     def test_stream_close_is_called(self):

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -51,6 +51,7 @@ def _make_agent(
     agent.tool_progress_callback = None
     agent._compression_warning = None
     agent._aux_compression_context_length_config = None
+    agent._config_context_length = None
     agent._custom_providers = []
     agent.tools = []
 
@@ -192,6 +193,48 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         provider="openrouter",
         custom_providers=[],
     )
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=1_048_576)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_inherited_aux_route_reuses_main_context_override(mock_get_client, mock_ctx_len):
+    """An aux route inherited from main must share its explicit context pin."""
+    agent = _make_agent(main_context=1_048_576, threshold_percent=0.50)
+    agent.model = "glm-5.3-flash"
+    agent.provider = "custom"
+    agent.base_url = "https://relay.example.invalid/v1"
+    agent._config_context_length = 1_048_576
+    mock_client = MagicMock()
+    mock_client.base_url = "https://relay.example.invalid/v1/"
+    mock_client.api_key = "sk-custom"
+    mock_get_client.return_value = (mock_client, "glm-5.3-flash")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] == 1_048_576
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=256_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_distinct_aux_route_does_not_reuse_main_context_override(
+    mock_get_client, mock_ctx_len
+):
+    """A separately routed aux model must resolve its own context window."""
+    agent = _make_agent(main_context=1_048_576, threshold_percent=0.50)
+    agent.model = "glm-5.3-flash"
+    agent.provider = "custom"
+    agent.base_url = "https://relay.example.invalid/v1"
+    agent._config_context_length = 1_048_576
+    mock_client = MagicMock()
+    mock_client.base_url = "https://aux.example.invalid/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "summary-model")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] is None
 
 
 

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -202,7 +202,9 @@ def test_inherited_aux_route_reuses_main_context_override(mock_get_client, mock_
     agent = _make_agent(main_context=1_048_576, threshold_percent=0.50)
     agent.model = "glm-5.3-flash"
     agent.provider = "custom"
-    agent.base_url = "https://relay.example.invalid/v1"
+    # The OpenAI client canonicalizes these equivalent URL components. The
+    # configured runtime route may retain its original spelling.
+    agent.base_url = "HTTPS://RELAY.EXAMPLE.INVALID:443/v1"
     agent._config_context_length = 1_048_576
     mock_client = MagicMock()
     mock_client.base_url = "https://relay.example.invalid/v1/"


### PR DESCRIPTION
## What does this PR do?

Long-lived sessions using a slow custom OpenAI-compatible relay can now stop a compression attempt after the configured no-output budget instead of treating empty SSE keepalives as model progress until the 600-second ceiling. When compression inherits the main model and route, it also reuses the main route's explicit context-length override so feasibility checks and the compressor use the same limit.

### Symptom

A custom relay can emit empty streaming events while producing no summary content. Hermes previously reset the compression inactivity clock on every empty event, so an attempt that should fail after 120 seconds remained active until the 600-second total ceiling. The inherited auxiliary feasibility probe could simultaneously report the generic 256K fallback while the main compressor used an explicit 1M context window.

### Impact

Affected sessions repeatedly spend the full compression ceiling without committing a summary, retain the oversized transcript, and resend it on later turns. Cancelled workers can also continue consuming keepalive streams and occupy compression capacity.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py` / `_ChatStreamAccumulator.feed` when a custom OpenAI-compatible relay emits empty SSE chunks, and `agent/conversation_compression.py` / `check_compression_model_feasibility` when compression inherits the main route.

**Causal chain:**
1. The relay emits an SSE chunk with no content, reasoning, or tool-call delta.
2. The stream accumulator marks that transport keepalive as forward progress, continuously extending the host inactivity deadline.
3. The host waits until the total ceiling, returns the original transcript, and later retries compression against an even larger session.
4. Independently, the feasibility check forwards only `auxiliary.compression.context_length`, so an inherited route drops `model.context_length` and can resolve a contradictory fallback limit.

**Why it is wrong:** Transport liveness is not summary progress, and an inherited auxiliary route is the same model-provider endpoint whose context window the user explicitly pinned.

**Working sibling / contrast:** Content, reasoning, and tool-call deltas remain meaningful progress and continue extending the inactivity budget. Separately configured auxiliary models and endpoints still resolve their own context windows.

**Ruled out:** The failure is not caused by the configured 600-second hard ceiling itself. The existing host timeout and cooldown ladder are reached correctly once empty keepalives stop resetting the inactivity clock.

### Fix

- Count only content, reasoning, or tool-call deltas as streamed auxiliary progress.
- Propagate host fence cancellation into the protected auxiliary call and stop consuming the stream on the next event, preventing cancelled attempts from reaching fallback calls or the larger wire ceiling.
- Reuse `model.context_length` only when the resolved auxiliary model and normalized endpoint exactly match the main runtime; preserve independent resolution for distinct auxiliary routes.

## Related Issue

Fixes #98567

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - distinguish model output from empty keepalive events and stop cancelled streams.
- `agent/conversation_compression.py` - share the main context override with an inherited compression route and propagate fence cancellation.
- `tests/agent/test_aux_progress_streaming.py` - cover empty keepalives and cancellation-driven stream closure.
- `tests/run_agent/test_compression_feasibility.py` - cover inherited and separately routed context overrides.

## How to Test

1. Run the targeted compression, feasibility, and auxiliary-client suites.
2. Confirm empty keepalive chunks do not tick the progress hook while content and reasoning chunks still do.
3. Confirm an inherited auxiliary route receives the main context override and a distinct route does not.

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_aux_progress_streaming.py tests/agent/test_compress_context_progress_timeout.py tests/run_agent/test_compression_feasibility.py -q
```

Result: 230 passed on Windows 11.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings: N/A - no user-facing configuration changed
- [x] `cli-config.yaml.example`: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - implementation uses platform-independent Python primitives
- [x] Tool descriptions and schemas: N/A - no model tool behavior changed
